### PR TITLE
Tiny weight decay wd=1e-6 with warmup

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ MAX_EPOCHS = 70
 @dataclass
 class Config:
     lr: float = 0.006
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-6
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"


### PR DESCRIPTION
## Hypothesis
Current config uses wd=0. Previous wd=1e-5 (#186, #204) was tested without warmup on a weaker config. A tiny wd=1e-6 provides extremely gentle regularization — penalizing large weights without meaningfully reducing effective LR. With 810 training samples and 70 epochs, even a 177K-param model sees each sample many times. This has never been tried.

## Instructions
In `train.py`, change weight_decay:
```python
weight_decay: float = 1e-6
```
Everything else stays the same.

Use `--wandb_name "askeladd/wd1e-6" --wandb_group mar14 --agent askeladd`

## Baseline
| Metric | Current Best (PR #228) |
|--------|-------------|
| surf_p | 37.16 |
| surf_ux | 0.50 |
| surf_uy | 0.27 |
| Config | 3-ep warmup + cosine T_max=67, lr=0.006, sw=10, wd=0, bf16, L1 surf, grad clip 1.0, 1L h128 nh2 slc32 |

---

## Results

**W&B run ID:** nucm1n30

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.5455 | ~0.54 | ~0 |
| surf_Ux MAE | 0.47 | 0.50 | -6% ✓ |
| surf_Uy MAE | 0.28 | 0.27 | +4% ~ |
| surf_p MAE | 37.30 | 37.16 | +0.4% ~ |
| Peak VRAM | 2.6 GB | 2.6 GB | 0 |
| Epoch time | ~4.4s | ~4.4s | 0 |
| Epochs completed | 69/70 | 70/70 | ~same |

**What happened:** wd=1e-6 produced essentially neutral results. The tiny regularization made a marginal improvement in surf_Ux (6% better) but surf_p and surf_Uy were essentially unchanged. The model trained stably through all 70 epochs (still improving at epoch 69), suggesting wd=1e-6 is benign but not meaningfully helpful.

The hypothesis that gentle regularization would help with repeated exposure to 810 samples was not confirmed — at this scale and parameter count, wd=1e-6 is too small to make a meaningful difference.

**Suggested follow-ups:**
- Try wd=1e-5 with the current warmup+cosine setup (previous tests at wd=1e-5 used no warmup, making this a fair new test)
- Investigate whether a larger model (more layers/hidden dim) benefits more from regularization
- Try dropout in the attention blocks rather than only the output MLP