### PR TITLE
CosineAnnealing at optimal config: lr=0.006, sw=25, T_max=30

### DIFF
--- a/train.py
+++ b/train.py
@@ -81,7 +81,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=30, eta_min=1e-5)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=38, eta_min=1e-5)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Background

The optimal fixed-lr config has been established by fern's sweep:
- **Best**: lr=0.006, sw=25, ~30 best_epochs → surf_p=42.62
- **2nd**: lr=0.005, sw=25, ~32 best_epochs → surf_p=42.86

fern's earlier CosineAnnealing run (tmax30) achieved surf_p=44.63 using lr=0.010, sw=30. That's +2 surf_p vs the fixed-lr equivalent (44.90). If the same schedule improvement applies to the new optimal config, CosineAnnealing at (lr=0.006, sw=25, T_max=30) could push below 42.

Previous tanjiro runs at lr=0.01, sw=20, T_max=10 gave surf_p=92-101 because T_max was too short. The fix is T_max=30 matching fern's working config.

## Hypothesis

CosineAnnealing with T_max=30 applied to the optimal (lr=0.006, sw=25) config gives the same proportional improvement as it did at the previous optimum, pushing surf_p from 42.62 toward 41-42.

## Instructions

In `train.py`, set epoch limit to 38 and add after optimizer creation:

```python
scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=30, eta_min=1e-5)
```

Call `scheduler.step()` at the end of each epoch. Use n_layers=1 (verify in printed config!), Huber δ=0.01.

**Run 1 — T_max=30, lr=0.006, sw=25:**
```
python train.py --wandb_name tanjiro/cosine-lr6e3-sw25-tmax30 --wandb_group cosine-optimal --lr 0.006 --surf_weight 25
```

**Run 2 — T_max=38 (full schedule), lr=0.006, sw=25:**
```
python train.py --wandb_name tanjiro/cosine-lr6e3-sw25-tmax38 --wandb_group cosine-optimal --lr 0.006 --surf_weight 25
```

## Baseline

| Run | surf_p | schedule | lr | sw | best_ep |
|-----|--------|----------|----|----|---------|
| lr6e3-sw25 (anonymous) | **42.62** | fixed | 0.006 | 25 | 30 |
| fern/tmax30 | 44.63 | CosineAnnealing T_max=30 | 0.010 | 30 | 30 |

---

## Results

| Run | surf_Ux | surf_Uy | surf_p | vol_p | Memory | W&B |
|-----|---------|---------|--------|-------|--------|-----|
| T_max=30, lr=0.006, sw=25 | 0.66 | 0.39 | 57.6 | 99.6 | 4.3 GB | [xa096cwy](https://wandb.ai/capecape/senpai/runs/xa096cwy) |
| T_max=38, lr=0.006, sw=25 | 0.63 | 0.35 | **49.5** | 88.1 | 4.3 GB | [av1p0xf5](https://wandb.ai/capecape/senpai/runs/av1p0xf5) |
| **baseline (fixed lr)** | — | — | **42.62** | — | — | — |

### What happened

**Negative result — did not beat baseline.** Both runs failed to reach the target of surf_p < 42.62. Best result was 49.5 (Run 2, T_max=38), which is 16% worse than the fixed-lr baseline.

**Root cause: 5-minute timeout truncates training.** Both runs completed only ~20 epochs in ~5 minutes. The fixed-lr baseline achieved surf_p=42.62 at epoch ~30. With cosine annealing and T_max=30/38, only the first ~20 epochs of the schedule were completed — the model never reached the low-LR "settling" phase where cosine scheduling would provide its main benefit.

**T_max=38 > T_max=30**: Run 2 outperformed Run 1 (49.5 vs 57.6), confirming that matching the schedule length to the actual run length helps. When T_max=30 but only 20 epochs run, the LR decays faster and leaves less LR budget in the final epochs. T_max=38 paces the decay better relative to the ~20 epochs actually completed.

The val_loss values (0.0303, 0.0268) are in Huber scale and not directly comparable to the baseline's 42.62 surf_p metric.

### Suggested follow-ups

- **Increase MAX_TIMEOUT**: If the 5-minute budget can be extended, cosine annealing over 30-38 epochs might achieve the expected gain. At ~14s/epoch, 30 epochs ≈ 7 minutes.
- **T_max=20**: Use a shorter full cosine cycle matched to the actual number of epochs completable in 5 min (~20 epochs), so the model sees a full schedule rather than a truncated one.
- **Warmup + cosine**: Use OneCycleLR with a warmup phase — designed to converge within a fixed budget.