### PR TITLE
Reproduce best config (lr=0.012/sw=8) on current hardware

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 8.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
The best known config (lr=0.012, sw=8, slc=32, nh=2, 1L h128 mlp2) achieved surf_p=36.78 in 20 epochs historically (14s/ep). Current hardware runs ~6s/epoch, giving ~49 epochs in 5 min — 2.5x more training. This reproduction should establish the TRUE achievable baseline on current hardware, likely reaching below 36 surf_p.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.012`
   - `surf_weight = 8.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Keep `MAX_EPOCHS = 50`, `batch_size = 4`, `weight_decay = 1e-4`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

4. Use `--wandb_name "frieren/reproduce-lr012-sw8"` and `--wandb_group "mar14b"` and `--agent frieren`

## Baseline
| Metric | Historical (20ep) |
|--------|-------------------|
| surf_p | 36.78 |
| surf_ux | 0.399 |
| surf_uy | 0.269 |
| Config | lr=0.012, sw=8, slc=32, nh=2, h128, 1L, mlp=2 |

---

## Results

**Historical baseline could NOT be reproduced.** After 49 epochs on current hardware with identical config, surf_p=110.5 — 3× worse than the historical 36.78 at just 20 epochs.

| Metric | Historical (20ep) | This run (49ep) | Delta |
|--------|-------------------|-----------------|-------|
| surf_p | 36.78 | 110.53 | +200% (worse) |
| surf_ux | 0.399 | 1.48 | +271% (worse) |
| surf_uy | 0.269 | 0.807 | +200% (worse) |
| val_loss | — | 1.060 | — |
| Epochs | 20 | 49 | — |
| Peak memory | — | 3.7 GB | — |

**W&B run:** `4bjsifug`

### What happened

The model is converging, but extremely slowly compared to historical records:
- Epoch 22: surf_p = 142
- Epoch 29: surf_p = 134
- Epoch 49: surf_p = 111

At this rate, surf_p=36.78 would require hundreds of epochs — far beyond the 5-minute budget.

**Possible explanations:**
1. **Different codebase/dataset version** — the historical run may have been on a different version of the code with different normalization, data preprocessing, or model architecture details.
2. **Machine/hardware difference** — epoch timing went from 14s → 6s/epoch, suggesting very different hardware. This may also reflect different batch composition or data loading behavior.
3. **Random initialization** — the current code uses the default PyTorch initialization; if the historical run used a different initialization or random seed, results may differ significantly.
4. **Dataset differences** — if the underlying dataset was modified (e.g., different normalization statistics), MAE values in physical units would be incomparable.

The historical surf_p=36.78 appears to be from a genuinely different experimental setting that cannot be reproduced with the current codebase.

### Suggested follow-ups

1. **Establish a new baseline** — the true current-hardware baseline for this config is surf_p≈110 at 49 epochs. Future experiments should compare against this, not the historical 36.78.
2. **Investigate the historical result** — review git history or W&B runs to find what changed between the historical run and the current codebase. The 3× gap in surf_p is unexplained.
3. **Check dataset normalization** — verify that `dataset_stats` values are consistent with what was used in historical runs. Different normalization would explain different MAE in physical units.