### PR TITLE
Tighter output head bottleneck (128→32→GELU→3 instead of 128→64→GELU→3)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -142,9 +142,9 @@ class TransolverBlock(nn.Module):
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.Linear(hidden_dim, hidden_dim // 4),
                 nn.GELU(),
-                nn.Linear(hidden_dim // 2, out_dim),
+                nn.Linear(hidden_dim // 4, out_dim),
             )
 
     def forward(self, fx):


### PR DESCRIPTION
## Hypothesis
The output head bottleneck is currently `hidden_dim // 2 = 64`. A tighter bottleneck at `hidden_dim // 4 = 32` forces more information compression before the final output projection. This acts as an implicit regularizer — the model must learn a more compact, generalizable representation of the output mapping. With target noise already providing explicit regularization, the combination could push generalization further.

This also reduces parameters slightly (128*32 + 32*3 = 4192 vs 128*64 + 64*3 = 8384 → ~4K fewer params), which is negligible for compute but may help prevent overfitting.

## Instructions

In `transolver.py`, change the output head bottleneck dimension (lines 143-147):

**Before:**
```python
            self.mlp2 = nn.Sequential(
                nn.Linear(hidden_dim, hidden_dim // 2),
                nn.GELU(),
                nn.Linear(hidden_dim // 2, out_dim),
            )
```

**After:**
```python
            self.mlp2 = nn.Sequential(
                nn.Linear(hidden_dim, hidden_dim // 4),
                nn.GELU(),
                nn.Linear(hidden_dim // 4, out_dim),
            )
```

That's the only change — `// 2` → `// 4` in two places.

W&B tag: `mar14b`, group: `tighter-bottleneck`

## Baseline
- **surf_p = 35.5**, surf_Ux = 0.46, surf_Uy = 0.29

---

## Results

**W&B run ID:** 4vt8vc0f
**Epochs completed:** 70 (hit epoch limit, not timeout)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 0.9881 | — |
| surf_p | 35.5 | 36.9 | +1.4 (+3.9%) ❌ |
| surf_Ux | 0.46 | 0.53 | +0.07 ❌ |
| surf_Uy | 0.29 | 0.29 | 0.00 ≈ |
| vol_Ux | — | 3.32 | — |
| vol_Uy | — | 1.22 | — |
| vol_p | — | 80.7 | — |

**Best epoch:** 68

### What happened

The tighter bottleneck (128→32) **hurt performance** significantly on all key metrics. surf_p worsened 35.5 → 36.9 (+3.9%) and surf_Ux worsened 0.46 → 0.53 (+15%).

The 32-dim bottleneck is too narrow for a 128-dim backbone — it creates too much information compression before the output projection. The output head needs enough capacity to map the 128-dim feature space to 3 output channels accurately. With 32 dims, the head is forced to discard useful information. This is over-regularization.

The 64-dim bottleneck (//2) appears to be the right balance for this model size. The target noise already provides sufficient regularization; making the output head narrower just reduces capacity without adding useful regularization signal.

### Suggested follow-ups

- **Keep 64-dim bottleneck**: This result confirms the current output head size is appropriate.
- **Wider bottleneck (hidden_dim)**: Try removing the bottleneck entirely — use a single linear layer `128→3` to see if the GELU + bottleneck adds value at all.
- **Direct linear head**: Replace the whole MLP2 with `nn.Linear(hidden_dim, out_dim)` — fewer parameters, simpler, may be sufficient given the target noise regularization.