### PR TITLE
Test-time augmentation: average K=4 noisy forward passes

### DIFF
--- a/train.py
+++ b/train.py
@@ -173,11 +173,18 @@ for epoch in range(MAX_EPOCHS):
             is_surface = is_surface.to(device, non_blocking=True)
             mask = mask.to(device, non_blocking=True)
 
-            x = (x - stats["x_mean"]) / stats["x_std"]
+            x_normed = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                pred = model({"x": x})["preds"]
+            TTA_K = 4
+            TTA_SIGMA = 0.01
+            preds = []
+            for _ in range(TTA_K):
+                x_tta = x_normed + torch.randn_like(x_normed) * TTA_SIGMA
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    p = model({"x": x_tta})["preds"]
+                preds.append(p)
+            pred = torch.stack(preds).mean(0)
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface


### PR DESCRIPTION
## Hypothesis
Average predictions from K=4 slightly perturbed inputs at validation time (add Gaussian noise sigma=0.01 to normalized inputs). This acts as an implicit ensemble that smooths prediction noise without any training cost.

## Instructions
In the validation loop, replace single forward pass with 4 TTA-averaged forward passes using x_normed + Gaussian noise.

Use `--wandb_name "tanjiro/tta-averaging" --wandb_group mar14 --agent tanjiro`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B Run:** mvtcujjg
**Epochs completed:** 63 of 70 (4x val cost reduced completed epochs)
**Peak memory:** 2.6 GB

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.5711 | — | — |
| surf_p | 37.58 | 34.91 | +2.67 (worse) |
| surf_Ux | 0.51 | 0.48 | +0.03 (worse) |
| surf_Uy | 0.29 | 0.28 | +0.01 (worse) |
| vol MAE Ux | 2.98 | — | — |
| vol MAE Uy | 1.12 | — | — |
| vol MAE p | 71.39 | — | — |

**What happened:** TTA averaging hurt performance — all surface MAE metrics are worse than baseline. Two factors explain this: (1) The 4x validation cost reduced completed epochs from ~68 to 63, so less training time. (2) More fundamentally, adding sigma=0.01 Gaussian noise to the already-normalized inputs introduces distribution shift — the model was never trained with perturbed inputs, so averaging 4 noisy predictions doesn't improve over the clean prediction; it dilutes signal. The sigma=0.01 relative to the input scale may actually be non-trivial (normalized inputs have std≈1 so 1% noise), causing predictions to deviate meaningfully. Classic TTA works best when the model is robust to the perturbation (e.g. flips in image models) or when the model is explicitly trained with the augmentation.

**Suggested follow-ups:**
- Try sigma=0.001 (10x smaller) to keep perturbations truly negligible
- Try training with TTA augmentation (add noise during training too) so the model is robust to it at test time
- Try clean single-pass inference with just the deterministic run (sigma=0) as a sanity check that the 4x val cost isn't the bottleneck