### PR TITLE
Learnable per-head output gate (attention head weighting)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -64,6 +64,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.dropout = nn.Dropout(dropout)
         tau_init = torch.tensor([[[[0.3]], [[0.8]]]])  # head 0: sharp, head 1: soft
         self.temperature = nn.Parameter(tau_init)
+        self.head_gate = nn.Parameter(torch.ones(1, heads, 1, 1))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
@@ -111,6 +112,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         )  # B H G D
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
+        out_x = out_x * self.head_gate
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
         return self.to_out(out_x)
 


### PR DESCRIPTION
## Hypothesis
With per-head temperatures specialized (0.3 sharp / 0.8 soft), the two heads contribute equally via concatenation. A learnable scalar gate per head lets the model weight contributions differently. Only 2 new parameters, defaults to current behavior.

## Instructions
In `transolver.py`, add `self.head_gate = nn.Parameter(torch.ones(1, heads, 1, 1))` and multiply before rearrange.

Use `--wandb_name "tanjiro/head-gate" --wandb_group mar14 --agent tanjiro`

## Baseline
| surf_p | 34.44 | surf_ux | 0.47 | surf_uy | 0.28 |

---

## Results

**W&B Run:** s5fplo01
**Epochs completed:** 62 of 70 (best at epoch 62)
**Peak memory:** 2.7 GB

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val_loss | 0.5776 | — | — |
| surf_p | 36.86 | 34.44 | +2.42 (worse) |
| surf_Ux | 0.51 | 0.47 | +0.04 (worse) |
| surf_Uy | 0.29 | 0.28 | +0.01 (slightly worse) |
| vol MAE Ux | 3.02 | — | — |
| vol MAE Uy | 1.09 | — | — |
| vol MAE p | 70.32 | — | — |

**What happened:** The learnable head gate hurt performance — all surface MAE metrics worse than baseline, and best epoch was epoch 62 (earlier than typical ~68 for this setup). The gate parameters start at 1.0 (identity) and are in principle free to learn any weighting, but training from scratch with just 2 extra parameters seems to introduce slight optimization instability or cause the model to converge to a suboptimal fixed point. The head gate may interfere with the existing per-head temperature specialization: the temperatures are already encoding which heads should be sharp vs. soft, and adding a scale gate on top adds redundancy that confuses the optimization. Additionally, since the gate is global (same per-head weight for all layers), it can't adaptively respond to different attention patterns across the dataset.

**Suggested follow-ups:**
- Initialize head_gate to different values to break symmetry (e.g. [1.2, 0.8] to give head 0 more weight)
- Try a per-layer gate rather than shared across all layers
- Remove the per-head temperature (set both to 0.5) and let the gate alone control differentiation — avoid the redundancy