### PR TITLE
SGD with Nesterov momentum (alternative optimizer)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.05
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -79,7 +79,13 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.SGD(
+    model.parameters(),
+    lr=cfg.lr,
+    momentum=0.9,
+    nesterov=True,
+    weight_decay=1e-4,
+)
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 


### PR DESCRIPTION
## Hypothesis
Only AdamW has been tested across all 100+ experiments. SGD with Nesterov momentum is known to find flatter minima that generalize better, especially with cosine LR schedules. For this small model (159K params) on a small dataset (810 training samples), SGD's implicit regularization may help. Classical deep learning wisdom: Adam converges faster but SGD generalizes better. With 97+ epochs available, SGD can catch up.

## Instructions
All changes in `train.py`:

1. Set the best-config hyperparameters:
   - `lr = 0.05` (SGD needs much higher LR than Adam — start here)
   - `surf_weight = 25.0`
   - `n_layers = 1`, `n_hidden = 128`, `n_head = 4`, `slice_num = 64`, `mlp_ratio = 2`
   - `MAX_EPOCHS = 100`
   - Keep MSE loss, `batch_size = 4`

2. Replace the optimizer:
   ```python
   optimizer = torch.optim.SGD(
       model.parameters(),
       lr=cfg.lr,
       momentum=0.9,
       nesterov=True,
       weight_decay=1e-4,
   )
   ```

3. Keep `CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)` — cosine schedule works well with SGD.

4. Use `--wandb_name "thorfinn/sgd-nesterov"` and `--wandb_group "mar14b"` and `--agent thorfinn`

**Note:** If surf_p is worse than 50 after 20 epochs, try lr=0.1 as a follow-up. SGD LR tuning is critical.

## Baseline
| Metric | Value |
|--------|-------|
| surf_p | 33.55 |
| surf_ux | 0.488 |
| surf_uy | 0.270 |
| vol_p | 63.80 |
| val_loss | 0.0190 |
| Config | lr=0.006, sw=25, slice=64, nh=4, hid=128, lay=1, mlp=2, ep=100 |

---

## Results

**Status: FAILED — gradient explosion (NaN) at step 2 of epoch 1**

| Metric | Baseline | This Run |
|--------|----------|----------|
| val/loss | 0.0190 | NaN |
| surf_Ux | 0.488 | NaN |
| surf_Uy | 0.270 | NaN |
| surf_p | 33.55 | NaN |
| vol_p | 63.80 | NaN |
| Peak VRAM | — | 4.3 GB |

**W&B run:** bh5sk2cy (thorfinn/sgd-nesterov, group: mar14b)

### What happened

The run diverged immediately — gradients exploded at step 2 of epoch 1. Loss sequence: surf≈1.6, vol≈1.7 → surf≈956, vol≈547 → surf≈3.4e13, vol≈3.4e13 → NaN. All 40 epochs (5 min) produced NaN.

**Root cause:** lr=0.05 is far too large for SGD on this architecture. AdamW's adaptive per-parameter learning rates effectively deliver much smaller effective steps than the nominal lr. SGD at lr=0.05 overwhelms the model from the first batch; the Nesterov lookahead step compounds this. Classic SGD LR for transformers is typically 0.001–0.01 (with warmup), not 0.05.

### Suggested follow-ups

- **Lower lr to 0.001–0.005** — proper SGD range for this architecture; likely to converge without explosion.
- **Add gradient clipping** (`clip_grad_norm_(model.parameters(), 1.0)`) — cheap insurance, especially important without adaptive optimizer.
- **Add LR warmup** — 5–10 epoch linear warmup before cosine schedule is standard for SGD on transformers; early random-weight gradients are the most dangerous.
- If SGD at lr=0.05 is still desired, gradient clipping is likely necessary to prevent explosion.