### PR TITLE
Higher LR (0.01) with matched T_max=50

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.01
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis

The baseline used lr=0.006 with CosineAnnealingLR T_max=100, but due to GPU contention with 8 concurrent students, runs complete only ~40-50 epochs in 5 minutes. At epoch 40 with T_max=100, the LR has only decayed to ~0.004 — the model never reaches the critical low-LR fine-convergence phase.

By setting T_max=50 (matching our actual budget), the full cosine arc completes within the training window. With lr=0.01 (higher start), the model learns faster in early epochs while cosine decay brings it to near-zero by epoch 50.

## Instructions

In `train.py`:

1. Set `MAX_EPOCHS = 50`
2. Set `lr = 0.01` in Config (or via CLI `--lr 0.01`)
3. Set `surf_weight = 25.0`
4. Set `weight_decay = 1e-4`
5. Model config: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2
6. Scheduler stays as `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)` — T_max=50 matches budget
7. Keep MSE loss (same as current codebase)
8. Use `--wandb_name edward/lr01-tmax50` and `--wandb_group lr-tmax`

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97, val_loss=0.0190
- Note: baseline ran at ~3s/epoch (no contention). Current runs get ~8s/epoch (~40 epochs in 5 min).

---

## Results

**W&B run**: `icjylwnv` (`edward/lr01-tmax50`)

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val_loss | 2.2303 | 0.0190 | +117x worse |
| surf_p | 98.75 | 33.55 | +195% worse |
| surf_Ux | 1.244 | 0.4875 | +155% worse |
| surf_Uy | 0.668 | 0.2704 | +147% worse |
| vol_p | 152.5 | 63.80 | worse |
| Best epoch | 40/50 | 97/100 | — |
| Epoch time | ~8s | ~3s | contention |
| Peak memory | 4.3 GB | — | — |

**What happened**: The hypothesis did not work — lr=0.01 with T_max=50 performed significantly worse than the lr=0.006/T_max=100 baseline across every metric. The model converges (loss trends downward), but the absolute quality at epoch 40 is far behind the baseline's epoch 97.

Two compounding issues:
1. **LR too high**: lr=0.01 is too aggressive. Training loss showed occasional large spikes (surf=4.3, 1.8), indicating instability. Even though cosine decay completes the arc, the high start overshoots good minima.
2. **Epoch deficit**: Baseline ran at ~3s/epoch (no contention) reaching epoch 97. Under contention (~8s/epoch) we get only ~40 epochs. The T_max alignment helps theoretically, but 40 epochs is simply not enough to match 97-epoch convergence at a similar LR.

Note: val_loss scale is consistent — both use surf_weight=25, so the 117x gap is real.

**Suggested follow-ups**:
- Try lr=0.006 with T_max=50 (baseline LR, T_max matched to actual budget) — isolates the T_max effect without the LR change
- Try warmup (3 epochs) + cosine decay to T_max=50 from lr=0.006 — allows slightly larger early steps while maintaining stability
- Investigate Huber loss for stability under higher LRs (the AMP/compile experiment used huber_delta=0.01)