### PR TITLE
lr=0.020 + sw=8 + grad clip: aggressive LR push

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,10 +24,10 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 5e-4
+    lr: float = 0.020
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 8.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -139,6 +139,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()


### PR DESCRIPTION
## Hypothesis
Gradient clipping stabilized lr=0.015 in batch 2. Pushing to lr=0.020 with sw=8 (stable surface weight) tests the upper LR boundary. If convergence is faster per epoch, we extract more from the 49-epoch budget. The gradient clipping (max_norm=1.0) provides a safety net against instability. This is the most aggressive LR tested at sw=8.

## Instructions
All changes in `train.py`:

1. Set `Config` defaults:
   - `lr = 0.020`
   - `surf_weight = 8.0`

2. Set `model_config`:
   ```python
   model_config = dict(
       space_dim=2, fun_dim=16, out_dim=3,
       n_hidden=128, n_layers=1, n_head=2,
       slice_num=32, mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

3. Add gradient clipping in the training loop after `loss.backward()`:
   ```python
   torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
   ```

4. Keep `MAX_EPOCHS = 50`, MSE loss, CosineAnnealingLR with T_max=MAX_EPOCHS.

5. Use `--wandb_name "askeladd/lr020-sw8-gradclip"` and `--wandb_group "mar14b"` and `--agent askeladd`

## Baseline
| Metric | lr=0.012/sw=8 (20ep) |
|--------|----------------------|
| surf_p | 36.78 |

---

## Results

**W&B run ID:** dxnz1nk9

| Metric | Baseline: lr=0.012/sw=8 (20ep) | This run: lr=0.020/sw=8 (49ep) |
|--------|-------------------------------|--------------------------------|
| surf_p | 36.78 | 60.6 |
| surf_ux | — | 0.81 |
| surf_uy | — | 0.44 |
| vol_p | — | 77.2 |
| val_loss | — | 0.534 |
| Peak memory | — | 3.7 GB |
| Epochs completed | 20 | 49 (5-min timeout) |

### What happened

lr=0.020 + grad clipping (max_norm=1.0) converged well but didn't beat the baseline lr=0.012 at 20 epochs. Results are much better than the lr=0.008/sw=25 run (surf_p=111.6), showing that sw=8 enables faster convergence.

Key observations:
1. **Grad clipping worked** — no training instability at lr=0.020. The run was smooth from epoch 1 through 49.
2. **Still converging at ep49** — surf_p declining: 64.7 at ep40 → 60.6 at ep49. Model hadn't plateaued, suggesting more epochs would help.
3. **High LR penalty** — despite aggressive LR=0.020 and 49 epochs, couldn't beat lr=0.012 at 20 epochs. The high LR may cause the CosineAnnealingLR schedule to decay LR faster, losing momentum midway through training.
4. **val_loss scale is now reasonable** — with sw=8, val_loss = vol_loss + 8*surf_loss ≈ 0.13 + 8*0.050 = 0.53, consistent with the reported 0.534. This aligns with the baseline structure.

**Verdict:** Aggressive LR + grad clipping is a useful combination but lr=0.020 overshoots — it's faster per early epoch but the LR decay hurts later. lr=0.012 appears to be the sweet spot in the CosineAnnealingLR framework.

### Suggested follow-ups

- Try lr=0.012 + grad clipping to see if clipping helps the proven best LR
- Try lr=0.015 (the previous experiment that was reportedly stabilized by clipping) for comparison
- Explore T_max tuning — longer cosine cycle (T_max=100 or T_max=200) with lr=0.020 might prevent early LR decay