### PR TITLE
Gradient-weighted surface loss (focus on hard regions)

### DIFF
--- a/train.py
+++ b/train.py
@@ -130,16 +130,42 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
+        vol_mask = mask & ~is_surface
+        surf_mask = mask & is_surface
+        # Gradient-weighted node weights: boost high-gradient surface regions
+        node_weight = torch.ones(x.shape[0], x.shape[1], device=device)
+        with torch.no_grad():
+            for b in range(x.shape[0]):
+                s_idx = surf_mask[b].nonzero(as_tuple=True)[0]
+                n_surf = s_idx.shape[0]
+                if n_surf < 3:
+                    continue
+                pos = x[b, s_idx, :2]  # normalized coords
+                p = y[b, s_idx, 2]     # raw pressure
+                centroid = pos.mean(0)
+                theta = torch.atan2(pos[:, 1] - centroid[1], pos[:, 0] - centroid[0])
+                order = theta.argsort()
+                p_sorted = p[order]
+                pos_sorted = pos[order]
+                dp = torch.cat([(p_sorted[1:] - p_sorted[:-1]).abs(),
+                                (p_sorted[0:1] - p_sorted[-1:]).abs()])
+                ds = torch.cat([(pos_sorted[1:] - pos_sorted[:-1]).norm(dim=1),
+                                (pos_sorted[0:1] - pos_sorted[-1:]).norm(dim=1)]) + 1e-8
+                grad_mag = dp / ds
+                mean_grad = grad_mag.mean().clamp(min=1e-10)
+                grad_norm = grad_mag / mean_grad
+                w = 1.0 + 0.5 * (grad_norm - 1.0)
+                inv_order = torch.empty_like(order)
+                inv_order[order] = torch.arange(n_surf, device=device)
+                node_weight[b, s_idx] = w[inv_order]
+        channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
             diff = pred - y_norm
             sq_err = diff ** 2
             abs_err = diff.abs()
-            vol_mask = mask & ~is_surface
-            surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w * node_weight.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis
Not all surface nodes contribute equally. Nodes near leading edges and separation points have steeper pressure gradients and higher errors. Weight each surface node by the local spatial gradient magnitude of the target pressure field to focus loss on the hardest regions.

## Instructions
Compute per-node gradient weights inside the batch loop before the autocast block. For each sample, sort surface nodes by angle from centroid, compute finite-difference gradient magnitudes, normalize to mean=1, apply boost factor 0.5.

Use `--wandb_name "fern/gradient-weighted-loss" --wandb_group mar14 --agent fern`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** nzte0uwn
**Epochs completed:** 65/70 (5.1 min timeout)
**Per-epoch time:** ~5s (vs ~4s baseline)
**Peak memory:** 2.6 GB
**Best epoch:** 65

| Metric | Baseline | This run (gradient-weighted) |
|--------|----------|-------------------------------|
| surf_p | 34.91 | 45.9 |
| surf_ux | 0.48 | 0.63 |
| surf_uy | 0.28 | 0.34 |
| val_loss | — | 0.6546 |
| vol MAE Ux | — | 3.54 |
| vol MAE Uy | — | 1.33 |
| vol MAE p | — | 87.4 |

**What happened:**

The gradient-weighted loss significantly hurt performance across all metrics. surf_p degraded from 34.91 to 45.9 (+32%), and surf_ux/surf_uy also worsened substantially.

Several likely explanations:

1. **Unstable weighting**: The per-batch gradient weights fluctuate because they're computed from y (target pressure), which is batch-dependent. High-gradient surface nodes get boosted differently every batch, creating noisy optimization signals that likely destabilize training.

2. **Angle-based sorting issues**: The angular sorting of surface nodes assumes the surface is a simple closed loop around a centroid. Tandem foil geometry may have complex shapes where angular order doesn't correspond to spatial adjacency along the surface, creating spurious finite-difference gradients.

3. **Training velocity lost**: The Python loop over batch samples adds ~1s/epoch, reducing epochs from ~69 to 65. Also, the inflated surf_loss values (train surf ~0.7 vs ~0.08 in baseline) may indicate the weighting makes the surface loss harder to minimize.

**Suggested follow-ups:**
- The simpler approximation suggested in the PR (weight by |y_pressure| normalized to mean 1) is worth trying separately — it avoids the spatial sorting complexity that likely causes issues here.
- Node weighting is a valid idea in principle, but needs stable weights. Pre-computed dataset-level statistics (e.g., average pressure gradient per node across training samples) would be more stable than per-batch computation.