### PR TITLE
slice4 + nhead8 + lr=0.005: slightly lower LR

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=8,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

The nhead8 model was still improving rapidly at epoch 51 (surf_p dropped from 48→42 in last 5 epochs). A slightly lower LR (0.005) may allow better fine-tuning in late epochs. The cosine schedule with T_max=60 and lr=0.005 gives a gentler decay that may reach a better minimum.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=8**, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `--lr 0.005 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead8 + lr=0.006: surf_p=42.2

---

## Results

**W&B run ID:** `1df24lfs`
**Best epoch:** 51 (hit 5-min timeout)
**Peak memory:** 3.6 GB

| Metric | This run (lr=0.005) | Baseline (lr=0.006) | Delta |
|--------|---------------------|---------------------|-------|
| surf_Ux | 0.61 | 0.56 | +9% worse |
| surf_Uy | 0.32 | 0.31 | +3% worse |
| surf_p | 47.2 | 42.2 | +12% worse |
| vol_p | 87.7 | 75.6 | +16% worse |
| val_loss | 0.0253 | 0.0230 | +10% worse |

**What happened:** Lower lr=0.005 is strictly worse than lr=0.006 on all metrics. The model converges more slowly and doesn't reach as good a solution in the same number of epochs. surf_p=47.2 vs 42.2 is a clear regression.

The hypothesis was that slower LR would fine-tune better in late epochs, but with only 51 epochs in 5 minutes, the model needs the higher LR to learn fast enough. lr=0.006 is confirmed as the better choice for this architecture and training budget.

**Suggested follow-ups:**
- lr=0.006 is the sweet spot for nhead8+slice4 — don't go lower
- Consider lr warmup: start from lr=0.001 for 5 epochs, then cosine from lr=0.006 (might help avoid early instability)
- The lr=0.006 run was still improving rapidly at epoch 51 — focus on getting more epochs rather than tuning LR