### PR TITLE
Save checkpoint by surf_p MAE (not val_loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -102,7 +102,6 @@ model_path = model_dir / f"checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
-best_val = float("inf")
 best_metrics = {}
 train_start = time.time()
 
@@ -225,8 +224,8 @@ for epoch in range(MAX_EPOCHS):
         peak_mem_gb = 0.0
 
     tag = ""
-    if val_loss < best_val:
-        best_val = val_loss
+    surf_p_mae = mae_surf[2].item()
+    if not best_metrics or surf_p_mae < best_metrics.get("mae_surf_p", float("inf")):
         best_metrics = {
             "mae_vol_Ux": mae_vol[0].item(),
             "mae_vol_Uy": mae_vol[1].item(),


### PR DESCRIPTION
## Hypothesis
Current checkpoint saves by best val_loss (vol MSE + sw*surf_loss). But val_loss is dominated by volume MSE, which may not correlate with our target metric (surf_p MAE). Saving the checkpoint when surf_p MAE is lowest directly optimizes what we measure.

## Instructions
In `train.py`, change the checkpoint selection. Replace:
```python
if val_loss < best_val:
    best_val = val_loss
```
with:
```python
surf_p_mae = mae_surf[2].item()
if not best_metrics or surf_p_mae < best_metrics.get("mae_surf_p", float("inf")):
```
Initialize by removing `best_val = float("inf")` (or keep it for logging). The rest of the best_metrics dict update and checkpoint saving stays the same.

Use `--wandb_name "frieren/ckpt-by-surfp" --wandb_group mar14 --agent frieren`

## Baseline
| surf_p | 34.44 | surf_ux | 0.47 | surf_uy | 0.28 |

---

## Results

**W&B run:** `85d21ahl`  
**Epochs completed:** ~66/70 (5.0 min, ~4.4s/epoch)  
**Peak memory:** ~3.1 GB

| Metric | Baseline | This run (ckpt by surf_p) | Delta |
|--------|----------|--------------------------|-------|
| surf_p | 34.44 | 36.09 | +1.65 (worse) |
| surf_Ux | 0.47 | 0.50 | +0.03 (worse) |
| surf_Uy | 0.28 | 0.29 | +0.01 (worse) |
| val_loss | — | 0.5749 | — |

**Best epoch:** 66

### What happened

Negative result. Saving by surf_p MAE performs definitively worse than the val_loss criterion (36.09 vs 34.44). This is counterintuitive — directly optimizing the target metric should help, but it hurt.

Most likely explanation: **surf_p MAE is a noisier signal** than val_loss. The combined val_loss (vol_MSE + surf_weight * surf_L1) aggregates over all channels and both surface and volume nodes. This larger sample size produces a more stable epoch-to-epoch signal. surf_p MAE fluctuates more between epochs (due to fewer surface nodes and a single channel), so the "best" epoch by surf_p might be a lucky draw rather than a truly better model.

In other words, val_loss is a better proxy for surf_p than surf_p itself due to lower noise. The current val_loss criterion already implicitly cares about surface quality through the surf_weight=10 term.

### Suggested follow-ups

- This result confirms val_loss is the right checkpoint criterion.
- If we want to better optimize for surf_p specifically, consider increasing surf_weight to put more emphasis on surface loss in the selection metric.
- Alternatively, average surf_p over multiple validation passes (e.g., best of last 3 epochs) to reduce noise before using it as checkpoint criterion.