### PR TITLE
lr=0.012 + sw=8 + nh=4: more attention heads at fast LR

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 8.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
The proven fast config uses nh=2. More attention heads (nh=4) allow finer-grained attention patterns that may better capture pressure distributions. With slc=32 and nh=4, each head attends to 32 slices (vs 16 per head with nh=2), providing more diverse attention patterns. This tests whether architectural diversity improves at the sweet-spot LR/sw without slowing epochs.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.012`
   - `surf_weight = 8.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=4,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Keep `MAX_EPOCHS = 50`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

4. Use `--wandb_name "alphonse/lr012-sw8-nh4"` and `--wandb_group "mar14b"` and `--agent alphonse`

## Baseline
| Metric | nh=2, sw=8 (20ep) |
|--------|-------------------|
| surf_p | 36.78 |

---

## Results

**W&B run:** `j9jikmqa`
**Peak memory:** 3.9 GB
**Epochs completed:** 45 / 50 (5.0 min wall-clock limit)
**Best epoch:** 45

| Metric | nh=2 baseline (20ep) | This run: nh=4 (45ep) |
|--------|----------------------|-----------------------|
| surf_Ux | — | 1.22 |
| surf_Uy | — | 0.61 |
| surf_p | 36.78 | 91.3 |
| val_loss | — | 0.7812 |
| vol_p | — | 116.5 |

**What happened:** nh=4 with slc=32 is significantly worse than the nh=2 baseline — surf_p=91.3 vs 36.78, even with 2x more epochs (45 vs 20). The hypothesis did not hold: more attention heads hurt rather than helped at this configuration.

The likely cause is that doubling the heads (nh=2→4) with the same slice_num=32 means each head now attends to all 32 slices instead of specializing over 16. With slc=32, nh=2 gives each head a manageable 16-slice specialization; nh=4 forces all heads to cover the full slice space, reducing diversity and likely causing redundant attention patterns. The nh=2 config appears well-tuned for slc=32.

Note: val_loss of 0.7812 with surf_weight=8 is not directly comparable to other runs with different surf_weights.

**Suggested follow-ups:**
- Try nh=4 with slc=64 at lr=0.012 and sw=8 — give each head more slices to specialize over (16 per head).
- Keep nh=2 and explore other improvements (deeper network, larger hidden dim) to avoid this false path.
- The nh=2 fast config (surf_p=36.78) remains the best baseline; future experiments should build on it.