### PR TITLE
slice4 + nhead4 + gradient clipping (max_norm=1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -139,6 +139,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

Gradient clipping is standard for transformers and costs zero compute. With Huber loss + slice4, some batches may still produce large gradients from outlier surface nodes. Clipping at max_norm=1.0 may stabilize training and improve convergence efficiency.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, **slice_num=4**, mlp_ratio=2
3. Add `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)` after `loss.backward()`, before `optimizer.step()`
4. MAX_EPOCHS=60, T_max=60
5. Run: `--lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + nhead4 + no clipping: surf_p=42.8/43.3

---

## Results

**W&B run ID:** `wz1k2x5u`
**Best epoch:** 52 (hit 5-min timeout)
**Peak memory:** 3.6 GB

| Metric | This run (grad_clip=1.0) | Baseline (no clip) | Delta |
|--------|--------------------------|--------------------|-------|
| surf_Ux | 0.59 | ~0.57 | worse |
| surf_Uy | 0.33 | ~0.32 | worse |
| surf_p | 47.2 | 42.8 | +10% worse |
| vol_p | 79.8 | ~84.1 | slightly better |
| val_loss | 0.0251 | 0.0237 | +6% worse |

**What happened:** Gradient clipping at max_norm=1.0 hurts surface metrics. surf_p=47.2 vs 42.8 without clipping. The clipping is too aggressive — it restricts the optimizer's ability to take large steps when needed, slowing convergence. With only 52 epochs in 5 minutes, the model needs those larger gradient steps to make progress on surface pressure.

Interestingly, vol_p improved slightly (79.8 vs 84.1), suggesting clipping might help the volume prediction while hurting the surface prediction. This could be because volume nodes have more outlier gradients that benefit from regularization.

**Suggested follow-ups:**
- Try clip_norm=5.0 or 10.0 (less aggressive clipping that only handles true spikes)
- Do NOT apply clipping to the nhead8 config — it would likely hurt even more given that config already achieves 42.2