### PR TITLE
Small weight decay (1e-5) for gentle regularization

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ MAX_EPOCHS = 80
 @dataclass
 class Config:
     lr: float = 0.015
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"


### PR DESCRIPTION
## Hypothesis

Small weight decay (1e-5) for gentle L2 regularization. Baseline (PR #175, mar14d group) used wd=0.0. Testing whether gentle L2 regularization helps the model generalize better on surface nodes.

## Instructions

- Set `weight_decay=1e-5` in Config (was 0.0 on the bf16 branch)
- Branch: `exp/wd1e-5-bf16` (targets advisor branch)
- Use `--wandb_group mar14d`

## Baseline (from PR #175, best in mar14d group)

| Metric | Value |
|--------|-------|
| val/loss | ~1.28 |
| surf_p | 43.64 |
| surf_ux | ~0.57 |
| surf_uy | ~0.29 |

## Results

W&B run: `2yfbmpfo` (alphonse/wd1e-5-bf16, group mar14d)
Best epoch: 68/80, Peak memory: 2.6 GB

| Metric | Baseline (PR #175) | wd=1e-5 | Delta |
|--------|-------------------|---------|-------|
| val/loss | ~1.28 | 1.306 | +2.0% worse |
| surf_p | 43.64 | 45.14 | +3.4% worse |
| surf_ux | ~0.57 | 0.60 | +5.3% worse |
| surf_uy | ~0.29 | 0.32 | +10.3% worse |

## What happened

Negative result. Adding wd=1e-5 made all surface metrics worse compared to wd=0.0. The model at wd=0.0 (baseline) was already performing well without regularization — on a dataset this size with this architecture, L2 regularization appears to hurt rather than help. The weight decay likely acts as a small but consistent gradient signal that competes with the surface loss signal, degrading surface accuracy.

## Suggested follow-ups

- Try even smaller wd (1e-6) to see if any regularization helps
- Instead of weight decay, try dropout in TransolverBlock (currently 0.0)
- Investigate whether wd hurts more on surface nodes than volume nodes (different gradients)