### PR TITLE
Hardcode physics normalization stats (save ~15s startup)

### DIFF
--- a/train.py
+++ b/train.py
@@ -6,7 +6,6 @@
 
 import os
 import time
-import numpy as np
 import torch
 import wandb
 import yaml
@@ -57,25 +56,11 @@ print(f"Train: {len(train_ds)}, Val: {len(val_ds)}")
 
 stats = {k: v.to(device) for k, v in dataset_stats[cfg.dataset].items()}
 
-# Precompute physics-scaled target normalization stats
-print("Computing physics-scaled normalization stats...")
-_scaled_sum = torch.zeros(3, dtype=torch.float64)
-_scaled_sq_sum = torch.zeros(3, dtype=torch.float64)
-_n_total = 0
-for _i in range(len(ds)):
-    _x_i, _y_i, _ = ds[_i]
-    _log_re = _x_i[0, 13].item()  # log(Re), constant across nodes
-    _umag = float(np.exp(_log_re)) * 1.461e-5  # Umag = Re * nu / c (nu=1.461e-5)
-    _q = 0.5 * 1.225 * _umag ** 2  # dynamic pressure (rho=1.225)
-    _scale = torch.tensor([_umag, _umag, _q], dtype=torch.float64)
-    _y_scaled = _y_i.double() / _scale
-    _scaled_sum += _y_scaled.sum(dim=0)
-    _scaled_sq_sum += (_y_scaled ** 2).sum(dim=0)
-    _n_total += _y_i.shape[0]
-_phys_y_mean = (_scaled_sum / _n_total).float()
-_phys_y_std = ((_scaled_sq_sum / _n_total - _phys_y_mean.double() ** 2).sqrt()).float()
-phys_y_stats = {"y_mean": _phys_y_mean.to(device), "y_std": _phys_y_std.to(device)}
-print(f"  Physics y_mean={_phys_y_mean.tolist()}, y_std={_phys_y_std.tolist()}")
+# Pre-computed physics-scaled normalization stats (avoids ~15s startup)
+phys_y_stats = {
+    "y_mean": torch.tensor([0.8387087, -0.02737183, -0.19293371], device=device),
+    "y_std": torch.tensor([0.41293243, 0.26277012, 0.59805059], device=device),
+}
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)


### PR DESCRIPTION
## Hypothesis
The physics stats computation iterates over all 899 samples at startup, taking ~15s. With 4s/epoch, that's 3-4 lost epochs. The baseline with phys-norm got best epoch at 58 (vs 67 without), partly because of this startup cost eating into the 5-minute budget. Hardcoding the pre-computed stats eliminates this overhead.

## Instructions

In `train.py`, replace the entire stats computation block (lines 58-76) with hardcoded values:

**Remove lines 58-76** (the `for _i in range(len(ds)):` loop) and replace with:

```python
# Pre-computed physics-scaled normalization stats (avoids ~15s startup)
phys_y_stats = {
    "y_mean": torch.tensor([0.8387087, -0.02737183, -0.19293371], device=device),
    "y_std": torch.tensor([0.41293243, 0.26277012, 0.59805059], device=device),
}
```

Also remove `import numpy as np` from line 9 (no longer needed since we don't compute exp at startup).

Keep the per-batch `log_re` → `umag` → `q` computation in the training and validation loops (that still needs np.exp equivalent via torch.exp, which is already there).

W&B tag: `mar14b`, group: `hardcode-phys-stats`

## Baseline
- **surf_p = 30.1**, best epoch 58, ~4.85s/epoch with 15s startup overhead

---

## Results

**W&B run ID:** anh1hxtw
**Epochs completed:** 70 (hit epoch limit, not timeout)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 1.7815 | — |
| surf_p | 30.1 | 33.2 | +3.1 ❌ |
| surf_Ux | 0.33 | 0.40 | +0.07 ❌ |
| surf_Uy | 0.27 | 0.28 | +0.01 ≈ |
| vol_Ux | — | 2.40 | — |
| vol_Uy | — | 1.07 | — |
| vol_p | — | 65.1 | — |

**Best epoch:** 54 (vs baseline 58)

### What happened

The hardcoded stats run shows **worse results** than the baseline (33.2 vs 30.1). However, this is almost certainly run-to-run variance rather than a causal effect of the change. The hardcoded values are numerically identical to the computed ones (matching to 7+ significant figures), so there's no algorithmic difference — only startup time savings.

The baseline's surf_p=30.1 was likely a favorable random seed outcome. The ±2-3 Pa variance noted in prior experiments makes this gap plausible as noise.

The code simplification is still valuable: removing the 899-sample startup loop makes the code cleaner, saves 15s, and removes a numpy dependency. The results are consistent with the baseline within variance.

### Suggested follow-ups

- **Run variance check**: Run the hardcoded stats version 2-3 times to confirm the mean is indeed ~30.1 Pa (not systematically worse).
- **Adopt as baseline**: If variance confirmed, the hardcoded stats version should replace the computed version as the standard configuration.