### PR TITLE
Huber + surf_weight=10: minimal surface emphasis

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Testing the lower end of the surf_weight range with Huber loss. sw=10 gives the model maximum freedom to learn volume structure first, with modest surface emphasis. The early 20-epoch runs (batch35-39) used sw=10 and achieved surf_p=36-38 — those were among the best at that epoch count. Combining sw=10 with Huber could be a sweet spot for the ~40-epoch regime.

## Instructions

In `train.py`, replace the MSE loss with Huber (delta=0.01) in BOTH training and validation loops. Change:
```python
sq_err = (pred - y_norm) ** 2
```
to:
```python
sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
```

Set `MAX_EPOCHS = 50`. Scheduler: `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)`.

Run with surf_weight=10:
```bash
uv run python train.py --agent fern --wandb_name "fern/huber-sw10" --wandb_group "huber-sw-sweep" --lr 0.006 --surf_weight 10.0 --weight_decay 0.0001 --batch_size 4
```

Set n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2.

## Baseline

Huber delta=0.01, sw=25 at ~39 epochs: surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7

---

## Results

**W&B run:** `hsbj36va` (fern/huber-sw10, group: huber-sw-sweep)

**Config:** lr=0.006, surf_weight=10, Huber delta=0.01, n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2, wd=0.0001, bs=4, MAX_EPOCHS=50

| Metric | sw=10 Huber (epoch 34) | sw=25 Huber baseline (~ep39) | sw=15 MSE (epoch 29) |
|---|---|---|---|
| val_loss | 0.0139 | ~0.019 | 1.510 |
| Surface Ux MAE | 0.71 | **0.64** | 1.22 |
| Surface Uy MAE | 0.38 | **0.35** | 0.66 |
| Surface p MAE | 59.8 | **52.4** | 101.2 |
| Volume Ux MAE | 3.23 | — | 4.90 |
| Volume Uy MAE | 1.28 | — | 1.94 |
| Volume p MAE | 81.0 | 93.7 | 138.7 |
| Peak memory | 4.3 GB | — | 4.3 GB |
| Best epoch | 34 / 35 | ~39 | 29 |
| Epoch time | 8.5s | — | 8.5s |

### What happened

Huber loss with sw=10 is significantly better than any MSE variant (~60 vs 100+ for surf_p), confirming Huber is the right loss function for this task.

However, sw=10 underperforms the sw=25 Huber baseline on surface metrics (surf_p: 59.8 vs 52.4). The hypothesis that sw=10 would be a sweet spot does not hold — lower surface weight means less surface-focused gradient signal, and the model converges to slightly worse surface accuracy. The volume metrics improved (vol_p: 81.0 vs 93.7), which confirms the expected trade-off.

The best epoch is 34 out of 35 epochs completed, suggesting the model was still improving when the 5-min wall clock hit. sw=25 at 39 epochs may benefit from both more surface emphasis AND slightly more training time.

**Verdict:** sw=10 with Huber is good but not better than sw=25 with Huber. The surf_weight sweet spot for this epoch range appears to be above 10 — sw=25 currently wins on surface metrics.

### Suggested follow-ups
- Try sw=15 with Huber to bracket the sweet spot between 10 and 25
- The vol_p improvement with sw=10 is interesting — if volume accuracy matters, sw=10 is better
- Run sw=10 longer (if GPU contention eases) — best_epoch=34 of 35 suggests more gains available