### PR TITLE
Wider model: n_hidden=256, n_head=8, 1 layer

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -64,9 +64,9 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
+    n_hidden=256,
+    n_layers=1,
+    n_head=8,
     slice_num=64,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],


### PR DESCRIPTION
## Hypothesis

The 1-layer Transolver with n_hidden=128 may be capacity-limited. Doubling the hidden dim to 256 with 8 heads (dim_head=32) gives roughly 4x the attention capacity while keeping the model shallow (1 layer) for fast epochs. More hidden units = more slice representation capacity = better pressure prediction. The per-epoch cost increase should be modest (~1-2s extra).

## Instructions

In \`train.py\`:

1. Set \`MAX_EPOCHS = 50\`
2. Set \`lr = 0.006\`, \`surf_weight = 25.0\`, \`weight_decay = 1e-4\`
3. Change model config: \`n_hidden=256\`, \`n_layers=1\`, \`n_head=8\`, \`slice_num=64\`, \`mlp_ratio=2\`
4. Scheduler: \`CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)\` — T_max=50
5. Keep MSE loss
6. Use \`--wandb_name thorfinn/wider-256h-1L\` and \`--wandb_group architecture\`

## Baseline

Current best (\`edward/lr6e3-sw25-100ep\`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97
- Note: baseline ran at ~3s/epoch. Current runs get ~8s/epoch (~40 epochs in 5 min).

---

## Results

**W&B run:** \`jn6oyyc4\` (thorfinn/wider-256h-1L, group: architecture)

| Metric | This run | Baseline |
|--------|----------|----------|
| val_loss | 5.49 | — |
| surf_Ux MAE | 2.34 | 0.4875 |
| surf_Uy MAE | 1.16 | 0.2704 |
| surf_p MAE | 167.7 | 33.55 |
| vol_Ux MAE | 8.87 | — |
| vol_Uy MAE | 3.51 | — |
| vol_p MAE | 235.4 | 63.80 |
| Best epoch | 21 | 97 |
| Peak memory | 8.3 GB | — |

**What happened:**

The wider model performed significantly worse than baseline on all metrics. The primary issue is epoch speed: n_hidden=256 with 8 heads takes **~15s/epoch** vs ~8s/epoch for n_hidden=128 — roughly 2x slower. This means only 21 epochs fit in the 5-minute budget instead of ~40.

At epoch 21, the model is still early in training (loss curves show active convergence). The results are not a fair comparison — the wider model simply didn't have time to train.

The hypothesis about per-epoch cost being "modest (~1-2s extra)" was wrong: the actual overhead is ~7s/epoch (2x slower), which halves the number of epochs achievable in the time budget.

Memory also increased from ~4.3GB (n_hidden=128) to 8.3GB (n_hidden=256) — still well within 96GB.

**Does widening help if given equal epochs?** We cannot tell from this run. At epoch 21 vs epoch 21 the wider model might be learning better representations — but we'd need to look at per-epoch convergence rate, not just final metrics.

**Suggested follow-ups:**
- Run n_hidden=256 with the n_hidden=128 baseline as a same-epoch-count comparison (both cut at epoch 21) to see if the wider model converges faster per epoch
- Try n_hidden=192 as a middle ground — faster than 256 but more capacity than 128
- If the goal is to test capacity limits fairly, a longer training budget (10-15 min) is needed