### PR TITLE
slice4 + nhead4 + sw=22 (slightly less surface emphasis)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=60)
 
 
 # --- wandb ---
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

sw=25 is optimal for most configs, sw=20 was worse on slice4. Testing sw=22 — a fine-grained probe slightly below 25. If the optimum is sharp at 25, this confirms it. If 22 is marginally better, the true optimum may be between 20-25.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, slice_num=4, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent fern --wandb_name "fern/huber-slice4-nhead4-sw22" --wandb_group "final-sweep" --lr 0.006 --surf_weight 22.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + sw=25: surf_p=42.8, slice4 + sw=20: 46.3, slice4 + sw=30: 54.3

---

## Results

- **W&B run**: go60cg9t
- **Epochs completed**: 37 (5.0 min wall-clock, ~7.6s/epoch)
- **Best epoch**: 37

| Metric | Value |
|--------|-------|
| surf_Ux MAE | 0.72 |
| surf_Uy MAE | 0.39 |
| **surf_p MAE** | **57.3** |
| vol_Ux MAE | 3.52 |
| vol_Uy MAE | 1.47 |
| vol_p MAE | 90.6 |

## Conclusion

**Negative** — sw=22 (surf_p=57.3) is significantly worse than sw=25 (surf_p=42.8). The optimum is not below 25; sw=25 remains the best surface weight found so far.