### PR TITLE
slice4 + nhead8 + nhidden96 (fast + best heads)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -64,10 +65,10 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_hidden=96,
+    n_layers=1,
+    n_head=8,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

nhead8+slice4 gave surf_p=42.2 (best). nhidden96+slice4 gave 43.63 (competitive, but 17% faster at ~5s/epoch). Combining: nhidden96 with nhead8 gives dim_per_head=96/8=12 (small but viable for 4 slices). If the speed gain from nhidden96 compensates, more epochs may push surf_p lower.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, **n_hidden=96**, **n_head=8**, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run with lr=0.006, surf_weight=25

## Baseline
- slice4 + nhead8 + nhidden128: surf_p=42.2 (51 epochs)
- slice4 + nhead4 + nhidden96: surf_p=43.63 (60 epochs, ~5s/epoch)

---

## Results

**W&B run:** `6th0ae0s`
**Epochs completed:** 35 (best at ep 35) / ~37 total (5-min wall-clock limit)
**Peak memory:** 2.7 GB

| Config | surf_p | surf_Ux | surf_Uy | vol_p | epochs | epoch_time |
|--------|--------|---------|---------|-------|--------|------------|
| slice4, nhead8, nhidden128 (baseline) | 42.2 | — | — | — | 51 | ~6s |
| slice4, nhead4, nhidden96 (baseline) | 43.63 | — | — | — | 60 | ~5s |
| **slice4, nhead8, nhidden96 (this run)** | **60.4** | **0.72** | **0.38** | **91.0** | **35** | **~8s** |

**What happened:** The combo of n_head=8 + n_hidden=96 is considerably worse than either individual component (60.4 vs 42.2 and 43.63). The dim_per_head=96/8=12 is too small to represent meaningful attention patterns. The speed gain from nhidden96 did not materialize — epoch time was ~8s, not ~5s, because n_head=8 adds overhead that cancels out the nhidden reduction.

The key constraint is that for n_head=8 to work, n_hidden must be divisible by 8 AND provide at least ~16 dims per head. n_hidden=96 gives only 12 dims/head — below the threshold where attention is informative. By contrast, n_hidden=128 with n_head=8 gives 16 dims/head, which is just barely viable.

**Suggested follow-ups:**
- The sweet spot is nhead8+nhidden128 (42.2) — don't reduce nhidden below 128 when using nhead=8
- Try increasing nhidden above 128 (e.g. 160, 192) with nhead=8+slice4 to add capacity
- Accept slice4+nhead8+nhidden128 as the current best and explore other dimensions (LR, loss, regularization)