### PR TITLE
Huber surface loss (delta=0.5) replacing L1

### DIFF
--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@
 import os
 import time
 import torch
+import torch.nn.functional as F
 import wandb
 import yaml
 from dataclasses import dataclass, asdict
@@ -139,7 +140,8 @@ for epoch in range(MAX_EPOCHS):
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
+            huber_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.5)
+            surf_loss = (huber_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis
L1 loss has discontinuous gradient at zero. Huber transitions from MSE (smooth) to L1 at threshold delta. With the model near convergence (surf_p=34.91), smoother gradients near zero could help fine-tune residuals. Log-cosh was tried and failed, but Huber is mechanically different (piecewise linear/quadratic). delta=0.5 in normalized space.

## Instructions
In `train.py`, replace the surface loss computation. Instead of:
```python
surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
```
Use:
```python
import torch.nn.functional as F
huber_err = F.huber_loss(pred, y_norm, reduction='none', delta=0.5)
surf_loss = (huber_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
```

Use `--wandb_name "nezuko/huber-surface" --wandb_group mar14 --agent nezuko`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run:** `y52a2djv`

| Metric | Baseline | This run |
|--------|----------|----------|
| val/loss | — | 0.5074 |
| surf_Ux MAE | 0.48 | **0.569** |
| surf_Uy MAE | 0.28 | **0.335** |
| surf_p MAE | 34.91 | **39.97** |
| vol_Ux MAE | — | 2.21 |
| vol_Uy MAE | — | 0.81 |
| vol_p MAE | — | 50.1 |

**Peak memory:** 2.6 GB  
**Epochs completed:** 67/70 (timeout at 5 min)

### What happened

Negative result — Huber loss made things significantly worse across all surface metrics. surf_p degraded from 34.91 → 39.97, surf_Ux from 0.48 → 0.57, surf_Uy from 0.28 → 0.34.

The Huber loss (delta=0.5) behaves like MSE for residuals below 0.5 and like L1 above. In normalized space, residuals of 0.5 are quite large at this stage of training, so the model was effectively seeing mostly quadratic loss — not the smooth gradient near-zero behavior we wanted. The mixed curvature likely disrupted the loss landscape compared to pure L1, without providing a meaningful smoothing benefit. Log-cosh also failed, suggesting the surface loss geometry really does benefit from pure L1's constant-gradient behavior, not a smoother approximation.

### Suggested follow-ups

- Try Huber with a much smaller delta (e.g. delta=0.05 or 0.1) to be in the L1 regime more quickly — but at this point these smooth-loss variants are 2/2 failures, suggesting L1 is simply the right choice here.
- Investigate whether the val/loss metric itself could be reformulated differently (e.g. weighted MAE for both vol and surf) rather than vol MSE + surf L1 hybrid.