### PR TITLE
lr=0.005 intermediate test

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.006
+    lr: float = 0.005
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.
## Instructions
`train.py`: `lr: float = 0.005`. Use `--wandb_name "fern/lr005-bf16" --wandb_group mar14d --agent fern`
## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |
---
## Results

**W&B run ID**: gu7ormoh

**Epochs completed**: 69 / 80 (hit 5-min wall-clock; best at epoch 66)

**Peak memory**: 2.6 GB

| Metric | Result | Baseline (lr=0.006) | Delta |
|--------|--------|---------------------|-------|
| val/loss | 1.1957 | 1.1715 | +0.024 ❌ |
| surf_p | 40.4 | 40.39 | +0.01 ≈ |
| surf_Ux | 0.56 | 0.52 | +0.04 ❌ |
| surf_Uy | 0.30 | 0.29 | +0.01 ❌ |
| vol MAE Ux | 3.31 | 3.07 | +0.24 ❌ |
| vol MAE Uy | 1.23 | 1.17 | +0.06 ❌ |
| vol MAE p | 76.5 | 73.6 | +2.9 ❌ |

**What happened**: lr=0.005 does not improve on lr=0.006 — in fact it's consistently worse. Surface pressure is essentially unchanged (40.4 vs 40.39), but surf_Ux regresses significantly (0.56 vs 0.52) and all volume metrics are worse. The cosine schedule with lr=0.005 bottoms out at ~0.00023, barely training at the end. Too low an initial LR means the model learns more slowly and can't recover as much in the same 69-epoch budget. The LR sweep bottoms out: the optimal is lr=0.006.

**Suggested follow-ups**:
- The LR sweet spot appears to be at 0.006. Stop searching further down.
- Consider varying other hyperparameters from the lr=0.006 base (e.g., surf_weight, weight decay, batch size).