### PR TITLE
Huber + slice4 + n_hidden=96 (slightly smaller model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -64,10 +65,10 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
+    n_hidden=96,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

n_hidden=64 may underfit, n_hidden=128 may be overkill for 4 slices. Testing n_hidden=96 — a ~25% reduction that preserves reasonable capacity while potentially speeding up epochs. With n_head=4, dim_per_head=24 which is still workable.

## Instructions

Huber (delta=0.01) in both loops. n_layers=1, n_hidden=96, n_head=4, slice_num=4, mlp_ratio=2. MAX_EPOCHS=60, T_max=60.

## Baseline
- slice4 + n_hidden=128: surf_p=42.8

---

## Results

**W&B run ID:** gzwz08ad

**Best epoch:** 60 (completed all 60 epochs — within 5-minute budget!)

| Metric | n_hidden=96 | n_hidden=128 (baseline) | Delta |
|---|---|---|---|
| surf_p | 43.63 | **42.8** | +1.9% (marginally worse) |
| surf_Ux | 0.57 | — | — |
| surf_Uy | 0.32 | — | — |
| vol_p | 88.5 | — | — |
| val_loss | **0.0240** | — | — |

**Peak memory:** ~2.6 GB (down from ~3.7 GB at n_hidden=128 — 30% reduction)
**Epoch time:** ~5s (down from ~6s at n_hidden=128)
**Epochs completed:** 60/60 (all epochs! vs ~49-55 for n_hidden=128)

### What happened

n_hidden=96 is **competitive with the baseline** — only 2% worse on surf_p, while being significantly lighter and faster:
- 30% less memory (2.6 vs 3.7 GB)
- 17% faster epochs (5s vs 6s)
- Ran all 60 epochs vs fewer epochs for n_hidden=128

The smaller model compensates for its lower capacity by training for more epochs within the 5-minute budget. val_loss=0.0240 is actually better than the slice16+sw25 result (0.0248), suggesting good overall convergence.

This suggests n_hidden=128 may be slightly over-parameterized for this slice/data combination. The 96→128 capacity increase doesn't fully justify the added compute cost.

### Implementation notes

Changed n_hidden from 128 to 96, n_layers from 5 to 1, slice_num from 64 to 4, MAX_EPOCHS from 50 to 60.

### Suggested follow-ups

- **Try n_hidden=80 or 64**: If 96 is close to 128, maybe 80 or 64 achieves similar results with even faster epochs.
- **Combine n_hidden=96 with lr or wd tuning**: If this is near-optimal capacity, fine-tune the optimization.
- **Run n_hidden=128 vs 96 at fixed epoch count (e.g., 55)**: To compare capacity intrinsically, not just epoch budget.
