### PR TITLE
fun_dim sweep: vary frequency embedding dimension

### DIFF
--- a/train.py
+++ b/train.py
@@ -19,16 +19,19 @@ from transolver import Transolver
 from utils import visualize, dataset_stats
 
 
-MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 20
-
 @dataclass
 class Config:
     lr: float = 5e-4
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    n_layers: int = 5
+    n_head: int = 4
+    n_hidden: int = 128
+    fun_dim: int = 16
+    epochs: int = 20
     dataset: str = "raceCar_single_randomFields"
+    agent: str = "unknown"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
     debug: bool = False
@@ -36,8 +39,8 @@ class Config:
 
 cfg = sp.parse(Config)
 
-if cfg.debug:
-    MAX_EPOCHS = 3
+MAX_EPOCHS = 3 if cfg.debug else cfg.epochs
+MAX_TIMEOUT = max(5.0, cfg.epochs * 0.5)  # scale timeout with epoch count
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
@@ -61,11 +64,12 @@ val_loader = DataLoader(val_ds, batch_size=cfg.batch_size, shuffle=False, **load
 
 model_config = dict(
     space_dim=2,
-    fun_dim=16,
+    fun_dim=cfg.fun_dim,
+    input_dim=18,  # fixed by dataset: pos(2)+saf(2)+dsdf(8)+is_surf(1)+log_Re(1)+AoA(1)+naca(3)
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
+    n_hidden=cfg.n_hidden,
+    n_layers=cfg.n_layers,
+    n_head=cfg.n_head,
     slice_num=64,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
@@ -87,6 +91,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent],
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )

--- a/transolver.py
+++ b/transolver.py
@@ -167,6 +167,7 @@ class Transolver(nn.Module):
         unified_pos=False,
         output_fields: list[str] | None = None,
         output_dims: list[int] | None = None,
+        input_dim: int | None = None,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -180,6 +181,13 @@ class Transolver(nn.Module):
             raise ValueError("out_dim must equal sum(output_dims)")
         self.output_fields = output_fields
         self.output_dims = output_dims
+
+        # Optional input projection: maps dataset's fixed input_dim → space_dim + fun_dim
+        effective_input = fun_dim + space_dim
+        if input_dim is not None and input_dim != effective_input:
+            self.input_proj = nn.Linear(input_dim, effective_input)
+        else:
+            self.input_proj = None
 
         if self.unified_pos:
             self.preprocess = MLP(
@@ -265,6 +273,9 @@ class Transolver(nn.Module):
                 raise ValueError("Missing required input tensor: pos")
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
+
+        if self.input_proj is not None:
+            x = self.input_proj(x)
 
         fx = self.preprocess(x)
         fx = fx + self.placeholder[None, None, :]


### PR DESCRIPTION
## Hypothesis

\`fun_dim=16\` has never been varied. This controls the frequency embedding dimension in the Transolver. Larger fun_dim gives the model richer positional/frequency information; smaller may reduce noise. Untested parameter at optimal config.

## Assignment

**Student: fern**

Run at the optimal 60-epoch config (current SOTA: edward/lr6e3-sw25-60ep = 38.856 surf_p).

**fun_dim = 8 (half default)**:
\`\`\`
python train.py \\
  --wandb_name fern/fundim8-lr6e3-sw25-60ep \\
  --wandb_group fun-dim-sweep \\
  --lr 0.006 \\
  --surf_weight 25 \\
  --n_layers 1 \\
  --n_hidden 128 \\
  --fun_dim 8 \\
  --epochs 60
\`\`\`

**fun_dim = 32 (double default)**:
\`\`\`
python train.py \\
  --wandb_name fern/fundim32-lr6e3-sw25-60ep \\
  --wandb_group fun-dim-sweep \\
  --lr 0.006 \\
  --surf_weight 25 \\
  --n_layers 1 \\
  --n_hidden 128 \\
  --fun_dim 32 \\
  --epochs 60
\`\`\`

## Success criteria

Beat surf_p < 38.856 (edward/lr6e3-sw25-60ep). If neither variant improves, fun_dim=16 is confirmed optimal.

## Context

Current SOTA: edward/lr6e3-sw25-60ep = 38.856 surf_p at best_epoch=58.
Optimal config: lr=0.006, sw=25, n_layers=1, n_hidden=128, mlp_ratio=2, slice_num=64.

## Implementation note

\`fun_dim\` in Transolver is actually the non-coordinate input feature count (18 total = 2 coords + 16 physics features from prepare.py). To make it tunable, an optional \`input_proj\` linear layer was added to Transolver that maps the fixed 18-dim input to \`space_dim + fun_dim\` when they differ (fun_dim=16 → no projection, original behavior).

## Results

| Config | surf_p | surf_Ux | surf_Uy | vol_p | vol_Ux | val_loss | best_epoch | memory | W&B |
|--------|--------|---------|---------|-------|--------|----------|------------|--------|-----|
| fun_dim=8 | 150.0 | 1.74 | 1.02 | 214.2 | 6.95 | 4.542 | 59 | 4.3 GB | dz8y0btj |
| fun_dim=32 | **96.2** | **1.25** | **0.69** | 163.7 | 5.67 | 2.305 | 58 | 4.3 GB | 96zboue4 |
| SOTA baseline (fun_dim=16) | 38.856 | — | — | — | — | — | 58 | — | edward/lr6e3-sw25-60ep |

### What happened

Neither variant beats the SOTA (38.856 surf_p). fun_dim=32 (96.2) substantially outperforms fun_dim=8 (150.0), confirming larger fun_dim is directionally better. However, both are significantly worse than the 38.856 baseline.

Key confound: the SOTA was trained with Huber loss (from a different code version), while this experiment uses MSE (current main branch). Huber loss is known to help pressure prediction significantly. The fun_dim comparison is internally consistent — larger is better — but neither result is directly comparable to the SOTA on equal footing.

Additionally, the input projection approach (projecting 18 → space_dim+fun_dim) changes the baseline when fun_dim≠16. For fun_dim=32, the model now has an extra expansion layer not present in the original fun_dim=16 config.

### Suggested follow-ups

1. **Run fun_dim=16 as an internal MSE baseline** to establish a fair within-experiment reference.
2. **Re-run fun_dim=32 with Huber loss** (delta=0.01) to match the SOTA code — this might actually beat 38.856.
3. **Push larger fun_dim values** (48, 64): the improvement from 8→32 is large; worth exploring further.
4. **Alternative architecture**: instead of projecting 18→34 for fun_dim=32, try appending a learned embedding to the existing 18 features (no compression of existing info).