### PR TITLE
slice4 + nhead4 + 3-epoch warmup

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,10 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+warmup_sched = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs)
+cosine_sched = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - warmup_epochs)
+scheduler = torch.optim.lr_scheduler.SequentialLR(optimizer, schedulers=[warmup_sched, cosine_sched], milestones=[warmup_epochs])
 
 
 # --- wandb ---
@@ -128,7 +131,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +173,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Testing warmup on the verified best config (nhead4+slice4). Warmup may stabilize early training, allowing the model to start converging earlier rather than wasting the first few epochs on random gradient directions.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. Replace scheduler:
   ```python
   warmup_epochs = 3
   warmup_sched = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_epochs)
   cosine_sched = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - warmup_epochs)
   scheduler = torch.optim.lr_scheduler.SequentialLR(optimizer, schedulers=[warmup_sched, cosine_sched], milestones=[warmup_epochs])
   ```
4. MAX_EPOCHS=60, T_max=60
5. Run: `uv run python train.py --agent alphonse --wandb_name "alphonse/huber-slice4-nhead4-warmup3" --wandb_group "slice4-schedule" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead4 + no warmup: surf_p=42.8/43.3

---

## Results

**W&B Run ID**: `b8syoldo`

**Best epoch**: 37 (~8s/epoch, timeout at 5 min)

| Metric | This run (warmup=3) | slice4 nhead4 no warmup |
|--------|---------------------|------------------------|
| val/loss | 0.0342 | — |
| surf_p | **63.9** | **42.8** |
| surf_Ux | 0.79 | — |
| surf_Uy | 0.45 | — |
| vol_Ux | 3.88 | — |
| vol_Uy | 1.66 | — |
| vol_p | 98.4 | — |
| Peak VRAM | 3.6 GB | — |

**What happened**: Strong negative result. The 3-epoch linear warmup (surf_p=63.9) is 49% worse than no warmup (42.8). The warmup is actively harmful.

Likely reasons:
1. **Timeout bottleneck**: With only ~37 epochs available in 5 minutes, starting at 10% LR for 3 epochs "wastes" capacity. No-warmup starts at full LR immediately and converges faster in the early epochs.
2. **LR already suitable**: lr=0.006 appears stable from epoch 1 (no gradient explosion without warmup), so the warmup constraint is unnecessary overhead.
3. **SequentialLR interaction**: The cosine schedule runs over 57 epochs instead of 60, slightly reducing the effective time at high LR.

**Suggested follow-ups**:
- Warmup is clearly harmful under the 5-minute timeout constraint. Skip warmup in future experiments.
- If experiments could run longer (e.g. 200+ epochs), warmup might be beneficial. But within the constraint, direct cosine from epoch 1 is better.
