### PR TITLE
2-layer model (h=112) + torch.compile for speed

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 70
+MAX_EPOCHS = 62
 @dataclass
 class Config:
     lr: float = 0.006
@@ -64,8 +64,8 @@ model_config = dict(
     space_dim=2,
     fun_dim=16,
     out_dim=3,
-    n_hidden=128,
-    n_layers=1,
+    n_hidden=112,
+    n_layers=2,
     n_head=2,
     slice_num=32,
     mlp_ratio=2,
@@ -77,12 +77,13 @@ model_config = dict(
 model = Transolver(
     **model_config
 ).to(device)
+model = torch.compile(model, mode="reduce-overhead")
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
-cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
+cosine = CosineAnnealingLR(optimizer, T_max=56, eta_min=1e-4)  # 62-5-1=56 remaining epochs
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 


### PR DESCRIPTION
## Hypothesis
Previous 2-layer attempt (h=96) was too slow (6s/epoch, 49 epochs). With h=112 and torch.compile(mode="reduce-overhead"), we can cut epoch time by 20-30% to ~4.5-5s, completing ~60 epochs. The second Transolver block adds compositional depth for richer flow representations.

## Instructions
In `train.py`:
1. model_config: `n_hidden=112`, `n_layers=2`, `n_head=2`, `slice_num=32`, `mlp_ratio=2`
2. `MAX_EPOCHS = 62`
3. Scheduler: `warmup total_iters=5`, `cosine T_max=56, eta_min=1e-4`, `milestones=[5]`
4. After model creation: `model = torch.compile(model, mode="reduce-overhead")`

If torch.compile fails, try `mode="default"`. If still fails, remove compile and just use the 2-layer model with reduced epochs.

The output MLP becomes 112→56→3 automatically.

Use `--wandb_name "askeladd/2layer-h112-compile" --wandb_group mar14 --agent askeladd`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** 8s5b5klx

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.6038 | ~0.54 | worse |
| surf_Ux MAE | 0.53 | 0.48 | +10% worse |
| surf_Uy MAE | 0.31 | 0.28 | +11% worse |
| surf_p MAE | 38.11 | 34.91 | +9% worse |
| Peak VRAM | 3.2 GB | 2.6 GB | +0.6 GB |
| Epoch time | ~4.1s | ~4.4s | -7% faster |
| Epochs completed | 58/62 | 70/70 | fewer |

**What happened:** The 2-layer h=112 + torch.compile model performed significantly worse than the 1-layer h=128 baseline across all surface metrics. There are two contributing issues:

1. **Compile overhead** — The first epoch took ~30s instead of ~4s due to torch.compile warmup (the compile graphs had to be traced for the first batch). This stole several epochs from training (we got 58 epochs instead of ~62), but more importantly the compile overhead meant the model started converging later.

2. **Depth vs width tradeoff** — The 2-layer model has more parameters and requires more epochs to converge. Even with 58 epochs, the model was still meaningfully improving at the end, suggesting it needed more time than 5 minutes allows. The 1-layer model converges faster.

torch.compile's ~7% per-epoch speedup did not compensate for the compile startup cost within the 5-minute budget, and the 2-layer model architecture itself needs more epochs to reach competitive performance.

**Suggested follow-ups:**
- Test the 2-layer h=112 model WITHOUT torch.compile to isolate the architectural effect from compile overhead
- Try torch.compile with a pre-warmup: run 1 dummy forward pass before the timing window starts
- If 2-layer models are of interest, reduce n_head=1 or slice_num=16 to cut per-epoch cost further