### PR TITLE
Wider feedforward MLP (mlp_ratio 2 → 4)

### DIFF
--- a/train.py
+++ b/train.py
@@ -90,7 +90,7 @@ model_config = dict(
     n_layers=1,
     n_head=2,
     slice_num=32,
-    mlp_ratio=2,
+    mlp_ratio=4,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
The TransolverBlock's feedforward MLP currently has hidden dim = 128 * 2 = 256 (mlp_ratio=2). Doubling to mlp_ratio=4 (hidden dim = 512) increases the per-node processing capacity without adding another attention layer. The MLP is where the model transforms each node's attended features — more width allows learning more complex per-node transformations.

With bf16 and the tiny 1-layer model, the additional 128*256 + 256*128 ≈ 65K params should add minimal epoch time (~0.2-0.5s). The model is currently capacity-limited (still improving at epoch 60+), so more width could help.

This is different from n_layers=2 (which added a full extra attention layer costing 3s/epoch). The MLP width increase is much cheaper.

## Instructions

In `train.py`, change one value in model_config (line 91):

**Before:**
```python
    mlp_ratio=2,
```

**After:**
```python
    mlp_ratio=4,
```

That's the only change.

W&B tag: `mar14b`, group: `mlp-ratio-4`

## Baseline
- **surf_p ≈ 29.5** (±2-3), surf_Ux = 0.33, surf_Uy = 0.26
- mlp_ratio=2, ~62 epochs at ~5s/epoch

---

## Results
_To be filled by student_