### PR TITLE
OneCycleLR max_lr=0.009 (super-convergence)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.009
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -80,7 +80,10 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.OneCycleLR(
+    optimizer, max_lr=0.009, epochs=MAX_EPOCHS, steps_per_epoch=len(train_loader),
+    div_factor=3, final_div_factor=100, pct_start=0.3
+)
 
 
 # --- wandb ---
@@ -127,26 +130,28 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        scheduler.step()
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
-
-    scheduler.step()
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
@@ -169,7 +174,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
CosineAnnealingLR starts at lr=0.006 and decays. OneCycleLR starts lower, ramps up to a peak, then decays aggressively — the "super-convergence" schedule (Smith & Topin, 2019). Previous OneCycleLR attempts (PR #20, #49, #127) used different baselines and MSE loss. On the current best config with L1 surface + bf16, OneCycleLR with max_lr=0.009, div_factor=3 (start at 0.003, peak at 0.009 around epoch 21, decay to near-zero by epoch 70) could find a better minimum. The initial low LR serves as implicit warmup, and aggressive final decay drives fine-tuning.

## Instructions
All changes in `train.py` unless noted:

1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.009` and `weight_decay: float = 0.0` (OneCycleLR overrides the initial lr, but set it for logging)
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`
6. Replace scheduler with OneCycleLR (per-batch stepping)
7. Deeper output MLP in `TransolverBlock.__init__`

Use `--wandb_name "edward/onecycle-lr009" --wandb_group mar14 --agent edward`

## Baseline
| Metric | Current Best |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0 |

---

## Results

**W&B run ID**: n1ljq8p2

| Metric | Baseline | OneCycleLR | Delta |
|--------|----------|------------|-------|
| surf_p | 37.82 | 142.4 | +104.6 (worse) |
| surf_ux | 0.49 | 2.57 | +2.08 (worse) |
| surf_uy | 0.29 | 0.99 | +0.70 (worse) |
| val_loss | 0.940 | 2.3341 | +1.39 (worse) |
| Peak memory | — | 12.2 GB | — |

Best at epoch 9/13 completed (timeout hit at 5 min; 70 epochs planned).

**What happened**: OneCycleLR performed significantly worse than baseline on all metrics. Surface pressure MAE is ~4x worse and val_loss is 2.5x worse. The fundamental issue is that the 5-minute timeout only allowed 13 of 70 planned epochs to complete. With pct_start=0.3, the LR peak is at epoch ~21 — the model was still in the ramp-up phase at timeout (lr=0.0071 and still increasing). It never reached the aggressive decay phase where super-convergence is supposed to do its work. The results at epoch 9 (best) reflect an under-trained model in a high-LR exploration state. This is an incomplete run, not a fair test of OneCycleLR.

**Suggested follow-ups**:
- Try OneCycleLR with a compressed schedule (e.g., MAX_EPOCHS=15) so it completes within the 5-min timeout — keep the same pct_start=0.3 so peak is at epoch ~5.
- Alternatively, try a simple linear warmup (5 epochs, 1e-4 → 0.006) + CosineAnnealingLR, which is more timeout-friendly than OneCycleLR.
- If a longer run budget becomes available, a full 70-epoch OneCycleLR run would give a proper comparison.