### PR TITLE
Huber + slice4 + wd=0

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=60)
 
 
 # --- wandb ---
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

wd=0 was marginal on slice32 (47.9 vs 48.15) but hurt slice16 (56.5 vs 44.59). Testing on slice4 — the most constrained architecture may behave differently.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-slice4-wd0" --wandb_group "slice4-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0 --batch_size 4`

## Baseline
- slice4 + wd=0.0001: surf_p=42.8

---

## Results

**W&B run:** `cwlyj48t` (thorfinn/huber-slice4-wd0, group: slice4-sweep)

| Metric | slice4 + wd=0 (this run) | slice4 + wd=0.0001 (baseline) |
|--------|------------------------|------------------------------|
| surf_Ux MAE | 0.76 | — |
| surf_Uy MAE | 0.39 | — |
| surf_p MAE | **61.0** | **42.8** |
| vol_Ux MAE | 3.75 | — |
| vol_Uy MAE | 1.58 | — |
| vol_p MAE | 101.5 | — |
| Best epoch | 35 | — |
| Peak memory | 3.6 GB | — |
| val_loss | 0.0319 | — |

**What happened:**

wd=0 dramatically hurts slice4: surf_p degrades from 42.8 to 61.0 (+43%). This is the strongest weight decay sensitivity observed in this sweep, and it's the opposite direction from slice32 (where wd=0 was marginally better). 

The pattern across slice_num values is now clear: **weight decay becomes increasingly important as slice_num decreases**. With slice4, the attention bottleneck is so extreme that without regularization the model overfits badly. The wd=0.0001 constraint keeps slice4's aggressive partitioning from collapsing into degenerate solutions.

**Suggested follow-ups:**
- Confirm the wd=0.0001 result for slice4 (42.8) with a re-run — it is the best result observed and weight decay is critical
- Try higher wd values for slice4 (wd=0.001, wd=0.01) to see if more regularization helps further