### PR TITLE
lr=0.020 + 3-epoch warmup with deeper MLP

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import math
 import os
 import time
 import torch
@@ -24,7 +25,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.020
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 8.0
@@ -80,7 +81,12 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+def lr_lambda(epoch):
+    if epoch < warmup_epochs:
+        return (epoch + 1) / warmup_epochs
+    return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
+scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Warmup + lr=0.018 alone gave surf_p=51.20 (vs 53.73 baseline, a 4.7% improvement). With the deeper output MLP now providing more decoder capacity, pushing to lr=0.020 with a 3-epoch warmup could extract more from the richer model. The warmup stabilizes early epochs, allowing a higher peak LR. Grad clipping provides the safety net. This tests whether the improved architecture can benefit from more aggressive optimization.

## Instructions
All changes in \`train.py\`:

1. Add import:
   \`\`\`python
   import math
   \`\`\`

2. Change Config default:
   \`\`\`python
   lr: float = 0.020
   \`\`\`

3. Replace the scheduler. Change:
   \`\`\`python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
   \`\`\`
   to:
   \`\`\`python
   warmup_epochs = 3
   def lr_lambda(epoch):
       if epoch < warmup_epochs:
           return (epoch + 1) / warmup_epochs
       return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
   scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
   \`\`\`

4. Keep everything else: sw=8, wd=1e-4, grad clip 1.0, 1L h128 nh=2 slc=32, L1 surface + MSE volume. Deeper MLP already in codebase.

5. Use \`--wandb_name "askeladd/lr020-warmup-deeper"\` and \`--wandb_group "mar14d"\` and \`--agent askeladd\`

## Baseline
| Metric | Current best (PR #163) |
|--------|----------------------|
| surf_p | 47.69 |
| surf_ux | 0.62 |
| surf_uy | 0.34 |
| val_loss | 0.961 |
| Config | lr=0.015, CosineAnnealingLR T_max=50 |

---

## Results

**W&B run ID:** n4aeu273

| Metric | Baseline (PR #163) | This run: lr=0.020 + warmup + deeper MLP |
|--------|-------------------|------------------------------------------|
| surf_p | 47.69 | **46.23** |
| surf_ux | 0.62 | **0.58** |
| surf_uy | 0.34 | 0.34 |
| val_loss | 0.961 | **0.9149** |
| Peak memory | — | 3.7 GB |
| Epochs completed | — | 49 (5-min timeout) |

### What happened

lr=0.020 + 3-epoch warmup with the deeper MLP beats the baseline on all key metrics: surf_p improves 3.1% (47.69→46.23), surf_ux improves 6.5% (0.62→0.58), surf_uy unchanged, and val_loss drops 4.8% (0.961→0.9149).

Key observations:
1. **Warmup + higher LR works with deeper MLP** — the additional decoder capacity of the deeper MLP appears to benefit from the more aggressive learning rate; the warmup prevents early-epoch instability.
2. **Still converging at ep49** — model hadn't plateaued, suggesting more epochs would yield further gains.
3. **surf_ux improvement is notable** — 0.62→0.58 is a meaningful gain that wasn't seen in the warmup-only run (PR #165), suggesting the deeper MLP contributes specifically to velocity prediction.
4. **Memory unchanged** — 3.7 GB, same as before. The deeper MLP adds parameters but negligible memory overhead at this scale.

**Verdict:** Positive result. The combination of lr=0.020 + warmup + deeper MLP outperforms the baseline cleanly. This is the new best configuration.

### Suggested follow-ups

- Try lr=0.022 or lr=0.025 with warmup — the model is still converging, so the LR upper bound may be higher with warmup protection
- Try 5-epoch warmup — if the model is still benefiting from ramp-up protection, more warmup might help at lr=0.020
- Combine with grad accumulation (effective bs=16) — address gradient noise from two angles