### PR TITLE
Increase surf_weight to 12 with L1 surface loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.015
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 8.0
+    surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
The optimal surf_weight=8 was tuned under MSE surface loss. Switching to L1 changes the loss scale — for normalized errors > 1, L1 gives smaller values than MSE (e.g., error of 2.0: MSE=4.0, L1=2.0). The surface gradient signal is now relatively weaker, so the optimal surf_weight should be higher to compensate. Re-tuning sw for the new L1 regime could recover lost surface emphasis.

## Instructions
All changes in `train.py`:

1. Change the Config default:
   ```python
   surf_weight: float = 12.0
   ```

2. Keep everything else exactly as baseline: lr=0.015, grad clip 1.0, 1L h128 nh=2 slc=32, L1 surface + MSE volume, CosineAnnealingLR T_max=50.

3. Use `--wandb_name "fern/sw12-l1"` and `--wandb_group "mar14d"` and `--agent fern`

## Baseline
| Metric | Current best (PR #152, L1 surface) |
|--------|-----------------------------------|
| surf_p | 53.73 |
| surf_ux | 0.62 |
| surf_uy | 0.38 |
| val_loss | 1.048 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0, L1 surf + MSE vol |

---

## Results

**W&B run**: `k9rgc8rg` | **Best epoch**: 49 | **Peak memory**: 3.7GB

| Metric | Baseline (sw=8, L1) | sw=12, L1 | Delta |
|--------|---------------------|-----------|-------|
| surf_p | 53.73 | 50.1 | -6.8% better |
| surf_Ux | 0.62 | 0.61 | -1.6% better |
| surf_Uy | 0.38 | 0.35 | -7.9% better |
| val_loss | 1.048 | 1.415 | higher (expected) |
| vol_Ux | — | 3.38 | — |
| vol_Uy | — | 1.38 | — |
| vol_p | — | 94.9 | — |

**What happened**: The hypothesis was correct — increasing surf_weight compensates for the reduced L1 loss scale and recovers more surface emphasis. Surface MAE improved across all three channels: pressure dropped ~7% and Uy dropped ~8%, which are meaningful gains. The val_loss number is higher but that is expected: with sw=12 the formula `vol + 12 * surf` produces a larger raw number, but the actual prediction quality (MAE) is better. Volume MAE is slightly higher (trade-off from more emphasis on surface), but surface accuracy is what matters most.

**Suggested follow-ups**:
- Try sw=16 or sw=20 to see if the trend continues, or if there's a point of diminishing returns / volume degradation
- Try sw=10 to narrow down the sweet spot between 8 and 12
- The volume MAE degraded (e.g., vol_p went up), so there may be a Pareto frontier to explore