### PR TITLE
Combined: Huber + sw=35 + wd=0 + beta1=0.95

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Combining all three improvements that showed positive signal:
- beta1=0.95 → surf_p=49.5 (-6%)
- sw=35 → surf_p=50.2 (-4%)
- wd=0 → surf_p=50.3 (-4%)

Testing whether all three compound. This is the "kitchen sink" experiment — if it works, it's our best config. If it fails, there's an interaction effect.

## Instructions

In `train.py`:
1. Replace MSE with Huber (delta=0.01) in BOTH train and val loops:
   ```python
   sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
   ```
2. Optimizer: `betas=(0.95, 0.999)`, `weight_decay=0.0`
3. Set `MAX_EPOCHS = 50`, T_max=50
4. Run with:
   ```bash
   uv run python train.py --agent alphonse --wandb_name "alphonse/huber-sw35-wd0-beta095" --wandb_group "combined" --lr 0.006 --surf_weight 35.0 --weight_decay 0.0 --batch_size 4
   ```
5. n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2

## Baseline

Huber + beta1=0.95 + sw=25: surf_p=49.5

---
## Results

**W&B run:** `ykl3d1s7` (alphonse/huber-sw35-wd0-beta095, group: combined)

**Training:** 40 epochs before 5-minute wall-clock timeout (5.1 min). Best at epoch 39. ~8s/epoch.

**Peak memory:** 4.3 GB

| Metric | Combined (sw=35, wd=0, beta=0.95) | beta=0.95 alone | sw=35 alone | wd=0 alone |
|--------|-----------------------------------|-----------------|-------------|------------|
| surf_p | 52.7 | 49.5 | 50.2 | 50.3 |
| surf_Ux | 0.68 | (N/A from PR) | (N/A) | 0.65 |
| surf_Uy | 0.37 | (N/A from PR) | (N/A) | 0.34 |
| val/loss | 0.0392 | — | — | 0.0269 |
| best_epoch | 39 | — | — | 40 |

**What happened:**

The hypothesis was **not confirmed** — the three improvements do not compound. The combined config (surf_p=52.7) is worse than any individual modification tested:
- Worse than beta1=0.95 alone (49.5)
- Worse than sw=35 alone (50.2)
- Worse than wd=0 alone (50.3)

There is a negative interaction effect. The most likely explanation: increasing surf_weight to 35 changes the loss landscape more aggressively toward surface fitting, while beta1=0.95 makes the optimizer less smooth (more responsive to recent gradients), and wd=0 removes the stabilizing effect of regularization. Together these three changes make optimization harder/noisier.

Note: val_loss is not comparable between sw=25 and sw=35 runs (the scale changes with surf_weight since val_loss = vol_loss + sw * surf_loss).

**Suggested follow-ups:**
- beta1=0.95 at sw=25 remains the best single modification (49.5). Test beta1=0.95 + wd=0 (without sw change) to check that pairwise combination
- The negative interaction with sw=35 suggests that increasing the surface pressure in the loss may conflict with the other optimizer changes — worth isolating
- Current best: beta1=0.95 at surf_p=49.5. Next step should be toward improving that further rather than combining multiple changes at once
