### PR TITLE
Surface Cp gradient penalty (physics-informed loss)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -247,6 +247,7 @@ for epoch in range(MAX_EPOCHS):
     model.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
+    epoch_grad_penalty = 0.0
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
@@ -266,22 +267,41 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+
+        # Surface Cp gradient penalty
+        grad_penalty = torch.tensor(0.0, device=device)
+        for b in range(pred.shape[0]):
+            surf_idx = torch.where(surf_mask[b])[0]
+            if len(surf_idx) < 3:
+                continue
+            x_coords = x[b, surf_idx, :2]
+            centroid = x_coords.mean(dim=0)
+            angles = torch.atan2(x_coords[:, 1] - centroid[1], x_coords[:, 0] - centroid[0])
+            sort_idx = angles.argsort()
+            sorted_surf = surf_idx[sort_idx]
+            dp_pred = pred[b, sorted_surf[1:], 2] - pred[b, sorted_surf[:-1], 2]
+            dp_true = y_norm[b, sorted_surf[1:], 2] - y_norm[b, sorted_surf[:-1], 2]
+            grad_penalty = grad_penalty + (dp_pred - dp_true).abs().mean()
+        grad_penalty = grad_penalty / pred.shape[0]
+
+        loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
 
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/grad_penalty": grad_penalty.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
+        epoch_grad_penalty += grad_penalty.item()
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
     epoch_vol /= n_batches
     epoch_surf /= n_batches
+    epoch_grad_penalty /= n_batches
 
     # --- Validate across all splits ---
     model.eval()
