### PR TITLE
Small fast model in FP32 (1 layer, no bf16, more epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -15,17 +15,18 @@ from tqdm import tqdm
 from torch.utils.data import DataLoader, random_split, Subset
 import simple_parsing as sp
 
+from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
 from prepare import FullFieldDataset, pad_collate, DATA_ROOT
 from transolver import Transolver
 from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 50
+MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 2e-3
-    weight_decay: float = 1e-4
+    lr: float = 0.006
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
     dataset: str = "raceCar_single_randomFields"
@@ -65,9 +66,9 @@ model_config = dict(
     fun_dim=16,
     out_dim=3,
     n_hidden=128,
-    n_layers=5,
-    n_head=4,
-    slice_num=64,
+    n_layers=1,
+    n_head=2,
+    slice_num=32,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -80,7 +81,9 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=10)
+warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
+scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 
 # --- wandb ---
@@ -144,13 +147,15 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        abs_err = (pred - y_norm).abs()
         channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
-        surf_loss = surface_loss_curriculum(pred, y_norm, surf_mask, channel_w, epoch, MAX_EPOCHS)
+        surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()
         loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         epoch_vol += vol_loss.item()

--- a/transolver.py
+++ b/transolver.py
@@ -62,7 +62,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        tau_init = torch.tensor([[[[0.3]], [[0.8]]]])
+        self.temperature = nn.Parameter(tau_init)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
PR #305 showed BF16 destabilizes physics attention (+63% surf_p regression). But the jurgen branch achieves surf_p ≈ 34.44 with a 1-layer model. This experiment tests whether the small model architecture works **in FP32** — getting speed from fewer parameters rather than lower precision.

A 1-layer model with 2 heads and 32 slices should be ~5x smaller than baseline, potentially running at ~10-15s/epoch and fitting 20-30 epochs in 5 minutes.

## Instructions

Make the following changes to `train.py`:

### 1. Model config (lines 63-74)
```python
model_config = dict(
    space_dim=2,
    fun_dim=16,
    out_dim=3,
    n_hidden=128,
    n_layers=1,       # was 5
    n_head=2,          # was 4
    slice_num=32,      # was 64
    mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

### 2. Hyperparameters (lines 23-30)
```python
MAX_EPOCHS = 70       # was 50

@dataclass
class Config:
    lr: float = 0.006            # was 2e-3
    weight_decay: float = 0.0    # was 1e-4
    batch_size: int = 4
    surf_weight: float = 10.0
```

### 3. Scheduler (line 83) — replace with 5-epoch warmup + cosine
```python
from torch.optim.lr_scheduler import LinearLR, CosineAnnealingLR, SequentialLR
warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
```

### 4. Surface loss — use pure L1 instead of MSE→L1 curriculum
Remove the `surface_loss_curriculum` function. Replace the surface loss computation (line 148) with:
```python
        abs_err = (pred - y_norm).abs()
        channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
        surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
```

### 5. Add gradient clipping (after loss.backward(), line 153)
```python
        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
```

### 6. In `transolver.py` — per-head temperature init (line 65)
Replace:
```python
self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
```
With:
```python
tau_init = torch.tensor([[[[0.3]], [[0.8]]]])
self.temperature = nn.Parameter(tau_init)
```

**NO bf16 autocast** — keep everything in FP32. **Keep dual output heads** (surface/volume).

W&B tag: `mar14b`, group: `small-model-fp32`

## Baseline
- **surf_p = 107.35**, surf_Ux = 1.23, surf_Uy = 0.84, val_loss = 2.45

---

## Results
_To be filled by student_