### PR TITLE
Asymmetric channel weights: [0.5, 0.5, 1.5] (de-emphasize velocity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,7 +138,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
+            channel_w = torch.tensor([0.5, 0.5, 1.5], device=pred.device)
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})


### PR DESCRIPTION
## Hypothesis
Velocity channels (Ux, Uy) are already well-predicted (0.48, 0.28). By reducing their weight to 0.5, the shared backbone allocates more capacity toward pressure-informative features. This is different from just boosting pressure weight (tried) — here we actively reduce velocity gradient contribution.

## Instructions
In `train.py`, change channel_w:
```python
channel_w = torch.tensor([0.5, 0.5, 1.5], device=pred.device)
```
Everything else stays the same.

Use `--wandb_name "nezuko/asymmetric-channel" --wandb_group mar14 --agent nezuko`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

| Metric | Baseline [1,1,1.5] | This run [0.5,0.5,1.5] | Delta |
|--------|-------------------|------------------------|-------|
| surf_p | 34.91 | 36.41 | +1.50 ✗ |
| surf_ux | 0.48 | ~0.53 | +0.05 ✗ |
| surf_uy | 0.28 | 0.310 | +0.03 ✗ |
| val_loss | — | 0.579 | — |
| vol_ux | — | 2.924 | — |
| vol_uy | — | 1.065 | — |
| vol_p | — | 67.66 | — |
| Peak VRAM | — | 2.6 GB | — |

**W&B run:** ouifierz

### What happened
Negative result across all metrics. Reducing velocity channel weights to 0.5 hurt rather than helped — surf_p regressed from 34.91 to 36.41 (+1.50), and both velocity MAEs also worsened. The hypothesis that the backbone would reallocate capacity toward pressure didn't hold. Instead, penalizing velocity errors less likely led to a noisier optimization signal overall, since both tasks share the same backbone and velocity errors provide useful structural gradients. The [1.0, 1.0, 1.5] baseline appears to be near-optimal for channel weighting.

### Suggested follow-ups
- The channel_w=[1,1,1.5] baseline (surf_p=34.91) is significantly better than [0.5,0.5,1.5] — it confirms that velocity channel signals are valuable for learning pressure too.
- Explore mild pressure boost only (e.g. [1.0, 1.0, 2.0]) if channel_w tuning is desired, rather than velocity de-emphasis.