### PR TITLE
Full combo: Huber + slice32 + beta1=0.95 + sw=35

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -79,7 +80,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.95, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Combining ALL three winning changes from our ablation sweep:
- slice_num=32 → surf_p=48.15 (-8% vs base, BEST so far)
- beta1=0.95 → surf_p=49.5 (-6%)
- sw=35 → surf_p=50.2 (-4%)

These are orthogonal: slice_num affects attention granularity, beta1 affects optimizer momentum, sw affects loss weighting. If additive, we expect surf_p ~43-45 at ~46 epochs.

## Instructions

In `train.py`:
1. Replace MSE with Huber (delta=0.01) in BOTH train and val loops
2. Optimizer: `betas=(0.95, 0.999)`
3. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=32**, mlp_ratio=2
4. Set `MAX_EPOCHS = 50`, T_max=50
5. Run with surf_weight=35, lr=0.006

## Baseline

Best under contention: slice_num=32 + Huber → surf_p=48.15 (ep 46)

---

## Results

**W&B run:** `tm5w3xgy`
**Epochs completed:** 38 / 50 (5-min wall-clock limit)
**Peak memory:** 3.9 GB

| Metric | This run | Baseline (slice32+Huber) | vs Baseline |
|--------|----------|--------------------------|-------------|
| surf_p | 55.83 | 48.15 | **+16% worse** |
| surf_Ux | 0.70 | ~0.55 | worse |
| surf_Uy | 0.40 | ~0.30 | worse |
| vol_p | 104.6 | ~80 | worse |
| val_loss | 0.0410 | ~0.019 | worse (different scale due to sw=35) |

**What happened:** The combo did not stack additively — it was worse than any individual component. The three changes are NOT orthogonal in practice:

- **sw=35 × beta1=0.95 interaction**: Higher surf_weight makes gradients larger for surface nodes. With beta1=0.95 (slower forgetting of past gradients), this creates gradient scale imbalance that destabilizes convergence. The optimizer accumulates a biased history poorly scaled for the elevated surface loss.
- **Fewer epochs**: We only got 38 epochs vs 46 for the slice32-only run. At sw=35, the loss scale is higher, so convergence is slower.
- **The hypothesis was optimistic**: Individual improvements from separate hyperparameter searches do not simply add when they interact through the loss landscape.

The best single-component result (slice_num=32 + Huber, surf_p=48.15) remains superior.

**Suggested follow-ups:**
- Try slice_num=32 alone to confirm the 48.15 result reproducibly
- Try slice_num=32 + sw=35 only (drop beta1 change) to isolate whether sw=35 hurts when combined with slice32
- Try slice_num=16 to see if further reducing slice_num helps (more granular attention)