### PR TITLE
Higher lr (0.008 → 0.010) for faster convergence

### DIFF
--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 0.008
+    lr: float = 0.010
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 15.0
@@ -81,7 +81,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-warmup = LinearLR(optimizer, start_factor=1e-5/0.008, total_iters=5)
+warmup = LinearLR(optimizer, start_factor=1e-5/0.010, total_iters=5)
 cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 


### PR DESCRIPTION
## Hypothesis
Going from lr=0.006 to 0.008 improved surf_p by 1.7% (PR #310). The model is still converging at epoch 70, suggesting we're under-learning per epoch. Pushing lr to 0.010 should accelerate convergence further. Gradient clipping at max_norm=1.0 provides stability. If 0.010 is too aggressive, the clipping will prevent divergence while still allowing faster learning.

## Instructions

In `train.py`, change one value (line 28):

**Before:**
```python
    lr: float = 0.008
```

**After:**
```python
    lr: float = 0.010
```

Also update the warmup start factor (line 83):
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.010, total_iters=5)
```

W&B tag: `mar14b`, group: `lr-010`

## Baseline
- **surf_p = 39.1**, surf_Ux = 0.56, surf_Uy = 0.31
- lr=0.008, surf_weight=15, 70 epochs at 4s/epoch

---

## Results

**W&B run:** `115r99wm`  
**Epochs completed:** 70 (all MAX_EPOCHS; 4s/epoch)  
**Best checkpoint:** epoch 70  
**Peak memory:** 2.6 GB

| Metric | Baseline (lr=0.008) | This run (lr=0.010) | Δ |
|--------|---------|----------|---|
| **surf_p** | **39.1** | **39.7** | **+1.5% ~** |
| surf_Ux | 0.56 | 0.56 | 0% ~ |
| surf_Uy | 0.31 | 0.30 | -3.2% ~ |
| vol_loss | — | 0.1531 | — |
| surf_loss | — | 0.0612 | — |

**What happened:** Essentially neutral result — lr=0.010 performs nearly identically to lr=0.008 on the primary metric (surf_p 39.7 vs 39.1). The incremental LR increase from 0.008 to 0.010 does not provide additional benefit. The training trajectory shows the model still improving at epoch 70, suggesting we're at the model's convergence limit for this LR range, not necessarily LR-limited.

Notably, the cosine scheduler drives LR down to eta_min=1e-4 by epoch 70, so the late-phase learning is well-controlled regardless of starting LR. The marginal difference between lr=0.008 and lr=0.010 becomes negligible by the end of training.

**Suggested follow-ups:**
- LR is likely not the key lever at this point — both 0.008 and 0.010 converge similarly in 70 epochs
- Try increasing MAX_EPOCHS to 100 or extending MAX_TIMEOUT: the model appears to still be learning at epoch 70
- Try a different LR schedule: OneCycleLR or CyclicLR might accelerate early convergence better than warmup+cosine