### PR TITLE
mlp4+slices48+sw20: best arch at 80+ epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -19,9 +19,6 @@ from transolver import Transolver
 from utils import visualize, dataset_stats
 
 
-MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 20
-
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -29,6 +26,12 @@ class Config:
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
+    epochs: int = 10
+    n_layers: int = 5
+    n_hidden: int = 128
+    mlp_ratio: int = 2
+    slice_num: int = 64
+    agent: str | None = None
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
     debug: bool = False
@@ -36,8 +39,8 @@ class Config:
 
 cfg = sp.parse(Config)
 
-if cfg.debug:
-    MAX_EPOCHS = 3
+MAX_EPOCHS = 3 if cfg.debug else cfg.epochs
+MAX_TIMEOUT = 5.0 if cfg.debug else cfg.epochs * 2.0  # minutes, scaled with epoch count
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
@@ -63,11 +66,11 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
+    n_hidden=cfg.n_hidden,
+    n_layers=cfg.n_layers,
     n_head=4,
-    slice_num=64,
-    mlp_ratio=2,
+    slice_num=cfg.slice_num,
+    mlp_ratio=cfg.mlp_ratio,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )
@@ -87,6 +90,7 @@ run = wandb.init(
     project="senpai",
     group=cfg.wandb_group,
     name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else [],
     config={**asdict(cfg), "model_config": model_config, "n_params": n_params, "train_samples": len(train_ds), "val_samples": len(val_ds)},
     mode="offline" if cfg.debug else "online",
 )


### PR DESCRIPTION
## Hypothesis

The best architecture at 30 epochs is **mlp4+slices48+sw=20**:
- mlp_ratio=4 (larger MLP projection)
- slice_num=48 (slightly fewer slices)
- surf_weight=20 (optimal for this arch combo)
- surf_p = 41.845 vs baseline 42.623

The epoch frontier shows: 30ep→42.62, 60ep→38.856, 80ep→35.845 (baseline config, still improving).

Question: does mlp4+slices48+sw=20 maintain its advantage at 80 epochs? If yes, we could hit ~35.0 or below.

## Assignment

**Student: fern**

Run mlp4+slices48+sw=20 at 80 epochs (fern's code reaches similar perf at fewer epochs):

```
python train.py \
  --wandb_name fern/mlp4-s48-sw20-80ep \
  --wandb_group mlp4s48-frontier \
  --lr 0.006 \
  --surf_weight 20 \
  --n_layers 1 \
  --n_hidden 128 \
  --mlp_ratio 4 \
  --slice_num 48 \
  --epochs 80
```

Also run the baseline at 80ep to confirm fern's code matches edward:

```
python train.py \
  --wandb_name fern/baseline-80ep \
  --wandb_group mlp4s48-frontier \
  --lr 0.006 \
  --surf_weight 25 \
  --n_layers 1 \
  --n_hidden 128 \
  --epochs 80
```

## Success criteria

mlp4+slices48+sw=20 at 80ep < baseline at 80ep (35.845 from edward). We want to push below 35.

## Context

30ep results:
- baseline (sw=25): 42.623
- mlp4-slices48 (sw=25): 42.112
- mlp4s48-sw20: **41.845** (best at 30ep)
- sw sweep optimal: sw=20 for mlp4+slices48 (vs sw=25 for baseline)

Note: freqs7 (fd=44) does NOT combine with mlp4+slices48 — tested and worse (44.25).

## Results

Ran both experiments in parallel (nezuko, GPUs 0-3 / 4-7).

| Config | epochs | surf_p | Vol MAE (Ux/Uy/p) | Surf MAE (Ux/Uy/p) | val/loss | W&B |
|--------|--------|--------|-------------------|---------------------|----------|-----|
| **mlp4+slices48+sw=20** | 80 (best@80) | **77.7** | 4.05/1.57/103.1 | 1.04/0.49/77.7 | 1.3532 | epulzed6 |
| baseline (sw=25) | 80 (best@72) | 80.3 | 4.09/1.64/116.2 | 1.01/0.51/80.3 | 1.7116 | m8qvxrwb |
| edward baseline (reference) | 80 | **35.845** | — | — | — | — |

Peak memory: ~5.2GB (run1), ~4.3GB (run2).

### What happened

**The mlp4+slices48+sw=20 variant maintains its advantage over baseline at 80 epochs** (77.7 vs 80.3 surf_p, ~3.2% better) — consistent with the 30ep advantage (41.845 vs 42.623, ~1.8%).

**However, both runs significantly underperform the reference target (35.845)**. The critical issue: this PR's commands use `--n_layers 1`, but the prior experiments (edward's 35.845 result, the 30ep sweep giving 41.845) were run with `n_layers=5` (the original hardcoded default). This PR was written for "fern's code" which apparently already had `--n_layers` as a CLI arg — when I added the arg, the new default is 5 but the PR commands pass 1. Running with only 1 Transolver layer instead of 5 dramatically reduces model capacity, explaining the 2x+ performance gap.

The `--n_layers 1` runs are **not comparable to previous results** and cannot answer the hypothesis.

### Suggested follow-ups

1. **Re-run with n_layers=5**: Run `nezuko/mlp4-s48-sw20-80ep-nl5` and `nezuko/baseline-80ep-nl5` with `--n_layers 5` to get results comparable to the edward/30ep sweep. This is the proper test of the hypothesis.
2. **Confirm whether n_layers=1 was intentional**: If fern's code was specifically optimized for n_layers=1, there may be a different architecture path worth exploring — but it needs to be compared against an n_layers=1 baseline from the start.