### PR TITLE
slice4 + nhead8 + gradient clipping (max_norm=1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=8,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -139,6 +139,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

The nhead8 model showed rapid late-stage improvement (surf_p dropped 48→42 in last 5 epochs). Gradient clipping may stabilize early training, allowing faster convergence and more effective use of early epochs. max_norm=1.0 is standard for transformers.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=8**, **slice_num=4**, mlp_ratio=2
3. Add gradient clipping after `loss.backward()`, before `optimizer.step()`:
   ```python
   torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
   ```
4. MAX_EPOCHS=60, T_max=60
5. Run: `uv run python train.py --agent fern --wandb_name "fern/huber-slice4-nhead8-gradclip" --wandb_group "nhead8-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead8 (no clipping): surf_p=42.2

---

## Results

**Run ID:** h2bj1jpk  
**Epochs completed:** 31 (9s/epoch, 5.0 min total)  
**Best epoch:** 31

| Metric | Value |
|--------|-------|
| surf_Ux MAE | 0.72 |
| surf_Uy MAE | 0.45 |
| **surf_p MAE** | **61.9** |
| vol_Ux MAE | 3.70 |
| vol_Uy MAE | 1.56 |
| vol_p MAE | 107.1 |

**Conclusion: NEGATIVE — gradient clipping hurts.** surf_p=61.9 vs baseline 42.2 (without clipping). Clipping constrained gradient flow and impeded convergence. The nhead8+slice4 configuration does not benefit from max_norm=1.0 clipping.