### PR TITLE
Higher LR (0.01) + 3-epoch warmup combined, T_max=50

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -80,7 +80,16 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+    optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs
+)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+    optimizer, T_max=max(1, MAX_EPOCHS - warmup_epochs)
+)
+scheduler = torch.optim.lr_scheduler.SequentialLR(
+    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_epochs]
+)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis

Combining lr=0.01 (testing in PR #54) with 3-epoch warmup (testing in PR #56). High LR accelerates convergence but may cause early instability; warmup exists precisely to tame this. Start at lr=0.001 (lr/10), ramp to 0.01 over 3 epochs, then cosine decay over 47 remaining epochs. Standard practice in transformer training.

## Instructions

In train.py:
1. Set MAX_EPOCHS = 50
2. Set lr = 0.01 (via CLI --lr 0.01)
3. Replace the scheduler with SequentialLR (3-epoch linear warmup + cosine over 47 epochs)
4. Keep scheduler.step() at epoch level
5. Keep: surf_weight=25, bs=4, n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2, wd=0.0001
6. Use --wandb_name tanjiro/warmup-lr01-tmax50 and --wandb_group combined

## Baseline

Current best (edward/lr6e3-sw25-100ep):
- surf_p=33.55, surf_ux=0.4875, surf_uy=0.2704
- vol_p=63.80, best_epoch=97 (ran at ~3s/epoch, no contention)
- Note: current runs get ~40 epochs in 5 min due to GPU contention.

---

## Results

**W&B run ID:** asrqso4o

**Best epoch:** 38 (5-minute wall-clock timeout at epoch 40)

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| surf_p | 95.15 | 33.55 | +184% (worse) |
| surf_Ux | 1.25 | 0.49 | +155% (worse) |
| surf_Uy | 0.63 | 0.27 | +133% (worse) |
| vol_p | 142.0 | 63.80 | +123% (worse) |
| vol_Ux | 5.65 | 2.71 | +108% (worse) |
| vol_Uy | 2.15 | 1.02 | +111% (worse) |
| val_loss | 2.2108 | 0.0190 | >> worse |

**Peak memory:** ~4.3 GB (unchanged)

### What happened

The lr=0.01 + warmup combination performed **significantly worse** than the baseline. The val_loss (2.21) is ~116x the baseline (0.019), a catastrophic gap.

**Why it failed:**

1. **MSE loss at high LR is explosive**: This branch uses MSE (sq_err), not Huber. With lr=0.01, large early errors produce enormous gradients under MSE (gradient ~ 2*error), amplifying any instability. The baseline uses Huber (delta=0.01) which clips gradient magnitude at 1/delta for large errors, making it far more stable. The training trace showed surf losses up to 5.0 in epoch 1 — the model was severely destabilized despite the warmup.

2. **3-epoch warmup insufficient for lr=0.01 with MSE**: At full lr=0.01 from epoch 4 onward, MSE gradients for large prediction errors (>1 unit) are enormous. Warmup helps but cannot compensate for the fundamental instability of MSE at this scale.

3. **Baseline used Huber**: The baseline (edward/lr6e3-sw25-100ep) uses huber_delta=0.01, which radically changes the loss landscape. A direct combination test needs to hold the loss function constant to isolate the lr/warmup effect.

### Implementation notes

- Added SequentialLR combining LinearLR (start_factor=0.1, total_iters=3) and CosineAnnealingLR (T_max=47)
- Added max(1, MAX_EPOCHS - warmup_epochs) to guard against T_max=0 in debug mode
- Set n_layers=1 to match baseline model config
- Loss function kept as MSE (as found on this branch from main)

### Suggested follow-ups

- **Re-test with Huber loss**: The core issue is MSE + high LR. Re-running with huber_delta=0.01 would give a fair test of whether lr=0.01 + warmup actually helps.
- **Lower LR (0.006) with warmup**: Test if warmup alone improves over the baseline lr (0.006 is the current best, does it benefit from 3-epoch warmup?).
- **Longer warmup (5 epochs)**: If lr=0.01+Huber still destabilizes, try a longer warmup period.
