### PR TITLE
Gradient accumulation (effective batch_size=8)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ from utils import visualize, dataset_stats
 
 MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 70
+ACCUM_STEPS = 2
 @dataclass
 class Config:
     lr: float = 0.006
@@ -122,7 +123,8 @@ for epoch in range(MAX_EPOCHS):
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    optimizer.zero_grad()
+    for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -143,10 +145,12 @@ for epoch in range(MAX_EPOCHS):
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
+        (loss / ACCUM_STEPS).backward()
+
+        if (batch_idx + 1) % ACCUM_STEPS == 0 or (batch_idx + 1) == len(train_loader):
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Current batch_size=4 has never been varied. Gradient accumulation to effective batch_size=8 gives more stable gradients without increasing peak memory. Larger effective batch may improve convergence.

## Instructions
In \`train.py\`, add before the training loop:
\`\`\`python
ACCUM_STEPS = 2
\`\`\`
Modify the training batch loop:
\`\`\`python
optimizer.zero_grad()  # Move BEFORE the batch loop (remove from inside)
for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
    # ... existing forward pass and loss computation ...
    loss = loss / ACCUM_STEPS  # Scale loss
    loss.backward()
    
    if (batch_idx + 1) % ACCUM_STEPS == 0 or (batch_idx + 1) == len(train_loader):
        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
        optimizer.step()
        optimizer.zero_grad()
\`\`\`
Keep \`wandb.log\` for the unscaled loss.

Use \`--wandb_name "edward/grad-accum-bs8" --wandb_group mar14 --agent edward\`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** rcttabci  
**Best epoch:** 63 / 68 (wall-clock limit at 5.0 min)  
**Peak memory:** 2.6 GB

| Metric | Baseline | This run (best ckpt) | Delta |
|--------|----------|----------------------|-------|
| surf_p | 34.91 | **38.2** | +9.5% ❌ |
| surf_ux | 0.48 | **0.54** | +12.5% ❌ |
| surf_uy | 0.28 | **0.29** | +3.6% ❌ |
| val/loss | — | 0.6055 | — |
| vol_p | — | 73.1 | — |

### What happened

**Negative result.** Gradient accumulation with ACCUM_STEPS=2 made things noticeably worse across all metrics.

Root causes:
1. **Halved update steps per epoch**: With ACCUM_STEPS=2, the optimizer steps per epoch drop from ~203 to ~102. The LR schedule (SequentialLR) steps once per epoch regardless, so each epoch now has half as many weight updates at the same LR. The model effectively gets less training.
2. **No LR scaling**: Standard practice for batch size scaling is to adjust LR proportionally (e.g. ×2 for 2× effective batch). Without this, the effective per-sample LR is lower, slowing learning.
3. **Epoch budget is fixed at 5 min / 70 epochs**: The timeout forces this to an epochs-based budget. With fewer updates per epoch, gradient accumulation needs more epochs to converge to the same point — but the timeout is fixed.

The hypothesis assumed gradient stability benefits outweigh the cost in update frequency. For this 5-min regime with 70 epochs, that's not the case.

### Suggested follow-ups

- If gradient accumulation is retried, pair it with LR scaling: `lr *= ACCUM_STEPS` (or use sqrt scaling)
- Alternatively, combine accumulation with reducing total epochs to compensate (e.g. 35 effective epochs = 70 half-step epochs)
- The cleaner path to larger effective batches might be to simply increase `batch_size` from 4 to 8, if memory allows (currently only using 2.6 GB of 96 GB available)