### PR TITLE
mlp_ratio=4 for wider FFN in Transolver block

### DIFF
--- a/train.py
+++ b/train.py
@@ -68,7 +68,7 @@ model_config = dict(
     n_layers=1,
     n_head=2,
     slice_num=32,
-    mlp_ratio=2,
+    mlp_ratio=4,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
The Transolver block's FFN uses mlp_ratio=2 (hidden→256→hidden). With bf16 making epochs faster, we can afford a wider FFN (mlp_ratio=4, hidden→512→hidden) without blowing the epoch budget. This gives the attention block more capacity to process physics attention outputs. The wider FFN may extract richer features for the output decoder.

## Instructions
Change in `train.py` model_config:
```python
model_config = dict(
    space_dim=2, fun_dim=16, out_dim=3,
    n_hidden=128, n_layers=1, n_head=2,
    slice_num=32, mlp_ratio=4,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```
Keep everything else. Use `--wandb_name "edward/mlp-ratio-4"` and `--wandb_group "mar14d"` and `--agent edward`

## Baseline
| Metric | Current best (PR #175) |
|--------|----------------------|
| surf_p | 43.64 | mlp_ratio | 2 |

---

## Results

**W&B run ID**: bui9imtn
**Best epoch**: 62 / 64 completed
**Peak memory**: 3.1 GB (same as baseline)

| Metric | Baseline (PR #175) | This run | Delta |
|--------|-------------------|----------|-------|
| surf_p | 43.64 | 49.5 | +5.86 |
| surf_ux | — | 0.57 | — |
| surf_uy | — | 0.32 | — |
| val_loss | — | 1.337 | — |
| vol MAE Ux | — | 3.10 | — |
| vol MAE Uy | — | 1.17 | — |
| vol MAE p | — | 83.6 | — |

### What happened

mlp_ratio=4 did not beat the baseline. surf_p = 49.5 vs baseline 43.64 — worse by about 13%. The model completed 64 epochs (baseline likely completes more with mlp_ratio=2 since the FFN is smaller). The wider FFN adds compute per epoch, meaning slightly fewer epochs in 5 minutes.

That said, the model was still actively improving at epoch 64 (surf_p was 47.8 at ep64 vs 49.5 at ep62). The validation was noisy throughout, with large swings between consecutive epochs. With more training time, mlp_ratio=4 might converge to a competitive result.

Memory actually decreased slightly (3.1GB vs 3.7GB), which is unexpected — likely due to the bf16 autocast reducing intermediate tensor sizes.

### Suggested follow-ups

- The wider FFN doesn't help within the 5-minute bf16 budget at mlp_ratio=4. mlp_ratio=2 remains the sweet spot for this epoch budget.
- If the epoch budget is the bottleneck, focus on other architectural changes that don't slow training.