### PR TITLE
lr=0.012 + sw=8 + 2L h96 mlp1: proven 2-layer variant

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 8.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -61,14 +61,9 @@ train_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=True, **l
 val_loader = DataLoader(val_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
 
 model_config = dict(
-    space_dim=2,
-    fun_dim=16,
-    out_dim=3,
-    n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
-    mlp_ratio=2,
+    space_dim=2, fun_dim=16, out_dim=3,
+    n_hidden=96, n_layers=2, n_head=2,
+    slice_num=32, mlp_ratio=1,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
The 2L h96 mlp1 architecture got surf_p=36.25 at sw=10 in 20 epochs (historically the best fast-converging result). Testing it with sw=8 and more epochs (~49 on current hardware) should improve further. The 2-layer variant may capture multi-scale flow features better than 1-layer, and h96 keeps epochs fast.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.012`
   - `surf_weight = 8.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=96, n_layers=2, n_head=2,
       slice_num=32, mlp_ratio=1,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Keep `MAX_EPOCHS = 50`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

4. Use `--wandb_name "edward/lr012-sw8-2L-h96"` and `--wandb_group "mar14b"` and `--agent edward`

## Baseline
| Metric | 2L h96 sw=10 (20ep) | 1L h128 sw=8 (20ep) |
|--------|---------------------|---------------------|
| surf_p | 36.25 | 36.78 |

---

## Results

**W&B run:** `cdzr3v5y` | Best epoch: 35/~35 completed | Runtime: 5.0 min | Peak memory: 3.9 GB

| Metric | This run (ep35) | Baseline 2L h96 sw=10 (20ep) | Δ |
|--------|-----------------|------------------------------|---|
| surf_p | 136.7 | 36.25 | +277% worse |
| surf_Ux | 1.70 | — | — |
| surf_Uy | 0.94 | — | — |
| vol_p | 159.5 | — | — |
| val_loss | 1.5051 | — | (sw different) |

**What happened:** The hypothesis failed significantly — results are 3-4x worse than the baseline despite running ~35 epochs (vs 20 in the baseline). The model was still clearly converging (epoch 34: surf_p=140.8 → epoch 35: surf_p=136.7), but nowhere near the baseline's surf_p=36.25. At the equivalent 20-epoch mark, this run had surf_p≈154.5 (vs baseline's 36.25), suggesting this is not merely a matter of needing more epochs.

The discrepancy vs the historical baseline is striking. Possible explanations: (1) the historical baseline may have used a different random seed, a warm-start, or different data preprocessing; (2) ~9s/epoch here vs presumably faster per-epoch in the baseline run, implying different hardware/batch speed; (3) some randomness/variance in convergence with high LR and this small architecture.

**Suggested follow-ups:**
- Verify the historical 2L h96 results by re-running the exact same config that produced surf_p=36.25 to confirm reproducibility.
- If reproducible, the difference may be in the wandb_group context or other environment factors.