### PR TITLE
Gradient accumulation (effective batch size 16)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,9 +22,10 @@ from utils import visualize, dataset_stats
 
 MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
+ACCUM_STEPS = 4
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.025
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 8.0
@@ -118,6 +119,7 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf = 0.0
     n_batches = 0
 
+    optimizer.zero_grad()
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
@@ -137,10 +139,13 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
+        scaled_loss = loss / ACCUM_STEPS
+        scaled_loss.backward()
+
+        if (n_batches + 1) % ACCUM_STEPS == 0 or (n_batches + 1) == len(train_loader):
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Instead of larger physical batches, accumulate gradients over 4 mini-batches of size 4 before stepping. This gives the gradient quality of bs=16 without changing memory footprint. With 96GB VRAM idle, the bottleneck is gradient noise for the minority surface nodes (~1.2% of all nodes). Effective bs=16 means each optimizer step sees 4x more surface nodes, producing much cleaner gradient estimates for the surface loss component. Combined with a proportionally higher LR (0.025) and existing grad clipping.

## Instructions
All changes in `train.py`:

1. Add a constant near the top:
   ```python
   ACCUM_STEPS = 4
   ```

2. Change Config default:
   ```python
   lr: float = 0.025
   ```

3. In the training loop, replace the backward/step section.

4. Important: `n_batches` is incremented AFTER this code block.

5. Keep all other settings: sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, CosineAnnealingLR T_max=50.

6. Use `--wandb_name "askeladd/grad-accumulation"` and `--wandb_group "mar14d"` and `--agent askeladd`

## Baseline
| Metric | Current best (PR #145) |
|--------|----------------------|
| surf_p | 59.08 |
| surf_ux | 0.82 |
| surf_uy | 0.43 |
| val_loss | 0.539 |
| Config | lr=0.015, sw=8, bs=4, 1L h128 nh=2 slc=32, grad clip 1.0 |

---

## Results

**W&B run ID:** u4nqiljv

| Metric | Baseline (PR #145) | This run: lr=0.025/gradaccum/gradclip (49ep) |
|--------|-------------------|---------------------------------------------|
| surf_p | 59.08 | 82.8 |
| surf_Ux | 0.82 | 1.10 |
| surf_Uy | 0.43 | 0.62 |
| vol_p | — | 114.0 |
| val_loss | 0.539 | 0.751 |
| Peak memory | — | 3.7 GB |
| Epochs completed | — | 49 (5-min timeout) |

### What happened

Gradient accumulation + lr=0.025 did **not** beat the baseline — all metrics are worse than lr=0.012/sw=8.

Key observations:

1. **LR=0.025 is too aggressive** — same pattern as lr=0.020 (PR #149): high LR causes CosineAnnealingLR to decay faster, model cannot recover. surf_p=82.8 vs 60.6 at lr=0.020 shows the extra LR increase made things worse.

2. **Gradient accumulation worked correctly** — no crashes, no NaN, steady monotonic improvement through 49 epochs. Memory identical at 3.7 GB.

3. **Still converging at ep49** — surf_p declining (92.2 at ep40 → 82.8 at ep49), learning but not fast enough within the 5-min budget at this LR.

4. **The hypothesis was partly wrong** — the bottleneck is not gradient noise from small batch size. lr=0.012 with bs=4 achieves surf_p=59.08. The issue is LR schedule interaction, not batch size / gradient quality.

**Verdict:** Gradient accumulation does not help here because LR=0.025 outweighs any benefit from cleaner gradients. lr=0.012 without accumulation remains superior.

### Suggested follow-ups

- Try grad accumulation with **lr=0.012** to isolate accumulation benefit from LR effects
- Try actual **batch_size=16** (no accumulation) — with 96GB VRAM this is feasible; would reveal if it is batch size or LR that matters