### PR TITLE
Skip gradient penalty every other batch (halve overhead, recover epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -184,24 +184,24 @@ for epoch in range(MAX_EPOCHS):
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
             abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            # Surface pressure gradient penalty (smooth Cp transitions)
-            grad_penalty = torch.tensor(0.0, device=device)
-            for b_idx in range(pred.shape[0]):
-                s_mask = surf_mask[b_idx]  # (N,)
-                if s_mask.sum() < 3:
-                    continue
-                # Sort surface nodes by arc-length feature (col 2 of normalized x)
-                saf_vals = x[b_idx, s_mask, 2]  # signed arc-length feature
-                sort_idx = saf_vals.argsort()
-                # Predicted vs target Cp along sorted surface
-                p_pred_sorted = pred[b_idx, s_mask, 2][sort_idx]  # pressure channel
-                p_tgt_sorted = y_norm[b_idx, s_mask, 2][sort_idx]
-                # Finite difference gradient penalty
-                dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
-                dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
-                grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
-            grad_penalty = grad_penalty / pred.shape[0]
-            loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
+            # Surface pressure gradient penalty (every other batch to reduce overhead)
+            if n_batches % 2 == 0:
+                grad_penalty = torch.tensor(0.0, device=device)
+                for b_idx in range(pred.shape[0]):
+                    s_mask = surf_mask[b_idx]
+                    if s_mask.sum() < 3:
+                        continue
+                    saf_vals = x[b_idx, s_mask, 2]
+                    sort_idx = saf_vals.argsort()
+                    p_pred_sorted = pred[b_idx, s_mask, 2][sort_idx]
+                    p_tgt_sorted = y_norm[b_idx, s_mask, 2][sort_idx]
+                    dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
+                    dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
+                    grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
+                grad_penalty = grad_penalty / pred.shape[0]
+                loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
+            else:
+                loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
The Cp gradient penalty Python loop costs ~1s/epoch (5s vs 4s per epoch), reducing total epochs from ~68 to ~62. Computing the penalty only on every other batch halves this overhead to ~0.5s/epoch, potentially recovering 3+ epochs while keeping most of the gradient penalty benefit.

The penalty is a regularizer — it doesn't need to be applied on every single batch to provide its smoothing effect.

## Instructions

In `train.py`, wrap the gradient penalty computation (lines 163-179) in a conditional:

**After:**
```python
            # Surface pressure gradient penalty (every other batch to reduce overhead)
            if n_batches % 2 == 0:
                grad_penalty = ...
                loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
            else:
                loss = vol_loss + cfg.surf_weight * surf_loss
```

W&B tag: `mar14b`, group: `skip-grad-penalty`

## Baseline
- **surf_p = 29.5**, ~62 epochs at ~5s/epoch (with gradient penalty)

---

## Results

**W&B run ID:** q36dmli8
**Epochs completed:** ~62 (still hitting timeout, no epoch recovery)
**Peak VRAM:** 2.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | — | 1.8669 | — |
| surf_p | 29.5 | 33.9 | +4.4 (+14.9%) ❌ |
| surf_Ux | 0.33 | 0.38 | +0.05 ❌ |
| surf_Uy | 0.26 | 0.28 | +0.02 ❌ |
| vol_Ux | — | 2.50 | — |
| vol_Uy | — | 1.11 | — |
| vol_p | — | 69.0 | — |

**Best epoch:** 53 (very early plateau)

### What happened

Skipping every other batch **significantly hurt** performance — surf_p worsened 29.5 → 33.9 (+14.9%). The epoch timing was also still ~5s/epoch, so no epochs were recovered. This is the worst outcome — all the cost, none of the benefit.

The physics gradient penalty is an effective regularizer, but it requires consistent application across batches to maintain the smoothing effect. Applying it only to half the batches creates an inconsistent training signal — the model gets mixed gradients from constrained and unconstrained batches, which disrupts the optimization trajectory.

The early best epoch (53 vs 60 baseline) indicates even faster overfitting without the full penalty, suggesting the penalty's regularization value extends beyond just gradient quality.

### Suggested follow-ups

- **Accept the full gradient penalty**: This experiment confirms the 5s/epoch cost is worth paying for the quality improvement. The surf_p=29.5 from the original gradient penalty is better than any skipping strategy.
- **Precompute sort indices**: A more principled optimization would precompute the argsort indices for all samples once before training (surface node ordering is fixed), eliminating the per-batch argsort cost. This could recover all or most of the lost epoch budget.