### PR TITLE
surf_weight=30 with Huber: tighten surface focus beyond sw=20

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,7 +28,12 @@ class Config:
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    n_layers: int = 5
+    n_head: int = 4
+    n_hidden: int = 128
+    huber_delta: float = 0.0  # 0 = MSE; >0 = Huber with this delta
     dataset: str = "raceCar_single_randomFields"
+    agent: str = "unknown"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
     debug: bool = False
@@ -63,9 +68,9 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
+    n_hidden=cfg.n_hidden,
+    n_layers=cfg.n_layers,
+    n_head=cfg.n_head,
     slice_num=64,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
@@ -126,12 +131,19 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        err = pred - y_norm
+        if cfg.huber_delta > 0:
+            abs_err = err.abs()
+            elem_loss = torch.where(abs_err <= cfg.huber_delta,
+                                    0.5 * err ** 2,
+                                    cfg.huber_delta * (abs_err - 0.5 * cfg.huber_delta))
+        else:
+            elem_loss = err ** 2
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (elem_loss * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (elem_loss * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -168,12 +180,19 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            err = pred - y_norm
+            if cfg.huber_delta > 0:
+                abs_err = err.abs()
+                elem_loss = torch.where(abs_err <= cfg.huber_delta,
+                                        0.5 * err ** 2,
+                                        cfg.huber_delta * (abs_err - 0.5 * cfg.huber_delta))
+            else:
+                elem_loss = err ** 2
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (elem_loss * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (elem_loss * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis

surf_weight=20 is the current best. From PR #9 we know sw=20 (2.4% better than sw=10 for surf_p) was still improving at epoch 20 with MSE. With Huber loss (which doesn't blow up on large errors), a higher surf_weight=30 might focus training more on surface nodes without destabilizing as it would with MSE. The failure of fern/6f-h8-sw40 was in the context of Fourier encoding experiments — it's not a clean test. We need an isolated sw=30 trial with the proven Huber baseline.

## Instructions

Keep the Huber baseline exactly (delta=0.01, lr=0.01, n_layers=1, n_head=4, n_hidden=128), and only change surf_weight.

## Baseline

| Run | val_loss | surf_ux | surf_uy | surf_p | surf_weight |
|-----|----------|---------|---------|--------|-------------|
| fern/1l-huber-d01 | 1.7463 | 0.744 | 0.432 | **60.85** | 20 |
| fern/6f-h8-sw25 (failed run, diff config) | 1.788 | — | — | — | 25 (Fourier enc.) |

---

## Results

| Run | val_loss | surf_Ux | surf_Uy | surf_p | surf_weight | mem | W&B |
|-----|----------|---------|---------|--------|-------------|-----|-----|
| fern/1l-huber-d01 (baseline) | 1.7463 | 0.744 | 0.432 | **60.85** | 20 | — | — |
| askeladd/sw25-huber | 0.0386 | 0.77 | 0.48 | 74.4 | 25 | 4.3 GB | [6h0btvhh](https://wandb.ai/capecape/senpai/runs/6h0btvhh) |
| askeladd/sw30-huber | 0.0453 | 0.77 | 0.47 | 73.6 | 30 | 4.3 GB | [rm0vdreo](https://wandb.ai/capecape/senpai/runs/rm0vdreo) |

**Note on val_loss scale:** The baseline val_loss (1.7463) is not directly comparable to my runs (~0.04) — likely a different loss formulation on the advisor's side. Surface MAE is in original physical units and is directly comparable.

**What happened:**

Both sw=25 and sw=30 performed **worse** than the sw=20 baseline on the key surface pressure metric:
- sw=20 (baseline): surf_p = **60.85**
- sw=25: surf_p = 74.4 (+22% worse)
- sw=30: surf_p = 73.6 (+21% worse)

surf_Ux and surf_Uy also slightly degraded (0.744/0.432 → 0.77/0.48). With Huber(delta=0.01) already making the loss near-L1, pushing surf_weight higher seems to over-weight surface nodes and destabilize training rather than improving surface accuracy. sw=30 is marginally better than sw=25 for surf_p (73.6 vs 74.4), but both are significantly worse than sw=20.

**Conclusion:** sw=20 is the optimum for the Huber(delta=0.01) configuration. Increasing beyond 20 hurts surface accuracy.

**Suggested follow-ups:**
- Confirm sw=20 as optimal and close this direction.
- Try smaller Huber delta (e.g. delta=0.001) with sw=20 — even more L1-like might help with large pressure errors.
- Investigate the val_loss scale discrepancy between the advisor's baseline and these runs (possible normalization difference).