### PR TITLE
Wider 1-layer model: n_hidden=160 (~247K params)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 70
+MAX_EPOCHS = 55
 @dataclass
 class Config:
     lr: float = 0.006
@@ -64,7 +64,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
+    n_hidden=160,
     n_layers=1,
     n_head=2,
     slice_num=32,
@@ -82,7 +82,7 @@ n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
-cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
+cosine = CosineAnnealingLR(optimizer, T_max=49, eta_min=1e-4)
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 


### PR DESCRIPTION
## Hypothesis
The 1-layer model (177K params) may be capacity-limited. n_hidden=160 gives ~247K params with more representational capacity. Previous attempt (PR #131) used wrong loss/config. Epoch time estimate ~5.5s = ~54 epochs.

## Instructions
In `train.py`, change model_config: `n_hidden: 160` (keep n_head=2, slice_num=32, mlp_ratio=2). Set `MAX_EPOCHS = 55`. Change scheduler: `cosine = CosineAnnealingLR(optimizer, T_max=49, eta_min=1e-4)` and `warmup total_iters=5`, `milestones=[5]`. The output MLP becomes 160→80→3 automatically.

Use `--wandb_name "frieren/wider-h160" --wandb_group mar14 --agent frieren`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 | Config | 1L h128, warmup5+eta_min+channel_w |

---

## Results

**W&B run:** `ikmocfeo`  
**Epochs completed:** 55/55 (4.7 min, ~5.1s/epoch)  
**Peak memory:** 3.1 GB

| Metric | Baseline (h128) | This run (h160) | Delta |
|--------|----------------|-----------------|-------|
| surf_p | 34.91 | 38.82 | +3.91 (worse) |
| surf_Ux | 0.48 | 0.53 | +0.05 (worse) |
| surf_Uy | 0.28 | 0.30 | +0.02 (worse) |
| val_loss | — | 0.6316 | — |
| vol_Ux | — | 3.22 | — |

**Best epoch:** 52/55

### What happened

Negative result. The wider model (n_hidden=160, ~247K params) performed definitively worse than the baseline h128 model across all surface metrics. surf_p regressed from 34.91 → 38.82, a clear +3.91 degradation.

With only 55 epochs (vs 70 for h128), the wider model may be underfitting — it has more parameters to optimize but fewer gradient steps. However, the epoch time was ~5.1s (vs ~4s for h128), so the 5-minute budget limits us to ~55 epochs with h160. Even with the full 55 epochs, the model did not converge as well as the smaller model.

The hypothesis that the 1-layer model is capacity-limited is not supported here. More width does not automatically help — the baseline h128 is better-tuned to the 5-minute training budget.

### Suggested follow-ups

- Try n_hidden=144 as a compromise between h128 and h160 — still within budget (~4.5s/epoch = ~65 epochs).
- Alternatively, investigate whether depth (n_layers=2) helps more than width — a 2-layer h112 model has comparable params and may capture more complex features.
- The stronger baseline is clearly h128 with current hypers — future experiments should build on that.