### PR TITLE
Input skip connection to output decoder

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +172,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
@@ -212,6 +216,7 @@ class Transolver(nn.Module):
         )
         self.initialize_weights()
         self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))
+        self.skip_proj = nn.Linear(n_hidden, n_hidden)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -268,8 +273,11 @@ class Transolver(nn.Module):
 
         fx = self.preprocess(x)
         fx = fx + self.placeholder[None, None, :]
+        fx_skip = self.skip_proj(fx)  # save projected input features
 
-        for block in self.blocks:
+        for block in self.blocks[:-1]:
             fx = block(fx)
+        fx = fx + fx_skip  # add skip before last block
+        fx = self.blocks[-1](fx)
         self._validate_output_dims(fx)
         return {"preds": fx}


### PR DESCRIPTION
## Hypothesis
The output MLP predicts Ux, Uy, p from 128-dim backbone features. After 5 Transolver blocks with attention and residuals, the original geometric signal (position, signed arc-length, distance-to-surface, Re, AoA) may be diluted. A skip connection from the preprocessed input to the last block provides a shortcut so the decoder can directly access spatial and condition information. PR #50 tested an input-to-output skip on an old config with MSE loss — the architecture and loss landscape have changed substantially since then.

## Instructions
All changes in `train.py` unless noted:

1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`

In `transolver.py`:
6. Deeper output MLP
7. **Experimental change** — add input skip connection in `Transolver`

Use `--wandb_name "thorfinn/input-skip-connection" --wandb_group mar14 --agent thorfinn`

## Baseline
| Metric | Current Best |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0 |

---

## Results

**W&B run ID:** fwpcfn8j
**Epochs completed:** 13/70 (hit 5-min wall-clock timeout)
**Peak memory:** 12.3 GB

| Metric | This run (epoch 13) | Baseline |
|--------|---------------------|----------|
| surf_p | 126.9 | 37.82 |
| surf_ux | 1.51 | 0.49 |
| surf_uy | 0.79 | 0.29 |
| val_loss | 1.7257 | 0.940 |
| vol Ux MAE | 5.01 | — |
| vol Uy MAE | 2.15 | — |
| vol p MAE | 144.4 | — |

**What happened:** The run was cut off at epoch 13/70 by the 5-minute timeout, so a fair comparison against the baseline is not possible. At epoch 13, all metrics are significantly worse than the baseline — but this is expected early in training with lr=0.006, which requires more epochs to converge. The skip connection adds modest overhead (one extra Linear(128,128) + residual add). Architecture looks clean, and early training loss curves are reasonable (surf loss decreasing from ~1.8 to ~0.23 in 13 epochs). Whether the skip helps requires running to full convergence.

**Suggested follow-ups:**
- Compare against a no-skip baseline using the same config at full convergence — the current baseline may have been trained under a slightly different config, making direct comparison ambiguous.
- If the skip is beneficial, try a learnable or fixed scale factor (< 1.0) on fx_skip to soften the injection.
- Try skip injection into an intermediate block (e.g., blocks[-2]) rather than just before the last block.