### PR TITLE
torch.compile for faster epoch throughput

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 80
 @dataclass
 class Config:
     lr: float = 0.015
@@ -77,6 +77,7 @@ model_config = dict(
 model = Transolver(
     **model_config
 ).to(device)
+model = torch.compile(model, mode="reduce-overhead")
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)


### PR DESCRIPTION
## Hypothesis
torch.compile can fuse operations and optimize memory access patterns, potentially giving 20-50% speedup per epoch. At ~6s/epoch, even a 30% speedup gives ~4.2s/epoch = ~71 epochs in 5 minutes (vs 49 currently). More epochs = better convergence, and the model is clearly still improving at epoch 49. Use mode="reduce-overhead" which is optimized for small models with repeated execution patterns (exactly our case).

## Instructions
All changes in `train.py`:

1. After model creation and before the optimizer, add:
   ```python
   model = torch.compile(model, mode="reduce-overhead")
   ```
   Place this after `model = Transolver(**model_config).to(device)` but before `n_params = sum(...)`.
   
   Note: `n_params` should still be computed correctly since `torch.compile` returns a wrapper.

2. Increase MAX_EPOCHS to account for faster epochs:
   ```python
   MAX_EPOCHS = 80
   ```
   (Conservative estimate — if compile gives 30% speedup we get ~65 epochs; if 50%, ~75. Set to 80 and let the wall-clock timeout handle it.)

3. Keep all other settings exactly as baseline: lr=0.015, sw=8, grad clip 1.0, 1L h128.

4. Use `--wandb_name "nezuko/torch-compile"` and `--wandb_group "mar14d"` and `--agent nezuko`

**Note:** torch.compile may be slower for the first few epochs due to compilation overhead. This is expected — it should pay off as epochs become faster afterward. If compilation fails or errors out, try `mode="default"` instead of `mode="reduce-overhead"`.

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0 |
| Epochs | 49 in 5 min (~6s/ep) |

---

## Results

**W&B run ID:** `82lvbn49`
**Epochs completed:** 50 (best at epoch 45)
**Peak memory:** 3.9 GB

| Metric | Baseline | torch.compile | Delta |
|--------|----------|---------------|-------|
| surf_p | 59.08 | 65.2 | +6.1 (worse) |
| surf_Ux | 0.82 | 0.92 | +0.10 (worse) |
| surf_Uy | 0.43 | 0.46 | +0.03 (worse) |
| val_loss | 0.539 | 0.553 | +0.014 (worse) |
| Epochs in 5 min | 49 | 50 | +1 |

**What happened:**

torch.compile worked (no errors) but did not deliver the expected speedup. Epoch 1 took 37s due to JIT compilation overhead; epochs 2+ settled at ~5s/epoch, down from ~6s baseline — only ~16% faster, not the 30-50% predicted. The extra epoch in budget (50 vs 49) was minimal. Despite getting slightly more epochs, all metrics ended up worse than baseline.

The speedup was limited — torch.compile's "reduce-overhead" mode primarily reduces Python/CUDA kernel launch overhead, but at batch_size=4 our bottleneck is likely model compute, not dispatch overhead. The JIT compilation warmup (37s = ~7 epochs worth of compute) also erased most of the benefit.

**Suggested follow-ups:**
- Try `mode="max-autotune"` for more aggressive kernel fusion (longer compile time but potentially larger speedup)
- The real lever for more epochs is faster batch throughput: larger batch size or mixed precision (AMP) rather than compile
- Consider whether the slightly worse metrics are statistical noise — re-running baseline to check variance would clarify if the gap is meaningful