### PR TITLE
Vectorize gradient penalty (remove Python loop, recover ~6 epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -184,21 +184,25 @@ for epoch in range(MAX_EPOCHS):
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
             abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            # Surface pressure gradient penalty (smooth Cp transitions)
+            # Vectorized gradient penalty (minimized Python overhead)
+            with torch.no_grad():
+                sort_indices = []
+                for b_idx in range(pred.shape[0]):
+                    s_mask = surf_mask[b_idx]
+                    if s_mask.sum() < 3:
+                        sort_indices.append(None)
+                        continue
+                    saf_vals = x[b_idx, s_mask, 2]
+                    sort_idx = saf_vals.argsort()
+                    sort_indices.append((s_mask, sort_idx))
+
             grad_penalty = torch.tensor(0.0, device=device)
-            for b_idx in range(pred.shape[0]):
-                s_mask = surf_mask[b_idx]  # (N,)
-                if s_mask.sum() < 3:
+            for b_idx, si in enumerate(sort_indices):
+                if si is None:
                     continue
-                # Sort surface nodes by arc-length feature (col 2 of normalized x)
-                saf_vals = x[b_idx, s_mask, 2]  # signed arc-length feature
-                sort_idx = saf_vals.argsort()
-                # Predicted vs target Cp along sorted surface
-                p_pred_sorted = pred[b_idx, s_mask, 2][sort_idx]  # pressure channel
-                p_tgt_sorted = y_norm[b_idx, s_mask, 2][sort_idx]
-                # Finite difference gradient penalty
-                dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
-                dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
+                s_mask, sort_idx = si
+                dp_pred = pred[b_idx, s_mask, 2][sort_idx].diff()
+                dp_tgt = y_norm[b_idx, s_mask, 2][sort_idx].diff()
                 grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
             grad_penalty = grad_penalty / pred.shape[0]
             loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty


### PR DESCRIPTION
## Hypothesis
The current Cp gradient penalty uses a Python for-loop over batch samples, costing ~1s/epoch overhead (5s vs 4s baseline) and reducing epochs from ~68 to ~62. Vectorizing this computation across the batch removes the Python overhead, potentially recovering those 6 lost epochs while keeping the gradient penalty benefit.

The key challenge: surface nodes vary in count per sample and need sorting by arc-length. We can use padding + masking to vectorize.

## Instructions

In `train.py`, replace the gradient penalty block (the for-loop after line 163) with a vectorized version:

**Before (Python loop):**
```python
        grad_penalty = torch.tensor(0.0, device=device)
        for b_idx in range(pred.shape[0]):
            ...
```

**After (vectorized — process each sample using a list comprehension but with torch operations):**

```python
        # Vectorized gradient penalty (minimized Python overhead)
        with torch.no_grad():
            sort_indices = []
            for b_idx in range(pred.shape[0]):
                s_mask = surf_mask[b_idx]
                if s_mask.sum() < 3:
                    sort_indices.append(None)
                    continue
                saf_vals = x[b_idx, s_mask, 2]
                sort_idx = saf_vals.argsort()
                sort_indices.append((s_mask, sort_idx))

        grad_penalty = torch.tensor(0.0, device=device)
        for b_idx, si in enumerate(sort_indices):
            if si is None:
                continue
            s_mask, sort_idx = si
            dp_pred = pred[b_idx, s_mask, 2][sort_idx].diff()
            dp_tgt = y_norm[b_idx, s_mask, 2][sort_idx].diff()
            grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
        grad_penalty = grad_penalty / pred.shape[0]
```

W&B tag: `mar14b`, group: `vectorize-grad-penalty`

## Baseline
- **surf_p = 29.5**, surf_Ux = 0.33, surf_Uy = 0.26
- ~62 epochs with Python loop gradient penalty

---

## Results

**W&B run ID:** x5sj6qwi
**Epochs completed:** 62 (still hitting timeout at 5 min; same as non-vectorized)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 1.8507 | — |
| surf_p | 29.5 | 29.8 | +0.3 (within noise) ≈ |
| surf_Ux | 0.33 | 0.33 | 0.00 ≈ |
| surf_Uy | 0.26 | 0.26 | 0.00 ≈ |
| vol_Ux | — | 2.38 | — |
| vol_Uy | — | 1.02 | — |
| vol_p | — | 64.2 | — |

**Best epoch:** 62

### What happened

The vectorization did **not recover the lost epochs** — still completing 62 epochs at ~5s/epoch. The `no_grad` separation for sorting didn't meaningfully reduce overhead.

The bottleneck is that `argsort()` and indexing with variable-length surface masks (each batch sample has a different number of surface nodes) cannot be easily eliminated with Python-level loop optimization. The Python interpreter overhead for the loop itself is negligible — the actual cost is the per-sample tensor operations with non-uniform shapes.

The results are within noise of the original loop version (29.8 vs 29.5). The gradient penalty provides roughly the same benefit regardless of implementation variant.

### Suggested follow-ups

- **Apply penalty every N batches**: Skip the penalty computation every other batch (e.g., `if n_batches % 2 == 0:`) to halve the overhead while keeping half the regularization signal.
- **Precompute surface sort indices**: Since the surface mask pattern is fixed per sample (same meshes), precompute all sort indices once before training and reuse them. This would eliminate the argsort cost entirely.
- **Accept the 62 epoch trade-off**: The gradient penalty with 62 epochs achieves surf_p≈29.5-29.8, which is still better than the 68-epoch no-penalty baseline at 30.1. The quality gain outweighs the epoch reduction.