### PR TITLE
Huber + slice16 + n_head=8 (more attention diversity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=8,
+    slice_num=16,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

n_head=4 with slice16 gives 4 slices per head. n_head=8 gives 2 slices per head — each head sees a finer partition of the flow field. More heads = more diverse attention patterns, potentially capturing different physical features (boundary layer, wake, free-stream). The tradeoff: dim_per_head = 128/8 = 16, which is small but may suffice.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=8**, **slice_num=16**, mlp_ratio=2
3. MAX_EPOCHS=50, T_max=50
4. Run: `uv run python train.py --agent fern --wandb_name "fern/huber-slice16-nhead8" --wandb_group "arch-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice16 + n_head=4: surf_p=44.59

---

## Results

**W&B run:** `gkq5i31f` (fern/huber-slice16-nhead8, group: arch-sweep)

**Config:** lr=0.006, surf_weight=25, Huber delta=0.01, slice_num=16, n_head=8, n_layers=1, n_hidden=128, mlp_ratio=2, wd=0.0001, bs=4, MAX_EPOCHS=50

| Metric | n_head=8 slice16 (ep 29) | n_head=4 slice16 baseline (~ep 46) |
|---|---|---|
| val_loss | 0.0351 | — |
| Surface Ux MAE | 0.78 | — |
| Surface Uy MAE | 0.43 | — |
| Surface p MAE | **68.0** | **44.59** |
| Volume Ux MAE | 4.15 | — |
| Volume Uy MAE | 1.68 | — |
| Volume p MAE | 101.4 | — |
| Peak memory | 3.9 GB | — |
| Best epoch | 29 / 30 | ~46 |
| Epoch time | 9.7s | ~7.6s |

### What happened

n_head=8 (surf_p=68.0) is substantially worse than n_head=4 (44.59). Two compounding issues:

1. **Slower per-epoch time:** 9.7s vs 7.6s — more attention heads require more compute, reducing epochs from ~46 to 30 in the 5-min window.
2. **Worse convergence:** With 16 slices and 8 heads, each head sees only 2 slices. This is likely too few for each head to capture meaningful spatial context — the spatial partitioning becomes too coarse per head.

The hypothesis that more heads = more diverse attention patterns is outweighed by the reduced spatial coverage per head and slower training.

**Verdict:** n_head=4 is clearly better for slice16. The optimal ratio appears to be 4 slices/head (slice16 with n_head=4, or equivalently slice32 with n_head=8).

### Suggested follow-ups
- Keep n_head=4 as the standard; it works well with the current slice counts
- If n_head=8 is desired, pair it with slice32 (4 slices/head) rather than slice16