### PR TITLE
Huber + surf_weight=15: lower surface emphasis for short runs

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -65,7 +66,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

PR #60 showed sw=15 outperforms sw=25 with MSE in the ~30-epoch regime (101.2 vs 103.2). But that test used MSE — now we test with Huber loss (our best finding). With Huber, the gradient magnitude is capped at delta for large errors, so the optimizer is less aggressive on hard surface nodes. Lower sw=15 may better balance volume vs surface learning in early epochs.

## Instructions

In `train.py`, replace the MSE loss with Huber (delta=0.01) in BOTH training and validation loops. Change:
```python
sq_err = (pred - y_norm) ** 2
```
to:
```python
sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
```

Set `MAX_EPOCHS = 50`. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)`.

Run with surf_weight=15:
```bash
uv run python train.py --agent frieren --wandb_name "frieren/huber-sw15" --wandb_group "huber-sw-sweep" --lr 0.006 --surf_weight 15.0 --weight_decay 0.0001 --batch_size 4
```

Set n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2.

## Baseline

Huber delta=0.01, sw=25 at ~39 epochs: surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7

---

## Results

**W&B run**: `otsjqq1d` (frieren/huber-sw15, group: huber-sw-sweep)
**Best epoch**: 40/50 (wall-clock timeout at 5.1 min; still improving)
**Peak memory**: 4.3 GB

| Metric | This run sw=15 (ep 40) | Baseline sw=25 (ep ~39) | Δ |
|---|---|---|---|
| surf_p | 51.29 | 52.4 | -2% better |
| surf_Ux | 0.65 | 0.64 | +2% worse |
| surf_Uy | 0.33 | 0.35 | -6% better |
| vol_p | 74.1 | 93.7 | -21% better |
| vol_Ux | 3.04 | — | — |
| vol_Uy | 1.24 | — | — |
| val_loss (Huber) | 0.017 | ~0.019 (baseline edward) | -10% better |

Note: val_loss is Huber-based with surf_weight=15, not directly comparable to sw=25 runs.

### What happened

**Marginally positive for surface, clearly positive for volume.** Compared to the Huber sw=25 baseline at the same epoch count:
- surf_p improved by ~1 unit (51.3 vs 52.4 — ~2%)
- surf_Uy improved slightly (0.33 vs 0.35)
- surf_Ux slightly worse (0.65 vs 0.64)
- vol_p improved substantially (74.1 vs 93.7 — 21%)

The lower surf_weight lets the optimizer spend more capacity on volume nodes in early training, which improves volume significantly. The surface benefit is marginal — consistent with the hypothesis that sw=15 balances learning, but the surface accuracy is relatively unaffected.

The val_loss=0.017 is better than the edward/lr6e3-sw25-100ep baseline (0.019), but that's partly due to different surf_weight scaling (15 vs 25).

Still well below the original baseline (surf_p=33.55 at ep 97). The fundamental limitation remains: ~40 epochs vs baseline's 97.

### Suggested follow-ups

1. **Try sw=10 with Huber**: If the trend continues, even lower surface weight might help. But there's a risk of underfitting surface at very low weights.
2. **Combine sw=15 + lr=0.01**: The best LR (0.01 from PR #59) wasn't tested with sw=15. Their combination could improve further.
3. **Longer runs**: The model was still improving at ep 40. If epoch throughput could be doubled (e.g., AMP), sw=15+Huber could show larger gains.