### PR TITLE
slice4 + nhead4 rerun #3: variance estimation

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

We need more data points on slice4+nhead4 to estimate the true mean and variance under GPU contention. Prior runs: 42.8 and 43.3. A third run helps establish confidence bounds.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent edward --wandb_name "edward/huber-slice4-nhead4-rerun2" --wandb_group "variance-check" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- Run 1: surf_p=42.8, Run 2: surf_p=43.3 → mean=43.05, spread=0.5

---

## Results

**W&B run:** https://wandb.ai/capecape/senpai/runs/a7yyxyac

| Metric | Run 3 | Run 1 | Run 2 |
|--------|-------|-------|-------|
| val/loss | 0.0301 | — | — |
| surf_Ux MAE | 0.75 | — | — |
| surf_Uy MAE | 0.39 | — | — |
| **surf_p MAE** | **55.9** | **42.8** | **43.3** |
| vol_Ux MAE | 3.34 | — | — |
| vol_Uy MAE | 1.48 | — | — |
| vol_p MAE | 88.0 | — | — |
| Peak VRAM | 3.6 GB | — | — |
| Best epoch | 37 / 37 (5.0 min) | — | — |
| Epoch time | ~8s | ~8s | ~8s |

**3-run statistics for slice4+nhead4+sw=25:**
- Values: 42.8, 43.3, 55.9
- Mean: **47.3**
- Std: **7.3**
- Min: 42.8, Max: 55.9

**What happened:** High variance confirmed. Run 3 (surf_p=55.9) is substantially worse than runs 1 and 2 (42.8, 43.3) despite identical hyperparameters and epoch count (~37 epochs, ~8s/epoch). The variance is driven by random seed and stochastic training dynamics under GPU contention — not just epoch count.

**Implication for comparisons:** Any single experiment comparison within ~14 surf_p units (2 std) is not statistically reliable. Only differences larger than ~15 units should be treated as meaningful. The nhead8 rerun at 66.2 is confidently worse (>2σ from 47.3 mean). The baseline best of 42.8 may reflect a lucky draw rather than a stable result.

**Suggested follow-ups:**
- Use the mean (47.3) as the more reliable baseline, not the best (42.8)
- Any new config needs to beat 42-45 range consistently to be considered better
- Consider architectural changes (n_layers=2, n_hidden=256) which may create larger, more signal-clear improvements