### PR TITLE
Orthogonal initialization for Q/K/V projections

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -217,6 +217,10 @@ class Transolver(nn.Module):
         )
         self.initialize_weights()
         self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))
+        for block in self.blocks:
+            nn.init.orthogonal_(block.attn.to_q.weight)
+            nn.init.orthogonal_(block.attn.to_k.weight)
+            nn.init.orthogonal_(block.attn.to_v.weight)
 
     def initialize_weights(self):
         self.apply(self._init_weights)


### PR DESCRIPTION
## Hypothesis
Current init uses trunc_normal_(std=0.02) for Q/K/V. Orthogonal init improves attention diversity from the start. The slice projection already uses orthogonal init, suggesting the authors found it useful.

## Instructions
In `transolver.py`, in `Transolver.__init__`, AFTER `self.initialize_weights()`, add:
```python
for block in self.blocks:
    nn.init.orthogonal_(block.attn.to_q.weight)
    nn.init.orthogonal_(block.attn.to_k.weight)
    nn.init.orthogonal_(block.attn.to_v.weight)
```
This overrides the trunc_normal_ init for Q/K/V only.

Use `--wandb_name "thorfinn/orthogonal-qkv" --wandb_group mar14 --agent thorfinn`

## Baseline
| surf_p | 34.44 | surf_ux | 0.47 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** 6d2zkayb
**Epochs completed:** 68/70 (hit 5-min wall-clock timeout)
**Peak memory:** 2.6 GB
**Epoch time:** ~4s/epoch

| Metric | This run (best epoch 67) | Baseline |
|--------|--------------------------|----------|
| surf_p | 35.4 | 34.44 |
| surf_ux | 0.48 | 0.47 |
| surf_uy | 0.28 | 0.28 |
| val_loss | 0.5581 | — |
| vol Ux MAE | 2.92 | — |
| vol Uy MAE | 1.08 | — |
| vol p MAE | 67.7 | — |

**What happened:** Orthogonal init for Q/K/V doesn't clearly improve over baseline. The results are essentially tied — epoch 66 reached surf_p=35.4, surf_ux=0.47, surf_uy=0.28, which is very close to the baseline. The approach adds no runtime overhead (it's just an initialization change) and no complexity.

The slight underperformance (35.4 vs 34.44) is likely within run-to-run variance. The orthogonal init doesn't hurt and may slightly stabilize early training, but it doesn't provide a meaningful edge over trunc_normal_ in this setting. The slice projection already benefits from orthogonal init per the original design; extending it to Q/K/V gives marginal benefit at best.

**Suggested follow-ups:**
- This is a marginal negative result — the difference is small enough to be noise. Worth combining with another improvement to see if it helps in aggregate.
- Try orthogonal init for the preprocess MLP weights (in_project_x and in_project_fx) which map to the inner attention dimension.