### PR TITLE
slice4 + nhead8 rerun: reproducibility check

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=8,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

nhead=8 + slice4 gave surf_p=42.2 (NEW BEST). Must verify reproducibility — the slice sweep is noisy due to GPU contention.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=8**, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent edward --wandb_name "edward/huber-slice4-nhead8-rerun" --wandb_group "nhead8-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead8 (first run): surf_p=42.2 (51 epochs)
- slice4 + nhead4 (baseline): surf_p=42.8/43.3

---

## Results

**W&B run:** https://wandb.ai/capecape/senpai/runs/pwy14d69

| Metric | Rerun (nhead8) | First run (nhead8) | Baseline (nhead4) |
|--------|---------------|-------------------|-------------------|
| val/loss | 0.0349 | — | — |
| surf_Ux MAE | 0.74 | — | — |
| surf_Uy MAE | 0.47 | — | — |
| **surf_p MAE** | **66.2** | **42.2** | **42.8** |
| vol_Ux MAE | 3.78 | — | — |
| vol_Uy MAE | 1.66 | — | — |
| vol_p MAE | 113.9 | — | — |
| Peak VRAM | 3.6 GB | — | — |
| Best epoch | 30 / 31 (5.0 min) | 51 epochs | ~37 epochs |
| Epoch time | ~9s | ~6s | ~8s |

**What happened:** **Not reproducible.** The first nhead8 run achieved surf_p=42.2 under lower GPU contention (~6s/epoch, ~51 epochs). This rerun ran under heavy contention (~9s/epoch), only completing 31 epochs, and achieved surf_p=66.2 — substantially worse.

The 42.2 result appears to be a lucky outlier from favorable training conditions (fewer competing processes, more epochs to converge). With equivalent contention to other experiments, nhead8 does not reliably outperform nhead4.

**Conclusion:** nhead4 + slice4 + sw=25 remains the best verified configuration at surf_p=42.8. The nhead8 advantage is not robust to training conditions and should not be treated as a real improvement.

**Suggested follow-ups:**
- Accept nhead4 + slice4 + sw=25 as the current best (surf_p=42.8)
- Explore architecture changes: n_layers=2, or n_hidden=256 to increase model capacity
- Try larger batch_size (8) to potentially improve gradient estimates and convergence speed