### PR TITLE
Huber + beta1=0.93 (fine-tune momentum)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.93, 0.999))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

beta1=0.95 gave surf_p=49.5 (-6%), beta1=0.98 gave 73.3 (too much). The optimum may be between 0.9 and 0.95. Testing beta1=0.93 to find the precise sweet spot.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Optimizer: `betas=(0.93, 0.999)`
3. n_layers=1, n_hidden=128, n_head=4, slice_num=64, mlp_ratio=2
4. MAX_EPOCHS=50, T_max=50
5. Run: `uv run python train.py --agent alphonse --wandb_name "alphonse/huber-beta093" --wandb_group "huber-optimizer" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- beta1=0.95: surf_p=49.5
- beta1=0.9 (default): surf_p=52.4

---

## Results

**W&B Run ID**: `no1l7mph`

**Best epoch**: 39/40 (~8s/epoch, timeout at 5 min)

| Metric | This run (beta1=0.93) | beta1=0.9 baseline | beta1=0.95 |
|--------|----------------------|-------------------|------------|
| val/loss | 0.0269 | 0.0276 | ~0.026 |
| surf_p | 51.4 | 52.4 | 49.5 |
| surf_Ux | 0.63 | 0.64 | ~0.63 |
| surf_Uy | 0.35 | 0.35 | ~0.34 |
| vol_Ux | 3.32 | — | — |
| vol_Uy | 1.41 | — | — |
| vol_p | 85.0 | — | — |
| Peak VRAM | 4.3 GB | — | — |

**What happened**: The sweet spot hypothesis was NOT confirmed. beta1=0.93 gives surf_p=51.4, which is between 0.9 (52.4) and 0.95 (49.5) but does not beat 0.95. The slight improvement over the default (51.4 vs 52.4) is minimal and does not justify the complexity. beta1=0.95 remains the best value tested so far.

The relationship is monotonically improving from 0.9 → 0.95 in this range, suggesting 0.95 may be close to the optimal, or that improvements are gradual rather than having a sharp optimum between 0.9 and 0.95.

**Suggested follow-ups**:
- Test beta1=0.97 to see if the trend continues past 0.95 (rather than the 0.98 that already showed regression)
- Combine beta1=0.95 with lr tuning — the real gain may come from combining optimal momentum with a better lr schedule
- The edward baseline (surf_p=33.55) uses lr=6e-3, sw=25, and runs 100 epochs — the timeout constraint may be the main bottleneck
