### PR TITLE
surf_weight=12 with deeper output MLP

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.015
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 8.0
+    surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
surf_weight=12 alone gave surf_p=50.14 (vs 53.73 baseline), a 6.7% improvement. The optimal sw was tuned under MSE surface loss; L1 changes the loss scale, making the surface gradient relatively weaker. Combined with the deeper output MLP (which already improved surf_p to 47.69), higher sw may push the model to focus even more on surface accuracy with its improved decoder capacity.

## Instructions
All changes in `train.py`:

1. Change the Config default:
   ```python
   surf_weight: float = 12.0
   ```

2. Keep everything else: lr=0.015, wd=1e-4, grad clip 1.0, 1L h128 nh=2 slc=32, L1 surface + MSE volume, CosineAnnealingLR T_max=50. Deeper MLP already in codebase.

3. Use `--wandb_name "fern/sw12-deeper-mlp"` and `--wandb_group "mar14d"` and `--agent fern`

## Baseline
| Metric | Current best (PR #163) |
|--------|----------------------|
| surf_p | 47.69 |
| surf_ux | 0.62 |
| surf_uy | 0.34 |
| val_loss | 0.961 |

---

## Results

**W&B run**: `w23fn3ni` | **Best epoch**: 48 | **Peak memory**: 3.7GB

| Metric | Baseline (sw=8, deeper MLP) | sw=12, deeper MLP | Delta |
|--------|------------------------------|-------------------|-------|
| surf_p | 47.69 | 53.7 | +12.6% worse |
| surf_Ux | 0.62 | 0.65 | +4.8% worse |
| surf_Uy | 0.34 | 0.38 | +11.8% worse |
| val_loss | 0.961 | 1.503 | higher |
| vol_Ux | — | 3.41 | — |
| vol_Uy | — | 1.42 | — |
| vol_p | — | 87.2 | — |

**What happened**: sw=12 helped when used alone with L1 (PR #159: 53.73→50.1, -7%), but hurt significantly when combined with the deeper MLP. This is the opposite of the hypothesis. The deeper MLP (PR #163) already achieved surf_p=47.69 with sw=8, and adding sw=12 pushed it to 53.7 — worse than even the sw=8+L1 baseline without the deeper MLP. The deeper MLP appears to already be amplifying the surface signal enough; further increasing sw to 12 seems to over-constrain or destabilize the training, possibly causing the model to focus too heavily on surface at the cost of generalization. The combination of the two improvements doesn't stack.

**Suggested follow-ups**:
- Try sw=10 with deeper MLP — there may be a sweet spot between 8 and 12 in this regime
- The deeper MLP baseline (sw=8) at surf_p=47.69 remains the best so far; leave sw=8 and explore other dimensions (lr, architecture)
- Try the triple combo: L1 + sw=12 + deeper MLP together vs pairwise — to understand interaction effects