### PR TITLE
Batch size 2 (double gradient updates per epoch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ MAX_EPOCHS = 70
 class Config:
     lr: float = 0.008
     weight_decay: float = 1e-5
-    batch_size: int = 4
+    batch_size: int = 2
     surf_weight: float = 15.0
     dataset: str = "raceCar_single_randomFields"
     wandb_group: str | None = None  # group related runs (e.g. iterations on the same idea)


### PR DESCRIPTION
## Hypothesis
With batch_size=4, we get ~202 gradient updates per epoch. Halving to batch_size=2 doubles this to ~405 updates per epoch. With the tiny 1-layer model (2.6GB VRAM), we have massive headroom — even with smaller batches, VRAM won't be an issue.

More gradient updates per epoch means faster convergence in epoch-limited training. The noisier gradients from smaller batches also act as implicit regularization (similar to how target noise helped in PR #324).

The tradeoff is potentially slower epochs due to more Python/CUDA kernel launch overhead, but with the tiny model this should be minimal.

## Instructions

In `train.py`, change one value (line 30):

**Before:**
```python
    batch_size: int = 4
```

**After:**
```python
    batch_size: int = 2
```

That's the only change.

W&B tag: `mar14b`, group: `bs2`

## Baseline
- **surf_p = 35.5**, surf_Ux = 0.46, surf_Uy = 0.29
- batch_size=4, ~202 updates/epoch, ~68 epochs at 4s/epoch

---

## Results

**surf_p = 37.0** (baseline: 35.6) — WORSE ❌

| Metric | This run | Baseline (PR #319) |
|--------|----------|--------------------|
| surf_p | 37.0 | 35.6 |
| surf_Ux | 0.44 | 0.49 |
| surf_Uy | 0.28 | 0.28 |
| val/loss | 0.997 | 0.975 |
| Best epoch | 64 | 67 |
| Epoch time | 4.69s | 4.40s |

W&B run: h3tdh8qu

**Analysis:** batch_size=2 increased epoch time from 4.4s → 4.7s (+7%) due to kernel launch overhead with more iterations. This reduced total epochs from ~68 to 64. The cosine schedule only reached LR=0.00026 (vs eta_min=1e-4), meaning training stopped before the LR fully decayed. Worse surf_p despite more gradient updates per epoch. **Conclusion: batch_size=4 is better — smaller batches slow epochs enough to hurt within the fixed wall-clock budget.**
