### PR TITLE
Stochastic Weight Averaging (SWA) over final 40% of training

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -194,7 +194,8 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 swa_model = AveragedModel(model)
-swa_start_min = MAX_TIMEOUT * 0.6  # Start SWA at 60% of wall-clock budget
+# swa_start_epoch is set after epoch 0 based on actual epoch time (60% of estimated total epochs)
+swa_start_epoch = MAX_EPOCHS  # default: no SWA (updated after first epoch)
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
@@ -405,8 +406,14 @@ for epoch in range(MAX_EPOCHS):
         f"val[{split_summary}]{tag}"
     )
 
-    # --- SWA update (time-based: start after 60% of wall-clock budget) ---
-    if (time.time() - train_start) / 60.0 >= swa_start_min:
+    # After epoch 0: estimate total epochs from actual epoch time, set SWA start at 60%
+    if epoch == 0:
+        est_epochs = min(MAX_EPOCHS, int(MAX_TIMEOUT * 60 / dt))
+        swa_start_epoch = max(1, int(est_epochs * 0.6))
+        print(f"  → Estimated {est_epochs} total epochs; SWA starts at epoch {swa_start_epoch} (60%)")
+
+    # --- SWA update (epoch-based: start after 60% of estimated total epochs) ---
+    if epoch >= swa_start_epoch:
         swa_model.update_parameters(model)
 
 
@@ -437,13 +444,19 @@ if swa_model.n_averaged > 0:
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
-                pred = swa_model({"x": x})["preds"]
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred = swa_model({"x": x})["preds"]
+                pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
+                abs_err = (pred - y_norm).abs()
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
-                val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
-                val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                val_vol += min(
+                    (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
+                    1e12
+                )
+                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
                 pred_orig = pred * stats["y_std"] + stats["y_mean"]
@@ -470,9 +483,14 @@ if swa_model.n_averaged > 0:
             f"swa/{split_name}/mae_surf_Uy": mae_surf[1].item(),
             f"swa/{split_name}/mae_surf_p":  mae_surf[2].item(),
         }
-        swa_val_loss_sum += split_loss
+        if math.isfinite(split_loss):
+            swa_val_loss_sum += split_loss
 
-    swa_mean_loss = swa_val_loss_sum / len(val_loaders)
+    swa_n_valid = sum(
+        1 for sm in swa_val_metrics_per_split.values()
+        if math.isfinite(list(sm.values())[2])  # index 2 = split loss
+    )
+    swa_mean_loss = swa_val_loss_sum / swa_n_valid if swa_n_valid > 0 else float("nan")
     swa_log: dict = {"swa/val_loss": swa_mean_loss, "global_step": global_step}
     for split_metrics in swa_val_metrics_per_split.values():
         swa_log.update(split_metrics)


### PR DESCRIPTION
## Hypothesis
With 30 minutes of training, the model completes many epochs. SWA (Izmailov et al., 2018) averages model weights over the final epochs, finding a flatter minimum that generalizes better — particularly relevant for OOD generalization (val_ood_re, val_ood_cond). Unlike snapshot ensembles (which failed in the previous track), SWA works with a standard schedule and adds zero inference cost.

## Instructions

Make these changes to `structured_split/structured_train.py`:

1. **Import SWA utilities:**
   ```python
   from torch.optim.swa_utils import AveragedModel, update_bn, SWALR
   ```

2. **Create SWA model** after the model is initialized:
   ```python
   swa_model = AveragedModel(model)
   swa_start_epoch = int(MAX_EPOCHS * 0.6)  # Start SWA at 60% of training
   ```

3. **Update SWA model** at the end of each epoch (after validation), when past the SWA start:
   ```python
   if epoch >= swa_start_epoch:
       swa_model.update_parameters(model)
   ```

4. **Run SWA model through validation** and log with prefix "swa/".

5. **Run with**: `--wandb_group "swa"`

## Baseline
| Val Split | mae_surf_p |
|---|---|
| val_in_dist | 172.7 |
| val_ood_re | 179.5 |
| val_ood_cond | 310.3 |
| val_tandem_transfer | 354.3 |
| best_val_loss | 2,256,060 |

---

## Results

### v1 (run `cjviovh7`) — SWA never activated
SWA epoch-based start (epoch 30) unreachable in 30 min. No checkpoint saved.

