### PR TITLE
CosineAnnealingWarmRestarts T_0=60 (late restart)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 80
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=60, T_mult=1)
 
 
 # --- wandb ---
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +172,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
Previous warm restart attempts (PR #161: T_0=25, PR #193: T_0=17) failed because the cycle was too short. With T_0=60, the first cycle covers 75% of an 80-epoch budget, allowing near-full convergence. The restart at epoch 60 gives a brief LR jolt back to 0.006 for 20 more epochs — enough to escape a local minimum without catastrophic forgetting.

## Instructions
All changes in `train.py` unless noted:

1. Set `MAX_EPOCHS = 80` (to accommodate second cycle after restart at epoch 60)
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`
6. **Experimental change** — replace the scheduler: `CosineAnnealingWarmRestarts(optimizer, T_0=60, T_mult=1)`
7. Deeper output MLP in `TransolverBlock.__init__`

Use `--wandb_name "fern/warm-restart-t0-60" --wandb_group mar14 --agent fern`

## Baseline
| Metric | Current Best |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0 |

---

## Results

**W&B run ID:** wlb2e2di
**Epochs completed:** 13/80 (stopped at 5-minute wall-clock timeout)
**Peak memory:** 12.2 GB

| Metric | Baseline | This run (epoch 13) |
|--------|----------|---------------------|
| surf_p | 37.82 | 117.4 |
| surf_ux | 0.49 | 1.33 |
| surf_uy | 0.29 | 0.68 |
| val_loss | 0.940 | 1.669 |
| vol MAE Ux | — | 5.32 |
| vol MAE Uy | — | 2.14 |
| vol MAE p | — | 137.7 |

**What happened:**

The hypothesis cannot be fairly evaluated under the 5-minute timeout constraint. T_0=60 means the first cosine cycle completes at epoch 60, but we only reached epoch 13 before timing out (~23s/epoch × 80 epochs ≈ 31 minutes needed). At epoch 13 the model was still rapidly improving — val_surf went from 0.747 (epoch 1) to 0.136 (epoch 13), still declining. The surface metrics are far worse than baseline simply because the model is undertrained, not because the scheduler design is flawed. The implementation is correct and working as intended.

**Suggested follow-ups:**
- The warm restart hypothesis is fundamentally incompatible with the 5-minute timeout at T_0=60. To test it properly, either increase MAX_TIMEOUT or use a shorter T_0 that fits within ~13 reachable epochs (e.g. T_0=10–12).
- Worth isolating the individual contributions: bf16 autocast, deeper MLP, L1 surf loss, and grad clipping are all bundled here — running a baseline with just these changes (no warm restart, standard cosine schedule) would reveal how much each component contributes.