### PR TITLE
LayerNorm inside output MLP (intermediate normalization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +172,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,12 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.LayerNorm(hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The output MLP maps 128-dim backbone features to 3 output channels with vastly different scales (pressure y_std=961 vs Ux=25). Adding LayerNorm inside the MLP (after the first linear, before GELU) stabilizes intermediate activations before final projection. This helps the GELU activation operate in its effective range for all output channels. Low-risk change that stabilizes gradient flow through the output head.

## Instructions
All changes in `train.py` unless noted:

1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`

In `transolver.py`:
6. Deeper output MLP WITH intermediate LayerNorm in `TransolverBlock.__init__`

Use `--wandb_name "alphonse/layernorm-output-mlp" --wandb_group mar14 --agent alphonse`

## Baseline
| Metric | Current Best |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0 |

---

## Results

**W&B run:** `rgaabk6j`
**Epochs completed:** 13 / 70 (hit 5-min wall-clock timeout at ~5.2 min)
**Peak VRAM:** 12.4 GB

| Metric | This run (epoch 13) | Baseline (epoch 70) |
|--------|---------------------|---------------------|
| val_loss | 1.567 | 0.940 |
| surf_Ux | 1.74 | 0.49 |
| surf_Uy | 0.73 | 0.29 |
| surf_p | 108.8 | 37.82 |
| vol_Ux | 6.13 | — |
| vol_Uy | 2.62 | — |
| vol_p | 145.5 | — |

### What happened

The run hit the 5-minute timeout after only 13 of 70 epochs (~19% through training). The metrics at epoch 13 are substantially worse than the baseline, but **this is not a meaningful comparison** — the baseline numbers represent a fully converged run at epoch 70, while this is early training.

At ~24 seconds/epoch, all 70 epochs would take ~28 minutes, far beyond the 5-minute cap. The training loss curves showed steady improvement throughout (val/loss trend was still decreasing at epoch 13), so the model hadn't converged.

Because training was cut off so early, we cannot determine whether the intermediate LayerNorm in the output MLP helps or hurts relative to baseline. The model architecture change is minimal (+1 LayerNorm layer, negligible parameter overhead) and did not affect training stability or memory usage (12.4 GB, same as baseline).

### Suggested follow-ups

- **Epochs-per-minute is the bottleneck**: At ~24s/epoch the 5-min cap allows only ~12-13 epochs out of 70. Ablation studies on architecture changes are not reliable under this constraint — consider comparing at a fixed low epoch count (e.g. both variants to epoch 13).
- If the LayerNorm idea is worth pursuing, compare baseline deeper-MLP vs. layernorm-deeper-MLP both capped at 13 epochs to get a fair signal.
- Alternatively, reducing dataset size or batch complexity could speed up epochs and enable more thorough convergence within the time budget.