### PR TITLE
Huber delta=0.005: more aggressive L1 behavior

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.005)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.005)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Our best loss is Huber with delta=0.01 (surf_p=52.4 at ~39 epochs). A smaller delta (0.005) behaves more like L1 for a wider range of errors, potentially improving robustness to outlier mesh nodes and surface pressure MAE.

## Instructions

In `train.py`, replace the MSE loss with Huber loss (delta=0.005) in BOTH training and validation loops. Change:
```python
sq_err = (pred - y_norm) ** 2
```
to:
```python
sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.005)
```

Set `MAX_EPOCHS = 50`. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)`.

Run with:
```bash
uv run python train.py --agent edward --wandb_name "edward/huber-delta-005" --wandb_group "huber-delta-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4
```

Keep all other params at base config: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2.

## Baseline

Huber delta=0.01 at ~39 epochs (askeladd/huber001-tmax50):
- surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7, val_loss=0.0276

---

## Results

**W&B run:** edward/huber-delta-005 (run ID: kgoplqk9)
**Config:** lr=0.006, surf_weight=25, n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2, bs=4, wd=1e-4, Huber delta=0.005, MAX_EPOCHS=50
**Best epoch:** 35 / 35 completed (5.1 min, ~8.7s/epoch)
**Peak VRAM:** 4.3 GB

| Metric | This run (delta=0.005) | Baseline (delta=0.01) | Delta |
|--------|----------------------|----------------------|-------|
| val_loss | 0.0162 | 0.0276 | better (different surf_weight context) |
| surf_p | 61.2 | 52.4 | **+8.8 worse** |
| surf_Ux | 0.69 | 0.64 | +0.05 worse |
| surf_Uy | 0.38 | 0.35 | +0.03 worse |
| vol_p | 98.1 | 93.7 | +4.4 worse |

**What happened:** Huber delta=0.005 performed worse than delta=0.01 on all surface metrics. The smaller delta makes the loss behave like L1 (linear) for any error above 0.005, while delta=0.01 stays quadratic over a wider range. The quadratic region of Huber provides stronger gradient signal for small errors, which seems important for surface pressure convergence. The L1-like behavior of delta=0.005 may have reduced the gradient push on errors in the 0.005–0.01 range, slowing fine-grained convergence. Despite only reaching epoch 35 (vs 39 for the baseline), the performance gap suggests the loss shape itself is the issue rather than epoch count.

**Note:** The val_loss comparison (0.0162 vs 0.0276) is not directly meaningful — the baseline used a different surf_weight, so the combined loss scales differently.

**Suggested follow-ups:**
- Delta=0.01 appears to be the better choice for this task — the quadratic regime aligns better with the error magnitudes seen during training
- Try delta=0.02 to see if an even wider quadratic range helps
- Investigate whether loss shape matters less than learning rate — the lr=0.01 + T_max=50 config might be more impactful than delta tuning