### PR TITLE
Separate deeper pressure head (128→64→32→1)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -140,17 +140,27 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
+            self.mlp2_vel = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim // 2),
                 nn.GELU(),
-                nn.Linear(hidden_dim // 2, out_dim),
+                nn.Linear(hidden_dim // 2, 2),
+            )
+            self.mlp2_pres = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, hidden_dim // 4),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 4, 1),
             )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            vel = self.mlp2_vel(h)
+            pres = self.mlp2_pres(h)
+            return torch.cat([vel, pres], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
PR #156 tested a pressure-specific head early (before L1 loss + deeper MLP) and it failed. Now with the current stronger baseline, retesting makes sense: the backbone representation is now better utilized (L1 surf, deeper shared decoder). A separate, deeper pressure head (128→64→32→1 with GELU) gives pressure its own non-linear pathway while velocity uses the existing 2-layer head. Pressure has y_std=961 vs 25/11.7 for Ux/Uy — it deserves dedicated capacity.

## Instructions
Changes in `transolver.py`:

1. In `TransolverBlock.__init__`, replace the output MLP. Change:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, out_dim),
       )
   ```
   to:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2_vel = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, 2),
       )
       self.mlp2_pres = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, hidden_dim // 4),
           nn.GELU(),
           nn.Linear(hidden_dim // 4, 1),
       )
   ```

2. In `TransolverBlock.forward`, replace:
   ```python
   if self.last_layer:
       return self.mlp2(self.ln_3(fx))
   ```
   with:
   ```python
   if self.last_layer:
       h = self.ln_3(fx)
       vel = self.mlp2_vel(h)
       pres = self.mlp2_pres(h)
       return torch.cat([vel, pres], dim=-1)
   ```

Changes in `train.py`:
3. Keep all settings: lr=0.015, sw=12, wd=0, grad clip 1.0, 1L h128.

4. Use `--wandb_name "thorfinn/pressure-head-v2"` and `--wandb_group "mar14d"` and `--agent thorfinn`

## Baseline
| Metric | Current best (PR #169) |
|--------|----------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |

---

## Results

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| surf_p | 45.47 | 236.2 | +190.7 (much worse) |
| surf_ux | 0.58 | 1.738 | +1.158 (much worse) |
| surf_uy | 0.34 | 1.018 | +0.678 (much worse) |
| val_loss | ~0.96 | 5.395 | much worse |
| Peak GPU mem | - | 3.9 GB | - |

W&B run: `dyhs07ic` (thorfinn/pressure-head-v2, group: mar14d)
Epochs completed: 45/50 — **34/45 epochs produced NaN** (training diverged after ~epoch 11)

**What happened:** Training diverged severely — same pattern as PR #164 (beta2=0.99). Only 11 valid epochs before NaN took over, and even those epochs show metrics 5-6× worse than baseline.

Split output heads appear to consistently cause training instability in this architecture, now at two different baseline configurations (PR #156 and PR #180). The likely mechanism: the pressure branch gradient (scaled by sw=12) may create a large gradient flow into the shared ln_3 LayerNorm that conflicts with the velocity branch, destabilizing the normalization statistics. This is especially problematic because pressure has ~38× higher variance than Ux.

Notably PR #156 (early baseline, sw=8) did NOT diverge — it just performed slightly worse. The difference here may be sw=12 + wd=0 makes gradients larger/noisier, and the 3-layer pressure head has more parameters to misalign early in training.

**Suggested follow-ups:**
- If split heads are worth revisiting, consider using a much smaller lr (e.g. 0.005) to stabilize the pressure branch.
- Alternatively, try a separate pressure output normalization layer (a learned scale/shift per-field before the loss) rather than a separate head architecture.
- The current bottleneck may not be the output head — the current best surf_p of ~45 may be limited by the shared backbone capacity rather than the output projection.