### PR TITLE
Sharper temperature init for head 0 ([0.3,0.8] → [0.1,0.8])

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -62,7 +62,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        tau_init = torch.tensor([[[[0.3]], [[0.8]]]])  # head 0: sharp, head 1: soft
+        tau_init = torch.tensor([[[[0.1]], [[0.8]]]])  # head 0: very sharp, head 1: soft
         self.temperature = nn.Parameter(tau_init)
 
         self.in_project_x = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
The physics attention temperature controls how sharply each head partitions nodes into slices. Head 0 currently starts at τ=0.3 (moderately sharp) and head 1 at τ=0.8 (soft). Making head 0 sharper (τ=0.1) creates a stronger contrast between the two heads: one that forms very tight, focused local physics groups and one that maintains broad global context. This diversity in attention patterns could help the 1-layer model capture both local boundary-layer effects and global flow patterns.

The temperature is learnable so it can adjust during training, but the initial value sets the optimization basin.

## Instructions

In `transolver.py`, change the temperature initialization (line 65):

**Before:**
```python
tau_init = torch.tensor([[[[0.3]], [[0.8]]]])  # head 0: sharp, head 1: soft
```

**After:**
```python
tau_init = torch.tensor([[[[0.1]], [[0.8]]]])  # head 0: very sharp, head 1: soft
```

That's the only change.

W&B tag: `mar14b`, group: `sharper-temp`

## Baseline
- **surf_p = 35.6**, surf_Ux = 0.49, surf_Uy = 0.28

---

## Results

**surf_p = 37.1** (baseline: 35.6) — WORSE ❌

| Metric | This run | Baseline (PR #319) |
|--------|----------|--------------------|
| surf_p | 37.1 | 35.6 |
| surf_Ux | 0.53 | 0.49 |
| surf_Uy | 0.30 | 0.28 |
| val/loss | 1.016 | 0.975 |
| Best epoch | 67 | 67 |

W&B run: ezici4gw

**Analysis:** τ=0.1 for head 0 (very sharp) hurt performance. An extremely sharp temperature initialization creates near-hard assignment of nodes to slices, which reduces the model's flexibility in early training and may lead to poor slice partitions that are hard to escape. The original τ=0.3 provides a better starting point that balances sharpness with gradient flow. **Conclusion: τ=[0.3, 0.8] remains better.**
