### PR TITLE
Small fast model: 1 layer, 2 heads, slice_num=32, bf16, pure L1

### DIFF
--- a/train.py
+++ b/train.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from tqdm import tqdm
 from torch.utils.data import DataLoader, random_split, Subset
 import simple_parsing as sp
+from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 
 from prepare import FullFieldDataset, pad_collate, DATA_ROOT
 from transolver import Transolver
@@ -21,11 +22,11 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 2e-3
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +81,9 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=10)
+warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 
 # --- wandb ---
@@ -138,19 +141,22 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-        pred = model({"x": x, "is_surface": is_surface})["preds"]
-        sq_err = (pred - y_norm) ** 2
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred = model({"x": x, "is_surface": is_surface})["preds"]
+            sq_err = (pred - y_norm) ** 2
 
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
-        surf_loss = surface_loss_curriculum(pred, y_norm, surf_mask, channel_w, epoch, MAX_EPOCHS)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
+            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
+            abs_err = (pred - y_norm).abs()
+            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()
@@ -181,8 +187,9 @@ for epoch in range(MAX_EPOCHS):
             x = (x - stats["x_mean"]) / stats["x_std"]
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-            pred = model({"x": x, "is_surface": is_surface})["preds"]
-            sq_err = (pred - y_norm) ** 2
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred = model({"x": x, "is_surface": is_surface})["preds"]
+            sq_err = (pred.float() - y_norm) ** 2
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
@@ -191,7 +198,7 @@ for epoch in range(MAX_EPOCHS):
             val_surf += (sq_err * surf_mask.unsqueeze(-1) * channel_w).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
-            pred_orig = pred * stats["y_std"] + stats["y_mean"]
+            pred_orig = pred.float() * stats["y_std"] + stats["y_mean"]
             err = (pred_orig - y).abs()
             mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
             mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))

--- a/transolver.py
+++ b/transolver.py
@@ -62,7 +62,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        tau_init = torch.tensor([[[[0.3]], [[0.8]]]])  # head 0: sharp, head 1: soft
+        self.temperature = nn.Parameter(tau_init)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
We've been stuck at surf_p=107.35 for 22 experiments, all using a 5-layer model at ~31s/epoch (10 epochs in 5 min). A parallel research track (`jurgen` branch) achieved **surf_p ≈ 34.44** with a radically different approach: a **1-layer model** that runs so fast it fits 30+ epochs in the same 5-minute budget. More training iterations on a simpler model dramatically outperforms fewer iterations on a complex one.

This experiment adapts the key elements from that successful configuration while keeping our proven improvements where compatible.

## Instructions

Make the following changes to `train.py`:

### 1. Model config (lines 63-74)
```python
model_config = dict(
    space_dim=2,
    fun_dim=16,
    out_dim=3,
    n_hidden=128,
    n_layers=1,       # was 5
    n_head=2,          # was 4
    slice_num=32,      # was 64
    mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

### 2. Hyperparameters (lines 26-30)
```python
MAX_EPOCHS = 70       # was 50 (smaller model = more epochs in 5 min)

@dataclass
class Config:
    lr: float = 0.006            # was 2e-3 (higher LR for fast convergence)
    weight_decay: float = 0.0    # was 1e-4 (no regularization needed for small model)
    batch_size: int = 4
    surf_weight: float = 10.0
```

### 3. Scheduler (line 83) — replace with warmup + cosine
```python
from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
```

### 4. BF16 autocast — wrap forward pass in training loop (around line 141)
```python
        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
            pred = model({"x": x, "is_surface": is_surface})["preds"]
            # ... all loss computation stays inside autocast block
```
And same in validation loop (around line 184).

### 5. Surface loss — use pure L1 instead of MSE→L1 curriculum
Remove the `surface_loss_curriculum` function. Replace the surface loss computation (line 148) with:
```python
        abs_err = (pred - y_norm).abs()
        channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
        surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
```

### 6. Add gradient clipping (after loss.backward(), line 153)
```python
        optimizer.zero_grad()
        loss.backward()
        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
        optimizer.step()
```

### 7. In `transolver.py` — per-head temperature init (line 65)
Replace:
```python
self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
```
With:
```python
tau_init = torch.tensor([[[[0.3]], [[0.8]]]])  # head 0: sharp, head 1: soft
self.temperature = nn.Parameter(tau_init)
```

**Keep dual output heads** (surface/volume) — this was one of our proven winners.

W&B tag: `mar14b`, group: `small-fast-model`

## Baseline
- **surf_p = 107.35**, surf_Ux = 1.23, surf_Uy = 0.84, val_loss = 2.45

---

## Results

**W&B run:** `svwko19f`  
**Epochs completed:** 67 (4s/epoch! vs 31s for 5-layer model)  
**Best checkpoint:** epoch 64  
**Peak memory:** 2.6 GB (vs 15.4 GB baseline — 6× reduction)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| **surf_p** | **107.35** | **40.7** | **-62.1% ✓✓✓** |
| surf_Ux | 1.23 | 0.57 | -53.7% ✓✓✓ |
| surf_Uy | 0.84 | 0.30 | -64.3% ✓✓✓ |
| vol_loss | — | 0.1210 | — |
| surf_loss | — | 0.0627 | — |

**What happened:** Massive breakthrough — across-the-board ~60% improvement on all surface metrics. The hypothesis is confirmed: with a 1-layer model running at 4s/epoch, we get 67 epochs in the 5-minute budget vs 10 with the 5-layer model. The model converges steadily throughout (still improving at epoch 67) and hasn't plateaued.

Key factors driving the success:
1. **Epoch count**: 67 vs 10 — more gradient updates dramatically improve convergence. The small model is still learning at epoch 67, suggesting even more epochs would help.
2. **Memory efficiency**: 2.6 GB vs 15.4 GB — the 1-layer model is 6× more memory efficient, enabling larger effective batch sizes or longer runs.
3. **BF16 + gradient clipping**: Enables stable higher-LR training without exploding gradients.
4. **Pure L1 loss + high lr=0.006**: With 67 epochs, the model can afford the unstable early L1 phase that hurt 10-epoch experiments.

Note: epoch 63 had surf_p=39.9 (slightly better), but epoch 64 had lower combined val_loss and was the saved checkpoint.

**Suggested follow-ups:**
- Increase MAX_EPOCHS or MAX_TIMEOUT to further exploit the fast convergence — model wasn't done training at epoch 67
- Try n_layers=2 or n_hidden=256 — the 1-layer model runs so fast it might still fit 40+ epochs even with slightly more capacity
- Run the same config without bf16 to isolate its contribution
- The per-head temperature init [0.3, 0.8] is a novel design; verify it's contributing by testing with uniform init