### PR TITLE
Separate surface/volume target normalization

### DIFF
--- a/train.py
+++ b/train.py
@@ -60,6 +60,23 @@ loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
 train_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=True, **loader_kwargs)
 val_loader = DataLoader(val_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
 
+# Compute surface-specific stats
+surf_y_sum = torch.zeros(3, device=device)
+surf_y_sq_sum = torch.zeros(3, device=device)
+surf_count = 0
+for x, y, is_surface, mask in train_loader:
+    y = y.to(device)
+    is_surface = is_surface.to(device)
+    mask = mask.to(device)
+    surf_mask = mask & is_surface
+    surf_y = y[surf_mask.unsqueeze(-1).expand_as(y)].view(-1, 3)
+    surf_y_sum += surf_y.sum(0)
+    surf_y_sq_sum += (surf_y ** 2).sum(0)
+    surf_count += surf_mask.sum().item()
+surf_y_mean = surf_y_sum / surf_count
+surf_y_std = ((surf_y_sq_sum / surf_count) - surf_y_mean ** 2).sqrt()
+print(f"Surface y stats: mean={surf_y_mean.tolist()}, std={surf_y_std.tolist()}")
+
 model_config = dict(
     space_dim=2,
     fun_dim=16,
@@ -128,7 +145,9 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        y_norm = (y - stats["y_mean"]) / stats["y_std"]
+        y_norm_vol = (y - stats["y_mean"]) / stats["y_std"]
+        y_norm_surf = (y - surf_y_mean) / surf_y_std
+        y_norm = torch.where(is_surface.unsqueeze(-1), y_norm_surf, y_norm_vol)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Target y is normalized with global stats dominated by volume nodes (~98.2% of all nodes). Surface nodes may have systematically different distributions. Using surface-specific normalization could reduce prediction bias on surfaces. Normalization strategy has never been explored.

## Instructions
This requires computing surface-specific stats. In `train.py`:
1. Before training, compute surface y stats from the training set
2. During training, normalize surface nodes with surface stats, volume nodes with global stats
3. During validation MAE, denormalization is already done in original space, so no changes needed for MAE computation.

Use `--wandb_name "thorfinn/separate-surf-norm" --wandb_group mar14 --agent thorfinn`

## Baseline
| surf_p | 34.91 | surf_ux | 0.48 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** ooz0gecc
**Epochs completed:** 68/70 (hit 5-min wall-clock timeout)
**Peak memory:** 2.6 GB
**Epoch time:** ~4-5s/epoch

**Surface y stats computed:** mean=[20.0, -0.32, -248.0], std=[24.4, 4.5, 1049.5]
(For reference, global stats: mean≈[20.0, -0.01, -195], std≈[25.8, 3.6, 894])

| Metric | This run (best epoch 23) | Baseline |
|--------|--------------------------|----------|
| surf_p | 148.4 | 34.91 |
| surf_ux | 11.09 | 0.48 |
| surf_uy | 3.22 | 0.28 |
| val_loss | 6.3595 | — |

**What happened:** The implementation as instructed fails catastrophically. The root cause is a normalization mismatch: during training, surface nodes are normalized with surface-specific stats, so model outputs for surface nodes are in the surface-normalized space. But validation MAE uses  (global stats) to denormalize — this is incorrect for surface nodes.

Example: surface std(Ux) ≈ 24.4 vs global std(Ux) ≈ 25.8. These are similar, but surface std(p) ≈ 1049 vs global std(p) ≈ 894, meaning surface pressure MAE is off by a factor of ~1049/894 ≈ 1.17 — plus there's a mean shift of -248 vs -195 ≈ 53 units. This explains the huge MAE values.

The hypothesis itself is sound (separate normalization is a principled idea), but it requires consistent denormalization at validation time. The instruction to leave validation unchanged is incorrect — you must denormalize surface predictions with surface stats.

**Suggested follow-ups:**
- Fix the validation denormalization: apply surface stats for surface nodes and global stats for volume nodes.
- Alternatively, use a simpler approach: only change the surface normalization scale (keep means the same, just adjust std ratio) to avoid mean shift artifacts.
- The surface stats show pressure is the most different (std ratio 1.17x), suggesting the global normalization may be slightly suboptimal for surface pressure specifically.