### PR TITLE
L1 volume loss (consistent loss formulation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,13 +143,11 @@ for epoch in range(MAX_EPOCHS):
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
-
+            abs_err = (pred - y_norm).abs()
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface
-            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+            vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
-            abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
             loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})


### PR DESCRIPTION
## Hypothesis
Currently the volume loss uses MSE (sq_err) while the surface loss uses L1 (abs_err). This inconsistency means the optimizer receives different gradient signals from volume vs surface nodes — MSE emphasizes large errors quadratically while L1 treats all errors equally. Using L1 for both creates a consistent optimization landscape.

Pure L1 has been the better loss for surface predictions in this regime. It may also be better for volume predictions, reducing interference between the two loss components. The volume loss directly affects the shared backbone representations that feed into the output head — better volume loss formulation could indirectly improve surface predictions.

## Instructions

In `train.py`, change the volume loss computation in the training loop (around line 147):

**Before:**
```python
            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
```

**After:**
```python
            vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
```

Note: `abs_err` is already computed on line 149. You may need to move the `abs_err` computation before the `vol_loss` line. Reorganize as:
```python
            abs_err = (pred - y_norm).abs()
            vol_mask = mask & ~is_surface
            surf_mask = mask & is_surface
            vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
```

You can remove the `sq_err` computation since it's no longer needed in the training loop.

W&B tag: `mar14b`, group: `l1-vol-loss`

## Baseline
- **surf_p = 35.9**, surf_Ux = 0.49, surf_Uy = 0.29
- Volume MSE + Surface L1, 70 epochs at 4s/epoch

---

## Results

**W&B run ID:** w98yt6da
**Epochs completed:** 70 (hit epoch limit, not timeout)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 0.9744 | — |
| surf_p | 35.9 | 36.6 | +0.7 (+2.0%) ❌ |
| surf_Ux | 0.49 | 0.51 | +0.02 ❌ |
| surf_Uy | 0.29 | 0.28 | -0.01 ✓ |
| vol_Ux | — | 2.59 | — |
| vol_Uy | — | 0.99 | — |
| vol_p | — | 54.6 | — |

**Best epoch:** 68

### What happened

L1 volume loss did **not** improve surface accuracy vs baseline — surf_p went 35.9 → 36.6, a small regression. The result is essentially neutral (within noise), but slightly worse on the most important metric.

The hypothesis that consistent L1 gradients would reduce interference doesn't appear to hold in practice. One explanation: MSE on volume may actually be beneficial as a regularizer for the backbone representations — quadratic penalty on large volume errors forces the model to learn globally accurate volume predictions, which may provide better geometric scaffolding for surface fine-tuning. With pure L1 volume loss, the model may tolerate larger volume errors that don't directly affect the surface metric.

The val/loss dropped (0.97 vs baseline), which is misleading — the loss scale changed because vol_loss is now L1 instead of MSE, making it numerically smaller. The actual surface MAE worsened slightly, which is what matters.

### Suggested follow-ups

- **Keep MSE for volume**: This result suggests MSE volume loss is better. The baseline asymmetry (MSE vol + L1 surf) may be intentionally useful — MSE captures gross accuracy for volume, L1 for surface robustness.
- **Higher surf_weight with L1 vol**: If L1 vol loss is numerically smaller than MSE, the effective relative weight on surface increases — could try adjusting surf_weight to compensate.
- **Volume loss weight tuning**: Rather than switching loss functions, tune how much volume loss contributes to overall training.