### PR TITLE
Channel weight curriculum (1.0→2.0 pressure weight synced with loss curriculum)

### DIFF
--- a/train.py
+++ b/train.py
@@ -144,7 +144,9 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
+        alpha = min(epoch / 4.0, 1.0)  # same schedule as loss curriculum
+        p_weight = 1.0 + alpha * 1.0   # 1.0 during MSE, ramps to 2.0 during L1
+        channel_w = torch.tensor([1.0, 1.0, p_weight], device=device)
         surf_loss = surface_loss_curriculum(pred, y_norm, surf_mask, channel_w, epoch, MAX_EPOCHS)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})


### PR DESCRIPTION
## Hypothesis
Currently `channel_w=[1,1,1.5]` is fixed throughout training. But during the MSE phase (epochs 0-4), MSE already naturally emphasizes pressure more (squaring larger errors). The fixed 1.5x on top of MSE may over-emphasize pressure early, pushing the model into a pressure-specialized basin before learning good shared representations.

During the L1 phase (epochs 4-10), L1 has uniform gradients regardless of error magnitude — so 1.5x may not be *enough* pressure emphasis.

**Key insight:** Fixed channel_w=2.0 was tried before and failed (+6.5%). But it may have failed because 2.0 was too aggressive *during MSE phase*, not because it's wrong *during L1 phase*. By scheduling pressure weight from 1.0 (MSE phase) → 2.0 (L1 phase), we get the best of both: natural MSE emphasis early, stronger explicit emphasis late.

Zero compute overhead — just changing a constant to a scheduled value.

## Instructions

In `train.py`, in the training loop, replace the fixed `channel_w` (line 147):

**Before:**
```python
channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
```

**After:**
```python
alpha = min(epoch / 4.0, 1.0)  # same schedule as loss curriculum
p_weight = 1.0 + alpha * 1.0   # 1.0 during MSE, ramps to 2.0 during L1
channel_w = torch.tensor([1.0, 1.0, p_weight], device=device)
```

**Important:** Keep the validation `channel_w` at `[1.0, 1.0, 1.5]` (line 191) unchanged so metrics remain comparable.

W&B tag: `mar14b`, group: `cosine-channel-curriculum`

## Baseline
- **surf_p = 107.35**, surf_Ux = 1.23, surf_Uy = 0.84, val_loss = 2.45

---

## Results

**W&B run:** `735x4wfw`  
**Epochs:** 10 (best at epoch 10)  
**Peak memory:** 15.4 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| **surf_p** | **107.35** | **113.5** | **+5.7% ❌** |
| surf_Ux | 1.23 | 1.15 | -6.5% ✓ |
| surf_Uy | 0.84 | 0.86 | +2.4% ~ |
| vol_loss | — | 0.3451 | — |
| surf_loss | — | 0.2156 | — |

**What happened:** The channel weight curriculum (1.0 → 2.0 synced with MSE→L1 transition) did not improve surf_p vs the baseline. This is another data point suggesting the channel_w baseline of 1.5 is already near-optimal, and that changes to it in either direction hurt or are neutral. Earlier experiments: channel_w=2.0 fixed gave +6.5%, this scheduled approach gives +5.7% — marginally better but still regressed. The hypothesis that "MSE already naturally emphasizes pressure" may be correct, which is why starting at 1.0 and ramping is no better than staying at 1.5.

Ux improved noticeably (-6.5%) suggesting the lower pressure weight during MSE phase let the model learn better velocity representations early.

**Suggested follow-ups:**
- Try a schedule from 1.5 → 2.0 (keeping the MSE phase at the proven baseline, boosting only in L1 phase)
- The consistent pattern is: channel_w changes don't help. May be time to abandon this axis.
- The bigger wins have come from architectural changes (dual heads, PR #279 brought surf_p to ~107) — further architectural experiments may have more upside