### PR TITLE
OneCycleLR on best MSE config

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -80,7 +80,14 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.OneCycleLR(
+    optimizer,
+    max_lr=0.012,
+    total_steps=MAX_EPOCHS * len(train_loader),
+    pct_start=0.15,
+    div_factor=6,
+    final_div_factor=1000,
+)
 
 
 # --- wandb ---
@@ -140,13 +147,12 @@ for epoch in range(MAX_EPOCHS):
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
+        scheduler.step()
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
-
-    scheduler.step()
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 


### PR DESCRIPTION
## Hypothesis
OneCycleLR ramps quickly to peak LR, spends more time at high LR for fast learning, then decays aggressively. This is better suited to time-budgeted training since CosineAnnealing spends too long at low LR early on. Previous OneCycleLR tests were confounded by Huber loss and wrong configs. Clean test on the proven best MSE config should squeeze 1-3 points off surf_p.

## Instructions
All changes in `train.py`:

1. Set the best-config hyperparameters:
   - `lr = 0.012` (OneCycleLR max_lr — higher than CosineAnnealing)
   - `surf_weight = 25.0`
   - `n_layers = 1`, `n_hidden = 128`, `n_head = 4`, `slice_num = 64`, `mlp_ratio = 2`
   - `MAX_EPOCHS = 100`
   - Keep MSE loss, `batch_size = 4`, `weight_decay = 1e-4`

2. Replace the CosineAnnealingLR scheduler with:
   ```python
   scheduler = torch.optim.lr_scheduler.OneCycleLR(
       optimizer,
       max_lr=0.012,
       total_steps=MAX_EPOCHS * len(train_loader),
       pct_start=0.15,
       div_factor=6,
       final_div_factor=1000,
   )
   ```

3. Move `scheduler.step()` from after each epoch to **after each batch** (inside the training loop, after `optimizer.step()`).

4. Remove the per-epoch `scheduler.step()` call that sits after the training loop.

5. Update the `lr` logging to use `scheduler.get_last_lr()[0]`.

6. Use `--wandb_name "fern/onecyclelr-best-config"` and `--wandb_group "mar14b"` and `--agent fern`

## Baseline
| Metric | Value |
|--------|-------|
| surf_p | 33.55 |
| surf_ux | 0.488 |
| surf_uy | 0.270 |
| vol_p | 63.80 |
| val_loss | 0.0190 |
| Config | lr=0.006, sw=25, slice=64, nh=4, hid=128, lay=1, mlp=2, ep=100 |

---

## Results

| Metric | Baseline | OneCycleLR | Delta |
|--------|----------|------------|-------|
| surf_p | 33.55 | 121.8 | +263% (worse) |
| surf_Ux | 0.488 | 1.53 | +214% (worse) |
| surf_Uy | 0.270 | 0.67 | +148% (worse) |
| vol_p | 63.80 | 159.5 | +150% (worse) |
| val_loss | 0.0190 | 3.057 | +160x (worse) |

- **Peak memory**: 4.3 GB
- **Epochs completed**: 40 of 100 (5-min wall-clock timeout)
- **Best epoch**: 36
- **W&B run**: uc4rc6cu

### What happened

OneCycleLR performed dramatically worse than CosineAnnealingLR — surf_p went from 33.55 to 121.8, a 3.6x regression. The experiment failed to confirm the hypothesis.

Looking at the training curves, there are clear instability spikes throughout (batch surf losses of 4.5, 2.4, 1.7, etc.), especially during the high-LR phase. With `div_factor=6`, the initial LR is 0.012/6 = 0.002, which ramps up to 0.012 within the first 15% of batches — that's very aggressive for this model. CosineAnnealing starts at lr=0.006 and decays smoothly, which avoids these instabilities.

The hypothesis assumes CosineAnnealing "wastes time at low LR early on," but for this problem, the warmup into a high LR (rather than starting high) appears to be what causes damage. The model hasn't converged nearly as well as baseline even after 40 epochs.

### Suggested follow-ups

- Try OneCycleLR with a much lower `max_lr` (e.g. 0.006 or 0.003) to see if the issue is purely the peak LR magnitude
- Try a longer warmup (`pct_start=0.3`) to reduce the ramp aggressiveness
- Try CyclicLR or a simple cosine schedule with warm restarts as alternatives to OneCycleLR
- The CosineAnnealing baseline (lr=0.006) may simply be well-matched to this problem; the scheduler shape matters less than the LR magnitude