### PR TITLE
Lookahead optimizer wrapping AdamW

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,8 +79,40 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+
+
+class Lookahead:
+    def __init__(self, optimizer, k=5, alpha=0.5):
+        self.optimizer = optimizer
+        self.k = k
+        self.alpha = alpha
+        self.step_count = 0
+        self.slow_params = [
+            [p.clone().detach() for p in group['params']]
+            for group in optimizer.param_groups
+        ]
+
+    def step(self):
+        self.optimizer.step()
+        self.step_count += 1
+        if self.step_count % self.k == 0:
+            for group_idx, group in enumerate(self.optimizer.param_groups):
+                for p_idx, p in enumerate(group['params']):
+                    slow = self.slow_params[group_idx][p_idx]
+                    slow.add_(self.alpha * (p.data - slow))
+                    p.data.copy_(slow)
+
+    def zero_grad(self):
+        self.optimizer.zero_grad()
+
+    @property
+    def param_groups(self):
+        return self.optimizer.param_groups
+
+
+base_optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = Lookahead(base_optimizer, k=5, alpha=0.5)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=MAX_EPOCHS)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Lookahead (Zhang et al., 2019) maintains slow weights periodically interpolated toward fast weights, reducing optimizer variance and finding flatter minima. The best run dropped surf_p from ~48 to 33.55 in the last 20 epochs — Lookahead stabilizes exactly this late-training convergence regime. It adds negligible compute cost (one extra param copy, updated every k steps).

## Instructions
All changes in `train.py`:

1. Set the best-config hyperparameters:
   - `lr = 0.006`, `surf_weight = 25.0`
   - `n_layers = 1`, `n_hidden = 128`, `n_head = 4`, `slice_num = 64`, `mlp_ratio = 2`
   - `MAX_EPOCHS = 100`
   - Keep MSE loss, `batch_size = 4`, `weight_decay = 1e-4`

2. Add the Lookahead wrapper class before the optimizer creation:
   ```python
   class Lookahead:
       def __init__(self, optimizer, k=5, alpha=0.5):
           self.optimizer = optimizer
           self.k = k
           self.alpha = alpha
           self.step_count = 0
           self.slow_params = [
               [p.clone().detach() for p in group['params']]
               for group in optimizer.param_groups
           ]

       def step(self):
           self.optimizer.step()
           self.step_count += 1
           if self.step_count % self.k == 0:
               for group_idx, group in enumerate(self.optimizer.param_groups):
                   for p_idx, p in enumerate(group['params']):
                       slow = self.slow_params[group_idx][p_idx]
                       slow.add_(self.alpha * (p.data - slow))
                       p.data.copy_(slow)

       def zero_grad(self):
           self.optimizer.zero_grad()

       @property
       def param_groups(self):
           return self.optimizer.param_groups
   ```

3. Create the optimizer with Lookahead wrapping:
   ```python
   base_optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
   optimizer = Lookahead(base_optimizer, k=5, alpha=0.5)
   ```

4. Pass `base_optimizer` (not `optimizer`) to the scheduler:
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=MAX_EPOCHS)
   ```

5. Use `--wandb_name "tanjiro/lookahead-adamw"` and `--wandb_group "mar14b"` and `--agent tanjiro`

## Baseline
| Metric | Value |
|--------|-------|
| surf_p | 33.55 |
| surf_ux | 0.488 |
| surf_uy | 0.270 |
| vol_p | 63.80 |
| val_loss | 0.0190 |
| Config | lr=0.006, sw=25, slice=64, nh=4, hid=128, lay=1, mlp=2, ep=100 |

---

---

## Results

| Metric | Baseline | This Run (ep 40/100) |
|--------|----------|----------------------|
| surf_p | 33.55 | 105.3 |
| surf_ux | 0.488 | 1.30 |
| surf_uy | 0.270 | 0.64 |
| vol_p | 63.80 | 151.5 |
| val_loss | 0.0190 | 2.3954 |
| Peak mem | — | 4.3 GB |

**W&B run:** exwpt7e0 (tanjiro/lookahead-adamw, group mar14b)

**What happened:**
The run hit the 5-minute wall-clock limit after 40 epochs (each epoch ~8s). All metrics are far worse than baseline: surf_p 105.3 vs 33.55, val_loss 2.3954 vs 0.0190. Two factors explain this:

1. **Epoch budget**: Only 40 of 100 epochs completed. The baseline appears to have run ~100 epochs, implying faster epochs (~3s/ep). This timing difference is significant — the model was still mid-convergence at timeout.

2. **Lookahead convergence drag**: Lookahead with alpha=0.5 and k=5 pulls parameters 50% back toward slow weights every 5 optimizer steps. At lr=0.006 this is aggressive — the optimizer makes progress, then gets dragged backward substantially, slowing net convergence. This likely explains why the model is further behind than expected even at 40 epochs.

The hypothesis that Lookahead stabilizes late-training convergence is plausible, but it appears to hurt early-phase convergence significantly at this learning rate and alpha setting.

**Suggested follow-ups:**
- Try a smaller alpha (e.g. 0.1 or 0.2) to reduce the pullback strength, especially important at high lr
- Try k=10 or k=20 to reduce frequency of slow weight sync (less interference)
- Do a direct apples-to-apples comparison: plain AdamW vs Lookahead with equal epoch count on a small subset to isolate Lookahead's effect on convergence speed
- Investigate why baseline achieved 100 epochs in 5 min — if data loading was different, the epoch timing may be improved