### PR TITLE
Cosine T_max=60 + eta_min=5e-5 (tighter schedule)

### DIFF
--- a/train.py
+++ b/train.py
@@ -82,7 +82,7 @@ n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
-cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
+cosine = CosineAnnealingLR(optimizer, T_max=60, eta_min=5e-5)
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 


### PR DESCRIPTION
## Hypothesis
With ~68 epochs in 5 min, T_max=65 means LR barely reaches minimum. T_max=60 lets the model spend more epochs near minimum LR. Lower eta_min=5e-5 (vs 1e-4) allows finer late-stage tuning.

## Instructions
In `train.py`, change the cosine scheduler:
```python
cosine = CosineAnnealingLR(optimizer, T_max=60, eta_min=5e-5)
```

Use `--wandb_name "alphonse/tmax60-eta5e5" --wandb_group mar14 --agent alphonse`

## Baseline
| surf_p | 34.44 | surf_ux | 0.47 | surf_uy | 0.28 |

---

## Results

**W&B run:** `7krvj1l1`  
**Best epoch:** 61/70 (wall-clock limit at 5.0 min)  
**Peak VRAM:** 2.6 GB

| Metric | T_max=60 eta_min=5e-5 | Baseline | Delta |
|--------|----------------------|----------|-------|
| val/loss | 0.5768 | — | +0.033 ❌ |
| surf_p | 36.1 | 34.44 | +1.7 ❌ |
| surf_Ux | 0.48 | 0.47 | +0.01 ❌ |
| surf_Uy | 0.28 | 0.28 | 0.00 — |
| vol_Ux | 2.95 | — | — |
| vol_Uy | 1.10 | — | — |
| vol_p | 69.0 | — | — |

**What happened:** The tighter schedule (T_max=60, eta_min=5e-5) performed worse than baseline across all surface metrics. Despite spending more epochs near minimum LR, the val loss (0.5768) and surface pressure (36.1 vs 34.44) are both worse. The final LR at epoch 68 was 9e-5, indicating the cosine had already reached near-minimum well before the end of training — so the "more time at low LR" hypothesis didn't translate to better convergence. The lower eta_min (5e-5 vs 1e-4) may have caused the model to get stuck rather than continue refining.

**Suggested follow-ups:**
- The baseline T_max=65 appears better than T_max=60. The original schedule (T_max=67, eta_min=0) from before the warmup extension may also be worth revisiting.
- Test eta_min=0 with T_max=65 to see if removing the LR floor helps.