### PR TITLE
lr=0.012 with bf16 (slower LR for more epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.015
+    lr: float = 0.012
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
With bf16 giving 69 epochs, a lower LR (0.012 vs 0.015) can converge more slowly but more precisely. Higher LR experiments (0.020) consistently failed. The extra epochs from bf16 give room for a gentler optimization curve that avoids overshooting. lr=0.012 with T_max=80 means the LR stays meaningful longer.

## Instructions
Change in `train.py`:
```python
lr: float = 0.012
```
Keep everything else. Use `--wandb_name "tanjiro/lr012-bf16"` and `--wandb_group "mar14d"` and `--agent tanjiro`

## Baseline
| Metric | Current best (PR #175) |
|--------|----------------------|
| surf_p | 43.64 |
| surf_ux | 0.59 |
| surf_uy | 0.32 |
| Epochs | 69 |

---

## Results

| Metric | Baseline (PR #175, lr=0.015) | lr=0.012 bf16 (ep 68/80) |
|--------|------------------------------|--------------------------|
| surf_p | 43.64 | **42.10** |
| surf_ux | 0.59 | **0.56** |
| surf_uy | 0.32 | **0.30** |
| val_loss | — | 1.2088 |
| Peak mem | — | 2.6 GB |

**W&B run:** jo6mnq2h (tanjiro/lr012-bf16, group mar14d)

**What happened:**
Positive result — lr=0.012 outperforms lr=0.015 on all three surface metrics. surf_p improved from 43.64 → 42.10 (-3.5%), surf_Ux from 0.59 → 0.56 (-5.1%), surf_Uy from 0.32 → 0.30 (-6.3%). Best epoch was 68 out of 80, so the model was still converging at the 5-minute wall clock limit — more epochs could yield further gains.

The hypothesis holds: bf16 provides enough extra epochs (69 vs ~50 at fp32) for the gentler lr=0.012 schedule to converge better than lr=0.015. The CosineAnnealingLR with T_max=80 keeps the LR meaningful longer, allowing fine-grained optimization in the later epochs.

**Suggested follow-ups:**
- Try lr=0.010 to see if an even lower LR continues improving
- Try T_max=120 with bf16 to give more epochs and a longer decay schedule
- Try lr=0.012 + T_max=100 with bf16 since best epoch was 68/80 (model still converging)