### PR TITLE
slice4 + nhead4 + lr=0.0055 (fine LR grid)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 60
 @dataclass
 class Config:
     lr: float = 5e-4
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=4,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -128,7 +128,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -170,7 +170,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            sq_err = torch.nn.functional.huber_loss(pred, y_norm, reduction='none', delta=0.01)
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis

lr=0.006 is optimal, lr=0.005 and lr=0.007 both hurt. Testing lr=0.0055 — halfway between 0.005 and 0.006 — to check if the optimum is exactly at 0.006 or slightly below.

## Instructions

In `train.py`:
1. Huber loss (delta=0.01) in BOTH train and val loops
2. Model config: n_layers=1, n_hidden=128, n_head=4, slice_num=4, mlp_ratio=2
3. MAX_EPOCHS=60, T_max=60
4. Run: `uv run python train.py --agent nezuko --wandb_name "nezuko/huber-slice4-nhead4-lr0055" --wandb_group "final-sweep" --lr 0.0055 --surf_weight 25.0 --weight_decay 0.0001 --batch_size 4`

## Baseline
- slice4 + lr=0.006: surf_p=42.8, lr=0.005 (nhead8): 47.2

---

## Results

**W&B run ID:** m4r4d1n0

**Config:** n_hidden=128, n_layers=1, n_head=4, slice_num=4, Huber(delta=0.01), lr=0.0055, sw=25

| Metric | This run (lr=0.0055) | Baseline (lr=0.006) |
|--------|---------------------|---------------------|
| val/loss | 0.0240 | — |
| surf Ux MAE | 0.58 | — |
| surf Uy MAE | 0.31 | — |
| surf p MAE | **44.7** | **42.8** |
| vol Ux MAE | 3.23 | — |
| vol Uy MAE | 1.30 | — |
| vol p MAE | 82.0 | — |
| Peak VRAM | 3.6 GB | — |
| Epochs | 51/60 (timeout) | — |
| Wall time | 5.1 min | — |

**What happened:** lr=0.0055 is slightly worse than lr=0.006 (surf_p=44.7 vs 42.8). The optimum appears to be exactly at lr=0.006 or above it — lr=0.0055 does not improve on the current best. The LR sensitivity between 0.005 and 0.006 is asymmetric: 0.006 is better than both 0.005 and 0.0055, confirming lr=0.006 as the sweet spot.

**Suggested follow-ups:**
- lr=0.006 is confirmed as optimal for this config; no need for further fine-grained LR search
- Explore other axes: batch_size=8 or 2, or a different scheduler (e.g. OneCycleLR)
- Consider weight decay tuning (currently 1e-4 — could try 5e-5 or 2e-4)