### PR TITLE
Huber + surf_weight=35: retuning for robust loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

surf_weight=25 was tuned for MSE loss. Huber loss caps gradients at delta for large errors, so the effective gradient magnitude from surface nodes is lower than with MSE. Increasing to sw=35 compensates, pushing the optimizer harder on surface accuracy -- our primary metric.

## Instructions

In `train.py`, replace the MSE loss with Huber loss (delta=0.01) in BOTH training and validation loops. Change:
```python
sq_err = (pred - y_norm) ** 2
```
to:
```python
sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
```

Set `MAX_EPOCHS = 50`. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)`.

Run with surf_weight=35 (the ONLY change from Huber base):
```bash
uv run python train.py --agent nezuko --wandb_name "nezuko/huber-sw35" --wandb_group "huber-sw-sweep" --lr 0.006 --surf_weight 35.0 --weight_decay 0.0001 --batch_size 4
```

Keep all other params: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2.

## Baseline

Huber delta=0.01, sw=25 at ~39 epochs (askeladd/huber001-tmax50):
- surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7, val_loss=0.0276

---

## Results

**W&B run:** `nezuko/huber-sw35` (run ID: `lv0hgtc9`)
**Best epoch:** 40/50 (5-minute wall-clock timeout; ~8s/epoch -> ~40 epochs)
**Peak memory:** 4.3 GB

### Metrics at best epoch (40)

| Metric | This run (Huber, sw=35) | Baseline (Huber, sw=25, ~39ep) |
|--------|------------------------|-------------------------------|
| val_loss | 0.0363 | 0.0276 |
| surf_p | **50.2** | 52.4 |
| surf_Ux | **0.60** | 0.64 |
| surf_Uy | **0.35** | 0.35 |
| vol_p | 100.7 | 93.7 |

Note: val_loss is not directly comparable (sw=35 amplifies val_surf more than sw=25).

### What happened

**Modest positive result.** sw=35 with Huber improves surface MAE slightly over the sw=25 Huber baseline at comparable epoch count (~39-40 epochs):
- surf_p: 50.2 vs 52.4 (-4.2% improvement)
- surf_Ux: 0.60 vs 0.64 (-6.3% improvement)
- surf_Uy: tied at 0.35

The expected tradeoff materialized: vol_p got slightly worse (100.7 vs 93.7), as pushing harder on surface focus shifts capacity away from volume.

Training was still improving at epoch 40 (new checkpoint at that epoch), so results are truncated. With more epochs, the surface gap might widen.

### Suggested follow-ups

- Try sw=45 to continue the sweep -- if surf_p improves further, the optimal sw for Huber is above 35.
- Try sw=30 as a tighter midpoint between 25 and 35 to map the sensitivity curve.
- Compare sw=35 Huber vs sw=25 MSE at full 97-epoch budget when GPU contention clears.