### PR TITLE
SWA (Stochastic Weight Averaging) over last 15 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -80,6 +80,10 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+from torch.optim.swa_utils import AveragedModel, update_bn
+swa_model = AveragedModel(model)
+SWA_START = 53  # start averaging from epoch 53 (last ~15 epochs)
+swa_n_updates = 0
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
 cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
@@ -154,6 +158,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    if epoch >= SWA_START:
+        swa_model.update_parameters(model)
+        swa_n_updates += 1
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
@@ -248,6 +255,72 @@ for epoch in range(MAX_EPOCHS):
         f"mae_surf=[Ux:{mae_surf[0]:.2f} Uy:{mae_surf[1]:.2f} p:{mae_surf[2]:.1f}]{tag}"
     )
 
+
+# --- SWA evaluation ---
+if swa_n_updates > 0:
+    print(f"\nEvaluating SWA model ({swa_n_updates} snapshots averaged)...")
+    update_bn(train_loader, swa_model, device=device)
+    swa_model.eval()
+    swa_vol = 0.0
+    swa_surf = 0.0
+    swa_mae_surf = torch.zeros(3, device=device)
+    swa_mae_vol = torch.zeros(3, device=device)
+    swa_n_surf = 0
+    swa_n_vol = 0
+    swa_n_val = 0
+
+    with torch.no_grad():
+        for x, y, is_surface, mask in tqdm(val_loader, desc="SWA [val]", leave=False):
+            x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+            is_surface = is_surface.to(device, non_blocking=True)
+            mask = mask.to(device, non_blocking=True)
+
+            x = (x - stats["x_mean"]) / stats["x_std"]
+            y_norm = (y - stats["y_mean"]) / stats["y_std"]
+
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = swa_model({"x": x})["preds"]
+            sq_err = (pred - y_norm) ** 2
+
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            swa_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            swa_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+            swa_n_val += 1
+
+            pred_orig = pred * stats["y_std"] + stats["y_mean"]
+            err = (pred_orig - y).abs()
+            swa_mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+            swa_mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+            swa_n_surf += surf_mask.sum().item()
+            swa_n_vol += vol_mask.sum().item()
+
+    swa_vol /= swa_n_val
+    swa_surf /= swa_n_val
+    swa_loss = swa_vol + cfg.surf_weight * swa_surf
+    swa_mae_surf /= max(swa_n_surf, 1)
+    swa_mae_vol /= max(swa_n_vol, 1)
+
+    wandb.log({
+        "swa/vol_loss": swa_vol,
+        "swa/surf_loss": swa_surf,
+        "swa/loss": swa_loss,
+        "swa/mae_vol_Ux": swa_mae_vol[0].item(),
+        "swa/mae_vol_Uy": swa_mae_vol[1].item(),
+        "swa/mae_vol_p": swa_mae_vol[2].item(),
+        "swa/mae_surf_Ux": swa_mae_surf[0].item(),
+        "swa/mae_surf_Uy": swa_mae_surf[1].item(),
+        "swa/mae_surf_p": swa_mae_surf[2].item(),
+        "swa/n_updates": swa_n_updates,
+    })
+    wandb.summary.update({
+        "swa_mae_surf_Ux": swa_mae_surf[0].item(),
+        "swa_mae_surf_Uy": swa_mae_surf[1].item(),
+        "swa_mae_surf_p": swa_mae_surf[2].item(),
+        "swa_loss": swa_loss,
+        "swa_n_updates": swa_n_updates,
+    })
+    print(f"SWA ({swa_n_updates} snapshots): val_loss={swa_loss:.4f}  mae_surf=[Ux:{swa_mae_surf[0]:.2f} Uy:{swa_mae_surf[1]:.2f} p:{swa_mae_surf[2]:.1f}]")
 
 # --- Final summary ---
 total_time = (time.time() - train_start) / 60.0


### PR DESCRIPTION
## Hypothesis
Instead of picking the single best checkpoint by val_loss, average weights from the last ~15 epochs using torch SWA. SWA finds flatter minima that generalize better, and is essentially free in compute. No previous experiment tried weight averaging.

## Instructions
In `train.py`:
1. After model creation, create an SWA model:
   ```python
   from torch.optim.swa_utils import AveragedModel, update_bn
   swa_model = AveragedModel(model)
   SWA_START = 53  # start averaging from epoch 53 (last ~15 epochs)
   ```
2. In the training loop, after `scheduler.step()`, add:
   ```python
   if epoch >= SWA_START:
       swa_model.update_parameters(model)
   ```
3. After the training loop ends, update batch norm stats and evaluate the SWA model:
   ```python
   if epoch >= SWA_START:
       update_bn(train_loader, swa_model, device=device)
       # Evaluate SWA model on validation set (same validation loop but using swa_model)
       # Report SWA metrics alongside best-checkpoint metrics
   ```
4. Log SWA metrics with prefix `swa/` to distinguish from checkpoint metrics.

Use `--wandb_name "frieren/swa-last15" --wandb_group mar14 --agent frieren`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run:** `xa38vubn`  
**Epochs completed:** ~67/70 (5.0 min, ~4.4s/epoch)  
**SWA snapshots:** 15 (epochs 53–67)  
**Peak memory:** ~3.0 GB

| Metric | Baseline (h128 best) | Best checkpoint (ep 65) | SWA (15 epochs) |
|--------|---------------------|------------------------|-----------------|
| surf_p | 34.91 | **34.29** | 34.80 |
| surf_Ux | 0.48 | 0.50 | 0.49 |
| surf_Uy | 0.28 | 0.28 | 0.28 |
| val_loss | — | 0.5416 | 0.5539 |

### What happened

Mixed result. The best checkpoint (epoch 65) achieves a **new programme best** of surf_p=34.29, beating the prior best of 34.91. However, **SWA did not outperform the best single checkpoint** — SWA gave surf_p=34.80, which is 0.51 worse than the checkpoint.

This is expected when the model is still actively improving near the end of training (best epoch = 65/67). SWA averages epochs 53–67, but the early portion of that window (epochs 53–60) includes weaker checkpoints that drag the average down. SWA helps most when training has plateaued — here the cosine schedule is still descending, so the late-epoch weights dominate and averaging slightly dilutes the best final state.

The real news here is the baseline run itself: surf_p=34.29 shows the h128+warmup5+eta_min+channel_w config is still improving with the full 70-epoch budget. The 5-minute wall clock allows ~67 epochs.

### Suggested follow-ups

- SWA would be more beneficial if we started averaging after the LR plateaus (e.g., after eta_min is reached), not 15 epochs before end. Try SWA_START=60 or SWA_START=62.
- Since the model was still improving at epoch 65, more epochs (if budget allows) or a longer cosine cycle could squeeze more gains.
- The best single-checkpoint result (34.29) is now the new baseline.