### PR TITLE
slice4 + nhead8 + sw=30: test sw on new best arch

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=8,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

sw=30 hurt slice4+nhead4 (54.3 vs 42.8). But nhead8 has more attention capacity — it may handle higher surface emphasis better. Testing if sw=30 helps the nhead8 config where it hurt nhead4.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=8**, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent nezuko --wandb_name "nezuko/huber-slice4-nhead8-sw30" --wandb_group "nhead8-sweep" --lr 0.006 --surf_weight 30.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead8 + sw=25: surf_p=42.2

---

## Results

**W&B run ID:** fwpvp3m9

**Config:** n_hidden=128, n_layers=1, n_head=8, slice_num=4, Huber(delta=0.01), lr=0.006, sw=30

| Metric | This run (sw=30) | Baseline (sw=25) |
|--------|-----------------|-----------------|
| val/loss | 0.0287 | — |
| surf Ux MAE | 0.61 | — |
| surf Uy MAE | 0.31 | — |
| surf p MAE | **44.7** | **42.2** |
| vol Ux MAE | 3.45 | — |
| vol Uy MAE | 1.42 | — |
| vol p MAE | 83.8 | — |
| Peak VRAM | 3.6 GB | — |
| Epochs | 51/60 (timeout) | — |
| Wall time | 5.1 min | — |

**What happened:** sw=30 hurts nhead8 too — surf_p=44.7 vs baseline 42.2 with sw=25. The hypothesis that nhead8's higher attention capacity would allow it to tolerate heavier surface weighting did not hold. The pattern is consistent: for this architecture, sw=25 is better than sw=30 regardless of n_head. Higher surface weight appears to distort the optimization landscape enough to hurt convergence, even when the model has more capacity.

**Suggested follow-ups:**
- Try sw=20 for nhead8 (check if the optimum is below 25)
- Confirm sw=25 as the best for the nhead8+slice4 config and move on to other hyperparameters
- Explore lr tuning for nhead8+slice4 (current best uses lr=0.006, could try lr=0.004 or 0.008)