### PR TITLE
MAX_EPOCHS=80 with T_max=80 for gentler LR schedule

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 80
 @dataclass
 class Config:
     lr: float = 0.015


### PR DESCRIPTION
## Hypothesis
With MAX_EPOCHS=50 and T_max=50, the cosine LR schedule decays to near-zero by epoch 50. But the model trains only ~48 epochs in 5 min — meaning the last few epochs train with negligible LR (~0.0002 at ep48). With T_max=80, the LR at epoch 48 would be ~0.0038 instead — nearly 20x higher. The model would train with meaningful LR throughout all epochs it actually completes, extracting far more learning in the final epochs.

## Instructions
All changes in `train.py`:

1. Change the constant:
   ```python
   MAX_EPOCHS = 80
   ```

2. The scheduler already uses `T_max=MAX_EPOCHS`, so it will automatically become 80.

3. Keep all other settings: lr=0.015, sw=12, wd=0, grad clip 1.0, 1L h128 nh=2 slc=32.

4. Use `--wandb_name "nezuko/tmax80"` and `--wandb_group "mar14d"` and `--agent nezuko`

## Baseline
| Metric | Current best (PR #169) |
|--------|----------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |
| LR at ep48 | ~0.0002 (with T_max=50) |
| LR at ep48 (proposed) | ~0.0038 (with T_max=80) |

---

## Results

**W&B run ID:** `fn8iolyq`
**Epochs completed:** 47 (best at epoch 47)
**Peak memory:** 3.7 GB

| Metric | Baseline (T_max=50) | T_max=80 | Delta |
|--------|---------------------|----------|-------|
| surf_p | 45.47 | 58.9 | +13.4 (worse) |
| surf_Ux | 0.58 | 0.73 | +0.15 (worse) |
| surf_Uy | 0.34 | 0.40 | +0.06 (worse) |
| val_loss | 1.325 | 1.648 | higher |
| Epochs in 5 min | 48 | 47 | -1 |

**What happened:**

T_max=80 is significantly worse than T_max=50 across all metrics. The hypothesis was wrong about the direction of the effect.

The issue: with T_max=80, the LR is still relatively high at epoch 47 (~0.0038). This means the model is still taking large gradient steps in the final epochs and cannot converge to a precise minimum. With T_max=50, the LR decays to near-zero by epoch 48-50, which allows fine-grained convergence in the final ~10-15 epochs. This late-phase fine-tuning is apparently very important for reaching low surf_p — the model needs time to settle at the end of training, not more aggressive steps.

The baseline's near-zero LR at ep48 was an asset, not a liability. Cosine decay to zero is well-suited for this 5-minute budget because the decay perfectly aligns with the training horizon.

**Suggested follow-ups:**
- The T_max=50 schedule is the right choice for this training budget — keep it
- If more learning is desired in later epochs, consider a warmup + decay schedule: start at a lower LR, peak around epoch 5-10, then decay to zero. This would give more learning per epoch early on while still allowing final convergence
- Alternatively: lr=0.020 with T_max=50 (more learning per step, same decay shape)