### PR TITLE
Huber + slice4 + n_hidden=64 (smaller → faster epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -64,10 +64,10 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
+    n_hidden=64,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

n_hidden=128 may be overkill for slice4 (only 4 attention tokens). Halving to n_hidden=64 reduces parameter count ~4x, potentially giving faster epoch times and more epochs in 5 min. If the model capacity isn't the bottleneck, surf_p could improve via more training steps.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, **n_hidden=64**, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent nezuko --wandb_name "nezuko/huber-slice4-nhidden64" --wandb_group "slice4-arch" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + n_hidden=128: surf_p=42.8

---

## Results

**W&B run ID:** 3kgdga18

**Config:** n_hidden=64, n_layers=1, slice_num=4, Huber(delta=0.01), lr=0.006, sw=25

| Metric | This run | Baseline (n_hidden=128) |
|--------|----------|------------------------|
| val/loss | 0.0249 | — |
| surf Ux MAE | 0.58 | — |
| surf Uy MAE | 0.33 | — |
| surf p MAE | **45.1** | **42.8** |
| vol Ux MAE | 3.60 | — |
| vol Uy MAE | 1.51 | — |
| vol p MAE | 90.5 | — |
| Peak VRAM | 1.8 GB | — |
| Epochs | 60/60 | — |
| Wall time | 3.9 min | — |

**What happened:** n_hidden=64 is slightly *worse* than n_hidden=128 on surf_p (45.1 vs 42.8). The run completed all 60 epochs cleanly in 3.9 min (~4s/epoch), confirming the smaller model is indeed faster. However, the reduced capacity hurt performance — model width matters more than extra epochs at this budget. The hypothesis that the model was oversized for 4 attention tokens does not hold: n_hidden=128 better captures the complexity even with slice_num=4.

**Suggested follow-ups:**
- Keep n_hidden=128 as the standard for slice4 experiments
- If epoch speed is still a bottleneck, try slice_num=2 (even fewer attention tokens) with n_hidden=128
- Consider whether the n_head=4 is too many heads for only 4 slices (n_head=4 means each head sees 1 slice — may be fine or may benefit from n_head=2)