### PR TITLE
LR fine-tuning: find optimal learning rate in the 0.006–0.01 range

### DIFF
--- a/train.py
+++ b/train.py
@@ -19,8 +19,8 @@ from transolver import Transolver
 from utils import visualize, dataset_stats
 
 
-MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 20
+MAX_TIMEOUT = 35.0 # minutes
+MAX_EPOCHS = 38
 
 @dataclass
 class Config:
@@ -28,9 +28,11 @@ class Config:
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    huber_delta: float = 0.01
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
+    agent: str | None = None  # agent name for filtering in W&B
     debug: bool = False
 
 
@@ -64,7 +66,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -87,6 +89,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else [],
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )
@@ -126,12 +129,12 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -168,12 +171,12 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            val_err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (val_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (val_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Background

fern/lr8e3-38ep (lr=0.008) is the **current best**: surf_p=44.54 at 31 epochs, sw=30. This beats the lr=0.01 run (44.90) by a small but consistent margin. The learning rate curve between 0.005 and 0.01 hasn't been mapped for the 38-epoch regime.

Previous results:
- lr=5e-3 with 10ep: surf_p=110 (bad, but that was with MSE and different config)
- lr=0.01 with 38ep: 44.90
- lr=0.008 with 38ep: **44.54** (best)

The optimum may be around 0.007–0.009.

## Hypothesis

Refining lr in the 0.006–0.009 range with the best other hyperparameters (sw=30, Huber δ=0.01, n_layers=1, 38 epochs) may yield another 1-2 surf_p improvement.

## Instructions

Use the best known configuration (n_layers=1, n_head=4, n_hidden=128, slice_num=64, Huber δ=0.01, sw=30, 38 epochs) and sweep learning rate.

**Run 1 — lr=0.007:**
```
python train.py --wandb_name frieren/lr7e3-38ep --wandb_group lr-fine-tuning --lr 0.007 --surf_weight 30
```

**Run 2 — lr=0.009:**
```
python train.py --wandb_name frieren/lr9e3-38ep --wandb_group lr-fine-tuning --lr 0.009 --surf_weight 30
```

**Run 3 — lr=0.006 (if time allows):**
```
python train.py --wandb_name frieren/lr6e3-38ep --wandb_group lr-fine-tuning --lr 0.006 --surf_weight 30
```

## Baseline

| Run | surf_p | lr | best_ep |
|-----|--------|-----|---------|
| fern/lr8e3-38ep | **44.54** | 0.008 | 31 |
| fern/sw30-38ep-v2 | 44.90 | 0.01 | 31 |

**Target**: find if lr=0.007 or lr=0.009 beats lr=0.008. If the curve is flat (±0.3 surf_p), lr=0.008 is confirmed optimal.

---

## Results

**W&B group:** lr-fine-tuning

**W&B run IDs:**
- lr=0.007 (frieren/lr7e3-38ep): i1f1wdxu
- lr=0.009 (frieren/lr9e3-38ep): bhveeopb
- lr=0.006 (frieren/lr6e3-38ep): tcadq20q

**Peak VRAM:** ~4.3 GB (1-layer model)

**Implementation:** Added `huber_delta` CLI flag (default=0.01) and `agent` tag. Huber loss (delta=0.01) replacing MSE. n_layers=1. MAX_EPOCHS=38, MAX_TIMEOUT=35 min. All runs passed --surf_weight 30 via CLI.

**Metrics (all best epoch=38):**

| Run | lr | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|-----|-----|----------|---------|---------|--------|--------|--------|-------|
| fern baseline | 0.008 | — | — | — | **44.54** | — | — | — |
| frieren/lr7e3-38ep | 0.007 | 0.0406 | 0.72 | 0.43 | 65.9 | 4.89 | 2.08 | 113.7 |
| frieren/lr9e3-38ep | 0.009 | 0.0368 | 0.68 | 0.39 | 57.9 | 4.72 | 1.92 | 120.9 |
| **frieren/lr6e3-38ep** | **0.006** | **0.0341** | **0.65** | **0.37** | **54.4** | **3.98** | **1.77** | **102.4** |

**What happened:** None of my runs beat the fern baseline (44.54), but lr=0.006 is the best of my three runs at surf_p=54.4. The relationship is non-monotone: 0.006→54.4, 0.007→65.9, 0.009→57.9. This non-monotone pattern strongly suggests the results are dominated by run-to-run variance (random initialization) rather than the learning rate effect.

The gap between my best run (54.4) and the fern baseline (44.54) mirrors the same variance pattern seen in earlier experiments (e.g., fourier-mse: my run 100.8 vs fern's 48.03). With only 38 epochs and a cosine LR schedule, the results are sensitive to random initialization.

**Key observation:** The absolute improvement from lr=0.006 over lr=0.008 could not be confirmed due to high variance. The lr=0.008 result of 44.54 may itself be a "lucky" initialization. To confirm whether lr in the 0.006–0.009 range matters, we would need multiple seeds per lr value.

**Suggested follow-ups:**
- Run each lr (0.006, 0.007, 0.008, 0.009) with 3 seeds to estimate variance and determine if lr differences are statistically significant.
- Alternatively, switch focus to architecture improvements (n_head=8, more layers) or Fourier features, which showed clearer gains in earlier experiments.
- The lr=0.006 trend (54.4) is encouraging but inconclusive — a longer run (60+ epochs) might distinguish signal from noise.
