### PR TITLE
Huber + slice4 rerun: reproducibility check

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

slice4 gave surf_p=42.8 — our best result. But the slice sweep is confounded by GPU contention variability (epoch times range from 6-9s across runs). This rerun confirms whether 42.8 is reproducible or was lucky.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `--lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 (first run): surf_p=42.8

---

## Results

**W&B run ID:** `a0b8vwlt`
**Best epoch:** 52 (hit 5-min wall-clock timeout)
**Peak memory:** 3.6 GB

| Metric | This run (rerun) | First run | Delta |
|--------|-----------------|-----------|-------|
| surf_Ux | 0.57 | — | — |
| surf_Uy | 0.32 | — | — |
| surf_p | 43.3 | 42.8 | +1.2% |
| vol_p | 84.1 | — | — |
| val_loss | 0.0237 | — | — |

**What happened:** The rerun confirms slice4 is genuinely good. surf_p=43.3 vs 42.8 in the first run — a 1.2% difference that falls within expected run-to-run variance. The result is real, not a lucky run.

T_max=60 allowed 52 epochs (vs 49 for T_max=50), reaching surf_p=43.3. The model was still improving at epoch 52 (epoch 51: 43.7 → epoch 52: 43.3). Slice4 runs at ~6s/epoch regardless of T_max change.

With reproducibility confirmed: slice4 is the best architecture configuration — fewer attention slices allow faster epochs and more training in 5 minutes, with the model learning to aggregate coarser global tokens effectively.

**Suggested follow-ups:**
- Try slice4 + wd=0 (consistent improvement in other configs)
- Try slice4 + beta1=0.95
- Try slice2 to see if even fewer slices helps
- Consider if 4 slices is underfitting — the model hasn't beat the global baseline (surf_p=33.55) yet