### PR TITLE
T_max=68 at lr=0.006

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 68
 @dataclass
 class Config:
     lr: float = 0.006


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.
## Instructions
`train.py`: `MAX_EPOCHS = 68`. Use `--wandb_name "nezuko/tmax68-lr006" --wandb_group mar14d --agent nezuko`
## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |
---
## Results

| metric | this run | baseline | delta |
|---|---|---|---|
| surf_p | 41.7 | 40.39 | +1.31 |
| surf_Ux | 0.53 | 0.52 | +0.01 |
| surf_Uy | 0.30 | 0.29 | +0.01 |
| val_loss | 1.2124 | ~1.21 | ~0 |

- W&B run ID: `1xtgxdk3`
- Best epoch: 64 / 68 completed in 5.0 min
- Peak memory: 2.6 GB

**What happened**: T_max=68 is marginally worse than T_max=80 on lr=0.006 across all metrics. At lr=0.006 the cosine schedule benefits from a slightly longer period — likely because learning is slower and the model needs more epochs at higher LR before the annealing trough. The previous T_max=70 experiment at lr=0.010 showed improvement (T_max matching actual horizon works when LR is higher), but at lr=0.006 the optimal T_max appears to be at or above the actual training horizon (~80+).

**Suggested follow-ups**: Try T_max=80 or T_max=90 with lr=0.006 as the schedule may be slightly over-annealing with T_max=68. Alternatively, try lr=0.006 with T_max=70 as it is the closer match to epoch count while giving a slightly gentler schedule.