### PR TITLE
Batch size variation: smaller batches for better gradient quality

### DIFF
--- a/train.py
+++ b/train.py
@@ -6,6 +6,7 @@
 
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -20,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 20
+MAX_EPOCHS = 38
 
 @dataclass
 class Config:
@@ -29,6 +30,7 @@ class Config:
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
+    agent: str = "thorfinn"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
     debug: bool = False
@@ -64,7 +66,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -87,6 +89,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent],
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )
@@ -126,12 +129,12 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        huber_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -168,12 +171,12 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            huber_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (huber_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (huber_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis

The current batch_size=4 has never been varied. With only 810 training samples, smaller batches give noisier but potentially more informative gradients, and allow the model to see more gradient updates per epoch. batch_size=2 would give 2× more optimizer steps per epoch, which might accelerate convergence — potentially achieving similar quality in fewer epochs, or better quality at the same epoch count.

## Instructions

**This experiment requires only a single hyperparameter change**: modify `batch_size` in `train.py`. No architecture changes needed.

IMPORTANT: Use **n_layers=1** in model_config (do not change the model architecture at all).

**Run 1 — batch_size=2:**
```
python train.py --wandb_name thorfinn/bs2-lr6e3-sw25 --wandb_group batch-size --lr 0.006 --surf_weight 25
```
Change batch_size to 2 in train.py. Keep everything else at the optimal config: n_layers=1, n_head=4, n_hidden=128, slice_num=64, Huber δ=0.01, epoch limit=38.

**Run 2 — batch_size=8 (larger batch, fewer updates/epoch):**
```
python train.py --wandb_name thorfinn/bs8-lr6e3-sw25 --wandb_group batch-size --lr 0.006 --surf_weight 25
```
Change batch_size to 8.

**Verification checklist** (print before training starts):
- [x] model_config['n_layers'] == 1
- [x] batch_size == 2 (or 8 for run 2)
- [x] lr == 0.006
- [x] surf_weight == 25

## Baseline

| Run | surf_p | batch_size | lr | sw | best_ep |
|-----|--------|------------|----|----|---------| 
| lr6e3-sw25 | **42.62** | 4 | 0.006 | 25 | 30 |

---

## Results

### Metrics

| Run | val_loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p | peak_mem | best_ep | W&B ID |
|-----|----------|---------|---------|--------|--------|--------|-------|----------|---------|--------|
| baseline (bs=4) | — | — | — | **42.62** | — | — | — | — | 30 | — |
| bs=2 (Run 1) | 0.0250 | 0.58 | 0.33 | 45.4 | 3.13 | 1.27 | 78.9 | 2.2 GB | 34* | cc7phssh |
| bs=8 (Run 2) | 0.0292 | 0.66 | 0.39 | 56.5 | 3.89 | 1.71 | 101.2 | 8.4 GB | 38 | 9huj746w |

*bs=2 hit the 5-minute wall-clock limit at epoch 34 (was still converging).

### What happened

**The hypothesis did not hold clearly.** Batch size 4 (baseline) outperforms both smaller (bs=2) and larger (bs=8) batches on surface pressure:

- **bs=2**: surf_p=45.4 — slightly worse than baseline (42.62), ~+7%. The run hit the wall-clock limit at epoch 34, meaning it only completed 34 of 38 epochs. Since epoch 34 was still the best checkpoint, convergence was ongoing. The larger per-epoch cost (405 batches vs 202 for bs=4) ran the clock out before completion, making this result inconclusive.

- **bs=8**: surf_p=56.5 — clearly worse than baseline (+32%). Fewer gradient updates per epoch (102 vs 202) hurt convergence noticeably.

**Memory**: bs=2 is very efficient (2.2 GB vs 8.4 GB for bs=8 — 4× increase, likely from larger padded batches with variable-length meshes).

**Key confound**: The bs=2 result is hard to interpret because it was time-limited. Both runs took ~5 minutes wall-clock, so this is a fair time comparison — and bs=4 wins within the same time budget.

### Suggested follow-ups

1. **Re-run bs=2 with longer timeout** (10+ min) to let it reach epoch 38 — current result is inconclusive.
2. **Apply linear LR scaling** (bs=2 → lr=0.003, bs=8 → lr=0.012) — standard practice not tested here; could recover bs=8 performance.
3. **Try bs=1** — if smaller batches improve final quality given enough time, bs=1 might push further.