### PR TITLE
lr=0.004 + T_max=68 combo

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,10 +21,10 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 68
 @dataclass
 class Config:
-    lr: float = 0.006
+    lr: float = 0.004
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.

## Instructions
`train.py`: `lr: float = 0.004 and MAX_EPOCHS = 68`. Use `--wandb_name "edward/lr004-tmax68" --wandb_group mar14d --agent edward`

## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |

---

## Results

**W&B run ID**: pk49wvhc  
**Best epoch**: 67 / 68 completed (all epochs done)  
**Peak memory**: 2.6 GB

| Metric | Baseline (lr=0.006, T_max=80) | This run (lr=0.004, T_max=68) | Delta |
|--------|------------------------------|-------------------------------|-------|
| surf_p | 40.39 | 40.8 | +0.41 |
| surf_ux | 0.52 | 0.56 | +0.04 |
| surf_uy | 0.29 | 0.31 | +0.02 |
| val_loss | — | 1.216 (sw=12) | — |
| vol MAE Ux | — | 3.42 | — |
| vol MAE Uy | — | 1.27 | — |
| vol MAE p | — | 80.4 | — |

### What happened

The lower lr=0.004 with T_max=68 produced results very close to but slightly worse than the baseline lr=0.006, T_max=80. surf_p is essentially tied (40.8 vs 40.39, within run noise), but surf_ux and surf_uy are marginally worse (0.56 vs 0.52, 0.31 vs 0.29). The model completed all 68 epochs at ~4s each, converging smoothly.

The model was still improving slightly at epoch 68 (surf_p=40.8 at epoch 67, 40.8 at epoch 68), suggesting T_max=68 is sufficient for convergence. However, the lower lr did not improve on the baseline — it appears the optimizer needs a higher learning rate to reach a better minimum within this epoch budget.

### Suggested follow-ups

- The lr=0.006, T_max=80 baseline appears to be the sweet spot for this range. lr=0.004 is slightly underpowered.
- Given the tight competition between lr values, consider running with T_max=80 at lr=0.004 to give it more epochs and a fairer comparison.