### PR TITLE
slice4 + nhead4 + lr=0.005: lower LR on best nhead

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=60)
 
 
 # --- wandb ---
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

lr=0.005 hurt nhead8 (47.2 vs 42.2), but nhead8 results are noisy. Testing on the reliable nhead4 config. If contention gives fewer epochs, lower LR may converge to a better minimum in a shorter training window.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent thorfinn --wandb_name "thorfinn/huber-slice4-nhead4-lr005" --wandb_group "slice4-lr-sweep" --lr 0.005 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead4 + lr=0.006: surf_p=42.8/43.3

---

## Results

**W&B run:** `owoir2z1` (thorfinn/huber-slice4-nhead4-lr005, group: slice4-lr-sweep)

| Metric | lr=0.005 (this run) | lr=0.006 (baseline) |
|--------|--------------------|--------------------|
| surf_Ux MAE | 0.64 | — |
| surf_Uy MAE | 0.35 | — |
| surf_p MAE | **54.3** | **42.8** |
| vol_Ux MAE | 3.21 | — |
| vol_Uy MAE | 1.35 | — |
| vol_p MAE | 84.5 | — |
| Best epoch | 36 | — |
| epoch_time | ~8s | ~8s |
| Peak memory | 3.6 GB | — |
| val_loss | 0.0277 | — |

**What happened:**

lr=0.005 is worse than lr=0.006 for slice4+nhead4 (surf_p 54.3 vs 42.8, +27%). The lower learning rate results in less surface pressure accuracy despite similar epoch counts (~36 vs ~37 for baseline). This confirms that lr=0.006 is well-tuned for this configuration and going lower hurts convergence within the 5-minute budget.

**Suggested follow-ups:**
- lr=0.006 appears to be the optimal or near-optimal learning rate for slice4 configs
- Could try lr=0.007 or lr=0.008 to test whether going slightly higher helps