### PR TITLE
Post-LayerNorm (swap normalization position in TransolverBlock)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -148,8 +148,8 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        fx = self.ln_1(self.attn(fx) + fx)
+        fx = self.ln_2(self.mlp(fx) + fx)
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx


### PR DESCRIPTION
## Hypothesis
The current architecture uses pre-LayerNorm: `fx = attn(LN(fx)) + fx`. Post-LayerNorm (`fx = LN(attn(fx) + fx)`) has different optimization dynamics — it normalizes the residual stream after the addition, which can stabilize training differently and sometimes leads to better convergence in shallow networks.

With only 1 layer, the normalization position significantly affects the gradient flow. Pre-norm was inherited from the original multi-layer Transolver where it helps with deep network training. For a 1-layer model, post-norm might be better since there's no deep gradient propagation concern.

## Instructions

In `transolver.py`, modify `TransolverBlock.forward` (lines 149-154):

**Before (pre-norm):**
```python
    def forward(self, fx):
        fx = self.attn(self.ln_1(fx)) + fx
        fx = self.mlp(self.ln_2(fx)) + fx
        if self.last_layer:
            return self.mlp2(self.ln_3(fx))
        return fx
```

**After (post-norm):**
```python
    def forward(self, fx):
        fx = self.ln_1(self.attn(fx) + fx)
        fx = self.ln_2(self.mlp(fx) + fx)
        if self.last_layer:
            return self.mlp2(self.ln_3(fx))
        return fx
```

That's the only change — swap where LN is applied relative to the residual addition.

W&B tag: `mar14b`, group: `post-layernorm`

## Baseline
- **surf_p ≈ 29.5** (±2-3), surf_Ux = 0.33, surf_Uy = 0.26

---

## Results

**surf_p = 38.0** (best epoch 62, 62 epochs in 5 min)
- surf_Ux = 0.52, surf_Uy = 0.33
- W&B: https://wandb.ai/capecape/senpai/runs/dt32ur3o

**Verdict: NEGATIVE** — surf_p 38.0 vs baseline 29.5 is +8.5 worse (well outside noise). Post-LayerNorm significantly hurts performance. Pre-norm is correct for this architecture — it stabilizes the physics attention's input distribution before the slice token computation, which is important for convergence.
