### PR TITLE
Remove gradient penalty (test if it's within noise)

### DIFF
--- a/train.py
+++ b/train.py
@@ -184,24 +184,7 @@ for epoch in range(MAX_EPOCHS):
             channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
             abs_err = (pred - y_norm).abs()
             surf_loss = (abs_err * surf_mask.unsqueeze(-1) * channel_w).sum() / surf_mask.sum().clamp(min=1)
-            # Surface pressure gradient penalty (smooth Cp transitions)
-            grad_penalty = torch.tensor(0.0, device=device)
-            for b_idx in range(pred.shape[0]):
-                s_mask = surf_mask[b_idx]  # (N,)
-                if s_mask.sum() < 3:
-                    continue
-                # Sort surface nodes by arc-length feature (col 2 of normalized x)
-                saf_vals = x[b_idx, s_mask, 2]  # signed arc-length feature
-                sort_idx = saf_vals.argsort()
-                # Predicted vs target Cp along sorted surface
-                p_pred_sorted = pred[b_idx, s_mask, 2][sort_idx]  # pressure channel
-                p_tgt_sorted = y_norm[b_idx, s_mask, 2][sort_idx]
-                # Finite difference gradient penalty
-                dp_pred = p_pred_sorted[1:] - p_pred_sorted[:-1]
-                dp_tgt = p_tgt_sorted[1:] - p_tgt_sorted[:-1]
-                grad_penalty = grad_penalty + (dp_pred - dp_tgt).abs().mean()
-            grad_penalty = grad_penalty / pred.shape[0]
-            loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
+            loss = vol_loss + cfg.surf_weight * surf_loss
         wandb.log({"train/loss": loss.item()})
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
The Cp gradient penalty (PR #337) showed surf_p 29.5 vs 30.1 baseline — a 0.6-point improvement. But our variance is ±2-3. The penalty costs ~1s/epoch (5s vs 4s), reducing epochs from ~68 to ~62. If the penalty's benefit is within noise, removing it gives us 6 extra epochs which could be worth more.

This is an ablation test: remove the gradient penalty and see if the extra epochs compensate.

## Instructions

In `train.py`, remove the gradient penalty block (lines 163-179) and simplify the loss:

**Remove lines 163-179** (the entire `grad_penalty` computation block).

**Replace line 180:**
```python
            loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
```
**With:**
```python
            loss = vol_loss + cfg.surf_weight * surf_loss
```

W&B tag: `mar14b`, group: `no-grad-penalty`

## Baseline
- **surf_p ≈ 29.5** (±2-3), ~62 epochs at ~5s/epoch (with grad penalty)

---

## Results

**W&B run ID:** eqnze20p  
**Epochs completed:** 68 (4.4s/epoch, 5.0 min) — vs ~62 epochs with gradient penalty  
**Peak memory:** 2.6 GB (unchanged)

| Metric | With grad penalty (baseline) | Without grad penalty | Change |
|--------|------------------------------|---------------------|--------|
| surf_Ux | 0.33 | 0.36 | +0.03 |
| surf_Uy | 0.26 | 0.27 | +0.01 |
| surf_p (best chkpt) | **29.5** | **31.0** | +1.5 |
| surf_p (last epoch) | — | **27.4** | — |
| vol_Ux | — | 2.35 | — |
| vol_p | — | 65.1 | — |
| Epoch time | ~5s | 4.4s | -0.6s |
| Best epoch | ~62 | 58 | — |

### What happened

**Mixed result.** Removing the gradient penalty saves 0.6s/epoch and gets 6 more epochs (68 vs 62), but the best-by-val-loss checkpoint (epoch 58) has surf_p=31.0, which is **worse** than the 29.5 baseline with gradient penalty. However, the last epoch (68) shows surf_p=27.4 — the model was still improving at timeout.

The core tension: the gradient penalty helps the model converge more efficiently to a good solution (lower val loss faster), even though it costs ~0.6s/epoch. Without it, the model needs more epochs to reach the same quality. With 68 vs 62 epochs available, the best checkpoint selected by val loss is at epoch 58 (surf_p=31.0), not epoch 68 (surf_p=27.4) — suggesting the model overfit slightly past epoch 58 in terms of val loss, even as surf_p kept improving.

**Key insight:** The gradient penalty provides a regularization signal that improves the best-val-loss checkpoint's surf_p. Without it, the model needs a longer tail of training. The 5-minute budget means the gradient penalty remains net positive.

If the budget were ~6-7 minutes, removing the gradient penalty might win (surf_p=27.4 type result). But within 5 minutes, keep the gradient penalty.

### Suggested follow-ups

- **Run the baseline for one more minute**: Would confirm whether the no-penalty model exceeds 29.5 at epoch 68+.
- **Use last epoch instead of best-by-val-loss**: The val loss may peak before surf_p does; tracking and checkpointing by surf_p directly might give better results.