### PR TITLE
Differential LR: 0.006 backbone, 0.012 output head

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -79,8 +79,15 @@ model = Transolver(
 ).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+# Separate output head params (last block's mlp2 and ln_3)
+head_params = list(model.blocks[-1].mlp2.parameters()) + list(model.blocks[-1].ln_3.parameters())
+head_ids = set(id(p) for p in head_params)
+backbone_params = [p for p in model.parameters() if id(p) not in head_ids]
+optimizer = torch.optim.AdamW([
+    {"params": backbone_params, "lr": 0.006},
+    {"params": head_params, "lr": 0.012},
+], weight_decay=0)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=70)
 
 
 # --- wandb ---
@@ -127,18 +134,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +179,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The deeper output MLP (128->64->3) maps backbone features to physical quantities with vastly different scales (p has y_std=961 vs Ux at 25). The head is small (~8K params) and can tolerate a higher LR than the backbone attention layers. A 2x higher LR on the output head lets it adapt faster to evolving backbone features, while the backbone trains at proven stable 0.006. This is standard practice in transfer learning but has not been tried here.

## Instructions
All changes in `train.py` unless noted:

1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`
6. **Experimental change** — create separate parameter groups with differential LR (backbone 0.006, head 0.012)
7. Deeper output MLP in `TransolverBlock.__init__` (128->64->3)

Use `--wandb_name "tanjiro/differential-lr" --wandb_group mar14 --agent tanjiro`

## Baseline
| Metric | Current Best |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0 |

---

## Results

**W&B Run:** 857c5dkr
**Epochs completed:** 13 (hit 5 min wall-clock at ~23s/epoch)
**Peak memory:** 12.2 GB

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 1.7062 | 0.940 | +0.766 (worse) |
| surf_p | 129.73 | 37.82 | +91.91 (much worse) |
| surf_Ux | 1.54 | 0.49 | +1.05 (much worse) |
| surf_Uy | 0.67 | 0.29 | +0.38 (much worse) |
| vol MAE Ux | 5.23 | — | — |
| vol MAE Uy | 2.25 | — | — |
| vol MAE p | 142.84 | — | — |

**What happened:** Differential LR (2x head) significantly hurt performance — val_loss 1.706 vs baseline 0.940, and surf_p 129.7 vs baseline 37.82. Only 13 epochs ran in 5 minutes (~23s/epoch). Even accounting for the early stopping, the best epoch was epoch 13 and the model had not converged close to baseline levels. The 0.012 head LR appears too aggressive for early training: the output head races ahead while the backbone is still forming meaningful representations, causing instability. In transfer learning, differential LR works when the backbone is pretrained/frozen; here both components train from scratch simultaneously, and the faster-moving head likely disrupts gradient flow back into the backbone.

**Suggested follow-ups:**
- Try a smaller multiplier (1.2–1.5x) rather than 2x — less aggressive differential may stabilize training
- Try delaying the higher head LR: start both at 0.006, then increase head LR after epoch 10–20 once backbone has formed stable representations
- Consider that the head LR should be *lower* than backbone in early training (to wait for backbone to stabilize), then possibly higher later