### PR TITLE
5-epoch warmup + cosine T_max=65

### DIFF
--- a/train.py
+++ b/train.py
@@ -81,9 +81,9 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
-warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
-cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
-scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
+warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+cosine = CosineAnnealingLR(optimizer, T_max=65)  # 70-5=65
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
PR #228 showed 3-epoch warmup improved surf_p from 37.82→37.16. A longer warmup (5 epochs) gives more time for the optimizer to settle into a good basin before cosine decay, potentially extracting more gains from the same mechanism.

## Instructions
The base code on jurgen already has the correct model config, bf16, L1 loss, grad clip, and warmup. Only change the warmup/cosine schedule:

In `train.py`, replace the scheduler block:
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
cosine = CosineAnnealingLR(optimizer, T_max=65)  # 70-5=65
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
```

Use `--wandb_name "frieren/warmup5-cosine" --wandb_group mar14 --agent frieren`

## Baseline
| Metric | Current Best (PR #228) |
|--------|-------------|
| surf_p | 37.16 |
| surf_ux | 0.50 |
| surf_uy | 0.27 |
| Config | 3-ep warmup + cosine T_max=67, lr=0.006, sw=10, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32 |

---

## Results

**W&B run:** `r86i3tgo` (`frieren/warmup5-cosine`, group: `mar14`)
**Peak memory:** 2.6 GB
**Epochs completed:** 69 of 70 (~4s/epoch, hit 5-min wall-clock after epoch 69)

| Metric | This Run (best @ ep 68) | Baseline (3-ep warmup) | Δ |
|--------|------------------------|------------------------|---|
| surf_p | **35.94** | 37.16 | -1.22 (better) |
| surf_Ux | **0.43** | 0.50 | -0.07 (better) |
| surf_Uy | **0.27** | 0.27 | 0.00 (tied) |
| val_loss | 0.533 | — | — |

**What happened:** 5-epoch warmup is a clear improvement over 3-epoch. Surface pressure drops from 37.16 → 35.94 (-3.3%), Ux improves 0.50 → 0.43 (-14%), Uy holds at 0.27. The model ran nearly all 70 epochs (69 completed) so this is a clean comparison. Looking at the training trajectory, the LR history shows the cosine decay reaching very near zero by the final epoch, meaning the full training budget was used effectively.

The improvement is consistent with the hypothesis: more warmup epochs allow the optimizer to explore the loss landscape more gently before committing to the cosine decay trajectory, leading to a better final basin.

**Conclusion:** 5-epoch warmup beats 3-epoch warmup. This is a new best on surf_p (35.94) and surf_Ux (0.43), tying on surf_Uy (0.27).

**Suggested follow-ups:**
- Try 7 or 10 epoch warmup to see if the trend continues — there may be a sweet spot.
- The improvement on Ux (+14%) is larger than on p (+3.3%), which is unusual since p is the harder metric. Might be worth checking if the validation set size (89 samples) is introducing noise.
- Consider combining longer warmup with a higher peak LR (e.g. lr=0.007 or 0.008) to see if warmup lets us safely use a higher LR.