### PR TITLE
Validate every 3 epochs for more training time

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from utils import visualize, dataset_stats
 
 MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 50
+VAL_EVERY = 3
 @dataclass
 class Config:
     lr: float = 0.015
@@ -153,97 +154,105 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
-    # --- Validate ---
-    model.eval()
-    val_vol = 0.0
-    val_surf = 0.0
-    mae_surf = torch.zeros(3, device=device)
-    mae_vol = torch.zeros(3, device=device)
-    n_surf = 0
-    n_vol = 0
-    n_val = 0
-
-    with torch.no_grad():
-        for x, y, is_surface, mask in tqdm(val_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [val]", leave=False):
-            x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
-            is_surface = is_surface.to(device, non_blocking=True)
-            mask = mask.to(device, non_blocking=True)
-
-            x = (x - stats["x_mean"]) / stats["x_std"]
-            y_norm = (y - stats["y_mean"]) / stats["y_std"]
-
-            pred = model({"x": x})["preds"]
-            diff = pred - y_norm
-            sq_err = diff ** 2
-            abs_err = diff.abs()
-
-            vol_mask = mask & ~is_surface
-            surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
-            n_val += 1
-
-            pred_orig = pred * stats["y_std"] + stats["y_mean"]
-            err = (pred_orig - y).abs()
-            mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
-            mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
-            n_surf += surf_mask.sum().item()
-            n_vol += vol_mask.sum().item()
-
-    val_vol /= n_val
-    val_surf /= n_val
-    val_loss = val_vol + cfg.surf_weight * val_surf
-    mae_surf /= max(n_surf, 1)
-    mae_vol /= max(n_vol, 1)
-
     dt = time.time() - t0
-
-    # --- Log to wandb ---
-    metrics = {
-        "train/vol_loss": epoch_vol,
-        "train/surf_loss": epoch_surf,
-        "val/vol_loss": val_vol,
-        "val/surf_loss": val_surf,
-        "val/loss": val_loss,
-        "val/mae_vol_Ux": mae_vol[0].item(),
-        "val/mae_vol_Uy": mae_vol[1].item(),
-        "val/mae_vol_p": mae_vol[2].item(),
-        "val/mae_surf_Ux": mae_surf[0].item(),
-        "val/mae_surf_Uy": mae_surf[1].item(),
-        "val/mae_surf_p": mae_surf[2].item(),
-        "lr": scheduler.get_last_lr()[0],
-        "epoch_time_s": dt,
-    }
-    wandb.log(metrics, commit=False)
 
     if torch.cuda.is_available():
         peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
     else:
         peak_mem_gb = 0.0
 
-    tag = ""
-    if val_loss < best_val:
-        best_val = val_loss
-        best_metrics = {
-            "mae_vol_Ux": mae_vol[0].item(),
-            "mae_vol_Uy": mae_vol[1].item(),
-            "mae_vol_p": mae_vol[2].item(),
-            "mae_surf_Ux": mae_surf[0].item(),
-            "mae_surf_Uy": mae_surf[1].item(),
-            "mae_surf_p": mae_surf[2].item(),
-            "epoch": epoch + 1,
-            "val_loss_loss": val_loss,
-        }
-        torch.save(model.state_dict(), model_path)
-        tag = f" * -> {model_path}"
+    # --- Validate ---
+    if (epoch + 1) % VAL_EVERY == 0 or epoch == 0:
+        model.eval()
+        val_vol = 0.0
+        val_surf = 0.0
+        mae_surf = torch.zeros(3, device=device)
+        mae_vol = torch.zeros(3, device=device)
+        n_surf = 0
+        n_vol = 0
+        n_val = 0
 
-    print(
-        f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
-        f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
-        f"val[vol={val_vol:.4f} surf={val_surf:.4f}]  "
-        f"mae_vol=[Ux:{mae_vol[0]:.2f} Uy:{mae_vol[1]:.2f} p:{mae_vol[2]:.1f}]  "
-        f"mae_surf=[Ux:{mae_surf[0]:.2f} Uy:{mae_surf[1]:.2f} p:{mae_surf[2]:.1f}]{tag}"
-    )
+        with torch.no_grad():
+            for x, y, is_surface, mask in tqdm(val_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [val]", leave=False):
+                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                is_surface = is_surface.to(device, non_blocking=True)
+                mask = mask.to(device, non_blocking=True)
+
+                x = (x - stats["x_mean"]) / stats["x_std"]
+                y_norm = (y - stats["y_mean"]) / stats["y_std"]
+
+                pred = model({"x": x})["preds"]
+                diff = pred - y_norm
+                sq_err = diff ** 2
+                abs_err = diff.abs()
+
+                vol_mask = mask & ~is_surface
+                surf_mask = mask & is_surface
+                val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                n_val += 1
+
+                pred_orig = pred * stats["y_std"] + stats["y_mean"]
+                err = (pred_orig - y).abs()
+                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                n_surf += surf_mask.sum().item()
+                n_vol += vol_mask.sum().item()
+
+        val_vol /= n_val
+        val_surf /= n_val
+        val_loss = val_vol + cfg.surf_weight * val_surf
+        mae_surf /= max(n_surf, 1)
+        mae_vol /= max(n_vol, 1)
+
+        # --- Log to wandb ---
+        metrics = {
+            "train/vol_loss": epoch_vol,
+            "train/surf_loss": epoch_surf,
+            "val/vol_loss": val_vol,
+            "val/surf_loss": val_surf,
+            "val/loss": val_loss,
+            "val/mae_vol_Ux": mae_vol[0].item(),
+            "val/mae_vol_Uy": mae_vol[1].item(),
+            "val/mae_vol_p": mae_vol[2].item(),
+            "val/mae_surf_Ux": mae_surf[0].item(),
+            "val/mae_surf_Uy": mae_surf[1].item(),
+            "val/mae_surf_p": mae_surf[2].item(),
+            "lr": scheduler.get_last_lr()[0],
+            "epoch_time_s": dt,
+        }
+        wandb.log(metrics, commit=False)
+
+        tag = ""
+        if val_loss < best_val:
+            best_val = val_loss
+            best_metrics = {
+                "mae_vol_Ux": mae_vol[0].item(),
+                "mae_vol_Uy": mae_vol[1].item(),
+                "mae_vol_p": mae_vol[2].item(),
+                "mae_surf_Ux": mae_surf[0].item(),
+                "mae_surf_Uy": mae_surf[1].item(),
+                "mae_surf_p": mae_surf[2].item(),
+                "epoch": epoch + 1,
+                "val_loss_loss": val_loss,
+            }
+            torch.save(model.state_dict(), model_path)
+            tag = f" * -> {model_path}"
+
+        print(
+            f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
+            f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
+            f"val[vol={val_vol:.4f} surf={val_surf:.4f}]  "
+            f"mae_vol=[Ux:{mae_vol[0]:.2f} Uy:{mae_vol[1]:.2f} p:{mae_vol[2]:.1f}]  "
+            f"mae_surf=[Ux:{mae_surf[0]:.2f} Uy:{mae_surf[1]:.2f} p:{mae_surf[2]:.1f}]{tag}"
+        )
+    else:
+        wandb.log({"train/vol_loss": epoch_vol, "train/surf_loss": epoch_surf,
+                   "lr": scheduler.get_last_lr()[0], "epoch_time_s": dt}, commit=False)
+        print(
+            f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
+            f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]"
+        )
 
 
 # --- Final summary ---


### PR DESCRIPTION
## Hypothesis
Validation runs every epoch and takes ~1.2s of the 6.3s per epoch. By validating only every 3 epochs, we save ~0.8s on 2 out of 3 epochs, gaining ~3-4 extra training epochs within the 5-minute budget (~51-52 instead of 48). The model is still converging at ep48, so every extra training epoch matters.

## Instructions
All changes in `train.py`:

1. Add a constant near the top (after MAX_EPOCHS):
   ```python
   VAL_EVERY = 3
   ```

2. Wrap the entire validation section in a conditional. Before `model.eval()` (around line 157), add:
   ```python
   if (epoch + 1) % VAL_EVERY == 0 or epoch == 0:
   ```
   And indent the entire validation block (from `model.eval()` through the best-model saving logic) under this condition.

3. Make sure the `scheduler.step()` call remains OUTSIDE the validation conditional (it should run every epoch).

4. Make sure the `best_val_loss`, `best_mae_surf`, and logging remain correct. If validation is skipped, don't update `best_val_loss` or `best_mae_surf` for that epoch. The training loop logging can continue every epoch.

5. Keep all other settings: lr=0.015, sw=12, wd=0, grad clip 1.0, 1L h128.

6. Use `--wandb_name "edward/val-every-3"` and `--wandb_group "mar14d"` and `--agent edward`

## Baseline
| Metric | Current best (PR #169) |
|--------|----------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |
| Epochs | ~48 in 5 min |

---

## Results

**W&B run ID**: cl2u6e2k
**Best epoch**: 48 (last validated epoch; total epochs completed: 49)
**Peak memory**: 3.7 GB

| Metric | Baseline (PR #169) | This run | Delta |
|--------|-------------------|----------|-------|
| surf_p | 45.47 | 52.2 | +6.73 |
| surf_ux | 0.58 | 0.62 | +0.04 |
| surf_uy | 0.34 | 0.37 | +0.03 |
| val_loss | — | 1.466 (sw=12) | — |
| vol MAE Ux | — | 3.60 | — |
| vol MAE Uy | — | 1.39 | — |
| vol MAE p | — | 92.7 | — |

### What happened

The hypothesis did not work. Validating every 3 epochs only gained 1 extra training epoch (49 vs 48) — the time savings were smaller than expected. Epoch training time is ~5s, and validation is ~1s, so saving validation on 2/3 epochs only frees up ~0.67s per epoch on average, insufficient for meaningfully more epochs in 5 minutes.

All metrics are worse than baseline: surf_p went from 45.47 to 52.2, surf_ux from 0.58 to 0.62, surf_uy from 0.34 to 0.37. This may partly be due to the sparse checkpoint selection — the best model is only checked at epochs 1, 3, 6, 9, ..., 48, missing potentially better checkpoints in between. The true best epoch might have been 49 or 50 (not validated).

The core problem is that training epochs are already much longer than validation, so skipping validation provides minimal time benefit while making checkpoint selection coarser.

### Suggested follow-ups

- This approach isn't worth pursuing further — the time savings are too small to matter with this fast training loop.
- A more promising direction: use the saved val time to run a slightly larger model (e.g., increase mlp_ratio=3 which would add capacity without as much overhead as doubling hidden_dim).