### PR TITLE
5-epoch warmup with channel_w=[1,1,1.5]

### DIFF
--- a/train.py
+++ b/train.py
@@ -81,9 +81,9 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
-warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
-cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
-scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
+warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+cosine = CosineAnnealingLR(optimizer, T_max=65)  # 70-5=65 remaining epochs
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
5-epoch warmup improved surf_p from 37.16→35.94 on the old baseline. Now with channel_w=[1,1,1.5] already in the baseline (surf_p=35.2), adding 5-epoch warmup should stack for further gains.

## Instructions
Change only the scheduler:
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
cosine = CosineAnnealingLR(optimizer, T_max=65)
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
```

Use `--wandb_name "fern/combo-warmup5" --wandb_group mar14 --agent fern`

## Baseline
| Metric | Current Best (PR #237) |
|--------|-------------|
| surf_p | 35.2 |
| surf_ux | 0.50 |
| surf_uy | 0.28 |

---

## Results

**W&B run ID:** lutetp5b
**Epochs completed:** ~69/70 (5-minute timeout)
**Peak memory:** 2.6 GB
**Best epoch:** 66

| Metric | Baseline | This run (5-ep warmup) |
|--------|----------|------------------------|
| surf_p | 35.2 | 35.7 |
| surf_ux | 0.50 | 0.51 |
| surf_uy | 0.28 | 0.28 |
| val_loss | — | 0.5664 |
| vol MAE Ux | — | 2.99 |
| vol MAE Uy | — | 1.11 |
| vol MAE p | — | 65.9 |

**What happened:**

The 5-epoch warmup did not improve over the baseline — it's marginally worse on surf_p (35.7 vs 35.2) and surf_ux (0.51 vs 0.50), with surf_uy tied. These differences are within run-to-run noise. The improvements that 5-epoch warmup gave in earlier experiments (without channel_w) appear to have been captured by or interact non-additively with the channel_w=[1,1,1.5] weighting. The 3-epoch warmup was already providing sufficient gradient stabilization.

**Suggested follow-ups:**
- The surf_p plateau around 35 may require more fundamental changes than scheduler tuning. The channel weighting is already helping pressure, so further gains likely need architectural changes (e.g., more expressive feature representations) or higher pressure-specific weighting.
- It's worth trying to understand if results are stable across seeds — the differences seen between 3-epoch and 5-epoch warmup could be noise.