### PR TITLE
Per-channel pressure weighting in surface loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -77,6 +77,9 @@ model_config = dict(
 model = Transolver(
     **model_config
 ).to(device)
+
+# Weight pressure 2x more in loss (channels: Ux=0, Uy=1, p=2)
+channel_weights = torch.tensor([1.0, 1.0, 2.0], device=device)
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
@@ -133,7 +136,7 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = (sq_err * surf_mask.unsqueeze(-1) * channel_weights).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -175,7 +178,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_surf += (sq_err * surf_mask.unsqueeze(-1) * channel_weights).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
The current loss treats all 3 output channels (Ux, Uy, p) equally in the surface term. But surf_p is our primary metric and has much larger absolute errors than velocity. By weighting pressure 2x higher in the surface loss, we directly focus optimization on the metric we care about most. A clean, conservative 2x weight avoids the destabilization seen in prior extreme-weighting attempts.

## Instructions
All changes in `train.py`:

1. Set the best-config hyperparameters:
   - `lr = 0.006`, `surf_weight = 25.0`
   - `n_layers = 1`, `n_hidden = 128`, `n_head = 4`, `slice_num = 64`, `mlp_ratio = 2`
   - `MAX_EPOCHS = 100`
   - Keep MSE loss, `batch_size = 4`, `weight_decay = 1e-4`

2. Add a per-channel weight tensor after the model is moved to device:
   ```python
   # Weight pressure 2x more in loss (channels: Ux=0, Uy=1, p=2)
   channel_weights = torch.tensor([1.0, 1.0, 2.0], device=device)
   ```

3. In the **training loop**, change the surface loss from:
   ```python
   surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```
   to:
   ```python
   surf_loss = (sq_err * surf_mask.unsqueeze(-1) * channel_weights).sum() / surf_mask.sum().clamp(min=1)
   ```

4. Apply the **same change** to the validation surface loss computation (the `val_surf +=` line).

5. **Do NOT change the MAE computation** — that must remain unweighted to report true metrics.

6. Use `--wandb_name "nezuko/perchannel-pressure-weight"` and `--wandb_group "mar14b"` and `--agent nezuko`

## Baseline
| Metric | Value |
|--------|-------|
| surf_p | 33.55 |
| surf_ux | 0.488 |
| surf_uy | 0.270 |
| vol_p | 63.80 |
| val_loss | 0.0190 |
| Config | lr=0.006, sw=25, slice=64, nh=4, hid=128, lay=1, mlp=2, ep=100 |

---

## Results

**W&B run ID:** yhfirztg
**Epochs completed:** 39 (5-minute timeout)
**Peak memory:** 4.3 GB

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| surf_p | 33.55 | 100.4 | +66.8 (worse) |
| surf_ux | 0.488 | 1.35 | +0.86 (worse) |
| surf_uy | 0.270 | 0.65 | +0.38 (worse) |
| vol_p | 63.80 | 151.2 | +87.4 (worse) |
| val_loss | 0.0190 | 3.857 | n/a (scale changed) |

Note: val_loss is not directly comparable to baseline — channel_weights inflate the val_surf term (pressure gets 2x weight), changing the loss scale.

**What happened:** The 2x pressure channel weighting made all metrics significantly worse. surf_p was 3x worse than baseline, velocities also degraded. Rather than helping the model focus on pressure accuracy, the unbalanced channel weights appear to have destabilized optimization, leading to a worse local minimum. This is consistent with prior observations that extreme weighting destabilizes training — even a modest 2x factor is detrimental here. As a side effect, the inflated val_surf (from channel_weights) makes cross-run comparison harder since the loss scale is different.

**Suggested follow-ups:**
- Instead of loss weighting, try normalizing each channel by its standard deviation before computing the surface loss, so all channels contribute equally in normalized space.
- Keep validation loss channel-unweighted even if training uses per-channel weights, to preserve comparability of val_loss across runs.