### PR TITLE
T_max=68 matched to actual epoch count

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 68
 @dataclass
 class Config:
     lr: float = 0.012


### PR DESCRIPTION
## Hypothesis
Current T_max=80 but model only trains ~68 epochs. At ep68, LR is ~3.8% of peak — still meaningful but suboptimal. Setting T_max=68 makes the cosine schedule decay to near-zero exactly at the last epoch, squeezing maximum fine-tuning from the final epochs. Simplest possible experiment.

## Instructions
In `train.py`, change:
```python
MAX_EPOCHS = 68
```
The scheduler uses T_max=MAX_EPOCHS. Use `--wandb_name "frieren/tmax68"` and `--wandb_group "mar14d"` and `--agent frieren`

## Baseline
| surf_p | 42.10 | surf_ux | 0.56 | surf_uy | 0.30 | Epochs | 68 |

---

## Results

**Status: MARGINAL POSITIVE — small improvement on surf_p**

| Metric | This run (T_max=68) | Baseline (T_max=80) | Change |
|--------|--------------------|--------------------|--------|
| surf_p | 41.88 | 42.10 | -0.5% better |
| surf_ux | 0.56 | 0.56 | same |
| surf_uy | 0.31 | 0.30 | +3% worse |
| val_loss | 1.235 | — | |
| Epochs | 68/68 | ~68/80 | |
| Peak memory | 2.6 GB | — | |

**W&B run ID:** 0r35aaa5

**What happened:**

A very small improvement on the primary metric (surf_p 42.10 → 41.88). The model completed all 68 epochs and best_epoch=68 (the final epoch) confirms it's still converging at the end — a consistent pattern across experiments.

The change makes theoretical sense: by aligning T_max with the actual epoch budget, the cosine schedule reaches near-zero LR at the final epoch rather than leaving ~3.8% LR "on the table." This provides slightly more refined fine-tuning in the last few epochs.

The improvement is tiny and may be within run-to-run variance. surf_uy slightly regressed (0.30 → 0.31) so it's not a clean win. Still, for a one-line change with no downside risk, the result is consistent with the hypothesis.

Since best_epoch equals the last epoch in every experiment, the training budget remains the main bottleneck. If epochs could be extended (e.g., by skipping validation every 2-3 epochs), we'd likely see meaningful gains.

**Suggested follow-ups:**
- Try skipping validation every N epochs (e.g., run val only every 2 epochs) to get more training steps in the budget. With ~4s/epoch, every saved validation pass is ~0.5-1s.
- This result now makes T_max=68 the correct setting for this config. If epoch count changes (due to bf16 speedup or val skip), T_max should be re-matched.