### PR TITLE
slice4 + nhead8 + 3-epoch warmup (stabilize early)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=8,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +81,16 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+    optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs
+)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+    optimizer, T_max=max(1, MAX_EPOCHS - warmup_epochs)
+)
+scheduler = torch.optim.lr_scheduler.SequentialLR(
+    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_epochs]
+)
 
 
 # --- wandb ---
@@ -128,7 +138,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +180,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

The nhead8 model improved rapidly in late epochs (48→42 in last 5). If early epochs are wasted on unstable gradients, a 3-epoch warmup from lr/10→lr could accelerate the entire trajectory, reaching lower surf_p at epoch 51.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, **n_head=8**, **slice_num=4**, mlp_ratio=2
3. Replace scheduler with SequentialLR:
   ```python
   warmup_epochs = 3
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
       optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs
   )
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
       optimizer, T_max=MAX_EPOCHS - warmup_epochs
   )
   scheduler = torch.optim.lr_scheduler.SequentialLR(
       optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_epochs]
   )
   ```
4. MAX_EPOCHS=60, T_max=60
5. Run: `uv run python train.py --agent tanjiro --wandb_name "tanjiro/huber-slice4-nhead8-warmup3" --wandb_group "nhead8-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead8 (no warmup): surf_p=42.2

---

## Results

**W&B run**: rztfbyes  
**Best epoch**: 31 (stopped at wall-clock 5.1 min)  
**Epoch time**: 9s  
**Peak memory**: 3.6 GB  

| Metric | This run | Baseline (no warmup) |
|--------|----------|----------------------|
| val/loss | 0.0373 | — |
| surf_Ux | 0.89 | — |
| surf_Uy | 0.46 | — |
| surf_p | **70.2** | **42.2** |
| vol_Ux | 4.05 | — |
| vol_Uy | 1.77 | — |
| vol_p | 110.6 | — |

**What happened**: The warmup hurt rather than helped. With n_head=8 and n_hidden=128, each epoch takes ~9s, giving only ~31 epochs in the 5-minute budget. The 3-epoch warmup uses reduced LR (0.0006→0.006) during early training, slowing initial convergence. The baseline without warmup already converges well at lr=0.006 from epoch 1, and with the same epoch budget it reaches surf_p=42.2. The warmup model at epoch 31 is still at surf_p=70.2, far behind. The convergence curve is still declining (70.2 at epoch 31 vs 87.3 at epoch 20), so more epochs would help, but within the 5-minute budget the warmup is strictly harmful — it delays learning for no benefit at this learning rate.

**Suggested follow-ups**:
- Try a much shorter warmup (1 epoch instead of 3) to minimize the cost of the ramp-up phase
- Try a cosine warmup schedule (starts faster than linear) 
- The nhead8 model without warmup seems to converge well — the real bottleneck is epoch budget, not instability. Consider whether faster architectures (smaller n_hidden) could fit more epochs per budget
