### PR TITLE
Huber + slice4 + n_head=8 (more heads, finer attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=8,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

n_head=4 with slice4 gives 1 slice per head. n_head=8 gives 0.5 slices per head — each head manages a sub-slice. More heads = more attention diversity on the same 4 basis tokens. dim_per_head = 128/8 = 16, which is small but viable.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=8**, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `--lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + n_head=4: surf_p=42.8

---

## Results

**W&B run ID:** `ugtfveaf`
**Best epoch:** 51 (hit 5-min wall-clock timeout; still improving rapidly)
**Peak memory:** 3.6 GB

| Metric | This run (n_head=8) | Baseline (n_head=4) | Delta |
|--------|---------------------|---------------------|-------|
| surf_Ux | 0.56 | ~0.57 | marginally better |
| surf_Uy | 0.31 | 0.32 | marginally better |
| surf_p | 42.2 | 42.8 | -1.4% better |
| vol_p | 75.6 | ~84.1 | -10% better |
| val_loss | 0.0230 | 0.0237 | -3% better |

**What happened:** n_head=8 is the new best config overall. surf_p=42.2 beats the slice4+n_head=4 runs (42.8 and 43.3). The volume metrics are notably better: vol_p dropped from ~84 to 75.6. This makes sense — more attention heads on 4 slice tokens gives each head more specialized processing capacity, especially for volume predictions.

The epoch-51 trajectory shows the model was still dropping surf_p aggressively (48.2 → 47.1 → 46.5 → 43.5 → 42.2 in the last 5 epochs). More training time would likely push it below 40.

**Suggested follow-ups:**
- Combine n_head=8 + wd=0 (consistent improvement in other configs)
- Try n_head=8 + beta1=0.95
- Try n_head=16 (4 heads per slice, dim_per_head=8 — may be too small but worth testing)
- The rapid late-stage improvement suggests the cosine LR decay helps — try a longer run or smaller T_max to keep LR higher longer