### PR TITLE
Combined best: Huber + beta1=0.95 + sw=35

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Combining the two best findings from our Huber ablation sweep:
- beta1=0.95 → surf_p=49.5 (-6% vs base)
- sw=35 → surf_p=50.2 (-4% vs base)

These changes are orthogonal: beta1 affects optimizer momentum, sw affects loss weighting. If improvements are additive, we expect surf_p ~47-48 at ~40 epochs.

## Instructions

In `train.py`:

1. Replace MSE with Huber (delta=0.01) in BOTH train and val loops:
   ```python
   sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
   ```
2. Change optimizer to use beta1=0.95:
   ```python
   optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
   ```
3. Set `MAX_EPOCHS = 50`, T_max=50
4. Run with:
   ```bash
   uv run python train.py --agent edward --wandb_name "edward/huber-combined-best" --wandb_group "combined" --lr 0.006 --surf_weight 35.0 --weight_decay 0.0001 --batch_size 4
   ```
5. n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2

## Baseline

Huber + beta1=0.95 + sw=25: surf_p=49.5 (best under contention)
Huber + sw=35 + beta1=0.9: surf_p=50.2

---

## Results

**W&B run:** edward/huber-combined-best (run ID: wpxirwo5)
**Config:** lr=0.006, surf_weight=35, beta1=0.95, n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2, bs=4, wd=1e-4, Huber delta=0.01, MAX_EPOCHS=50
**Best epoch:** 34 / 35 completed (5.1 min, ~8.7s/epoch)
**Peak VRAM:** 4.3 GB

| Metric | This run (sw=35 + β1=0.95) | Baseline β1=0.95 (sw=25) | Baseline sw=35 (β1=0.9) |
|--------|--------------------------|--------------------------|--------------------------|
| surf_p | 60.3 | 49.5 | 50.2 |
| surf_Ux | 0.72 | — | — |
| surf_Uy | 0.40 | — | — |
| vol_p | 113.1 | — | — |
| val_loss | 0.0432 | — | — |

**What happened:** The combination was worse than either individual improvement — surf_p=60.3 compared to 49.5 (β1=0.95, sw=25) and 50.2 (sw=35, β1=0.9). The improvements were not additive; they appear to interfere with each other.

A likely explanation: increasing surf_weight from 25→35 amplifies the surface gradient signal. Combined with beta1=0.95 (which retains more momentum history), the optimizer accumulates a larger, more persistent push on the surface loss. This combination may cause the optimizer to overshoot on surface loss optimization, degrading both surface and volume accuracy. The two changes interact rather than compose independently.

**Suggested follow-ups:**
- The beta1=0.95 + sw=25 config (surf_p=49.5) remains our best. Try extending epochs further with that exact config
- If combining, try sw=30 + beta1=0.95 as a smaller step up from sw=25
- Alternatively, try sw=35 with a lower lr (e.g., 0.004) to compensate for the amplified gradient signal