### PR TITLE
Higher LR (0.008 → 0.012) with physics normalization

### DIFF
--- a/train.py
+++ b/train.py
@@ -26,7 +26,7 @@ MAX_TIMEOUT = 5.0 # minutes
 MAX_EPOCHS = 70
 @dataclass
 class Config:
-    lr: float = 0.008
+    lr: float = 0.012
     weight_decay: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 15.0
@@ -102,7 +102,7 @@ model = Transolver(
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-warmup = LinearLR(optimizer, start_factor=1e-5/0.008, total_iters=5)
+warmup = LinearLR(optimizer, start_factor=1e-5/0.012, total_iters=5)
 cosine = CosineAnnealingLR(optimizer, T_max=65, eta_min=1e-4)
 scheduler = SequentialLR(optimizer, schedulers=[warmup, cosine], milestones=[5])
 


### PR DESCRIPTION
## Hypothesis
With physics-based normalization, the target distribution is fundamentally different — more uniform across Reynolds numbers, tighter variance (y_std ≈ [0.41, 0.26, 0.60]). The optimal learning rate may have shifted. The phys-norm run only got 58 best epochs (vs 67 with global norm), suggesting the model may benefit from a higher LR to converge faster in the new normalized space.

A higher LR (0.012) with the gradient clipping safety net could push convergence further in the available epochs.

## Instructions

In `train.py`, change two values:

### 1. Learning rate (line 28):
```python
    lr: float = 0.012            # was 0.008
```

### 2. Warmup start factor (line 83):
```python
warmup = LinearLR(optimizer, start_factor=1e-5/0.012, total_iters=5)
```

W&B tag: `mar14b`, group: `phys-norm-lr-tune`

## Baseline
- **surf_p = 30.1**, surf_Ux = 0.33, surf_Uy = 0.27
- Physics normalization, lr=0.008

---

## Results

**W&B run ID:** 5iqg0qrf
**Epochs completed:** 70 (hit epoch limit, not timeout)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 1.7654 | — |
| surf_p | 30.1 | 32.7 | +2.6 (+8.6%) ❌ |
| surf_Ux | 0.33 | 0.40 | +0.07 ❌ |
| surf_Uy | 0.27 | 0.29 | +0.02 ❌ |
| vol_Ux | — | 2.40 | — |
| vol_Uy | — | 1.10 | — |
| vol_p | — | 65.4 | — |

**Best epoch:** 52 (earlier plateau vs baseline's 58+)

### What happened

LR 0.012 **hurt** with physics normalization — surf_p worsened 30.1 → 32.7. The model peaked much earlier (epoch 52 vs 58+), suggesting the higher LR causes the model to converge too fast and then start to diverge or overfit.

The LR 0.008 appears to be a better fit for the physics-normalized space. With physics normalization, the gradient magnitudes may already be amplified (tighter y_std means normalized targets are relatively larger), so increasing LR further is over-aggressive.

The early best epoch (52) indicates the model overshoots the optimum and doesn't settle as nicely in the later epochs with 0.012 LR.

### Suggested follow-ups

- **Keep LR=0.008**: The baseline LR is already well-calibrated for physics normalization.
- **Lower LR (0.005-0.006)**: Try going the other direction — a slightly lower LR might allow the model to converge more smoothly in the physics-normalized space.
- **Extended cosine schedule**: With the model peaking at epoch 52, adjusting T_max to match physics-norm convergence (e.g., T_max=55) might help.