### PR TITLE
Cosine warmup instead of linear warmup

### DIFF
--- a/train.py
+++ b/train.py
@@ -80,10 +80,16 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
-warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+import math
+from torch.optim.lr_scheduler import CosineAnnealingLR, SequentialLR
+warmup_epochs = 5
+def warmup_fn(epoch):
+    if epoch < warmup_epochs:
+        return (1e-5/0.006) + (1 - 1e-5/0.006) * 0.5 * (1 - math.cos(math.pi * epoch / warmup_epochs))
+    return 1.0
+warmup = torch.optim.lr_scheduler.LambdaLR(optimizer, warmup_fn)
 cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
-scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[warmup_epochs])
 
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Linear warmup ramps LR uniformly. Cosine warmup spends more time at low LR initially, letting the model find a good basin before ramping up. Used in ViT/DeiT and often outperforms linear warmup.

## Instructions
In `train.py`, replace the warmup scheduler:
```python
import math
warmup_epochs = 5
def warmup_fn(epoch):
    if epoch < warmup_epochs:
        return (1e-5/0.006) + (1 - 1e-5/0.006) * 0.5 * (1 - math.cos(math.pi * epoch / warmup_epochs))
    return 1.0
warmup = torch.optim.lr_scheduler.LambdaLR(optimizer, warmup_fn)
cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[warmup_epochs])
```

Use `--wandb_name "alphonse/cosine-warmup" --wandb_group mar14 --agent alphonse`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run:** `1lr2bb7w`  
**Best epoch:** 65/70 (wall-clock limit at 5.0 min)  
**Peak VRAM:** 2.6 GB

| Metric | Cosine Warmup | Baseline | Delta |
|--------|--------------|----------|-------|
| val/loss | 0.5664 | — | — |
| surf_p | 36.5 | 34.91 | +1.6 ❌ |
| surf_Ux | 0.47 | 0.48 | -0.01 ✅ |
| surf_Uy | 0.29 | 0.28 | +0.01 ❌ |
| vol_Ux | 2.91 | — | — |
| vol_Uy | 1.09 | — | — |
| vol_p | 68.7 | — | — |

**What happened:** Cosine warmup did not improve over linear warmup. The pressure surface MAE (36.5) is notably worse than baseline (34.91), and Uy is also slightly worse. The small win on Ux does not compensate. The warmup schedule difference (cosine vs linear over 5 epochs) appears to have no meaningful positive effect here — the model may be robust to warmup shape given the smooth cosine annealing that follows.

**Suggested follow-ups:**
- The baseline with linear warmup (3 epochs) + cosine was 34.91 on surf_p. Extending to 5 warmup epochs (linear) would be worth checking in isolation to separate warmup length vs warmup shape effects.
- Try `eta_min=0` in CosineAnnealingLR to see if a lower LR floor at the end of training helps convergence.