### PR TITLE
Fourier positional encoding at 100 epochs: spatial feature enrichment on best config

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,9 +4,11 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import math
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,18 +23,45 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 5e-4
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    huber_delta: float = 0.01
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
     agent: str | None = None  # agent name (e.g. pepe) for filtering in W&B
     debug: bool = False
+
+
+def fourier_encode(coords, num_freqs=6):
+    """Fourier positional encoding for spatial coordinates.
+
+    For k=0..num_freqs-1, computes sin(2^k * pi * coord) and cos(2^k * pi * coord)
+    for each coordinate. Returns 4*num_freqs features (12 per coord × 2 coords = 24).
+    """
+    freqs = (2 ** torch.arange(num_freqs, device=coords.device, dtype=coords.dtype)) * math.pi
+    x_freqs = coords.unsqueeze(-1) * freqs  # (..., 2, num_freqs)
+    sin_feats = torch.sin(x_freqs)
+    cos_feats = torch.cos(x_freqs)
+    feats = torch.cat([sin_feats, cos_feats], dim=-1)  # (..., 2, 2*num_freqs)
+    return feats.reshape(*coords.shape[:-1], -1)  # (..., 4*num_freqs = 24)
+
+
+class FourierWrapper(torch.nn.Module):
+    """Wraps model to apply Fourier encoding inside forward, for use with visualize()."""
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, data, **kwargs):
+        x = data["x"]
+        x = torch.cat([fourier_encode(x[..., :2]), x[..., 2:]], dim=-1)
+        return self.model({"x": x}, **kwargs)
 
 
 cfg = sp.parse(Config)
@@ -61,11 +90,11 @@ train_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=True, **l
 val_loader = DataLoader(val_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
 
 model_config = dict(
-    space_dim=2,
+    space_dim=24,  # 6-freq Fourier encoding: 12 features per coord × 2 coords
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -125,15 +154,16 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        x = torch.cat([fourier_encode(x[..., :2]), x[..., 2:]], dim=-1)
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        huber_err = F.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -167,15 +197,16 @@ for epoch in range(MAX_EPOCHS):
             mask = mask.to(device, non_blocking=True)
 
             x = (x - stats["x_mean"]) / stats["x_std"]
+            x = torch.cat([fourier_encode(x[..., :2]), x[..., 2:]], dim=-1)
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            huber_err = F.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (huber_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (huber_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]
@@ -261,7 +292,7 @@ if best_metrics:
     print("\nGenerating flow field plots...")
     model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
     plot_dir = Path("plots") / run.id
-    images = visualize(model, val_ds, stats, device, n_samples=2 if cfg.debug else 4, out_dir=plot_dir)
+    images = visualize(FourierWrapper(model), val_ds, stats, device, n_samples=2 if cfg.debug else 4, out_dir=plot_dir)
     if images:
         wandb.log({"val_predictions": [wandb.Image(str(p)) for p in images]})
 


### PR DESCRIPTION
## Hypothesis

Fourier features showed ~10 point improvement at 30 epochs in early experiments. PR #37 attempted this at 100 epochs but was closed before running. Now that we have the best config (lr=0.006, sw=25, Huber 0.01, 100ep), combining Fourier positional encoding with it could yield a major gain. The mechanism: Fourier features let the model resolve high-frequency spatial variations near the airfoil surface without learning those frequencies from raw coordinates.

## Instructions

In `train.py`, after input normalization, replace the raw x,y coordinate features with 6-frequency Fourier encoding. Specifically:
1. Read how the input tensor `x` is constructed and where the spatial (x,y) coordinates appear in the feature vector
2. After normalization, apply Fourier encoding to the first 2 spatial coordinates: for k=0..5, add `sin(2^k * π * coord)` and `cos(2^k * π * coord)`, giving 24 features (12 per coordinate) replacing the 2 raw coords. Total input features change from the current count to (current - 2 + 24)
3. Update `space_dim` in model_config to match the new input dimension (the Transolver's space_dim parameter should reflect the first stage of processing — check how space_dim is used in transolver.py)
4. Use `--wandb_name tanjiro/fourier6-100ep` and `--wandb_group fourier-100ep`
5. Keep all other parameters identical to baseline: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

Note: The encoding should be applied at training and validation time consistently.

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.5473, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, vol_ux=2.71, vol_uy=1.02
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run ID:** `zrrzpmwg`

**Best epoch:** 39 (5-minute wall-clock timeout hit at epoch 40)

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| surf_p | 52.84 | 33.55 | +57% (worse) |
| surf_Ux | 0.72 | 0.49 | +47% (worse) |
| surf_Uy | 0.37 | 0.27 | +37% (worse) |
| vol_p | 84.3 | 63.80 | +32% (worse) |
| vol_Ux | 3.40 | 2.71 | +25% (worse) |
| vol_Uy | 1.37 | 1.02 | +34% (worse) |
| val_loss | 0.0284 | — | — |

**Peak memory:** ~4.3 GB (no change, well within 96 GB)

### What happened

Fourier positional encoding **did not help** — all metrics are worse than the baseline across the board.

1. **Slower convergence**: Input dimensionality increased from 18 to 40 (space_dim 2→24). The larger preprocess MLP takes more steps to converge, and both runs are limited to ~40 epochs by the 5-minute timeout.

2. **Possible interaction with Huber delta=0.01**: At this delta the loss saturates for large errors. With more parameters, the Fourier model may need more epochs to escape the initial high-error regime.

3. **Context**: Earlier experiments showing +10 point gains were at 30 epochs under possibly different hyperparams. This suggests gains may depend on the overall config context.

### Implementation notes

- Added `fourier_encode()` function applying sin/cos at 2^k*π for k=0..5 per coordinate
- Added `FourierWrapper` class to apply encoding inside forward for `visualize()` (utils.py is read-only and doesn't do the encoding)
- Updated `space_dim=24`, `n_layers=1`, `MAX_EPOCHS=100`, added `huber_delta` to Config

### Suggested follow-ups

- **Fewer frequencies (3–4 bands)**: Less dimensionality expansion → faster convergence within the 5-min budget; still richer than raw coords.
- **Try with a longer training budget**: Validation loss was still decreasing at epoch 39 — Fourier features may need more epochs to show benefit.
- **Fourier on 30-ep baseline without Huber**: Isolate the Fourier effect from the Huber interaction by testing on the simpler config first.