### PR TITLE
Triple combo: 5-ep warmup + eta_min=1e-4 + channel_w=[1,1,1.5]

### DIFF
--- a/train.py
+++ b/train.py
@@ -81,9 +81,9 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
-warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
-cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
-scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
+warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Three independently validated improvements combined: 5-epoch warmup (surf_p=35.94), eta_min=1e-4 (surf_p=35.49), and channel_weight=[1,1,1.5] (surf_p=35.2, already in baseline). If gains stack, we could push well below 35.

## Instructions
The base code already has channel_weight=[1,1,1.5]. Change only the scheduler:
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
```

Use `--wandb_name "frieren/combo-warmup5-eta" --wandb_group mar14 --agent frieren`

## Baseline
| Metric | Current Best (PR #237) |
|--------|-------------|
| surf_p | 35.2 |
| surf_ux | 0.50 |
| surf_uy | 0.28 |
| Config | channel_w=[1,1,1.5], 3-ep warmup, cosine T_max=67, lr=0.006, sw=10, wd=0, 1L h128 |

---

## Results

**W&B run:** `2dxr10z0` (`frieren/combo-warmup5-eta`, group: `mar14`)
**Peak memory:** 2.6 GB
**Epochs completed:** 68 of 70 (~4s/epoch, hit 5-min wall-clock after epoch 68)

| Metric | This Run (best @ ep 66) | Baseline | Δ |
|--------|------------------------|----------|---|
| surf_p | **34.91** | 35.2 | -0.29 (better) |
| surf_Ux | **0.48** | 0.50 | -0.02 (better) |
| surf_Uy | 0.28 | 0.28 | 0.00 (tied) |
| val_loss | 0.533 | — | — |

**What happened:** The three-way combo delivers a new programme best on surf_p (34.91), beating the channel_weight-only baseline (35.2) by 0.29. The gains do partially stack, though not fully additively — the individual improvements summed would predict ~34.7, but we achieved 34.91. This is consistent with overlapping mechanisms: both warmup and eta_min affect late-training dynamics, so their combined benefit is less than additive.

The improvement over the baseline is modest but real: -0.29 Pa on surf_p and -0.02 on surf_Ux. Surf_Uy is unchanged at 0.28.

**Conclusion:** Positive result — this is the new best surf_p (34.91). The combo works and is worth keeping. The gains partially stack rather than fully stacking, which is normal for hyperparameter interactions.

**Suggested follow-ups:**
- Push further by trying surf_weight=12 with this combo (previous sw=12 experiments showed improvement on p specifically).
- Try 7-epoch warmup with eta_min=1e-4 to probe whether more warmup continues to help.
- The LR ended at ~1.1e-4 (eta_min=1e-4), which is much higher than the previous runs that decayed to ~0. The 2-3 final epochs with LR at eta_min may be providing a gentle "fine-tuning" effect — worth investigating systematically.