### PR TITLE
lr=0.012 + sw=25: combine fast LR with best surface weight

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
The two best parameter regimes have never been combined: lr=0.012 (fastest convergence per epoch, surf_p=36.8 in 20ep) and sw=25 (best surface weight, surf_p=33.5 but needed 97ep). By combining lr=0.012 with sw=25, we may get fast convergence AND strong surface focus, reaching below 36 within the 5-min/~40-epoch budget. This is the highest-priority experiment.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.012`
   - `surf_weight = 25.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50` (the code default; scheduler T_max will match)

4. Use `--wandb_name "frieren/fast-lr012-sw25"` and `--wandb_group "mar14b"` and `--agent frieren`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) | lr=0.006/sw=25 (40ep) |
|--------|----------------------|----------------------|
| surf_p | 36.78 | ~80 |
| surf_ux | 0.399 | ~1.3 |
| surf_uy | 0.269 | ~0.6 |
| Config | slc=32,nh=2,h128,1L,mlp2 | slc=64,nh=4,h128,1L,mlp2 |

---

## Results

**The hypothesis failed.** Combining lr=0.012 with sw=25 did not produce fast convergence — it gave *worse* results than either baseline after 49 epochs.

| Metric | lr=0.012/sw=8 (20ep) | lr=0.006/sw=25 (40ep) | This run (49ep) |
|--------|----------------------|-----------------------|-----------------|
| surf_p | 36.78 | ~80 | 99.35 |
| surf_ux | 0.399 | ~1.3 | 1.31 |
| surf_uy | 0.269 | ~0.6 | 0.67 |
| val_loss | — | — | 2.345 |
| Epochs | 20 | 40 | 49 |
| Peak memory | — | — | 3.7 GB |

**W&B run:** `6uq2mwtv`

### What happened

The combination of high lr (0.012) and high surf_weight (25) appears to cause training instability. The surf loss gradient is amplified by 25× compared to sw=8, and with lr=0.012 the optimizer takes large steps in a direction dominated by surface error. This likely creates oscillatory behavior — visible in validation metrics that swing wildly between epochs (e.g., epoch 20 surf_p=311, epoch 21 surf_p=161, epoch 24 surf_p=134, epoch 29 surf_p=164).

In contrast, lr=0.012/sw=8 converges smoothly because the gradient scale is lower. The model reaches surf_p=36.78 in just 20 epochs with that config.

The lr=0.006/sw=25 baseline also converges (slowly) because the smaller lr dampens the high-sw gradient amplification.

Conclusion: **lr=0.012 and sw=25 are incompatible** — the learning rate is calibrated for lower surface weighting.

### Suggested follow-ups

1. **Try lr=0.008 or lr=0.010 with sw=25** — split the difference between 0.006 (too slow) and 0.012 (too unstable at sw=25). This is the natural next experiment.
2. **Use gradient clipping with lr=0.012/sw=25** — if instability is the issue, clipping gradient norms might help stabilize training.
3. **Try lr=0.012/sw=15 as an intermediate** — maybe sw=15 is compatible with lr=0.012 before going all the way to sw=25.
4. **The lr=0.012/sw=8 config is still the best in 20 epochs** — any improvement strategy should beat surf_p=36.78 as the 20-epoch reference.