### PR TITLE
Triple combo: wd=0 + sw=12 + deeper MLP

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,9 +25,9 @@ MAX_EPOCHS = 50
 @dataclass
 class Config:
     lr: float = 0.015
-    weight_decay: float = 1e-4
+    weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 8.0
+    surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
Three independently validated improvements combined: weight_decay=0 (surf_p=49.33), surf_weight=12 (surf_p=50.14), and deeper output MLP (surf_p=47.69). All three address different axes: wd=0 removes optimization drag, sw=12 compensates for L1 loss scale, deeper MLP adds decoder capacity. If gains stack even partially, we could reach ~40-43 surf_p, approaching the 36.78 target.

## Instructions
All changes in `train.py`:

1. Change Config defaults:
   ```python
   weight_decay: float = 0.0
   surf_weight: float = 12.0
   ```

2. Keep everything else: lr=0.015, grad clip 1.0, 1L h128 nh=2 slc=32, L1 surface + MSE volume, CosineAnnealingLR T_max=50. Deeper MLP already in codebase.

3. Use `--wandb_name "nezuko/triple-combo"` and `--wandb_group "mar14d"` and `--agent nezuko`

## Baseline
| Metric | Current best (PR #163) |
|--------|----------------------|
| surf_p | 47.69 |
| surf_ux | 0.62 |
| surf_uy | 0.34 |
| val_loss | 0.961 |

---

## Results

**W&B run ID:** `zfem9fe0`
**Epochs completed:** 48 (best at epoch 48)
**Peak memory:** 3.7 GB

| Metric | Baseline | Triple Combo | Delta |
|--------|----------|--------------|-------|
| surf_p | 47.69 | 45.5 | -2.2 (better, ~4.6%) |
| surf_Ux | 0.62 | 0.58 | -0.04 (better) |
| surf_Uy | 0.34 | 0.34 | 0.00 (same) |
| val_loss | 0.961 | 1.325 | higher (expected: sw=12 vs 8) |
| Epochs in 5 min | 49 | 48 | -1 |

**What happened:**

The combination delivered a clear improvement on surface pressure: 45.5 vs 47.69 (4.6% better). surf_Ux also improved slightly (0.58 vs 0.62) while surf_Uy stayed the same. The gains appear to stack at least partially — this is better than any of the three individual experiments achieved when compared to their own baselines.

Note: val_loss is higher than baseline (1.325 vs 0.961) because surf_weight=12 scales the loss term by 50% more than sw=8. This does not indicate worse performance — the MAE metrics confirm the model is genuinely better at surface prediction.

The model was still improving at epoch 48 (and appears to still be declining), suggesting this config would benefit from more epochs. The 5-minute wall clock limit is the binding constraint.

**Suggested follow-ups:**
- This config is now the best combination found so far. Consider it the new baseline for further experiments.
- Try lr=0.020 or cosine warmup — with wd=0 and sw=12, a slightly higher LR may be safe and could accelerate convergence in the 5-min budget
- The model is clearly not converged at epoch 48 — any technique that increases epoch throughput (AMP/mixed precision, larger batch) would directly translate to better final results