### PR TITLE
Cosine Annealing with Warm Restarts (SGDR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -80,7 +80,9 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+    optimizer, T_0=25, T_mult=2, eta_min=1e-6
+)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Instead of a single cosine decay, use multiple short cosine cycles (T_0=25, T_mult=2). Each restart "reheats" the LR, allowing the model to escape local minima. The best run showed rapid improvement in the final epochs, suggesting it found a good basin but possibly not the best one. SGDR restarts could push it to a better basin. Previous cosine tests (PR 16) were misconfigured with wrong T_max — a properly configured SGDR has never been tested.

## Instructions
All changes in `train.py`:

1. Set the best-config hyperparameters:
   - `lr = 0.006`, `surf_weight = 25.0`
   - `n_layers = 1`, `n_hidden = 128`, `n_head = 4`, `slice_num = 64`, `mlp_ratio = 2`
   - `MAX_EPOCHS = 100`
   - Keep MSE loss, `batch_size = 4`, `weight_decay = 1e-4`

2. Replace the scheduler:
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
       optimizer, T_0=25, T_mult=2, eta_min=1e-6
   )
   ```
   This gives cycles of length 25, 50, 25 epochs = 100 total. The first cycle learns fast, the second refines.

3. Keep `scheduler.step()` per epoch (this scheduler supports epoch-level stepping).

4. Use `--wandb_name "alphonse/sgdr-warm-restarts"` and `--wandb_group "mar14b"` and `--agent alphonse`

## Baseline
| Metric | Value |
|--------|-------|
| surf_p | 33.55 |
| surf_ux | 0.488 |
| surf_uy | 0.270 |
| vol_p | 63.80 |
| val_loss | 0.0190 |
| Config | lr=0.006, sw=25, slice=64, nh=4, hid=128, lay=1, mlp=2, ep=100 |

---

## Results

**W&B run:** vgf5yanr
**Peak memory:** 4.3 GB
**Epochs completed:** 40 (5-minute wall-clock limit)

| Metric | Baseline | SGDR Result | Δ |
|--------|----------|-------------|---|
| val_loss | 0.0190 | 2.5605 | +134x worse |
| surf_Ux | 0.488 | 1.39 | +185% worse |
| surf_Uy | 0.270 | 0.70 | +159% worse |
| surf_p | 33.55 | 103.2 | +208% worse |
| vol_p | 63.80 | 156.8 | +146% worse |

Best checkpoint at epoch 24 (end of first SGDR cycle).

**What happened:** SGDR warm restarts performed significantly worse than the baseline cosine decay — across every metric, by 2–134x. The hypothesis that restarts would help escape local minima did not hold. Likely causes:

1. **Time budget mismatch:** The 5-minute cap allows ~40 epochs. We only see one full cosine descent + the start of a second cycle. The restarts are never given a chance to demonstrate their benefit — we don't even reach epoch 75 where the second restart would occur.

2. **LR restart is too aggressive:** Starting back at lr=0.006 at epoch 25 undoes learned progress. The baseline cosine has decayed to ~0.003 by then; SGDR's jump back to full LR is too disruptive to recover from in 5 minutes.

3. **Baseline is already well-tuned:** A single cosine decay from 0.006→0 over 100 epochs is a good fit for this task. The assumption that the model is stuck in local minima may simply be wrong for this architecture.

**Suggested follow-ups:**
- Try SGDR with shorter first cycle (T_0=10, T_mult=1) so multiple restarts occur within the 5-minute/~40-epoch budget.
- Try smaller initial LR for SGDR (e.g., 0.001–0.002) to reduce disruption from restarts.
- Test cosine decay with T_max calibrated to actual runtime (~40 epochs) rather than 100, to see if a tighter decay is better within the time budget.