### PR TITLE
Select best checkpoint by mae_surf_p (not val_loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -237,8 +237,9 @@ for epoch in range(MAX_EPOCHS):
         peak_mem_gb = 0.0
 
     tag = ""
-    if val_loss < best_val:
-        best_val = val_loss
+    current_surf_p = mae_surf[2].item()  # pressure channel MAE
+    if current_surf_p < best_val:
+        best_val = current_surf_p
         best_metrics = {
             "mae_vol_Ux": mae_vol[0].item(),
             "mae_vol_Uy": mae_vol[1].item(),


### PR DESCRIPTION
## Hypothesis
Currently the best checkpoint is selected by lowest `val_loss` (MSE-based combined loss). But our primary metric is `mae_surf_p` (L1-based surface pressure error). These might not agree — the epoch with the lowest combined MSE loss may not be the epoch with the lowest surface pressure MAE. By selecting the checkpoint that directly minimizes our target metric, we could get a better final model for free.

This is a zero-cost change — same training, same epochs, just a different checkpoint selection criterion.

## Instructions

In `train.py`, change the checkpoint selection criterion (around lines 233-246).

**Before:**
```python
    tag = ""
    if val_loss < best_val:
        best_val = val_loss
        best_metrics = {
            ...
        }
        torch.save(model.state_dict(), model_path)
        tag = f" * -> {model_path}"
```

**After:**
```python
    tag = ""
    current_surf_p = mae_surf[2].item()  # pressure channel MAE
    if current_surf_p < best_val:
        best_val = current_surf_p
        best_metrics = {
            ...
        }
        torch.save(model.state_dict(), model_path)
        tag = f" * -> {model_path}"
```

Also change the initialization of `best_val` (line 113):
```python
best_val = float("inf")  # now tracks best mae_surf_p instead of val_loss
```

And update the `best_metrics` dict to include `val_loss_loss` still (for W&B reporting):
```python
        best_metrics = {
            "mae_vol_Ux": mae_vol[0].item(),
            "mae_vol_Uy": mae_vol[1].item(),
            "mae_vol_p": mae_vol[2].item(),
            "mae_surf_Ux": mae_surf[0].item(),
            "mae_surf_Uy": mae_surf[1].item(),
            "mae_surf_p": mae_surf[2].item(),
            "epoch": epoch + 1,
            "val_loss_loss": val_loss,
        }
```

W&B tag: `mar14b`, group: `best-by-surf-p`

## Baseline
- **surf_p = 35.6**, surf_Ux = 0.49, surf_Uy = 0.28
- Best checkpoint selected by val_loss (MSE-based)

---

## Results

**surf_p = 35.9** (baseline: 35.6) — no improvement ❌

| Metric | This run | Baseline (PR #319) |
|--------|----------|--------------------|
| surf_p | 35.9 | 35.6 |
| surf_Ux | 0.54 | 0.49 |
| surf_Uy | 0.28 | 0.28 |
| val/loss | 0.955 | 0.975 |
| Best epoch | 68 | 67 |

W&B run: urj7tvd8

**Analysis:** Selecting the checkpoint by mae_surf_p instead of val_loss made no improvement (35.9 vs 35.6). The val_loss and mae_surf_p metrics are highly correlated — the best epoch by either criterion tends to be the same. The hypothesis that they diverge in this regime was incorrect. **Conclusion: revert to val_loss-based checkpoint selection (baseline is better).**
