### PR TITLE
Linear warmup (3 epochs) + cosine decay T_max=50

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -80,7 +80,16 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+    optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs
+)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+    optimizer, T_max=MAX_EPOCHS - warmup_epochs
+)
+scheduler = torch.optim.lr_scheduler.SequentialLR(
+    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_epochs]
+)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis

The first 3-5 epochs with random initialization + high LR produce unstable gradients. A short 3-epoch linear warmup from lr/10 to lr=0.006, then cosine decay to T_max=50, stabilizes early training. With only ~40 useful epochs, every epoch counts -- wasting 3 epochs on unstable gradients is costly.

## Instructions

In `train.py`:

1. Set `MAX_EPOCHS = 50`
2. Set `lr = 0.006`, `surf_weight = 25.0`, `weight_decay = 1e-4`
3. Model config: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2
4. Replace the scheduler with SequentialLR:
   ```python
   warmup_epochs = 3
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
       optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs
   )
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
       optimizer, T_max=MAX_EPOCHS - warmup_epochs
   )
   scheduler = torch.optim.lr_scheduler.SequentialLR(
       optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_epochs]
   )
   ```
5. Keep `scheduler.step()` at epoch level
6. Keep MSE loss
7. Use `--wandb_name nezuko/warmup3-cosine50` and `--wandb_group lr-schedule`

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97
- Note: baseline ran at ~3s/epoch. Current runs get ~8s/epoch (~40 epochs in 5 min).

---

## Results

**W&B run:** `nezuko/warmup3-cosine50` (run ID: `xra09ofr`)
**Best epoch:** 38/50 (5-minute wall-clock timeout hit; ~8s/epoch -> ~40 epochs available)
**Peak memory:** 4.3 GB

### Metrics at best epoch (38)

| Metric | This run (warmup3-cosine50) | Baseline (sw=25, 100ep) |
|--------|---------------------------|------------------------|
| val_loss | 2.0642 | 0.0190 |
| surf_p | 88.3 | 33.55 |
| surf_Ux | 1.20 | 0.4875 |
| surf_Uy | 0.62 | 0.2704 |
| vol_p | 134.6 | 63.80 |

Note: Baseline val_loss used surf_weight=25 and ran 97 epochs; direct comparison is not valid.

### What happened

**Inconclusive due to epoch budget mismatch.** As with other recent experiments on this node, per-epoch time is ~8s (vs baseline's ~3.1s), leaving only ~40 usable epochs in the 5-minute budget. The model was still improving at epoch 38 -- no plateau reached.

The training trajectory looks healthy: val_surf improved steadily from 0.756 (ep 1) to 0.072 (ep 38). Early epochs (1-3) during warmup show no instability -- losses descend cleanly. This suggests the warmup either isn't needed or works well, but we can't distinguish "warmup helped" vs "warmup had no effect" without a control run at the same epoch count.

Comparing warmup vs no-warmup at equal epochs is impossible given the current GPU contention situation.

### Suggested follow-ups

- Once GPU contention clears (epochs back to ~3s), re-run a back-to-back warmup vs no-warmup comparison at 50 epochs to get a clean signal.
- If warmup helps: try warmup_epochs=5 or warmup from lr/100.
- The LR schedule experiments may all need revisiting once the epoch-throughput issue is resolved.