### PR TITLE
Physics-based target normalization (predict Cp coefficients)

### DIFF
--- a/train.py
+++ b/train.py
@@ -6,6 +6,7 @@
 
 import os
 import time
+import numpy as np
 import torch
 import wandb
 import yaml
@@ -55,6 +56,26 @@ if cfg.debug:
 print(f"Train: {len(train_ds)}, Val: {len(val_ds)}")
 
 stats = {k: v.to(device) for k, v in dataset_stats[cfg.dataset].items()}
+
+# Precompute physics-scaled target normalization stats
+print("Computing physics-scaled normalization stats...")
+_scaled_sum = torch.zeros(3, dtype=torch.float64)
+_scaled_sq_sum = torch.zeros(3, dtype=torch.float64)
+_n_total = 0
+for _i in range(len(ds)):
+    _x_i, _y_i, _ = ds[_i]
+    _log_re = _x_i[0, 13].item()  # log(Re), constant across nodes
+    _umag = float(np.exp(_log_re)) * 1.461e-5  # Umag = Re * nu / c (nu=1.461e-5)
+    _q = 0.5 * 1.225 * _umag ** 2  # dynamic pressure (rho=1.225)
+    _scale = torch.tensor([_umag, _umag, _q], dtype=torch.float64)
+    _y_scaled = _y_i.double() / _scale
+    _scaled_sum += _y_scaled.sum(dim=0)
+    _scaled_sq_sum += (_y_scaled ** 2).sum(dim=0)
+    _n_total += _y_i.shape[0]
+_phys_y_mean = (_scaled_sum / _n_total).float()
+_phys_y_std = ((_scaled_sq_sum / _n_total - _phys_y_mean.double() ** 2).sqrt()).float()
+phys_y_stats = {"y_mean": _phys_y_mean.to(device), "y_std": _phys_y_std.to(device)}
+print(f"  Physics y_mean={_phys_y_mean.tolist()}, y_std={_phys_y_std.tolist()}")
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
@@ -138,8 +159,17 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
+        # Extract per-sample Umag from log_Re (feature 13) BEFORE x normalization
+        log_re = x[:, 0, 13]  # (B,) -- constant across nodes
+        umag = torch.exp(log_re) * 1.461e-5
+        q = 0.5 * 1.225 * umag ** 2
+        phys_scale = torch.stack([umag, umag, q], dim=-1)  # (B, 3)
+
         x = (x - stats["x_mean"]) / stats["x_std"]
-        y_norm = (y - stats["y_mean"]) / stats["y_std"]
+
+        # Physics-based target normalization
+        y_scaled = y / phys_scale[:, None, :]
+        y_norm = (y_scaled - phys_y_stats["y_mean"]) / phys_y_stats["y_std"]
 
         # Target noise regularization (only during training)
         y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
@@ -187,8 +217,14 @@ for epoch in range(MAX_EPOCHS):
             is_surface = is_surface.to(device, non_blocking=True)
             mask = mask.to(device, non_blocking=True)
 
+            log_re_val = x[:, 0, 13]
+            umag_val = torch.exp(log_re_val) * 1.461e-5
+            q_val = 0.5 * 1.225 * umag_val ** 2
+            phys_scale_val = torch.stack([umag_val, umag_val, q_val], dim=-1)
+
             x = (x - stats["x_mean"]) / stats["x_std"]
-            y_norm = (y - stats["y_mean"]) / stats["y_std"]
+            y_scaled = y / phys_scale_val[:, None, :]
+            y_norm = (y_scaled - phys_y_stats["y_mean"]) / phys_y_stats["y_std"]
 
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                 pred = model({"x": x})["preds"]
@@ -201,7 +237,9 @@ for epoch in range(MAX_EPOCHS):
             val_surf += (sq_err * surf_mask.unsqueeze(-1) * channel_w).sum().item() / surf_mask.sum().clamp(min=1).item()
             n_val += 1
 
-            pred_orig = pred.float() * stats["y_std"] + stats["y_mean"]
+            # Reverse physics scaling for original-scale MAE
+            pred_scaled = pred.float() * phys_y_stats["y_std"] + phys_y_stats["y_mean"]
+            pred_orig = pred_scaled * phys_scale_val[:, None, :]
             err = (pred_orig - y).abs()
             mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
             mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))


