### PR TITLE
Mild pressure boost: channel_weight=[1,1,1.5] in surface L1

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,7 +138,8 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis
The 3x pressure weight (#227) was too aggressive (39.0 vs 37.82). A milder 1.5x boost for pressure targets our key metric without destabilizing the other channels. Combined with warmup, this should be stable.

## Instructions
In `train.py`, modify the surface loss computation inside the autocast block. Replace:
```python
surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```
with:
```python
channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
```
Everything else stays the same.

Use `--wandb_name "alphonse/channel-w-1p5" --wandb_group mar14 --agent alphonse`

## Baseline
| Metric | Current Best (PR #228) |
|--------|-------------|
| surf_p | 37.16 |
| surf_ux | 0.50 |
| surf_uy | 0.27 |
| Config | 3-ep warmup + cosine T_max=67, lr=0.006, sw=10, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32 |

---

## Results

**W&B run:** `qxhrthh7`
**Epochs completed:** 68 / 70 (hit 5-min wall-clock — nearly full run)
**Best epoch:** 68
**Peak VRAM:** 2.6 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.557 | — | — |
| surf_Ux | 0.50 | 0.50 | 0% |
| surf_Uy | 0.28 | 0.27 | +4% |
| surf_p | 35.2 | 37.16 | **-5.3%** |
| vol_Ux | 3.07 | — | — |
| vol_Uy | 1.16 | — | — |
| vol_p | 71.0 | — | — |

### What happened

The mild 1.5x pressure channel weight worked well. **surf_p improved from 37.16 to 35.2, a 5.3% gain** — the best pressure result seen so far. surf_Ux is unchanged (0.50) and surf_Uy is marginally worse (0.28 vs 0.27, within noise).

Training was stable throughout: the loss converged cleanly, best epoch at 68/70, and val/loss trend shows steady improvement all the way to the end. VRAM was 2.6 GB, slightly lower than the baseline.

The hypothesis is confirmed: a mild pressure weight boost (1.5x) selectively improves pressure prediction without destabilizing velocity channels, whereas the 3x boost in #227 was too aggressive.

### Suggested follow-ups

- Try channel_w=[1.0, 1.0, 2.0] — may further improve surf_p while staying moderate enough to avoid the instability seen at 3x
- The slight surf_Uy regression (0.27→0.28) is borderline noise but could be explored by trying channel_w=[1.0, 0.9, 1.5] to counter-balance
- Combine this pressure weighting with other improvements (e.g., warmup, deeper MLP) for a cumulative best-configuration run