### PR TITLE
Loss curriculum: MSE first 30 epochs, then L1 surface

### DIFF
--- a/train.py
+++ b/train.py
@@ -136,7 +136,10 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            if epoch < 30:
+                surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            else:
+                surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis
MSE provides stronger gradient signal for large errors (gradient proportional to error size), while L1 is more robust for fine-tuning (constant gradient). A curriculum that uses MSE everywhere for the first 30 epochs (rapid error reduction) then switches to L1 surface for remaining epochs (precise surface refinement) gets the best of both. MSE was the original loss and L1 gave a 9% improvement — combining them temporally could compound benefits.

## Instructions
All changes in `train.py`:

1. In the training loop, change the surface loss computation to be epoch-dependent. Replace:
   ```python
   surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```
   with:
   ```python
   if epoch < 30:
       surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   else:
       surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```

2. Apply the same logic in validation (use MSE for val_surf in first 30 epochs, L1 after). Or keep validation always using L1 for consistent comparison — your choice, but note it in results.

3. Keep all other settings. Use `--wandb_name "tanjiro/loss-curriculum"` and `--wandb_group "mar14d"` and `--agent tanjiro`

## Baseline
| surf_p | 42.10 | surf_ux | 0.56 | surf_uy | 0.30 |

---

## Results

| Metric | Baseline (pure L1 surf, lr=0.012 bf16) | Loss curriculum (ep 68/80) |
|--------|----------------------------------------|---------------------------|
| surf_p | 42.10 | 46.24 |
| surf_ux | 0.56 | **0.55** |
| surf_uy | 0.30 | 0.34 |
| val_loss | 1.2088 | 1.3046 |
| Peak mem | — | 2.6 GB |

**W&B run:** zj4qfpn9 (tanjiro/loss-curriculum, group mar14d)

**Validation note:** Validation uses L1 throughout (not switched) for consistent comparison across epochs.

**What happened:**
Negative result — the loss curriculum degraded surf_p (42.10 → 46.24, +9.8%) and surf_uy (0.30 → 0.34, +13%), with only a trivial gain on surf_Ux (0.56 → 0.55). val_loss also worsened from 1.2088 → 1.3046.

The hypothesis did not hold. The MSE phase in epochs 1-30 likely establishes a different optimization trajectory than pure-L1 training — when L1 kicks in at epoch 30, the optimizer must adapt to a different loss landscape, effectively interrupting convergence. Pure L1 surface loss from the start appears to build a more coherent gradient signal throughout training, producing a better final model within the 5-minute budget.

**Suggested follow-ups:**
- Try the reverse: L1 first (stable early gradients), then MSE in later epochs for sharp convergence
- Accept pure L1 surface loss as the best formulation and explore other axes
- Try a shorter MSE warmup (10 epochs instead of 30) to reduce disruption at the switchover