### PR TITLE
Huber + slice_num=8: push the frontier

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=8,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

The slice reduction trend is clear and powerful: 64→48.15→44.59 (surf_p). Each halving gives ~4 points + faster epochs. slice_num=8 should give ~5s/epoch, ~55 epochs in 5 min, and possibly surf_p ~40-42. Risk: too few slices may finally under-represent the flow structure.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=8**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run with lr=0.006, surf_weight=25

## Baseline

| slice_num | surf_p | epochs | epoch_time |
|-----------|--------|--------|------------|
| 64 | 52.4 | ~39 | ~8s |
| 32 | 48.15 | ~46 | ~7s |
| 16 | 44.59 | 49 | ~6s |
| **8** | **?** | **~55?** | **~5s?** |

---

## Results

**W&B run:** `tm3mx1xe`
**Epochs completed:** 36 / 50 (5-min wall-clock limit)
**Peak memory:** 3.6 GB

| slice_num | surf_p | surf_Ux | surf_Uy | vol_p | epochs | epoch_time |
|-----------|--------|---------|---------|-------|--------|------------|
| 64 | 52.4 | ~0.55 | ~0.32 | ~90 | ~39 | ~8s |
| 32 | 48.15 | ~0.55 | ~0.30 | ~80 | ~46 | ~7s |
| 16 | 44.59 | — | — | — | 49 | ~6s |
| **8** | **52.58** | **0.66** | **0.36** | **89.5** | **36** | **~8s** |

**What happened:** The trend did NOT continue. slice_num=8 is worse than slice_num=16 (52.58 vs 44.59) and even slightly worse than slice_num=64 (52.4). Two hypotheses were both wrong:

1. **Epoch time did not decrease**: Still ~8s/epoch, not ~5s. The bottleneck is not the attention computation with 64 slices — it's the data loading or other operations that dominate regardless of slice count.

2. **Quality degraded**: 8 slices is insufficient to represent the full range of flow structures in the mesh. The model can no longer group mesh nodes into meaningful physics-based clusters with only 8 slice prototypes.

The slice_num=16 sweet spot at surf_p=44.59 appears to be the actual optimum — enough granularity to capture flow variation, with modestly faster epochs than 64. Going below 16 sacrifices representation capacity without speed gains.

**Suggested follow-ups:**
- Confirm slice_num=16 as best with a clean re-run
- Try slice_num=12 to narrow down the optimal range (between 8 and 16)
- Investigate why epoch time doesn't decrease with fewer slices (profile the bottleneck)