### PR TITLE
Huber delta=0.02 + slice16 (wider quadratic region)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=16,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.02)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.02)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

delta=0.01 vs 0.1 was nearly tied on slice64 (52.4 vs 51.7). On slice16, delta=0.02 widens the quadratic region slightly, giving stronger gradient signal for errors in the 0.01-0.02 range. This may help slice16 converge faster on medium-scale errors.

## Instructions

In `train.py`:
1. Huber loss (**delta=0.02**) in BOTH train and val loops:
   ```python
   sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.02)
   ```
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=16**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent fern --wandb_name "fern/huber-slice16-delta002" --wandb_group "slice16-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice16 + delta=0.01: surf_p=44.59

---

## Results

**W&B run:** `9ap4rnv7` (fern/huber-slice16-delta002, group: slice16-sweep)

**Config:** lr=0.006, surf_weight=25, Huber delta=0.02, slice_num=16, n_layers=1, n_hidden=128, n_head=4, mlp_ratio=2, wd=0.0001, bs=4, MAX_EPOCHS=50

| Metric | delta=0.02 slice16 (ep 33) | delta=0.01 slice16 baseline (~ep 46) |
|---|---|---|
| val_loss | 0.0538 | — |
| Surface Ux MAE | 0.65 | — |
| Surface Uy MAE | 0.38 | — |
| Surface p MAE | **56.1** | **44.59** |
| Volume Ux MAE | 3.41 | — |
| Volume Uy MAE | 1.50 | — |
| Volume p MAE | 92.4 | — |
| Peak memory | 3.7 GB | — |
| Best epoch | 33 / 35 | ~46 |
| Epoch time | 8.2s | — |

### What happened

delta=0.02 (surf_p=56.1) is worse than delta=0.01 (44.59) on slice16. The hypothesis does not hold — a wider quadratic region hurts rather than helps. The baseline runs to 46 epochs vs our 33, which accounts for some of the gap, but a ~12-point difference is unlikely to close with 13 more epochs.

The larger delta means the Huber loss behaves more like MSE for a wider range of errors, reducing the robustness benefit that makes delta=0.01 effective. With delta=0.01, most errors beyond a small threshold are penalized linearly (more robustly), which appears to be the right regime for this normalized prediction space.

**Verdict:** delta=0.01 remains the best Huber delta for slice16. Increasing delta beyond 0.01 is detrimental.

### Suggested follow-ups
- Try delta=0.005 — even smaller delta pushes more errors into the linear regime, potentially more robust
- The slice16 + delta=0.01 combination is already strong at 44.59; focus should be on other hyperparameters (lr, sw, wd) rather than delta tuning