### PR TITLE
Pressure-specific output head with deeper MLP

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -140,13 +140,21 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2_vel = nn.Linear(hidden_dim, out_dim - 1)  # Ux, Uy
+            self.mlp2_p = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, 1),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            vel = self.mlp2_vel(h)   # (B, N, 2) for Ux, Uy
+            p = self.mlp2_p(h)       # (B, N, 1) for pressure
+            return torch.cat([vel, p], dim=-1)  # (B, N, 3)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Currently all 3 output channels (Ux, Uy, p) share a single linear layer (128→3) as the output head. Pressure has vastly different statistics (y_std=961 vs 25 for Ux, 11.7 for Uy) and likely requires different feature representations. A separate 2-layer MLP head for pressure (128→64→1 with GELU) could give the model more capacity specifically where it's needed, with minimal parameter/compute overhead (~8K extra params, negligible time).

## Instructions
Changes in `transolver.py`:

1. In the `TransolverBlock.__init__` method, when `last_layer=True`, replace:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Linear(hidden_dim, out_dim)
   ```
   with:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2_vel = nn.Linear(hidden_dim, out_dim - 1)  # Ux, Uy
       self.mlp2_p = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, 1),
       )
   ```

2. In `TransolverBlock.forward`, replace:
   ```python
   if self.last_layer:
       return self.mlp2(self.ln_3(fx))
   ```
   with:
   ```python
   if self.last_layer:
       h = self.ln_3(fx)
       vel = self.mlp2_vel(h)   # (B, N, 2) for Ux, Uy
       p = self.mlp2_p(h)       # (B, N, 1) for pressure
       return torch.cat([vel, p], dim=-1)  # (B, N, 3)
   ```

Changes in `train.py`:

3. Keep all settings exactly as baseline: lr=0.015, sw=8, grad clip 1.0, 1L h128 nh=2 slc=32.

4. Use `--wandb_name "thorfinn/pressure-head"` and `--wandb_group "mar14d"` and `--agent thorfinn`

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0 |

---

## Results

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| surf_p | 59.08 | 60.20 | +1.12 (worse) |
| surf_ux | 0.82 | 0.851 | +0.031 (worse) |
| surf_uy | 0.43 | 0.470 | +0.040 (worse) |
| val_loss | 0.539 | 0.565 | +0.026 (worse) |
| Peak GPU mem | - | 66.0 GB | - |

W&B run: `u6o9urlt` (thorfinn/pressure-head, group: mar14d)
Epochs completed: 45/50

**What happened:** The pressure-specific head did not help — all metrics are slightly worse than baseline. The hypothesis was that dedicating a separate MLP (128→64→1 with GELU) for pressure would give the model more capacity to learn the high-variance pressure field. However, the outcome was the opposite: surf_p degraded by ~1.1, and val_loss increased by ~0.026.

A plausible explanation: the current bottleneck is not the output head capacity but feature quality in the shared representation. With only 1 layer and hidden_dim=128, the internal features may not be rich enough to benefit from split heads — both the velocity and pressure heads are reading the same 128-dim representation that was trained end-to-end with a single head, and the added non-linearity in the pressure path may simply add noise at this scale. The extra ~8K parameters appear to have no positive effect.

**Suggested follow-ups:**
- Try a deeper shared backbone (2L instead of 1L) before splitting at the head — if richer features are the bottleneck, the split head might then help.
- Try scaling the hidden_dim in the pressure head more aggressively (128→128→1) to see if the bottleneck is head width vs. depth.
- Investigate output normalization: pressure has much higher variance (y_std=961) — separate per-field output scaling/normalization might help more than a separate head architecture.