### PR TITLE
bf16 + T_max=80 + 3x pressure weight combo

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 80
 @dataclass
 class Config:
     lr: float = 0.015
@@ -42,6 +42,7 @@ if cfg.debug:
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
+surf_channel_weights = torch.tensor([1.0, 1.0, 3.0], device=device)
 
 # Eager cache — all 899 samples preprocessed into RAM (~13GB)
 ds = FullFieldDataset([DATA_ROOT / f"{cfg.dataset}.pickle"], cache_size=0)
@@ -127,16 +128,17 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        diff = pred - y_norm
-        sq_err = diff ** 2
-        abs_err = diff.abs()
+        with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
 
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
@@ -172,15 +174,16 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            diff = pred - y_norm
-            sq_err = diff ** 2
-            abs_err = diff.abs()
+            with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+                diff = pred - y_norm
+                sq_err = diff ** 2
+                abs_err = diff.abs()
 
-            vol_mask = mask & ~is_surface
-            surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                vol_mask = mask & ~is_surface
+                surf_mask = mask & is_surface
+                val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+                val_surf += (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
Targeted combination of three complementary improvements: (1) bfloat16 AMP for ~30% faster epochs, (2) T_max=80 to maintain meaningful LR through all epochs, (3) 3x pressure channel weighting to direct gradients toward the hardest metric. Unlike the full-stack experiment (PR #174 which also changes LR+warmup), this keeps lr=0.015 and the cosine schedule — isolating the bf16+T_max+pressure-weight interaction.

## Instructions
All changes in \`train.py\`:

1. Change constant:
   \`\`\`python
   MAX_EPOCHS = 80
   \`\`\`

2. After device setup, add:
   \`\`\`python
   surf_channel_weights = torch.tensor([1.0, 1.0, 3.0], device=device)
   \`\`\`

3. In training loop, wrap forward+loss in autocast and apply pressure weighting.

4. Same autocast in validation, with pressure weighting for val_surf.

5. Keep lr=0.015, sw=12, wd=0, grad clip 1.0. Scheduler uses T_max=MAX_EPOCHS (now 80).

6. Use \`--wandb_name "askeladd/bf16-tmax80-3xp"\` and \`--wandb_group "mar14d"\` and \`--agent askeladd\`

## Baseline
| Metric | Current best (PR #169) |
|--------|----------------------|
| surf_p | 45.47 |
| surf_ux | 0.58 |
| surf_uy | 0.34 |
| Epochs | ~48 in 5 min |

---

## Results

**W&B run ID:** 1yyqlo3h

| Metric | Baseline (PR #169) | This run: bf16 + T_max=80 + 3xP |
|--------|-------------------|----------------------------------|
| surf_p | 45.47 | **42.91** |
| surf_ux | 0.58 | 0.67 (worse) |
| surf_uy | 0.34 | 0.35 |
| val_loss | ~0.96 | 2.41 (not comparable — 3xP inflates scale) |
| Peak memory | 3.7 GB | **2.6 GB** |
| Epochs completed | ~48 | **68** |

### What happened

Mixed result. surf_p improved meaningfully (45.47 → 42.91, -5.6%) and throughput gains are substantial (68 vs ~48 epochs, 42% more; memory down 30% to 2.6 GB). However surf_ux degraded (0.58 → 0.67), which is a real regression on velocity prediction.

Key observations:
1. **bf16 throughput is real** — 68 epochs in 5 min confirms ~40% speedup. Memory also drops from 3.7 GB → 2.6 GB. These are clean wins.
2. **T_max=80 helps** — the model was still converging at ep68, and benefited from the extended cosine schedule reaching a better minimum.
3. **3x pressure weighting is a double-edged sword** — surf_p improved significantly but surf_ux got worse. The model is trading off velocity accuracy for pressure accuracy, which is the expected behavior of channel weighting.
4. **val_loss not comparable** — 2.41 vs ~0.96 baseline, but this is purely due to the 3x pressure weight inflating the surf_loss term. The actual MAE values are what matter.

**Verdict:** Partial win. bf16 + T_max=80 are unambiguous improvements (speed + memory). The 3x pressure weight is a questionable trade-off — it helps the metric we care most about (surf_p) but hurts surf_ux. Whether this is net positive depends on how much the advisor weights pressure vs velocity.

### Suggested follow-ups

- Separate the effects: try bf16 + T_max=80 without 3xP to confirm throughput gains transfer cleanly to accuracy
- Try 2x pressure weight instead of 3x — a softer emphasis may improve pressure without sacrificing velocity as much
- Combine bf16 speedup with warmup + lr=0.020 (PR #173 config) — more epochs at the best known LR schedule