### PR TITLE
Huber + beta1=0.98: even higher momentum

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.98, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

beta1=0.95 improved surf_p by 6% vs default 0.9. Push further to beta1=0.98 -- SGD-like momentum. Higher momentum smooths gradient noise even more, potentially helping convergence in the ~40-epoch regime. Risk: too much momentum may cause overshooting.

## Instructions

In `train.py`:
1. Replace MSE with Huber (delta=0.01) in BOTH train and val loops:
   ```python
   sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
   ```
2. Optimizer: `betas=(0.98, 0.999)`
3. Set `MAX_EPOCHS = 50`, T_max=50
4. Run with:
   ```bash
   uv run python train.py --agent nezuko --wandb_name "nezuko/huber-beta098" --wandb_group "huber-optimizer" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4
   ```
5. n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2

## Baseline

Huber + beta1=0.95 + sw=25: surf_p=49.5

---

## Results

**W&B run:** `nezuko/huber-beta098` (run ID: `ld57a281`)
**Best epoch:** 40/50 (5-minute wall-clock timeout; ~8s/epoch)
**Peak memory:** 4.3 GB

### Metrics at best epoch (40)

| Metric | This run (beta1=0.98) | Baseline (beta1=0.95) | Default (beta1=0.9) |
|--------|----------------------|----------------------|---------------------|
| surf_p | 73.3 | **49.5** | ~52.4 |
| surf_Ux | 0.86 | -- | 0.64 |
| surf_Uy | 0.49 | -- | 0.35 |
| vol_p | 125.9 | -- | 93.7 |

### What happened

**Negative result.** beta1=0.98 converges significantly slower than beta1=0.95. At epoch 40:
- surf_p: 73.3 vs baseline 49.5 — **48% worse**
- The training loss is also higher (train vol=0.0047 surf=0.0012 at ep 40, vs the Huber sw=35 run which had 0.0034/0.0008 at ep 40)

The degradation is consistent across all metrics. Beta1=0.98 creates excessively slow gradient updates — with the 5-minute budget limiting us to ~40 epochs, there isn't enough time for the heavy momentum to accumulate and smooth gradients effectively. The model is still far from converged when the clock runs out.

This follows the principle: very high momentum (beta1>0.95) works well for long training runs but hurts in budget-limited settings where quick adaptation to the loss landscape is needed.

### Suggested follow-ups

- Beta1=0.95 is the sweet spot found so far. The curve peaks somewhere between 0.9 and 0.95.
- Try beta1=0.93 to precisely identify the optimal value.
- Combine beta1=0.95 with sw=35 (both showed improvement individually) to test for additive gains.