### PR TITLE
Wider output decoder: 128→128→64→3 (two hidden layers)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -141,6 +141,8 @@ class TransolverBlock(nn.Module):
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
                 nn.Linear(hidden_dim, hidden_dim // 2),
                 nn.GELU(),
                 nn.Linear(hidden_dim // 2, out_dim),


### PR DESCRIPTION
## Hypothesis
The current deeper MLP (128→64→3) was a big win over plain linear. Adding another hidden layer (128→128→64→3 with GELU) adds more decoder capacity without touching the backbone. Previous LayerNorm and Dropout MLP experiments failed because they added regularization, not capacity. This adds capacity where it matters — the output mapping.

## Instructions
In `transolver.py`, replace the deeper output MLP in `TransolverBlock.__init__` (the `if self.last_layer` block):
```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.mlp2 = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim),
        nn.GELU(),
        nn.Linear(hidden_dim, hidden_dim // 2),
        nn.GELU(),
        nn.Linear(hidden_dim // 2, out_dim),
    )
```
Everything else stays the same.

Use `--wandb_name "thorfinn/wider-decoder" --wandb_group mar14 --agent thorfinn`

## Baseline
| Metric | Current Best (PR #228) |
|--------|-------------|
| surf_p | 37.16 |
| surf_ux | 0.50 |
| surf_uy | 0.27 |
| Config | 3-ep warmup + cosine T_max=67, lr=0.006, sw=10, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32 |

---

## Results

**W&B run ID:** 06gwn4iz
**Epochs completed:** 66/70 (hit 5-min wall-clock timeout)
**Peak memory:** 2.7 GB
**Epoch time:** ~5s/epoch (slightly slower than baseline due to extra layer)

| Metric | This run (best epoch 61) | Baseline |
|--------|--------------------------|----------|
| surf_p | 38.1 | 37.16 |
| surf_ux | 0.52 | 0.50 |
| surf_uy | 0.29 | 0.27 |
| val_loss | 0.6068 | — |
| vol Ux MAE | 2.82 | — |
| vol Uy MAE | 1.11 | — |
| vol p MAE | 68.0 | — |

**What happened:** The wider decoder (128→128→64→3) does not improve over the 2-layer decoder (128→64→3). All surface metrics are slightly worse than the baseline. The extra hidden layer also slows each epoch from ~4s to ~5s, reducing total epochs completed from ~70 to 66. Looking at later epochs (64-66: surf_p≈37.7-37.8), the model is still approaching baseline levels, suggesting it might match with more epochs — but there's no sign of improvement.

The hypothesis doesn't hold: the 2-layer decoder already has sufficient capacity for this 1-layer backbone. Adding more decoder layers doesn't help — the bottleneck is likely the backbone representation quality, not the decoder.

**Suggested follow-ups:**
- The backbone (1-layer Transolver) is likely the limiting factor. Try increasing backbone width (n_hidden=192 or 256) while keeping the 2-layer decoder.
- Alternatively, test n_layers=2 backbone with the 2-layer decoder to see if more backbone depth helps.
- The per-epoch slowdown from the wider decoder suggests it's not worth the tradeoff even if results marginally improved.