### PR TITLE
lr=0.012 + sw=15: mild surface weight increase

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 15.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
Systematically sweeping sw between 8 (proven fast) and 25 (proven best long-run). sw=15 is the midpoint. If sw=15 improves surf_p over sw=8 without slowing convergence, we know the optimal sw for the fast config is somewhere above 8. Combined with sw=20 and sw=25 tests, this gives a 3-point sweep to find the optimum.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.012`
   - `surf_weight = 15.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50`

4. Use `--wandb_name "tanjiro/fast-lr012-sw15"` and `--wandb_group "mar14b"` and `--agent tanjiro`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) |
|--------|----------------------|
| surf_p | 36.78 |
| surf_ux | 0.399 |
| surf_uy | 0.269 |
| Config | slc=32,nh=2,h128,1L,mlp2 |

---

---

## Results

| Metric | Baseline (sw=8, 20ep) | This Run (sw=15, 49ep) |
|--------|----------------------|------------------------|
| surf_p | 36.78 | 89.9 |
| surf_ux | 0.399 | 1.24 |
| surf_uy | 0.269 | 0.62 |
| vol_p | — | 124.5 |
| val_loss | — | 1.3347 |
| Peak mem | — | 3.7 GB |

**W&B run:** 35eayft8 (tanjiro/fast-lr012-sw15, group mar14b)

**What happened:**
Ran 49 of 50 epochs within the 5-minute limit (6s/epoch). Despite running more than twice the baseline epoch count (49 vs 20), all surface metrics are substantially worse than the sw=8 baseline: surf_p 89.9 vs 36.78, surf_ux 1.24 vs 0.399. This is a clear negative result — increasing surf_weight from 8 to 15 hurts convergence significantly.

The likely explanation is gradient imbalance: at sw=15, surface gradients dominate the loss ~3x more than at sw=8. For this small model (1L, h=128, slc=32), the higher surface weighting over-constrains surface learning early in training, producing worse representations overall. The model learns to minimize surface loss at the cost of general flow understanding, leading to poor generalization even on surface nodes.

The sw=8 baseline appears to be a better balance point for this architecture — the surface signal is useful but not overwhelming. This suggests the optimal sw for the fast config (lr=0.012, small model) is at or below 8, not above it.

**Suggested follow-ups:**
- Try sw=5 or sw=3 to see if even lower surface weight helps the small model converge faster
- Test if sw=8 stays optimal across different model sizes (hypothesis: larger models tolerate higher sw better)
- Compare with a warm-up strategy: start with sw=8 and increase to sw=15 later (curriculum-style)