### PR TITLE
slice4 + nhead=16: extreme head diversity

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=16,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=60)
 
 
 # --- wandb ---
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

nhead8 beat nhead4 on slice4. nhead16 pushes further — 4 heads per slice token, dim_per_head=128/16=8. Very small per-head dimension, but with only 4 slices the attention computation is trivial. If more heads = better specialization, 16 might work. Risk: dim=8 per head may be too small.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=16**, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-slice4-nhead16" --wandb_group "nhead-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead8: surf_p=42.2
- slice4 + nhead4: surf_p=42.8

---

## Results

**W&B run:** `5niwovzh` (thorfinn/huber-slice4-nhead16, group: nhead-sweep)

| Metric | nhead=16 (this run) | nhead=8 (baseline) | nhead=4 |
|--------|--------------------|--------------------|---------|
| surf_Ux MAE | 0.90 | — | — |
| surf_Uy MAE | 0.48 | — | — |
| surf_p MAE | **77.6** | **42.2** | **42.8** |
| vol_Ux MAE | 4.45 | — | — |
| vol_Uy MAE | 1.80 | — | — |
| vol_p MAE | 119.8 | — | — |
| Best epoch | 21 | — | — |
| epoch_time | ~13s | ~8s | ~8s |
| Peak memory | 3.7 GB | — | — |
| val_loss | 0.0399 | — | — |

**What happened:**

n_head=16 is severely worse: surf_p=77.6 vs 42.2 for nhead=8. Two compounding problems:
1. **Too slow**: epoch time jumped from ~8s to ~13s — only 21 epochs vs ~37 for nhead=8, putting it at a significant training budget disadvantage
2. **Per-head dimension too small**: dim_per_head = 128/16 = 8 is insufficient for meaningful representation

The head count sweet spot appears to be nhead=8 for slice4. nhead=4 and nhead=8 were close (42.8 vs 42.2) but nhead=16 falls off a cliff.

**Suggested follow-ups:**
- nhead=8 appears to be the optimal for slice4; confirm with a re-run
- The n_head limit where performance degrades is somewhere between 8 and 16 — could try nhead=12 if interested, but the return is likely minimal