### PR TITLE
Output MLP dropout=0.1 (regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,11 +21,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 5e-4
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +65,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +80,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=70)
 
 
 # --- wandb ---
@@ -127,18 +127,21 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x})["preds"]
-        sq_err = (pred - y_norm) ** 2
-
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x})["preds"]
+            diff = pred - y_norm
+            sq_err = diff ** 2
+            abs_err = diff.abs()
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -169,8 +172,9 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x})["preds"]
+            sq_err = (pred.float() - y_norm) ** 2
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
@@ -178,7 +182,7 @@ for epoch in range(MAX_EPOCHS):
             val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
-            pred_orig = pred * stats["y_std"] + stats["y_mean"]
+            pred_orig = pred.float() * stats["y_std"] + stats["y_mean"]
             err = (pred_orig - y).abs()
             mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
             mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))

--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,12 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Dropout(0.1),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The 1-layer Transolver (177K params) trains for 70 epochs on 810 samples. With ~4s/epoch, it sees each sample ~70 times. The deeper output MLP (128→64→3) may overfit to training surface patterns. Adding dropout=0.1 before the final projection forces the MLP to learn more robust feature mappings. This is a cheap regularization — no extra compute, just better generalization.

## Instructions

**Model config (CRITICAL — change from code defaults):**
```python
model_config = dict(
    space_dim=2, fun_dim=16, out_dim=3,
    n_hidden=128, n_layers=1, n_head=2,
    slice_num=32, mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

**In `train.py`:**
1. Set `MAX_EPOCHS = 70`
2. Set Config defaults: `lr: float = 0.006` and `weight_decay: float = 0.0`
3. Set `T_max=70`: `CosineAnnealingLR(optimizer, T_max=70)`
4. bf16 autocast with L1 surface loss, MSE volume loss
5. Same bf16 autocast for validation forward pass.
6. Gradient clipping: `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)`

**In `transolver.py`:**
7. Deeper output MLP **with dropout**:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim // 2),
           nn.GELU(),
           nn.Dropout(0.1),
           nn.Linear(hidden_dim // 2, out_dim),
       )
   ```

Use `--wandb_name "askeladd/dropout-output-mlp" --wandb_group mar14 --agent askeladd`

## Baseline
| Metric | Current Best (1-layer model) |
|--------|-------------|
| surf_p | 37.82 |
| surf_ux | 0.49 |
| surf_uy | 0.29 |
| val_loss | 0.940 |
| Config | lr=0.006, sw=10, wd=0, T_max=70, bf16, L1 surf + MSE vol, deeper MLP, grad clip 1.0, **n_layers=1, n_head=2, slice_num=32** |

---

## Results

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| surf_p | 41.9 | 37.82 | +11% worse |
| surf_Ux | 0.59 | 0.49 | +20% worse |
| surf_Uy | 0.32 | 0.29 | +10% worse |
| val_loss | 0.609 | 0.940 | **-35% better** |
| vol Ux | 2.87 | — | — |
| vol Uy | 1.12 | — | — |
| vol p | 70.5 | — | — |

- **W&B run:** `j9q7plm8` (askeladd/dropout-output-mlp, group: mar14)
- **Best epoch:** 59 / 68 completed
- **Peak memory:** 2.6 GB
- **Epoch time:** ~4.4s per epoch (68 epochs in 5 min — as expected for 1-layer model)

### What happened

**Mixed result.** The overall val/loss improved substantially (0.609 vs 0.940, 35% better), but the surface MAE metrics — which are the most important — got slightly worse across the board (surf_p: 41.9 vs 37.82, surf_Ux: 0.59 vs 0.49, surf_Uy: 0.32 vs 0.29).

The divergence between val/loss and surface MAE suggests the dropout is helping regularize the overall model but slightly hurts surface accuracy. The model's output at surface nodes is being regularized too aggressively — dropout at inference is off, but the training distribution shift from dropout noise may be making the surface predictions less sharp at the fine-grained level that matters for pressure.

The lower vol_loss component is what's driving the overall val/loss improvement: the volume field predictions are better generalized. But since surface accuracy is what the advisor cares about most, dropout=0.1 at the output head appears to be a mild negative change for surface predictions despite helping overall.

### Suggested follow-ups

- **Try lower dropout** (0.05 or 0.01): the dropout might be too aggressive at the output layer. A smaller value might retain the regularization benefit while not degrading surface predictions.
- **Move dropout earlier** (before the GELU, or into the attention/MLP backbone): the output head may need to remain precise; regularizing earlier layers could help generalization without hurting surface accuracy.
- **Separate surface/volume heads**: if surface and volume predictions diverge in their optimal regularization strength, decoupling them might allow stronger vol regularization while keeping surf head sharp.