### PR TITLE
Huber + slice4 + n_layers=2 (depth on fast arch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=2,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Earlier n_layers=2 experiments at slice64 were too slow (13s/epoch → only 23 epochs). With slice4, the attention is ~16x cheaper. Adding a second layer might cost only +1-2s/epoch, giving ~42-45 epochs with much more representational power.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: **n_layers=2**, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run with lr=0.006, surf_weight=25

## Baseline
- slice4 + n_layers=1: surf_p=42.8 (52 epochs, ~6s/epoch)
- slice64 + n_layers=2: surf_p=119.4 (23 epochs, ~13s/epoch — too slow)

---

## Results

**W&B run:** `e8onn8go`
**Epochs completed:** 22 / 60 (5-min wall-clock limit)
**Peak memory:** 5.7 GB

| Config | surf_p | surf_Ux | surf_Uy | vol_p | epochs | epoch_time |
|--------|--------|---------|---------|-------|--------|------------|
| slice4, n_layers=1 (baseline) | 42.8 | — | — | — | 52 | ~6s |
| **slice4, n_layers=2 (this run)** | **75.8** | **1.06** | **0.46** | **119.8** | **22** | **~13s** |

**What happened:** The hypothesis was wrong — epoch time is still ~13s with n_layers=2 regardless of slice_num. The original slow experiment with slice64+n_layers=2 was 13s/epoch because of the depth, not the slice count. Reducing slice_num from 64 to 4 gave essentially no speedup for a 2-layer model.

As a result, only 22 epochs completed vs 52 for the 1-layer baseline. The model is severely under-trained (not enough epochs to converge), and surf_p=75.8 is almost twice the baseline 42.8.

This confirms a key finding: **the bottleneck with n_layers>1 is NOT the attention computation but something deeper in the 2-layer forward pass** (likely the MLP layers or data movement). Halving slice_num from 64→4 (16x less attention work) only saves ~0s/epoch in the 2-layer case.

**Suggested follow-ups:**
- Accept that n_layers=1 is the only viable depth under 5-min budget with current architecture
- For more capacity: explore n_hidden variations (128→192, 256) with n_layers=1 — wider is cheaper than deeper
- Profile the model forward pass to understand where the 13s/epoch comes from (MLP vs attention)