### PR TITLE
Weighted domain loss (1.5x for tandem/cruise domains)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -47,6 +47,30 @@ sys.path.insert(0, str(Path(__file__).parent))  # structured_split dir
 from prepare_multi import MultiFieldDataset, X_DIM
 
 
+class DomainWeightedSubset(torch.utils.data.Dataset):
+    """Wraps a dataset to attach a per-sample domain loss weight."""
+    def __init__(self, base_ds, indices, idx_to_group, domain_weights):
+        self.base_ds = base_ds
+        self.indices = indices
+        self.idx_to_group = idx_to_group
+        self.domain_weights = domain_weights
+
+    def __len__(self):
+        return len(self.indices)
+
+    def __getitem__(self, i):
+        global_idx = self.indices[i]
+        x, y, is_surface = self.base_ds[global_idx]
+        weight = self.domain_weights[self.idx_to_group[global_idx]]
+        return x, y, is_surface, weight
+
+
+def domain_collate(batch):
+    weights = torch.tensor([item[3] for item in batch], dtype=torch.float32)
+    x, y, is_surface, mask = pad_collate([item[:3] for item in batch])
+    return x, y, is_surface, mask, weights
+
+
 MAX_TIMEOUT = 30.0  # minutes
 MAX_EPOCHS = 50
 
@@ -149,6 +173,16 @@ for name, idxs in manifest["domain_groups"].items():
     for i in idxs:
         idx_to_group[i] = name
 
+domain_loss_weight = {
+    "racecar_single": 1.0,
+    "racecar_tandem": 1.5,
+    "cruise": 1.5,
+}
+
+domain_weighted_train_ds = DomainWeightedSubset(
+    ds, train_ds.indices, idx_to_group, domain_loss_weight
+)
+
 # Use train_ds.indices (not manifest directly) so weights always match the
 # actual train set — robust whether or not debug mode truncated it.
 sample_weights = torch.tensor(
@@ -158,19 +192,20 @@ sample_weights = torch.tensor(
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
+train_loader_kwargs = {**loader_kwargs, "collate_fn": domain_collate}
 
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
-                              shuffle=True, **loader_kwargs)
+    train_loader = DataLoader(domain_weighted_train_ds, batch_size=cfg.batch_size,
+                              shuffle=True, **train_loader_kwargs)
 else:
     sampler = WeightedRandomSampler(
         weights=sample_weights,
         num_samples=len(train_ds),
         replacement=True,
     )
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
-                              sampler=sampler, **loader_kwargs)
+    train_loader = DataLoader(domain_weighted_train_ds, batch_size=cfg.batch_size,
+                              sampler=sampler, **train_loader_kwargs)
 
 val_loaders = {
     name: DataLoader(subset, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
@@ -250,10 +285,11 @@ for epoch in range(MAX_EPOCHS):
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    for x, y, is_surface, mask, domain_w in pbar:
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
+        domain_w = domain_w.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
@@ -265,7 +301,10 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        # Per-sample domain-weighted surface L1 loss: weight tandem/cruise samples 1.5x
+        surf_nodes = surf_mask.sum(dim=1).float().clamp(min=1)  # [B]
+        surf_abs_err = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2))  # [B]
+        surf_loss = (surf_abs_err / surf_nodes * domain_w).mean()
         loss = vol_loss + cfg.surf_weight * surf_loss
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
The structured benchmark has 3 domain groups (racecar_single, racecar_tandem, cruise) with very different flow physics. While the WeightedRandomSampler balances sampling, the loss treats all samples equally. The worst val splits (tandem_transfer=354, ood_cond=310) are from the harder tandem/cruise domains. By applying a per-sample loss multiplier of 1.5x for tandem and cruise samples, we steer the model to allocate more capacity to the domains that drive the worst metrics.

## Baseline (noam — sw=20 + L1, from advisor review)

| Val Split | mae_surf_p |
|---|---|
| val_in_dist | 119.7 |
| val_tandem_transfer | 113.2 |
| val_ood_cond | 86.8 |
| val_ood_re | NaN (overflow) |

---

## Results (v3: domain weighting only, rebased onto noam)

**W&B run:** nqb5hju2  
**W&B group:** domain-weighted-v3  
**Training:** 15 epochs, 30.1 min (wall-clock limit)  
**Peak memory:** 40.1 GB  

