### PR TITLE
Huber + slice4 + mlp_ratio=1 (smaller FFN → faster)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,10 +65,10 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
-    mlp_ratio=2,
+    slice_num=4,
+    mlp_ratio=1,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

mlp_ratio=2 gives FFN dim=256. With slice4's minimal attention, reducing FFN to mlp_ratio=1 (FFN=128) cuts FFN compute in half. If attention (not FFN) is the representation bottleneck at 4 slices, this won't hurt quality but may speed up epochs.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, **mlp_ratio=1**
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent alphonse --wandb_name "alphonse/huber-slice4-mlpratio1" --wandb_group "slice4-arch" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + mlp_ratio=2: surf_p=42.8

---

## Results

**W&B Run ID**: `k1h3zsqt`

**Best epoch**: 36 (~7s/epoch, ~38 epochs before timeout)

| Metric | This run (mlp_ratio=1) | slice4 mlp_ratio=2 baseline |
|--------|------------------------|----------------------------|
| val/loss | 0.0291 | — |
| surf_p | **56.0** | **42.8** |
| surf_Ux | 0.66 | — |
| surf_Uy | 0.37 | — |
| vol_Ux | 3.56 | — |
| vol_Uy | 1.50 | — |
| vol_p | 96.2 | — |
| Peak VRAM | 3.1 GB | — |

**What happened**: Negative result. mlp_ratio=1 (surf_p=56.0) is significantly worse than mlp_ratio=2 (42.8). The hypothesis that FFN is not the representation bottleneck at 4 slices is contradicted — cutting FFN capacity by half leads to a 31% degradation in surface pressure MAE.

Speed benefit is minor: ~7s/epoch vs ~8s/epoch (only 12% faster), while quality degrades substantially. The trade-off is clearly unfavorable. FFN capacity does matter even with small slice_num — the model needs the wider FFN to compensate for having few attention slices.

**Suggested follow-ups**:
- Keep mlp_ratio=2 as the default for slice4. The FFN is doing real work.
- If speed is desired, reducing slice_num further would hurt quality even more. The slice4 + mlp_ratio=2 combination is already a well-tuned minimal config.
- Explore whether mlp_ratio=4 improves quality by giving more FFN capacity.
