### PR TITLE
Huber delta=0.1: softer transition to L1

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.1)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.1)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Huber delta=0.01 is very aggressive toward L1 behavior. A larger delta=0.1 keeps more MSE-like behavior for medium-sized errors while still clipping large outliers. This may allow faster convergence on surface metrics by not over-penalizing medium errors.

## Instructions

In \`train.py\`, replace the MSE loss with Huber loss (delta=0.1) in BOTH training and validation loops. Change:
\`\`\`python
sq_err = (pred - y_norm) ** 2
\`\`\`
to:
\`\`\`python
sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.1)
\`\`\`

Set \`MAX_EPOCHS = 50\`. Scheduler: \`CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)\`.

Run with:
\`\`\`bash
uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-delta-01" --wandb_group "huber-delta-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4
\`\`\`

Keep all other params at base config: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2.

## Baseline

Huber delta=0.01 at ~39 epochs (askeladd/huber001-tmax50):
- surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7, val_loss=0.0276

---

## Results

**W&B run:** \`i8ld8t2z\` (thorfinn/huber-delta-01, group: huber-delta-sweep)

| Metric | delta=0.1 (this run) | delta=0.01 (baseline) |
|--------|---------------------|----------------------|
| surf_Ux MAE | 0.71 | 0.64 |
| surf_Uy MAE | 0.37 | 0.35 |
| surf_p MAE | **51.7** | 52.4 |
| vol_Ux MAE | 3.31 | — |
| vol_Uy MAE | 1.37 | — |
| vol_p MAE | **86.8** | 93.7 |
| Best epoch | 40 | ~39 |
| Peak memory | 4.3 GB | — |

**What happened:**

delta=0.1 performs nearly identically to delta=0.01 on surface pressure (51.7 vs 52.4 — ~1% difference), but is slightly worse on surface Ux and Uy (+11% and +6% respectively). Volume pressure improves meaningfully (86.8 vs 93.7, ~7% better).

The training was still improving at epoch 40 (best epoch = last epoch), suggesting both runs are still converging and the comparison is noisy.

**Interpretation:** Huber delta controls the L1/L2 transition point. delta=0.01 aggressively treats errors >0.01 as linear (L1), while delta=0.1 keeps quadratic behavior for a wider range. For surface metrics, the more aggressive delta=0.01 appears slightly better on Ux/Uy, possibly because surface node errors are often in the 0.01-0.1 range where the two losses differ most. For volume pressure (with larger errors), the softer delta=0.1 transition is better.

Neither delta clearly wins. The differences are small and within noise given the short training window.

**Suggested follow-ups:**
- Try delta=0.05 as an intermediate point
- Compare both deltas at equal wall-clock time with a longer run to see if one converges to a better optimum
- Check if the surf_Ux/Uy difference persists at later epochs or is a transient effect