### PR TITLE
lr=0.012 + sw=25 + slc=64 + nh=4: fast LR on original arch

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,7 +65,7 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
     slice_num=64,
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
The best long-run config used slc=64/nh=4 (original architecture). The fast config used slc=32/nh=2. The fast LR (0.012) was only tested with slc=32/nh=2. Testing lr=0.012 on the original slc=64/nh=4 arch with sw=25 answers: does the fast LR help the original architecture too? This isolates the LR effect from the architecture change.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.012`
   - `surf_weight = 25.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=4,
       slice_num=64, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50`

4. Use `--wandb_name "alphonse/fast-lr012-sw25-slc64"` and `--wandb_group "mar14b"` and `--agent alphonse`

## Baseline
| Metric | lr=0.012/sw=8/slc=32 (20ep) | lr=0.006/sw=25/slc=64 (40ep) |
|--------|------------------------------|------------------------------|
| surf_p | 36.78 | ~80 |
| Config | nh=2,h128,1L,mlp2 | nh=4,h128,1L,mlp2 |

---

## Results

**W&B run:** `lulbww5z`
**Peak memory:** 4.3 GB
**Epochs completed:** ~40 / 50 (5.1 min wall-clock limit)
**Best epoch:** 38

| Metric | lr=0.012/slc=32 baseline | lr=0.006/slc=64 baseline | This run (lr=0.012/slc=64) |
|--------|--------------------------|--------------------------|----------------------------|
| surf_Ux | — | — | 1.45 |
| surf_Uy | — | — | 0.79 |
| surf_p | 36.78 | ~80 | 114.4 |
| val_loss | — | — | 2.8688 |

**What happened:** lr=0.012 on slc=64/nh=4 performs worse than both baselines — surf_p=114.4 vs 36.78 (slc=32) and ~80 (slc=64/lr=0.006). The fast LR does not transfer to the larger architecture.

The slc=32/nh=2 architecture is smaller and more robust to aggressive LR; the slc=64/nh=4 model has more parameters and appears to need a lower LR to converge stably. At lr=0.012, the larger model oscillates or overshoots during the first cosine cycle without settling. This answers the isolation question clearly: **the benefit of lr=0.012 is tied to the slc=32/nh=2 architecture, not transferable to slc=64/nh=4**.

**Suggested follow-ups:**
- Try lr=0.009 (between 0.006 and 0.012) with slc=64/nh=4 to find the optimal LR for this architecture.
- Warm up LR before the main cosine decay — a short linear warmup (5 epochs) may help slc=64 handle a higher peak LR.
- Compare slc=32/nh=2 vs slc=64/nh=4 at the same lr=0.006/sw=25 to isolate the pure architecture effect.