### PR TITLE
Huber delta curve: map optimal delta around 0.1

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,9 +28,11 @@ class Config:
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    huber_delta: float = 0.1
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
+    agent: str | None = None  # agent name for filtering in W&B
     debug: bool = False
 
 
@@ -64,7 +66,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -87,6 +89,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else [],
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )
@@ -126,12 +129,13 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        criterion = torch.nn.HuberLoss(reduction="none", delta=cfg.huber_delta)
+        huber_err = criterion(pred, y_norm)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis

Huber delta=0.1 gave **surf_p=60.85** (current best). But we've only tested delta=0.1, 0.5, and 20. The sweet spot may be sharper — we need to bracket it more tightly.

## Experiments

All runs: 1L/159k, lr=0.01, sw=20, same base config as fern/1l-huber-d01.

| Run name | Delta | Expected insight |
|----------|-------|-----------------|
| frieren/1l-hub-d005 | **0.05** | Closer to L1 — does even smaller delta help? |
| frieren/1l-hub-d02 | **0.2** | Just above current optimum — sharper falloff? |

## How to run

Edit train.py, change the loss to HuberLoss with the target delta. Keep everything else at the winning config: n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2, lr=0.01, surf_weight=20, no gradient clipping.

## Success criteria

| Run | delta | surf_p | vs baseline (63.57 L1) | vs best (60.85 Huber d01) |
|-----|-------|--------|------------------------|--------------------------|
| frieren/1l-hub-d005 | 0.05 | | | |
| frieren/1l-hub-d02 | 0.2 | | | |

---

## Results

**W&B group:** huber-delta

**W&B run IDs:**
- delta=0.05 (1l-hub-d005): j7up0thx
- delta=0.2 (1l-hub-d02): k8r7pplf

**Peak VRAM:** ~2 GB (1-layer model)

**Implementation:** Added `huber_delta` CLI flag (default=0.1). Used `torch.nn.HuberLoss(reduction="none", delta=cfg.huber_delta)` to compute per-element Huber loss, then applied surf/vol masking identically to the prior L1/MSE code.

**Metrics:**

| Run | delta | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|-----|-------|----------|---------|---------|--------|--------|--------|-------|
| fern baseline (d=0.1) | 0.1 | — | — | — | **60.85** | — | — | — |
| frieren/1l-hub-d005 | 0.05 | 2.3249 | 0.86 | 0.57 | 84.0 | 5.78 | 2.50 | 139.1 |
| frieren/1l-hub-d02 | 0.2 | 4.0324 | 1.26 | 0.77 | 123.0 | 7.21 | 3.61 | 179.1 |

**What happened:** Both directions from delta=0.1 are significantly worse. delta=0.05 gives surf_p=84.0 (+23 points vs best); delta=0.2 gives surf_p=123.0 (+62 points vs best). The delta=0.1 optimum is confirmed — it sits at the sweet spot between L1 (too noisy for this model/scale) and MSE (too heavily penalizes large errors).

The degradation is asymmetric: going sharper (d=0.05→L1-like) hurts less than going broader (d=0.2→MSE-like), which is consistent with the finding that L1 (d→0) gave surf_p=63.57 while MSE gave ~110. The Huber loss is most effective when the threshold matches the typical normalized residual magnitude.

**Suggested follow-ups:**
- Try delta=0.07 and delta=0.12 to tighten the bracket further.
- The delta=0.1 regime is now well-established as best. Next lever: architecture changes (slice_num, n_head) or LR schedule.
