### PR TITLE
Huber + AdamW beta1=0.95: higher momentum

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Default AdamW uses beta1=0.9. Higher momentum (beta1=0.95) smooths out Huber loss gradient discontinuities at the delta boundary, potentially leading to more stable convergence and better surface metrics within 50 epochs.

## Instructions

In `train.py`, replace the MSE loss with Huber loss (delta=0.01) in BOTH training and validation loops. Change:
```python
sq_err = (pred - y_norm) ** 2
```
to:
```python
sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
```

Then change the optimizer initialization to use beta1=0.95:
```python
optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
```

Set `MAX_EPOCHS = 50`. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)`.

Run with:
```bash
uv run python train.py --agent askeladd --wandb_name "askeladd/huber-beta1-095" --wandb_group "huber-optimizer" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4
```

Keep all other params: n_hidden=128, n_layers=1, n_head=4, slice_num=64, mlp_ratio=2.

## Baseline

Huber delta=0.01, beta1=0.9 at ~39 epochs (askeladd/huber001-tmax50):
- surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7, val_loss=0.0276

---

## Results

**W&B run ID:** `jamzrb6u`
**Best epoch:** 39 (hit 5-min wall-clock timeout)
**Peak memory:** 4.3 GB

| Metric | This run (beta1=0.95) | Baseline (beta1=0.9) | Delta |
|--------|----------------------|----------------------|-------|
| val_loss | 0.0268 | 0.0276 | -3% (better) |
| surf_Ux | 0.63 | 0.64 | -2% (better) |
| surf_Uy | 0.35 | 0.35 | same |
| surf_p | 49.5 | 52.4 | -6% (better) |
| vol_p | 88.2 | 93.7 | -6% (better) |

**What happened:** Higher beta1=0.95 gives a small but consistent improvement across all metrics: surf_p improves from 52.4 to 49.5, val_loss from 0.0276 to 0.0268. The improvement is real but modest (~3–6%). The trajectory at epoch 39 was still improving (epoch 39: surf_p=49.5 vs epoch 38: surf_p=52.8), so more epochs would likely widen the gap.

Compared to the global baseline (surf_p=33.55), both runs are still significantly worse — the timing constraint remains the main blocker. beta1=0.95 with Huber loss is now the best setup seen in the 5-minute budget.

**Suggested follow-ups:**
- Validate this improvement with more epochs (if timing can be resolved)
- Try beta1=0.98 to see if even higher momentum helps
- Combine beta1=0.95 with the val-every-5 trick (if that experiment confirms time savings) to get more training epochs