### PR TITLE
lr=0.008 continuing LR reduction trend

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.010
+    lr: float = 0.008
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
LR trend: 0.015→0.012→0.010 each improved. Test 0.008.
## Instructions
`train.py`: `lr: float = 0.008`. Use `--wandb_name "frieren/lr008-bf16" --wandb_group mar14d --agent frieren`
## Baseline
| surf_p | 41.38 | surf_ux | 0.55 | surf_uy | 0.31 | lr | 0.010 | sw | 12 | T_max | 80 |
---
## Results

**Status: NEGATIVE — lr=0.008 is worse than lr=0.010**

| Metric | This run (lr=0.008) | Baseline (lr=0.010) | Change |
|--------|--------------------|--------------------|--------|
| surf_p | 43.04 | 41.38 | +4.0% worse |
| surf_ux | 0.55 | 0.55 | same |
| surf_uy | 0.30 | 0.31 | slightly better |
| val_loss | 1.231 | — | |
| Epochs | 69/80 | — | |
| Peak memory | 2.6 GB | — | |

**W&B run ID:** eu0ffx6q

**What happened:**

The LR reduction trend stopped at 0.008. surf_p regressed from 41.38 (lr=0.010) to 43.04 (lr=0.008). With lower LR, the model converges more slowly and may not reach as good a minimum within the 5-minute budget. At lr=0.008, the model is learning too slowly to fully exploit the 69 epoch budget — the 5-minute wall clock is binding and more epochs at slightly lower quality each outweigh the stability benefit.

The optimal lr appears to be around 0.010 for this config. The downward trend (0.015→0.012→0.010) was likely driven by finding a stable training regime; below 0.010, convergence speed drops below what's useful.

**Suggested follow-ups:**
- lr=0.010 with T_max=68 or T_max matched to actual epoch count might be worth trying, following the same logic as PR #190.
- Explore orthogonal improvements rather than continuing to tune LR downward.