### PR TITLE
CosineAnnealingWarmRestarts (T_0=25) for two LR cycles

### DIFF
--- a/train.py
+++ b/train.py
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=25, T_mult=1)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
CosineAnnealingLR with T_max=50 decays LR monotonically to near-zero by epoch 50. The model is still converging at epoch 49 but with a tiny LR that limits progress. With warm restarts (T_0=25, T_mult=1), the LR resets at epoch 25, giving two full cosine cycles. The restart at epoch 25 can jolt the model out of a local minimum. This is particularly relevant with L1 surface loss where the loss landscape is piecewise linear — warm restarts help escape flat regions.

Previous SGDR test (PR #130) used different configs and MSE loss. This tests warm restarts under the new L1 surface loss regime.

## Instructions
All changes in `train.py`:

1. Replace the scheduler definition. Change:
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
   ```
   to:
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=25, T_mult=1)
   ```

2. Keep everything else: lr=0.015, sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, wd=1e-4, L1 surface + MSE volume.

3. Use `--wandb_name "nezuko/warm-restarts"` and `--wandb_group "mar14d"` and `--agent nezuko`

## Baseline
| Metric | Current best (PR #152, L1 surface) |
|--------|-----------------------------------|
| surf_p | 53.73 |
| surf_ux | 0.62 |
| surf_uy | 0.38 |
| val_loss | 1.048 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0, CosineAnnealingLR T_max=50 |

---

## Results

**W&B run ID:** `2g12w3am`
**Epochs completed:** 49 (best at epoch 49)
**Peak memory:** 3.7 GB

| Metric | Baseline | Warm Restarts | Delta |
|--------|----------|---------------|-------|
| surf_p | 53.73 | 53.9 | +0.2 (worse, ~0.3%) |
| surf_Ux | 0.62 | 0.66 | +0.04 (worse) |
| surf_Uy | 0.38 | 0.38 | 0.00 (same) |
| val_loss | 1.048 | 1.063 | +0.015 (worse) |
| Epochs in 5 min | 49 | 49 | same |

**What happened:**

Warm restarts did not improve results — performance is effectively the same as baseline (within ~0.3% on surf_p, ~0.02 on surf_Uy). The LR restart at epoch 26 visibly disrupted the model: epochs 26-31 showed elevated val losses and surface MAE spiked back to levels seen at ~epoch 10. The model recovered in the second cycle and by epoch 48-49 just barely recaptured the performance level of epoch 25.

The key observation is that the model was still clearly improving at epoch 25 (surf_p at 72.4, still declining). The warm restart was premature — instead of escaping a local minimum, it interrupted productive descent and wasted the second cycle catching back up. The final result at epoch 49 (surf_p=53.9) is nearly identical to baseline (53.73), suggesting the second restart cycle recovered all lost ground but provided no additional benefit.

**Suggested follow-ups:**
- Try T_0=40 (single long cycle, reset near convergence) instead of T_0=25 — the restart is more likely to help when the model is actually stalled
- Alternatively T_0=50, T_mult=2 (one full long cycle + short explorations) to avoid disrupting early learning
- Consider whether warm restarts even make sense here: with only 49 epochs in budget, two 25-epoch cycles is barely enough time for each cycle to converge