### PR TITLE
Surface Cp gradient penalty (physics-informed loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -184,7 +184,24 @@ for epoch in range(MAX_EPOCHS):
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
             abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            loss = vol_loss + cfg.surf_weight * surf_loss
+            # Surface pressure gradient penalty (smooth Cp transitions)
+            grad_penalty = torch.tensor(0.0, device=device)
+            for b_idx in range(pred.shape[0]):
+                s_mask = surf_mask[b_idx]  # (N,)
+                if s_mask.sum() < 3:
+                    continue
+                # Sort surface nodes by arc-length feature (col 2 of normalized x)
+                saf_vals = x[b_idx, s_mask, 2]  # signed arc-length feature
+                sort_idx = saf_vals.argsort()
+                # Predicted vs target Cp along sorted surface
+                p_pred_sorted = pred[b_idx, s_mask, 2][sort_idx]  # pressure channel
+                p_tgt_sorted = y_norm[b_idx, s_mask, 2][sort_idx]
+                # Finite difference gradient penalty
+                dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
+                dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
+                grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
+            grad_penalty = grad_penalty / pred.shape[0]
+            loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
The model predicts Cp coefficients, but the loss treats every surface node equally. The hardest regions to predict are where pressure changes rapidly: leading edge stagnation, suction peak, and trailing edge separation. Adding a finite-difference penalty on the *spatial gradient* of predicted surface pressure along the airfoil forces the model to match not just pointwise values but the spatial structure of the pressure field.

This is fundamentally different from all previous loss experiments (channel_w, surf_weight) which only changed weighting of pointwise errors. This introduces a *structural* constraint targeting the hardest regions.

## Instructions

In `train.py`, replace the loss computation line (line 163):

**Before:**
```python
            loss = vol_loss + cfg.surf_weight * surf_loss
```

**After (add the gradient penalty block, then the combined loss):**
```python
        # Surface pressure gradient penalty (smooth Cp transitions)
        grad_penalty = torch.tensor(0.0, device=device)
        for b_idx in range(pred.shape[0]):
            s_mask = surf_mask[b_idx]  # (N,)
            if s_mask.sum() < 3:
                continue
            # Sort surface nodes by arc-length feature (col 2 of normalized x)
            saf_vals = x[b_idx, s_mask, 2]  # signed arc-length feature
            sort_idx = saf_vals.argsort()
            # Predicted vs target Cp along sorted surface
            p_pred_sorted = pred[b_idx, s_mask, 2][sort_idx]  # pressure channel
            p_tgt_sorted = y_norm[b_idx, s_mask, 2][sort_idx]
            # Finite difference gradient penalty
            dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
            dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
            grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
        grad_penalty = grad_penalty / pred.shape[0]
        loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
```

W&B tag: `mar14b`, group: `cp-grad-penalty`

## Baseline
- **surf_p = 30.1**, surf_Ux = 0.33, surf_Uy = 0.27

---

## Results

**W&B run ID:** q1hf84so
**Epochs completed:** 62 (hit timeout at 5 min; Python loop adds ~1s/epoch overhead)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 1.8012 | — |
| surf_p | 30.1 | 29.5 | -0.6 (-2.0%) ✓ |
| surf_Ux | 0.33 | 0.33 | 0.00 ≈ |
| surf_Uy | 0.27 | 0.26 | -0.01 ✓ |
| vol_Ux | — | 2.33 | — |
| vol_Uy | — | 1.02 | — |
| vol_p | — | 63.3 | — |

**Best epoch:** 60

### What happened

The gradient penalty shows a **positive signal** — surf_p improved 30.1 → 29.5 (-2.0%), and surf_Uy improved slightly. The structural pressure gradient constraint does seem to help the model learn smoother, more physically consistent pressure distributions.

The trade-off: the Python loop over batch samples adds ~1s overhead per epoch (5s vs 4s normally), reducing completed epochs from ~68 to 62. Despite fewer epochs, the result is still better, which means the gradient penalty provides quality improvement sufficient to offset the epoch count reduction.

The sorted arc-length feature (col 2 of normalized x) appears to be a valid proxy for spatial ordering of surface nodes. The finite-difference penalty between consecutive surface nodes effectively penalizes sharp transitions that differ from the target.

### Suggested follow-ups

- **Vectorized gradient penalty**: The Python for-loop is the bottleneck. Vectorizing the surface node sorting and gradient computation could eliminate the 1s overhead, recovering the lost epochs.
- **Higher grad_penalty weight (4.0 or 5.0)**: The current 2.0 is conservative. A stronger penalty might push surface pressure gradients to match better.
- **Gradient penalty on Ux/Uy too**: Extend the structural penalty to velocity channels, not just pressure.