### PR TITLE
Cosine schedule with eta_min=1e-4 (non-zero floor)

### DIFF
--- a/train.py
+++ b/train.py
@@ -82,7 +82,7 @@ n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
-cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
+cosine = CosineAnnealingLR(optimizer, T_max=67, eta_min=1e-4)
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
 
 


### PR DESCRIPTION
## Hypothesis
The current cosine schedule decays LR to exactly 0 at T_max. The final ~5 epochs have effectively no learning. With eta_min=1e-4, the model continues making small adjustments in late training rather than freezing. The warmup showed LR schedule details matter (3 epochs gave 0.66 improvement).

## Instructions
In `train.py`, add eta_min to the cosine scheduler:
```python
cosine = CosineAnnealingLR(optimizer, T_max=67, eta_min=1e-4)
```
Everything else stays the same.

Use `--wandb_name "edward/eta-min-1e4" --wandb_group mar14 --agent edward`

## Baseline
| Metric | Current Best (PR #228) |
|--------|-------------|
| surf_p | 37.16 |
| surf_ux | 0.50 |
| surf_uy | 0.27 |
| Config | 3-ep warmup + cosine T_max=67, lr=0.006, sw=10, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32 |

---

## Results

**W&B run ID**: h6ajcbdb

| Metric | Baseline | eta_min=1e-4 | Delta |
|--------|----------|--------------|-------|
| surf_p | 37.16 | **35.49** | -1.67 (better) |
| surf_ux | 0.50 | **0.44** | -0.06 (better) |
| surf_uy | 0.27 | **0.27** | same |
| val_loss | 0.940 | **0.546** | -0.394 (better) |
| Peak memory | — | 2.6 GB | — |

Best at epoch 69/70 (near-complete run — hit timeout by ~5s). Completed 69 full epochs.

**What happened**: Positive result. Adding eta_min=1e-4 improved all surface metrics. Pressure MAE dropped from 37.16 to 35.49 (-4.5%), Ux from 0.50 to 0.44 (-12%), and Uy held flat at 0.27. Val_loss improved substantially (0.940 → 0.546, -42%). The learning curve shows smooth, sustained improvement all the way to epoch 69 — the model was still improving when the timeout hit, with no plateau. Previously, the final epochs with LR≈0 contributed nothing; with eta_min=1e-4 the model keeps refining through the end.

This is a clean win: one-line change, measurable improvement on the primary metric (surf_p), no added complexity.

**Suggested follow-ups**:
- Try eta_min=5e-4 or 1e-3 to see if a higher floor helps more.
- Run for more epochs (if budget allows) — the model was still improving at epoch 69.
- Combine this with other improvements (e.g., wider model) to see if the eta_min benefit stacks.