### PR TITLE
Residual skip connection in output head

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -146,12 +146,14 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim // 2, out_dim),
             )
+            self.out_skip = nn.Linear(hidden_dim, out_dim)
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            return self.mlp2(h) + self.out_skip(h)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The output head is `Linear(128→64) → GELU → Linear(64→3)`. The GELU activation creates an information bottleneck — hidden units with large negative pre-activation have near-zero gradient. Adding a residual linear shortcut from 128-dim directly to 3-dim output changes the gradient flow: the GELU path only needs to learn a *correction* to the linear prediction, and gradients flow unimpeded through the skip path.

This is qualitatively different from all previous experiments — it changes gradient flow topology, not hyperparameters. Cost: +387 params (0.2% of 177K), one tiny 128×3 matmul.

## Instructions

In `transolver.py`, modify `TransolverBlock.__init__` (lines 142-147):

**Before:**
```python
        if self.last_layer:
            self.ln_3 = nn.LayerNorm(hidden_dim)
            self.mlp2 = nn.Sequential(
                nn.Linear(hidden_dim, hidden_dim // 2),
                nn.GELU(),
                nn.Linear(hidden_dim // 2, out_dim),
            )
```

**After:**
```python
        if self.last_layer:
            self.ln_3 = nn.LayerNorm(hidden_dim)
            self.mlp2 = nn.Sequential(
                nn.Linear(hidden_dim, hidden_dim // 2),
                nn.GELU(),
                nn.Linear(hidden_dim // 2, out_dim),
            )
            self.out_skip = nn.Linear(hidden_dim, out_dim)
```

Modify `TransolverBlock.forward` (line 152-153):

**Before:**
```python
        if self.last_layer:
            return self.mlp2(self.ln_3(fx))
```

**After:**
```python
        if self.last_layer:
            h = self.ln_3(fx)
            return self.mlp2(h) + self.out_skip(h)
```

That's it — two small changes in one file.

W&B tag: `mar14b`, group: `output-skip`

## Baseline
- **surf_p ≈ 35.5** (±2-3 variance), surf_Ux = 0.46, surf_Uy = 0.29

---

## Results

**W&B run ID:** q2hw4y53
**Epochs completed:** 70 (hit epoch limit, not timeout)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 1.0725 | — |
| surf_p | 35.5 | 40.1 | +4.6 (+13%) ❌ |
| surf_Ux | 0.46 | 0.56 | +0.10 ❌ |
| surf_Uy | 0.29 | 0.30 | +0.01 ❌ |
| vol_Ux | — | 3.39 | — |
| vol_Uy | — | 1.29 | — |
| vol_p | — | 87.1 | — |

**Best epoch:** 63 (earlier plateau)

### What happened

The output skip connection **significantly hurt** performance — surf_p worsened 35.5 → 40.1 (+13%). This is a large regression across all metrics.

The hypothesis about improved gradient flow doesn't hold here. One explanation: the skip connection adds a direct linear mapping that may interfere with the carefully learned nonlinear output head. The model now has two competing output paths (nonlinear through mlp2, linear through out_skip), and their sum may produce less accurate predictions than the single nonlinear path alone.

Another explanation: the skip connection makes the optimization landscape less smooth — the model must learn both paths to work together correctly, which is harder than learning a single path. The training seems to plateau earlier (epoch 63 vs 67-68 typical), suggesting optimization difficulties.

The current `128→64→GELU→3` output head appears well-suited for this task. The bottleneck + nonlinearity provides the right inductive bias for predicting 3 continuous physical fields.

### Suggested follow-ups

- **Keep current output head**: This result confirms the existing two-layer nonlinear head is effective. Skip connections in the output head add complexity without benefit.
- **Direct linear head**: Try the opposite extreme — single `Linear(128→3)` with no nonlinearity and no bottleneck, to understand what the GELU bottleneck contributes.