### PR TITLE
lr=0.004 continuing LR trend

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.006
+    lr: float = 0.004
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.
## Instructions
`train.py`: `lr: float = 0.004`. Use `--wandb_name "frieren/lr004-bf16" --wandb_group mar14d --agent frieren`
## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |
---
## Results

**Status: NEGATIVE — lr=0.004 is worse than lr=0.006**

| Metric | This run (lr=0.004) | Baseline (lr=0.006) | Change |
|--------|--------------------|--------------------|--------|
| surf_p | 41.61 | 40.39 | +3.0% worse |
| surf_ux | 0.51 | 0.52 | slightly better |
| surf_uy | 0.30 | 0.29 | slightly worse |
| val_loss | 1.181 | — | |
| best_epoch | 66 (not final) | — | |
| Peak memory | 2.6 GB | — | |

**W&B run ID:** rkzpwdex

**What happened:**

lr=0.004 is worse than lr=0.006. The LR reduction trend reverses here. The primary metric (surf_p) regressed from 40.39 to 41.61.

Notably, best_epoch=66 rather than the final epoch (68) — in most prior experiments, the final epoch was the best. At lr=0.004, the model appears to overfit slightly in the last few epochs, possibly because the learning rate is so small that the optimizer makes noise-dominated updates that hurt generalization.

This confirms lr=0.006 is near the optimum for this 5-minute training budget. Going lower doesn't help because:
1. Convergence speed drops below what 68 epochs can exploit
2. Late-epoch learning is too slow to escape local minima

**Suggested follow-ups:**
- lr=0.006 is the best found so far (surf_p=40.39). Focus on orthogonal improvements rather than continuing LR tuning.
- The best_epoch < final_epoch pattern at lr=0.004 hints that slight overfitting occurs. A mild weight decay (1e-5) might help at this small LR.