### PR TITLE
Combined: Huber + beta1=0.95 + sw=45 (push sw further)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

sw=35 improved over sw=25 with Huber. Push further to sw=45 while keeping beta1=0.95 (our best optimizer setting). If the sw trend continues, more surface emphasis could help. Huber's gradient capping prevents the instability that high sw caused with MSE.

## Instructions

In `train.py`:
1. Replace MSE with Huber (delta=0.01) in BOTH train and val loops:
   ```python
   sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
   ```
2. Optimizer: `betas=(0.95, 0.999)`
3. Set `MAX_EPOCHS = 50`, T_max=50
4. Run with:
   ```bash
   uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-sw45-beta095" --wandb_group "combined" --lr 0.006 --surf_weight 45.0 --weight_decay 0.0001 --batch_size 4
   ```
5. n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2

## Baseline

Huber + beta1=0.95 + sw=25: surf_p=49.5

---

## Results

**W&B run:** `ltafskqn` (thorfinn/huber-sw45-beta095, group: combined)

| Metric | sw=45 (this run) | sw=25 baseline |
|--------|-----------------|----------------|
| surf_Ux MAE | 0.68 | — |
| surf_Uy MAE | 0.38 | — |
| surf_p MAE | **56.4** | **49.5** |
| vol_Ux MAE | 4.38 | — |
| vol_Uy MAE | 1.83 | — |
| vol_p MAE | 118.6 | — |
| Best epoch | 35 | — |
| Peak memory | 4.3 GB | — |
| val_loss | 0.0514 | — |

**What happened:**

sw=45 is worse than the sw=25 baseline on surf_p (56.4 vs 49.5, +14%). The surface weight sweep appears to have a sweet spot somewhere between sw=25 and sw=35, rather than continuing to improve with higher values. Pushing to sw=45 overshoots — the model becomes dominated by surface loss, which may prevent it from learning accurate volume features that also support surface predictions.

Both runs have similar epoch throughput (~8s/epoch) and got ~35 epochs, so the comparison is fair in terms of training budget.

**Suggested follow-ups:**
- Try sw=35 with beta1=0.95 to find the exact optimum in the sw sweep (the sw=35 and sw=25 results don't share the same beta1=0.95 setting — need a clean comparison)
- The sw trend is clearly non-monotonic; a sweep of sw=[20, 25, 30, 35] with consistent hyperparameters would identify the optimum precisely