### PR TITLE
Per-sample spatial coordinate normalization

### DIFF
--- a/train.py
+++ b/train.py
@@ -127,6 +127,16 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
+        # Per-sample normalize spatial coords (first 2 features) after global norm
+        # Use mask to only compute stats over valid nodes
+        spatial = x[:, :, :2]  # (B, N, 2)
+        mask_expanded = mask.unsqueeze(-1).float()  # (B, N, 1)
+        n_valid = mask_expanded.sum(dim=1, keepdim=True).clamp(min=1)  # (B, 1, 1)
+        spatial_mean = (spatial * mask_expanded).sum(dim=1, keepdim=True) / n_valid  # (B, 1, 2)
+        spatial_centered = spatial - spatial_mean
+        spatial_std = ((spatial_centered ** 2 * mask_expanded).sum(dim=1, keepdim=True) / n_valid).sqrt().clamp(min=1e-6)
+        x[:, :, :2] = spatial_centered / spatial_std
+
         with torch.amp.autocast('cuda', dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
             diff = pred - y_norm
@@ -172,6 +182,15 @@ for epoch in range(MAX_EPOCHS):
 
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
+
+            # Per-sample normalize spatial coords (first 2 features) after global norm
+            spatial = x[:, :, :2]  # (B, N, 2)
+            mask_expanded = mask.unsqueeze(-1).float()  # (B, N, 1)
+            n_valid = mask_expanded.sum(dim=1, keepdim=True).clamp(min=1)  # (B, 1, 1)
+            spatial_mean = (spatial * mask_expanded).sum(dim=1, keepdim=True) / n_valid  # (B, 1, 2)
+            spatial_centered = spatial - spatial_mean
+            spatial_std = ((spatial_centered ** 2 * mask_expanded).sum(dim=1, keepdim=True) / n_valid).sqrt().clamp(min=1e-6)
+            x[:, :, :2] = spatial_centered / spatial_std
 
             with torch.amp.autocast('cuda', dtype=torch.bfloat16):
                 pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Current normalization uses dataset-wide stats for all 18 input features. Mesh samples vary in spatial extent. Per-sample normalization of spatial coordinates (x[:,:,:2] = pos.x, pos.y) makes the model invariant to absolute position and scale. This is a zero-cost change that removes a confound the model currently has to learn. Keep dataset-wide normalization for other features (saf, dsdf, is_surface, Re, AoA, naca).

## Instructions
All changes in `train.py`:

1. After the global normalization `x = (x - stats["x_mean"]) / stats["x_std"]`, add per-sample normalization for spatial dims (accounting for the mask):
   ```python
   # Per-sample normalize spatial coords (first 2 features) after global norm
   # Use mask to only compute stats over valid nodes
   spatial = x[:, :, :2]  # (B, N, 2)
   mask_expanded = mask.unsqueeze(-1).float()  # (B, N, 1)
   n_valid = mask_expanded.sum(dim=1, keepdim=True).clamp(min=1)  # (B, 1, 1)
   spatial_mean = (spatial * mask_expanded).sum(dim=1, keepdim=True) / n_valid  # (B, 1, 2)
   spatial_centered = spatial - spatial_mean
   spatial_std = ((spatial_centered ** 2 * mask_expanded).sum(dim=1, keepdim=True) / n_valid).sqrt().clamp(min=1e-6)
   x[:, :, :2] = spatial_centered / spatial_std
   ```

2. Apply same per-sample spatial normalization in validation loop.

3. Keep all other settings. Use `--wandb_name "alphonse/per-sample-norm"` and `--wandb_group "mar14d"` and `--agent alphonse`

## Baseline
| surf_p | 42.10 | surf_ux | 0.56 | surf_uy | 0.30 |

---

## Results

W&B run: `u6hquvx1` (alphonse/per-sample-norm, group mar14d)
Best epoch: 68/80, Peak memory: 2.6 GB

| Metric | Baseline | per-sample-norm | Delta |
|--------|----------|-----------------|-------|
| val/loss | ~1.28 | 1.9127 | +49.4% worse |
| surf_p | 42.10 | 71.51 | +69.9% worse |
| surf_ux | 0.56 | 0.76 | +35.7% worse |
| surf_uy | 0.30 | 0.49 | +63.3% worse |

## What happened

Strong negative result. Per-sample spatial normalization significantly degraded all surface metrics. The per-sample normalization is applied *after* global normalization, meaning it overwrites the position information that had already been carefully scaled. This double-normalization likely destroys the spatial coordinate signal that the model uses to distinguish surface vs volume nodes and their relative positions. The model was probably already handling position variation well through the global stats; stripping the absolute scale per-sample makes the task harder, not easier.

Additionally, the normalization is computed from all valid nodes in the padded batch, which mixes surface and volume node statistics and may introduce noise.

## Suggested follow-ups

- Try per-sample normalization applied *instead of* global norm for spatial coords (not after)
- Use surface-only stats for spatial normalization (i.e., normalize relative to surface centroid/scale)
- Consider whether the confound hypothesis is actually valid for this dataset (airfoils vary in scale?)