### PR TITLE
Epoch frontier at optimal config: lr=0.006 sw=25 for 50-80 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -19,8 +19,8 @@ from transolver import Transolver
 from utils import visualize, dataset_stats
 
 
-MAX_TIMEOUT = 25.0 # minutes
-MAX_EPOCHS = 60
+MAX_TIMEOUT = 35.0 # minutes
+MAX_EPOCHS = 80
 
 @dataclass
 class Config:


### PR DESCRIPTION
## Background

Two epoch frontier results so far:
- askeladd/60ep-sw30 (lr=0.01, sw=30): surf_p=43.91 at best_epoch=58 — still improving!
- askeladd/80ep-sw30 (lr=0.01, sw=30): results pending

The **optimal hyperparameters** are now known: lr=0.006, sw=25. But the epoch frontier study used lr=0.01, sw=30 (suboptimal). We need to test the epoch frontier at the true optimal config.

The anonymous sweep showed lr=0.006, sw=25 reaches surf_p=42.62 at epoch 30. The question: does it plateau at 30 epochs, or can it go below 42 with more training?

## Hypothesis

The model at lr=0.006, sw=25 converges faster than lr=0.01, sw=30 (achieves good results at epoch 30 vs epoch 58). But it may still benefit from additional epochs, potentially pushing below 42.

## Instructions

Set epoch limit to 60 in `train.py`. Use n_layers=1, Huber δ=0.01.

**Run 1 — 60 epochs, optimal config:**
```
python train.py --wandb_name edward/lr6e3-sw25-60ep --wandb_group epoch-frontier --lr 0.006 --surf_weight 25
```

**Run 2 — 80 epochs, optimal config (if GPU time allows):**
```
python train.py --wandb_name edward/lr6e3-sw25-80ep --wandb_group epoch-frontier --lr 0.006 --surf_weight 25
```

Record best_epoch in results. If best_epoch ≈ max_epochs, the model is still learning and we should push further. If best_epoch << max_epochs, the plateau has been reached.

## Baseline

| Run | surf_p | lr | sw | best_ep | max_ep |
|-----|--------|----|----|---------|--------|
| lr6e3-sw25 (anonymous) | **42.62** | 0.006 | 25 | 30 | 38 |
| askeladd/60ep-sw30 | 43.91 | 0.010 | 30 | 58 | 60 |

---

## Results
_To be filled by student_