### PR TITLE
Increase MAX_EPOCHS to 100 (let wall-clock timeout be the limit)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,7 +22,7 @@ from utils import visualize, dataset_stats
 
 
 MAX_TIMEOUT = 5.0 # minutes
-MAX_EPOCHS = 70
+MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 0.008
@@ -82,7 +82,7 @@ model = Transolver(
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 warmup = LinearLR(optimizer, start_factor=1e-5/0.008, total_iters=5)
-cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
+cosine = CosineAnnealingLR(optimizer, T_max=95, eta_min=1e-4)
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 
 


### PR DESCRIPTION
## Hypothesis
The model was still converging at epoch 68 (best checkpoint) in PR #315 and hit the MAX_EPOCHS=70 cap. At 4s/epoch, the 5-minute wall-clock timeout would allow ~75 epochs. But with MAX_EPOCHS=70, we're leaving 5 epochs on the table. Increasing to MAX_EPOCHS=100 removes the artificial cap and lets the wall-clock timeout be the only limit.

Also adjust T_max for the cosine scheduler to match: with T_max=95 (100-5 warmup), the LR schedule covers the full training run. Currently T_max=65 was tuned for the old 70-epoch budget.

## Instructions

### 1. In `train.py`, change MAX_EPOCHS (line 25):
```python
MAX_EPOCHS = 100      # was 70
```

### 2. Adjust cosine scheduler T_max (line 84):
```python
cosine = CosineAnnealingLR(optimizer, T_max=95, eta_min=1e-4)
```

That's it. The wall-clock timeout at 5 minutes will naturally cap training.

W&B tag: `mar14b`, group: `max-epochs-100`

## Baseline
- **surf_p = 35.9**, surf_Ux = 0.49, surf_Uy = 0.29
- MAX_EPOCHS=70, T_max=65, ~70 epochs at 4s/epoch (still converging at ep 68)

---

## Results

**surf_p = 44.2** (baseline: 35.9) — WORSE ❌

| Metric | This run | Baseline (PR #315) |
|--------|----------|--------------------|
| surf_p | 44.2 | 35.9 |
| surf_Ux | 0.59 | 0.49 |
| surf_Uy | 0.34 | 0.29 |
| val/loss | 1.029 | 0.969 |
| Best epoch | 68 | 68 |

W&B run: nhpn9flr

**Analysis:** Wall-clock timeout still caps training at epoch ~68 — same as before. Changing T_max from 65→95 means the cosine LR schedule doesn't finish by the time training stops. At epoch 68, LR was 0.00211 (mid-schedule) vs near eta_min=1e-4 with T_max=65. The incomplete LR decay resulted in worse convergence. The hypothesis that we could squeeze more epochs in 5 min was incorrect — epoch time is ~4.4s, giving ~68 epochs regardless of MAX_EPOCHS cap. **Conclusion: increasing MAX_EPOCHS doesn't help; the wall-clock is the real constraint and the original T_max=65 was better tuned for actual runtime.**
