### PR TITLE
Deeper preprocess MLP (2 residual hidden layers)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -198,7 +198,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
The preprocess MLP is a bottleneck: it transforms 18 raw input features (2 spatial + 16 function dims) into 128-dim representations using just two linear layers (n_layers=0 in the MLP class). All 5 physics attention blocks then work with these representations. If the initial projection is too simple, the attention layers are limited by poor input representations.

Adding 2 residual hidden layers to the preprocess MLP gives the model more capacity to learn complex feature transformations *before* the attention layers. The MLP class already supports this via the `n_layers` parameter with residual connections. This adds ~131K params (256×256×2) to a ~400K model — moderate increase, well within VRAM budget.

## Instructions

In `train.py`, change the `model_config` dict. Find the `Transolver` constructor call and modify the MLP architecture by passing a new parameter.

In `transolver.py`, the `Transolver.__init__` creates the preprocess MLP at line 201:
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
```

Change this to use 2 residual hidden layers with residual connections enabled:
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
```

That's the only change — two characters: `n_layers=0` → `n_layers=2` and `res=False` → `res=True`. Everything else stays the same.

W&B tag: `mar14b`, group: `deeper-preprocess`

## Baseline
- **surf_p = 107.35**, surf_Ux = 1.23, surf_Uy = 0.84, val_loss = 2.45

---

## Results

**W&B run:** `z4fd6u2l`  
**Epochs completed:** 9 (hit 5-min wall-clock limit; 35s/epoch vs 31s baseline)  
**Peak memory:** 16.9 GB (+1.5 GB vs baseline 15.4 GB)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| **surf_p** | **107.35** | **118.2** | **+10.2% ❌** |
| surf_Ux | 1.23 | 1.35 | +9.8% ❌ |
| surf_Uy | 0.84 | 0.78 | -7.1% ✓ |
| vol_loss | — | 0.3652 | — |
| surf_loss | — | 0.2247 | — |

**What happened:** Negative result overall. The deeper preprocess MLP made things worse due to two compounding factors:

1. **Epoch budget loss**: The additional layers add ~3s/epoch (35s vs 31s). This reduces the epoch count from 10 to 9 within the 5-minute budget. Looking at the baseline's convergence, epoch 10 often has the best checkpoint — missing it costs real accuracy.

2. **More complex optimization landscape**: The extra residual layers significantly increase the number of parameters (~131K added). With 809 training samples and only 9 epochs, the model doesn't have enough data/steps to fully train these extra parameters. The learning is likely underfitting on the new parameters while overfitting on old ones.

Uy improved slightly (0.78 vs 0.84), which could indicate the deeper representation helps velocity, but it's not worth the surf_p regression.

**Suggested follow-ups:**
- Try `n_layers=1` (single residual layer, less parameter overhead, ~65K params added)
- Profile whether the bottleneck is the preprocess or the attention layers — maybe deeper blocks (mlp_ratio>1) would be better
- Try 1 additional hidden layer in the output MLP head instead (final projection) where the capacity might matter more