### PR TITLE
3-epoch warmup + lr=0.018 with L1 surface loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import math
 import os
 import time
 import torch
@@ -24,7 +25,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.018
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 8.0
@@ -80,7 +81,12 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+def lr_lambda(epoch):
+    if epoch < warmup_epochs:
+        return (epoch + 1) / warmup_epochs
+    return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
+scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Warmup alone (PR #155) gave a marginal improvement (59.08→58.66) under MSE surface loss. Now that L1 surface loss is the baseline and produces different gradient dynamics (constant-magnitude gradients), warmup may interact differently. The L1 gradients are noisier in early epochs when the model is far from the solution — a warmup period could stabilize the initial phase while a slightly higher peak LR (0.018) extracts more progress. This tests the combination of two orthogonal improvements.

## Instructions
All changes in \`train.py\`:

1. Add import at top:
   \`\`\`python
   import math
   \`\`\`

2. Change Config default:
   \`\`\`python
   lr: float = 0.018
   \`\`\`

3. Replace the scheduler definition. Change:
   \`\`\`python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
   \`\`\`
   to:
   \`\`\`python
   warmup_epochs = 3
   def lr_lambda(epoch):
       if epoch < warmup_epochs:
           return (epoch + 1) / warmup_epochs
       return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
   scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
   \`\`\`

4. Keep everything else: sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, wd=1e-4, L1 surface + MSE volume.

5. Use \`--wandb_name "askeladd/warmup-l1"\` and \`--wandb_group "mar14d"\` and \`--agent askeladd\`

## Baseline
| Metric | Current best (PR #152, L1 surface) |
|--------|-----------------------------------|
| surf_p | 53.73 |
| surf_ux | 0.62 |
| surf_uy | 0.38 |
| val_loss | 1.048 |
| Config | lr=0.015, sw=8, 1L h128 nh=2 slc=32, grad clip 1.0, L1 surf + MSE vol, CosineAnnealingLR |

---

## Results

**W&B run ID:** v0iz1eqr

| Metric | Baseline (PR #152, L1 surf) | This run: warmup + lr=0.018 |
|--------|----------------------------|------------------------------|
| surf_p | 53.73 | **51.20** |
| surf_ux | 0.62 | 0.63 |
| surf_uy | 0.38 | **0.34** |
| val_loss | 1.048 | **0.9978** |
| Peak memory | — | 3.7 GB |
| Epochs completed | — | 49 (5-min timeout) |

### What happened

Warmup + lr=0.018 beat the L1 baseline on surf_p (53.73 → 51.20, -4.7%) and surf_uy (0.38 → 0.34), with val_loss also improving (1.048 → 0.9978). surf_ux is essentially unchanged (0.62 → 0.63).

Key observations:
1. **Warmup helps with L1** — the hypothesis held: noisy L1 gradients in early epochs benefited from gradual LR ramp-up. Smooth initial training likely avoided early bad optima.
2. **Still converging at ep49** — surf_p declining through final epochs (model hadn't plateaued), suggesting more epochs would help further.
3. **lr=0.018 works well with warmup** — higher than the 0.015 baseline but warmup prevents early overshooting; cosine decay then takes over smoothly.
4. **Small but consistent improvement** — not dramatic, but reliable improvement across the key metrics. Warmup adds minimal complexity.

**Verdict:** Warmup + lr=0.018 is a genuine improvement over the L1 baseline. The combination is clean and principled.

### Suggested follow-ups

- Try longer warmup (5 epochs) to see if more ramp-up time helps further
- Combine warmup with grad accumulation (effective bs=16 + warmup) — both address noisy gradients from different angles
- Try lr=0.020 with warmup — now that warmup provides stability, the LR upper bound may be higher