### PR TITLE
Target noise regularization (label smoothing for regression)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.006
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,
@@ -126,6 +126,7 @@ for epoch in range(MAX_EPOCHS):
 
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
+        y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         pred = model({"x": x})["preds"]
         sq_err = (pred - y_norm) ** 2


### PR DESCRIPTION
## Hypothesis
With only 810 training samples, the model may overfit to specific mesh configurations. Adding small Gaussian noise to target values during training (sigma=0.01 in normalized space) acts as label smoothing for regression — it flattens sharp loss landscapes and improves generalization. This is a well-known technique from the early neural network literature (Bishop 1995) applied to modern deep learning. Minimal compute cost and zero architectural changes.

## Instructions
All changes in `train.py`:

1. Set the best-config hyperparameters:
   - `lr = 0.006`, `surf_weight = 25.0`
   - `n_layers = 1`, `n_hidden = 128`, `n_head = 4`, `slice_num = 64`, `mlp_ratio = 2`
   - `MAX_EPOCHS = 100`
   - Keep MSE loss, `batch_size = 4`, `weight_decay = 1e-4`

2. In the **training loop only**, after the line:
   ```python
   y_norm = (y - stats["y_mean"]) / stats["y_std"]
   ```
   Add:
   ```python
   y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
   ```

3. **Do NOT** add noise to the validation targets — validation must remain clean.

4. Use `--wandb_name "askeladd/target-noise-reg"` and `--wandb_group "mar14b"` and `--agent askeladd`

## Baseline
| Metric | Value |
|--------|-------|
| surf_p | 33.55 |
| surf_ux | 0.488 |
| surf_uy | 0.270 |
| vol_p | 63.80 |
| val_loss | 0.0190 |
| Config | lr=0.006, sw=25, slice=64, nh=4, hid=128, lay=1, mlp=2, ep=100 |

---

## Results

**W&B run ID:** kz3tn0fm

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| surf_p | 33.55 | 114.9 | +242% worse |
| surf_ux | 0.488 | 1.48 | +203% worse |
| surf_uy | 0.270 | 0.68 | +152% worse |
| vol_p | 63.80 | 165.3 | +159% worse |
| val_loss | 0.0190 | 2.7500 | — (different scale, see below) |
| Peak memory | — | 4.3 GB | — |
| Epochs completed | 100 | 40 | Timeout at 5 min |

**Note on val_loss scale:** The computed val_loss = val_vol + surf_weight * val_surf. With surf_weight=25 and val_surf≈0.097 at best epoch, val_loss ≈ 2.75. The baseline val_loss=0.0190 cannot be reconciled with this formula at surf_weight=25, suggesting it was computed differently (perhaps without surf_weight multiplication, or with a different codebase version). Direct val_loss comparison is not meaningful here.

### What happened

The target noise regularization produced worse surface MAE than baseline at every metric. However, there are important caveats:

1. **Epoch count mismatch:** The 5-minute timeout allowed only ~40 epochs at 8s/epoch, vs the baseline's 100 epochs. The model was still actively improving at epoch 40.

2. **High variance:** Val metrics showed significant epoch-to-epoch noise (surf pressure oscillating between ~108 and ~197). This volatility makes it hard to conclude cleanly whether noise helps or hurts.

3. **Noise effect on training loss:** The noisy targets inflate the training-time sq_err and may destabilize gradient estimates slightly — expected behavior for label smoothing. The model still converged.

**Verdict:** Target noise at sigma=0.01 does not appear to help. If anything it adds gradient noise that slows convergence. The regularization benefit (if any) is outweighed by the noise corrupting the loss signal.

### Suggested follow-ups

- Try a much smaller sigma (e.g. 0.001) to see if milder smoothing avoids the convergence degradation
- Apply noise only to surface nodes (where overfitting concern is highest) rather than all targets
- Try dropout in the model instead — a cleaner regularization without corrupting the loss signal
- Investigate the baseline val_loss=0.0190 figure — it seems inconsistent with the formula in the current code at surf_weight=25