### PR TITLE
Huber surface loss (delta=1.0) for smoother convergence

### DIFF
--- a/train.py
+++ b/train.py
@@ -130,12 +130,18 @@ for epoch in range(MAX_EPOCHS):
         pred = model({"x": x})["preds"]
         diff = pred - y_norm
         sq_err = diff ** 2
-        abs_err = diff.abs()
+        abs_diff = diff.abs()
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+
+        # Huber loss for surface: smooth near zero, L1 for large errors
+        huber_delta = 1.0
+        huber_err = torch.where(abs_diff <= huber_delta,
+                                0.5 * sq_err / huber_delta,
+                                abs_diff - 0.5 * huber_delta)
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -175,12 +181,16 @@ for epoch in range(MAX_EPOCHS):
             pred = model({"x": x})["preds"]
             diff = pred - y_norm
             sq_err = diff ** 2
-            abs_err = diff.abs()
+            abs_diff = diff.abs()
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            huber_delta = 1.0
+            huber_err = torch.where(abs_diff <= huber_delta,
+                                    0.5 * sq_err / huber_delta,
+                                    abs_diff - 0.5 * huber_delta)
+            val_surf += (huber_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
Pure L1 has non-smooth gradients at zero, causing oscillation near convergence. Huber loss (L1 far from zero, MSE near zero) gives the best of both: L1-like robustness for large errors (which drove the L1 win) plus smooth gradients near the optimum. Previous Huber experiments (PR #60, #87) used Huber for ALL nodes with tiny deltas (0.001-0.1) — this uses Huber only for surface nodes at delta=1.0 in normalized space, a fundamentally different regime.

## Instructions
All changes in `train.py`:

1. Replace surface loss computation in training loop with Huber loss (delta=1.0).
2. Apply the same change in the validation loop.
3. Keep all other settings: lr=0.015, sw=8, grad clip 1.0, 1L h128 nh=2 slc=32.
4. Use `--wandb_name "frieren/huber-surface-loss"` and `--wandb_group "mar14d"` and `--agent frieren`

## Baseline
| Metric | Current best (PR #152, L1 surface) |
|--------|-----------------------------------|
| surf_p | 53.73 |
| surf_ux | 0.62 |
| surf_uy | 0.38 |
| val_loss | 1.048 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0, L1 surf + MSE vol |

---

## Results

**Status: NEGATIVE — Huber loss worse than L1 on all surface metrics**

| Metric | This run (Huber δ=1.0) | Baseline (L1) | Change |
|--------|----------------------|---------------|--------|
| surf_p | 59.23 | 53.73 | +10.2% worse |
| surf_ux | 0.85 | 0.62 | +37% worse |
| surf_uy | 0.46 | 0.38 | +21% worse |
| val_loss | 0.294 | 1.048 | (not comparable — different loss units) |
| Epochs | 48/50 | — | |
| Peak memory | 3.7 GB | — | |

**W&B run ID:** r1u7f19w

**What happened:**

Huber loss with delta=1.0 performed worse than pure L1 on every surface metric. The pressure MAE went from 53.73 to 59.23 (+10%), and velocity components also degraded significantly. The val_loss number is lower (0.294 vs 1.048) but this is purely because Huber loss values are smaller than L1 values by construction (near zero errors contribute `0.5 * err^2 / delta` instead of `|err|`), so the numbers aren't comparable across formulations.

The hypothesis that smooth gradients near zero would help was not supported. One likely explanation: with delta=1.0 in normalized space, most surface errors during the bulk of training are *below* the delta threshold (they're in the MSE regime, not the L1 regime). So this experiment effectively behaved more like a scaled MSE than like L1, losing the robustness properties that made L1 better.

At best_epoch=48, the model is still converging — this pattern matches all recent runs, suggesting the 5-minute budget rather than the loss function is the limiting factor.

**Suggested follow-ups:**
- Try a much smaller delta (e.g., 0.1 or 0.01) so that errors spend more time in the L1 regime. With delta=0.01, only very small residuals get the MSE treatment, keeping L1 robustness for the majority of training.
- Alternatively, accept that L1 surface loss is a good baseline and explore other directions (architecture changes, more epochs via faster training, etc.).