### PR TITLE
3x pressure channel weight in surface L1 loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=70)
 
 
 # --- wandb ---
@@ -127,18 +127,24 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            # Per-channel weight: [Ux=1, Uy=1, p=3]
+            channel_weight = torch.tensor([1.0, 1.0, 3.0], device=pred.device)
+            weighted_abs = abs_err * channel_weight
+            surf_loss = (weighted_abs * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +175,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
Surface pressure (p) has the largest absolute MAE (37.82 vs 0.49/0.29 for Ux/Uy) and is the hardest channel to predict (y_std=961 vs ~25 for velocity). The current L1 surface loss treats all 3 channels equally, but pressure deserves more gradient signal. Weighting the pressure channel 3x in the surface loss directly targets our most important metric. PR #176 tried 3x pressure on an older config — this tests it on the current best.

## Instructions

**Model config (CRITICAL — change from code defaults):**
```python
model_config = dict(
    space_dim=2, fun_dim=16, out_dim=3,
    n_hidden=128, n_layers=1, n_head=2,
    slice_num=32, mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

**In `train.py`:**
1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Set `T_max=70`
4. Wrap training forward+loss in bf16 autocast with per-channel weighted L1 surface loss (channel_weight=[Ux=1, Uy=1, p=3])
5. Same bf16 autocast for validation forward pass.
6. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`

**In `transolver.py`:**
7. Deeper output MLP (128->64->3)

Use `--wandb_name "tanjiro/3x-pressure-surface" --wandb_group mar14 --agent tanjiro`

## Baseline
| Metric | Current Best (1-layer model) |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0, **n_layers=1, n_head=2, slice_num=32** |

---

## Results

**W&B Run:** avaxgfu4
**Epochs completed:** 68 of 70 (best at epoch 68, ~5s/epoch with 1-layer model)
**Peak memory:** 2.6 GB

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.6601 | 0.940 | -0.280 (improved) |
| surf_p | 39.00 | 37.82 | +1.18 (slightly worse) |
| surf_Ux | 0.57 | 0.49 | +0.08 (slightly worse) |
| surf_Uy | 0.32 | 0.29 | +0.03 (slightly worse) |
| vol MAE Ux | 3.39 | — | — |
| vol MAE Uy | 1.33 | — | — |
| vol MAE p | 86.51 | — | — |

**What happened:** Mixed result. val_loss improved significantly (0.660 vs 0.940), but the surface MAE metrics — the ones engineers care about — were all slightly *worse* than baseline despite the 3x pressure weighting in the loss. The pressure MAE actually went up slightly (39.0 vs 37.82). The val_loss improvement likely reflects a discrepancy between the training loss (3x-weighted L1) and the eval loss (MSE-based), rather than genuine surface accuracy improvement. The model learned to minimize the biased training loss but this didn't translate to better actual predictions. In other words, the 3x pressure weight shifted optimization effort toward pressure during training but the resulting model was marginally worse on all channels at evaluation time.

**Suggested follow-ups:**
- Try a higher multiplier (5x or 10x) for pressure — 3x may not be strong enough to overcome the scale difference
- Use normalized per-channel loss during training and evaluation (divide each channel by its std), which would naturally equalize gradient signal across the large scale difference between p and velocity
- The val_loss improvement might be noise from the MSE/L1 mismatch — try computing val_loss consistently with the training loss for better comparison