### PR TITLE
lr=0.008 + sw=25: intermediate LR between fast and slow configs

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.008
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 25.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
lr=0.006 converges too slowly (80 surf_p at 40ep). lr=0.012 converges fast (36.8 at 20ep). lr=0.008 is an intermediate point that may balance convergence speed with stability. Combined with sw=25 and the 1L h128 mlp2 architecture, this tests whether a slightly lower LR than 0.012 leads to better final quality within the epoch budget.

## Instructions
All changes in `train.py`:

1. Set these hyperparameters in `Config`:
   - `lr = 0.008`
   - `surf_weight = 25.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Set `MAX_EPOCHS = 50`

4. Use `--wandb_name "askeladd/fast-lr008-sw25"` and `--wandb_group "mar14b"` and `--agent askeladd`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) | lr=0.006/sw=25 (40ep) |
|--------|----------------------|----------------------|
| surf_p | 36.78 | ~80 |
| Config | slc=32,nh=2,h128,1L,mlp2 | slc=64,nh=4,h128,1L,mlp2 |

---

## Results

**W&B run ID:** kxsvo2py

| Metric | lr=0.012/sw=8 (20ep, baseline) | This run: lr=0.008/sw=25 (49ep) |
|--------|-------------------------------|----------------------------------|
| surf_p | 36.78 | 111.6 |
| surf_ux | — | 1.45 |
| surf_uy | — | 0.81 |
| vol_p | — | 175.3 |
| val_loss | — | 2.849 |
| Peak memory | — | 3.7 GB |
| Epochs completed | 20 | 49 (5-min timeout) |

### What happened

lr=0.008 with sw=25 is significantly worse than the lr=0.012/sw=8 baseline (surf_p=111.6 vs 36.78). The model ran 49 epochs in 5 minutes (~6s/epoch with slc=32, nh=2) and showed a slow, steady improvement — surf pressure was still declining at epoch 49 (110.8 at ep49 vs 124.7 at ep35), suggesting it hadn't converged yet.

Two factors likely explain the gap:

1. **Higher surf_weight slows convergence:** With sw=25 vs sw=8, the surface loss term is weighted 3x more. This changes the gradient balance and requires the optimizer to make smaller effective steps. lr=0.008 with this weighting may be functionally equivalent to a lower effective LR than lr=0.012 with sw=8.

2. **Not enough epochs:** The trend suggests surf_p would continue declining with more epochs. But within 5 minutes, lr=0.012/sw=8 converges much faster.

**Verdict:** lr=0.008 + sw=25 does not outperform the faster lr=0.012 config. The intermediate LR doesn't balance the convergence speed tradeoff — it just inherits the slowness of higher surface weight without enough speed gain over lr=0.006.

### Suggested follow-ups

- Try lr=0.012 + sw=25 to see if higher LR compensates for the surf_weight penalty
- Try a warmup schedule (e.g., 5 epochs linear warmup) with lr=0.012/sw=25 to avoid instability at high LR
- The lr=0.012/sw=8 baseline appears to be the sweet spot for this 5-min budget — consider whether increasing sw is worth any LR adjustment