### PR TITLE
lr=0.015 + sw=25 + grad clip: push LR higher with safety

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.015
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -139,6 +139,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()


### PR DESCRIPTION
## Hypothesis
If lr=0.012 converges fast, lr=0.015 may converge even faster. But higher LR risks instability, so we add gradient clipping (max_norm=1.0) as a safety net. With sw=25 for strong surface focus, this tests whether we can push the convergence speed frontier further. Gradient clipping has near-zero overhead and prevents the NaN explosions seen with SGD.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.015`
   - `surf_weight = 25.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50`

4. Add gradient clipping after `loss.backward()` and before `optimizer.step()`:
   ```python
   torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
   ```

5. Use `--wandb_name "nezuko/fast-lr015-sw25-gradclip"` and `--wandb_group "mar14b"` and `--agent nezuko`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) |
|--------|----------------------|
| surf_p | 36.78 |
| surf_ux | 0.399 |
| surf_uy | 0.269 |
| Config | slc=32,nh=2,h128,1L,mlp2 |

---

## Results

**W&B run ID:** 7ka1ac6j
**Epochs completed:** 49 (5-minute timeout, still converging at epoch 49)
**Peak memory:** 3.7 GB

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| surf_p | 36.78 | 61.7 | +24.9 (worse) |
| surf_ux | 0.399 | 0.79 | +0.39 (worse) |
| surf_uy | 0.269 | 0.43 | +0.16 (worse) |
| vol_p | - | 96.6 | - |
| val_loss | - | 1.46 | - |

Note: Baseline used sw=8; this run uses sw=25, so val_loss scales differ.

**What happened:** The higher lr=0.015 with sw=25 did not improve over the baseline. The model was still converging at epoch 49 (best epoch = last epoch), suggesting the 5-minute budget was not enough to reach the sweet spot. Gradient clipping kept training stable — no NaN explosions — but couldn't overcome the harder optimization from sw=25 and higher lr. The combination of sw=25 and lr=0.015 appears to slow convergence within the 5-minute window compared to sw=8/lr=0.012. The larger surface weight dominates the loss and creates a rougher landscape that takes more epochs to navigate.

**Suggested follow-ups:**
- Try lr=0.015 with sw=8 to isolate whether the issue is the LR itself or the sw=25 combination.
- Gradient clipping proved safe (no instability) — worth keeping in future runs as a low-cost safeguard.
- The model converging at epoch 49 suggests more training time would help; try a smaller architecture (fewer params) to fit more epochs in the time budget.