### PR TITLE
Huber + slice4 + batch_size=2 (more gradient steps)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

With bs=4, we get ~203 steps/epoch. With bs=2, we get ~406 steps/epoch — 2x more gradient updates. Each update is noisier, but Huber loss already stabilizes gradients. If the data loading bottleneck is per-batch (not per-sample), epoch time might increase, but total gradient steps in 5 min could be higher.

Key: if data loading is the bottleneck and it's per-epoch (not per-batch), bs=2 won't help. If per-batch overhead is small, bs=2 gives 2x more gradient signal.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent fern --wandb_name "fern/huber-slice4-bs2" --wandb_group "slice4-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 2`

Note: lr stays at 0.006 (no linear scaling — the intent is more noisy updates, not equivalent batch gradient).

## Baseline
- slice4 + bs=4: surf_p=42.8 (52 epochs, ~203 steps/epoch)

---

## Results

**W&B run:** `94e97o52` (fern/huber-slice4-bs2, group: slice4-sweep)

**Config:** lr=0.006, surf_weight=25, Huber delta=0.01, slice_num=4, n_layers=1, n_hidden=128, n_head=4, mlp_ratio=2, wd=0.0001, bs=2, MAX_EPOCHS=60

| Metric | bs=2 slice4 (ep 27) | bs=4 slice4 baseline (ep 52) |
|---|---|---|
| val_loss | 0.0347 | — |
| Surface Ux MAE | 0.82 | — |
| Surface Uy MAE | 0.41 | — |
| Surface p MAE | **65.2** | **42.8** |
| Volume Ux MAE | 3.89 | — |
| Volume Uy MAE | 1.62 | — |
| Volume p MAE | 103.6 | — |
| Best epoch | 27 / 27 | 52 |
| Epoch time | 8.5s | ~5.7s |
| Steps/epoch | 405 | 203 |

### What happened

bs=2 substantially underperforms bs=4 (surf_p 65.2 vs 42.8). The key finding: **epoch time did not decrease** — it's 8.5s with bs=2 vs ~5.7s with bs=4. This means total gradient steps in 5 minutes are actually *fewer* with bs=2 (27 epochs × 405 steps = 10,935 steps) compared to bs=4 (52 epochs × 203 steps = 10,556 steps) — roughly comparable step count but significantly fewer epochs completed.

The problem: the 5-min budget is governed by epochs, not steps. With bs=2, each epoch takes 8.5s instead of 5.7s, so we get 27 epochs instead of 52. The noisier gradients from bs=2 don't compensate for seeing the data fewer times.

**Verdict:** bs=2 is detrimental for the 5-minute budget. bs=4 reaches 52 epochs and gets surf_p=42.8; bs=2 only reaches 27 epochs and gets surf_p=65.2. Stick with bs=4.

### Suggested follow-ups
- bs=8 might be worth trying — fewer steps/epoch but faster epoch time could give more epochs
- The limiting factor is data loading per epoch, not per batch