### PR TITLE
2 layers + Huber: revisit depth with the right loss function

### DIFF
--- a/train.py
+++ b/train.py
@@ -29,6 +29,7 @@ class Config:
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
+    agent: str = "unknown"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
     debug: bool = False
@@ -64,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=2,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -126,12 +127,12 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -168,12 +169,12 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis

The only 2-layer experiment so far (fern/2l-lr5e3) used MSE loss and lr=5e-3, getting surf_p=111 — no better than the 1-layer MSE baseline. But MSE was our worst loss choice. We now know Huber δ=0.01 dramatically reduces surf_p to 60.85 on 1 layer. The question is: can a 2-layer model with Huber and lr=0.01 go further? More layers = more feature abstraction, which might help the model capture the pressure boundary layer near the airfoil surface.

## Instructions

In `train.py`, change `n_layers` in the model config from 1 to 2:

```python
model_config = {
    'n_layers': 2,   # changed from 1
    'n_head': 4,
    'n_hidden': 128,
    'slice_num': 64,
    'mlp_ratio': 2,
    # ... rest unchanged
}
```

Use Huber delta=0.01, lr=0.01, surf_weight=20 (same as the current best 1L run).

```bash
python train.py \
  --agent edward \
  --wandb_name "edward/2l-huber-lr1e2" \
  --wandb_group "2layer-huber" \
  --lr 0.01 --surf_weight 20
```

If 2L converges well but doesn't beat 1L, try 2L with a slightly reduced lr=7e-3 (larger model may need a smaller step size):
```bash
python train.py \
  --agent edward \
  --wandb_name "edward/2l-huber-lr7e3" \
  --wandb_group "2layer-huber" \
  --lr 0.007 --surf_weight 20
```

## Baseline

| Run | val_loss | surf_ux | surf_uy | surf_p | n_layers | Loss |
|-----|----------|---------|---------|--------|----------|------|
| fern/1l-huber-d01 | 1.7463 | 0.744 | 0.432 | **60.85** | 1 | Huber δ=0.01 |
| fern/2l-lr5e3 | 1.3619 | 1.427 | 0.766 | 111.25 | 2 | MSE |

The 2L+MSE result had better val_loss but terrible surf_p. This run tests if 2L+Huber gives the best of both.

---

## Results
_To be filled by student_