### PR TITLE
3x pressure channel weight on bf16 baseline

### DIFF
--- a/train.py
+++ b/train.py
@@ -42,6 +42,7 @@ if cfg.debug:
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
+surf_channel_weights = torch.tensor([1.0, 1.0, 3.0], device=device)
 
 # Eager cache — all 899 samples preprocessed into RAM (~13GB)
 ds = FullFieldDataset([DATA_ROOT / f"{cfg.dataset}.pickle"], cache_size=0)
@@ -136,7 +137,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -182,7 +183,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_surf += (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
In round 4, bf16+T_max=80+3x pressure weight achieved surf_p=42.91 vs bf16-only at 43.64. The 3x pressure weight was validated as helpful with bf16. This is a clean re-test on the merged bf16 baseline to confirm the improvement and make it mergeable.

## Instructions
All changes in `train.py`.

## Baseline
| Metric | Current best (PR #175, bf16) |
|--------|----------------------------|
| surf_p | 43.64 |
| surf_ux | 0.59 |
| surf_uy | 0.32 |
| Epochs | 69 in 5 min |

---

## Results

**Status: NEGATIVE — 3x pressure weight regresses on the merged bf16 baseline**

| Metric | This run (3xp on bf16) | Baseline (bf16 only) | Change |
|--------|----------------------|---------------------|--------|
| surf_p | 46.11 | 43.64 | +5.6% worse |
| surf_ux | 0.64 | 0.59 | +8.5% worse |
| surf_uy | 0.37 | 0.32 | +15.6% worse |
| val_loss | 2.530 | — | (not comparable — different loss scale) |
| Epochs | 68/80 | 69/80 | similar |
| Peak memory | 2.6 GB | — | |

**W&B run ID:** c8h7crz3

**What happened:**

The 3x pressure channel weight on the current bf16 baseline actually made things worse on all surface metrics. The previous result of 42.91 (from round 4) that motivated this PR does not replicate here.

The discrepancy is likely because the previous experiment ran on a different configuration (different base branch state — different surf_weight, weight_decay, or other settings). The "merged bf16 baseline" (PR #175) has sw=12, wd=0, lr=0.015, deeper MLP, which may interact differently with the 3x pressure weight than whatever config was used in round 4.

The val_loss here (2.53) is not comparable to the baseline's loss — with 3x pressure weights, the surf_loss is computed on a weighted sum (channel p gets 3x weight), inflating the absolute val_loss number.

The surf_ux and surf_uy also degraded, which is expected when you upweight pressure at the expense of velocity channels in the loss — the model prioritizes pressure but the net effect was not an improvement here.

**Suggested follow-ups:**
- Check what config the original round-4 experiment used when it achieved 42.91 — if it had different sw/wd/lr, that context matters.
- Try reducing surf_weight from 12 to 8 when using 3x pressure weight, since the effective pressure weight becomes sw*3x = 36 which might be too high. sw=8 with 3x pressure = 24 which was the original scale.
- Accept that the bf16 baseline at 43.64 is strong and explore other directions (architecture width, longer training via val skip, etc.).