### PR TITLE
Full stack: bf16 + lr=0.020 + warmup + T_max=80

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import math
 import os
 import time
 import torch
@@ -21,10 +22,10 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.020
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0
@@ -80,7 +81,12 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+def lr_lambda(epoch):
+    if epoch < warmup_epochs:
+        return (epoch + 1) / warmup_epochs
+    return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
+scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
 # --- wandb ---
@@ -127,16 +133,17 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        diff = pred - y_norm
-        sq_err = diff ** 2
-        abs_err = diff.abs()
+        with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
 
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
@@ -172,10 +179,11 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            diff = pred - y_norm
-            sq_err = diff ** 2
-            abs_err = diff.abs()
+            with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+                diff = pred - y_norm
+                sq_err = diff ** 2
+                abs_err = diff.abs()
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis
Combine four orthogonal improvements: (1) bfloat16 AMP for ~30% faster epochs (~62 instead of 48), (2) lr=0.020 with 3-epoch warmup for faster convergence, (3) T_max=80 so the cosine schedule keeps meaningful LR through all epochs, (4) MAX_EPOCHS=80 to take advantage of faster epochs. Each ingredient has either proven independently or has strong theoretical backing. This is the highest-potential experiment for breaking below 40 surf_p.

## Instructions
All changes in `train.py`.

## Baseline
| Metric | Current best (PR #169, triple combo) |
|--------|-------------------------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |
| val_loss | 1.325 |
| Config | lr=0.015, sw=12, wd=0, 1L h128 nh=2 slc=32, deeper MLP, CosineAnnealingLR T_max=50 |
| Epochs | ~48 in 5 min |

---

## Results

**Status: NEGATIVE — full-stack combination does not improve over triple-combo baseline**

| Metric | This run (full-stack) | Baseline (triple combo) | Change |
|--------|----------------------|------------------------|--------|
| surf_p | 49.01 | 45.47 | +7.8% worse |
| surf_ux | 0.60 | 0.58 | +3.4% worse |
| surf_uy | 0.34 | 0.34 | same |
| val_loss | 1.378 | 1.325 | slightly worse |
| Epochs | 69/80 | ~48 | +44% more epochs |
| Epoch time | ~4s | ~6s | 33% faster |
| Peak memory | 2.6 GB | — | |

**W&B run ID:** 3z41dgol

**What happened:**

The bfloat16 speedup worked well — 69 epochs completed in 5 minutes vs ~48 baseline, confirming ~33% faster epoch time with no NaN instability (bfloat16's wide dynamic range was key). The model was still converging at epoch 69 (best_epoch=69), consistent with the pattern across all experiments.

However, despite getting significantly more epochs, the surface metrics regressed vs the triple-combo baseline. Possible explanations:

1. **lr=0.020 interacts poorly with the triple-combo config**: The triple combo had sw=12, wd=0, deeper MLP — adding lr=0.020 with warmup on top may overshoot. The previous lr=0.020 experiments may have used different base configs.

2. **The warmup schedule may have hurt**: Starting with low lr for 3 epochs and then hitting 0.020 may cause instability. The triple-combo was stable at lr=0.015 with standard cosine.

3. **Regression to the mean**: Stacking multiple changes that each slightly help may still lose to a well-tuned single combination, especially with limited epochs.

The key positive finding is that bfloat16 works stably and provides real speedup — the question is which hyperparameters to pair it with.

**Suggested follow-ups:**
- Try bfloat16 alone (or paired just with T_max=80 and MAX_EPOCHS=80) on top of the triple-combo baseline (lr=0.015, sw=12, wd=0, deeper MLP). Don't change lr or add warmup. The epoch budget is the limiting factor and bf16 directly addresses that.
- If bf16 + triple-combo works, the model might get ~62-65 epochs at lr=0.015 which could break through the 45 surf_p barrier.