### PR TITLE
EMA model weights (decay=0.998)

### DIFF
--- a/train.py
+++ b/train.py
@@ -102,6 +102,20 @@ model_path = model_dir / f"checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
+class EMA:
+    def __init__(self, model, decay=0.998):
+        self.decay = decay
+        self.shadow = {k: v.clone() for k, v in model.state_dict().items()}
+    def update(self, model):
+        for k, v in model.state_dict().items():
+            self.shadow[k].mul_(self.decay).add_(v, alpha=1-self.decay)
+    def apply(self, model):
+        self.backup = {k: v.clone() for k, v in model.state_dict().items()}
+        model.load_state_dict(self.shadow)
+    def restore(self, model):
+        model.load_state_dict(self.backup)
+ema = EMA(model, decay=0.998)
+
 best_val = float("inf")
 best_metrics = {}
 train_start = time.time()
@@ -147,6 +161,7 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        ema.update(model)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -157,7 +172,8 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
-    # --- Validate ---
+    # --- Validate (with EMA weights) ---
+    ema.apply(model)
     model.eval()
     val_vol = 0.0
     val_surf = 0.0
@@ -247,6 +263,7 @@ for epoch in range(MAX_EPOCHS):
         f"mae_vol=[Ux:{mae_vol[0]:.2f} Uy:{mae_vol[1]:.2f} p:{mae_vol[2]:.1f}]  "
         f"mae_surf=[Ux:{mae_surf[0]:.2f} Uy:{mae_surf[1]:.2f} p:{mae_surf[2]:.1f}]{tag}"
     )
+    ema.restore(model)
 
 
 # --- Final summary ---


### PR DESCRIPTION
## Hypothesis
Exponential Moving Average maintains a running average of model weights (decay=0.998), updated every step. EMA smooths noisy gradient updates and consistently improves generalization in diffusion models and transformers. With ~68 epochs x ~203 steps = ~13,800 updates, EMA has plenty of averaging.

## Instructions
1. Add EMA class + instantiation before training loop
2. `ema.update(model)` after each `optimizer.step()`
3. `ema.apply(model)` before validation, `ema.restore(model)` after
4. EMA weights saved to checkpoint (automatically, since checkpoint saved during EMA-applied validation)

Use `--wandb_name "tanjiro/ema-weights" --wandb_group mar14 --agent tanjiro`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B Run:** 0wqy6dtz
**Epochs completed:** 68 of 70 (best at epoch 68)
**Peak memory:** 2.6 GB

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.5503 | — | — |
| surf_p | 35.58 | 34.91 | +0.67 (slightly worse) |
| surf_Ux | 0.48 | 0.48 | 0.00 (same) |
| surf_Uy | 0.28 | 0.28 | 0.00 (same) |
| vol MAE Ux | 3.01 | — | — |
| vol MAE Uy | 1.11 | — | — |
| vol MAE p | 66.84 | — | — |

**What happened:** Neutral result. EMA (decay=0.998) with ~13,800 weight updates produces predictions essentially identical to the baseline — surf_Ux and surf_Uy unchanged, surf_p slightly worse (+0.67). The EMA averages over many gradient steps, but with this training regime the online model weights are already fairly stable (warmup + cosine schedule + gradient clipping). The added EMA smoothing doesn't provide a meaningful advantage and the slight pressure degradation suggests the averaged weights may be slightly underfitting relative to the endpoint weights. EMA tends to help most when training is noisy/unstable (high LR, no schedule) — here the schedule already controls stability.

**Suggested follow-ups:**
- Try a higher decay (e.g. 0.9995) so EMA tracks slower and maintains smoother weights
- Try EMA with a higher learning rate (no warmup or higher peak LR) where the benefit of smoothing is larger
- The model appears near a performance plateau — more impactful changes may require architectural modifications rather than optimization tricks