### PR TITLE
Huber + slice_num=12: find the optimal point

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=12,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

If slice8 hits diminishing returns, the optimum may be between 8 and 16. slice12 brackets the sweet spot. If slice8 is still improving, 12 gives us interpolation data.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=12**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent fern --wandb_name "fern/huber-slice12" --wandb_group "slice-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline

slice16: surf_p=44.59, slice32: surf_p=48.15

---

## Results

**W&B run:** `7tapwp2n` (fern/huber-slice12, group: slice-sweep)

**Config:** lr=0.006, surf_weight=25, Huber delta=0.01, slice_num=12, n_layers=1, n_hidden=128, n_head=4, mlp_ratio=2, wd=0.0001, bs=4, MAX_EPOCHS=50

| Metric | slice12 (ep 36) | slice16 baseline | slice32 |
|---|---|---|---|
| val_loss | 0.0286 | — | — |
| Surface Ux MAE | 0.66 | — | — |
| Surface Uy MAE | 0.36 | — | — |
| Surface p MAE | **55.4** | **44.59** | **48.15** |
| Volume Ux MAE | 3.40 | — | — |
| Volume Uy MAE | 1.45 | — | — |
| Volume p MAE | 92.9 | — | — |
| Peak memory | 3.7 GB | — | — |
| Best epoch | 36 / 36 | ~46 | ~46 |
| Epoch time | 7.8s | — | — |

### What happened

slice12 (surf_p=55.4) is worse than both slice16 (44.59) and slice32 (48.15). The hypothesis that slice12 might find the sweet spot does not hold — going below slice16 hurts performance. The trend from slice32→slice16→slice12 is monotonically worsening: smaller slice counts below 16 are degrading the model's ability to capture spatial structure.

Note: the baselines (slice16, slice32) ran to ~46 epochs while this run reached 36 epochs. However, a ~11-point gap vs slice16 is too large to close with 10 extra epochs.

**Verdict:** slice16 remains the best in the slice sweep. The optimum is at or above 16, not below. slice12 closes off the lower end of the search space.

### Suggested follow-ups
- Run slice8 to confirm the downward trend continues (or check if results are already available)
- The slice16 vs slice32 comparison suggests a local optimum near 16; testing slice20-24 might be worthwhile
- Focus remaining compute on slice16 combinations (lr, sw, wd tuning)