### v2 (run `vmuwjbhk`) — sw=10, SWA activated (10 checkpoints)
SWA tandem: 94.1 vs regular 100.2 (-6%).

### v3 (run `gwjfaifi`) — sw=20, SWA activated (10 checkpoints)
Rebased onto #368.

### v4 (run `fzmyi6my`) — 5-layer model, time-based SWA start
10 checkpoints. SWA tandem 93.3 vs 94.9 (-1.6%).

### v5 (run `rmz3t0dy`) — 2-layer model, epoch-based SWA start
47 epochs, 24 checkpoints. SWA improved all splits: in=55.3 vs 64.4 (-14%), cond=54.2 vs 57.1 (-5.1%), tandem=68.8 vs 72.2 (-4.7%). Strong positive result.

### **v6 — Final (run `1za69z4a`) — rebased onto noam w/ 1-layer model (#376)**

**W&B run:** `1za69z4a` | **Peak memory:** 8.5 GB | **Duration:** 30.2 min | **Epochs:** 80

Config: n_layers=1, sw=20, L1 surface + MSE volume, bf16, lr=3e-3 + 3-epoch warmup + cosine, grad clip (max_norm=1.0). **Epoch-based SWA start: epoch 37 (60% of estimated 62 total). Averaged 43 checkpoints.**

| Val Split | New baseline (1-layer) | Regular (epoch 79) | SWA (43 ckpts) |
|---|---|---|---|
| val_in_dist | 46.4 | **42.6** ✓ | 48.8 ✗ |
| val_ood_re | — | NaN | NaN |
| val_ood_cond | 46.7 | **46.6** ≈ | 50.2 ✗ |
| val_tandem_transfer | 65.4 | 68.2 ✗ | 70.1 ✗ |

**Surface MAE breakdown (surf_p / surf_Ux / surf_Uy):**

| Split | Regular (best, epoch 79) | SWA (43 ckpts) |
|---|---|---|
| val_in_dist | **42.6 / 0.514 / 0.265** | 48.8 / 0.566 / 0.282 |
| val_ood_cond | **46.6 / 0.516 / 0.304** | 50.2 / 0.571 / 0.323 |
| val_tandem_transfer | **68.2 / 1.197 / 0.522** | 70.1 / 1.280 / 0.530 |
| val_ood_re | NaN / 0.448 / 0.275 | NaN / 0.476 / 0.280 |

**best_val_loss:** 3.049 | **swa_val_loss:** 3.261 (SWA is worse)

### What happened

**SWA does not help on the 1-layer model.** The best regular checkpoint (epoch 79) beats the SWA model on every split. This is the opposite of the 2-layer result.

The root cause: the 1-layer model is still strongly improving at epoch 37 (SWA start). At 60% of the budget, the model hasn't converged — the best checkpoint is at epoch 79 (the last epoch). SWA averaging from epoch 37 to 79 includes 43 checkpoints, most of which are suboptimal compared to the final state. The early checkpoint drag outweighs any flatter-minimum benefit.

**Context**: SWA theory assumes the model is near convergence when averaging starts. With the 2-layer model (47 epochs, best at epoch 39), the model converged earlier and SWA helped by smoothing near the minimum. With the 1-layer model (80 epochs, best at epoch 79), the model is still descending and SWA is averaging over the descent path — which moves the average away from the minimum.

**Against the new baseline (1-layer PR #376):**
- Regular epoch 79: in=42.6 (**beats** 46.4), cond=46.6 (**ties** 46.7), tandem=68.2 (**loses** vs 65.4)
- SWA: all worse than new baseline

The regular checkpoint beats the 1-layer baseline on in_dist and cond, but loses on tandem_transfer. This may indicate the single run has variance — tandem_transfer was 68.8 under SWA in v5 (2-layer) which is competitive with 65.4 baseline.

### Suggested follow-ups

1. **SWA conclusion**: SWA is model-dependent. It helps when the model converges before the SWA window (2-layer, 47 epochs). It hurts when the model is still improving (1-layer, 80 epochs). SWA start should be delayed further or tied to convergence signal (plateau detection).
2. **Late SWA**: Try starting SWA at epoch 70-75 (last 5-10% of 1-layer training) rather than 60%. This would average only well-converged states.
3. **tandem_transfer regression**: The 1-layer model underperforms the 2-layer model on tandem (68.2 vs 68.8), despite beating on in_dist. The 2-layer model may generalize better to unseen tandem geometries despite having fewer total epochs.