### PR TITLE
lr=0.012 + sw=12: upper boundary of stable surface weight

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
Batch 2 showed sw=15 is too high for lr=0.012 (causes instability). sw=10 worked historically. sw=12 tests the upper boundary — if it works, it pushes surface focus to the max compatible with lr=0.012. The historical "ffvhigh sw=12" got surf_p=37.51, so sw=12 at this LR has a track record of working.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.012`
   - `surf_weight = 12.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Keep `MAX_EPOCHS = 50`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

4. Use `--wandb_name "tanjiro/lr012-sw12"` and `--wandb_group "mar14b"` and `--agent tanjiro`

## Baseline
| Metric | sw=8 (20ep) |
|--------|-------------|
| surf_p | 36.78 |

---

---

## Results

| Metric | Baseline (sw=8, 20ep) | sw=12 (ep 49/50) | sw=15 (ep 49/50) |
|--------|----------------------|-------------------|-------------------|
| surf_p | 36.78 | 97.7 | 89.9 |
| surf_ux | 0.399 | 1.23 | 1.24 |
| surf_uy | 0.269 | 0.68 | 0.62 |
| val_loss | — | 1.2327 | 1.3347 |
| Peak mem | — | 3.7 GB | 3.7 GB |

**W&B run:** h6ou1ld3 (tanjiro/lr012-sw12, group mar14b)

**What happened:**
Ran all 50 epochs (49 completed before 5-minute limit, 6s/epoch). The result is another negative: surf_p=97.7 vs the sw=8 baseline of 36.78 — a factor of ~2.7x worse. The table above also shows sw=12 is slightly worse than sw=15 on surf_p (97.7 vs 89.9), suggesting the relationship between sw and convergence quality is not monotonic and both are well below the sw=8 optimum.

The consistent finding across sw=12 and sw=15: any increase in surface weight above 8 at lr=0.012 with this small model (1L, h=128, slc=32, nh=2) degrades convergence significantly. The optimizer appears unable to make good progress on the surface loss at these higher weights within the 5-minute budget — the gradient dynamics are unfavorable.

The sw=8 baseline may benefit from a favorable implicit balance: low enough surface weight to let volume gradients stabilize the representation, while still providing signal to improve surface accuracy.

**Suggested follow-ups:**
- Accept sw=8 as the optimum for this fast config and explore other axes (architecture, lr schedule)
- Try lr=0.008 with sw=12 to see if a lower lr can stabilize convergence with more surface focus
- Check if the sw=8 baseline result is reproducible — the gap vs sw=12/15 is surprisingly large