### PR TITLE
MAX_EPOCHS=120 with T_max=120 for even gentler LR

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 120
 @dataclass
 class Config:
     lr: float = 0.015


### PR DESCRIPTION
## Hypothesis
With MAX_EPOCHS=50 and T_max=50, the cosine LR schedule decays to near-zero by epoch 50. But the model trains only ~48 epochs in 5 min — meaning the last few epochs train with negligible LR (~0.0002 at ep48). With T_max=80, the LR at epoch 48 would be ~0.0038 instead — nearly 20x higher. The model would train with meaningful LR throughout all epochs it actually completes, extracting far more learning in the final epochs.

## Instructions
Change in `train.py`:
```python
MAX_EPOCHS = 120
```
Scheduler uses T_max=MAX_EPOCHS automatically. Keep everything else.
Use `--wandb_name "nezuko/max-epochs-120"` and `--wandb_group "mar14d"` and `--agent nezuko`

## Baseline
| Metric | Current best (PR #175) |
|--------|----------------------|
| surf_p | 43.64 | Epochs | 69 | LR at ep68 | ~0.0015 (T_max=80) |

---

## Results

**W&B run ID:** `ronlxuxm`
**Epochs completed:** 69 (best at epoch 67)
**Peak memory:** 2.6 GB

| Metric | Baseline (T_max=80, 69ep) | T_max=120 (69ep) | Delta |
|--------|---------------------------|------------------|-------|
| surf_p | 43.64 | 52.5 | +8.9 (worse) |
| surf_Ux | — | 0.61 | — |
| surf_Uy | — | 0.37 | — |
| val_loss | — | 1.447 | higher |
| Epochs in 5 min | 69 | 69 | same |

**What happened:**

T_max=120 is worse than T_max=80 baseline (surf_p 52.5 vs 43.64), despite completing the same number of epochs. This is consistent with the earlier finding (PR #177) that increasing T_max hurts performance.

The hypothesis was that higher LR at ep68 (~0.0045 with T_max=120 vs ~0.0015 with T_max=80) would provide more gradient signal and improve convergence. Instead, the higher LR in later epochs prevents the fine-grained settling that leads to low surface pressure error. The model needs the LR to have decayed significantly by the time it's in the last 15-20% of training.

T_max=80 appears to be the sweet spot for this bf16 regime (69 epochs in 5 min). The LR at ep68 with T_max=80 (~0.0015) is already high enough to maintain learning while low enough to allow convergence.

**Suggested follow-ups:**
- T_max=80 is confirmed as the right T_max for the bf16+5min budget — do not increase it further
- The consistent pattern across all T_max experiments: cosine decay works best when T_max ≈ actual training horizon
- Future LR experiments should try initial LR variations (lr=0.018, 0.020) with T_max=80 rather than adjusting T_max