### PR TITLE
Huber loss (delta=0.01) with matched T_max=50

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

The best-ever result used Huber delta=0.01, but no experiment has tested it with a properly matched T_max for the ~40-epoch regime. Huber loss (delta=0.01, essentially L1 for errors > 0.01) is more robust to outlier mesh nodes and produces smoother gradients than MSE on large errors. This should show benefit early because it reduces the impact of hard-to-fit outlier nodes that dominate MSE gradients, letting the optimizer focus on the bulk of the mesh.

## Instructions

In `train.py`:

1. Set `MAX_EPOCHS = 50`
2. Set `lr = 0.006`, `surf_weight = 25.0`, `weight_decay = 1e-4`
3. Model config: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2
4. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)` — T_max=50
5. Replace MSE loss with Huber loss in BOTH training and validation loops. Change:
   ```python
   sq_err = (pred - y_norm) ** 2
   ```
   to:
   ```python
   sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
   ```
6. Use `--wandb_name askeladd/huber001-tmax50` and `--wandb_group loss-function`

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97
- Note: baseline ran at ~3s/epoch. Current runs get ~8s/epoch (~40 epochs in 5 min).

---

## Results

**W&B run ID:** `oy7njcv6`
**Best epoch:** 39 (hit 5-min wall-clock timeout; still improving)
**Peak memory:** 4.3 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.0276 | 0.0190 | +45% worse |
| surf_Ux | 0.64 | 0.4875 | +31% worse |
| surf_Uy | 0.35 | 0.2704 | +29% worse |
| surf_p | 52.4 | 33.55 | +56% worse |
| vol_p | 93.7 | 63.80 | +47% worse |

**What happened:** Huber loss with T_max=50 gives noticeably better results than the previous MSE-based experiment (e.g., surf_p=52.4 vs 61.2 from the input-bypass run that also used Huber). This is the cleanest Huber-only comparison available in the 5-minute budget. All metrics remain worse than the baseline, but the gap has narrowed. The training was still clearly converging at epoch 39 — epoch-by-epoch surface_p continued to trend down.

The per-epoch timing (~8s/epoch here vs ~3s/epoch in baseline) remains the main confound. If the baseline achieved epoch 97 in 5 minutes, it ran roughly 2.5x faster per epoch, suggesting a hardware or environment difference during that run. Within the current ~40-epoch budget, Huber loss with these hyperparameters is the best result seen so far.

**Suggested follow-ups:**
- Investigate epoch timing: profile data loading vs GPU compute to understand the ~8s/epoch cost
- Try reducing val frequency (e.g., every 5 epochs) to recover wall-clock time for more training epochs
- If more epochs can be squeezed in, Huber loss should continue to improve — the trajectory looks good
- Compare Huber delta=0.01 vs delta=0.1 to see if a larger delta helps with the pressure outliers