### PR TITLE
Stochastic Weight Averaging (SWA) in last 20 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -15,6 +15,8 @@ from tqdm import tqdm
 from torch.utils.data import DataLoader, random_split, Subset
 import simple_parsing as sp
 
+from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
+
 from prepare import FullFieldDataset, pad_collate, DATA_ROOT
 from transolver import Transolver
 from utils import visualize, dataset_stats
@@ -81,6 +83,9 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+swa_model = AveragedModel(model)
+swa_start = 48
+swa_scheduler = SWALR(optimizer, swa_lr=0.001)
 
 
 # --- wandb ---
@@ -150,12 +155,17 @@ for epoch in range(MAX_EPOCHS):
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
-    scheduler.step()
+    if epoch >= swa_start:
+        swa_model.update_parameters(model)
+        swa_scheduler.step()
+    else:
+        scheduler.step()
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
     # --- Validate ---
-    model.eval()
+    eval_model = swa_model if epoch >= swa_start else model
+    eval_model.eval()
     val_vol = 0.0
     val_surf = 0.0
     mae_surf = torch.zeros(3, device=device)
@@ -174,7 +184,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             with torch.amp.autocast('cuda', dtype=torch.bfloat16):
-                pred = model({"x": x})["preds"]
+                pred = eval_model({"x": x})["preds"]
                 diff = pred - y_norm
                 sq_err = diff ** 2
                 abs_err = diff.abs()
@@ -213,7 +223,7 @@ for epoch in range(MAX_EPOCHS):
         "val/mae_surf_Ux": mae_surf[0].item(),
         "val/mae_surf_Uy": mae_surf[1].item(),
         "val/mae_surf_p": mae_surf[2].item(),
-        "lr": scheduler.get_last_lr()[0],
+        "lr": optimizer.param_groups[0]['lr'],
         "epoch_time_s": dt,
     }
     wandb.log(metrics, commit=False)
@@ -236,7 +246,8 @@ for epoch in range(MAX_EPOCHS):
             "epoch": epoch + 1,
             "val_loss_loss": val_loss,
         }
-        torch.save(model.state_dict(), model_path)
+        state = swa_model.module.state_dict() if epoch >= swa_start else model.state_dict()
+        torch.save(state, model_path)
         tag = f" * -> {model_path}"
 
     print(
@@ -247,6 +258,8 @@ for epoch in range(MAX_EPOCHS):
         f"mae_surf=[Ux:{mae_surf[0]:.2f} Uy:{mae_surf[1]:.2f} p:{mae_surf[2]:.1f}]{tag}"
     )
 
+
+update_bn(train_loader, swa_model, device=device)
 
 # --- Final summary ---
 total_time = (time.time() - train_start) / 60.0


### PR DESCRIPTION
## Hypothesis
SWA (Izmailov et al., 2018) averages weights during a constant-LR tail phase, finding flatter minima that generalize better. Run normal cosine decay for 48 epochs, then switch to constant lr=0.001 for 20 epochs while averaging weights. PyTorch has built-in support via torch.optim.swa_utils.

## Instructions
All changes in `train.py`:

1. Add imports:
   ```python
   from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
   ```

2. After model and optimizer creation, add:
   ```python
   swa_model = AveragedModel(model)
   swa_start = 48
   swa_scheduler = SWALR(optimizer, swa_lr=0.001)
   ```

3. In the epoch loop, after scheduler.step(), add logic to switch at epoch 48:
   ```python
   if epoch >= swa_start:
       swa_model.update_parameters(model)
       swa_scheduler.step()
   else:
       scheduler.step()
   ```
   Remove the original `scheduler.step()` and replace with the conditional above.

4. After the training loop ends (after the epoch for-loop), add:
   ```python
   update_bn(train_loader, swa_model, device=device)
   ```

5. For validation in epochs >= swa_start, use `swa_model` instead of `model`:
   ```python
   eval_model = swa_model if epoch >= swa_start else model
   eval_model.eval()
   ```
   And use `eval_model({"x": x})` for predictions.

6. Save `swa_model.module.state_dict()` as the best checkpoint.

7. Use `--wandb_name "fern/swa-last20"` and `--wandb_group "mar14d"` and `--agent fern`

## Baseline
| surf_p | 42.10 | surf_ux | 0.56 | surf_uy | 0.30 |

---

## Results

**W&B run ID**: f5xey2qb

**Epochs completed**: 68 / 80 (hit 5-min wall-clock; SWA active for epochs 49–68)

**Peak memory**: 2.6 GB

| Metric | Result | Baseline | Delta |
|--------|--------|----------|-------|
| val/loss | 1.2363 | — | — |
| surf_p | 44.2 | 42.10 | +2.1 ❌ |
| surf_Ux | 0.50 | 0.56 | −0.06 ✅ |
| surf_Uy | 0.32 | 0.30 | +0.02 ❌ |
| vol MAE Ux | 3.12 | — | — |
| vol MAE Uy | 1.19 | — | — |
| vol MAE p | 77.7 | — | — |

**What happened**: SWA did not improve the most important metric. Surface pressure regressed by +2.1 (44.2 vs 42.10). Surface Ux improved slightly (0.50 vs 0.56), but surface Uy got marginally worse. The cosine schedule runs for 48 epochs and we hit epoch 68 total, so SWA got 20 epochs as intended. However, with our short 5-minute budget (only ~68 epochs total), the cosine schedule may still be converging meaningfully at epoch 48 — switching to a flat LR and weight averaging at that point interrupts the descent. The averaged weights flatten the model into a compromise point that is worse for surface pressure in this regime.

**Suggested follow-ups**:
- Start SWA later (e.g., epoch 60–65) to let cosine decay converge further before averaging begins.
- Try a lower swa_lr (e.g., 0.0003) to reduce the impact of the LR jump when SWA kicks in.
- The baseline (bf16 + L1 surf + sw=12) appears to be a well-tuned point; weight averaging may require more total epochs to show benefit.