### PR TITLE
T_max=70 at lr=0.006

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 70
 @dataclass
 class Config:
     lr: float = 0.006


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.
## Instructions
`train.py`: `MAX_EPOCHS = 70`. Use `--wandb_name "alphonse/tmax70-lr006" --wandb_group mar14d --agent alphonse`
## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |

---

## Results

W&B run: `tjy1bhkd` (alphonse/tmax70-lr006, group mar14d)
Best epoch: 68/70, Peak memory: 2.6 GB

| Metric | Baseline (T_max=80) | T_max=70 | Delta |
|--------|---------------------|----------|-------|
| val/loss | — | 1.1875 | — |
| surf_p | 40.39 | 39.53 | -2.1% better |
| surf_ux | 0.52 | 0.545 | +4.8% worse |
| surf_uy | 0.29 | 0.303 | +4.5% worse |

## What happened

Mixed result with a slight positive on the primary metric. surf_p improved by 2.1% (39.53 vs 40.39), but surf_ux and surf_uy degraded by ~4-5%. The cosine scheduler at T_max=70 reaches a lower minimum LR earlier (epoch 70 vs 80), which means the final learning rate is slightly higher at the end of training. This may help pressure but slightly hurt the velocity predictions.

Run completed 68/70 epochs before the 5-minute wall clock limit — very close to completing the full schedule.

## Suggested follow-ups

- Try T_max=65 to push even further in the same direction
- Try T_max=75 as the midpoint between 70 and 80 to see if the trend is monotonic
- The tradeoff between pressure and velocity MAE at different T_max values suggests an optimal around T_max=70 if pressure is the primary concern