### PR TITLE
Huber + slice_num=6: between 4 and 8

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=6,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=60)
 
 
 # --- wandb ---
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

slice4=42.8 (best), slice8=52.58 (36ep, maybe contention). Testing slice6 to map the curve between 4 and 8 more precisely.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=6**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-slice6" --wandb_group "slice-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4: surf_p=42.8, slice8: 52.58, slice16: 44.59

---

## Results

**W&B run:** `dvhgs7q8` (thorfinn/huber-slice6, group: slice-sweep)

| Metric | slice6 (this run) | slice4 | slice8 | slice16 |
|--------|------------------|--------|--------|---------|
| surf_Ux MAE | 0.72 | — | — | — |
| surf_Uy MAE | 0.38 | — | — | — |
| surf_p MAE | **58.6** | **42.8** | **52.58** | **44.59** |
| vol_Ux MAE | 3.97 | — | — | — |
| vol_Uy MAE | 1.66 | — | — | — |
| vol_p MAE | 92.2 | — | — | — |
| Best epoch | 37 | — | — | — |
| Peak memory | 3.6 GB | — | — | — |
| val_loss | 0.0308 | — | — | — |

**What happened:**

slice6 (surf_p=58.6) is worse than both slice4 (42.8) and slice8 (52.58). There's no simple monotonic or U-shaped relationship between slice_num and surf_p across this range. The slice4 result of 42.8 stands out as an outlier that is substantially better than all nearby values (6, 8, 16). This non-monotonic behavior may indicate:
1. slice4 with n_layers=1 creates an extremely constrained bottleneck that acts as strong regularization for surface prediction
2. The 5-minute budget introduces noise between runs that makes it hard to cleanly map the slice_num-vs-performance curve

Note: epoch throughput was ~8s/epoch across all these runs, so the epoch count (~35-37) is consistent and the comparisons are fair.

**Suggested follow-ups:**
- Re-run slice4 to confirm 42.8 is reliable and not a lucky run
- If confirmed, explore why such extreme partitioning helps (only 4 tokens per attention pass)