### PR TITLE
slice4 + nhead4 + Huber delta=0.005 (more L1-like)

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -21,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +129,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.005)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +171,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = F.huber_loss(pred, y_norm, reduction="none", delta=0.005)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

delta=0.005 hurt slice64 (61.2 vs 52.4) but that was at fewer epochs. With slice4's faster epochs (~6s), we get ~52 epochs. Testing if more aggressive L1 behavior helps the simpler architecture converge better.

## Instructions

In `train.py`:
1. Huber loss (**delta=0.005**) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, slice_num=4, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent tanjiro --wandb_name "tanjiro/huber-slice4-nhead4-delta005" --wandb_group "final-sweep" --lr 0.006 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + delta=0.01: surf_p=42.8

---

## Results

**W&B run**: ktagqwwj  
**Best epoch**: 37 (wall-clock stopped at 5.1 min)  
**Epoch time**: 8s  
**Peak memory**: 3.6 GB  

| Metric | This run (delta=0.005) | Baseline (delta=0.01) |
|--------|------------------------|----------------------|
| val/loss | 0.0162 | — |
| surf_Ux | 0.75 | — |
| surf_Uy | 0.38 | — |
| surf_p | **60.1** | **42.8** |
| vol_p | 93.8 | — |

**What happened**: delta=0.005 is worse than delta=0.01. Reducing delta makes the loss more L1-like for smaller errors (the L1 regime kicks in at 0.005 instead of 0.01). The result is slower convergence — at 37 epochs the model is still at surf_p=60.1, well behind the delta=0.01 baseline of 42.8. The convergence curve is still declining, but the more aggressive L1 behavior appears to reduce gradient signal for large errors early in training, where MSE-like gradients (below delta) are more informative. The hypothesis that more L1 behavior helps is not supported.

**Suggested follow-ups**:
- Try delta=0.02 (less L1, more MSE-like) — if delta=0.01 is better than delta=0.005, going slightly higher might further improve convergence
- The key bottleneck is epoch count: 8s/epoch × 5min ≈ 37 epochs. The nhead4 model with delta=0.01 runs at ~6s/epoch. Check whether epoch time difference is significant and what drives it (possibly delta=0.005 causes more instability requiring smaller effective steps)
