### PR TITLE
Batch size 16 + 350 epochs + warmup/cosine: aggressive epoch frontier push

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 350
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.024
     weight_decay: float = 1e-4
-    batch_size: int = 4
-    surf_weight: float = 10.0
+    batch_size: int = 16
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -80,7 +80,10 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+from torch.optim.lr_scheduler import SequentialLR, LinearLR, CosineAnnealingLR
+warmup = LinearLR(optimizer, start_factor=1/24, end_factor=1.0, total_iters=5)
+cosine = CosineAnnealingLR(optimizer, T_max=345, eta_min=1e-6)
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis

batch_size=16 gives ~51 steps/epoch (vs 203 at bs=4), potentially fitting 300+ epochs in 5 minutes. Linear LR scaling (4x: 0.006→0.024) with a 5-epoch warmup stabilizes the aggressive initial LR. If the convergence trend holds (model improved ~2.3 pts/20ep between 60→80→100ep), 350 epochs could push surf_p well into the high 20s. This is the most aggressive epoch frontier push yet.

## Instructions

In `train.py`, make the following changes:
1. Change `batch_size = 4` → `batch_size = 16`
2. Change `lr = 0.006` → `lr = 0.024` (4x linear LR scaling)
3. Change `MAX_EPOCHS` to `350`
4. Replace the current LR scheduler with a warmup + cosine schedule:
   ```python
   from torch.optim.lr_scheduler import SequentialLR, LinearLR, CosineAnnealingLR
   warmup = LinearLR(optimizer, start_factor=1/24, end_factor=1.0, total_iters=5)
   cosine = CosineAnnealingLR(optimizer, T_max=345, eta_min=1e-6)
   scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
   ```
5. Use `--wandb_name fern/bs16-350ep-lrscale` and `--wandb_group bs16-epoch-frontier`
6. Keep all other parameters identical to baseline: surf_weight=25, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, weight_decay=0.0001, huber_delta=0.01

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.5473, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, vol_ux=2.71, vol_uy=1.02
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run**: `rr3fbmvk` (`fern/bs16-350ep-lrscale`, group: `bs16-epoch-frontier`)

| Metric | This run (best ep 41) | Baseline | Delta |
|---|---|---|---|
| surf_p | 106.1 | 33.55 | **+72.6 (worse)** |
| surf_Ux | 1.57 | 0.4875 | **+1.08 (worse)** |
| surf_Uy | 0.69 | 0.2704 | **+0.42 (worse)** |
| vol_p | 159.3 | 63.80 | worse |
| vol_Ux | 6.01 | 2.71 | worse |
| vol_Uy | 2.29 | 1.02 | worse |
| val_loss | 2.6204 | — | — |

- **Epochs completed**: 46 of 350 (5-min wall-clock timeout hit)
- **Epoch time**: ~7 s/epoch
- **Peak memory**: 16.6 GB

### What happened

The hypothesis failed on its core assumption. With batch_size=16, each epoch has ~51 steps (vs 203 at bs=4) — but each step is ~4x more expensive, so wall-clock time per epoch barely decreases (~7s/epoch). In 5 minutes we completed only **46 epochs**, not 300+.

As a result we ran ~2,350 gradient updates total vs ~20,300 for the baseline (46×51 vs 100×203). We were roughly at the equivalent of 23 "bs=4 epochs." The model was still converging and improving at the timeout; at epoch 45, surf_p had just dropped to 104.8 and was trending down.

The 4x LR scaling and warmup/cosine schedule appear technically sound — no instability observed — but the experiment simply doesn't have enough gradient steps to reach baseline quality within the 5-minute budget.

### Suggested follow-ups

1. **Abandon bs=16 for epoch-count gains**: it doesn't compress wall-clock time per epoch meaningfully. Stick with bs=4 for maximizing gradient updates per minute.
2. **Profile data loading**: if data loading is the bottleneck at bs=4, increasing `num_workers` could free up real wall-clock budget.
3. **Cosine schedule at bs=4**: try the warmup+cosine schedule shape alone with bs=4 and 100 epochs to see if schedule shape helps final accuracy without the batch-size overhead.