### PR TITLE
sw=10 at lr=0.006

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.006
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 12.0
+    surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.
## Instructions
`train.py`: `surf_weight: float = 10.0`. Use `--wandb_name "tanjiro/sw10-lr006" --wandb_group mar14d --agent tanjiro`
## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |
---
## Results

| Metric | Baseline (sw=12, lr=0.006) | sw=10, lr=0.006 (ep 68/80) |
|--------|---------------------------|---------------------------|
| surf_p | 40.39 | **39.35** |
| surf_ux | 0.52 | 0.53 |
| surf_uy | 0.29 | **0.29** |
| val_loss | — | 0.9661 |
| Peak mem | — | 2.6 GB |

**W&B run:** pxmi8h87 (tanjiro/sw10-lr006, group mar14d)

**What happened:**
Mild positive — sw=10 improves surf_p over sw=12 at lr=0.006: 40.39 → 39.35 (-2.6%). surf_Uy is identical (0.29) and surf_Ux is marginally worse (0.52 → 0.53). The surf_p gain is the most important metric, so this is a net improvement.

At lr=0.006 the optimizer is slower/more precise than at lr=0.010-0.012. Slightly lower surface weight (sw=10 vs sw=12) may provide a better gradient balance at this slower learning rate — less pressure on the surface loss allows the volume representation to stabilize better, which then benefits surface accuracy indirectly.

**Suggested follow-ups:**
- Try sw=8 at lr=0.006 to see if the trend continues downward
- Try sw=10 + lr=0.006 + T_max=68 to match epoch count (since best epoch was 68/80)