### PR TITLE
EMA model weights for smoother validation

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import copy
 import os
 import time
 import torch
@@ -78,6 +79,9 @@ model = Transolver(
     **model_config
 ).to(device)
 
+ema_model = copy.deepcopy(model)
+ema_decay = 0.999
+
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
@@ -142,6 +146,10 @@ for epoch in range(MAX_EPOCHS):
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
+        with torch.no_grad():
+            for p_ema, p in zip(ema_model.parameters(), model.parameters()):
+                p_ema.data.mul_(ema_decay).add_(p.data, alpha=1 - ema_decay)
+
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
         n_batches += 1
@@ -152,7 +160,7 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf /= n_batches
 
     # --- Validate ---
-    model.eval()
+    ema_model.eval()
     val_vol = 0.0
     val_surf = 0.0
     mae_surf = torch.zeros(3, device=device)
@@ -170,7 +178,7 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            pred = ema_model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface
@@ -230,7 +238,7 @@ for epoch in range(MAX_EPOCHS):
             "epoch": epoch + 1,
             "val_loss_loss": val_loss,
         }
-        torch.save(model.state_dict(), model_path)
+        torch.save(ema_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 
     print(


### PR DESCRIPTION
## Hypothesis
Exponential Moving Average (EMA) of model weights is a nearly free regularization technique. The current best run's model is still actively converging at epoch 48-49, meaning the final weights are noisy. EMA averages weights over training, producing a smoother model that generalizes better. This is standard in vision transformers and diffusion models. Expected to shave 5-15% off validation MAE with zero architectural change and negligible compute overhead.

## Instructions
All changes in `train.py`:

1. Add import at top:
   ```python
   import copy
   ```

2. After `model = Transolver(**model_config).to(device)` (line ~77-79), add:
   ```python
   ema_model = copy.deepcopy(model)
   ema_decay = 0.999
   ```

3. After `optimizer.step()` in the training loop (after grad clip), add:
   ```python
   with torch.no_grad():
       for p_ema, p in zip(ema_model.parameters(), model.parameters()):
           p_ema.data.mul_(ema_decay).add_(p.data, alpha=1 - ema_decay)
   ```

4. In the validation section, replace `model.eval()` with using the EMA model. Change:
   ```python
   model.eval()
   ```
   to:
   ```python
   ema_model.eval()
   ```
   And replace all `model({"x": x})` calls in validation with `ema_model({"x": x})`.

5. When saving the best checkpoint, save the EMA model instead:
   ```python
   torch.save(ema_model.state_dict(), model_path)
   ```

6. For the final visualization, load the EMA model:
   ```python
   model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
   ```
   (This already loads the saved checkpoint which will be the EMA weights.)

7. Use `--wandb_name "fern/ema-weights"` and `--wandb_group "mar14d"` and `--agent fern`

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0 |

---

## Results

**W&B run**: `shh9g9vs` | **Best epoch**: 49 | **Peak memory**: 3.7GB

| Metric | Baseline | EMA (this run) | Delta |
|--------|----------|----------------|-------|
| surf_p | 59.08 | 62.9 | +6.5% worse |
| surf_Ux | 0.82 | 0.86 | +5% worse |
| surf_Uy | 0.43 | 0.45 | +5% worse |
| val_loss | 0.539 | 0.558 | +3.5% worse |
| vol_Ux | — | 3.10 | — |
| vol_Uy | — | 1.21 | — |
| vol_p | — | 80.0 | — |

**What happened**: EMA hurt rather than helped. All surface metrics degraded ~5-6% vs baseline. The likely reason: with only ~49 epochs and 203 batches/epoch (~10k steps total), the model is still actively converging throughout the run. EMA with decay=0.999 has an effective averaging window of 1/(1-0.999) = 1,000 steps, meaning it is averaging over a long history of weights that were worse than the current model. The EMA lags the actual model's improvement, especially in a short-run regime. The hypothesis that weights are noisy at the end is less of an issue than the cost of averaging over early bad weights in a fast-converging, short-horizon run.

**Suggested follow-ups**:
- Try a lower decay (0.99 or 0.995) to make EMA track faster — might reduce the lag cost in short runs
- Try warmup-then-EMA: only start accumulating EMA after epoch 20+ when the model has largely converged, avoiding early noisy weight contamination
- EMA may be more beneficial if training runs were longer (more epochs to converge fully before EMA smoothing matters)