### PR TITLE
3x pressure channel weight in L1 surface loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -42,6 +42,7 @@ if cfg.debug:
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
+surf_channel_weights = torch.tensor([1.0, 1.0, 3.0], device=device)
 
 # Eager cache — all 899 samples preprocessed into RAM (~13GB)
 ds = FullFieldDataset([DATA_ROOT / f"{cfg.dataset}.pickle"], cache_size=0)
@@ -135,7 +136,7 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -180,7 +181,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_surf += (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
surf_p (45.47) is the bottleneck while surf_Ux (0.58) and surf_Uy (0.34) are already relatively good. The current L1 surface loss weights all 3 channels equally. By weighting the pressure channel 3x in the L1 surface loss, we direct more gradient signal to pressure prediction. Previous per-channel experiments (PRs #52, #129) used MSE and different configs — this is the first test under L1 + deeper MLP.

## Instructions
All changes in `train.py`:

1. After the device setup (after `device = torch.device(...)`, around line 43), add:
   ```python
   surf_channel_weights = torch.tensor([1.0, 1.0, 3.0], device=device)
   ```

2. In the training loop, change the surface loss computation. Replace:
   ```python
   surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```
   with:
   ```python
   surf_loss = (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum() / surf_mask.sum().clamp(min=1)
   ```

3. Apply the same change in the validation loop surface loss computation.

4. Keep all other settings: lr=0.015, sw=12, wd=0, grad clip 1.0, 1L h128.

5. Use `--wandb_name "tanjiro/3x-pressure-weight"` and `--wandb_group "mar14d"` and `--agent tanjiro`

## Baseline
| Metric | Current best (PR #169) |
|--------|----------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |

---

## Results

| Metric | Baseline (PR #169) | 3x pressure weight (ep 47/50) |
|--------|-------------------|-------------------------------|
| surf_p | 45.47 | 48.55 |
| surf_ux | 0.58 | 0.65 |
| surf_uy | 0.34 | 0.40 |
| val_loss | — | 2.69 (channel-weighted, not comparable) |
| Peak mem | — | 3.7 GB |

**W&B run:** we4e4gf2 (tanjiro/3x-pressure-weight, group mar14d)

**What happened:**
Negative result — 3x pressure weighting made all surface metrics slightly worse across the board. surf_p went from 45.47 → 48.55 (+6.8%), surf_Ux from 0.58 → 0.65 (+12%), surf_Uy from 0.34 → 0.40 (+18%). The val_loss of 2.69 is inflated and not directly comparable to baseline since the channel-weighted surf_loss is ~5x larger in magnitude.

The hypothesis that redirecting gradient signal toward pressure would reduce surf_p did not hold. A likely explanation: the optimizer is already allocating appropriate capacity to pressure implicitly — forcing a 3x gradient skew on pressure may have disrupted the balance between surface channels, causing all three to degrade. The equal-weight L1 surface loss (baseline) appears better calibrated for this model size.

**Suggested follow-ups:**
- Try a smaller pressure weight (1.5x or 2x) to see if a gentler bias helps
- Try weighting only in the loss (not val), keeping val unweighted for fair comparison
- Accept equal-weight L1 as optimal and focus on architecture/LR improvements