### PR TITLE
Batch size 8 + 200 epochs + linear LR scaling: double the epoch budget

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,13 +22,14 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 200
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
-    batch_size: int = 4
-    surf_weight: float = 10.0
+    batch_size: int = 8
+    surf_weight: float = 25.0
+    huber_delta: float = 0.01
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +67,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,12 +130,12 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        err = F.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction="none")
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -170,12 +172,12 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            err = F.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction="none")
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis

The best run (best_epoch=97/100, still improving) is limited by our 5-minute wall clock. By doubling batch_size from 4→8, we halve steps/epoch (203→101), fitting ~200 epochs in the same 5-minute budget. Linear LR scaling (doubling lr from 0.006→0.012 when doubling batch size) is the standard correction (Goyal et al., 2017) — the prior batch-size experiment (PR #29) tried bs=8 without this correction. 200 epochs with proper LR should push surf_p significantly lower.

## Instructions

In `train.py`, make the following changes:
1. Change `batch_size = 4` → `batch_size = 8`
2. Change `lr = 0.006` → `lr = 0.012` (2x linear LR scaling for doubled batch)
3. Change `MAX_EPOCHS` (or epochs argument) to `200`
4. Use `--wandb_name frieren/bs8-200ep-lrscale` and `--wandb_group bs8-epoch-frontier`
5. Keep all other parameters identical to baseline: surf_weight=25, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, weight_decay=0.0001, huber_delta=0.01

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.5473, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, vol_ux=2.71, vol_uy=1.02
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run**: `4w5zwx7u` (frieren/bs8-200ep-lrscale, group: bs8-epoch-frontier)
**Best epoch**: 42/200 (wall-clock timeout at 5.1 min)
**Peak memory**: 8.4 GB

| Metric | This run (ep 42) | Baseline (ep 97) | Δ |
|---|---|---|---|
| surf_p | 80.30 | 33.55 | +139% worse |
| surf_Ux | 0.97 | 0.49 | +98% worse |
| surf_Uy | 0.47 | 0.27 | +74% worse |
| vol_p | 120.0 | 63.80 | +88% worse |
| vol_Ux | 4.37 | 2.71 | +61% worse |
| vol_Uy | 1.89 | 1.02 | +85% worse |
| val_loss | 0.0400 | — | — |

### What happened

**The hypothesis was wrong.** The core assumption — that bs=8 would fit ~200 epochs in 5 minutes — did not hold. Each epoch with bs=8 (~102 batches) still took ~7 seconds, so only ~44 epochs completed in 5 minutes. The baseline with bs=4 (~203 batches/epoch) ran 100 epochs in 5 minutes, meaning it achieved ~20,300 gradient steps. This run only achieved ~4,500 gradient steps (~22% as many), which explains the far worse metrics.

The epoch time bottleneck is not batch processing but overhead (val loop, data loading, logging) — roughly constant per epoch regardless of batch size. At ~7s/epoch, fitting 200 epochs would require ~23 minutes, not 5.

The lr=0.012 may also be too aggressive at early training (the model was still converging steeply at epoch 42), potentially slowing convergence further.

### Suggested follow-ups

1. **Re-examine the epoch timing**: The bottleneck is fixed overhead per epoch, not compute. If the val loop or logging dominates, reducing val frequency (e.g., validate every 5 epochs) could free up budget for more training.
2. **Multi-GPU training**: With 8 GPUs, DDP could multiply throughput substantially — more steps in the same 5-minute wall clock.
3. **Fewer steps per epoch strategy is flawed for fixed overhead**: Future batch-size experiments should account for constant per-epoch overhead, not assume proportional speedup.