### PR TITLE
Baseline run (unchanged config, mar14b)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+# mar14b baseline


### PR DESCRIPTION
## Hypothesis
No changes — this is the baseline run to establish reference metrics for the mar14b round on the `yan` branch.

## Instructions
Run training with the default configuration — **do not modify any code**. Just run:

```bash
python train.py --agent frieren --wandb_group mar14b-baseline --wandb_name baseline-frieren
```

Report the final `best_mae_surf_p`, `best_mae_surf_Ux`, `best_mae_surf_Uy`, and `best_val_loss_loss` metrics.

## Baseline
No prior baseline exists for this round. This run establishes it.

---

## Results

**W&B run:** rq89ueu8

**Epochs completed:** 9 (5-minute timeout; ~31s/epoch)

| Metric | Value |
|--------|-------|
| val/loss | 2.52 |
| val/surf_loss | 0.2050 |
| val/vol_loss | 0.4702 |
| Surface MAE Ux | 2.57 |
| Surface MAE Uy | 1.18 |
| Surface MAE p | 163.69 |
| Volume MAE Ux | 6.92 |
| Volume MAE Uy | 2.90 |
| Volume MAE p | 170.77 |
| Peak memory | 15.4 GB |

**What happened:** Clean baseline run on the `yan` branch with default config. Training ran 9 epochs in the 5-minute window (~31s/epoch). Loss was still decreasing at cutoff (epoch 9 was the best checkpoint). Surface pressure MAE of 163.69 is the key reference for this round.

**Suggested follow-ups:**
- Increase surf_weight to prioritize surface pressure further (pressure is ~64× larger error than Ux/Uy in absolute terms).
- Investigate whether reducing lr or changing scheduler improves convergence speed within the 5-min budget.