### PR TITLE
Per-channel loss weighting: pressure 3x, velocity 1x

### DIFF
--- a/train.py
+++ b/train.py
@@ -129,6 +129,8 @@ for epoch in range(MAX_EPOCHS):
 
         pred = model({"x": x})["preds"]
         sq_err = (pred - y_norm) ** 2
+        channel_w = torch.tensor([1.0, 1.0, 3.0], device=device)  # [Ux, Uy, p]
+        sq_err = sq_err * channel_w[None, None, :]
 
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
@@ -171,6 +173,8 @@ for epoch in range(MAX_EPOCHS):
 
             pred = model({"x": x})["preds"]
             sq_err = (pred - y_norm) ** 2
+            channel_w = torch.tensor([1.0, 1.0, 3.0], device=device)  # [Ux, Uy, p]
+            sq_err = sq_err * channel_w[None, None, :]
 
             vol_mask = mask & ~is_surface
             surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis
The current MSE loss treats all 3 output channels (Ux, Uy, p) equally after normalization. But pressure has ~100x larger absolute MAE than velocity channels in physical units — pressure is both the hardest to predict and the most important metric for engineers. After global normalization the residual error variance also differs significantly by channel. Weighting the pressure channel's contribution to the loss 3x higher than velocity channels will steer gradient flow toward reducing pressure error specifically, likely improving our most important metric (surf_p).

## Instructions
In `train.py`, after computing `sq_err = (pred - y_norm) ** 2`, apply per-channel weights before aggregation:

```python
channel_w = torch.tensor([1.0, 1.0, 3.0], device=device)  # [Ux, Uy, p]
sq_err = sq_err * channel_w[None, None, :]
```

Apply the **same weighting** in the **validation loss** computation so that checkpoint selection (`best_val`) is pressure-aware and consistent. Do **not** change the MAE reporting — keep that unweighted for fair comparison.

Run with:
```bash
python train.py --agent frieren --wandb_name "frieren/per-channel-loss-weights" --wandb_group "per-channel-loss-weights"
```

## Baseline
No runs have completed yet — this experiment will help establish the first data points. Target: minimize `val/mae_surf_p` and overall `val/mae_surf_*`.

---

## Results

**W&B run ID:** mylsco7f  
**Epochs completed:** 10 (31s/epoch, 5.2 min wall-clock)  
**Peak memory:** 15.4 GB (larger model: n_layers=5, n_head=4, slice_num=64)

| Metric | Per-channel p=3x (this run) |
|--------|----------------------------|
| surf_Ux | 2.51 |
| surf_Uy | 1.28 |
| surf_p | 157.2 |
| vol_Ux | 7.97 |
| vol_Uy | 3.31 |
| val/loss | 5.42 |

This is the first run on this experimental track — no existing baseline to compare against.

### What happened

**Inconclusive — too few epochs to evaluate.** The larger model (n_layers=5 vs n_layers=1, n_head=4 vs 2) makes each epoch ~31s vs ~5s in the lightweight track. Within the 5-minute budget, only 10 epochs completed. At epoch 10 the model is still in early training (val loss 5.42, surf_p declining rapidly from higher values), so these metrics don't reflect a converged model.

The per-channel weighting is implemented correctly:
- Training loss and validation loss both use `channel_w = [1.0, 1.0, 3.0]` applied to `sq_err`
- MAE reporting is left unweighted for fair comparison
- Checkpoint selection uses the pressure-aware val loss

However, with only 10 epochs, we can't determine if the p=3x weighting improves surf_p compared to equal weights. We'd need either (a) a longer training budget, or (b) the same number of epochs from an equal-weights run to make a fair comparison.

### Suggested follow-ups

- **Run without the weighting for comparison**: Create a baseline run with equal channel weights (all 1.0) for the same 10 epochs to see if p=3x actually helps at this model scale.
- **Reduce model size for faster iteration**: Switching to n_layers=1 or n_layers=2 would bring epochs back to ~5s, allowing proper convergence within 5 minutes.
- **Longer training budget**: The per-channel weighting idea can only be properly evaluated with more epochs (20-50) — the model hasn't converged at epoch 10.