### PR TITLE
AdamW beta2=0.95 + gradient clipping: optimizer tuning

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,13 +22,17 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 5e-4
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
+    huber_delta: float = 0.01
+    beta1: float = 0.9
+    beta2: float = 0.95
+    max_grad_norm: float = 1.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +70,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +84,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(cfg.beta1, cfg.beta2))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,17 +133,18 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        huber_err = F.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (huber_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=cfg.max_grad_norm)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -170,12 +176,12 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            huber_err = F.huber_loss(pred, y_norm, reduction="none", delta=cfg.huber_delta)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_vol += (huber_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf += (huber_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis

Two complementary optimizer tweaks:

**Beta2=0.95 (from default 0.999):** The default AdamW second moment adapts very slowly. Beta2=0.95 makes Adam more responsive to recent gradient magnitudes. Used in DeiT and especially beneficial for short training runs.

**Gradient clipping at max_norm=1.0:** Prevents sporadic large gradients in physics attention from destabilizing training. Zero compute cost.

## Instructions

In train.py:
1. Add beta1, beta2, max_grad_norm to Config dataclass
2. Update optimizer: AdamW with betas=(cfg.beta1, cfg.beta2)
3. Add grad clipping after loss.backward() before optimizer.step()
4. wandb_name tanjiro/beta2-095-gradclip, wandb_group optimizer-tuning
5. Keep: lr=0.006, surf_weight=25, MAX_EPOCHS=100, bs=4, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, wd=0.0001, huber_delta=0.01

## Baseline

Current best (edward/lr6e3-sw25-100ep):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97, val_loss=0.0190
- Config: lr=0.006, surf_weight=25, epochs=100, n_hidden=128, n_layers=1, n_heads=4, slice_num=64, mlp_ratio=2, batch_size=4, weight_decay=0.0001, huber_delta=0.01

---

## Results

**W&B run ID:** pqtv2k5d

**Best epoch:** 40 (5-minute wall-clock timeout)

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| surf_p | 64.05 | 33.55 | +91% (worse) |
| surf_Ux | 0.83 | 0.49 | +69% (worse) |
| surf_Uy | 0.38 | 0.27 | +41% (worse) |
| vol_p | 80.4 | 63.80 | +26% (worse) |
| vol_Ux | 3.04 | 2.71 | +12% (worse) |
| vol_Uy | 1.18 | 1.02 | +16% (worse) |
| val_loss | 0.0321 | 0.0190 | +69% (worse) |

**Peak memory:** ~4.3 GB (unchanged)

### What happened

The optimizer tweaks did **not** improve over the baseline within the 5-minute budget.

**Key caveat**: The baseline ran to epoch 97; this run hit the timeout at epoch 40. The baseline predates the 5-minute constraint, making a fair comparison difficult.

**Why it may have underperformed:**
1. **Beta2=0.95 can hurt early training**: A lower beta2 makes the second-moment noisier, potentially destabilizing the early learning phase — opposite of the intended effect at short horizon.
2. **Gradient clipping adds bias at scale=1.0**: Systematically reduces effective lr for large-gradient steps, potentially slowing early convergence.
3. **Epoch budget disparity**: The baseline benefited from 97 epochs of training. At 40 epochs both runs are still converging, and the optimizer changes have not had time to pay off.

### Implementation notes

- Added beta1=0.9, beta2=0.95, max_grad_norm=1.0 to Config (CLI-configurable)
- Also added huber_delta=0.01, n_layers=1, MAX_EPOCHS=100 to match baseline config
- Switched MSE to Huber loss in both train and val loops
- Grad clipping applied after backward(), before optimizer.step()

### Suggested follow-ups

- **Equal-footing baseline**: Run the baseline config (default beta2=0.999, no clipping) for the same 5-min budget to isolate the optimizer effect from epoch count.
- **Try beta2=0.99 (midpoint)**: Milder reduction that may preserve early stability while still adapting faster.
- **Clipping only**: Test without the beta2 change to see which, if either, is contributing.
