### PR TITLE
Huber + slice32 + sw=30 (moderate surface emphasis)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

sw=35 with beta1=0.95 caused interference (PR #70). sw=30 is a gentler increase that may avoid the overshooting while still benefiting from more surface emphasis than sw=25. Combined with slice32 (our best architecture finding).

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=32**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent edward --wandb_name "edward/huber-slice32-sw30" --wandb_group "slice32-sweep" --lr 0.006 --surf_weight 30.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice32 + Huber (sw=25): surf_p=48.15

---

## Results

**W&B run:** edward/huber-slice32-sw30 (run ID: 88ir57gi)
**Config:** lr=0.006, surf_weight=30, slice_num=32, n_layers=1, n_hidden=128, n_head=4, mlp_ratio=2, bs=4, wd=1e-4, Huber delta=0.01, MAX_EPOCHS=50
**Best epoch:** 37 / 37 completed (5.0 min, ~8.1s/epoch)
**Peak VRAM:** 3.9 GB

| Metric | This run (sw=30) | Baseline (sw=25) | Delta |
|--------|-----------------|-----------------|-------|
| surf_p | 53.0 | 48.15 | **+4.85 worse** |
| surf_Ux | 0.63 | — | — |
| surf_Uy | 0.36 | — | — |
| vol_p | 95.9 | — | — |
| val_loss | 0.0327 | — | — |

**What happened:** Increasing surf_weight from 25→30 made performance worse (surf_p=53.0 vs 48.15). This is a negative result — sw=25 appears to be at or near the optimal surface weighting for this model. A larger surf_weight forces the model to over-prioritize surface nodes during training, potentially at the expense of learning good feature representations that generalize to surface accuracy. The sweet spot is sw=25; going higher consistently degrades results (sw=30 here, sw=35 in prior experiments).

**Suggested follow-ups:**
- sw=25 is confirmed as the best surface weight for slice32+Huber — stop exploring higher values
- The slice32 architecture improvement (surf_p=48.15) remains the best result; focus on other dimensions like LR tuning or deeper architecture for slice32
- Try combining slice32 + beta1=0.95 (without changing sw) — beta1=0.95 helped at sw=25 in prior runs