### PR TITLE
Increase surf_weight from 10 to 15

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# alpha=1 by epoch 4
+# surf_weight=15


### PR DESCRIPTION
## Hypothesis
With the MSE→L1 curriculum, the effective surface loss magnitude has changed (L1 produces smaller gradients than MSE for large errors). Increasing surf_weight from 10 to 15 compensates by giving more weight to surface accuracy in the total loss, pushing the optimizer to prioritize surface predictions more aggressively.

## Instructions

In `train.py`, change the default surf_weight (line 30):

```python
# OLD:
    surf_weight: float = 10.0

# NEW:
    surf_weight: float = 15.0
```

**No other changes.** Run:
```bash
python train.py --surf_weight 15 --agent fern --wandb_group mar14b-sw15 --wandb_name "fern/sw15"
```

## Baseline
| Metric | Value |
|--------|-------|
| **surf_p** | **107.35** |
| surf_Ux | 1.23 |
| surf_Uy | 0.84 |

---

## Results

**W&B run**: `jz3i93hj`
**Epochs completed**: 10 (wall-clock ~5.4 min)
**Best epoch**: 9
**Peak VRAM**: ~15.4 GB

| Metric | This run (sw=15) | Baseline (sw=10) | Delta |
|---|---|---|---|
| val/loss | 3.7779 | 2.45 | +1.33 (expected — higher weight) |
| Surface MAE Ux | 1.22 | 1.23 | -0.01 |
| Surface MAE Uy | 0.86 | 0.84 | +0.02 |
| Surface MAE p | 117.97 | **107.35** | **+10.62 (+9.9%)** |
| Volume MAE Ux | 5.88 | 5.44 | +0.44 |
| Volume MAE Uy | 2.90 | 2.57 | +0.33 |
| Volume MAE p | 169.2 | 152.5 | +16.7 |

**What happened**: Increasing surf_weight to 15 hurt performance — surf_p regressed from 107.35 → 117.97 (+9.9%), and volume metrics also got worse. The higher surface weighting appears to over-concentrate gradient energy on surface nodes at the expense of learning good volume representations, which likely also degrades pressure accuracy on the surface (since pressure is a global field). The current surf_weight=10 with alpha=4 curriculum is the better balance.

**Suggested follow-ups**:
- surf_weight=10 is confirmed good. No further tuning needed here.
- Try lower surf_weight (e.g., 7 or 8) to see if slightly reducing surface pressure allows better volume-guided pressure learning.