### PR TITLE
Gradient accumulation (effective bs=16 at actual bs=4)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,16 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
+accumulation_steps = 4
+
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.024
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
+    huber_delta: float = 0.01
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +68,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -119,7 +122,8 @@ for epoch in range(MAX_EPOCHS):
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    optimizer.zero_grad()
+    for step_idx, (x, y, is_surface, mask) in enumerate(pbar):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -128,18 +132,20 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        huber_err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
-        optimizer.zero_grad()
+        loss = loss / accumulation_steps
         loss.backward()
-        optimizer.step()
+        if (step_idx + 1) % accumulation_steps == 0 or (step_idx + 1) == len(train_loader):
+            optimizer.step()
+            optimizer.zero_grad()
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -170,12 +176,12 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            huber_err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (huber_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (huber_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis

PRs #43 and #44 test larger batch sizes with LR scaling, but larger batches change padding/collation dynamics. Gradient accumulation simulates bs=16 while keeping actual bs=4 — preserving identical per-sample computation and padding behavior. With accumulation over 4 steps, we use 4x LR (0.024) following the linear scaling rule. MAX_EPOCHS=100 still fits because per-epoch step count stays the same — we just make each optimizer step use 4x more gradient signal.

This tests whether batch scaling gains come from effective batch size or from the reduced epoch count enabled by faster epochs.

## Instructions

In \`train.py\`, make the following changes:

1. Add \`accumulation_steps = 4\` as a constant near hyperparams
2. Set \`lr = 0.024\` (4x scaling for 4x effective batch)
3. Modify the training loop to accumulate gradients
4. Keep MAX_EPOCHS=100, all other params same as baseline: sw=25, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, bs=4, wd=0.0001, huber_delta=0.01
5. Use \`--wandb_name thorfinn/gradaccum4-100ep\` and \`--wandb_group grad-accumulation\`

## Baseline

Current best (\`edward/lr6e3-sw25-100ep\`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97, val_loss=0.0190
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run:** \`f63yg5t0\` (thorfinn/gradaccum4-100ep, group: grad-accumulation)

| Metric | This run | Baseline |
|--------|----------|----------|
| val_loss | 0.0494 | 0.0190 |
| surf_Ux MAE | 1.17 | 0.4875 |
| surf_Uy MAE | 0.65 | 0.2704 |
| surf_p MAE | 86.0 | 33.55 |
| vol_Ux MAE | 5.47 | — |
| vol_Uy MAE | 2.62 | — |
| vol_p MAE | 146.7 | 63.80 |
| Best epoch | 36 | 97 |
| Peak memory | 4.3 GB | — |

**What happened:**

Gradient accumulation performed significantly worse than baseline on all surface metrics. The results are heavily confounded by epoch count:

- This run: 40 epochs in 5.1 minutes (hit wall-clock limit)
- Baseline best_epoch=97: at ~8s/epoch this implies ~13 minutes of training — the baseline appears to have run without the 5-minute timeout

Within the 5-minute budget, gradient accumulation is neutral vs plain bs=4 at the same LR — it provides identical per-sample computation and the same number of epochs. The 4x LR (0.024) with cosine annealing over 100 epochs is suboptimal here: the LR decays assuming 100 epochs but training is cut at ~40, so we never reach the low-LR convergence phase where the baseline achieves its best results.

The hypothesis (batch scaling gains come from effective batch size vs faster epochs) cannot be fairly tested within the 5-minute timeout when the baseline ran unconstrained.

**Suggested follow-ups:**
- Re-run the baseline config with the 5-minute timeout to get a fair comparison at equal wall-clock time
- If testing gradient accumulation, use OneCycleLR or shorten cosine T_max to match expected epoch count rather than MAX_EPOCHS
- The real question (does larger effective batch size help?) should be tested with a longer training budget that allows both approaches to converge