### PR TITLE
Linear warmup 3 epochs + cosine decay

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,10 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
+warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
+cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
 
 
 # --- wandb ---
@@ -127,18 +130,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +175,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The current schedule starts at lr=0.006 and immediately decays via cosine annealing. A brief 3-epoch linear warmup (1e-5 → 0.006) before cosine decay allows the model to stabilize before high-LR training. This is particularly useful with L1 loss, which has sharp gradients — warmup prevents early instability. PR #165 tried warmup with lr=0.018 (too aggressive); this uses the proven lr=0.006 base.

## Instructions

**Model config (CRITICAL — change from code defaults):**
```python
model_config = dict(
    space_dim=2, fun_dim=16, out_dim=3,
    n_hidden=128, n_layers=1, n_head=2,
    slice_num=32, mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

**In `train.py`:**
1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Wrap training forward+loss in bf16 autocast with L1 surface loss
4. Same bf16 autocast for validation forward pass.
5. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`
6. **Replace scheduler** with SequentialLR combining warmup + cosine:
   ```python
   from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
   warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
   cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
   scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
   ```

**In `transolver.py`:**
7. Deeper output MLP

Use `--wandb_name "nezuko/warmup3-cosine" --wandb_group mar14 --agent nezuko`

## Baseline
| Metric | Current Best (1-layer model) |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0, **n_layers=1, n_head=2, slice_num=32** |

---

## Results

**W&B run**: `dkcmmfss` | Run: nezuko/warmup3-cosine | Group: mar14

| Metric | Baseline | This Run | Delta |
|--------|----------|----------|-------|
| surf_p | 37.82 | 37.16 | -0.66 ✓ |
| surf_Ux | 0.49 | 0.50 | +0.01 ~ |
| surf_Uy | 0.29 | 0.27 | -0.02 ✓ |
| val_loss | 0.940 | 0.579 | — (loss scale changed) |
| Peak VRAM | — | 2.6 GB | — |

Best epoch: 69/70 (hit 5-min wall-clock limit). 69 epochs completed.

**What happened**: The 3-epoch linear warmup produced marginal improvements on surf_p (37.82→37.16) and surf_Uy (0.29→0.27), while surf_Ux was essentially unchanged. The val_loss drop (0.940→0.579) is not directly comparable since it reflects the L1 surface loss formulation vs MSE. The practical surface accuracy gains are small but directionally positive. Warmup did not cause instability at the start — training proceeded smoothly. However, the gains are modest; the 1-layer model may be close to its capacity ceiling regardless of LR schedule, so the hypothesis that early LR instability was a major bottleneck appears only weakly supported.

**Suggested follow-ups**:
- Try longer warmup (5–10 epochs) to see if more stabilization time helps
- Try warmup with a slightly larger base LR (e.g. 0.008) to test if the ceiling is LR-limited
- Investigate whether the 1-layer model is capacity-limited and needs more layers to benefit from schedule tuning