### PR TITLE
AMP bfloat16 for more epochs (no other changes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 80
 @dataclass
 class Config:
     lr: float = 0.015
@@ -127,16 +127,17 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        diff = pred - y_norm
-        sq_err = diff ** 2
-        abs_err = diff.abs()
+        with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
 
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
@@ -172,10 +173,11 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            diff = pred - y_norm
-            sq_err = diff ** 2
-            abs_err = diff.abs()
+            with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+                diff = pred - y_norm
+                sq_err = diff ** 2
+                abs_err = diff.abs()
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis
AMP with float16 caused NaN (PR #150) but bfloat16 has the same exponent range as float32 — no overflow risk. This should give ~30% speedup per epoch (4.3s vs 6.3s), yielding ~62 epochs instead of 48. The model is still converging at ep48, so 14 more epochs could give 3-5 point improvement. This is the clean ablation to isolate the bfloat16 speed gain.

## Instructions
All changes in `train.py`:

1. Set `MAX_EPOCHS = 80` (to allow the model to run more epochs with faster throughput)

2. Wrap training forward pass in autocast (around the pred + loss computation):
   ```python
   with torch.amp.autocast('cuda', dtype=torch.bfloat16):
       pred = model({"x": x})["preds"]
       diff = pred - y_norm
       sq_err = diff ** 2
       abs_err = diff.abs()

       vol_mask = mask & ~is_surface
       surf_mask = mask & is_surface
       vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
       surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
       loss = vol_loss + cfg.surf_weight * surf_loss
   ```
   No GradScaler needed for bfloat16. backward/step stay float32.

3. Same autocast for validation:
   ```python
   with torch.amp.autocast('cuda', dtype=torch.bfloat16):
       pred = model({"x": x})["preds"]
       diff = pred - y_norm
       sq_err = diff ** 2
       abs_err = diff.abs()
   ```

4. Keep all other settings: lr=0.015, sw=12, wd=0, grad clip 1.0, CosineAnnealingLR T_max=MAX_EPOCHS.

5. Use `--wandb_name "fern/bf16-only"` and `--wandb_group "mar14d"` and `--agent fern`

## Baseline
| Metric | Current best (PR #169) |
|--------|----------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |
| Epochs | ~48 in 5 min (~6.3s/ep) |

---

## Results

**W&B run**: `vkt89pdv` | **Best epoch**: 69 | **Peak memory**: 2.6GB (was 3.7GB)

| Metric | Baseline (PR #169) | bf16 + 80ep | Delta |
|--------|-------------------|-------------|-------|
| surf_p | 45.47 | 43.6 | -4.1% better |
| surf_Ux | 0.58 | 0.59 | +1.7% worse |
| surf_Uy | 0.34 | 0.32 | -5.9% better |
| Epoch time | ~6.3s | ~4s | ~37% faster |
| Epochs completed | ~48 | ~69 | +21 more |
| Peak memory | ~3.7GB | 2.6GB | -30% |

**What happened**: The hypothesis was confirmed — bfloat16 gave a ~37% speedup (6.3s→4s per epoch), enabling 69 epochs in the 5-minute budget vs 48 before. The extra 21 epochs yielded meaningful improvement: surf_p improved from 45.47 to 43.6 (new best), surf_Uy improved from 0.34 to 0.32. surf_Ux is slightly worse (0.58→0.59) but likely within run-to-run variance. Memory also dropped ~30% from bfloat16's lower footprint, which is a useful bonus. No NaN instabilities were observed, confirming bfloat16 is safe here.

**Suggested follow-ups**:
- The model was still converging at epoch 69 — try MAX_EPOCHS=100 or even 120 to see if there's more to extract
- Try combining bf16 with the deeper MLP (PR #163) since both independently help
- Investigate surf_Ux specifically — it's the one metric that didn't improve, which may indicate a different bottleneck