### PR TITLE
Larger batch size (bs=8) with scaled LR

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,9 +24,9 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.020
     weight_decay: float = 1e-4
-    batch_size: int = 4
+    batch_size: int = 8
     surf_weight: float = 8.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)


### PR DESCRIPTION
## Hypothesis
batch_size=4 on ~810 training samples means ~202 gradient updates per epoch. With 96GB VRAM available and only 3.7GB used, we can easily increase to batch_size=8. Larger batches give cleaner gradient estimates, which is especially important for surface nodes (a tiny fraction of total mesh nodes — ~1000 out of ~86K). With bs=4, the surface gradient signal is noisy. bs=8 should stabilize surface loss convergence. Following the linear scaling rule, we scale LR from 0.015 to 0.020 (sqrt(2) x 0.015 ≈ 0.021, rounded to 0.020).

## Instructions
All changes in `train.py`:

1. Change `Config` defaults:
   ```python
   lr: float = 0.020
   batch_size: int = 8
   ```

2. Keep all other settings: sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, CosineAnnealingLR T_max=50, weight_decay=1e-4.

3. Use `--wandb_name "alphonse/batch-size-8"` and `--wandb_group "mar14d"` and `--agent alphonse`

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, bs=4, 1L h128 nh=2 slc=32, grad clip 1.0 |

---

## Results

**W&B run**: ekcdwvpk (alphonse/batch-size-8, group: mar14d)

| Metric | Baseline (PR #145) | bs=8 lr=0.020 | Delta |
|--------|-------------------|---------------|-------|
| surf_p | 59.08 | 72.66 | +23% worse |
| surf_ux | 0.82 | 0.97 | +18% worse |
| surf_uy | 0.43 | 0.51 | +19% worse |
| val_loss | 0.539 | 0.614 | +14% worse |
| Peak memory | ~3.7 GB | 7.3 GB | +97% |

Best epoch: 48/50

**What happened**: The hypothesis did not work — bs=8 with lr=0.020 performed worse than baseline across all metrics, with surf_p degrading most (+23%). The core issue is that doubling the batch size halves the number of gradient updates per epoch (from ~202 to ~101), and this apparently dominates over any benefit from cleaner gradient estimates. With only 50 epochs and fewer steps per epoch, the model simply gets less optimization signal overall. The linear scaling rule for LR may also not apply well here since this is a small-batch regime where gradient noise provides implicit regularization. Memory doubled as expected (3.7→7.3GB), still well within 96GB budget.

**Suggested follow-ups**:
- Try bs=8 with the original lr=0.015 (no LR scaling) — isolate whether the issue is batch size or LR
- Try bs=8 with more epochs (e.g. 100) to compensate for fewer steps/epoch — though this may need timeout adjustments
- Gradient accumulation (2 steps x bs=4) might give bs=8 effective batch size while keeping the same number of gradient updates