### Metrics at best epoch (epoch 15) — compared to noam baseline

| Val Split | mae_surf_p (noam) | mae_surf_p (v3) | delta |
|---|---|---|---|
| val_in_dist | 119.7 | **111.3** | −8.4 (−7.0%) |
| val_tandem_transfer | 113.2 | **104.2** | −9.0 (−7.9%) |
| val_ood_cond | 86.8 | **105.3** | +18.5 (+21.3%) ✗ |
| val_ood_re | NaN | NaN | — |

### Full surface and volume MAE at best epoch

| Val Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 5.8955 | 1.186 | 0.579 | 111.3 | 5.357 | 2.354 | 150.0 |
| val_tandem_transfer | 6.9457 | 1.937 | 0.835 | 104.2 | 5.860 | 3.084 | 124.7 |
| val_ood_cond | 5.3493 | 0.935 | 0.648 | 105.3 | 3.979 | 1.857 | 115.9 |
| val_ood_re | NaN | 0.860 | 0.596 | NaN | 3.772 | 1.751 | NaN |
| **val/loss (mean of 3)** | **6.0635** | | | | | | |

### What happened

Domain weighting produces **mixed results** when cleanly isolated on the noam baseline:

- **Tandem transfer improved**: −9.0 mae_surf_p (−7.9%) — exactly what domain weighting was meant to do. More loss signal on tandem samples steered capacity toward the hard tandem distribution.
- **In-dist improved**: −8.4 mae_surf_p (−7.0%) — likely because tandem samples partially cover the in-dist airfoil shapes.
- **OOD condition regressed**: +18.5 mae_surf_p (+21.3%) — clear failure mode. The ood_cond split tests OOD flow conditions on single-foil samples. By upweighting tandem/cruise (1.5x) relative to racecar_single (1.0x), we reduced effective learning signal for the domain ood_cond evaluates. The model learned less about extreme conditions on single foils.

The net effect is zero-sum: tandem improves but ood_cond pays the price. The static 1.5x weight is too blunt — it cannot simultaneously improve tandem and preserve ood_cond.

**Implementation (v3 — domain weighting only on noam baseline):**
- `DomainWeightedSubset`: wraps train dataset, attaches per-sample domain loss weight
- `domain_collate`: custom collate collecting domain weights as tensor
- Per-sample L1 surface loss: `(surf_abs_err / surf_nodes * domain_w).mean()`
- Domain weights: racecar_single=1.0, racecar_tandem=1.5, cruise=1.5
- No bf16, no lr change, no warmup, no grad clipping — identical to noam baseline config

**val_ood_re:** NaN pressure as in noam baseline (Re=4.445M overflow). Not caused by domain weighting.

**Memory:** 40.1 GB — same as noam baseline (no bf16).

### Suggested follow-ups

1. **Per-split weighting:** Weight tandem up (1.5x) but keep single-foil at 1.0x — separate cruise from tandem rather than grouping both at 1.5x. Or protect ood_cond with single=1.2, tandem=1.5, cruise=1.0.
2. **Softer weighting:** Try 1.2x instead of 1.5x — smaller nudge may improve tandem without starving single-foil OOD.
3. **Sampler interaction:** WeightedRandomSampler already upsamples tandem/cruise. Adding 1.5x loss weight may double-count the effect. Try removing sampler weights and using only domain loss weights for a cleaner formulation.

---

## Previous: Results (v2: domain weighting + L1+bf16+lr=3e-3+warmup+grad_clip)

**W&B run:** 3z40cpmq  
**W&B group:** domain-weighted-v2  
**Training:** 20 epochs, 31.3 min  
**Peak memory:** 31.8 GB  

| Val Split | mae_surf_p (frieren baseline) | mae_surf_p (v2) | delta |
|---|---|---|---|
| val_in_dist | 107.5 | **99.1** | −8.4 (−7.8%) |
| val_tandem_transfer | 100.5 | **100.3** | −0.2 (−0.2%) |
| val_ood_cond | 91.0 | **87.1** | −3.9 (−4.3%) |
| val_ood_re | NaN | NaN | — |

v2 was confounded with base recipe changes (bf16, lr=3e-3, warmup, grad clip). v3 above isolates domain weighting cleanly.