### PR TITLE
T_max=70 with lr=0.010 (fine-tune schedule)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 70
 @dataclass
 class Config:
     lr: float = 0.010


### PR DESCRIPTION
## Hypothesis
T_max=70 is between 68 and 80. Explores intermediate schedule where LR at ep68 is ~1.2% of peak — very low for fine-tuning but not zero.

## Instructions
`train.py`: `MAX_EPOCHS = 70`. Use `--wandb_name "nezuko/tmax70-lr010" --wandb_group mar14d --agent nezuko`

## Baseline
| surf_p | 41.38 | surf_ux | 0.55 | surf_uy | 0.31 | lr | 0.010 | sw | 12 | T_max | 80 |

---

## Results

**W&B run ID:** `tcw2nsup`
**Epochs completed:** 69 (best at epoch 68)
**Peak memory:** 2.6 GB

| Metric | Baseline (T_max=80) | T_max=70 | Delta |
|--------|---------------------|----------|-------|
| surf_p | 41.38 | 41.2 | -0.18 (marginal improvement) |
| surf_Ux | 0.55 | 0.48 | -0.07 (better) |
| surf_Uy | 0.31 | 0.29 | -0.02 (better) |
| val_loss | — | 1.155 | — |
| Epochs in 5 min | ~69 | 69 | same |

**What happened:**

T_max=70 shows marginal improvement over T_max=80 on surf_p (41.2 vs 41.38, ~0.4%). surf_Ux and surf_Uy show clearer gains (0.48 vs 0.55, 0.29 vs 0.31).

The model still improved monotonically through epoch 68 with loss and metrics declining smoothly — suggesting the cosine decay with T_max=70 provided better LR behavior than T_max=80 for this training budget. With T_max=70, the LR at ep68 is ~0.0005 (5% of peak lr=0.010), giving slightly more aggressive final-epoch learning than T_max=80's ~0.0002 while still decaying to very low values.

The difference is small and may be within run-to-run variance, but the direction is consistent with the hypothesis.

**Suggested follow-ups:**
- Try T_max=68 (exact match to training horizon) to compare with T_max=70
- The sweet spot appears to be near T_max = actual_training_epochs. A systematic sweep of T_max=65, 68, 70, 75 would confirm whether 70 or 68 is optimal
- With lr=0.010 and this schedule, the model is still improving at epoch 68 — further gains possible with more epochs/faster training