### PR TITLE
surf_weight=12 with warmup (re-tune sw)

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.006
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
surf_weight was tuned to 10 on the pre-warmup config. Warmup changes the training dynamics — early epochs now use near-zero LR, so the effective gradient balance is different. With warmup stabilizing early training, the model may tolerate sw=12 without the overfitting that previously made sw>10 counterproductive.

## Instructions
In `train.py`, change surf_weight:
```python
surf_weight: float = 12.0
```
Everything else stays the same (warmup 3ep, cosine T_max=67, lr=0.006, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32).

Use `--wandb_name "nezuko/sw12-warmup" --wandb_group mar14 --agent nezuko`

## Baseline
| Metric | Current Best (PR #228) |
|--------|-------------|
| surf_p | 37.16 |
| surf_ux | 0.50 |
| surf_uy | 0.27 |
| Config | 3-ep warmup + cosine T_max=67, lr=0.006, sw=10, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32 |

---

## Results

| Metric | Baseline (sw=10) | This run (sw=12) | Delta |
|--------|-----------------|-----------------|-------|
| surf_p | 37.16 | **36.61** | -0.55 ✓ |
| surf_ux | 0.50 | **0.446** | -0.054 ✓ |
| surf_uy | 0.27 | 0.279 | +0.009 ✗ |
| val_loss | — | 0.656 | — |
| vol_ux | — | 2.949 | — |
| vol_uy | — | 1.121 | — |
| vol_p | — | 71.33 | — |
| Peak VRAM | — | 2.6 GB | — |
| Best epoch | — | 67 | — |

**W&B run:** srbmnki6

### What happened
sw=12 with warmup is a clear improvement over sw=10 with warmup on the most important metric (surf_p: 36.61 vs 37.16, -0.55). surf_ux also improves notably (0.446 vs 0.50). surf_uy regresses very slightly (+0.009), which is negligible. The hypothesis holds: warmup stabilizes early training enough that a higher surface weight does not cause the overfitting previously seen with sw>10.

### Suggested follow-ups
- Try sw=14 or sw=16 with warmup to see if the trend continues, or if 12 is near the optimum.
- Since surf_uy barely moved, the gains are concentrated in surf_p and surf_ux — may be worth investigating whether separate per-component weights could help.