### PR TITLE
3x pressure + sw=16 combo on bf16 baseline

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.015
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 12.0
+    surf_weight: float = 16.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -42,6 +42,7 @@ if cfg.debug:
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
+surf_channel_weights = torch.tensor([1.0, 1.0, 3.0], device=device)
 
 # Eager cache — all 899 samples preprocessed into RAM (~13GB)
 ds = FullFieldDataset([DATA_ROOT / f"{cfg.dataset}.pickle"], cache_size=0)
@@ -136,7 +137,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
@@ -182,7 +183,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-            val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            val_surf += (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
             pred_orig = pred * stats["y_std"] + stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
Aggressive surface focus: combine 3x pressure channel weight (proven in PR #181, surf_p=42.91) with sw=16 (pushing surface emphasis even higher). With bf16 giving 69 epochs and the model clearly capable of handling high surface weights (sw=12 works), pushing both levers simultaneously may drive surf_p closer to the 36.78 target.

## Instructions
All changes in \`train.py\`:

1. Change Config:
   \`\`\`python
   surf_weight: float = 16.0
   \`\`\`

2. After device setup, add:
   \`\`\`python
   surf_channel_weights = torch.tensor([1.0, 1.0, 3.0], device=device)
   \`\`\`

3. In training loop (inside autocast), change:
   \`\`\`python
   surf_loss = (abs_err * surf_mask.unsqueeze(-1) * surf_channel_weights).sum() / surf_mask.sum().clamp(min=1)
   \`\`\`

4. Same in validation.

5. Use \`--wandb_name "askeladd/3xp-sw16-combo"\` and \`--wandb_group "mar14d"\` and \`--agent askeladd\`

## Baseline
| Metric | Current best (PR #175) |
|--------|----------------------|
| surf_p | 43.64 |
| surf_ux | 0.59 |
| surf_uy | 0.32 |

---

## Results

**W&B run ID:** vsom2h81

| Metric | Baseline (PR #175) | This run: sw=16 + 3xP |
|--------|-------------------|----------------------|
| surf_p | 43.64 | 45.21 (worse) |
| surf_ux | 0.59 | 0.68 (worse) |
| surf_uy | 0.32 | 0.37 (worse) |
| val_loss | — | 3.32 (not comparable) |
| Peak memory | — | 2.6 GB |
| Epochs completed | — | 69 |

### What happened

Negative result — sw=16 + 3x pressure is worse than the baseline on all metrics. surf_p=45.21 vs 43.64 baseline, and surf_ux/uy both regressed significantly.

Key observations:
1. **Too much pressure emphasis** — the combination of sw=16 and 3x pressure weighting is overconstrained. The model is penalizing pressure so heavily (effectively 48x the base loss) that the optimizer can't make progress cleanly.
2. **Worse than PR #181** — PR #181 used sw=12 + 3xP and got surf_p=42.91 (better). The step from sw=12 to sw=16 actually hurt. This suggests there's a sweet spot around sw=12 for the 3xP variant.
3. **Velocity degraded most** — surf_ux went from 0.59 to 0.68. With the pressure channel getting 3x weight inside sw=16, velocity gradients are proportionally much smaller and the model under-learns them.
4. **69 epochs, still 2.6 GB** — bf16 throughput is working fine; the problem is purely in the optimization objective.

**Verdict:** Negative. Combining sw=16 and 3x pressure is too aggressive. The PR #181 result (sw=12 + 3xP, surf_p=42.91) remains the best pressure result, and PR #175 (surf_p=43.64, surf_ux=0.59) remains the best overall balanced result.

### Suggested follow-ups

- sw=12 + 3xP already showed surf_p=42.91 — consider keeping that as the 3xP sweet spot
- Instead of more pressure weight, try 2x pressure only (softer bias) to see if it can improve pressure without hurting ux
- Explore sw=8 + 3xP to see if lower surface weight with pressure focus gives a better trade-off