### PR TITLE
Wider model (n_hidden=160) with lower LR

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.004
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -64,9 +64,9 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
+    n_hidden=160,
+    n_layers=1,
+    n_head=4,      # 40 dims per head
     slice_num=64,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],


### PR DESCRIPTION
## Hypothesis
n_hidden=128 produces ~159K params. n_hidden=160 gives ~247K params — still tiny for 96GB VRAM. Previous wider-model attempts failed because they used the same LR (too high for more parameters) and insufficient epochs. With lr=0.004 (scaled down proportional to parameter count increase) and 100 epochs, a wider model may have more expressivity to capture complex pressure distributions near the airfoil surface. At ~3.5s/epoch, we'd still fit ~85 epochs in 5 minutes.

## Instructions
Changes in `train.py`:

1. Set hyperparameters:
   - `lr = 0.004` (lower to match wider model — LR scales inversely with width)
   - `surf_weight = 25.0`
   - `MAX_EPOCHS = 100`
   - Keep MSE loss, `batch_size = 4`, `weight_decay = 1e-4`

2. Update model_config:
   ```python
   model_config = dict(
       space_dim=2,
       fun_dim=16,
       out_dim=3,
       n_hidden=160,
       n_layers=1,
       n_head=4,      # 40 dims per head
       slice_num=64,
       mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Use `--wandb_name "edward/wider-160h-lr004"` and `--wandb_group "mar14b"` and `--agent edward`

## Baseline
| Metric | Value |
|--------|-------|
| surf_p | 33.55 |
| surf_ux | 0.488 |
| surf_uy | 0.270 |
| vol_p | 63.80 |
| val_loss | 0.0190 |
| Config | lr=0.006, sw=25, slice=64, nh=4, hid=128, lay=1, mlp=2, ep=100 |

---

## Results

**W&B run:** `796ai7db` | Best epoch: 29/32 completed | Runtime: 5.1 min | Peak memory: 5.1 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| surf_p | 113.2 | 33.55 | +237% worse |
| surf_Ux | 1.41 | 0.488 | +189% worse |
| surf_Uy | 0.67 | 0.270 | +148% worse |
| vol_p | 157.6 | 63.80 | +147% worse |
| val_loss | 2.9554 | 0.0190 | much worse |

**What happened:** The hypothesis failed. Both the baseline and this run use n_layers=1; the only differences are n_hidden (160 vs 128) and lr (0.004 vs 0.006). The lower LR appears too slow to converge within the 5-minute budget — only 32 epochs ran (~10s/epoch, not the projected ~3.5s). The model was still descending at epoch 29 (val_surf=0.1070) but hadn't reached anywhere near baseline quality. The wider model is slower per-epoch than expected (~10s vs ~3.5s assumed), leaving far fewer training steps than the baseline.

**Suggested follow-ups:**
- Try n_hidden=160 with lr=0.006 (baseline LR) — isolates width effect from LR, and keeps same epoch count budget.
- Investigate epoch time discrepancy: ~10s/epoch for 160-hidden suggests the wider model may not be worth the compute overhead at this scale.