### PR TITLE
AMP mixed-precision training to double epoch count

### DIFF
--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ import time
 import torch
 import wandb
 import yaml
+from torch.amp import autocast, GradScaler
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from tqdm import tqdm
@@ -21,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 0.015
@@ -81,6 +82,7 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scaler = GradScaler()
 
 
 # --- wandb ---
@@ -127,20 +129,24 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        with autocast(device_type='cuda', dtype=torch.float16):
+            pred = model({"x": x})["preds"]
+            sq_err = (pred - y_norm) ** 2
 
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
+
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
-        loss.backward()
+        scaler.scale(loss).backward()
+        scaler.unscale_(optimizer)
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
+        scaler.step(optimizer)
+        scaler.update()
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -170,8 +176,9 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            with autocast(device_type='cuda', dtype=torch.float16):
+                pred = model({"x": x})["preds"]
+                sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis
The model completes ~49 epochs in 5 minutes at ~6s/epoch, and is still converging at the final epoch (best_epoch=48). Using torch.amp (automatic mixed precision) with float16 should roughly halve per-epoch time by reducing memory bandwidth pressure, allowing ~90-100 epochs in the same 5-minute budget. Since surf_p is still dropping at epoch 49, doubling the epoch count could yield a significant improvement. We also increase MAX_EPOCHS to 100 and set T_max=100 to match.

## Instructions
All changes in `train.py`:

1. Add import at top:
   ```python
   from torch.amp import autocast, GradScaler
   ```

2. Before the training loop (after `scheduler = ...`), add:
   ```python
   scaler = GradScaler()
   ```

3. Change `MAX_EPOCHS = 50` to `MAX_EPOCHS = 100`

4. The scheduler already uses `T_max=MAX_EPOCHS`, so it will auto-adjust to 100. Verify this.

5. In the training loop, wrap the forward pass and loss computation with autocast, and use the scaler for backward/step.

6. Also wrap the validation forward pass with autocast.

7. Use `--wandb_name "frieren/amp-mixed-precision"` and `--wandb_group "mar14d"` and `--agent frieren`

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0 |
| Epochs | 49 in 5 min (~6s/ep) |

---

## Results

**Status: FAILED — NaN overflow in float16 forward pass**

| Metric | This run | Baseline |
|--------|----------|----------|
| surf_p | NaN | 59.08 |
| surf_ux | NaN | 0.82 |
| surf_uy | NaN | 0.43 |
| val_loss | NaN | 0.539 |
| Epochs completed | 0 (all NaN) | 49 |
| Epoch time | ~4.3s (30% faster) | ~6s |
| Peak memory | 2.6 GB | ~similar |

**W&B run ID:** q8fmrtdk

**What happened:**

Training failed completely due to float16 overflow in the forward pass. NaN appeared at step 11/203 of epoch 1, before the GradScaler could help. The GradScaler detects NaN/Inf in *gradients* and skips optimizer steps, but when the model's own *outputs* overflow to NaN (likely in Transolver's softmax attention or intermediate activations with large initial values), the scaler cannot recover. Once NaN contaminated outputs feed back into training, all subsequent epochs remain NaN. The `best_metrics` dict was never populated, confirming no valid epoch was completed.

Epoch time did drop to ~4.3s vs ~6s baseline (~30% speedup), but this is irrelevant given the NaN failure.

**Root cause:** Transolver's attention mechanism is not numerically stable in float16. The initial loss values (surf ~13, vol ~9 in early batches before training converges) and intermediate activations can produce values exceeding the float16 range (~65504). This is a known issue with attention-based models and float16 AMP.

**Suggested follow-ups:**
- Try `bfloat16` instead of `float16` — bfloat16 has the same exponent range as float32 (8-bit exponent vs 5-bit for float16), so it handles large values without overflow and doesn't need a GradScaler. This is the most promising fix for numeric instability while preserving speedup.
- Try `torch.compile(model)` as a way to accelerate epochs without AMP precision risks. Could give some speedup (10-20%) without NaN risk.
- The ~30% epoch speedup from AMP is real and worth preserving if NaN can be resolved; more epochs would be valuable since baseline was still converging at epoch 49.