### PR TITLE
Pressure weight 2x: channel_weight=[1,1,2.0]

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,7 +138,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
+            channel_w = torch.tensor([1.0, 1.0, 2.0], device=pred.device)
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})


### PR DESCRIPTION
## Hypothesis
channel_w=[1,1,1.5] was a big win (surf_p 37.16→35.2). Pushing to 2.0 tests if more pressure emphasis helps further. The 3x weight was too aggressive (39.0), but 2.0 is a moderate step from 1.5.

## Instructions
Change the channel weight tensor in the training loss:
```python
channel_w = torch.tensor([1.0, 1.0, 2.0], device=pred.device)
```

Use `--wandb_name "alphonse/channel-w-2p0" --wandb_group mar14 --agent alphonse`

## Baseline
| Metric | Current Best (PR #237) |
|--------|-------------|
| surf_p | 35.2 |
| surf_ux | 0.50 |
| surf_uy | 0.28 |

---

## Results

**W&B run:** `k0az4okb`
**Epochs completed:** 68 / 70 (hit 5-min wall-clock)
**Best epoch:** 67
**Peak VRAM:** 2.6 GB

| Metric | This run (2.0x) | Baseline (1.5x) | Delta |
|--------|-----------------|-----------------|-------|
| val_loss | 0.630 | 0.557 | +13% worse |
| surf_Ux | 0.54 | 0.50 | +8% worse |
| surf_Uy | 0.30 | 0.28 | +7% worse |
| surf_p | 36.0 | 35.2 | +2.3% worse |
| vol_Ux | 3.17 | 3.07 | — |
| vol_Uy | 1.21 | 1.16 | — |
| vol_p | 75.0 | 71.0 | — |

### What happened

The 2.0x weight is uniformly worse than 1.5x across all metrics. surf_p regressed from 35.2 to 36.0 (+2.3%), surf_Ux worsened from 0.50 to 0.54 (+8%), surf_Uy from 0.28 to 0.30 (+7%), and val_loss from 0.557 to 0.630 (+13%).

The pattern is consistent with what was seen between 1.5x and 3x: higher pressure weighting starts hurting velocity predictions as the optimizer over-prioritizes pressure at the expense of Ux and Uy. **1.5x appears to be the optimal pressure channel weight** — it's the "sweet spot" between no-weight (baseline) and too-aggressive (2.0x and above).

The diminishing returns and then reversal suggest the network has a limited capacity to optimize all channels simultaneously, and forcing too much pressure emphasis pushes velocity channels out of their optimal training regime.

### Suggested follow-ups

- Confirmed: 1.5x is the current best for pressure weighting. Can close this line of exploration.
- Try fractional weights like 1.2x or 1.3x to see if there's a better sweet spot between 1.0 and 1.5x (though the gain from 1.0→1.5 is already substantial)
- Explore asymmetric velocity weights, e.g. [0.8, 0.8, 1.5] — reduce velocity loss contribution while boosting pressure, which might preserve the velocity quality from 1.5x run while further improving pressure