### PR TITLE
Snapshot ensemble: 4-cycle cosine + weight averaging

### DIFF
--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@
 
 """Train Transolver on full-field airfoil flow prediction with separate surface/volume losses."""
 
+import copy
 import os
 import time
 import torch
@@ -80,7 +81,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=17, T_mult=1)
 
 
 # --- wandb ---
@@ -102,6 +103,8 @@ with open(model_dir / "config.yaml", "w") as f:
 best_val = float("inf")
 best_metrics = {}
 train_start = time.time()
+snapshots = []
+snapshot_epochs = [16, 33, 50, 67]  # 0-indexed end of each 17-epoch cycle
 
 for epoch in range(MAX_EPOCHS):
     # Check wall-clock timeout
@@ -246,6 +249,90 @@ for epoch in range(MAX_EPOCHS):
         f"mae_vol=[Ux:{mae_vol[0]:.2f} Uy:{mae_vol[1]:.2f} p:{mae_vol[2]:.1f}]  "
         f"mae_surf=[Ux:{mae_surf[0]:.2f} Uy:{mae_surf[1]:.2f} p:{mae_surf[2]:.1f}]{tag}"
     )
+
+    if epoch in snapshot_epochs:
+        snapshots.append(copy.deepcopy(model.state_dict()))
+        print(f"  [Snapshot saved at epoch {epoch+1}, total snapshots: {len(snapshots)}]")
+
+
+# --- Snapshot averaging ---
+if len(snapshots) >= 2:
+    print(f"\nAveraging {len(snapshots)} snapshots...")
+    avg_state = {}
+    for key in snapshots[0]:
+        avg_state[key] = torch.stack([s[key].float() for s in snapshots]).mean(dim=0)
+    model.load_state_dict(avg_state)
+
+    # Run validation with averaged model
+    model.eval()
+    val_vol_ens = 0.0
+    val_surf_ens = 0.0
+    mae_surf_ens = torch.zeros(3, device=device)
+    mae_vol_ens = torch.zeros(3, device=device)
+    n_surf_ens = 0
+    n_vol_ens = 0
+    n_val_ens = 0
+
+    with torch.no_grad():
+        for x, y, is_surface, mask in tqdm(val_loader, desc="Ensemble [val]", leave=False):
+            x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+            is_surface = is_surface.to(device, non_blocking=True)
+            mask = mask.to(device, non_blocking=True)
+
+            x = (x - stats["x_mean"]) / stats["x_std"]
+            y_norm = (y - stats["y_mean"]) / stats["y_std"]
+
+            with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+                diff = pred - y_norm
+                sq_err = diff ** 2
+                abs_err = diff.abs()
+
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            val_vol_ens += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_surf_ens += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            n_val_ens += 1
+
+            pred_orig = pred * stats["y_std"] + stats["y_mean"]
+            err = (pred_orig - y).abs()
+            mae_surf_ens += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+            mae_vol_ens += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+            n_surf_ens += surf_mask.sum().item()
+            n_vol_ens += vol_mask.sum().item()
+
+    val_vol_ens /= n_val_ens
+    val_surf_ens /= n_val_ens
+    val_loss_ens = val_vol_ens + cfg.surf_weight * val_surf_ens
+    mae_surf_ens /= max(n_surf_ens, 1)
+    mae_vol_ens /= max(n_vol_ens, 1)
+
+    ens_metrics = {
+        "mae_vol_Ux": mae_vol_ens[0].item(),
+        "mae_vol_Uy": mae_vol_ens[1].item(),
+        "mae_vol_p": mae_vol_ens[2].item(),
+        "mae_surf_Ux": mae_surf_ens[0].item(),
+        "mae_surf_Uy": mae_surf_ens[1].item(),
+        "mae_surf_p": mae_surf_ens[2].item(),
+        "val_loss": val_loss_ens,
+    }
+    wandb.summary.update({"ensemble_" + k: v for k, v in ens_metrics.items()})
+    print(f"Ensemble val_loss: {val_loss_ens:.4f}")
+    print(f"  Volume  MAE:  Ux={mae_vol_ens[0]:.2f}  Uy={mae_vol_ens[1]:.2f}  p={mae_vol_ens[2]:.1f}")
+    print(f"  Surface MAE:  Ux={mae_surf_ens[0]:.2f}  Uy={mae_surf_ens[1]:.2f}  p={mae_surf_ens[2]:.1f}")
+
+    # Use ensemble as the final model for visualization
+    best_metrics = {
+        "mae_vol_Ux": mae_vol_ens[0].item(),
+        "mae_vol_Uy": mae_vol_ens[1].item(),
+        "mae_vol_p": mae_vol_ens[2].item(),
+        "mae_surf_Ux": mae_surf_ens[0].item(),
+        "mae_surf_Uy": mae_surf_ens[1].item(),
+        "mae_surf_p": mae_surf_ens[2].item(),
+        "epoch": "ensemble",
+        "val_loss_loss": val_loss_ens,
+    }
+    torch.save(avg_state, model_path)
 
 
 # --- Final summary ---


### PR DESCRIPTION
## Hypothesis
Instead of one long cosine schedule, use 4 short cycles (CosineAnnealingWarmRestarts T_0=17, T_mult=1). Save model weights at the end of each cycle (ep 17, 34, 51, 68). After training, average all 4 weight snapshots. This is the Snapshot Ensemble technique — each cycle endpoint is a different local minimum, and their average finds a flatter, more generalizable solution. Zero extra training cost; just a post-processing step.

## Instructions
All changes in `train.py`: see PR diff.

## Baseline
| surf_p | 42.10 | surf_ux | 0.56 | surf_uy | 0.30 |

---

## Results

**W&B run ID:** `xbzrfy7d`
**Epochs completed:** 68 (4 snapshots at ep 17, 34, 51, 68)
**Peak memory:** 2.6 GB

| Metric | Baseline | Best individual (ep68) | Ensemble (4 snapshots) |
|--------|----------|------------------------|------------------------|
| surf_p | 42.10 | 45.9 | 80.2 |
| surf_Ux | 0.56 | 0.57 | 2.78 |
| surf_Uy | 0.30 | 0.33 | 0.49 |

**What happened:**

The snapshot ensemble dramatically hurt performance: surf_p went from 45.9 (best individual) to 80.2 (ensemble). Weight averaging across 4 snapshots from different convergence stages is actively harmful.

The fundamental problem: snapshots are from very different loss regions. Snapshot at ep17 has surf_p ~95, ep34 ~62, ep51 ~51, ep68 ~46. Averaging poorly-converged early weights with well-converged late weights creates a model that is not good at anything.

The Snapshot Ensemble technique assumes all snapshots are near different good local minima. But 17 epochs is not enough to converge, so early cycle endpoints are just bad checkpoints.

Also: the best individual model (surf_p=45.9) is itself worse than baseline (42.10), showing that 4 short cycles with T_0=17 is worse than a single longer cosine decay.

**Suggested follow-ups:**
- Snapshot ensemble requires all snapshots near convergence — needs much longer T_0 (50+ epochs) for each cycle to actually converge
- Better averaging: SWA (Stochastic Weight Averaging) — average only the last N checkpoints of a single run where the model IS near convergence
- The individual best (ep68, surf_p=45.9) shows warm restarts with T_0=17 are suboptimal vs. a single cosine schedule to convergence