### PR TITLE
lr=0.006 aggressive LR reduction

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.010
+    lr: float = 0.006
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
Testing further down the LR curve. If 0.008 is too fast, 0.006 might find a better optimum with 69 bf16 epochs.
## Instructions
`train.py`: `lr: float = 0.006`. Use `--wandb_name "fern/lr006-bf16" --wandb_group mar14d --agent fern`
## Baseline
| surf_p | 41.38 | surf_ux | 0.55 | surf_uy | 0.31 | lr | 0.010 | sw | 12 | T_max | 80 |
---
## Results

**W&B run ID**: czfne2hq

**Epochs completed**: 69 / 80 (hit 5-min wall-clock)

**Peak memory**: 2.6 GB

| Metric | Result | Baseline | Delta |
|--------|--------|----------|-------|
| val/loss | 1.1715 | — | — |
| surf_p | 40.4 | 41.38 | **−1.0 ✅** |
| surf_Ux | 0.52 | 0.55 | **−0.03 ✅** |
| surf_Uy | 0.29 | 0.31 | **−0.02 ✅** |
| vol MAE Ux | 3.07 | — | — |
| vol MAE Uy | 1.17 | — | — |
| vol MAE p | 73.6 | — | — |

**What happened**: Clear win across all surface metrics. lr=0.006 improves on lr=0.010 for all three surface quantities — most importantly surface pressure drops from 41.38 to 40.4. The lower learning rate lets the cosine schedule descend more carefully within the 5-minute / ~69 epoch budget. The result suggests we are still in a regime where lower LR continues to help, though the gains may be diminishing.

**Suggested follow-ups**:
- Try lr=0.004 to see if the trend continues further down the curve.
- lr=0.006 is now a strong new baseline; other experiments should be rebased on it.