### PR TITLE
Deeper output head (Linear→GELU→Linear instead of single Linear)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -141,7 +141,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)       # single unified head
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
Our output head is a single `Linear(128→3)` — a simple linear projection from hidden dim to 3 output channels. The jurgen branch (which achieved surf_p ≈ 34.44) uses a 2-layer output head: `Linear(128→64) + GELU + Linear(64→3)`. This adds a nonlinear bottleneck that could allow the model to learn more complex output mappings.

With only 1 attention layer, the model's capacity is limited. Adding a nonlinear output head is a cheap way to add expressiveness at the output level without affecting epoch time significantly (~8K extra params, negligible compute).

## Instructions

In `transolver.py`, modify the output head in `TransolverBlock.__init__` (lines 142-144):

**Before:**
```python
        if self.last_layer:
            self.ln_3 = nn.LayerNorm(hidden_dim)
            self.mlp2 = nn.Linear(hidden_dim, out_dim)       # single unified head
```

**After:**
```python
        if self.last_layer:
            self.ln_3 = nn.LayerNorm(hidden_dim)
            self.mlp2 = nn.Sequential(
                nn.Linear(hidden_dim, hidden_dim // 2),
                nn.GELU(),
                nn.Linear(hidden_dim // 2, out_dim),
            )
```

That's the only change. Everything else stays the same.

W&B tag: `mar14b`, group: `deeper-output-head`

## Baseline
- **surf_p = 39.1**, surf_Ux = 0.56, surf_Uy = 0.31
- Single Linear output head, 70 epochs at 4s/epoch

---

## Results
_To be filled by student_