### PR TITLE
Reintroduce MSE→L1 curriculum (alpha=1 by epoch 10, 60 pure L1)

### DIFF
--- a/train.py
+++ b/train.py
@@ -104,7 +104,7 @@ with open(model_dir / "config.yaml", "w") as f:
 
 def surface_loss_curriculum(pred, target, surf_mask, channel_w, epoch, max_epochs):
     """Smoothly interpolate surface loss from MSE to L1."""
-    alpha = min(epoch / 4.0, 1.0)  # 0 at epoch 0, 1.0 at epoch 4
+    alpha = min(epoch / 10.0, 1.0)  # 0 at epoch 0, 1.0 at epoch 10
     diff = pred - target
     sq_err = diff ** 2
     abs_err = diff.abs()
@@ -149,8 +149,7 @@ for epoch in range(MAX_EPOCHS):
             surf_mask = mask & is_surface
             vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
-            abs_err = (pred - y_norm).abs()
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
+            surf_loss = surface_loss_curriculum(pred, y_norm, surf_mask, channel_w, epoch, MAX_EPOCHS)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 


### PR DESCRIPTION
## Hypothesis
The MSE→L1 curriculum was our single biggest win in the early rounds (34% cumulative improvement, rounds 3-6). When we switched to the small fast model (PR #304), we dropped it in favor of pure L1 because the jurgen branch used pure L1. But with 70 epochs available now, we have room for a proper curriculum: MSE in early epochs helps the model learn the right ballpark fast (quadratic gradient scaling), then L1 takes over for robust fine-tuning.

With alpha=1 by epoch 10, the model gets 10 epochs of MSE→L1 transition followed by 60 epochs of pure L1 refinement. This is the best of both worlds — MSE for fast initial convergence, L1 for the long tail.

## Instructions

In `train.py`, add the curriculum function back and modify the surface loss computation.

### 1. Add the curriculum function (before the training loop, around line 102):
```python
def surface_loss_curriculum(pred, target, surf_mask, channel_w, epoch, max_epochs):
    """Smoothly interpolate surface loss from MSE to L1."""
    alpha = min(epoch / 10.0, 1.0)  # 0 at epoch 0, 1.0 at epoch 10
    diff = pred - target
    sq_err = diff ** 2
    abs_err = diff.abs()
    elem_loss = (1.0 - alpha) * sq_err + alpha * abs_err
    masked = elem_loss * surf_mask.unsqueeze(-1) * channel_w
    return masked.sum() / surf_mask.sum().clamp(min=1)
```

### 2. Replace the surface loss in the training loop (around lines 148-150):
**Before:**
```python
            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
            abs_err = (pred - y_norm).abs()
            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
```

**After:**
```python
            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
            surf_loss = surface_loss_curriculum(pred, y_norm, surf_mask, channel_w, epoch, MAX_EPOCHS)
```

Everything else stays the same.

W&B tag: `mar14b`, group: `mse-l1-curriculum`

## Baseline
- **surf_p = 39.1**, surf_Ux = 0.56, surf_Uy = 0.31
- Pure L1 surface loss, 70 epochs at 4s/epoch

---

## Results

**W&B run ID:** h22599pl
**Epochs completed:** 70 (hit epoch limit, not timeout)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 1.1535 | — |
| surf_p | 39.1 | 42.1 | +3.0 (+7.7%) ❌ |
| surf_Ux | 0.56 | 0.60 | +0.04 ❌ |
| surf_Uy | 0.31 | 0.31 | 0.00 ≈ |
| vol_Ux | — | 3.79 | — |
| vol_Uy | — | 1.42 | — |
| vol_p | — | 92.0 | — |

**Best epoch:** 66

### What happened

The MSE→L1 curriculum did **not** improve over pure L1 in this setting. surf_p went from 39.1 → 42.1, a regression of ~8%.

The key difference from the earlier rounds where curriculum helped: back then the model had far fewer epochs due to being larger and slower. The curriculum's MSE phase helped the model converge faster in fewer steps. Now with the small 1-layer model at 4s/epoch completing all 70 epochs, the pure L1 already runs long enough for fine-tuning. Adding the MSE phase for the first 10 epochs may actually slow progress on the metric that matters — the MSE phase (alpha < 1) uses a mixed loss that doesn't optimize directly for L1 accuracy.

In other words: the curriculum was a workaround for limited epoch budget. With 70 epochs of pure L1, we don't need the MSE warmup anymore — it just delays reaching pure L1 refinement.

### Suggested follow-ups

- **Curriculum on volume loss**: The volume loss already uses MSE throughout. We could try an MSE→L1 curriculum on volume too — or flip it and try pure L1 everywhere.
- **Shorter curriculum**: Try alpha=1 by epoch 4 (faster transition) — less MSE warmup might preserve more of the L1 fine-tuning benefit.
- **Pure L1 everywhere**: Try applying L1 to both surface and volume loss, removing MSE entirely.