### PR TITLE
Huber + slice_num=48 (intermediate between 32 and 64)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=48,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

slice32 beat slice64 (48.15 vs 52.4). Testing slice48 as the midpoint — it may balance representation capacity with learning simplicity better than either extreme.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=48**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-slice48" --wandb_group "slice-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice32: surf_p=48.15 (ep 46)
- slice64: surf_p=52.4 (ep 39)

---

## Results

**W&B run:** `1iaexuic` (thorfinn/huber-slice48, group: slice-sweep)

| Metric | slice48 (this run) | slice32 | slice64 |
|--------|-------------------|---------|---------|
| surf_Ux MAE | 0.71 | — | — |
| surf_Uy MAE | 0.36 | — | — |
| surf_p MAE | **54.8** | **48.15** | **52.4** |
| vol_Ux MAE | 3.49 | — | — |
| vol_Uy MAE | 1.52 | — | — |
| vol_p MAE | 95.8 | — | — |
| Best epoch | 35 | 46 | 39 |
| Peak memory | 4.1 GB | — | — |
| val_loss | 0.0290 | — | — |

**What happened:**

Contrary to the hypothesis, slice48 is the worst of the three (surf_p=54.8 vs slice32=48.15 and slice64=52.4). The relationship between slice_num and performance is non-monotonic — the midpoint does not perform better than either extreme. slice32 remains the clear winner.

One possible explanation: with n_layers=1, the model has a single attention pass. slice32 forces more aggressive partitioning, which may act as a form of regularization preventing overfitting to noisy surface nodes. slice48 and slice64 may allow the attention to spread over more tokens, diluting the surface signal.

The epoch counts differ somewhat (35 vs 46 vs 39) due to the 5-min timeout, which may slightly favor runs with fewer epochs per minute, but all three are within the same order of magnitude.

**Suggested follow-ups:**
- slice32 appears robustly better — confirm with longer training to see if the advantage holds
- Try slice32 with different n_layers (2 or 3) to see if adding depth interacts with slice_num