### PR TITLE
lr=0.015 + sw=8 + grad clip: faster LR at proven surface weight

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.015
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 8.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -139,6 +139,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()


### PR DESCRIPTION
## Hypothesis
lr=0.012 is the proven fast LR. Pushing to lr=0.015 with gradient clipping (which proved effective in batch 2 PR #137) could speed convergence further. Crucially, we use sw=8 (not sw=25 as in batch 2) to avoid the LR-sw instability. Gradient clipping (max_norm=1.0) prevents any explosion from the higher LR. This tests whether faster LR at stable sw improves surf_p.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.015`
   - `surf_weight = 8.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Add gradient clipping in the training loop after `loss.backward()`:
   ```python
   torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
   ```

4. Keep `MAX_EPOCHS = 50`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

5. Use `--wandb_name "nezuko/lr015-sw8-gradclip"` and `--wandb_group "mar14b"` and `--agent nezuko`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) |
|--------|----------------------|
| surf_p | 36.78 |

---

## Results

**W&B run ID:** 45h9ecp0
**Epochs completed:** 49 (5-minute timeout, still converging at epoch 48)
**Peak memory:** 3.7 GB

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| surf_p | 36.78 | 59.1 | +22.3 (worse) |
| surf_ux | 0.399 | 0.82 | +0.42 (worse) |
| surf_uy | 0.269 | 0.43 | +0.16 (worse) |
| vol_p | - | 75.0 | - |
| val_loss | - | 0.539 | - |

**What happened:** lr=0.015 with sw=8 and gradient clipping is still significantly worse than the baseline at 36.78 surf_p. The model had best_epoch=48 (second-to-last), meaning it was still improving at timeout — suggesting it simply needs more training time. The small architecture (n_head=2, slice_num=32) may also be a limiting factor. Gradient clipping kept training stable (no NaNs or explosions), but didn't help overcome the convergence gap. The baseline used lr=0.012 and reached 36.78 at only 20 epochs — suggesting lr=0.012 converges faster to a better solution, not slower. lr=0.015 may actually be counterproductive in this regime.

**Suggested follow-ups:**
- The baseline's superior result at 20 epochs vs this run at 48 epochs suggests lr=0.012 is genuinely better for convergence rate, not just stability. Consider lr=0.010 as a comparison.
- Gradient clipping is safe to keep — it adds zero overhead and prevents worst-case scenarios.
- The architecture differences (n_head=2 vs n_head=4, slice_num=32 vs 64) may matter more than the LR. The baseline config should be pinned more carefully.