### PR TITLE
Epoch frontier: how far can we push with 50+ epochs?

### DIFF
--- a/train.py
+++ b/train.py
@@ -19,16 +19,19 @@ from transolver import Transolver
 from utils import visualize, dataset_stats
 
 
-MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 20
-
 @dataclass
 class Config:
     lr: float = 5e-4
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    n_layers: int = 5
+    n_head: int = 4
+    n_hidden: int = 128
+    huber_delta: float = 0.0  # 0 = MSE; >0 = Huber with this delta
+    max_epochs: int = 20
     dataset: str = "raceCar_single_randomFields"
+    agent: str = "unknown"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
     debug: bool = False
@@ -36,8 +39,8 @@ class Config:
 
 cfg = sp.parse(Config)
 
-if cfg.debug:
-    MAX_EPOCHS = 3
+MAX_EPOCHS = 3 if cfg.debug else cfg.max_epochs
+MAX_TIMEOUT = max(5.0, cfg.max_epochs * 0.5)  # generous timeout scaled to epoch count
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
@@ -63,9 +66,9 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
+    n_hidden=cfg.n_hidden,
+    n_layers=cfg.n_layers,
+    n_head=cfg.n_head,
     slice_num=64,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
@@ -126,12 +129,19 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        err = pred - y_norm
+        if cfg.huber_delta > 0:
+            abs_err = err.abs()
+            elem_loss = torch.where(abs_err <= cfg.huber_delta,
+                                    0.5 * err ** 2,
+                                    cfg.huber_delta * (abs_err - 0.5 * cfg.huber_delta))
+        else:
+            elem_loss = err ** 2
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (elem_loss * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (elem_loss * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -168,12 +178,19 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            err = pred - y_norm
+            if cfg.huber_delta > 0:
+                abs_err = err.abs()
+                elem_loss = torch.where(abs_err <= cfg.huber_delta,
+                                        0.5 * err ** 2,
+                                        cfg.huber_delta * (abs_err - 0.5 * cfg.huber_delta))
+            else:
+                elem_loss = err ** 2
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (elem_loss * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (elem_loss * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Background

The biggest finding of this session: **more epochs dramatically improve surf_p**. Previous experiments used 10 epochs (budget from the program). fern discovered that running 38 epochs gives:

| Epochs | Best surf_p | Config |
|--------|-------------|--------|
| 10 | 60.85 | baseline (Huber δ=0.01, lr=0.01, sw=20) |
| 20 | 47.64 | sw=30, seed=42 |
| 31 | **44.54** | lr=0.008, sw=30 |

The model hasn't plateaued — the best result (best_epoch=31) suggests we haven't hit the convergence floor at 38 epochs.

## Hypothesis

Training beyond 38 epochs may push surf_p further below 44. The validation loss is still decreasing at epoch 31, suggesting more training time is beneficial. This experiment tests the 50+ epoch regime.

## Instructions

Modify `train.py` to run for longer. Find the `max_epochs` or epoch loop limit and increase it to 60. Use the **best known configuration**:
- Huber loss δ=0.01
- lr=0.01 (fixed, no scheduler)
- surf_weight=30
- n_layers=1, n_head=4, n_hidden=128, slice_num=64

## Baseline

| Run | surf_p | best_ep | max_ep | surf_weight | lr |
|-----|--------|---------|--------|-------------|-----|
| fern/lr8e3-38ep | **44.54** | 31 | 38 | 30 | 0.008 |
| fern/sw30-38ep-v2 | 44.90 | 31 | 38 | 30 | 0.01 |

**Target**: determine if training beyond 38 epochs further reduces surf_p below 44.

---

## Results

| Run | val_loss | surf_Ux | surf_Uy | surf_p | best_ep | max_ep | mem | W&B |
|-----|----------|---------|---------|--------|---------|--------|-----|-----|
| fern/lr8e3-38ep (baseline) | — | — | — | **44.54** | 31 | 38 | — | — |
| askeladd/60ep-sw30 | 0.0285 | 0.59 | 0.32 | **43.9** | 58 | 60 | 4.3 GB | [ga7n1rql](https://wandb.ai/capecape/senpai/runs/ga7n1rql) |
| askeladd/80ep-sw30 | 0.0283 | 0.58 | 0.32 | **43.5** | 80 | 80 | 4.3 GB | [iccoxczf](https://wandb.ai/capecape/senpai/runs/iccoxczf) |

**What happened:**

Both runs beat the 44.54 baseline:
- 60 epochs: surf_p = **43.9** (best epoch 58/60 — near the limit)
- 80 epochs: surf_p = **43.5** (best epoch 80/80 — **at the limit**, model still improving)

The 80-epoch run's best epoch is epoch 80 itself, which means the model has not converged. Every 20 additional epochs is yielding ~0.4 improvement in surf_p (44.54 → 43.9 → 43.5). Volume MAE also improved: vol_p went from 88.6 (60ep) to 83.3 (80ep).

**The model is still learning.** Pushing to 100+ epochs should yield further gains.

**Implementation note:** Added  as a CLI flag (along with , , //) to . The wall-clock timeout now scales with max_epochs ( minutes).

**Suggested follow-ups:**
- Try 120 epochs — the trend suggests surf_p could reach ~42–43.
- Try combining a learning rate schedule (e.g. cosine decay over 120 epochs) with sw=30 and Huber δ=0.01 — the model might converge faster with a decaying LR.
- Check if the plateau arrives before 120 epochs, or if linear extrapolation keeps holding.