### PR TITLE
lr=0.008 with 3-epoch warmup

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,7 +24,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 0.006
+    lr: float = 0.008
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
@@ -81,7 +81,7 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
-warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
+warmup = LinearLR(optimizer, start_factor=1e-5/0.008, total_iters=3)
 cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
 


### PR DESCRIPTION
## Hypothesis
Before warmup, lr=0.006 was the sweet spot because higher LRs caused early instability. Now that warmup protects against that, we can safely push peak LR to 0.008. OneCycleLR at 0.009 was slightly worse (38.4), but that used a different schedule shape; here we keep the proven warmup+cosine shape.

## Instructions
In `train.py`, change lr and adjust warmup start factor:
```python
lr: float = 0.008
```
And update the scheduler:
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.008, total_iters=3)
cosine = CosineAnnealingLR(optimizer, T_max=67)
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
```

Use `--wandb_name "fern/lr008-warmup" --wandb_group mar14 --agent fern`

## Baseline
| Metric | Current Best (PR #228) |
|--------|-------------|
| surf_p | 37.16 |
| surf_ux | 0.50 |
| surf_uy | 0.27 |
| Config | 3-ep warmup + cosine T_max=67, lr=0.006, sw=10, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32 |

---

## Results

**W&B run ID:** qaimjjl6
**Epochs completed:** ~69/70 (5-minute timeout)
**Peak memory:** 2.6 GB
**Best epoch:** 63

| Metric | Baseline (lr=0.006) | This run (lr=0.008) |
|--------|---------------------|---------------------|
| surf_p | 37.16 | 37.5 |
| surf_ux | 0.50 | 0.48 |
| surf_uy | 0.27 | 0.28 |
| val_loss | — | 0.5551 |
| vol MAE Ux | — | 2.86 |
| vol MAE Uy | — | 1.09 |
| vol MAE p | — | 64.7 |

**What happened:**

The result is essentially a wash with the lr=0.006 baseline. lr=0.008 improved surf_ux (0.48 vs 0.50) but is marginally worse on surf_p (37.5 vs 37.16) and surf_uy (0.28 vs 0.27). All differences are within typical run-to-run noise. The warmup does appear to allow stable training at lr=0.008 (no instability observed), but it doesn't yield a meaningful improvement over 0.006.

**Suggested follow-ups:**
- Given the tight clustering of results near this setting, further lr tuning around this range is unlikely to yield big gains. The architecture or loss formulation may be the current bottleneck.
- Pressure accuracy (surf_p) seems to plateau around 37 regardless of lr. Trying a higher surf_weight specifically for pressure (e.g., decomposing surf_loss into per-channel components with different weights) could target this directly.