### PR TITLE
weight_decay=0 with deeper output MLP

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ MAX_EPOCHS = 50
 @dataclass
 class Config:
     lr: float = 0.015
-    weight_decay: float = 1e-4
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 8.0
     dataset: str = "raceCar_single_randomFields"


### PR DESCRIPTION
## Hypothesis
Both weight_decay=0 (surf_p=49.33) and deeper output MLP (surf_p=47.69) independently improved over the L1 baseline (53.73). These changes are orthogonal: wd=0 affects optimization dynamics while deeper MLP affects model capacity. If gains are additive, we could reach ~43-44 surf_p. The model has only 1 layer with 128 hidden dims — too small to overfit in 49 epochs, making weight decay unnecessary regularization tax.

## Instructions
All changes in `train.py`:

1. Change the Config default:
   ```python
   weight_decay: float = 0.0
   ```

2. Keep everything else exactly as current baseline: lr=0.015, sw=8, grad clip 1.0, 1L h128 nh=2 slc=32, L1 surface + MSE volume, CosineAnnealingLR T_max=50. The deeper output MLP is already in the codebase (transolver.py).

3. Use `--wandb_name "frieren/wd0-deeper-mlp"` and `--wandb_group "mar14d"` and `--agent frieren`

## Baseline
| Metric | Current best (PR #163, deeper MLP + L1 surface) |
|--------|------------------------------------------------|
| surf_p | 47.69 |
| surf_ux | 0.62 |
| surf_uy | 0.34 |
| val_loss | 0.961 |
| Config | lr=0.015, sw=8, wd=1e-4, 1L h128 nh=2 slc=32, grad clip 1.0, deeper output MLP |

---

## Results

**Status: NEGATIVE — combination does not improve over either individual change**

| Metric | This run (wd=0 + deeper MLP) | Baseline (deeper MLP, wd=1e-4) | wd=0 alone | Change vs baseline |
|--------|------------------------------|-------------------------------|------------|-------------------|
| surf_p | 50.04 | 47.69 | 49.33 | +4.9% worse |
| surf_ux | 0.61 | 0.62 | — | -1.6% better |
| surf_uy | 0.37 | 0.34 | — | +8.8% worse |
| val_loss | 1.000 | 0.961 | — | slightly worse |
| Epochs | 48/50 | — | — | |
| Peak memory | 3.7 GB | — | — | |

**W&B run ID:** v7bju6cy

**What happened:**

The gains did not combine. surf_p (50.04) is worse than deeper MLP alone (47.69) and only marginally better than wd=0 alone (49.33). The hypothesis of additive improvements was incorrect — the combination actually regressed on the most important metric (surf_p) versus the best individual component.

This is a common pattern in ML: two changes that independently improve a metric don't always stack. Possible explanations:
- With wd=0, the deeper MLP has more capacity to memorize rather than generalize, and without regularization the extra parameters may hurt validation performance.
- The interaction between wd=0 dynamics and the deeper architecture may destabilize optimization in a way neither alone does.
- Variance from the stochastic training process: these margins are small enough that any individual run could be noise.

The best result remains the deeper output MLP with wd=1e-4 (surf_p=47.69).

**Suggested follow-ups:**
- Run a larger sweep over wd values (0, 1e-5, 1e-4, 1e-3) with the deeper MLP to find the sweet spot, rather than jumping straight to 0.
- Consider that the 5-minute training budget may be masking the true benefit — with more epochs, wd=0 might diverge while small wd stays stable.