### PR TITLE
Validate every 5 epochs: reduce per-epoch overhead

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,13 +22,15 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 130
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
+    huber_delta: float = 0.01
+    val_every: int = 5  # validate every N epochs
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +68,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,12 +131,12 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        err = F.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction="none")
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -150,7 +153,21 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
-    # --- Validate ---
+    # --- Validate (every val_every epochs or on the last epoch) ---
+    run_val = (epoch % cfg.val_every == 0) or (epoch == MAX_EPOCHS - 1)
+
+    if not run_val:
+        dt = time.time() - t0
+        metrics = {
+            "train/vol_loss": epoch_vol,
+            "train/surf_loss": epoch_surf,
+            "lr": scheduler.get_last_lr()[0],
+            "epoch_time_s": dt,
+        }
+        wandb.log(metrics)
+        print(f"Epoch {epoch+1:3d} ({dt:.0f}s) train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}] [val skipped]")
+        continue
+
     model.eval()
     val_vol = 0.0
     val_surf = 0.0
@@ -170,18 +187,18 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            err = F.huber_loss(pred, y_norm, delta=cfg.huber_delta, reduction="none")
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]
-            err = (pred_orig - y).abs()
-            mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
-            mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+            abs_err = (pred_orig - y).abs()
+            mae_surf += (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+            mae_vol += (abs_err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
             n_surf += surf_mask.sum().item()
             n_vol += vol_mask.sum().item()
 


### PR DESCRIPTION
## Hypothesis

The best run (surf_p=33.55) was still improving at epoch 97/100 when it hit the 5-min timeout. Closed experiments (PRs #43, #44) proved that per-epoch overhead (val loop, data loading, logging) dominates epoch time — not compute. Currently validation runs every epoch, consuming ~1.0-1.5s per epoch out of ~3.1s total.

By validating only every 5 epochs, we eliminate ~80% of val overhead, fitting ~120-130 epochs in 5 minutes instead of 100. Since the model was still actively improving at timeout, more epochs directly translates to lower surf_p.

## Instructions

In `train.py`:

1. Add a `val_every` config parameter:
   ```python
   # In the Config dataclass:
   val_every: int = 5  # validate every N epochs
   ```

2. Wrap the validation block in a conditional:
   ```python
   run_val = (epoch % cfg.val_every == 0) or (epoch == MAX_EPOCHS - 1)
   if run_val:
       # ... existing val code ...
   ```

3. Handle the case where val is skipped — keep previous val metrics for logging, only update `best_val`/checkpoint when val actually runs:
   ```python
   if not run_val:
       metrics = {
           "train/vol_loss": epoch_vol,
           "train/surf_loss": epoch_surf,
           "lr": scheduler.get_last_lr()[0],
           "epoch_time_s": time.time() - t0,
       }
       wandb.log(metrics)
       print(f"Epoch {epoch+1:3d} ({time.time()-t0:.0f}s) train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}] [val skipped]")
       continue  # skip rest of epoch loop body
   ```

4. Move `scheduler.step()` BEFORE the val conditional so it always runs.

5. Set `MAX_EPOCHS = 130` at the top (the 5-min timeout still enforces the cap).

6. Use `--wandb_name frieren/val-every-5` and `--wandb_group val-frequency`

7. Keep all other params: lr=0.006, surf_weight=25, bs=4, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, wd=0.0001, huber_delta=0.01

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97, val_loss=0.0190
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run**: `7o3z15s7` (frieren/val-every-5, group: val-frequency)
**Best epoch**: 41/130 (wall-clock timeout at 5.0 min; still improving)
**Peak memory**: 4.3 GB

| Metric | This run (ep 41) | Baseline (ep 97) | Δ |
|---|---|---|---|
| surf_p | 59.47 | 33.55 | +77% worse |
| surf_Ux | 0.87 | 0.49 | +78% worse |
| surf_Uy | 0.38 | 0.27 | +41% worse |
| vol_p | 109.2 | 63.80 | +71% worse |
| vol_Ux | 3.93 | 2.71 | +45% worse |
| vol_Uy | 1.59 | 1.02 | +56% worse |
| val_loss | 0.0326 | 0.0190 | +72% worse |

### What happened

**The hypothesis was wrong about epoch timing.** The PR assumed val overhead was 1-1.5s out of ~3.1s/epoch. In practice, epochs took ~7-8s (train ~7s, val adds ~1s), so the val savings are a much smaller fraction. With val_every=5, we freed up ~0.8s per epoch on average — not enough to substantially increase the epoch count. We reached epoch 41 vs baseline's 97 epochs.

The real bottleneck turns out to be the training loop itself (203 batches × bs=4), not the val loop. The val loop runs 23 batches and completes in ~0.5s — it's already fast.

The model at epoch 41 is still clearly improving (best_epoch=41, still dropping at timeout). The gap from baseline (surf_p=33.5 at ep 97) makes sense — we simply have far fewer training steps.

Comparing to PR #43 (which only achieved 42 epochs with bs=8), this approach is somewhat better (surf_p=59.5 vs 80.3) since we use the correct bs=4 with more batches per epoch.

### Suggested follow-ups

1. **Reduce train overhead instead**: The train loop is the bottleneck. AMP (fp16/bf16) mixed precision could cut the ~7s train time roughly in half, potentially doubling epoch throughput.
2. **Multi-GPU**: DDP across 8 GPUs would give 8× more gradient steps per second.
3. **Accept the epoch budget**: Instead of trying to get more epochs, focus on getting better metrics per epoch — better architectures, better loss formulations, better LR schedules.