### PR TITLE
Per-channel pressure-weighted loss (3x pressure)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,14 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 5e-4
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    channel_weights: str = "1.0,1.0,3.0"  # Ux, Uy, p weights
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -41,6 +42,9 @@ if cfg.debug:
     MAX_EPOCHS = 3
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+channel_w = torch.tensor([float(w) for w in cfg.channel_weights.split(",")], device=device)
+channel_w = channel_w / channel_w.sum() * 3.0  # normalize so mean weight = 1.0
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
 
 # Eager cache — all 899 samples preprocessed into RAM (~13GB)
@@ -65,7 +69,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +132,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = (pred - y_norm) ** 2 * channel_w[None, None, :]  # (B, N, 3) * (1, 1, 3)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +174,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = (pred - y_norm) ** 2 * channel_w[None, None, :]  # (B, N, 3) * (1, 1, 3)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

The current loss computes MSE uniformly across all 3 output channels (Ux, Uy, p) in normalized space. But pressure has the highest MAE (33.55 vs 0.49 Ux, 0.27 Uy on surface) — it is by far the hardest channel. By adding per-channel weights that upweight pressure 3x in the loss, we force the optimizer to allocate more capacity to pressure prediction.

This is orthogonal to surf_weight (which weights surface vs volume) — this weights WITHIN the 3 output channels. Since pressure dominates the metric we care about, even small improvement in pressure learning efficiency matters.

## Instructions

In `train.py`:

1. Add a config parameter:
   ```python
   # In the Config dataclass:
   channel_weights: str = "1.0,1.0,3.0"  # Ux, Uy, p weights
   ```

2. After Config parsing, create the weight tensor:
   ```python
   channel_w = torch.tensor([float(w) for w in cfg.channel_weights.split(",")], device=device)
   channel_w = channel_w / channel_w.sum() * 3.0  # normalize so mean weight = 1.0
   ```

3. In BOTH the training and validation loss computation, replace:
   ```python
   sq_err = (pred - y_norm) ** 2
   ```
   with:
   ```python
   sq_err = (pred - y_norm) ** 2 * channel_w[None, None, :]  # (B, N, 3) * (1, 1, 3)
   ```

4. Do NOT apply channel weights to the MAE computation — those must stay unweighted for fair metric comparison.

5. Use `--wandb_name fern/pressure-weight-3x` and `--wandb_group channel-weights`

6. Keep all other params: lr=0.006, surf_weight=25, MAX_EPOCHS=100, bs=4, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, wd=0.0001, huber_delta=0.01

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97, val_loss=0.0190
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run:** `njqgta44` (fern/pressure-weight-3x, group: channel-weights)

**Config:** lr=0.006, surf_weight=25, bs=4, wd=0.0001, channel_weights=1.0,1.0,3.0, n_layers=1, MAX_EPOCHS=100. Note: huber_delta not in current codebase — used plain MSE with channel weights.

| Metric | This run (epoch 39) | Baseline (epoch 97) |
|---|---|---|
| val_loss | 2.9598 * | 0.0190 * |
| Surface Ux MAE | 1.483 | 0.4875 |
| Surface Uy MAE | 0.752 | 0.2704 |
| Surface p MAE | **103.2** | **33.55** |
| Volume Ux MAE | 5.94 | — |
| Volume Uy MAE | 2.23 | — |
| Volume p MAE | 138.9 | 63.80 |
| Peak memory | 4.3 GB | — |
| Best epoch | 39 / 100 | 97 / 100 |

\* val_loss not directly comparable: channel weights inflate the loss scale (pressure contributes 3x), so absolute values differ from the unweighted baseline.

### What happened

The 5-minute timeout limited this run to 39 epochs (~7.6s/epoch). The baseline reached epoch 97, suggesting it was run before the current 5-minute enforcement or with faster per-epoch timing. This makes a head-to-head comparison impossible.

At 39 epochs, all MAEs are worse than baseline at 97 epochs. However, comparing against fern/bs16-350ep-lrscale at epoch 41 (surf_p=106.1, Ux=1.57, Uy=0.69 with n_layers=5, bs=16), this run with channel_weights at epoch 39 shows surf_p=103.2, Ux=1.48 — suggesting a marginal benefit, though different architecture/batch size confound this.

The implementation is correct: MAE metrics are computed from unweighted predictions in original space, unaffected by channel_w.

**Verdict:** Inconclusive due to epoch/timeout mismatch with the baseline. The idea is sound and cleanly implemented, but we need an equal-epoch A/B comparison to assess the real impact.

### Suggested follow-ups
- A/B test: channel_weights=1,1,3 vs 1,1,1 at equal epochs within the 5-min budget to isolate the effect
- Try stronger pressure weighting (1,1,5 or 1,1,10)
- Combine channel_weights with best baseline once fair comparison is possible