### PR TITLE
L1 surface loss with MSE volume loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,12 +128,14 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        diff = pred - y_norm
+        sq_err = diff ** 2
+        abs_err = diff.abs()
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -171,12 +173,14 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
We evaluate surface MAE but train with MSE. MSE penalizes large errors quadratically, so a few outlier surface nodes with large pressure errors dominate the loss while many nodes with moderate errors contribute little gradient signal. Switching to L1 (MAE) loss specifically for the surface component directly aligns the training objective with the evaluation metric. Keep MSE for volume (where it works well), use L1 only for surface. Previous Huber experiments (PR #60) used Huber for ALL nodes — this is more targeted.

## Instructions
All changes in `train.py`:

1. In the training loop, replace the surface loss computation. Change:
   ```python
   sq_err = (pred - y_norm) ** 2

   vol_mask = mask & ~is_surface
   surf_mask = mask & is_surface
   vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
   surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```
   to:
   ```python
   diff = pred - y_norm
   sq_err = diff ** 2
   abs_err = diff.abs()

   vol_mask = mask & ~is_surface
   surf_mask = mask & is_surface
   vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
   surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```

2. The validation loss computation should also match. In the validation section, apply the same change:
   ```python
   diff = pred - y_norm
   sq_err = diff ** 2
   abs_err = diff.abs()

   vol_mask = mask & ~is_surface
   surf_mask = mask & is_surface
   val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
   val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
   ```

3. Keep all other settings exactly as baseline: lr=0.015, sw=8, grad clip 1.0, 1L h128, CosineAnnealingLR.

4. Use `--wandb_name "tanjiro/l1-surface-loss"` and `--wandb_group "mar14d"` and `--agent tanjiro`

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0 |

---

## Results

| Metric | Baseline (MSE, PR #145) | L1 surface loss (ep 49/50) |
|--------|------------------------|----------------------------|
| surf_p | 59.08 | **53.7** |
| surf_ux | 0.82 | **0.62** |
| surf_uy | 0.43 | **0.38** |
| val_loss | 0.539* | 1.0481* |
| Peak mem | — | 3.7 GB |

*Note: val_loss values are **not directly comparable** — baseline uses MSE for surf_loss, this run uses L1. The raw val_loss number appears higher but only because L1 and MSE are on different scales.

**W&B run:** mr7rbpr0 (tanjiro/l1-surface-loss, group mar14d)

**What happened:**
All three surface MAE metrics improved over the MSE baseline:
- surf_p: 59.08 → 53.7 (−9%)
- surf_ux: 0.82 → 0.62 (−24%)
- surf_uy: 0.43 → 0.38 (−12%)

Ran all 50 epochs (~6 s/epoch), stopping at the 5-minute wall-clock limit. The hypothesis holds: directly aligning the training objective (L1) with the evaluation metric (MAE) improves surface accuracy. The improvement is consistent across all three output fields, with Ux showing the largest relative gain.

The val_loss increase from 0.539 to 1.0481 is an artefact of the loss function change — L1 values are not comparable to MSE values at the same scale, so the combined `val_loss = vol_loss + sw * surf_loss` is inherently different. The meaningful comparison is the surface MAE metrics, which all improved.

**Suggested follow-ups:**
- Try Huber loss for the surface (delta tunable) — a middle ground between L1 and MSE that could be more robust to outliers while still being differentiable at 0
- Combine this change with other improvements (e.g. lr=0.015 + sw=8 + L1 surface is now the new baseline config)
- Investigate whether the volume MAE also changed (vol MAE: Ux=3.39, Uy=1.39, p=90.6 — hard to compare without the baseline volume numbers from PR #145)