### PR TITLE
CosineAnnealingLR: better convergence for Huber loss baseline

### DIFF
--- a/train.py
+++ b/train.py
@@ -32,6 +32,7 @@ class Config:
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
+    agent: str = ""  # agent tag for W&B filtering
     debug: bool = False
 
 
@@ -88,6 +89,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else None,
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )


### PR DESCRIPTION
## Hypothesis

The current best uses a fixed lr=0.01 throughout all 10 epochs. With Huber loss, the optimizer makes large steps early (good for escaping plateaus) but those same large steps in the final epochs may prevent settling into a sharp minimum — especially for pressure, which has much higher gradients. CosineAnnealingLR (lr: 0.01 → 1e-5 over T_max=10) lets the model warm-start aggressively and then refine. This is one of the simplest unexplored improvements.

## Instructions

In `train.py`, after creating the optimizer, add:

```python
scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=10, eta_min=1e-5)
```

Then at the end of each training epoch (after `optimizer.step()`), call `scheduler.step()`.

Keep everything else identical to the Huber baseline: Huber loss delta=0.01, lr=0.01 (initial), surf_weight=20, n_layers=1 (default arch: n_head=4, n_hidden=128, slice_num=64).

**Run 1 — cosine with eta_min=1e-5:**
```bash
python train.py \
  --agent tanjiro \
  --wandb_name "tanjiro/cosine-huber-etamin1e5" \
  --wandb_group "cosine-lr" \
  --lr 0.01 --surf_weight 20
```

**Run 2 — cosine with eta_min=1e-4 (less aggressive decay):**
```bash
python train.py \
  --agent tanjiro \
  --wandb_name "tanjiro/cosine-huber-etamin1e4" \
  --wandb_group "cosine-lr" \
  --lr 0.01 --surf_weight 20
```
(Change eta_min=1e-4 in the scheduler constructor for Run 2.)

## Baseline

| Run | val_loss | surf_ux | surf_uy | surf_p | Config |
|-----|----------|---------|---------|--------|--------|
| fern/1l-huber-d01 | 1.7463 | 0.744 | 0.432 | **60.85** | Huber δ=0.01, lr=0.01 fixed, sw=20 |
| frieren/1l-l1-clip2 | 1.7320 | 0.703 | 0.447 | 63.35 | L1, lr=0.01 fixed, clip=2 |

Target: push surf_p below 60.

---

## Results

| Run | surf_Ux | surf_Uy | surf_p | vol_p | Memory | W&B |
|-----|---------|---------|--------|-------|--------|-----|
| cosine eta_min=1e-5 | 0.92 | 0.54 | 92.6 | 142.7 | 4.3 GB | [btl0dzer](https://wandb.ai/capecape/senpai/runs/btl0dzer) |
| cosine eta_min=1e-4 | 0.96 | 0.62 | 101.4 | 169.8 | 4.3 GB | [u6kf9wz5](https://wandb.ai/capecape/senpai/runs/u6kf9wz5) |
| **baseline (fixed lr)** | 0.744 | 0.432 | **60.85** | — | — | — |

### What happened

**Negative result.** Cosine LR scheduling made things significantly worse. Surface pressure jumped from 60.85 (baseline) to 92.6 (Run 1) and 101.4 (Run 2) — a 52–67% regression on the most important metric.

The likely cause: the current code runs **20 epochs** with T_max=10, so the cosine schedule completes a full decay cycle by epoch 10, then the LR ramps back up (SGDR-style) for epochs 11–20. This LR oscillation disrupts convergence. Run 1 (eta_min=1e-5) is marginally better than Run 2 (eta_min=1e-4).

The hypothesis that cosine annealing would help settle into a sharp minimum doesn't hold — fixed lr=0.01 baseline is simply better in this short training regime.

### Suggested follow-ups

- **Set T_max=MAX_EPOCHS (20)**: A single cosine cycle aligned with training length (no oscillation) may behave as intended.
- **Lower initial lr + cosine**: Try lr=1e-3 with cosine — lr=0.01 may be too large as a starting point.
- **OneCycleLR**: Warmup → peak → decay in one structured schedule, designed for short training runs.
- **Linear decay**: Simpler than cosine, might avoid oscillation while still decaying toward the end.