### PR TITLE
wd=1e-5 with lr=0.010 (gentle regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ MAX_EPOCHS = 80
 @dataclass
 class Config:
     lr: float = 0.010
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"


### PR DESCRIPTION
## Hypothesis
With lr=0.010 and 69 epochs, the model trains more slowly with more steps. A tiny wd=1e-5 could help regularize without the drag seen at higher wd values. Tested at lr=0.012 and gave 45.14 — but lr=0.010 may benefit more from regularization.

## Instructions
`train.py`: `weight_decay: float = 1e-5`. Use `--wandb_name "thorfinn/lr010-wd1e-5" --wandb_group mar14d --agent thorfinn`

## Baseline
| surf_p | 41.38 | surf_ux | 0.55 | surf_uy | 0.31 | lr | 0.010 | sw | 12 | T_max | 80 |

---

## Results

| Metric | Baseline (wd=0) | This run (wd=1e-5) | Delta |
|--------|-----------------|---------------------|-------|
| surf_p | 41.38 | 41.9 | +0.52 (worse) |
| surf_ux | 0.547 | 0.50 | -0.047 (better) |
| surf_uy | 0.311 | 0.31 | ~same |
| val_loss | 1.212 | 1.184 | -0.028 (better) |

W&B run: `3nathryx` (thorfinn/lr010-wd1e-5, group: mar14d)
Epochs completed: 67 valid (all valid)

**What happened:** Mixed result. val_loss and surf_ux improved, but surf_p (the most important metric) got slightly worse (41.9 vs 41.38). This is an interesting split: wd=1e-5 seems to help velocity prediction but slightly hurts pressure. Pressure has much larger gradient scale (y_std=961 vs 25/11.7), and even tiny weight decay may disproportionately penalize the pressure-related weights.

Overall, this is not a clear win — the primary metric (surf_p) went up by 0.52. The val_loss improvement (driven by better Ux) may be misleading about pressure quality.

**Suggested follow-ups:**
- The wd=0 configuration at lr=0.010 remains the better choice for surf_p.
- If regularization is desired, try wd=1e-6 (even gentler) to see if the pressure regression still hurts.
- The surf_ux improvement is real and consistent — if surf_ux becomes a bottleneck later, revisit wd=1e-5.