### PR TITLE
Higher surface weight (10 → 15) for stronger pressure focus

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,7 +28,7 @@ class Config:
     lr: float = 0.008
     weight_decay: float = 0.0
     batch_size: int = 4
-    surf_weight: float = 10.0
+    surf_weight: float = 15.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
With lr=0.008, the model's val/loss was slightly worse but surf_p improved. This suggests we have headroom to trade overall loss for surface-specific accuracy. Increasing surf_weight from 10 to 15 pushes the optimizer harder on surface predictions at the expense of volume accuracy — a worthwhile trade since surface pressure is our primary metric.

surf_weight=15 was tried before (rounds 7-13) on the old 5-layer model and didn't help, but the dynamics are completely different now with a 1-layer model, higher LR, and pure L1 loss. Worth re-testing in the new regime.

## Instructions

In `train.py`, change one value (line 31):

**Before:**
```python
    surf_weight: float = 10.0
```

**After:**
```python
    surf_weight: float = 15.0
```

That's the only change.

W&B tag: `mar14b`, group: `sw15`

## Baseline
- **surf_p = 39.4**, surf_Ux = 0.58, surf_Uy = 0.31
- surf_weight=10.0, 1-layer, lr=0.008

---

## Results
_To be filled by student_