### PR TITLE
lr=0.012 + sw=25 + 2L h96: depth variant with high surface weight

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -64,11 +64,11 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
-    mlp_ratio=2,
+    n_hidden=96,
+    n_layers=2,
+    n_head=2,
+    slice_num=32,
+    mlp_ratio=1,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
The second-best fast config used 2 layers + h96 (surf_p=36.25 at 20ep). This tests whether adding sw=25 to that architecture helps. Two layers may capture multi-scale features better for pressure prediction. With h96 instead of h128, epochs may be slightly faster, yielding more training steps.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.012`
   - `surf_weight = 25.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=96, n_layers=2, n_head=2,
       slice_num=32, mlp_ratio=1,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50`

4. Use `--wandb_name "thorfinn/fast-lr012-sw25-2L-h96"` and `--wandb_group "mar14b"` and `--agent thorfinn`

## Baseline
| Metric | 2L h96 lr=0.012/sw=10 (20ep) | 1L h128 lr=0.012/sw=8 (20ep) |
|--------|------------------------------|------------------------------|
| surf_p | 36.25 | 36.78 |
| Config | slc=32,nh=2,mlp=1 | slc=32,nh=2,mlp=2 |

---

## Results

| Metric | This run (best ep=26) | Baseline sw=10 (20ep) |
|--------|----------------------|----------------------|
| val/loss | 18.13 | — |
| surf_Ux MAE | 5.66 | — |
| surf_Uy MAE | 2.39 | — |
| surf_p MAE | **319.6** | **36.25** |
| vol_Ux MAE | 14.36 | — |
| vol_Uy MAE | 7.46 | — |
| vol_p MAE | 388.0 | — |
| Peak VRAM | 3.9 GB | — |
| Epochs completed | 35 / 50 (5-min timeout) | — |
| W&B run | ma94rhc7 | — |

### What happened

**Failed to converge — surf_p ~10x worse than baseline.** The model reached surf_p=319.6 at best (epoch 26) vs the baseline sw=10 result of 36.25. This is a clear regression.

The W&B trend for surf_p showed a U-shape: improved through epoch ~25, hit a minimum, then degraded. This indicates oscillation rather than convergence — consistent with lr=0.012 being too aggressive when sw=25 amplifies surface gradients. The effective gradient scale on surface nodes is 25x larger, destabilizing training at this LR.

The 2L h96 architecture itself is not the issue — it reached surf_p=36.25 at only 20 epochs with sw=10. The problem is high LR combined with high surf_weight.

### Suggested follow-ups
- **Lower LR with sw=25**: Try lr=0.004–0.006 with 2L h96, sw=25 — gradient amplification from sw=25 requires proportionally lower LR
- **Grad clipping**: Add gradient clipping (max_norm=1.0) to stabilize sw=25 training at higher LRs
- **sw=15 compromise**: May provide surface improvement without the instability of sw=25 at these LR values