### PR TITLE
Huber + slice_num=3: interpolation near optimum

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=3,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Fine-grained search between slice2 and slice4. If slice4 is optimal, slice3 will be worse. If slice2 improves, slice3 maps the curve.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=3**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent alphonse --wandb_name "alphonse/huber-slice3" --wandb_group "slice-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4: surf_p=42.8

---

## Results

**W&B Run ID**: `piw4ue83`

**Best epoch**: 37 (~8s/epoch, timeout at 5 min)

| Metric | This run (slice3) | slice4 baseline |
|--------|-------------------|----------------|
| val/loss | 0.0299 | — |
| surf_p | **57.9** | **42.8** |
| surf_Ux | 0.67 | — |
| surf_Uy | 0.38 | — |
| vol_Ux | 3.31 | — |
| vol_Uy | 1.43 | — |
| vol_p | 103.9 | — |
| Peak VRAM | 3.6 GB | — |

**What happened**: Negative result. slice_num=3 (surf_p=57.9) is significantly worse than slice4 (42.8). The hypothesis that the optimum might be between 2 and 4 is not supported — the trend is clear: reducing slice_num below 4 degrades performance. slice4 appears to be a local optimum (or minimum useful number of slices).

The model with only 3 slices may have insufficient capacity to represent the physics attention structure effectively, leading to poorer approximation of the flow field.

**Suggested follow-ups**:
- slice4 (surf_p=42.8) is the confirmed optimum in the downward direction. The search should focus on whether larger slice values (8, 12, 16) can beat it.
- If slice4 truly is optimal, combine it with other hyperparameter improvements (lr tuning, surf_weight tuning) to maximize that architecture's potential.
