### PR TITLE
Huber + slice32 + wd=0 (no weight decay)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

wd=0 showed marginal improvement on slice64 (50.3 vs 52.4). Testing on slice32 base — Huber + no regularization may allow tighter fitting on the simpler (32-slice) architecture.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=32**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `--lr 0.006 --surf_weight 25.0 --weight_decay 0.0 --batch_size 4`

## Baseline
- slice32 + wd=0.0001: surf_p=48.15

---

## Results

**W&B run ID:** `cgbqazuc`
**Best epoch:** 44 (hit 5-min wall-clock timeout; slice32 runs 7s/epoch vs 8s for slice64)
**Peak memory:** 3.9 GB

| Metric | This run (slice32, wd=0) | Baseline (slice32, wd=0.0001) | Best prev (slice64, wd=0.0001) |
|--------|--------------------------|-------------------------------|-------------------------------|
| surf_Ux | 0.59 | — | 0.63 |
| surf_Uy | 0.34 | — | 0.35 |
| surf_p | 47.9 | 48.15 | 49.5 |
| vol_p | 88.9 | — | 88.2 |
| val_loss | 0.0258 | — | 0.0268 |

**What happened:** This is the new best result overall. slice_num=32 with wd=0 achieves surf_p=47.9, marginally better than the slice32+wd=0.0001 baseline (48.15), and better than the slice64+beta1=0.95 run (49.5). The faster epoch time (7s vs 8s) allowed 44 epochs vs 39 in the slice64 runs, which likely contributes to the improvement.

The wd=0 marginal gain here is consistent with the observation on slice64. Without weight decay the model fits the training data more aggressively, which in this relatively simple 1-layer architecture seems to help rather than hurt.

**Suggested follow-ups:**
- Combine slice32 + wd=0 + beta1=0.95 (the best individual improvements together)
- Verify wd=0 benefit is real with another seed/run
- Try slice_num=16 to see if further reduction in slices helps or hurts