### PR TITLE
lr=0.012 + sw=10 + nh=4: combine best sw and more heads

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.012
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 10.0
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
+    n_layers=1,
     n_head=4,
-    slice_num=64,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
sw=10 was the best historical surface weight for fast convergence (surf_p=36.25 in 20ep). Combining it with nh=4 (more attention diversity) and h128 mlp2 may further improve. This combines two independent improvements: the slightly better sw=10 result and the potential benefit of more attention heads.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.012`
   - `surf_weight = 10.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=4,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Keep `MAX_EPOCHS = 50`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

4. Use `--wandb_name "thorfinn/lr012-sw10-nh4"` and `--wandb_group "mar14b"` and `--agent thorfinn`

## Baseline
| Metric | sw=10/nh=2 (20ep) | sw=8/nh=2 (20ep) |
|--------|-------------------|-------------------|
| surf_p | 36.25 | 36.78 |

---

## Results

| Metric | This run (45ep) | Baseline sw=10/nh=2 (20ep) | Best overall |
|--------|-----------------|---------------------------|--------------|
| surf_Ux | 1.25 | — | 0.488 |
| surf_Uy | 0.63 | — | 0.270 |
| surf_p | 92.8 | 36.25 | 33.55 |
| vol_Ux | 4.68 | — | — |
| vol_Uy | 1.83 | — | — |
| vol_p | 123.5 | — | 63.80 |
| val_loss | 0.9756 | — | 0.0190 (sw=25) |
| Peak VRAM | 3.9 GB | — | — |
| Epochs | 45/50 (timeout) | — | — |

**W&B run ID:** `l5shqv2x`

### What happened

**Negative result.** Switching from nh=2 to nh=4 with slice_num=32 dramatically worsens performance: surf_p=92.8 at epoch 45 vs the baseline surf_p=36.25 at epoch 20. All surface metrics are 2–3× worse than the best-known config.

The combination of nh=4 + slice_num=32 is likely the culprit: with 4 heads and only 32 slices, each head gets only 8 slices — much less than the nh=4 + slice_num=64 configuration that achieves surf_p=33.55 (the best known config, which uses slc=64). When slices are spread too thin across heads, the attention mechanism may lose resolution.

The hypothesis that sw=10 + nh=4 would compound gains does not hold at slc=32.

### Suggested follow-ups

- Try nh=4 + slice_num=64 with sw=10 (maintaining 16 slices/head) — the best config already uses this combination with sw=25; sw=10 may or may not improve it.
- The nh=2 + sw=10 baseline at 20 epochs (surf_p=36.25) is still competitive — worth running to 50 epochs to see if it catches the best-known config.