### PR TITLE
AdamW beta2=0.99 for faster adaptation to L1 gradients

### DIFF
--- a/train.py
+++ b/train.py
@@ -79,7 +79,7 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.9, 0.99))
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
 
 


### PR DESCRIPTION
## Hypothesis
Default AdamW uses beta2=0.999, meaning the second moment estimate adapts very slowly. With L1 surface loss, gradients have constant magnitude (sign only) — the variance estimator tracks gradient sign flips rather than magnitude changes. Lower beta2=0.99 makes the optimizer adapt faster to the L1 gradient structure, giving more responsive step sizes. This is a well-known interaction between L1-style losses and Adam optimizers.

## Instructions
All changes in `train.py`:

1. Change the optimizer definition. Replace:
   ```python
   optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
   ```
   with:
   ```python
   optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay, betas=(0.9, 0.99))
   ```

2. Keep everything else: lr=0.015, sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, wd=1e-4, L1 surface + MSE volume, CosineAnnealingLR T_max=50.

3. Use `--wandb_name "thorfinn/beta2-099"` and `--wandb_group "mar14d"` and `--agent thorfinn`

## Baseline
| Metric | Current best (PR #152, L1 surface) |
|--------|-----------------------------------|
| surf_p | 53.73 |
| surf_ux | 0.62 |
| surf_uy | 0.38 |
| val_loss | 1.048 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0, L1 surf + MSE vol, beta2=0.999 |

---

## Results

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| surf_p | 53.73 | 95.46 | +41.73 (much worse) |
| surf_ux | 0.62 | 1.205 | +0.585 (much worse) |
| surf_uy | 0.38 | 0.585 | +0.205 (much worse) |
| val_loss | 1.048 | 1.793 | +0.745 (much worse) |

W&B run: `5qga45pl` (thorfinn/beta2-099, group: mar14d)
Epochs completed: 49/50 — but **31/49 epochs produced NaN** (training diverged after ~epoch 18)

**What happened:** Training diverged. beta2=0.99 caused severe instability — the second-moment estimate decays too quickly, causing the adaptive step sizes to fluctuate wildly. With L1 gradients (constant-magnitude sign signals), a fast-decaying v_t means that any consistent gradient direction gets amplified to very large effective step sizes within a few steps, which then destabilizes training. Even the best valid epoch (14) showed metrics roughly 2× worse than baseline.

The grad clip of 1.0 was not enough to prevent divergence — the instability appears to come from the denominator (sqrt(v_t) → 0) rather than the numerator (gradient magnitude).

**Suggested follow-ups:**
- Try a milder beta2=0.995 (halfway between 0.999 and 0.99) to see if there is a stable middle ground.
- Alternatively, pair beta2=0.99 with a lower lr (e.g. lr=0.005) and/or tighter grad clip (0.5) to compensate for larger effective step sizes.
- The hypothesis about L1/beta2 interaction may be valid in principle, but the interaction with CosineAnnealingLR (which starts at lr=0.015, quite high) likely exacerbates instability early in training.