### PR TITLE
Input skip connection to output decoder v2

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=70)
 
 
 # --- wandb ---
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +172,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
@@ -210,6 +214,7 @@ class Transolver(nn.Module):
                 for idx in range(n_layers)
             ]
         )
+        self.skip_proj = nn.Linear(n_hidden, n_hidden)
         self.initialize_weights()
         self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))
 
@@ -268,8 +273,11 @@ class Transolver(nn.Module):
 
         fx = self.preprocess(x)
         fx = fx + self.placeholder[None, None, :]
+        fx_skip = self.skip_proj(fx)
 
-        for block in self.blocks:
+        for i, block in enumerate(self.blocks):
+            if i == len(self.blocks) - 1:
+                fx = fx + fx_skip
             fx = block(fx)
         self._validate_output_dims(fx)
         return {"preds": fx}


### PR DESCRIPTION
## Hypothesis
The output MLP predicts Ux, Uy, p from backbone features. After the Transolver block with attention, the original geometric signal (position, arc-length, distance-to-surface, Re, AoA) may be diluted. A skip connection from the preprocessed input to the last block provides a shortcut so the decoder can directly access spatial and condition information. With a 1-layer model, this is especially relevant — there's only one block, so the skip connects input directly to the output.

## Instructions

**Model config (CRITICAL — change from code defaults):**
```python
model_config = dict(
    space_dim=2, fun_dim=16, out_dim=3,
    n_hidden=128, n_layers=1, n_head=2,
    slice_num=32, mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

**In `train.py`:**
1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Set `T_max=70`: `CosineAnnealingLR(optimizer, T_max=70)`
4. bf16 autocast with L1 surface loss
5. Same bf16 autocast for validation forward pass.
6. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`

**In `transolver.py`:**
7. Deeper output MLP
8. Input skip connection: `self.skip_proj = nn.Linear(n_hidden, n_hidden)` in `__init__`, add `fx = fx + fx_skip` before last block

Use `--wandb_name "edward/input-skip-v2" --wandb_group mar14 --agent edward`

## Baseline
| Metric | Current Best (1-layer model) |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0, **n_layers=1, n_head=2, slice_num=32** |

---

## Results

**W&B run ID**: 2tfsv5kc

| Metric | Baseline | Input-skip-v2 | Delta |
|--------|----------|---------------|-------|
| surf_p | 37.82 | 50.9 | +13.1 (worse) |
| surf_ux | 0.49 | 0.63 | +0.14 (worse) |
| surf_uy | 0.29 | 0.36 | +0.07 (worse) |
| val_loss | 0.940 | 0.742 | -0.198 (better) |
| Peak memory | — | 2.7 GB | — |

Best at epoch 62/63 completed (full 70 epochs would have been reached with a few more seconds). Training ran ~5s/epoch with the 1-layer model.

**What happened**: The skip connection produced a confusing split result. The val/loss (normalized) improved by ~21% (0.940 → 0.742), but all three physical surface MAE metrics got worse — pressure went from 37.82 to 50.9 (+35%), Ux from 0.49 to 0.63, Uy from 0.29 to 0.36. Surface accuracy is what matters most, so this is a negative result on the primary metric. The val_loss improvement doesn't translate to better physical predictions.

A possible explanation: the skip connection `fx = fx + fx_skip` before the last block gives the block a shortcut that's in the same normalized space as the loss, making normalized squared errors smaller without making the predictions better in physical units. The skip may also be redundant in a 1-layer architecture — with just one block, the attention already has direct access to the preprocessed input, and adding the same representation twice via a learned projection may just create a degenerate fixed point.

**Suggested follow-ups**:
- Try the skip connection on a deeper model (n_layers=3 or 5) where the information dilution hypothesis is actually plausible.
- Instead of adding the skip before the last block, try a post-block residual: add the skip directly to the output MLP's input after ln_3, bypassing the attention block entirely.
- Investigate why val_loss improved while physical MAE worsened — this could indicate an issue with the loss formulation not aligning with the metric.