### PR TITLE
Huber + slice4 + mlp_ratio=4 (wider FFN)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,10 +66,10 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
-    mlp_ratio=2,
+    slice_num=4,
+    mlp_ratio=4,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

mlp_ratio=2 is the current default (FFN hidden dim = 128*2 = 256). With slice4's minimal attention, the FFN does most of the heavy lifting. A wider FFN (mlp_ratio=4, FFN=512) may help learn better representations.

## Instructions

Huber loss (delta=0.01) in both loops. slice_num=4, n_layers=1, mlp_ratio=4. MAX_EPOCHS=60, T_max=60. Run with lr=0.006, sw=25.

## Baseline
- slice4 + mlp_ratio=2: surf_p=42.8

---

## Results

**W&B run ID:** r6m5ouun

**Best epoch:** 45 (5-minute wall-clock timeout)

| Metric | slice4 + mlp_ratio=4 | slice4 + mlp_ratio=2 (baseline) | Delta |
|---|---|---|---|
| surf_p | 47.45 | **42.8** | +10.8% (worse) |
| surf_Ux | 0.64 | — | — |
| surf_Uy | 0.35 | — | — |
| vol_p | 81.9 | — | — |
| val_loss | 0.0261 | — | — |

**Peak memory:** ~4.7 GB (up from ~3.7 GB at mlp_ratio=2)
**Epoch time:** ~7s (up from ~6s at mlp_ratio=2 — wider FFN is slower)
**Epochs completed:** 45 (vs ~49 for mlp_ratio=2 — fewer epochs due to slower training)

### What happened

mlp_ratio=4 **degraded performance** relative to mlp_ratio=2 for slice4. surf_p worsened by 10.8%.

Two effects compound here:
1. **Epoch budget**: Wider FFN takes 7s/epoch vs ~6s, giving only 45 epochs vs ~49 for the baseline. The model trains for fewer steps.
2. **Intrinsic quality**: Even at similar epochs, the larger FFN may be harder to optimize within the 5-minute budget. More parameters in the FFN = more gradient steps needed to find good weights.

With slice_num=4, there are only 4 slice prototypes driving the attention. The FFN after attention is expected to do heavy lifting, but doubling its width here made things worse — the model needs more time to benefit from the additional capacity.

### Implementation notes

Changed mlp_ratio from 2 to 4 and MAX_EPOCHS from 50 to 60. Added F import and Huber loss as in other slice experiments.

### Suggested follow-ups

- **Accept mlp_ratio=2 for slice experiments**: The extra capacity of ratio=4 doesn't pay off in the 5-minute budget.
- **Try mlp_ratio=3 as intermediate**: Less capacity increase, possibly a sweet spot.
- **Combine slice4 + mlp_ratio=2 + other gains**: The slice4 baseline (42.8) is better than slice16 (44.59). Focus on tuning around slice4 with mlp_ratio=2.
