### PR TITLE
Update W&B entity and project to wandb-applied-ai-team/senpai-v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Autonomous ML research on CFD surrogates, powered by Claude Code agents coordina
 
 ![val/loss over time](scatter_plot.png)
 
-[W&B Dashboard](https://wandb.ai/capecape/senpai)
+[W&B Dashboard](https://wandb.ai/wandb-applied-ai-team/senpai-v1)
 
 ## The problem
 

--- a/k8s/launch.py
+++ b/k8s/launch.py
@@ -33,8 +33,8 @@ class Args:
     repo_url: str = "https://github.com/wandb/senpai.git"  # git repo URL
     repo_branch: str = "main"  # git branch to clone
     image: str = "ghcr.io/tcapelle/dev_box:latest"  # container image for students
-    wandb_entity: str = "capecape"  # W&B entity (team or username)
-    wandb_project: str = "senpai"  # W&B project name
+    wandb_entity: str = "wandb-applied-ai-team"  # W&B entity (team or username)
+    wandb_project: str = "senpai-v1"  # W&B project name
     advisor_branch: str = "jurgen"  # branch the advisor works on (PRs target this, not main)
     advisor: bool = False  # also deploy the advisor pod
     students_only: bool = False  # only deploy students, skip advisor

--- a/train.py
+++ b/train.py
@@ -85,7 +85,7 @@ scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOC
 
 # --- wandb ---
 run = wandb.init(
-    project=os.environ.get("WANDB_PROJECT", "senpai"),
+    project=os.environ.get("WANDB_PROJECT", "senpai-v1"),
     group=cfg.wandb_group,
     name=cfg.wandb_name,
     tags=[cfg.agent] if cfg.agent else [],


### PR DESCRIPTION
## Summary

- Updates default W&B entity from `capecape` to `wandb-applied-ai-team` in `launch.py`
- Updates default W&B project from `senpai` to `senpai-v1` in `launch.py` and `train.py`
- Updates W&B dashboard link in `README.md`

## Test plan

- [ ] Verify `python k8s/launch.py --tag test --dry_run` uses the new entity/project defaults
- [ ] Verify a training run logs to `wandb-applied-ai-team/senpai-v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)