### PR TITLE
L1 volume loss (replace MSE for volume nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,7 +137,7 @@ for epoch in range(MAX_EPOCHS):
             abs_err = diff.abs()
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=pred.device)
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
@@ -179,10 +179,11 @@ for epoch in range(MAX_EPOCHS):
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                 pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
+            abs_err_val = (pred - y_norm).abs()
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+            val_vol += (abs_err_val * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
             val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 


### PR DESCRIPTION
## Hypothesis
Surface uses L1 (the biggest single improvement in programme history). Volume still uses MSE. Switching volume to L1 creates a consistent optimization landscape. L1 is more robust to outlier volume nodes and provides consistent gradient magnitude.

## Instructions
In `train.py`, change volume loss from MSE to L1:
```python
# Change from:
vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
# To:
vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
```
Also update validation volume loss to L1:
```python
# In val loop, change:
val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
# To:
abs_err_val = (pred - y_norm).abs()
val_vol += (abs_err_val * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
```

Use `--wandb_name "askeladd/l1-volume-loss" --wandb_group mar14 --agent askeladd`

## Baseline
| surf_p | 34.44 | surf_ux | 0.47 | surf_uy | 0.28 |

---

## Results

**W&B run ID:** bxhec820

| Metric | This Run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.6813 | ~0.55 | N/A (loss scale changed) |
| surf_Ux MAE | 0.50 | 0.47 | +6% worse |
| surf_Uy MAE | 0.29 | 0.28 | +4% worse |
| surf_p MAE | 35.68 | 34.44 | +3.6% worse |
| vol_Ux MAE | 2.45 | ~3.0 | -18% better ✓ |
| vol_Uy MAE | 0.92 | ~1.1 | -16% better ✓ |
| vol_p MAE | 52.4 | ~70 | -25% better ✓ |
| Peak VRAM | 2.6 GB | 2.6 GB | 0 |
| Epoch time | ~4.4s | ~4.4s | 0 |
| Epochs completed | 68/70 | 68/70 | same |

**What happened:** Switching volume loss to L1 significantly improved volume accuracy (20-25% across all fields) but hurt surface performance by ~4-6%. The L1 volume loss hypothesis is a tradeoff: it trains a better model for bulk flow prediction at the cost of surface precision.

The most likely cause: MSE amplifies large volume errors, forcing the model to correct big outliers (which may also indirectly benefit boundary region accuracy). L1 treats all volume residuals equally, so the model spends more gradient effort on the typical case at the expense of accurate boundary-adjacent regions.

Note: val/loss is not directly comparable due to the loss scale change (L1 is typically smaller magnitude than MSE for the same prediction quality).

**Suggested follow-ups:**
- Try a weighted combination: e.g., 0.5*MSE + 0.5*L1 for volume to get benefits of both
- If volume accuracy is important, L1 is a clear win — but for the stated goal (surface MAE), MSE volume loss remains better
- Try Huber loss for volume (smooth transition between L1 and MSE, delta tunable)