### PR TITLE
Log-cosh surface loss (smooth L1 alternative) v2

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=70)
 
 
 # --- wandb ---
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            logcosh = torch.log(torch.cosh(diff.clamp(-20, 20)))
+            surf_loss = (logcosh * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,8 +172,9 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+            sq_err = (pred.float() - y_norm) ** 2
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
@@ -178,7 +182,7 @@ for epoch in range(MAX_EPOCHS):
             val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
-            pred_orig = pred * stats["y_std"] + stats["y_mean"]
+            pred_orig = pred.float() * stats["y_std"] + stats["y_mean"]
             err = (pred_orig - y).abs()
             mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
             mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
L1 surface loss was the single biggest improvement in programme history. However, L1 has a discontinuous gradient at zero, causing oscillation near convergence. `log(cosh(x))` behaves like L1 for large errors but has a smooth quadratic region near zero with continuous second derivative. The gradient is `tanh(x)` — saturating to +/-1 for large x (L1-like) but smooth through zero. This should help the optimizer make finer adjustments in the final epochs where the model tunes small residuals.

## Instructions

**Model config (CRITICAL — change from code defaults):**
```python
model_config = dict(
    space_dim=2, fun_dim=16, out_dim=3,
    n_hidden=128, n_layers=1, n_head=2,
    slice_num=32, mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

**In `train.py`:**
1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Set `T_max=70` in the scheduler: `CosineAnnealingLR(optimizer, T_max=70)`
4. Wrap training forward+loss in bf16 autocast. Use **log-cosh** for surface loss:
   ```python
   with torch.amp.autocast("cuda", dtype=torch.bfloat16):
       pred = model({"x": x})["preds"]
       diff = pred - y_norm
       sq_err = diff ** 2
       vol_mask = mask & ~is_surface
       surf_mask = mask & is_surface
       vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
       logcosh = torch.log(torch.cosh(diff.clamp(-20, 20)))
       surf_loss = (logcosh * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
       loss = vol_loss + cfg.surf_weight * surf_loss
   ```
5. Same bf16 autocast for validation forward pass. Keep validation MAE using `.abs()`.
6. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`

**In `transolver.py`:**
7. Deeper output MLP:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Linear(hidden_dim // 2, out_dim),
       )
   ```

Use `--wandb_name "frieren/logcosh-surface-v2" --wandb_group mar14 --agent frieren`

## Baseline
| Metric | Current Best (1-layer model) |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0, **n_layers=1, n_head=2, slice_num=32** |

---

## Results

**W&B run:** `tej8v0as` (`frieren/logcosh-surface-v2`, group: `mar14`)
**Peak memory:** 2.6 GB
**Epochs completed:** 68 of 70 (~4s/epoch, hit 5-min wall-clock after epoch 68)

| Metric | This Run (best @ ep 65) | Baseline | Δ |
|--------|------------------------|----------|---|
| surf_p | 44.52 | 37.82 | +6.70 (worse) |
| surf_Ux | 0.62 | 0.49 | +0.13 (worse) |
| surf_Uy | 0.35 | 0.29 | +0.06 (worse) |
| val_loss* | 0.517 | 0.940 | — (different scale) |

*val_loss not directly comparable: baseline uses `vol_MSE + 10*surf_L1`; this run uses `vol_MSE + 10*surf_logcosh`. Since log-cosh(x) < |x| for small x, the combined loss is numerically lower even when MAEs are worse.

**Training trajectory (selected epochs):**
| Epoch | surf_p | surf_Ux | surf_Uy |
|-------|--------|---------|---------|
| 1 | 300.3 | 4.42 | 2.00 |
| 10 | ~150 | ~2.0 | ~1.0 |
| 30 | ~70 | ~0.9 | ~0.5 |
| 65 (best) | 44.5 | 0.62 | 0.35 |
| 68 | 45.0 | 0.61 | 0.35 |

**What happened:** Log-cosh converged to worse surface MAE than L1 across all fields. The training ran nearly to completion (68/70 epochs) so this is a clean comparison. With the 1-layer model, the baseline L1 achieves surf_p=37.82, while log-cosh plateaus at ~44.5 — about 18% worse on pressure. Ux and Uy are also ~25-30% worse.

The likely reason: log-cosh behaves like 0.5*x² near zero rather than |x|, meaning it penalizes small errors more weakly than L1. For a model that still has surface pressure residuals in the 40–50 range, the "smooth near zero" regime of log-cosh never activates — we're not close enough to zero for it to matter. Meanwhile, the weaker gradient near zero may be reducing the effective weight on surface loss, letting the optimizer focus on volume loss at the expense of surface accuracy.

**Conclusion:** Log-cosh is worse than L1 for this task. L1 remains the better choice for surface loss. The hypothesis that L1's discontinuous gradient causes oscillation near convergence is not supported — the model benefits from L1's consistent per-unit gradient signal throughout training.

**Suggested follow-ups:**
- The baseline L1 surface loss already performs well; consider tuning `surf_weight` (e.g. 15 or 20) to squeeze more improvement rather than changing the loss function.
- If oscillation near convergence is still suspected, a small LR warmdown in the final 10 epochs might help without changing the loss structure.