### PR TITLE
sw=10 with lr=0.010 (re-tune surface weight)

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.010
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 12.0
+    surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
At lr=0.010, the optimal sw may shift. sw=10 was tested at lr=0.012 and gave 44.15 — worse then, but lr=0.010 may interact differently.
## Instructions
`train.py`: `surf_weight: float = 10.0`. Use `--wandb_name "alphonse/sw10-lr010" --wandb_group mar14d --agent alphonse`
## Baseline
| surf_p | 41.38 | surf_ux | 0.55 | surf_uy | 0.31 | lr | 0.010 | sw | 12 | T_max | 80 |

---

## Results

W&B run: `ny2jho6k` (alphonse/sw10-lr010, group mar14d)
Best epoch: 68/80, Peak memory: 2.6 GB

| Metric | Baseline (sw=12, lr=0.010) | sw=10, lr=0.010 | Delta |
|--------|---------------------------|-----------------|-------|
| val/loss | ~1.28 (adj) | 1.0213 | — |
| surf_p | 41.38 | 40.83 | -1.3% better |
| surf_ux | 0.55 | 0.567 | +3.1% worse |
| surf_uy | 0.31 | 0.307 | tied |

## What happened

Marginally positive result. surf_p improved slightly (40.83 vs 41.38, -1.3%) while surf_ux degraded slightly (+3.1%) and surf_uy was essentially unchanged. The val/loss of 1.0213 is lower than previous runs but uses a different surf_weight so direct comparison is not apples-to-apples. Net effect: very small improvement on the most important metric (pressure).

The hypothesis is partially confirmed: at lr=0.010, sw=10 does perform differently than sw=10 at lr=0.012. The lower surface weight slightly reduces pressure emphasis, but the model at lr=0.010 appears better calibrated at this weight.

## Suggested follow-ups

- Try sw=11 to see if there's a sweet spot between 10 and 12
- Also try sw=8 to see if even less emphasis improves volume without hurting surface
- The val/loss metric is confounded by surf_weight — consider tracking raw surf MAE as primary metric going forward