### PR TITLE
Halve volume loss weight (1.0 → 0.5) to prioritize surface

### DIFF
--- a/train.py
+++ b/train.py
@@ -151,7 +151,7 @@ for epoch in range(MAX_EPOCHS):
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
             abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            loss = vol_loss + cfg.surf_weight * surf_loss
+            loss = 0.5 * vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
Currently `loss = 1.0 * vol_loss + 15.0 * surf_loss`. The volume loss anchors the backbone representations but may also pull them toward volume-optimal features that aren't ideal for surface predictions. Halving the volume weight to 0.5 gives even more relative emphasis to surface accuracy while still maintaining some volume regularization.

This is a different axis than surf_weight: instead of increasing the surface side, we're decreasing the volume side. The effect is similar but not identical — reducing vol_loss weight means volume errors contribute less gradient, freeing the backbone to focus more on surface-relevant features.

## Instructions

In `train.py`, change the loss computation (line 151):

**Before:**
```python
            loss = vol_loss + cfg.surf_weight * surf_loss
```

**After:**
```python
            loss = 0.5 * vol_loss + cfg.surf_weight * surf_loss
```

That's the only change.

W&B tag: `mar14b`, group: `vol-weight-half`

## Baseline
- **surf_p = 35.6**, surf_Ux = 0.49, surf_Uy = 0.28
- loss = 1.0 * vol_loss + 15.0 * surf_loss

---

## Results

**W&B run ID:** 3i8aungv
**Epochs completed:** 70 (hit epoch limit, not timeout)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 0.9697 | — |
| surf_p | 35.6 | 35.7 | +0.1 (~neutral) ≈ |
| surf_Ux | 0.49 | 0.50 | +0.01 ≈ |
| surf_Uy | 0.28 | 0.28 | 0.00 ≈ |
| vol_Ux | — | 3.77 | — |
| vol_Uy | — | 1.38 | — |
| vol_p | — | 90.3 | — |

**Best epoch:** 68

### What happened

Halving the volume loss weight produced **no meaningful change** — results are essentially identical to baseline (within noise). surf_p is 35.7 vs baseline 35.6, a difference of 0.1 that's within run-to-run variance.

This suggests the current vol_weight=1.0 is not a significant bottleneck. The model is already optimizing primarily for surface accuracy at the current balance (surf_weight=15 effectively means surface loss dominates the gradient). Reducing vol from 1.0 to 0.5 doesn't noticeably shift the optimization landscape.

One interpretation: the gradient signal from the volume loss (even at 1.0×) is already small enough relative to the surface signal (15×) that halving it further has no effect.

### Suggested follow-ups

- **vol_weight=0**: Try removing volume loss entirely to see if it helps or hurts surface accuracy. This would clarify whether volume regularization is needed at all.
- **vol_weight=2.0**: Try the opposite direction — more volume loss as a regularizer for the backbone.
- **Different vol_weight with L1 vol**: The earlier L1 vol experiment (PR #318) had numerically smaller vol_loss; the effective contribution was already reduced without adjusting the weight.