### PR TITLE
eta_min=1e-4 with channel_w=[1,1,1.5]

### DIFF
--- a/train.py
+++ b/train.py
@@ -82,7 +82,7 @@ n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
-cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
+cosine = CosineAnnealingLR(optimizer, T_max=67, eta_min=1e-4)  # 70-3=67 remaining epochs
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
 
 


### PR DESCRIPTION
## Hypothesis
eta_min=1e-4 improved surf_p from 37.16→35.49 on the old baseline. Combined with channel_w=[1,1,1.5] (now in baseline), the non-zero LR floor should let the model keep refining pressure predictions in late training.

## Instructions
Change only the cosine scheduler to add eta_min:
```python
cosine = CosineAnnealingLR(optimizer, T_max=67, eta_min=1e-4)
```

Use `--wandb_name "tanjiro/combo-eta-min" --wandb_group mar14 --agent tanjiro`

## Baseline
| Metric | Current Best (PR #237) |
|--------|-------------|
| surf_p | 35.2 |
| surf_ux | 0.50 |
| surf_uy | 0.28 |

---

## Results

**W&B Run:** i4t5vokj
**Epochs completed:** 68 of 70 (best at epoch 68)
**Peak memory:** 2.6 GB

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.5812 | — | — |
| surf_p | 35.15 | 35.2 | -0.05 (negligible) |
| surf_Ux | 0.48 | 0.50 | -0.02 (tiny improvement) |
| surf_Uy | 0.28 | 0.28 | 0.00 (same) |
| vol MAE Ux | 2.93 | — | — |
| vol MAE Uy | 1.08 | — | — |
| vol MAE p | 67.30 | — | — |

**What happened:** Essentially neutral result. Adding eta_min=1e-4 produced changes within noise range across all metrics: surf_p improved by 0.05 (from 35.2 to 35.15), surf_Ux by 0.02, and surf_Uy unchanged. The LR floor doesn't appear to meaningfully help when channel_w=[1,1,1.5] is already in the loss. On the old baseline (without channel weights), eta_min=1e-4 gave a larger gain because the model was learning pressure less efficiently; with channel weights already emphasizing pressure, the LR floor adds minimal additional signal. The model converges similarly with or without this floor.

**Suggested follow-ups:**
- Try eta_min=1e-3 (10x higher floor) to give the model more latitude in late training
- Combine eta_min with a higher surf_weight (e.g. sw=12) to see if both together provide cumulative benefit
- The marginal gains here suggest the 1-layer h128 architecture may genuinely be near its capacity ceiling — exploring larger model variants or better architectural changes may be more fruitful