### PR TITLE
Input-space Mixup augmentation (Beta(0.4,0.4))

### DIFF
--- a/train.py
+++ b/train.py
@@ -138,6 +138,15 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
+        # Input-space Mixup: interpolate pairs within the batch
+        if x.size(0) > 1:
+            lam = torch.distributions.Beta(0.4, 0.4).sample().item()
+            idx = torch.randperm(x.size(0), device=device)
+            x = lam * x + (1 - lam) * x[idx]
+            y_norm = lam * y_norm + (1 - lam) * y_norm[idx]
+            # Keep original surface mask (conservative); intersect validity masks
+            mask = mask & mask[idx]
+
         pred = model({"x": x, "is_surface": is_surface})["preds"]
         sq_err = (pred - y_norm) ** 2
 


### PR DESCRIPTION
## Hypothesis
The training set has only 809 samples. With 10 epochs of batch_size=4, the model sees each sample only ~10 times. **Data augmentation has never been tried** in any experiment. Input-space Mixup (Zhang et al., 2018) creates virtual training samples by linearly interpolating pairs within each batch: `x_mix = λ*x_a + (1-λ)*x_b`, `y_mix = λ*y_a + (1-λ)*y_b`.

This is well-suited to CFD because the Navier-Stokes equations are approximately linear for small perturbations around a solution. Mixup acts as a strong regularizer without reducing gradient update frequency (unlike dropout, grad accum). It effectively multiplies the training set size, which is critical with only 809 samples.

## Instructions

In `train.py`, add Mixup in the training loop. After normalization of x and y_norm (around line 139), before the forward pass, add:

```python
# Input-space Mixup: interpolate pairs within the batch
if x.size(0) > 1:
    lam = torch.distributions.Beta(0.4, 0.4).sample().item()
    idx = torch.randperm(x.size(0), device=device)
    x = lam * x + (1 - lam) * x[idx]
    y_norm = lam * y_norm + (1 - lam) * y_norm[idx]
    # Keep original surface mask (conservative); intersect validity masks
    mask = mask & mask[idx]
```

The Beta(0.4, 0.4) distribution is bimodal, favoring λ near 0 or 1 (most samples stay close to real data, with occasional strong interpolations). This is gentler than standard Beta(1,1)=Uniform.

**Important:** The `is_surface` mask stays unchanged (use the original). The `mask` must be intersected (`mask & mask[idx]`) so we only train on nodes valid in BOTH mixed samples.

Everything else stays the same — same loss, same curriculum, same hyperparams.

W&B tag: `mar14b`, group: `mixup-input`

## Baseline
- **surf_p = 107.35**, surf_Ux = 1.23, surf_Uy = 0.84, val_loss = 2.45

---

## Results

**W&B run:** `6lt4ritp`  
**Epochs:** 10 (best at epoch 10)  
**Peak memory:** 15.4 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| **surf_p** | **107.35** | **157.6** | **+46.9% ❌** |
| surf_Ux | 1.23 | 1.55 | +26.0% ❌ |
| surf_Uy | 0.84 | 0.98 | +16.7% ❌ |
| vol_loss | — | 0.4443 | — |
| surf_loss | — | 0.3694 | — |

**What happened:** Strong negative result — Mixup massively degraded accuracy on all metrics. The hypothesis that Navier-Stokes is approximately linear doesn't hold for this CFD setting:

1. **Mesh structure incompatibility**: Each sample has a different mesh topology (variable-resolution unstructured meshes). Mixing `x_a` and `x_b` produces a hybrid input where the spatial coordinates don't correspond to any real geometry. The physics attention slices are built on feature similarity in this mixed space, yielding incoherent representations.

2. **Non-linearity of pressure**: Pressure (especially near airfoil surfaces) has highly nonlinear dependence on geometry and flow conditions. Interpolating two pressure fields from different geometries doesn't produce a physically meaningful intermediate. The model must learn to predict "hallucinated" pressure distributions that don't exist.

3. **Convergence slowdown**: Mixup acts as a strong regularizer, preventing overfitting to real samples. With only 10 epochs, the model doesn't recover from this regularization — val metrics are still high at epoch 10, suggesting the model never fully learned from real data.

**Suggested follow-ups:**
- Feature-space Mixup (mix in latent space after `preprocess`, not in input space) might preserve physical coherence better
- If augmentation is desired, try geometry-aware augmentation: small rotations or scaling of the geometry that preserve flow physics
- The small dataset issue (809 samples) may be better addressed by more training epochs or better use of the 5-min budget rather than augmentation