### PR TITLE
Linear warmup (3 epochs) with lr=0.018

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import math
 import os
 import time
 import torch
@@ -24,7 +25,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.018
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 8.0
@@ -80,7 +81,12 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+def lr_lambda(epoch):
+    if epoch < warmup_epochs:
+        return (epoch + 1) / warmup_epochs
+    return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
+scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
A 3-epoch linear warmup from 0 to lr=0.018 could stabilize the critical first few epochs where the model is far from the solution and gradients are noisy. Warmup was tried in earlier batches (PRs #56, #120) but always with old slower configs and without grad clipping. The combination of warmup + grad clip + current best architecture has NOT been tested. The warmup lets us safely push to a slightly higher peak LR (0.018 vs 0.015) since the initial epochs ramp up gradually.

## Instructions
All changes in `train.py`:

1. Add import at top:
   ```python
   import math
   ```

2. Change Config default:
   ```python
   lr: float = 0.018
   ```

3. Replace the scheduler definition. Change:
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
   ```
   to:
   ```python
   warmup_epochs = 3
   def lr_lambda(epoch):
       if epoch < warmup_epochs:
           return (epoch + 1) / warmup_epochs
       return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
   scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
   ```

4. Keep all other settings: sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, weight_decay=1e-4.

5. Use `--wandb_name "edward/warmup-lr018"` and `--wandb_group "mar14d"` and `--agent edward`

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0, CosineAnnealingLR |

---

## Results

**W&B run ID**: utw7rq02
**Best epoch**: 48 / 50 (hit 5-min wall clock at epoch 49)
**Peak memory**: 3.7 GB

| Metric | Baseline (PR #145) | This run | Delta |
|--------|-------------------|----------|-------|
| surf_p | 59.08 | 58.7 | -0.38 |
| surf_ux | 0.82 | 0.80 | -0.02 |
| surf_uy | 0.43 | 0.44 | +0.01 |
| val_loss | 0.539 | 0.518 | -0.021 |
| vol MAE Ux | — | 2.94 | — |
| vol MAE Uy | — | 1.12 | — |
| vol MAE p | — | 75.0 | — |

### What happened

The warmup + lr=0.018 combination produced a modest but consistent improvement. val_loss dropped from 0.539 to 0.518 (~3.9% improvement), and surf_p improved slightly (59.08 → 58.7). surf_ux also improved slightly (0.82 → 0.80). surf_uy is essentially flat (0.43 → 0.44, within noise). Peak memory stayed the same at 3.7 GB — no overhead from the scheduler change.

Training was stable throughout — no instability or gradient explosions during the warmup period. The best checkpoint came at epoch 48, still improving at the end, suggesting training hadn't fully converged within the 5-minute budget.

The improvement is real but small. The warmup appears to help slightly, possibly by letting the optimizer settle before hitting the peak lr. However, the gain is modest enough that it could be run variance.

### Suggested follow-ups

- Try a longer warmup (5–6 epochs) to see if a more gradual ramp-up helps further.
- Try warmup with lr=0.020 to see if we can push higher now that warmup stabilizes early epochs.
- Run the same config twice to assess variance and confirm this improvement is reproducible.