### PR TITLE
lr=0.012 + sw=20: moderate surface weight with fast LR

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 20.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
sw=25 may be too aggressive at lr=0.012, potentially destabilizing training. sw=20 is a safer middle ground between the proven sw=8 (fast config) and sw=25 (best config). This tests whether increasing surface weight from 8 to 20 improves surf_p when paired with the fast lr=0.012.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.012`
   - `surf_weight = 20.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50`

4. Use `--wandb_name "fern/fast-lr012-sw20"` and `--wandb_group "mar14b"` and `--agent fern`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) |
|--------|----------------------|
| surf_p | 36.78 |
| surf_ux | 0.399 |
| surf_uy | 0.269 |
| Config | slc=32,nh=2,h128,1L,mlp2 |

---

## Results

| Metric | Baseline (sw=8) | sw=20 | Delta |
|--------|-----------------|-------|-------|
| surf_p | 36.78 | 88.9 | +142% (worse) |
| surf_Ux | 0.399 | 1.19 | +198% (worse) |
| surf_Uy | 0.269 | 0.62 | +130% (worse) |
| val_loss | — | 1.681 | — |

- **Peak memory**: 3.7 GB
- **Epochs completed**: 49 of 50 (5-min wall-clock timeout)
- **Best epoch**: 47
- **W&B run**: v4y0izlf

### What happened

sw=20 with lr=0.012 is significantly worse than sw=8 with the same lr. The hypothesis that sw=20 would be a safe "middle ground" did not hold — it's worse across all metrics even with more epochs (49 vs 20 in baseline).

The training shows occasional large loss spikes (surf=3.96, 1.69, 0.69) suggesting instability from the elevated surface weight at lr=0.012. The convergence curve is also much slower — after 49 epochs we haven't approached the surf_p=36.78 the baseline achieved in just 20 epochs.

This pattern is consistent with PR #127 (OneCycleLR at lr=0.012 was catastrophic) and suggests lr=0.012 is close to the instability boundary for this problem. Any factor that amplifies gradient magnitude — whether a higher max_lr or a higher surface weight — pushes training into an unstable regime.

### Suggested follow-ups

- Try sw=12 or sw=15 with lr=0.012 to narrow down where instability begins
- Try sw=20 with a lower lr (e.g. lr=0.006) to test whether the issue is the combination, not sw alone
- The baseline sw=8/lr=0.012 appears well-calibrated; the key variable to improve surf_p may be architecture (more layers/heads) rather than loss weighting