### PR TITLE
lr=0.020 + 3-epoch warmup (on current best config)

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import math
 import os
 import time
 import torch
@@ -24,7 +25,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.020
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0
@@ -80,7 +81,12 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+warmup_epochs = 3
+def lr_lambda(epoch):
+    if epoch < warmup_epochs:
+        return (epoch + 1) / warmup_epochs
+    return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
+scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
lr=0.020 + warmup gave surf_p=46.23 on the old baseline (before wd=0+sw=12). The current best config (wd=0, sw=12, deeper MLP) may benefit even more from higher LR since wd=0 removes the regularization drag. Warmup stabilizes the first 3 epochs, then the higher peak LR accelerates convergence for the remaining ~45 epochs.

## Instructions
All changes in `train.py`:

1. Add import:
   ```python
   import math
   ```

2. Change Config:
   ```python
   lr: float = 0.020
   ```

3. Replace scheduler. Change:
   ```python
   scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
   ```
   to:
   ```python
   warmup_epochs = 3
   def lr_lambda(epoch):
       if epoch < warmup_epochs:
           return (epoch + 1) / warmup_epochs
       return 0.5 * (1 + math.cos(math.pi * (epoch - warmup_epochs) / (MAX_EPOCHS - warmup_epochs)))
   scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
   ```

4. Keep all other settings: sw=12, wd=0, grad clip 1.0, 1L h128.

5. Use `--wandb_name "alphonse/lr020-warmup-v2"` and `--wandb_group "mar14d"` and `--agent alphonse`

## Baseline
| Metric | Current best (PR #169) |
|--------|----------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |

---

## Results

**W&B run**: 5madx8t9 (alphonse/lr020-warmup-v2, group: mar14d)

| Metric | Baseline (PR #169) | lr=0.020+warmup | Delta |
|--------|-------------------|-----------------|-------|
| surf_p | 45.47 | 48.10 | +6% (worse) |
| surf_ux | 0.58 | 0.59 | +2% (worse) |
| surf_uy | 0.34 | 0.35 | +3% (worse) |
| val_loss | (unknown) | 1.389 | — |
| Peak memory | 3.7 GB | 3.7 GB | no change |

Best epoch: 48/48 (wall-clock limit reached at 5.1 min, model still improving at epoch 48)

**What happened**: The hypothesis did not work. lr=0.020 with warmup performed worse than the baseline lr=0.015 on the wd=0, sw=12 config. The model was still improving at epoch 48 (checkpoint updated at epoch 47 and 48), suggesting it was still converging when the timeout hit — the warmup in the first 3 epochs effectively reduces early training speed, meaning the model reaches 48 productive epochs vs baseline's full 50. This timing issue may explain the regression. The 3-epoch warmup consumes ~6% of the training budget at lower-than-peak LR, which hurts more than it helps at this timescale.

**Suggested follow-ups**:
- Try lr=0.020 without warmup — if the problem is the warmup stealing training budget, raw higher LR may still help
- Try 1-epoch warmup instead of 3 to reduce the budget cost while still stabilizing early steps
- The wd=0 config may already be well-tuned for lr=0.015 — higher LR might need some weight decay back to be stable