### PR TITLE
Huber + slice16 + lr=0.007 (best LR on best arch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=16,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

lr=0.007 improved slice32 by 2.4% (47.0 vs 48.15). Testing on slice16, our best architecture (44.59). If the LR benefit transfers, we expect surf_p ~43.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=16**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent edward --wandb_name "edward/huber-slice16-lr007" --wandb_group "slice16-sweep" --lr 0.007 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice16 + lr=0.006: surf_p=44.59 (ep 49)
- slice32 + lr=0.007: surf_p=47.0 (ep 45)

---

## Results

**W&B run:** edward/huber-slice16-lr007 (run ID: 2zrxsv8x)
**Config:** lr=0.007, surf_weight=25, slice_num=16, n_layers=1, n_hidden=128, n_head=4, mlp_ratio=2, bs=4, wd=1e-4, Huber delta=0.01, MAX_EPOCHS=50
**Best epoch:** 34 / 34 completed (5.1 min, ~9s/epoch)
**Peak VRAM:** 3.7 GB

| Metric | This run (slice16 + lr=0.007) | Baseline (slice16 + lr=0.006) | Delta |
|--------|------------------------------|------------------------------|-------|
| surf_p | 58.0 | 44.59 | **+13.4 worse** |
| surf_Ux | 0.69 | — | — |
| surf_Uy | 0.39 | — | — |
| vol_p | 104.3 | — | — |
| val_loss | 0.0306 | — | — |

**What happened:** lr=0.007 significantly hurt slice16 (surf_p=58.0 vs 44.59), contrary to the hypothesis. The LR benefit does not transfer from slice32 to slice16. This suggests slice16 and slice32 have different optimization landscapes — slice16 (with fewer attention slices) may be more sensitive to LR because each slice carries more representational burden. A higher LR may cause the fewer slices to oscillate or settle in a suboptimal basin. By contrast, slice32 has more redundancy and can tolerate slightly more aggressive learning.

Also note this run reached only epoch 34 vs 49 for the baseline — likely due to GPU contention, which independently limits convergence quality.

**Suggested follow-ups:**
- The slice16 + lr=0.006 baseline (surf_p=44.59) remains the best result; lr=0.006 is the right choice for slice16
- Try lr=0.005 on slice16 to see if a lower LR helps further
- Investigate other slice16 improvements: batch size, weight decay, or architecture tweaks