### PR TITLE
Remove dual output heads (single unified head)

### DIFF
--- a/train.py
+++ b/train.py
@@ -142,7 +142,7 @@ for epoch in range(MAX_EPOCHS):
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x, "is_surface": is_surface})["preds"]
+            pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
 
             vol_mask = mask & ~is_surface
@@ -188,7 +188,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                pred = model({"x": x, "is_surface": is_surface})["preds"]
+                pred = model({"x": x})["preds"]
             sq_err = (pred.float() - y_norm) ** 2
 
             vol_mask = mask & ~is_surface

--- a/transolver.py
+++ b/transolver.py
@@ -141,20 +141,13 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)       # volume head
-            self.surf_mlp = nn.Linear(hidden_dim, out_dim)    # surface head
+            self.mlp2 = nn.Linear(hidden_dim, out_dim)       # single unified head
 
-    def forward(self, fx, is_surface=None):
+    def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            h = self.ln_3(fx)
-            if is_surface is not None:
-                vol_pred = self.mlp2(h)
-                surf_pred = self.surf_mlp(h)
-                mask = is_surface.unsqueeze(-1).expand_as(vol_pred)
-                return torch.where(mask, surf_pred, vol_pred)
-            return self.mlp2(h)
+            return self.mlp2(self.ln_3(fx))
         return fx
 
 
@@ -274,15 +267,10 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
-        is_surface = data.get("is_surface", None)
-
         fx = self.preprocess(x)
         fx = fx + self.placeholder[None, None, :]
 
         for block in self.blocks:
-            if block.last_layer and is_surface is not None:
-                fx = block(fx, is_surface=is_surface)
-            else:
-                fx = block(fx)
+            fx = block(fx)
         self._validate_output_dims(fx)
         return {"preds": fx}


### PR DESCRIPTION
## Hypothesis
PR #306 found that dual output heads may slightly hurt on the 1-layer model (surf_p=49.2 without dual heads vs 57.6 with, in FP32). With only 1 attention layer, the model has limited capacity — splitting that capacity into separate surface/volume heads may be counterproductive. A single unified head can focus all parameters on learning a shared output mapping.

The dual heads added ~384 params (trivial) but more importantly force the model to maintain separate output representations. With 1 layer, the shared representation may not be rich enough to specialize.

## Instructions

In `transolver.py`, simplify the last layer to use a single output head:

### 1. In `TransolverBlock.__init__` (lines 141-144), replace:
```python
        if self.last_layer:
            self.ln_3 = nn.LayerNorm(hidden_dim)
            self.mlp2 = nn.Linear(hidden_dim, out_dim)       # volume head
            self.surf_mlp = nn.Linear(hidden_dim, out_dim)    # surface head
```
With:
```python
        if self.last_layer:
            self.ln_3 = nn.LayerNorm(hidden_dim)
            self.mlp2 = nn.Linear(hidden_dim, out_dim)       # single unified head
```

### 2. In `TransolverBlock.forward` (lines 146-157), replace:
```python
    def forward(self, fx, is_surface=None):
        fx = self.attn(self.ln_1(fx)) + fx
        fx = self.mlp(self.ln_2(fx)) + fx
        if self.last_layer:
            h = self.ln_3(fx)
            if is_surface is not None:
                vol_pred = self.mlp2(h)
                surf_pred = self.surf_mlp(h)
                mask = is_surface.unsqueeze(-1).expand_as(vol_pred)
                return torch.where(mask, surf_pred, vol_pred)
            return self.mlp2(h)
        return fx
```
With:
```python
    def forward(self, fx):
        fx = self.attn(self.ln_1(fx)) + fx
        fx = self.mlp(self.ln_2(fx)) + fx
        if self.last_layer:
            return self.mlp2(self.ln_3(fx))
        return fx
```

### 3. In `Transolver.forward` (lines 281-285), simplify:
```python
        for block in self.blocks:
            fx = block(fx)
```
(Remove the `is_surface` routing.)

### 4. In `train.py`, remove `is_surface` from model call (lines 142, 185):
```python
        # Training:
        pred = model({"x": x})["preds"]
        # Validation:
        pred = model({"x": x})["preds"]
```

W&B tag: `mar14b`, group: `no-dual-heads`

## Baseline
- **surf_p = 40.7**, surf_Ux = 0.57, surf_Uy = 0.30
- 1-layer model with dual heads, bf16, 67 epochs

---

## Results
_To be filled by student_