### PR TITLE
Mixed precision (AMP + torch.compile) for ~150 epochs at bs=4

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,13 +22,14 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 200
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
+    huber_delta: float = 0.01
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +67,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,6 +81,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
+model = torch.compile(model)
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
@@ -127,14 +130,14 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            huber_err = F.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction='none')
+            vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
@@ -169,16 +172,16 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
-
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+                huber_err = F.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction='none')
+                val_vol += (huber_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+                val_surf += (huber_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
-            pred_orig = pred * stats["y_std"] + stats["y_mean"]
+            pred_orig = pred.float() * stats["y_std"] + stats["y_mean"]
             err = (pred_orig - y).abs()
             mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
             mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))


### PR DESCRIPTION
## Hypothesis

The best run (edward/lr6e3-sw25-100ep, surf_p=33.55) hit epoch 97/100 in 5 minutes (~3.1s/epoch) and was still improving. By enabling `torch.amp.autocast(dtype=torch.bfloat16)` for the forward pass and `torch.compile(model)`, we can reduce per-epoch time by 30-50%, fitting ~140-160 epochs at bs=4 with the proven lr=0.006 config. This is the lowest-risk way to push the epoch frontier: same batch size, same LR, same gradient noise — just faster compute.

BFloat16 halves memory bandwidth for matmuls and the GPU has native BF16 tensor cores. `torch.compile` fuses operations and eliminates Python overhead. Unlike batch size scaling (PRs #43/#44), this preserves the exact same optimization trajectory.

## Instructions

In `train.py`, make the following changes:

1. Set `MAX_EPOCHS = 200` (generous ceiling; the 5-min timeout will stop it naturally)
2. After model creation, add: `model = torch.compile(model)`
3. Wrap the forward pass in **both** train and val loops with autocast:
   ```python
   with torch.amp.autocast('cuda', dtype=torch.bfloat16):
       pred = model({"x": x})["preds"]
       sq_err = (pred - y_norm) ** 2
       # ... loss computation stays inside autocast
   ```
4. Do NOT use GradScaler — BFloat16 has sufficient dynamic range and does not need loss scaling
5. Keep all other hyperparameters identical: lr=0.006, sw=25, bs=4, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, wd=0.0001, huber_delta=0.01
6. Use `--wandb_name edward/amp-compile-200ep` and `--wandb_group amp-speedup`

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97, val_loss=0.0190
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run:** r5vy53gy (`edward/amp-compile-200ep`)
**Peak memory:** 2.7 GB
**Epochs completed:** 86 (5 min wall clock)
**Best epoch:** 84

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 0.0236 | 0.0190 | +24% (worse) |
| surf_p | 47.51 | 33.55 | +42% (worse) |
| surf_Ux | 0.525 | 0.4875 | +8% (worse) |
| surf_Uy | 0.322 | 0.2704 | +19% (worse) |
| vol_p | 69.3 | 63.80 | +9% (worse) |
| vol_Ux | 2.74 | — | — |
| vol_Uy | 1.07 | — | — |

**Epoch timing:** Epoch 1 took 37s (torch.compile warmup), then ~3s/epoch after — same as the baseline's ~3.1s/epoch.

### What happened

The hypothesis failed on both counts:

1. **No speedup from AMP + compile.** After the initial warmup epoch, per-epoch time was ~3s — essentially identical to the baseline. The model is small (n_layers=1) and the data pipeline is likely the bottleneck, not GPU compute. BF16 tensor cores provide no benefit when the model is already so cheap to run.

2. **torch.compile warmup cost ~34s** = ~11 epochs lost. This is ironic: the technique meant to gain epochs actually cost us epochs. We ended up with 86 epochs vs the baseline's 97.

3. **T_max=200 hurt the LR schedule.** With CosineAnnealingLR(T_max=200) and only 86 epochs completed, the LR only decayed from 0.006 to ~0.0037 (62% of initial). The baseline with T_max=100 reached near-zero LR by epoch 97, giving critical fine-tuning at the end. The higher residual LR likely hurt convergence quality.

4. **Possible Huber vs MSE effect.** The existing code used MSE; I added Huber loss (delta=0.01) as instructed. It's unclear whether this further hurt performance or is orthogonal.

The model and dataset are already fast enough that AMP/compile provide no benefit. The real bottleneck is optimization quality, not GPU throughput.

### Suggested follow-ups

- **Fix T_max**: If AMP+compile is retried, set T_max to match expected epoch count (e.g., T_max=90), not MAX_EPOCHS=200. The cosine schedule mismatch was a major regression source.
- **Skip torch.compile for small models**: Compile warmup (~34s) only pays off for large models. For this 1-layer Transolver, it's pure overhead. Try AMP-only without compile.
- **Isolate Huber vs MSE**: Run baseline config with Huber loss (delta=0.01) vs MSE to see if it helps or hurts independently.
- **Investigate the real bottleneck**: If epochs are the constraint, reducing val loop overhead or increasing batch size may be more effective than AMP.