### PR TITLE
Huber + slice4 + sw=20 (tune sw on best arch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

sw=20 gave marginal improvement on slice16 (44.0 vs 44.59). Testing on slice4 -- with even fewer slices, lower surface emphasis may help the model converge faster on both fields.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent nezuko --wandb_name "nezuko/huber-slice4-sw20" --wandb_group "slice4-sweep" --lr 0.006 --surf_weight 20.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + sw=25: surf_p=42.8

---

## Results

**W&B run:** `nezuko/huber-slice4-sw20` (run ID: `twsu482u`)
**Best epoch:** 52/60 (5-minute timeout; 6s/epoch -> 52 epochs)
**Peak memory:** 3.6 GB

### Metrics at best epoch (52)

| Config | surf_p | surf_Ux | surf_Uy | vol_p | val_loss |
|--------|--------|---------|---------|-------|---------|
| slice4, sw=20 (this) | 46.3 | 0.59 | 0.34 | 78.7 | 0.0205 |
| slice4, sw=25 (baseline) | **42.8** | **0.59** | **0.32** | 80.9 | 0.0237 |

### What happened

**Negative result.** sw=20 is worse than sw=25 on slice4 for surface accuracy: surf_p=46.3 vs 42.8 (+8% worse). The hypothesis was wrong -- reducing surface emphasis from 25 to 20 hurts surface MAE on this architecture.

As expected, vol_p improved slightly (78.7 vs 80.9), showing the typical surface/volume tradeoff. But since surface accuracy is our primary metric, sw=25 is better for slice4.

The "marginal improvement" seen on slice16 (44.0 vs 44.59) may have been noise or architecture-specific, and doesn't generalize to slice4 where sw=25 is clearly the better setting.

### Suggested follow-ups

- Try sw=30 with slice4 to see if increasing surface weight (vs sw=25) helps -- we know higher sw helped moving from MSE (sw=25) to initial Huber (sw=25), so the optimal Huber sw may be above 25 even with slice4.
- Keep sw=25 as the default for slice4 -- it's confirmed better than sw=20.