### PR TITLE
Huber + slice_num=2: minimum viable slices

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=2,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

slice4 → surf_p=42.8 (NEW BEST). Does slice2 continue the trend? With only 2 slices, the attention degenerates to a binary partition of the mesh — the model learns 2 basis functions. This is the absolute minimum for physics attention. If it works, the Transolver's slice mechanism is essentially regularization, not representation.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=2**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent edward --wandb_name "edward/huber-slice2" --wandb_group "slice-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4: surf_p=42.8 (52 epochs, ~6s/epoch)
- slice16: surf_p=44.59

---

## Results

**W&B run:** edward/huber-slice2 (run ID: 36paeorl)
**Config:** lr=0.006, surf_weight=25, slice_num=2, n_layers=1, n_hidden=128, n_head=4, mlp_ratio=2, bs=4, wd=1e-4, Huber delta=0.01, MAX_EPOCHS=60
**Best epoch:** 35 / 35 completed (5.1 min, ~8.7s/epoch)
**Peak VRAM:** 3.6 GB

| Metric | This run (slice2) | Baseline (slice4) | Baseline (slice16) |
|--------|------------------|------------------|-------------------|
| surf_p | 56.8 | **42.8** | 44.59 |
| surf_Ux | 0.75 | — | — |
| surf_Uy | 0.37 | — | — |
| vol_p | 91.3 | — | — |
| val_loss | 0.0299 | — | — |

**What happened:** slice2 is significantly worse than slice4 (surf_p=56.8 vs 42.8). The trend does NOT continue — the minimum viable slice count is above 2. With only 2 slices, the model lacks sufficient representational capacity to capture the complexity of airfoil flow fields. A binary partition of the mesh (inside/outside airfoil, or top/bottom) cannot capture the detailed flow structures near the surface that matter for pressure and velocity accuracy.

Note: this run reached only 35 epochs vs 52 for slice4, due to GPU contention. However the performance gap (56.8 vs 42.8 = +33%) is large enough that epoch count alone cannot explain the difference.

**Conclusion:** slice_num=4 is the sweet spot — it provides the minimum useful number of basis functions without overfitting or fragmentation. Going below 4 degrades quality, going above ~16 also degrades quality.

**Suggested follow-ups:**
- slice4 is confirmed as the best architecture; focus on other hyperparameters for that config
- Try slice3 to narrow the boundary if useful, but the sharp drop from 4→2 suggests the boundary is steep
- With slice4 confirmed, try tuning lr, weight_decay, or batch_size specifically for slice4