### PR TITLE
Huber + slice16 + lr=0.008 (push LR on fast arch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=16,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

lr=0.007 helped slice32. With slice16's even faster epochs (~6s, ~49 epochs), lr=0.008 may work — more aggressive learning is viable because the model sees more gradient steps. Huber prevents instability.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=16**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent alphonse --wandb_name "alphonse/huber-slice16-lr008" --wandb_group "slice16-sweep" --lr 0.008 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice16 + lr=0.006: surf_p=44.59

---

## Results

**W&B Run ID**: `4tt6iox5`

**Best epoch**: 33/35 (~8s/epoch, timeout at 5 min)

| Metric | This run (lr=0.008) | slice16 lr=0.006 baseline |
|--------|---------------------|--------------------------|
| val/loss | 0.0306 | — |
| surf_p | **59.9** | **44.59** |
| surf_Ux | 0.73 | — |
| surf_Uy | 0.36 | — |
| vol_Ux | 3.53 | — |
| vol_Uy | 1.51 | — |
| vol_p | 96.5 | — |
| Peak VRAM | 3.7 GB | — |

**What happened**: Negative result. lr=0.008 is too aggressive for slice16 — surf_p degraded to 59.9 vs 44.59 at lr=0.006. The hypothesis that more gradient steps with faster epochs justifies higher LR was not confirmed. Instead, the higher learning rate appears to cause instability or overshoot, worsening generalization on the surface nodes.

Note: epochs ran at ~8s rather than the expected ~6s for slice16, yielding only ~35 epochs vs the anticipated ~49. Regardless, even with fewer epochs, the quality degradation is clear.

**Suggested follow-ups**:
- The lr=0.006 result (surf_p=44.59) is the current best for slice16. Consider whether this architecture is worth keeping as the baseline.
- Test lr=0.007 on slice16 to see if there is a sweet spot between 0.006 and 0.008, similar to the slice32 experiment.
- Investigate why slice16 epochs run at ~8s instead of the expected ~6s — if the speed advantage is smaller than expected, the architecture rationale changes.
