### PR TITLE
Deeper output MLP (128→64→3 with GELU)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The last layer of TransolverBlock uses a single linear projection (128→3) as the output decoder. This is a very thin decoder that must project 128-dim features directly to 3 output channels with vastly different scales (Ux, Uy, p). A small 2-layer MLP (128→64→3 with GELU) gives the model more capacity to map learned features to outputs without adding a full Transolver layer (which exceeds the 5-min budget). This is cheaper than the pressure-specific head (PR #156) that failed — instead of splitting heads, we just add depth to the shared decoder.

## Instructions
Changes in `transolver.py`:

1. In the `TransolverBlock.__init__` method, replace the output layer definition. Change:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Linear(hidden_dim, out_dim)
   ```
   to:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, out_dim),
       )
   ```

2. No changes needed in `forward` — `self.mlp2(self.ln_3(fx))` works the same with nn.Sequential.

Changes in `train.py`:

3. Keep all settings exactly as baseline: lr=0.015, sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, L1 surface + MSE volume.

4. Use `--wandb_name "edward/deeper-output-mlp"` and `--wandb_group "mar14d"` and `--agent edward`

## Baseline
| Metric | Current best (PR #152, L1 surface) |
|--------|-----------------------------------|
| surf_p | 53.73 |
| surf_ux | 0.62 |
| surf_uy | 0.38 |
| val_loss | 1.048 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0, L1 surf + MSE vol |

---

## Results

**W&B run ID**: tfzodwwf
**Best epoch**: 48 / 50 (hit 5-min wall clock at epoch 48)
**Peak memory**: 3.7 GB

| Metric | Baseline (PR #152) | This run | Delta |
|--------|-------------------|----------|-------|
| surf_p | 53.73 | 47.7 | -6.03 |
| surf_ux | 0.62 | 0.62 | 0.00 |
| surf_uy | 0.38 | 0.34 | -0.04 |
| val_loss | 1.048 | 0.961 | -0.087 |
| vol MAE Ux | — | 3.36 | — |
| vol MAE Uy | — | 1.29 | — |
| vol MAE p | — | 79.1 | — |

### What happened

This is a meaningful improvement. surf_p dropped from 53.73 to 47.7 (~11% improvement), and surf_uy improved from 0.38 to 0.34. surf_ux is essentially unchanged (0.62 → 0.62). Val_loss improved by ~8.3% (1.048 → 0.961). No change in memory (3.7 GB) — the extra two linear layers are tiny.

The model was still clearly improving at epoch 47-48 (best checkpoint at 48, continuing to decline), suggesting the 5-minute budget is the limiting factor here, not convergence. The hypothesis appears valid: a thin 2-layer decoder adds useful capacity for mapping features to the multi-scale outputs, particularly helping pressure prediction.

Interestingly, the vol_loss appears somewhat worse (val_vol ~0.14 vs the L1-baseline), but the surface improvements are substantial. The L1 surface + deeper decoder combination works well together.

### Suggested follow-ups

- Try combining this deeper MLP with the warmup + lr=0.018 (PR #155) since both appear to help independently.
- Try a 3-layer decoder (128→64→32→3) to see if even more capacity helps further.
- Given the model is still improving at epoch 48, test with a higher epoch budget if the 5-min constraint can be stretched slightly for a best-of-breed config.