### PR TITLE
Higher surface weight (15 → 20)

### DIFF
--- a/train.py
+++ b/train.py
@@ -28,7 +28,7 @@ class Config:
     lr: float = 0.008
     weight_decay: float = 1e-5
     batch_size: int = 4
-    surf_weight: float = 15.0
+    surf_weight: float = 20.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)
     wandb_name: str | None = None  # name for this specific run


### PR DESCRIPTION
## Hypothesis
Going from surf_weight=10 to 15 (PR #312) improved surf_p by 0.8%. Pushing to 20 tests whether we can extract more surface accuracy by further trading off volume accuracy. The model now has weight_decay=1e-5 which helps prevent the potential overfitting from aggressive surface weighting.

## Instructions

In `train.py`, change one value (line 31):

**Before:**
```python
    surf_weight: float = 15.0
```

**After:**
```python
    surf_weight: float = 20.0
```

That's the only change.

W&B tag: `mar14b`, group: `sw20`

## Baseline
- **surf_p = 35.6**, surf_Ux = 0.49, surf_Uy = 0.28
- surf_weight=15.0

---

## Results

**surf_p = 36.2** (baseline: 35.6) — WORSE ❌

| Metric | This run | Baseline (PR #319) |
|--------|----------|--------------------|
| surf_p | 36.2 | 35.6 |
| surf_Ux | 0.46 | 0.49 |
| surf_Uy | 0.28 | 0.28 |
| val/loss | 1.244 | 0.975 |
| Best epoch | 67 | 67 |

W&B run: e8yw6pmy

**Analysis:** surf_weight=20 made things worse despite the prior trend from 10→15. The val/loss jumped from 0.975→1.244 (inflated by the larger weight multiplier). While surf_Ux improved slightly (0.46 vs 0.49), surf_p regressed (36.2 vs 35.6). This suggests surf_weight=15 is near the optimum — pushing higher over-penalizes volume accuracy in ways that hurt overall generalization. **Conclusion: surf_weight=15 remains the best setting.**
