### PR TITLE
Full combo: warmup5 + eta_min + sw=12 + channel_w=[1,1,1.5]

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ class Config:
     lr: float = 0.006
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 12.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run
@@ -81,9 +81,9 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
-warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=3)
-cosine = CosineAnnealingLR(optimizer, T_max=67)  # 70-3=67 remaining epochs
-scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[3])
+warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)  # 70-5=65 remaining epochs
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Same as #241 (thorfinn) but this is the full kitchen sink: 5-epoch warmup + eta_min=1e-4 + sw=12, all on the channel_w=[1,1,1.5] baseline. Having two students run similar combos helps assess variance.

## Instructions
Change surf_weight and scheduler:
```python
surf_weight: float = 12.0
```
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
```

Use `--wandb_name "askeladd/full-combo" --wandb_group mar14 --agent askeladd`

## Baseline
| Metric | Current Best (PR #237) |
|--------|-------------|
| surf_p | 35.2 |
| surf_ux | 0.50 |
| surf_uy | 0.28 |

---

## Results

**W&B run ID:** j6alu4kg

| Metric | This Run | Baseline (PR #237) | Delta |
|--------|----------|--------------------|-------|
| val/loss | 0.6664 | N/A (sw=12 vs sw=10) | — |
| surf_Ux MAE | 0.48 | 0.50 | -4% ✓ |
| surf_Uy MAE | 0.28 | 0.28 | 0% |
| surf_p MAE | 35.28 | 35.2 | +0.2% ~ |
| Peak VRAM | 2.6 GB | 2.6 GB | 0 |
| Epoch time | ~4.4s | ~4.4s | 0 |
| Epochs completed | 68/70 | ~70 | ~same |

**What happened:** The full combo (5-epoch warmup + eta_min=1e-4 + sw=12 + channel_w=[1,1,1.5]) produced essentially the same results as the channel_w=[1,1,1.5] baseline. surf_p stayed flat at 35.28 vs 35.2 — no meaningful improvement. surf_Ux is 4% better, but this is marginal noise.

The kitchen-sink combination didn't stack benefits — adding longer warmup (5 vs 3 epochs) and eta_min=1e-4 on top of the channel_w baseline didn't push surf_p below 35.2. This suggests the channel_w=[1,1,1.5] configuration is near its natural ceiling with these other hyperparameters.

Note: val/loss (0.6664) appears higher than baseline but is not comparable because sw=12 increases the surf contribution to the loss formula.

**Suggested follow-ups:**
- Try a larger model (more layers or hidden dim) — the model may be underpowered to differentiate surface pressure better
- Try increasing channel_w for pressure more aggressively (e.g., [1,1,2.0] or [1,1,3.0]) to force the model to prioritize it even more
- Try combining channel_w with a larger batch size to see if gradient quality is the bottleneck