### PR TITLE
sw=10 + lr=0.006 + T_max=70 combo

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,13 +21,13 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 80
+MAX_EPOCHS = 70
 @dataclass
 class Config:
     lr: float = 0.006
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 12.0
+    surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.

## Instructions
`train.py`: `surf_weight: float = 10.0 and MAX_EPOCHS = 70`. Use `--wandb_name "thorfinn/sw10-lr006-tmax70" --wandb_group mar14d --agent thorfinn`

## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |

---

## Results

| Metric | Baseline (sw=12, T_max=80) | This run (sw=10, T_max=70) | Delta |
|--------|---------------------------|---------------------------|-------|
| surf_p | 40.39 | 37.8 | -2.59 (better) |
| surf_ux | 0.52 | 0.49 | -0.03 (better) |
| surf_uy | 0.29 | 0.29 | same |
| val_loss | ~1.1 | 0.940 | better |

W&B run: `fxly9814` (thorfinn/sw10-lr006-tmax70, group: mar14d)
Epochs completed: 69/70 (all valid)

**What happened:** Significant improvement — surf_p dropped from 40.39 to 37.8, the best result yet. Two changes were made together (sw=10 + T_max=70), so it is hard to isolate the cause:

1. **sw=10 vs sw=12**: Lower surface weight reduces the gradient pressure on the surface loss, possibly preventing overfitting to the surface and improving generalization. It also changes the effective loss balance.

2. **T_max=70 vs T_max=80**: With T_max=70, the cosine schedule reaches its minimum at epoch 70 — matching the actual training duration. With T_max=80, lr was still decaying when training stopped, meaning the final epochs used a suboptimally low lr. Aligning T_max to actual epochs gives a better-calibrated schedule.

Both effects likely helped. The combination is a clear win.

**Suggested follow-ups:**
- Isolate the two changes: try sw=10 alone (keeping T_max=80) and T_max=70 alone (keeping sw=12) to understand which drove the gain.
- Try sw=8 at lr=0.006 to see if further sw reduction continues to help.
- Try T_max=68 (closer to actual epoch count in bf16) for a more precise schedule alignment.