### PR TITLE
Surface-only fine-tuning in last 10 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -140,7 +140,10 @@ for epoch in range(MAX_EPOCHS):
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            loss = vol_loss + cfg.surf_weight * surf_loss
+            if epoch >= 58:  # Last ~10 epochs: surface-only
+                loss = cfg.surf_weight * surf_loss
+            else:
+                loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
In the final epochs (LR near eta_min), volume loss still contributes gradients irrelevant to surface MAE. By zeroing out volume loss for the last 10 epochs, the model's final updates focus purely on surface prediction.

## Instructions
In \`train.py\`, add a phase check in the training loop after computing both losses:
\`\`\`python
if epoch >= 58:  # Last ~10 epochs: surface-only
    loss = cfg.surf_weight * surf_loss
else:
    loss = vol_loss + cfg.surf_weight * surf_loss
\`\`\`
Everything else stays the same.

Use \`--wandb_name "edward/surface-finetune" --wandb_group mar14 --agent edward\`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** 1l47njrh  
**Best epoch:** 57 / 68 (wall-clock stop at 5.1 min)  
**Peak memory:** 2.6 GB

| Metric | Baseline | This run (best ckpt) | Delta |
|--------|----------|----------------------|-------|
| surf_p | 34.91 | **40.64** | +16% ❌ |
| surf_ux | 0.48 | **0.61** | +27% ❌ |
| surf_uy | 0.28 | **0.30** | +7% ❌ |
| val/loss | — | 0.5747 | — |

### What happened

**Negative result.** The surface-only phase backfired. Here's why:

1. From epoch 58 onward, dropping vol_loss freed the model to drift on volume predictions. Vol_loss increased (~0.11 → 0.19), raising overall val_loss above the pre-finetune level.
2. The checkpoint is saved based on minimum val_loss (which includes vol). Since val_loss was lowest at epoch 57 — just before the phase switch — the saved checkpoint is from before the surface-only phase.
3. At epoch 67-68, surface MAE was actually 0.48/0.28/34.8 (slightly better than or matching baseline), but those weights were never checkpointed because val_loss had degraded.
4. So the reported best metrics reflect epoch 57's surface accuracy (40.6), which is significantly worse than baseline.

The hypothesis assumed that late-epoch volume gradients were noise for surface prediction — but volume loss also acts as a regularizer preventing surface overfitting/drift. Removing it caused model quality to degrade on the joint metric.

### Suggested follow-ups

- Try a soft volume downweight rather than hard zero: `loss = alpha * vol_loss + surf_weight * surf_loss` with `alpha` ramping from 1.0 to 0.1 over the last 10 epochs
- Alternatively, track two checkpoints: one by val_loss (current) and one by val/mae_surf_p, then report both
- Or increase surf_weight beyond 10 for the entire run instead of a late-phase switch