### PR TITLE
Huber + slice16 + sw=30 (moderate sw on best slice)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=16,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

slice16 is our best architecture. sw=35 interfered with beta1=0.95 but we haven't tested sw=30 with slice16 at default beta1=0.9. A moderate sw increase (25->30) with the faster slice16 architecture may help surface accuracy without the interference seen at sw=35.

## Instructions

Huber loss (delta=0.01) in both loops. slice_num=16, n_layers=1. MAX_EPOCHS=50, T_max=50. Run with sw=30.

## Baseline

slice16 + sw=25: surf_p=44.59

---

## Results

**W&B run ID:** c7i2f22t

**Best epoch:** 49 (5-minute timeout)

| Metric | sw=30 | sw=25 (baseline) | Delta |
|---|---|---|---|
| surf_p | 46.43 | 44.59 | +4.1% (worse) |
| surf_Ux | **0.58** | 0.60 | -3.3% (better) |
| surf_Uy | 0.34 | 0.34 | same |
| vol_p | 88.1 | 79.0 | +11.5% (worse) |
| vol_Ux | 3.45 | 3.30 | +4.5% (worse) |
| val_loss | 0.0297 | 0.0248 | +20% (worse) |

**Peak memory / epoch time:** ~3.7 GB / 6s (same as slice16 baseline — sw change has no compute impact)

### What happened

sw=30 gave **mixed results**: surf_Ux improved slightly (0.58 vs 0.60), but surf_p worsened (46.43 vs 44.59) and volume metrics degraded significantly. The overall combined val_loss (0.0297 vs 0.0248) is 20% worse.

The higher surface weight forced the optimizer to trade off volume accuracy for surface nodes, but this didn't actually improve the most important metric (surf_p). The trade-off appears to hurt volume without corresponding surface gains at this surf_weight level.

sw=25 remains the better choice for slice16. Surface pressure is the hardest target and doesn't benefit from simply increasing the surface weight without other changes.

### Implementation notes

Same changes as the slice16 PR (import F, Huber loss, n_layers=1, slice_num=16). Only difference: surf_weight passed as 30.0 via CLI.

### Suggested follow-ups

- **Try sw=20 or sw=15**: sw=25 may already be too high. Reducing pressure on surface nodes might allow better pressure learning overall.
- **Accept sw=25 as optimal for slice16**: The sw=25+slice16 combination appears to be near-optimal. Focus on other dimensions (lr, model width, etc.).
- **Test sw=27 or sw=28**: Fine-grained search between 25 and 30 to see if there is a small gain in the surf_Ux direction without hurting surf_p.
