### PR TITLE
Output MLP residual skip projection (128→3 linear shortcut)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -146,12 +146,14 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim // 2, out_dim),
             )
+            self.skip_proj = nn.Linear(hidden_dim, out_dim)
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx_ln = self.ln_3(fx)
+            return self.mlp2(fx_ln) + self.skip_proj(fx_ln)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The output MLP (128→64→3) has no residual. Adding a linear skip from hidden to output (128→3) creates a residual path — the MLP only needs to learn corrections. Adds 387 params. Previous skip attempt (PR #230) added skip before the block; this adds skip within the output head.

## Instructions
In \`transolver.py\`, in \`TransolverBlock.__init__\` where \`last_layer=True\`:
\`\`\`python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.mlp2 = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim // 2),
        nn.GELU(),
        nn.Linear(hidden_dim // 2, out_dim),
    )
    self.skip_proj = nn.Linear(hidden_dim, out_dim)
\`\`\`
In \`forward\`, change the last-layer return:
\`\`\`python
if self.last_layer:
    fx_ln = self.ln_3(fx)
    return self.mlp2(fx_ln) + self.skip_proj(fx_ln)
\`\`\`

Use \`--wandb_name "edward/output-skip-proj" --wandb_group mar14 --agent edward\`

## Baseline
| surf_p | 34.44 | surf_ux | 0.47 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** wpxped69  
**Best epoch:** 65 / 65 (wall-clock limit at 5.0 min)  
**Peak memory:** 2.6 GB

| Metric | Baseline | This run (best ckpt) | Delta |
|--------|----------|----------------------|-------|
| surf_p | 34.44 | **39.2** | +14% ❌ |
| surf_ux | 0.47 | **0.53** | +13% ❌ |
| surf_uy | 0.28 | **0.30** | +7% ❌ |
| val/loss | — | 0.5832 | — |

### What happened

**Negative result.** The output skip projection hurt performance across all surface metrics.

Root causes:
1. **Initialization scale mismatch**: `skip_proj` is initialized with `trunc_normal_(std=0.02)` like all other Linear layers. With `mlp2` also initialized randomly, both paths start at similar scales but the skip projection creates a direct linear path that may dominate early training before `mlp2` can learn useful corrections.
2. **Redundant paths**: In a 1-layer model, the hidden representation `fx_ln` is already passed through the attention + FFN pipeline. Adding a direct linear mapping `128→3` alongside the nonlinear `128→64→3` creates ambiguity — the model has two ways to write the output, making optimization harder.
3. **The hypothesis assumed bottleneck**: The residual skip is most useful when the bottleneck (64-dim) is too tight to represent everything needed. With `n_hidden=128` and `out_dim=3`, the 128→64→3 path is already quite expressive for a 3D output; the skip doesn't add information capacity.

### Suggested follow-ups

- Zero-initialize `skip_proj` so it starts as identity-residual rather than random: `nn.init.zeros_(self.skip_proj.weight); nn.init.zeros_(self.skip_proj.bias)`
- Instead of skip within output head, try a larger output MLP (128→128→3) without skip
- The output head architecture may not be the bottleneck; architecture experiments on the attention mechanism (more heads, more slices) might be more impactful