### PR TITLE
CosineAnnealingWarmRestarts T_0=55 (late restart)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=55, T_mult=1)
 
 
 # --- wandb ---
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,7 +172,8 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
With the correct 1-layer model (~4s/epoch, ~70 epochs in 5 min), a warm restart makes sense. T_0=55 means the first cosine cycle completes at epoch 55, then the LR jumps back to 0.006 for a short 15-epoch refinement cycle. This gives the model near-full convergence before the restart, then a brief exploration phase to escape the local minimum. Previous attempts (T_0=25, T_0=17) used too-short first cycles.

## Instructions

**Model config (CRITICAL — change from code defaults):**
```python
model_config = dict(
    space_dim=2, fun_dim=16, out_dim=3,
    n_hidden=128, n_layers=1, n_head=2,
    slice_num=32, mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

**In `train.py`:**
1. Set `MAX_EPOCHS = 70`, `lr=0.006`, `weight_decay=0.0`
2. bf16 autocast with L1 surface loss + grad clip 1.0
3. Scheduler: `CosineAnnealingWarmRestarts(optimizer, T_0=55, T_mult=1)`

**In `transolver.py`:**
4. Deeper output MLP (Linear → GELU → Linear)

Use `--wandb_name "thorfinn/warm-restart-t55" --wandb_group mar14 --agent thorfinn`

## Baseline
| Metric | Current Best (1-layer model) |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0, **n_layers=1, n_head=2, slice_num=32** |

---

## Results

**W&B run ID:** r71di6hl
**Epochs completed:** 69/70 (hit 5-min wall-clock timeout at epoch 70 warmup)
**Peak memory:** 2.6 GB
**Epoch time:** ~4s/epoch (as predicted for 1-layer model)

| Metric | This run (best epoch 52) | Baseline |
|--------|--------------------------|----------|
| surf_p | 41.7 | 37.82 |
| surf_ux | 0.51 | 0.49 |
| surf_uy | 0.30 | 0.29 |
| val_loss | 0.6125 | 0.940 |
| vol Ux MAE | 3.07 | — |
| vol Uy MAE | 1.18 | — |
| vol p MAE | 71.7 | — |

**What happened:** The model ran nearly all 70 epochs (4s/epoch confirmed). Convergence looked good through epoch 55 — surf_p reached 41.6, surf_ux=0.50, surf_uy=0.30. But at epoch 56 (the warm restart), metrics jumped sharply: surf=[Ux:1.10 Uy:0.54 p:76.1]. The remaining 14 epochs (56–69) were spent partially recovering from the LR spike, with the metrics only getting back to ~65-75 for surf_p by epoch 69. The restart clearly disrupted a well-converged minimum.

The hypothesis doesn't hold: T_0=55 with 15 epochs of refinement is not beneficial. The model converges well with simple cosine annealing, and the LR jump at epoch 56 causes more harm than good in this setting. All surface metrics are slightly worse than the baseline.

**Suggested follow-ups:**
- Try T_0=65 or T_0=68 to leave only 2-5 epochs for the second cycle — a very brief refinement jump. Or skip warm restarts entirely for the 1-layer model.
- Try a much lower LR multiplier for the restart (e.g., `eta_min` for the second cycle) so the jump is less disruptive.
- The 1-layer model may be too simple to benefit from warm restarts — its loss landscape is smoother and there are fewer local minima to escape.