### PR TITLE
Huber + slice16 + wd=0 (no weight decay)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=16,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

wd=0 gave marginal improvement on slice32 (47.9 vs 48.15). Testing on slice16. Fewer slices = simpler model, may benefit more from removing regularization.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=16**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-slice16-wd0" --wandb_group "slice16-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0 --batch_size 4`

## Baseline
- slice16 + wd=0.0001: surf_p=44.59

---

## Results

**W&B run:** `w1ak1blr` (thorfinn/huber-slice16-wd0, group: slice16-sweep)

| Metric | slice16 + wd=0 (this run) | slice16 + wd=0.0001 (baseline) |
|--------|--------------------------|-------------------------------|
| surf_Ux MAE | 0.71 | — |
| surf_Uy MAE | 0.39 | — |
| surf_p MAE | **56.5** | **44.59** |
| vol_Ux MAE | 3.60 | — |
| vol_Uy MAE | 1.54 | — |
| vol_p MAE | 96.6 | — |
| Best epoch | 33 | — |
| Peak memory | 3.7 GB | — |
| val_loss | 0.0300 | — |

**What happened:**

wd=0 is substantially worse than wd=0.0001 on slice16: surf_p degraded from 44.59 to 56.5 (+27%). This is the opposite of what was observed on slice32 (where wd=0 gave a small improvement). 

Weight decay appears important for slice16 — the fewer slices may lead to each attention head attending to very few tokens, making the model more prone to overfitting without regularization. The assumption that a simpler model benefits more from removing regularization did not hold here.

**Suggested follow-ups:**
- Confirm slice16 + wd=0.0001 is robust (the baseline 44.59 is surprisingly good — re-run to verify it's not a lucky seed)
- Try intermediate wd values for slice16 (e.g., wd=0.0005, wd=0.001) to find the optimal regularization level