### PR TITLE
Input-to-output skip connection: residual bypass

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,14 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
+    huber_delta: float = 0.01
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +66,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,12 +129,12 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -170,12 +171,12 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            h_err = torch.nn.functional.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (h_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (h_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]

--- a/transolver.py
+++ b/transolver.py
@@ -210,6 +210,7 @@ class Transolver(nn.Module):
                 for idx in range(n_layers)
             ]
         )
+        self.input_bypass = nn.Linear(fun_dim + space_dim, out_dim)
         self.initialize_weights()
         self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))
 
@@ -260,6 +261,8 @@ class Transolver(nn.Module):
         if condition is not None:
             raise ValueError("Transolver does not support conditioning inputs")
 
+        x_raw = x  # save raw input for bypass
+
         if self.unified_pos:
             if pos is None:
                 raise ValueError("Missing required input tensor: pos")
@@ -271,5 +274,9 @@ class Transolver(nn.Module):
 
         for block in self.blocks:
             fx = block(fx)
+
+        # Add input bypass: attention output + linear(raw input)
+        fx = fx + self.input_bypass(x_raw)
+
         self._validate_output_dims(fx)
         return {"preds": fx}


### PR DESCRIPTION
## Hypothesis

The Transolver has a preprocess MLP (18→128), attention blocks, then a linear head (128→3). There is no skip connection from raw input features to the output. Adding a learnable linear shortcut (18→3) from raw normalized input directly to the output gives the model a "fast path" — attention only needs to learn the residual correction.

This is especially valuable for pressure, where spatial coordinates and flow conditions (AoA, Re) have strong direct correlations with output. The prediction becomes `attention_output + linear(input)`, so attention focuses on the complex nonlinear residual. This pattern is standard in ResNets/U-Nets but untested here.

## Instructions

In `transolver.py`, make the following changes:

1. In `Transolver.__init__`, add a bypass linear layer after existing layer definitions:
   ```python
   self.input_bypass = nn.Linear(fun_dim + space_dim, out_dim)
   ```
2. In `Transolver.forward`, save the raw input and add the bypass to the output.
3. In `train.py`, keep all params identical: lr=0.006, MAX_EPOCHS=100, sw=25, bs=4, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, wd=0.0001, huber_delta=0.01
4. Use `--wandb_name askeladd/input-bypass-100ep` and `--wandb_group architecture`

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97, val_loss=0.0190
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run ID:** `8ck0dmiq`
**Best epoch:** 38 (hit 5-min wall-clock timeout; training was still improving)
**Peak memory:** 4.3 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.0347 | 0.0190 | +82% worse |
| surf_Ux | 0.92 | 0.4875 | +89% worse |
| surf_Uy | 0.44 | 0.2704 | +63% worse |
| surf_p | 61.2 | 33.55 | +82% worse |
| vol_p | 98.6 | 63.80 | +55% worse |

**What happened:** All metrics are substantially worse than baseline. However, this comparison is complicated: the baseline achieved epoch 97 in 5 minutes (~3 s/epoch), while this run only reached epoch 38 (~8 s/epoch). The bypass layer itself is negligible (18→3 linear), so the slower epoch time is surprising. The model was clearly still converging at timeout — surface_p dropped from 115 at epoch 31 to 61 at epoch 38. Even so, the gap at epoch 38 is large enough that the bypass alone cannot be blamed: surface_p of 61 vs baseline of 34 is a big miss.

The bypass idea is theoretically sound (ResNet-style skip connection), but in the 5-minute budget it does not help.

**Suggested follow-ups:**
- Investigate the per-epoch timing discrepancy (~8s here vs ~3s in baseline)
- If epochs can be equalized, rerun to get a clean ablation
- Try zero-initializing `input_bypass` weights so the shortcut starts inactive and is learned gradually
- Try bypass on the pressure channel only, where linear input correlation is strongest