### PR TITLE
Stronger pressure channel weight (1.5 → 2.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -148,7 +148,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
+            channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
             abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
With surf_weight=15 now merged and helping, we can try further strengthening pressure-specific emphasis via channel_w. Going from [1,1,1.5] to [1,1,2.0] gives the pressure channel even more weight in the surface loss. 

channel_w=2.0 was tested before (round 7-13) on the old 5-layer model with surf_weight=10 and failed. But the dynamics are completely different now: 1-layer model, lr=0.008, surf_weight=15, pure L1, 70 epochs. The combination of higher surf_weight (15) AND higher channel_w (2.0) may push pressure accuracy further.

## Instructions

In `train.py`, change the channel_w in the training loop (line 148):

**Before:**
```python
            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
```

**After:**
```python
            channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
```

That's the only change. Keep validation channel_w at [1,1,1.5] for comparable metrics (line 191).

W&B tag: `mar14b`, group: `chanw-2`

## Baseline
- **surf_p = 39.1**, surf_Ux = 0.56, surf_Uy = 0.31
- channel_w=[1,1,1.5], surf_weight=15

---

## Results
_To be filled by student_