### PR TITLE
Huber + slice_num=32: fewer attention slices

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

slice_num=64 has never been ablated. The Transolver's physics attention groups mesh nodes into 64 slices for soft clustering. With only 1 layer and ~40 epochs, 64 slices may be over-parameterized. Reducing to 32 slices halves the attention computation, potentially speeding up epochs AND simplifying the learning problem (fewer slice prototypes to learn).

## Instructions

In train.py, replace MSE loss with Huber (delta=0.01) in both training and validation loops. Set MAX_EPOCHS=50, CosineAnnealingLR(T_max=MAX_EPOCHS). Change model config: slice_num=32. Set n_layers=1, n_hidden=128, n_head=4, mlp_ratio=2.

## Baseline

Huber delta=0.01, slice_num=64 at ~39 epochs: surf_p=52.4, surf_Ux=0.64, surf_Uy=0.35, vol_p=93.7

---

## Results

**W&B run ID:** nvkuzovj

**Best epoch:** 46 (5-minute wall-clock timeout)

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| surf_p | 48.15 | 52.4 | -8.1% (better) |
| surf_Ux | 0.62 | 0.64 | -3.1% (better) |
| surf_Uy | 0.34 | 0.35 | -2.9% (better) |
| vol_p | 92.1 | 93.7 | -1.7% (better) |
| vol_Ux | 3.72 | — | — |
| vol_Uy | 1.54 | — | — |
| val_loss | 0.0264 | — | — |

**Peak memory:** ~3.9 GB (down from ~4.3 GB with slice_num=64 — 400 MB reduction)
**Epoch time:** ~7s (down from ~8s with slice_num=64)

### What happened

slice_num=32 **improved all metrics** over the baseline. Two factors contributed:

1. **More epochs in same time budget**: Faster epoch time (7s vs 8s) meant the model reached epoch 46 vs ~39 for the baseline — roughly 18% more training steps.

2. **Better optimization landscape**: Fewer slice prototypes (32 vs 64) may be easier to learn with limited data (~810 samples). The model can form cleaner, more generalizable slice assignments when not trying to maintain 64 distinct prototypes simultaneously.

3. **Less memory**: 3.9 GB vs 4.3 GB — the halved attention computation also reduces activation memory.

The improvement is modest but consistent across all metrics. The hypothesis holds: 64 slices is likely over-parameterized for 1-layer model at this dataset scale.

### Implementation notes

- Added torch.nn.functional import; replaced sq_err = (pred - y_norm) ** 2 with F.huber_loss(..., reduction=none, delta=0.01) in both loops
- Changed slice_num from 64 to 32 in model_config
- Changed n_layers from 5 to 1 to match baseline

### Suggested follow-ups

- **Try slice_num=16**: If 32 is better than 64, does 16 improve further? There is likely a floor where too few slices hurt representation.
- **slice_num=48 (intermediate)**: Find the optimal slice count.
- **Confirm it is not just the epoch count**: Limit both runs to the same epoch count (e.g., 39 epochs) to see if slice_num=32 is intrinsically better or just benefits from more epochs.
