### PR TITLE
Move gradient penalty outside bf16 autocast (fp32 precision)

### DIFF
--- a/train.py
+++ b/train.py
@@ -184,24 +184,28 @@ for epoch in range(MAX_EPOCHS):
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
             abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            # Surface pressure gradient penalty (smooth Cp transitions)
-            grad_penalty = torch.tensor(0.0, device=device)
-            for b_idx in range(pred.shape[0]):
-                s_mask = surf_mask[b_idx]  # (N,)
-                if s_mask.sum() < 3:
-                    continue
-                # Sort surface nodes by arc-length feature (col 2 of normalized x)
-                saf_vals = x[b_idx, s_mask, 2]  # signed arc-length feature
-                sort_idx = saf_vals.argsort()
-                # Predicted vs target Cp along sorted surface
-                p_pred_sorted = pred[b_idx, s_mask, 2][sort_idx]  # pressure channel
-                p_tgt_sorted = y_norm[b_idx, s_mask, 2][sort_idx]
-                # Finite difference gradient penalty
-                dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
-                dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
-                grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
-            grad_penalty = grad_penalty / pred.shape[0]
-            loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
+            loss_base = vol_loss + cfg.surf_weight * surf_loss
+
+        # Gradient penalty in fp32 (outside autocast for precision)
+        pred_f = pred.float()
+        y_norm_f = y_norm.float()
+        grad_penalty = torch.tensor(0.0, device=device)
+        for b_idx in range(pred_f.shape[0]):
+            s_mask = surf_mask[b_idx]  # (N,)
+            if s_mask.sum() < 3:
+                continue
+            # Sort surface nodes by arc-length feature (col 2 of normalized x)
+            saf_vals = x[b_idx, s_mask, 2]  # signed arc-length feature
+            sort_idx = saf_vals.argsort()
+            # Predicted vs target Cp along sorted surface
+            p_pred_sorted = pred_f[b_idx, s_mask, 2][sort_idx]  # pressure channel
+            p_tgt_sorted = y_norm_f[b_idx, s_mask, 2][sort_idx]
+            # Finite difference gradient penalty
+            dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
+            dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
+            grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
+        grad_penalty = grad_penalty / pred_f.shape[0]
+        loss = loss_base + 2.0 * grad_penalty
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
The Cp gradient penalty loop currently runs inside `torch.amp.autocast("cuda", dtype=torch.bfloat16)`. The sorting, indexing, and finite-difference operations lose precision in bf16 — especially the subtraction of nearby values (dp_pred = p[i+1] - p[i]) where catastrophic cancellation is worst in low-precision formats.

Moving the gradient penalty computation outside autocast (in fp32) gives full precision for the penalty without affecting the forward pass speed (which stays in bf16).

## Instructions

In `train.py`, restructure the autocast block. Move the gradient penalty outside:

**Before (lines 153-180):**
```python
        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
            pred = model({"x": x})["preds"]
            sq_err = (pred - y_norm) ** 2
        
```

**After:**
```python
        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
            pred = model({"x": x})["preds"]
            ...
            loss_base = vol_loss + cfg.surf_weight * surf_loss

        # Gradient penalty in fp32 (outside autocast for precision)
        pred_f = pred.float()
        ...
        loss = loss_base + 2.0 * grad_penalty
```

W&B tag: `mar14b`, group: `grad-penalty-fp32`

## Baseline
- **surf_p ≈ 29.5** (±2-3), surf_Ux = 0.33, surf_Uy = 0.26

---

## Results

**surf_p = 30.3** (best epoch 57, 62 epochs in 5 min)
- surf_Ux = 0.34, surf_Uy = 0.27
- W&B: https://wandb.ai/capecape/senpai/runs/kqxfqtv3

**Verdict: NEUTRAL** — surf_p 30.3 vs baseline 29.5 is within noise (±2-3 units). Moving the gradient penalty to fp32 does not measurably improve Cp smoothness or surface MAE. The bf16 precision loss in the penalty term does not appear to be a limiting factor at this scale.
