### PR TITLE
LayerNorm inside output MLP v2

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +172,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,12 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.LayerNorm(hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The deeper output MLP (128→64→3 with GELU) maps backbone features to 3 channels with vastly different scales (p has y_std=961 vs Ux=25). Adding LayerNorm after the first linear layer (before GELU) stabilizes intermediate activations, helping the GELU operate in its effective range for all output channels. Low-risk change with negligible parameter overhead.

## Instructions

**Model config (CRITICAL — change from code defaults):**
n_hidden=128, n_layers=1, n_head=2, slice_num=32, mlp_ratio=2

**In `train.py`:**
1. MAX_EPOCHS=70, lr=0.006, weight_decay=0.0
2. T_max=70 for CosineAnnealingLR
3. bf16 autocast for train forward+loss (L1 surface loss, MSE volume loss)
4. bf16 autocast for validation forward pass
5. Gradient clipping max_norm=1.0

**In `transolver.py`:**
6. Deeper output MLP with intermediate LayerNorm (Linear(128→64) + LayerNorm(64) + GELU + Linear(64→3))

Use `--wandb_name "alphonse/layernorm-mlp-v2" --wandb_group mar14 --agent alphonse`

## Baseline
| Metric | Current Best (1-layer model) |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0, **n_layers=1, n_head=2, slice_num=32** |

---

## Results

**W&B run:** `bqrifppj`
**Epochs completed:** 65 / 70 (hit 5-min wall-clock; nearly full run)
**Best epoch:** 62
**Peak VRAM:** 2.8 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.607 | 0.940 | -35% |
| surf_Ux | 0.52 | 0.49 | +6% |
| surf_Uy | 0.30 | 0.29 | +3% |
| surf_p | 40.1 | 37.82 | +6% |
| vol_Ux | 3.11 | — | — |
| vol_Uy | 1.23 | — | — |
| vol_p | 75.0 | — | — |

### What happened

The experiment ran to near-completion (65/70 epochs, ~5 min). The intermediate LayerNorm produced a large improvement in val_loss (0.607 vs 0.940, -35%), but surface MAE metrics are marginally worse than baseline: surf_p=40.1 vs 37.82 (+6%), surf_Ux=0.52 vs 0.49 (+6%), surf_Uy≈same.

The val_loss and surface MAE divergence is puzzling — val_loss uses MSE-based surface loss while the surface MAE is in physical units (Pa, m/s). The large val_loss improvement may reflect better-calibrated intermediate activations reducing MSE loss, while MAE in physical units is slightly worse. The difference is small enough (~6%) to potentially be within run-to-run noise given the 5-minute constraint.

The intermediate LayerNorm shows **no clear benefit** for surface MAE (our primary metric) compared to baseline. The hypothesis that normalizing before GELU would help the different-scale outputs is not supported — the small performance gap (6%) in either direction may be noise. Memory impact is negligible (2.8 GB vs negligible additional overhead).

### Suggested follow-ups

- To confirm whether the 6% degradation is real or noise, run both variants (with/without intermediate LayerNorm) at a fixed seed and compare at equal epochs
- The large val_loss improvement (+35%) vs slight MAE degradation is interesting — it suggests the model learns different internal representations. Worth exploring whether a longer training run (e.g. 100+ epochs) would allow the LayerNorm variant to also close the MAE gap
- If we want to help with multi-scale outputs, a direct approach might be output-specific scaling or per-channel loss weighting rather than intermediate normalization