### PR TITLE
sw=12 with channel_w=[1,1,1.5]

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.006
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
sw=12 improved surf_p from 37.16→36.61 on the old baseline. Combined with channel_w=[1,1,1.5], more gradient emphasis on surfaces (especially pressure) may further close the gap.

## Instructions
Change only surf_weight:
```python
surf_weight: float = 12.0
```

Use `--wandb_name "nezuko/sw12-channel-1p5" --wandb_group mar14 --agent nezuko`

## Baseline
| Metric | Current Best (PR #237) |
|--------|-------------|
| surf_p | 35.2 |
| surf_ux | 0.50 |
| surf_uy | 0.28 |

---

## Results

| Metric | Baseline (sw=10, channel_w=[1,1,1.5]) | This run (sw=12) | Delta |
|--------|---------------------------------------|-----------------|-------|
| surf_p | 35.2 | 38.4 | +3.2 ✗ |
| surf_ux | 0.50 | 0.51 | +0.01 ✗ |
| surf_uy | 0.28 | 0.29 | +0.01 ✗ |
| Best epoch | — | 68 (run timed out) | — |
| Peak VRAM | — | 2.6 GB | — |

**W&B run:** qp3x24z5 (run timed out at epoch 68/70, W&B metadata updated)

### What happened
This is a clear negative result. sw=12 with channel_w=[1,1,1.5] performs significantly worse than the baseline sw=10 config on the same branch (surf_p 38.4 vs 35.2, +3.2). This is also worse than the plain sw=12 run without channel_w=[1,1,1.5] (36.61). The channel weighting already puts extra emphasis on pressure (1.5x); stacking sw=12 on top appears to over-emphasize surface pressure in a way that hurts overall optimization. The two forms of surface weighting interact badly — each alone may help, but together they destabilize training.

### Suggested follow-ups
- Try sw=8 with channel_w=[1,1,1.5] — the channel weighting may itself be providing sufficient extra pressure emphasis, making sw=10 the effective optimum for that config.
- Investigate whether the channel_w baseline (surf_p=35.2) result is robust before combining with other hyperparameter changes.