### PR TITLE
Huber + slice16 + lr=0.007 + wd=0 (combine marginals)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=16,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

lr=0.007 improved slice32 by 2.4%. wd=0 improved slice32 marginally. These are orthogonal. On slice16, combining both may compound since neither changes the loss or optimizer momentum.

## Instructions

Huber loss (delta=0.01) in both loops. slice_num=16, n_layers=1. MAX_EPOCHS=50, T_max=50. Run with lr=0.007, wd=0.

## Baseline
- slice16 + lr=0.006 + wd=0.0001: surf_p=44.59

---

## Results

**W&B run ID:** 37fdchzr

**Best epoch:** 49 (5-minute timeout)

| Metric | lr=0.007+wd=0 | baseline (lr=0.006+wd=1e-4) | Delta |
|---|---|---|---|
| surf_p | 46.63 | **44.59** | +4.6% (worse) |
| surf_Ux | **0.58** | 0.60 | -3.3% (better) |
| surf_Uy | **0.34** | 0.34 | same |
| vol_p | 82.3 | **79.0** | +4.2% (worse) |
| vol_Ux | **3.17** | 3.30 | -4.0% (better) |
| vol_Uy | **1.30** | 1.37 | -5.1% (better) |
| val_loss | 0.0250 | **0.0248** | +0.8% (worse) |

**Peak memory / epoch time:** ~3.7 GB / 6s (same as slice16 baseline)

### What happened

The combination of lr=0.007 + wd=0 gives **mixed results**. Volume Ux/Uy improved noticeably, but the most important metric (surf_p) got worse (46.63 vs 44.59). The val_loss difference is tiny (0.025 vs 0.0248), but the surface pressure regression is meaningful.

The pattern mirrors the sw=30 experiment: adjustments that seem like improvements on individual dimensions (Ux) come at the expense of pressure. This suggests surf_p is a difficult target that requires balanced optimization — not increasing lr or removing regularization.

The hypothesis that lr=0.007 and wd=0 "compound" holds for volume Ux/Uy but not for surface pressure.

### Implementation notes

Same changes as other slice16 PRs. Only difference: lr=0.007 and weight_decay=0.0 passed via CLI.

### Suggested follow-ups

- **Accept slice16 + lr=0.006 + wd=0.0001 as the sweet spot**: Repeated attempts to improve on it with sw, lr, and wd tweaks have not beaten surf_p=44.59. The current config appears well-calibrated.
- **Model depth**: Try n_layers=2 on the slice16 config — more capacity may improve surface pressure without hurting volume.
- **n_hidden=192 or 256**: Wider model with fewer slices may find a better representation.
