### PR TITLE
Progressive freezing: freeze blocks 0-2 after epoch 10

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 100
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=100)
 
 
 # --- wandb ---
@@ -110,6 +110,15 @@ for epoch in range(MAX_EPOCHS):
         print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {MAX_TIMEOUT} min). Stopping.")
         break
 
+    FREEZE_AFTER_EPOCH = 10
+    if epoch == FREEZE_AFTER_EPOCH:
+        for i, block in enumerate(model.blocks[:3]):
+            for param in block.parameters():
+                param.requires_grad = False
+        for param in model.preprocess.parameters():
+            param.requires_grad = False
+        print(f"Froze first 3 blocks + preprocess at epoch {FREEZE_AFTER_EPOCH}")
+
     t0 = time.time()
 
     # --- Train ---
@@ -127,18 +136,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,8 +181,9 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+            sq_err = (pred.float() - y_norm) ** 2
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
@@ -178,7 +191,7 @@ for epoch in range(MAX_EPOCHS):
             val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
-            pred_orig = pred * stats["y_std"] + stats["y_mean"]
+            pred_orig = pred.float() * stats["y_std"] + stats["y_mean"]
             err = (pred_orig - y).abs()
             mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
             mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
With 5 Transolver blocks and ~70 epochs, early layers must learn general features AND receive gradients from surface loss simultaneously. Freezing the first 3 blocks after a 10-epoch warmup: (1) speeds up per-epoch time by ~40% since backprop only traverses 2 blocks + head, potentially yielding ~100 epochs in 5 min, (2) stabilizes early-layer features, preventing late-stage gradient noise from perturbing good representations. This is progressive freezing from NLP fine-tuning (Howard & Ruder, 2018). Early blocks likely converge to good physics features within 10 epochs; the remaining 90 epochs should refine only the later, task-specific layers.

## Instructions
All changes in `train.py` unless noted:

1. Set `MAX_EPOCHS = 100` (to take advantage of faster epochs post-freeze)
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`
6. Set scheduler: `scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=100)`
7. **Experimental change** — add progressive freezing at epoch 10: freeze blocks 0-2 + preprocess
8. Deeper output MLP in TransolverBlock (hidden_dim//2 bottleneck)

Use `--wandb_name "askeladd/freeze-early-blocks" --wandb_group mar14 --agent askeladd`

## Baseline
| Metric | Current Best |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0 |

---

## Results

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| surf_p | 108.2 | 37.82 | +186% worse |
| surf_Ux | 1.29 | 0.49 | +163% worse |
| surf_Uy | 0.68 | 0.29 | +134% worse |
| val_loss | 1.616 | 0.940 | +72% worse |
| vol Ux | 5.07 | — | — |
| vol Uy | 2.42 | — | — |

- **W&B run:** `1fwezyx4` (askeladd/freeze-early-blocks, group: mar14)
- **Best epoch:** 12 / 14 completed
- **Peak memory:** 12.2 GB
- **Epoch time:** ~20s per epoch (both pre- and post-freeze)

### What happened

**The run failed to improve on the baseline.** Only 14 epochs completed in 5.3 minutes — far fewer than the ~70 the baseline achieves. The core assumption of the hypothesis was wrong: **freezing 3 blocks did not meaningfully speed up per-epoch time.** Epochs took ~20s both before and after the freeze at epoch 10.

Two consequences:
1. The model was severely undertrained (14 vs ~70 epochs). At epoch 12 the model was still descending — it never got close to convergence.
2. Even if the freeze had worked as hoped, 10 warmup epochs is too short — the model likely had not yet learned useful early-layer features to freeze.

The computation bottleneck appears to be elsewhere (data loading, validation, or the 2 remaining active blocks), not backprop through the frozen 3 blocks.

### Suggested follow-ups

- **Diagnose why epochs are slow (~20s vs baseline's ~4s):** profile whether the bottleneck is data loading, forward pass, or something else. If the baseline genuinely runs ~70 epochs in 5 min, there may be a caching or I/O optimization difference not captured in this branch.
- **If per-epoch speedup from freezing is confirmed in a controlled test:** try freezing at a later epoch (e.g., 30) once the model has more time to learn good features.
- **Reverse progressive unfreezing:** start with only the output block trainable, then progressively unfreeze earlier blocks — this is the ULMFiT approach and avoids the risk of freezing underfitted features.