### PR TITLE
Combined: Huber + beta1=0.95 + sw=35 + lr=0.008

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Our combined best config (Huber + beta1=0.95 + sw=35) should tolerate a slightly higher LR than 0.006 because: (1) Huber caps gradient magnitude, (2) beta1=0.95 smooths updates. Testing lr=0.008 — a modest 33% increase that may accelerate convergence without the instability seen at lr=0.01.

## Instructions

In `train.py`:
1. Replace MSE with Huber (delta=0.01) in BOTH train and val loops
2. Optimizer: `betas=(0.95, 0.999)`
3. Set `MAX_EPOCHS = 50`, T_max=50
4. Run with `--lr 0.008 --surf_weight 35.0 --weight_decay 0.0001 --batch_size 4`
5. n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2

## Baseline

Huber + beta1=0.95 + sw=25 + lr=0.006: surf_p=49.5

---

## Results

**W&B run ID:** `8m5vom50`
**Best epoch:** 37 (hit 5-min wall-clock timeout)
**Peak memory:** 4.3 GB

| Metric | This run (lr=0.008, sw=35) | Baseline (lr=0.006, sw=25) | Delta |
|--------|---------------------------|---------------------------|-------|
| surf_Ux | 0.63 | 0.63 | same |
| surf_Uy | 0.35 | 0.35 | same |
| surf_p | 52.5 | 49.5 | +6% worse |

**What happened:** The combined lr=0.008 + sw=35 does not improve over the lr=0.006 + sw=25 baseline. surf_p went from 49.5 to 52.5 — slightly worse. The val_loss is higher (0.0379 vs 0.0268) partly due to the larger surf_weight (35 vs 25), but even looking at raw surface metrics, the improvement isn't there. The model reached similar surf_Ux/Uy but worse surf_p.

The higher learning rate (lr=0.008) likely introduced more instability that offset any convergence benefit, and the sw=35 penalized volume loss more aggressively, which may have hurt overall balance. The best config remains lr=0.006 + sw=25 + beta1=0.95.

**Suggested follow-ups:**
- Keep beta1=0.95 + Huber but try lr=0.007 (halfway between 0.006 and 0.008) as a finer grid search
- Test sw=35 independently with lr=0.006 to disentangle the lr and sw effects
- Accept lr=0.006 as the sweet spot and focus on other improvements (architecture, data augmentation)