### PR TITLE
lr=0.012 + sw=10: mild surface weight increase from baseline

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
The "ffhigh sw=10" run historically achieved surf_p=36.25 (slightly better than sw=8's 36.78) in 20 epochs. With current hardware giving ~49 epochs, sw=10 at lr=0.012 may push further below 36. This tests the smallest reasonable sw increase from the proven sw=8 baseline.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.012`
   - `surf_weight = 10.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Keep `MAX_EPOCHS = 50`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

4. Use `--wandb_name "fern/lr012-sw10"` and `--wandb_group "mar14b"` and `--agent fern`

## Baseline
| Metric | sw=8 (20ep) | sw=10 historical (20ep) |
|--------|-------------|------------------------|
| surf_p | 36.78 | 36.25 |

---

## Results

| Metric | sw=8 baseline | sw=10 (49ep) | Delta |
|--------|---------------|--------------|-------|
| surf_p | 36.78 | 88.4 | +140% (worse) |
| surf_Ux | 0.399 | 1.21 | +203% (worse) |
| surf_Uy | 0.269 | 0.59 | +119% (worse) |
| val_loss | — | 0.919 | — |

- **Peak memory**: 3.7 GB
- **Epochs completed**: 49 of 50 (5-min wall-clock timeout)
- **Best epoch**: 44
- **W&B run**: lfetyd5v

### What happened

sw=10 with lr=0.012 performed dramatically worse than the sw=8 historical baseline (surf_p=88.4 vs 36.78), even with more than double the epochs (49 vs 20). This directly contradicts the hypothesis that sw=10 would improve surf_p.

Notably, the results are nearly identical to sw=20 (PR #135: surf_p=88.9, surf_Ux=1.19). The surface weight makes almost no difference once above 8 — both sw=10 and sw=20 plateau at ~88-89 surf_p with lr=0.012. This strongly suggests that lr=0.012 paired with this architecture (1L, nh=2, slc=32) converges to a fundamentally different (worse) solution than the historical runs, regardless of surface weight.

The historical sw=10 baseline (36.25) may have been run with different hyperparameters or a different code version. The current sw=8 / lr=0.012 baseline of 36.78 appears inconsistent with what we're reproducing now — the architecture and lr are the same but the results differ by 2.4x.

### Suggested follow-ups

- Run a direct reproduction of the sw=8 / lr=0.012 baseline to verify whether 36.78 is still achievable (PR #reproducable may already exist)
- If the baseline is reproducible, investigate what's different about the sw=8 vs sw=10 initialization/run that produces the divergent result
- The pattern of sw=10 and sw=20 both giving ~88 suggests an attractor state — investigate gradient clipping or AdamW weight decay as stabilizing mechanisms at sw>8