### PR TITLE
surf_weight=16 with bf16 baseline

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.015
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 12.0
+    surf_weight: float = 16.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
sw went from 8→12 successfully. With bf16 providing 69 epochs (more training time), we can push sw higher. sw=16 further emphasizes surface accuracy. The extra epochs compensate for any slower convergence from higher surface weight.

## Instructions
Change in `train.py`:
```python
surf_weight: float = 16.0
```
Keep everything else. Use `--wandb_name "fern/sw16-bf16"` and `--wandb_group "mar14d"` and `--agent fern`

## Baseline
| Metric | Current best (PR #175) |
|--------|----------------------|
| surf_p | 43.64 |
| surf_ux | 0.59 |
| surf_uy | 0.32 |

---

## Results

**W&B run**: `04sbi3b8` | **Best epoch**: 65 | **Peak memory**: 2.6GB

| Metric | Baseline (sw=12, bf16) | sw=16, bf16 | Delta |
|--------|------------------------|-------------|-------|
| surf_p | 43.64 | 45.0 | +3.1% worse |
| surf_Ux | 0.59 | 0.59 | same |
| surf_Uy | 0.32 | 0.34 | +6.3% worse |
| val_loss | 1.27 | 1.72 | higher |
| vol_Ux | — | 3.38 | — |
| vol_Uy | — | 1.38 | — |
| vol_p | — | 86.9 | — |

**What happened**: sw=16 is worse than sw=12. The surface MAE degraded across the board — pressure up ~3% and Uy up ~6%. This confirms there is a sweet spot around sw=12 for the bf16 regime; beyond that, the loss over-emphasizes surface at the expense of volume accuracy and possibly training stability. The volume MAE (vol_p=86.9 vs ~76.5 for sw=12 run) also degraded noticeably, suggesting the model is being pushed too hard toward surface minimization and struggling to maintain volume accuracy.

**Suggested follow-ups**:
- sw=12 appears to be the sweet spot — treat it as the baseline going forward
- Try sw=10 to confirm the trend (sw=8 < sw=10 < sw=12 > sw=16?)
- Explore other improvements orthogonal to surf_weight: architecture changes, learning rate schedule, or deeper features