### PR TITLE
Per-channel MAE pressure weight: focus loss directly on worst metric

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,6 +28,9 @@ class Config:
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    p_weight: float = 1.0       # per-channel pressure multiplier in surface Huber loss
+    huber_delta: float = 1.0    # Huber loss delta (transition from quadratic to linear)
+    agent: str = ""              # agent name tag for W&B
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -87,6 +90,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else None,
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )
@@ -126,12 +130,13 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        huber_err = torch.nn.functional.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction='none')
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        channel_weights = torch.tensor([1.0, 1.0, cfg.p_weight], device=huber_err.device)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1) * channel_weights).sum() / (surf_mask.sum().clamp(min=1) * 3)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -168,12 +173,13 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            huber_err = torch.nn.functional.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction='none')
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (huber_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            channel_weights = torch.tensor([1.0, 1.0, cfg.p_weight], device=huber_err.device)
+            val_surf += (huber_err * surf_mask.unsqueeze(-1) * channel_weights).sum().item() / (surf_mask.sum().clamp(min=1).item() * 3)
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis

Pressure (p) is the hardest channel — its MAE is ~80–100× higher than velocity. The loss function currently treats all three output channels (Ux, Uy, p) equally within the surface loss term. PR #9 showed per-channel weighting with **MSE** backfires (scaled squared gradients destabilize training). However, with **MAE/Huber loss**, scaling gradients linearly is far safer. Weighting p by 3–5× inside the Huber surface loss should focus optimization where the model is weakest without causing instability.

## Instructions

In \`train.py\`, modify the surface loss computation to apply per-channel weights. After computing the per-node, per-channel absolute errors for the surface, multiply the pressure channel (index 2) by a weight before averaging:

\`\`\`python
# Assume abs_err has shape [N, 3] (Ux, Uy, p)
channel_weights = torch.tensor([1.0, 1.0, p_weight], device=abs_err.device)
surf_loss = (huber_err * surf_mask.unsqueeze(-1) * channel_weights).sum() / (surf_mask.sum().clamp(min=1) * 3)
\`\`\`

Where \`huber_err\` is the elementwise Huber loss and \`p_weight\` is a scalar multiplier.
**Keep the validation MAE computation unweighted** — the metric should not be affected.

**Run 1 — p_weight=3:**
\`\`\`bash
python train.py \
  --agent nezuko \
  --wandb_name "nezuko/ch-pweight3-huber" \
  --wandb_group "per-channel-weight" \
  --lr 0.01 --surf_weight 20
\`\`\`

**Run 2 — p_weight=5:**
\`\`\`bash
python train.py \
  --agent nezuko \
  --wandb_name "nezuko/ch-pweight5-huber" \
  --wandb_group "per-channel-weight" \
  --lr 0.01 --surf_weight 20
\`\`\`

Use Huber delta=0.01 in both runs. If p_weight=3 hurts Ux/Uy without improving p, the idea is probably not working.

## Baseline

| Run | val_loss | surf_ux | surf_uy | surf_p | Config |
|-----|----------|---------|---------|--------|--------|
| fern/1l-huber-d01 | 1.7463 | 0.744 | 0.432 | **60.85** | Huber δ=0.01, lr=0.01, sw=20, no ch_weight |
| frieren/1L-ch-w5 (PR#9) | 1.5936 | 1.99 | 1.05 | 115.4 | MSE, p×5, lr=5e-3, sw=10 — backfired! |

Note: per-channel weighting with MSE at lr=5e-3 failed badly. This attempt uses Huber (linear gradients) at lr=0.01 (different config). The mechanism should be more stable.

---

## Results

| Run | val_loss | surf_Ux | surf_Uy | surf_p | mem | W&B |
|-----|----------|---------|---------|--------|-----|-----|
| nezuko/ch-pweight3-huber | 0.1780 | 19.25 | 2.47 | 476.3 | 15.4 GB | 2xbzjyab |
| nezuko/ch-pweight5-huber | 0.2154 | 12.20 | 2.41 | 459.0 | 15.4 GB | kfs4cr8r |
| **baseline (fern/1l-huber-d01)** | **1.7463** | **0.744** | **0.432** | **60.85** | — | — |

Both runs are dramatically worse than the baseline across all surface metrics.

### What happened

The hypothesis did not work — both runs performed far worse than baseline, and per-channel weighting did not improve pressure MAE.

The core issue is a **denominator mismatch** that inadvertently reduced surface loss emphasis:

- The original code uses \`surf_loss = sum / surf_mask.sum()\` (sum over 3 channels, divide by n_surf_nodes)
- The new formula uses \`sum / (surf_mask.sum() * 3)\` — a proper per-node-per-channel mean

This denominator change **reduces the surface loss scale by 3×** relative to the original. With \`surf_weight=20\`, the effective weight of each channel becomes:
- Ux: \`20 * 1/3 ≈ 6.7\` (was 20)
- Uy: \`20 * 1/3 ≈ 6.7\` (was 20)
- p (p_weight=3): \`20 * 3/3 = 20.0\` (unchanged from original)
- p (p_weight=5): \`20 * 5/3 ≈ 33.3\` (only modest boost)

So the change de-emphasizes Ux/Uy more than it boosts pressure. The total surface signal is weaker — resulting in a model that is worse on everything. The val_loss numbers (0.178, 0.215) look better than baseline's 1.7463 but are not comparable because the denominator shift changes the scale.

p_weight=5 was marginally better than p_weight=3 (surf_p 459 vs 476), consistent with giving pressure slightly more gradient signal, but both are far below baseline quality.

### Suggested follow-ups

- **Fix the denominator**: Use \`surf_mask.sum()\` (not \`* 3\`) to preserve the original scale, then apply p_weight on top. With the original denominator, p_weight=3 would give a genuine 3× boost to pressure without reducing Ux/Uy signal.
- **Separate loss terms**: Split surface loss into \`surf_vel_loss\` (Ux, Uy) and \`surf_p_loss\` (p) with independent weights, allowing pressure boost without penalizing velocity.
- **Increase surf_weight to compensate**: With the current \`* 3\` denominator, surf_weight=60 would restore the original scale, and p_weight=3 would then genuinely boost pressure to 3× above baseline.