### PR TITLE
GradNorm-inspired adaptive surface weight

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -102,6 +102,7 @@ with open(model_dir / "config.yaml", "w") as f:
 best_val = float("inf")
 best_metrics = {}
 train_start = time.time()
+dynamic_sw = cfg.surf_weight  # start at 10.0
 
 for epoch in range(MAX_EPOCHS):
     # Check wall-clock timeout
@@ -127,18 +128,36 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + dynamic_sw * surf_loss
 
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        if n_batches == 0:  # first batch of each epoch
+            optimizer.zero_grad()
+            vol_loss.backward(retain_graph=True)
+            vol_grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), float('inf'))
+            optimizer.zero_grad()
+            (dynamic_sw * surf_loss).backward(retain_graph=True)
+            surf_grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), float('inf'))
+            optimizer.zero_grad()
+            if surf_grad_norm > 0:
+                ratio = (vol_grad_norm / surf_grad_norm).item()
+                dynamic_sw = max(2.0, min(20.0, dynamic_sw * 0.9 + ratio * 0.1))
+            wandb.log({"dynamic_sw": dynamic_sw})
+            loss = vol_loss + dynamic_sw * surf_loss
+
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +188,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The fixed sw=10 was tuned by grid search, but the optimal balance between surface and volume gradients likely changes throughout training. Early on, volume loss gradients dominate (86K volume vs ~1K surface nodes); later, surface refinement matters more. GradNorm-inspired balancing adjusts sw dynamically so both losses contribute roughly equal gradient norms. Unlike static sw experiments (sw=8,10,12,14,16), this adapts per-epoch.

## Instructions
All changes in `train.py` unless noted:

1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`
6. Dynamic surf_weight via GradNorm (first batch of each epoch)
7. Deeper output MLP in `TransolverBlock.__init__`

Use `--wandb_name "nezuko/gradnorm-adaptive-sw" --wandb_group mar14 --agent nezuko`

## Baseline
| Metric | Current Best |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0 |

---

## Results

**W&B run:** `ajbqgaqo` (nezuko/gradnorm-adaptive-sw, group: mar14)
**Epochs completed:** 13/70 (5-min timeout)
**Peak memory:** 13.8 GB

| Metric | Baseline | This Run | Delta |
|--------|----------|----------|-------|
| val_loss | 0.940 | 1.698 | +0.758 worse |
| surf_p | 37.82 | 124.7 | +86.9 worse |
| surf_Ux | 0.49 | 2.39 | +1.90 worse |
| surf_Uy | 0.29 | 0.72 | +0.43 worse |
| vol_Ux | — | 5.24 | — |
| vol_Uy | — | 1.97 | — |
| vol_p | — | 136.3 | — |

dynamic_sw trajectory: 10.0 → 2.65 over 13 epochs (steadily decreasing).

### What happened

The GradNorm approach failed. dynamic_sw dropped aggressively from 10.0 to 2.65 — well below the tuned baseline of 10.0 — because vol_grad_norm was consistently larger than surf_grad_norm. GradNorm interpreted this as surface dominating and kept reducing the surface weight. But surface nodes are sparse (~1K vs 86K volume nodes), so the surface gradient norm is naturally small due to fewer contributing nodes, not because the surface is winning. With sw at ~2.65, the model had far less incentive to fit surface nodes, causing surf_p to degrade 3.3x vs baseline.

The fundamental issue: gradient norm balancing is inappropriate here. The gradient norm imbalance is a deliberate consequence of node count imbalance, not a training pathology. The static sw=10 was tuned to compensate for this — dynamically undoing it hurts.

### Suggested follow-ups

- **Higher floor**: Try floor=8.0 instead of 2.0 to prevent sw from drifting below the tuned value.
- **Slower EMA**: Use alpha=0.99 to make changes very gradual, allowing fine-tuning rather than collapse.
- **Node-count-corrected ratio**: Divide the gradient ratio by (n_vol / n_surf) before the EMA update, separating structural imbalance from true gradient signal.
- **Abandon adaptive sw**: The static sw=10 may be near-optimal given the node count structure; this approach may not be suitable for this problem.