### PR DESCRIPTION
## Hypothesis
Global normalization creates a ~40x spread in normalized pressure variance across Reynolds numbers. High-Re samples dominate the loss (mean|p| = 1089 vs 21 for low-Re). By normalizing targets per-sample using physical scaling laws — divide velocities by Umag, pressure by dynamic pressure q = 0.5·ρ·Umag² — the model predicts non-dimensional coefficients (Cp) with uniform O(1) variance across all Reynolds numbers. This converts a heterogeneous multi-scale regression into a uniform prediction problem.

This is a fundamentally different approach — changing what the model predicts, not how it trains.

## Instructions

### 1. Add `import numpy as np` at the top of `train.py`

### 2. After `stats` loading (line 57), compute physics-scaled stats:
```python
import numpy as np

# Precompute physics-scaled target normalization stats
print("Computing physics-scaled normalization stats...")
_scaled_sum = torch.zeros(3, dtype=torch.float64)
_scaled_sq_sum = torch.zeros(3, dtype=torch.float64)
_n_total = 0
for _i in range(len(ds)):
    _x_i, _y_i, _ = ds[_i]
    _log_re = _x_i[0, 13].item()  # log(Re), constant across nodes
    _umag = float(np.exp(_log_re)) * 1.461e-5  # Umag = Re * nu / c (nu=1.461e-5)
    _q = 0.5 * 1.225 * _umag ** 2  # dynamic pressure (rho=1.225)
    _scale = torch.tensor([_umag, _umag, _q], dtype=torch.float64)
    _y_scaled = _y_i.double() / _scale
    _scaled_sum += _y_scaled.sum(dim=0)
    _scaled_sq_sum += (_y_scaled ** 2).sum(dim=0)
    _n_total += _y_i.shape[0]
_phys_y_mean = (_scaled_sum / _n_total).float()
_phys_y_std = ((_scaled_sq_sum / _n_total - _phys_y_mean.double() ** 2).sqrt()).float()
phys_y_stats = {"y_mean": _phys_y_mean.to(device), "y_std": _phys_y_std.to(device)}
print(f"  Physics y_mean={_phys_y_mean.tolist()}, y_std={_phys_y_std.tolist()}")
```

### 3. In the training loop, replace target normalization (lines 138-142):
```python
        # Extract per-sample Umag from log_Re (feature 13) BEFORE x normalization
        log_re = x[:, 0, 13]  # (B,) -- constant across nodes
        umag = torch.exp(log_re) * 1.461e-5
        q = 0.5 * 1.225 * umag ** 2
        phys_scale = torch.stack([umag, umag, q], dim=-1)  # (B, 3)

        x = (x - stats["x_mean"]) / stats["x_std"]

        # Physics-based target normalization
        y_scaled = y / phys_scale[:, None, :]
        y_norm = (y_scaled - phys_y_stats["y_mean"]) / phys_y_stats["y_std"]

        # Target noise regularization
        y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
```

### 4. In the validation loop, replace target normalization and MAE computation.

**Note:** The stats computation adds ~10s at startup (one pass over dataset). Per-epoch cost is negligible (one `exp` + multiply per batch).

W&B tag: `mar14b`, group: `phys-norm`

## Baseline
- **surf_p ≈ 35.5** (±2-3 variance), surf_Ux = 0.46, surf_Uy = 0.29

---

## Results

**surf_p = 30.1** (baseline: 35.6) — **STRONG IMPROVEMENT** ✅ (~5.5 points, >2σ noise floor)

| Metric | This run | Baseline (PR #319) | Delta |
|--------|----------|--------------------|-------|
| surf_p | 30.1 | 35.6 | **-5.5** |
| surf_Ux | 0.33 | 0.49 | -0.16 |
| surf_Uy | 0.27 | 0.28 | -0.01 |
| val/loss | 1.814 | 0.975 | +0.84 (different scale) |
| Best epoch | 58 | 67 | -9 |
| Epoch time | 4.85s | 4.40s | +0.45s |

W&B run: u732ca3a

Physics stats computed: y_mean=[0.84, -0.03, -0.19], y_std=[0.41, 0.26, 0.60]

**Analysis:** Physics normalization (predicting Cp = p/q, Cx = Ux/Umag) gives a **15% improvement** in surf_p, well beyond the ±2 noise floor confirmed in PR #329. The val/loss is higher in absolute terms because the loss is now in normalized Cp space (different scale), but the original-scale MAE is dramatically better. Epoch time is ~0.4s slower (stats precomputation adds ~15s at startup, per-batch exp is negligible). **This is the new best configuration.**
