### PR TITLE
Huber + slice32 + lr=0.007 (mild LR increase)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

slice32 gives faster epochs (~7s vs 8s), allowing more training. A mild LR increase from 0.006 to 0.007 (~17%) may extract more from each epoch without the instability seen at lr=0.01. Huber stabilizes gradients at higher LR.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=32**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent nezuko --wandb_name "nezuko/huber-slice32-lr007" --wandb_group "slice32-sweep" --lr 0.007 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice32 + lr=0.006: surf_p=48.15

---

## Results

**W&B run:** `nezuko/huber-slice32-lr007` (run ID: `lqjctuwd`)
**Best epoch:** 45/50 (5-minute timeout; 7s/epoch -> 45 epochs vs ~40 for slice64)
**Peak memory:** 3.9 GB (vs 4.3 GB for slice64 -- memory savings from smaller slice)

### Metrics at best epoch (45)

| Metric | This run (slice32, lr=0.007) | Baseline (slice32, lr=0.006) |
|--------|------------------------------|------------------------------|
| val_loss | 0.0252 | -- |
| surf_p | **47.0** | 48.15 |
| surf_Ux | **0.59** | -- |
| surf_Uy | **0.33** | -- |
| vol_p | 85.5 | -- |

### What happened

**Positive result.** lr=0.007 with slice32+Huber improves over the baseline (surf_p 47.0 vs 48.15, -2.4%). The extra epoch budget from slice32's faster per-epoch time (45 epochs vs ~40) likely contributes alongside the higher LR. Training showed a consistent improvement across all surface metrics.

Notably, surf_p=47.0 also beats our Huber+sw=35+slice64 run from PR #64 (surf_p=50.2), suggesting that the combination of slice32 + slightly higher LR is beneficial.

The model was still improving at epoch 45 (new checkpoints at ep 40, 41, 42, 43, 44, 45), so results may improve further.

### Suggested follow-ups

- Try lr=0.008 with slice32 to see if the improvement continues (risk: instability at higher lr).
- Combine lr=0.007 + slice32 + beta1=0.95 (two confirmed improvements stacked).
- Try lr=0.007 + slice32 + sw=35 (combine slice32 benefit with surface weight tuning).