### PR TITLE
Huber loss + higher LR (0.01) combined, T_max=50

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -27,7 +28,7 @@ class Config:
     lr: float = 5e-4
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +66,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Combining two promising ideas from running experiments: Huber loss (delta=0.01, testing in PR #58) dampens outlier gradients while higher LR (0.01, testing in PR #54) accelerates convergence. Together they should converge faster and more stably within ~40 epochs than either alone. Huber stabilizes training at high LR by clipping large gradients from outliers.

## Instructions

In `train.py`:

1. Set `MAX_EPOCHS = 50`
2. Set `lr = 0.01` (via CLI `--lr 0.01`)
3. Replace MSE with Huber loss in the **training loop only**. Change:
   ```python
   sq_err = (pred - y_norm) ** 2
   ```
   to:
   ```python
   sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
   ```
   Keep validation using MSE `(pred - y_norm) ** 2` so metrics are comparable.
4. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)` — T_max=50
5. Keep: surf_weight=25, bs=4, n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2, wd=0.0001
6. Use `--wandb_name frieren/huber001-lr01-tmax50` and `--wandb_group combined`

## Baseline

Current best (`edward/lr6e3-sw25-100ep`):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97 (ran at ~3s/epoch, no contention)
- Note: current runs get ~40 epochs in 5 min due to GPU contention.

---

## Results

**W&B run**: `af7udton` (frieren/huber001-lr01-tmax50, group: combined)
**Best epoch**: 39/50 (wall-clock timeout at 5.1 min; still improving)
**Peak memory**: 4.3 GB

| Metric | This run (ep 39) | Baseline (ep 97) | Δ |
|---|---|---|---|
| surf_p | 53.27 | 33.55 | +59% worse |
| surf_Ux | 0.69 | 0.49 | +41% worse |
| surf_Uy | 0.38 | 0.27 | +41% worse |
| vol_p | 102.4 | 63.80 | +61% worse |
| vol_Ux | 3.94 | 2.71 | +45% worse |
| vol_Uy | 1.57 | 1.02 | +54% worse |
| val_loss (MSE) | 1.84 | — | not comparable |

Note: val_loss here uses MSE (as instructed) while baseline used Huber — not directly comparable. MAE metrics are the right comparison.

### What happened

**Partially positive.** Comparing to other ~40-epoch runs:
- This run (Huber train + lr=0.01): surf_p=53.27 at ep 39
- PR #51 (Huber both + lr=0.006): surf_p=59.47 at ep 41
- PR #43 (MSE + bs=8 + lr=0.012): surf_p=80.3 at ep 42

The combination of Huber loss in training + lr=0.01 does converge faster than lr=0.006. The surf_p improvement of ~6 units (~10%) over PR #51 in the same epoch budget is meaningful. The model was still improving at timeout.

However, we're still far from baseline (33.55 at ep 97). The fundamental constraint is epoch count — we get ~40 epochs and the baseline got ~97. The hypothesis that Huber stabilizes high-LR training is supported: lr=0.01 with Huber (53.3) outperforms PR #43's lr=0.012 with MSE (80.3).

Comparing to PR #54 (lr=0.01 alone, no Huber) and PR #58 (Huber alone) would show whether the combination adds value beyond each individually.

### Suggested follow-ups

1. **Compare to components alone**: If PR #54 (lr=0.01 + MSE) and PR #58 (Huber + lr=0.006) show similar or better results, the combination may not add value. But if this beats both, it confirms synergy.
2. **Warmup + lr=0.01**: A short LR warmup (3-5 epochs) could help lr=0.01 converge more stably.
3. **AMP mixed precision**: Could roughly double throughput to ~80 epochs, potentially reaching close to baseline quality.