### PR TITLE
Huber + no weight decay (wd=0.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Huber loss already acts as a regularizer by reducing the influence of large errors. The additional regularization from weight_decay=0.0001 may be over-regularizing, preventing the model from fitting surface details. Removing weight decay (wd=0.0) could allow tighter surface pressure fits within the 50-epoch window.

## Instructions

In `train.py`, replace the MSE loss with Huber loss (delta=0.01) in BOTH training and validation loops. Change:
```python
sq_err = (pred - y_norm) ** 2
```
to:
```python
sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
```

Set `MAX_EPOCHS = 50`. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)`.

Run with weight_decay=0.0 (the ONLY change from Huber base):
```bash
uv run python train.py --agent alphonse --wandb_name "alphonse/huber-wd0" --wandb_group "huber-regularization" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0 --batch_size 4
```

Keep all other params: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2.

## Baseline

Huber delta=0.01, wd=0.0001 at ~39 epochs (askeladd/huber001-tmax50):
- surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7, val_loss=0.0276

---
## Results

**W&B run:** `2m108tzc` (alphonse/huber-wd0, group: huber-regularization)

**Training:** 40 epochs completed before 5-minute wall-clock timeout (hit at 5.1 min). Best at epoch 40 (final epoch — still improving at cutoff). ~8s/epoch.

**Peak memory:** 4.3 GB

| Metric | wd=0.0 (this run) | Baseline wd=0.0001 | Delta |
|--------|-------------------|-------------------|-------|
| val/loss | 0.0269 | 0.0276 | -2.5% |
| surf_p | 50.3 | 52.4 | -4.0% |
| surf_Ux | 0.65 | 0.64 | +1.6% |
| surf_Uy | 0.34 | 0.35 | -2.9% |
| vol_p | 88.3 | 93.7 | -5.8% |
| best_epoch | 40/40 | 39/50 | — |

**What happened:**

The hypothesis was not confirmed. Removing weight decay (wd=0.0) produced only marginal improvement over the baseline with wd=0.0001: ~2–6% better on most metrics, but surf_Ux was actually marginally worse (+1.6%). The differences are small enough to be within run-to-run noise.

**Key result:** The much larger story here is that Huber loss makes an enormous difference. The MSE experiments in earlier PRs (surf_p ~120+) show that the loss function choice dominates over the wd choice. With Huber loss properly implemented, the model achieves surf_p=50.3 in 40 epochs — much closer to the best known result (33.55 at 97 epochs).

**About the 'best_epoch=40=last_epoch' pattern:** Both this run and the baseline show the model is still improving at the timeout. Neither has converged. More training time would help both, and the wd comparison might look different at full convergence.

**Suggested follow-ups:**
- Test significance of wd difference with longer runs or multiple seeds — the current difference is too small to trust
- Try wd=0.01 or wd=0.001 to probe the other direction — maybe current wd=0.0001 is actually under-regularizing for this task
- Focus on what differentiates our best (surf_p=50) from the all-time best (surf_p=33.55): that was also n_layers=1, lr=0.006, Huber — need to investigate if those runs ran longer or had different configs
