### PR TITLE
SiLU activation in output MLP (replace GELU)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -142,7 +142,7 @@ class TransolverBlock(nn.Module):
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim // 2),
-                nn.GELU(),
+                nn.SiLU(),
                 nn.Linear(hidden_dim // 2, out_dim),
             )
 


### PR DESCRIPTION
## Hypothesis
The output head uses GELU. SiLU (Swish) has smoother gradients near zero and has shown improvements in many architectures. 1-line change in the output MLP activation.

## Instructions
In `transolver.py`, in `TransolverBlock.__init__`, change the output MLP activation from `nn.GELU()` to `nn.SiLU()`.

Use `--wandb_name "fern/silu-output" --wandb_group mar14 --agent fern`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** 2qfd6b08
**Epochs completed:** ~69/70 (5-minute timeout)
**Peak memory:** 2.6 GB
**Best epoch:** 66

| Metric | Baseline (GELU) | This run (SiLU) |
|--------|-----------------|-----------------|
| surf_p | 34.91 | 35.71 |
| surf_ux | 0.48 | 0.48 |
| surf_uy | 0.28 | 0.28 |
| vol MAE Ux | — | 3.05 |
| vol MAE Uy | — | 1.11 |
| vol MAE p | — | 71.4 |

**What happened:**

SiLU is essentially equivalent to GELU for this task. surf_ux/surf_uy are tied, and surf_p is marginally worse (35.71 vs 34.91) — within run-to-run noise. The activation choice in the 2-layer output MLP appears to have negligible impact on model performance.

**Suggested follow-ups:**
- The output head activation is not a meaningful lever here. Pursuing it further would be diminishing returns.
- Structural changes to the architecture (e.g., more attention slices, wider hidden dim, residual connections in the output head) are more likely to move the needle.