### PR TITLE
FP32 loss computation (forward pass stays bf16)

### DIFF
--- a/train.py
+++ b/train.py
@@ -146,15 +146,17 @@ for epoch in range(MAX_EPOCHS):
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
-            sq_err = (pred - y_norm) ** 2
 
-            vol_mask = mask & ~is_surface
-            surf_mask = mask & is_surface
-            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
-            abs_err = (pred - y_norm).abs()
-            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            loss = vol_loss + cfg.surf_weight * surf_loss
+        # Loss computation in fp32 for precision
+        pred = pred.float()
+        sq_err = (pred - y_norm) ** 2
+        vol_mask = mask & ~is_surface
+        surf_mask = mask & is_surface
+        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
+        abs_err = (pred - y_norm).abs()
+        surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
+        loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
Currently the entire forward pass AND loss computation happen inside `torch.amp.autocast("cuda", dtype=torch.bfloat16)`. This means `sq_err`, `abs_err`, and the loss accumulation are all in bf16. BF16 has only ~3 decimal digits of precision — when computing `sq_err = (pred - y_norm) ** 2`, small differences get truncated, and the loss gradients lose precision.

By moving only the loss computation outside autocast (keeping the forward pass in bf16 for speed), we get full fp32 precision on the loss while maintaining the bf16 speed advantage for the heavy matrix multiplications.

## Instructions

In `train.py`, restructure the autocast block in the training loop (lines 144-154):

**Before:**
```python
        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
            pred = model({"x": x})["preds"]
            sq_err = (pred - y_norm) ** 2

            vol_mask = mask & ~is_surface
            surf_mask = mask & is_surface
            vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
            channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
            abs_err = (pred - y_norm).abs()
            surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
            loss = vol_loss + cfg.surf_weight * surf_loss
```

**After:**
```python
        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
            pred = model({"x": x})["preds"]

        # Loss computation in fp32 for precision
        pred = pred.float()
        sq_err = (pred - y_norm) ** 2
        vol_mask = mask & ~is_surface
        surf_mask = mask & is_surface
        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
        channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
        abs_err = (pred - y_norm).abs()
        surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
        loss = vol_loss + cfg.surf_weight * surf_loss
```

That's it — move everything after `pred = model(...)` outside autocast, and add `pred = pred.float()`.

W&B tag: `mar14b`, group: `fp32-loss`

## Baseline
- **surf_p = 35.5**, surf_Ux = 0.46, surf_Uy = 0.29

---

## Results

**W&B run ID:** ls9wlrgo
**Epochs completed:** 68 (hit timeout, 5.0 min)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 0.9954 | — |
| surf_p | 35.5 | 36.7 | +1.2 (+3.4%) ❌ |
| surf_Ux | 0.46 | 0.47 | +0.01 ≈ |
| surf_Uy | 0.29 | 0.29 | 0.00 ≈ |
| vol_Ux | — | 3.21 | — |
| vol_Uy | — | 1.16 | — |
| vol_p | — | 72.9 | — |

**Best epoch:** 67

### What happened

FP32 loss computation **did not improve** surface accuracy — surf_p worsened 35.5 → 36.7. The precision hypothesis doesn't hold here.

The current training already works well in bf16. The model's intermediate activations are already bf16 throughout the forward pass, so the final loss gradients that flow back are already bf16-precision. Converting `pred.float()` before the loss gives fp32 precision for the loss computation, but the gradients still flow back through the bf16 backward pass through the model. The actual gradient precision bottleneck is in the backbone, not the loss layer.

Additionally, fp32 loss computation adds marginal overhead and changes the numerical dynamics slightly — this may explain the slight performance degradation.

### Suggested follow-ups

- **Keep bf16 loss**: This result confirms the bf16 loss computation is fine. The precision issue is not a bottleneck.
- **Full fp32 training**: If precision matters, switch the entire model to fp32 (remove autocast). This would be slower but might close the precision gap more completely — though likely not worth it given VRAM and speed trade-offs.