### PR TITLE
lr=0.012 + sw=25 + T_max=40: scheduler matched to epoch budget

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -61,14 +61,9 @@ train_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=True, **l
 val_loader = DataLoader(val_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
 
 model_config = dict(
-    space_dim=2,
-    fun_dim=16,
-    out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
-    mlp_ratio=2,
+    space_dim=2, fun_dim=16, out_dim=3,
+    n_hidden=128, n_layers=1, n_head=2,
+    slice_num=32, mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )
@@ -80,7 +75,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=40)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
CosineAnnealingLR with T_max=50 means the LR hasn't fully decayed by epoch 40 (when timeout hits). With T_max=40, the LR decay matches the actual epoch budget, ensuring the model enters the fine-tuning low-LR regime before timeout. This is critical: the fast config's best results came at the last epoch of its cosine cycle. Matching T_max to the real budget maximizes late-epoch convergence.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.012`
   - `surf_weight = 25.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50` but change the scheduler to:
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=40)
   ```
   This ensures the LR reaches near-zero by epoch 40, matching the 5-min budget.

4. Use `--wandb_name "edward/fast-lr012-sw25-tmax40"` and `--wandb_group "mar14b"` and `--agent edward`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) |
|--------|----------------------|
| surf_p | 36.78 |
| surf_ux | 0.399 |
| surf_uy | 0.269 |
| Config | slc=32,nh=2,h128,1L,mlp2 |

---

## Results

**W&B run:** `clk3kxay` | Best epoch: 38/~42 completed | Runtime: 5.1 min | Peak memory: 3.7 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| surf_p | 128.2 | 36.78 | +249% worse |
| surf_Ux | 1.62 | 0.399 | +306% worse |
| surf_Uy | 0.89 | 0.269 | +231% worse |
| val_loss | 3.4795 | — | (sw=25 not comparable) |
| vol_p (best ep) | 185.6 | — | — |

**What happened:** The hypothesis failed. Despite matching T_max=40 to the actual epoch budget (~42 epochs in 5 min at ~6s/epoch), results are dramatically worse than the baseline. The key difference is surf_weight: 25 here vs 8 in the baseline. Higher surf_weight makes optimization harder — the model struggles to balance surface vs volume losses at sw=25, especially early in training when the network is far from convergence.

The matched cosine schedule (T_max=40) did ensure the LR decayed properly within the budget, and the model was still improving at epoch 38 (val_surf 0.1218 vs 0.3826 at epoch 8), so the T_max alignment didn't hurt. But the surf_weight=25 regime appears fundamentally more difficult to converge on this architecture/LR within 5 minutes compared to sw=8.

**Suggested follow-ups:**
- Test T_max=40 with sw=8 (baseline surf_weight) to isolate whether the T_max improvement matters independent of surf_weight change.
- The faster convergence at sw=8 may simply be because it's a less constrained objective — consider whether sw=25 gives better physical predictions or just slows learning.