### PR TITLE
3-layer decoder (128→64→32→3) for more output capacity

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -143,7 +143,9 @@ class TransolverBlock(nn.Module):
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim // 2),
                 nn.GELU(),
-                nn.Linear(hidden_dim // 2, out_dim),
+                nn.Linear(hidden_dim // 2, hidden_dim // 4),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 4, out_dim),
             )
 
     def forward(self, fx):


### PR DESCRIPTION
## Hypothesis
The 2-layer decoder (128→64→3 with GELU) gave a huge improvement (53.73→47.69). Pushing to 3 layers (128→64→32→3) adds more non-linear capacity to the output mapping. The extra layer adds only ~2K params and negligible compute. If the bottleneck is the decoder's ability to map the 128-dim representation to multi-scale outputs, more depth should help.

## Instructions
Changes in `transolver.py`:

1. In `TransolverBlock.__init__`, replace the output MLP. Change:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, out_dim),
       )
   ```
   to:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, hidden_dim // 4),
           nn.GELU(),
           nn.Linear(hidden_dim // 4, out_dim),
       )
   ```

2. No changes to `forward` needed.

Changes in `train.py`:
3. Keep all settings as baseline: lr=0.015, sw=8, wd=1e-4, grad clip 1.0, 1L h128 nh=2 slc=32.

4. Use `--wandb_name "alphonse/3layer-decoder"` and `--wandb_group "mar14d"` and `--agent alphonse`

## Baseline
| Metric | Current best (PR #163) |
|--------|----------------------|
| surf_p | 47.69 |
| surf_ux | 0.62 |
| surf_uy | 0.34 |
| val_loss | 0.961 |

---

## Results

**W&B run**: s8s0q9w1 (alphonse/3layer-decoder, group: mar14d)

| Metric | Baseline (PR #163) | 3-layer decoder | Delta |
|--------|-------------------|-----------------|-------|
| surf_p | 47.69 | 47.97 | +0.6% (wash) |
| surf_ux | 0.62 | 0.60 | -3% (marginal gain) |
| surf_uy | 0.34 | 0.36 | +6% (marginal loss) |
| val_loss | 0.961 | 0.965 | +0.4% (wash) |
| Peak memory | 3.7 GB | 3.7 GB | no change |

Best epoch: 46/47 (wall-clock limit reached at 5.0 min, 47 epochs completed)

**What happened**: The 3-layer decoder did not improve over the 2-layer baseline. All metrics are within noise — surf_p 47.97 vs 47.69 is a trivial difference that could easily flip direction with a different random seed. The extra decoder layer (128→64→32→3) adds ~2K parameters and slightly slows training (33 it/s vs ~35 it/s baseline). The decoder bottleneck hypothesis does not appear to be the limiting factor at this model size. The representation capacity (128-dim, 1 layer, nh=2, slc=32) is likely the binding constraint rather than the final projection.

**Suggested follow-ups**:
- The 2-layer decoder seems sufficient — the limiting factor is likely in the Transolver attention/representation, not the output head
- Try wider hidden_dim (e.g., 256) to increase representation capacity throughout the model
- Try more slices (slc=64) to give the physics attention more granularity