### PR TITLE
T_max=68 with lr=0.010 (match epoch count)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 68
 @dataclass
 class Config:
     lr: float = 0.010


### PR DESCRIPTION
## Hypothesis
T_max=68 gave 41.88 at lr=0.012. With lr=0.010, matching T_max to actual epochs (~68) ensures full cosine decay. LR at ep68 goes from 3.8% of peak (T_max=80) to near-zero (T_max=68).
## Instructions
`train.py`: `MAX_EPOCHS = 68`. Use `--wandb_name "tanjiro/tmax68-lr010" --wandb_group mar14d --agent tanjiro`
## Baseline
| surf_p | 41.38 | surf_ux | 0.55 | surf_uy | 0.31 | lr | 0.010 | sw | 12 | T_max | 80 |
---
## Results

| Metric | Baseline (T_max=80, lr=0.010) | T_max=68, lr=0.010 (ep 68/68) |
|--------|-------------------------------|-------------------------------|
| surf_p | 41.38 | 41.59 |
| surf_ux | 0.55 | **0.54** |
| surf_uy | 0.31 | 0.31 |
| val_loss | — | 1.2131 |
| Peak mem | — | 2.6 GB |

**W&B run:** se4mtg9l (tanjiro/tmax68-lr010, group mar14d)

**What happened:**
Neutral result — T_max=68 (full cosine decay to LR=0) and T_max=80 (LR≈3.8% of peak at ep68) are essentially equivalent. surf_p is 41.59 vs 41.38, a difference of 0.21 which is within run-to-run noise. surf_Ux improved trivially (0.54 vs 0.55) and surf_Uy is identical.

The hypothesis that squeezing the cosine schedule to exactly match epoch count would improve convergence did not produce meaningful gains. At lr=0.010 the optimizer appears to converge robustly regardless of whether the LR reaches exactly zero or ~4% of peak by the final epoch.

**Suggested follow-ups:**
- The T_max choice appears to not matter much at lr=0.010 — try a different axis (e.g. more layers, wider model)
- Try T_max=100-120 to see if a longer, slower decay helps (fewer epochs but better final LR at each epoch)