@@ -360,6 +380,7 @@ for epoch in range(MAX_EPOCHS):
     metrics = {
         "train/vol_loss": epoch_vol,
         "train/surf_loss": epoch_surf,
+        "train/grad_penalty": epoch_grad_penalty,
         "val/loss": mean_val_loss,
         "lr": scheduler.get_last_lr()[0],
         "epoch_time_s": dt,


### PR DESCRIPTION
## Hypothesis
The Cp gradient penalty was the best single result in the previous track (PR #337, surf_p 30.1→29.5, ~2% improvement). It adds a finite-difference penalty on surface pressure spatial gradients, forcing the model to learn physically consistent pressure distributions. The structured benchmark includes tandem foils and OOD conditions — the gradient penalty should help even more because tandem foil wakes create sharp pressure transitions that are hard to predict pointwise.

## Instructions

Make these changes to `structured_split/structured_train.py`:

1. **Add a Cp gradient penalty to the loss.** After computing `surf_loss`, add:
   ```python
   # Surface Cp gradient penalty
   grad_penalty = torch.tensor(0.0, device=device)
   for b in range(pred.shape[0]):
       surf_idx = torch.where(surf_mask[b])[0]
       if len(surf_idx) < 3:
           continue
       # Sort surface nodes by angle around centroid (arc-length proxy)
       x_coords = x[b, surf_idx, :2]  # spatial coordinates (first 2 dims of x before normalization)
       # Need raw spatial coords — use the unnormalized x or extract before normalization
       centroid = x_coords.mean(dim=0)
       angles = torch.atan2(x_coords[:, 1] - centroid[1], x_coords[:, 0] - centroid[0])
       sort_idx = angles.argsort()
       sorted_surf = surf_idx[sort_idx]
       
       # Finite-difference on pressure channel (index 2 in normalized space)
       dp_pred = pred[b, sorted_surf[1:], 2] - pred[b, sorted_surf[:-1], 2]
       dp_true = y_norm[b, sorted_surf[1:], 2] - y_norm[b, sorted_surf[:-1], 2]
       grad_penalty = grad_penalty + (dp_pred - dp_true).abs().mean()
   
   grad_penalty = grad_penalty / pred.shape[0]
   loss = vol_loss + cfg.surf_weight * surf_loss + 2.0 * grad_penalty
   ```

2. **IMPORTANT:** The spatial coordinates need to be pre-normalization. Save `x_raw = x.clone()` before applying `x = (x - stats["x_mean"]) / stats["x_std"]`, then use `x_raw[b, surf_idx, :2]` for the angle computation. Or alternatively, use the normalized coords — the angle ordering should be the same.

3. **Log the gradient penalty**:
   ```python
   wandb.log({"train/grad_penalty": grad_penalty.item(), ...})
   ```

4. **Run with**: `--wandb_group "cp-grad-penalty-v2"`

**Note:** The Python loop over batch elements is slow. If time permits, try to vectorize it (sort all batches at once). But correctness first.

## Baseline
| Val Split | mae_surf_p |
|---|---|
| val_in_dist | 172.7 |
| val_ood_re | 179.5 |
| val_ood_cond | 310.3 |
| val_tandem_transfer | 354.3 |
| best_val_loss | 2,256,060 |

---

## Results (Revision 3 — run `c8rgjquw`, L1+sw=20 baseline)

**W&B run ID**: `c8rgjquw`  
**Epochs completed**: 15 (30 min wall-clock limit hit)  
**Best epoch**: 11  
**Best val/loss** (finite splits only, NaN-robust): **6.5808**  
**Peak memory**: 40.1 GB

### Surface MAE — Best Checkpoint (Epoch 11)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs new baseline p |
|---|---|---|---|---|
| val_in_dist | 1.383 | 0.626 | 124.1 | 119.7 → **124.1 (+4%, worse)** |
| val_ood_re | 1.036 | 0.548 | NaN (vol overflow) | 179.5 → NaN (data issue) |
| val_ood_cond | 1.189 | 0.635 | 105.6 | 86.8 → **105.6 (+22%, worse)** |
| val_tandem_transfer | 2.211 | 0.860 | 116.5 | 113.2 → **116.5 (+3%, worse)** |

### Volume MAE — Best Checkpoint (Epoch 11)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 5.687 | 2.413 | 145.97 |
| val_ood_cond | 4.432 | 1.936 | 112.65 |
| val_tandem_transfer | 6.058 | 3.060 | 135.33 |
| val_ood_re | 4.142 | 1.781 | Inf (vol overflow) |

### Val Loss — Best Checkpoint (Epoch 11)

| val_in_dist | val_tandem_transfer | val_ood_cond | val_ood_re | mean_val_loss |
|---|---|---|---|---|
| 6.5403 | 7.6154 | 5.5867 | NaN (skipped) | **6.5808** |

### What happened

**Gradient penalty does not improve on the new L1+sw=20 baseline.** On all three evaluable splits, adding the Cp gradient penalty slightly hurts performance: val_in_dist +4%, val_tandem_transfer +3%, val_ood_cond +22% vs the new baseline. This is a clean negative result on the stronger baseline.

**Why the reversal from the previous run?** In the previous run (against MSE+sw=10), the gradient penalty appeared to show large improvements, but those were largely attributable to the MSE→L1 switch and sw=10→20 change in the baseline itself. Now that we're comparing against the proper L1+sw=20 baseline, the gradient penalty adds marginal noise rather than signal.

**Possible explanations:** The Cp gradient penalty enforces pressure gradient consistency in normalized space. With L1 loss already strongly driving surface prediction (sw=20), the gradient penalty term may conflict with or redundantly target the same signal, potentially causing the optimizer to take suboptimal steps. The penalty weight of 2.0 may also need retuning for the new loss scale.

**val_ood_re** still has NaN/Inf in pressure (pre-existing data issue, unrelated to gradient penalty).

**Gradient penalty magnitude**: converged to ~0.13–0.15 (similar to previous run), well-behaved, not dominating the loss.

### Suggested follow-ups

1. **Try lower penalty weight** (0.5 or 1.0) — at sw=20, the surface loss is already 20× weighted; the gradient penalty at 2.0 may be relatively over-weighted.
2. **Try gradient penalty only on pressure channel explicitly** rather than in normalized space, since L1 at sw=20 may already handle Ux/Uy consistency.
3. The large L1+sw=20 improvement (PR #368) dominates; other physics-informed regularizers may have diminishing returns at this loss scale. Consider architectural changes instead.