### PR TITLE
lr=0.010 for even slower convergence with bf16

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.012
+    lr: float = 0.010
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
lr went from 0.015→0.012 and improved (43.64→42.10). Continuing the trend: lr=0.010 with 68 bf16 epochs may converge more precisely. The extra epochs from bf16 compensate for the slower learning. Each LR reduction has helped — this tests the next step down.

## Instructions
Change in `train.py`:
```python
lr: float = 0.010
```
Keep everything else. Use `--wandb_name "thorfinn/lr010-bf16"` and `--wandb_group "mar14d"` and `--agent thorfinn`

## Baseline
| surf_p | 42.10 | lr | 0.012 |

---

## Results

| Metric | Baseline (lr=0.012) | This run (lr=0.010) | Delta |
|--------|---------------------|---------------------|-------|
| surf_p | 42.10 | 41.38 | -0.72 (better) |
| surf_ux | ~0.60 | 0.547 | better |
| surf_uy | ~0.33 | 0.311 | better |
| val_loss | ~1.25 | 1.212 | better |
| Peak GPU mem | - | - | - |

W&B run: `bwtddcao` (thorfinn/lr010-bf16, group: mar14d)
Epochs completed: 69 valid (all valid, no NaN)

**What happened:** Another improvement from lr reduction — surf_p dropped from 42.10 to 41.38, continuing the trend lr=0.015 > 0.012 > 0.010. All metrics improved modestly. The bf16 mode provides ~69 epochs in 5 minutes (~4.4s/epoch), giving the slower lr enough budget to converge well. 69 epochs at lr=0.010 is effective.

Note the diminishing returns pattern: 0.015→0.012 gave -1.54 on surf_p, and 0.012→0.010 gave -0.72. The gains are halving with each step down.

**Suggested follow-ups:**
- Try lr=0.008 to test if the trend continues (expected gain ~0.3-0.4 based on the pattern).
- Try lr=0.010 with T_max=68 (matching actual epoch count) for a better-calibrated cosine schedule.
- The model may be near its capacity limit at 1L h128 — gains from further lr tuning will be small. Consider increasing model capacity (h256 or 2L).