### PR TITLE
Per-channel pressure weighting in surface loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,9 +28,13 @@ class Config:
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    n_layers: int = 5
+    n_hidden: int = 128
+    mlp_ratio: int = 2
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
+    agent: str | None = None  # agent name for filtering in W&B
     debug: bool = False
 
 
@@ -63,11 +67,11 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
+    n_hidden=cfg.n_hidden,
+    n_layers=cfg.n_layers,
     n_head=4,
     slice_num=64,
-    mlp_ratio=2,
+    mlp_ratio=cfg.mlp_ratio,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )
@@ -87,6 +91,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else [],
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )
@@ -131,7 +136,8 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        channel_weights = torch.tensor([1.0, 1.0, 10.0], device=device)
+        surf_loss = (sq_err * channel_weights * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis

Pressure (p) is the hardest surface channel — best known result has surf_p≈36 while surf_Ux≈0.52 and surf_Uy≈0.29. The p values are ~70x larger in absolute magnitude than velocity channels, yet the surface loss averages all three channels equally. By giving p extra weight *within* the surface loss we push the model to reduce the metric that engineers care about most.

All prior surface-weighting experiments adjusted the surface-vs-volume balance (surf_weight hyperparameter) but never broke out per-channel weighting inside the surface loss itself. This is the next lever to pull.

## Instructions

In `train.py`, locate the surface loss computation. It currently computes MAE across all three output channels equally. Modify it to weight the pressure channel (index 2, field `p`) more than the velocity channels. The channel order in the output tensor is `[Ux, Uy, p]`.

```python
# Add per-channel weights — p gets 5x more weight than Ux/Uy
channel_weights = torch.tensor([1.0, 1.0, 5.0], device=pred_surf.device)
# Reshape to broadcast over (batch, nodes, channels) or (batch, channels) — check your tensor shape
surf_loss = (torch.abs(pred_surf - target_surf) * channel_weights).mean()
```

Exact shape depends on how surf_loss is computed — read the current code carefully before modifying.

Run with current best config (p-weight=5, then p-weight=10):
```bash
python train.py \
  --agent frieren \
  --wandb_name "frieren/surf-ch-w5" \
  --wandb_group "surf-channel-weight" \
  --n_layers 1 --n_hidden 128 --mlp_ratio 2 \
  --lr 0.011 --surf_weight 8
```
```bash
python train.py \
  --agent frieren \
  --wandb_name "frieren/surf-ch-w10" \
  --wandb_group "surf-channel-weight" \
  --n_layers 1 --n_hidden 128 --mlp_ratio 2 \
  --lr 0.011 --surf_weight 8
```

## Baseline

Best 1-layer run ("1L h128 mlp2", batch38, 20 epochs):
- val/loss: 0.4834
- Surface MAE: Ux=0.399  Uy=0.269  **p=36.78**
- Volume  MAE: Ux=1.916  Uy=0.717  p=40.25

Overall best (any arch, "ffhigh sw=10", batch35):
- val/loss: 0.6427
- Surface MAE: Ux=0.521  Uy=0.287  **p=36.25**
- Volume  MAE: Ux=2.242  Uy=0.797  p=44.49

---

## Results

**W&B run IDs:** f1ekav28 (w5), mo0xlhzx (w10)

**W&B group:** surf-channel-weight

**Peak VRAM:** ~2 GB (1-layer model, very light)

**Implementation note:** The existing surf_loss uses squared error (MSE), not MAE. Channel weights were applied to the existing MSE computation: `surf_loss = (sq_err * channel_weights * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum()`. The channel_weights tensor broadcasts correctly over (batch, nodes, 3). Validation MAE metrics are unweighted (computed in original units), so they are directly comparable across runs.

**Metrics (best epoch = 20 for both runs):**

| Metric | w5 (p×5) | w10 (p×10) | Historical baseline |
|---|---|---|---|
| val/loss | 2.6670 | 2.4410 | 0.4834 |
| Surface MAE Ux | 3.45 | 3.49 | 0.399 |
| Surface MAE Uy | 1.38 | 1.41 | 0.269 |
| Surface MAE p | 175.3 | **150.3** | **36.78** |
| Volume MAE Ux | 11.07 | 11.18 | 1.916 |
| Volume MAE Uy | 4.19 | 3.73 | 0.717 |
| Volume MAE p | 279.7 | 297.4 | 40.25 |

**What happened:** Per-channel pressure weighting does have the intended directional effect: increasing p-weight from 5→10 reduces surface p MAE from 175.3→150.3 (a 14% improvement). The trade-off is a slight increase in surface Ux/Uy MAE, which is consistent with the optimizer prioritizing pressure at the cost of velocity accuracy.

However, both runs remain far from the historical baseline (surf_p=150 vs 36.78, ~4x worse), so the absolute results are disappointing. The same issue noted in PR #3 applies: the current codebase appears to produce much worse results than historical benchmarks. Both experiments were best at epoch 20 (still improving, not converged), suggesting more training could help, but the gap is too large to attribute to convergence alone.

The directional signal (higher p-weight → lower surf_p, at cost of velocity) is clear and confirms the hypothesis mechanism works. The benefit saturates or even reverses for volume p (279.7→297.4), which is expected since we only weight p in the surface loss.

**Suggested follow-ups:**
- Establish a clean current-codebase baseline (default config, no modifications) to understand the true starting point before chasing further improvements.
- Once a baseline is established, re-test per-channel pressure weighting against it rather than the historical benchmark.
- Try even higher p-weights (20, 50) to see where the surf_p MAE floor is.
- Consider whether the val_loss should also use channel weights for consistent training/eval signal.