### PR TITLE
lr=0.003 aggressive LR reduction

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 0.006
+    lr: float = 0.003
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 12.0


### PR DESCRIPTION
## Hypothesis
Systematic sweep around lr=0.006 winning config.

## Instructions
\`train.py\`: \`lr: float = 0.003\`. Use \`--wandb_name "askeladd/lr003-bf16" --wandb_group mar14d --agent askeladd\`

## Baseline
| surf_p | 40.39 | surf_ux | 0.52 | surf_uy | 0.29 | lr | 0.006 | sw | 12 | T_max | 80 |

---

## Results

**W&B run ID:** ftg41s4z

| Metric | Baseline (lr=0.006) | This run (lr=0.003) |
|--------|--------------------|--------------------|
| surf_p | 40.39 | **39.85** |
| surf_ux | 0.52 | **0.48** |
| surf_uy | 0.29 | **0.28** |
| val_loss | — | 1.129 |
| Peak memory | — | 2.6 GB |
| Epochs completed | — | 69 (5-min timeout) |

### What happened

Positive result — lr=0.003 beats the baseline on all metrics. surf_p: 40.39 → 39.85 (-1.3%), surf_ux: 0.52 → 0.48, surf_uy: 0.29 → 0.28.

Key observations:
1. **LR reduction trend continues** — the consistent pattern holds: lower LR consistently improves results within this bf16 + sw=12 config. Each halving has yielded gains.
2. **surf_ux particularly benefits** — 0.52 → 0.48 is a meaningful improvement in velocity prediction, suggesting the finer gradient steps help the model distinguish local flow features.
3. **Final lr is very low (0.00014)** — with T_max=80 and initial lr=0.003, the cosine schedule decays to near-zero by ep69. The model has essentially converged.
4. **69 epochs, still improving** — best epoch was 69, the last one before timeout, suggesting the model was still extracting value from training.

**Verdict:** Positive. lr=0.003 is a new best. The lower-LR trend is reliable, though we may be approaching diminishing returns (each step yields ~0.5 surf_p improvement).

### Suggested follow-ups

- Try lr=0.001 to test if the trend continues to even smaller values
- Try lr=0.003 + T_max=68 (matched to epoch budget) — cosine may work better with matched T_max
- Consider that the trend may reverse at some point — worth benchmarking lr=0.002 as the next step