### PR TITLE
Sharper temperature init [0.15, 0.5] (more distinct slicing)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -62,7 +62,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        tau_init = torch.tensor([[[[0.3]], [[0.8]]]])  # head 0: sharp, head 1: soft
+        tau_init = torch.tensor([[[[0.15]], [[0.5]]]])  # head 0: sharp, head 1: soft
         self.temperature = nn.Parameter(tau_init)
 
         self.in_project_x = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
Current [0.3, 0.8] was a win over the original 0.5. Sharper init [0.15, 0.5] creates more distinct physics clusters from the start. Temperatures remain learnable, so if 0.15 is too sharp, gradient descent will adjust.

## Instructions
In `transolver.py`, change the temperature init:
```python
tau_init = torch.tensor([[[[0.15]], [[0.5]]]])
self.temperature = nn.Parameter(tau_init)
```

Use `--wandb_name "nezuko/sharper-temp" --wandb_group mar14 --agent nezuko`

## Baseline
| surf_p | 34.44 | surf_ux | 0.47 | surf_uy | 0.28 |

---

## Results

**W&B run:** `2ce27jf4`

| Metric | Baseline | This run |
|--------|----------|----------|
| val/loss | — | 0.5484 |
| surf_Ux MAE | 0.47 | **0.479** |
| surf_Uy MAE | 0.28 | **0.278** |
| surf_p MAE | 34.44 | **35.14** |
| vol_Ux MAE | — | 2.96 |
| vol_Uy MAE | — | 1.07 |
| vol_p MAE | — | 67.2 |

**Peak memory:** ~2.6 GB (estimated)
**Epochs completed:** 68/70

### What happened

Negative result — the sharper init [0.15, 0.5] slightly hurt vs baseline [0.3, 0.8]. surf_p worsened from 34.44 → 35.14, surf_Ux from 0.47 → 0.479. surf_Uy marginally improved (0.28 → 0.278) but not meaningfully.

The hypothesis was that sharper initial temperatures would create more distinct physics clusters from the start. But with tau=0.15, attention weights over 32 slices become very peaked — possibly too peaked to cover the full distribution of physics in the training set early on. This may have made training less stable initially, hurting the final converged point. Since temperatures are learnable, the model presumably adjusted away from 0.15 during training, but the early-training dynamics still mattered for final convergence quality.

The [0.3, 0.8] init found in the previous experiment appears to be at or near a sweet spot for this architecture.

### Suggested follow-ups

- Try an intermediate init, e.g. [0.2, 0.6], to narrow in on the sweet spot.
- Try initializing all heads to the same temperature (e.g. [0.3, 0.3]) to see if the sharp/soft asymmetry is actually important, or if it's just the absolute scale that matters.