### PR TITLE
n_hidden=256: double model capacity on best loss config

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,9 +28,11 @@ class Config:
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    huber_delta: float = 0.01
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
+    agent: str | None = None  # agent name for filtering in W&B
     debug: bool = False
 
 
@@ -63,8 +65,8 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
+    n_hidden=256,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -87,6 +89,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else [],
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )
@@ -126,12 +129,13 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        criterion = torch.nn.HuberLoss(reduction="none", delta=cfg.huber_delta)
+        huber_err = criterion(pred, y_norm)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis

The current best model has n_hidden=128 and ~159K parameters — a very small model. We haven't tested whether more capacity can improve predictions, because previous larger-model attempts used the 5-layer default arch which is unstable at high LR. With the proven 1-layer, Huber, lr=0.01 config, it's safe to now increase hidden dim to 256 (doubling capacity to ~600K params) and test if expressivity was the bottleneck.

## Instructions

In `transolver.py` (or wherever the model is instantiated in `train.py`), change `n_hidden` from 128 to 256:

```python
model_config = {
    'n_layers': 1,
    'n_head': 4,
    'n_hidden': 256,   # changed from 128
    'slice_num': 64,
    'mlp_ratio': 2,
    'fun_dim': 16,
    # ... rest unchanged
}
```

Keep all training settings identical to the Huber baseline: Huber delta=0.01, lr=0.01, surf_weight=20.

**Run 1 — n_hidden=256:**
```bash
python train.py \
  --agent alphonse \
  --wandb_name "alphonse/h256-huber" \
  --wandb_group "wider-hidden" \
  --lr 0.01 --surf_weight 20
```

If this improves surf_p, also try n_hidden=192 (intermediate) to calibrate the capacity curve:
```bash
python train.py \
  --agent alphonse \
  --wandb_name "alphonse/h192-huber" \
  --wandb_group "wider-hidden" \
  --lr 0.01 --surf_weight 20
```

Note VRAM usage in your results — at 256 hidden dim it should still be well within the 96 GB budget.

## Baseline

| Run | val_loss | surf_ux | surf_uy | surf_p | n_params | n_hidden |
|-----|----------|---------|---------|--------|----------|---------|
| fern/1l-huber-d01 | 1.7463 | 0.744 | 0.432 | **60.85** | 159K | 128 |

Target: improve surf_p with the extra capacity. If it doesn't help, that tells us the bottleneck is elsewhere (loss formulation, LR schedule — not capacity).

---

## Results

### n_hidden=256 run

| Run | val_loss | surf_ux | surf_uy | surf_p | vol_ux | vol_uy | vol_p | n_params | VRAM | W&B |
|-----|----------|---------|---------|--------|--------|--------|-------|----------|------|-----|
| fern/1l-huber-d01 (baseline) | 1.7463 | 0.744 | 0.432 | **60.85** | — | — | — | 159K | — | — |
| alphonse/h256-huber | 8.6334 | 1.77 | 0.91 | **195.0** | 10.09 | 4.51 | 244.7 | ~620K | 7.6 GB | gha2jyba |

n_hidden=192 run: **not run** — n_hidden=256 degraded surf_p significantly, no point calibrating the curve.

### What happened

**n_hidden=256 is much worse than baseline** — surf_p regressed from 60.85 → 195.0 (+220%), and all other metrics degraded similarly. The hypothesis is rejected: expressivity was not the bottleneck.

The most likely explanation is **training budget sensitivity**. With ~4× more parameters, the model converges more slowly under the same 5-minute / 20-epoch budget. Looking at the epoch progression, the model was still clearly improving at epoch 20 (surf_p dropping from ~400+ in early epochs toward ~195). By contrast, the 128-dim model converged well within the budget. The larger model simply needs more training time.

VRAM usage (7.6 GB) was well within budget — the constraint is not memory but convergence speed under the fixed time limit.

### Suggested follow-ups

- **LR scaling for n_hidden=256**: the larger model may benefit from a lower lr (e.g. lr=0.001 or 0.005) which could converge more reliably in the same budget. The 128-dim model uses lr=0.01 which is aggressive for a larger net.
- **Confirm the bottleneck is training budget**: if we ran n_hidden=256 for longer (3× epochs), would it surpass the baseline? This would distinguish "too big for budget" from "wrong architecture".
- **Try n_hidden=160 or 192 with the current budget**: smaller capacity increases (n_hidden=160, ~240K params) might get the benefit of more expressivity without the convergence slowdown.