### PR TITLE
Higher learning rate (0.006 → 0.008) with adjusted warmup

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 0.006
+    lr: float = 0.008
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 10.0
@@ -81,7 +81,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-warmup = LinearLR(optimizer, start_factor=1e-5/0.006, total_iters=5)
+warmup = LinearLR(optimizer, start_factor=1e-5/0.008, total_iters=5)
 cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 


### PR DESCRIPTION
## Hypothesis
The model is still improving at epoch 70, suggesting it hasn't fully converged. A higher LR (0.008 vs 0.006) with gradient clipping should accelerate convergence, effectively squeezing more learning into the same epoch budget. With only 1 layer and gradient clipping at max_norm=1.0, the model is unlikely to diverge — clipping provides a safety net.

The warmup start_factor also needs to scale proportionally to maintain the warmup ratio.

## Instructions

In `train.py`, make these changes:

### 1. Learning rate (line 28):
```python
    lr: float = 0.008            # was 0.006
```

### 2. Warmup start factor (line 83):
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.008, total_iters=5)
```

That's it — two small changes. Everything else stays the same.

W&B tag: `mar14b`, group: `lr-008`

## Baseline
- **surf_p = 40.1**, surf_Ux = 0.57, surf_Uy = 0.31
- lr=0.006, 1-layer single-head model, 70 epochs at 4s/epoch

---

## Results
_To be filled by student_