### PR TITLE
Batch size 8 (leverage 2-layer VRAM headroom)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -53,9 +53,9 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 6e-3
     weight_decay: float = 1e-4
-    batch_size: int = 4
+    batch_size: int = 8
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"
     stats_file: str = "structured_split/split_stats.json"


### PR DESCRIPTION
## Hypothesis
The 2-layer model uses only 14.3 GB VRAM (vs 40 GB for 5 layers). Doubling batch size from 4 to 8 should:
1. Improve gradient quality with more samples per step
2. Roughly halve the number of steps per epoch (but each step is heavier)
3. Net effect depends on whether better gradients outweigh fewer update steps

In convex optimization, larger batches give better gradient estimates. For this model, the training data has high variance across samples (different airfoil geometries, Re, AoA), so larger batches should provide more representative gradients.

## Instructions

Make this change to `structured_split/structured_train.py`:

1. **Double batch size:**
   ```python
   parser.add_argument("--batch_size", type=int, default=8)  # was 4
   ```

2. **Adjust learning rate proportionally** (linear scaling rule):
   ```python
   parser.add_argument("--lr", type=float, default=6e-3)  # was 3e-3, doubled with batch
   ```

3. **Everything else stays the same** — 2 layers, L1 surface, surf_weight=20, bf16, warmup, gradient clipping, NaN-robust checkpoint.

4. **Run with**: `--wandb_group "batch-size-8"`

## Baseline (batch_size=4, 2 layers, 47 epochs/30min)
| Val Split | mae_surf_p |
|---|---|
| val_in_dist | 65.3 |
| val_ood_cond | 53.4 |
| val_tandem_transfer | 70.8 |
| val_ood_re | NaN (systemic) |

---

## Results

**W&B run**: `g5zg579e` | **Best epoch**: 43 (30-min timeout) | **Peak VRAM**: 28.6 GB

### Surface MAE (best checkpoint, epoch 43)
| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs Baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.846 | 0.344 | **60.2** | 65.3 → **-7.8%** ✓ |
| val_ood_cond | 0.634 | 0.363 | **62.4** | 53.4 → **+16.9%** ✗ |
| val_tandem_transfer | 1.416 | 0.578 | **78.8** | 70.8 → **+11.3%** ✗ |
| val_ood_re | 0.657 | 0.329 | NaN (systemic) | NaN → same |

### Volume MAE (best checkpoint, epoch 43)
| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 3.878 | 1.492 | 90.6 |
| val_ood_cond | 3.177 | 1.284 | 75.8 |
| val_tandem_transfer | 4.548 | 2.109 | 102.4 |

**val/loss (best)**: 3.860 (NaN-robust mean of 3 finite splits: val_in_dist=3.384, val_ood_cond=3.221, val_tandem_transfer=4.977)

### What happened

Mixed/negative result. Doubling the batch size did not uniformly improve performance:
- **val_in_dist improved slightly** (-7.8% on mae_surf_p), consistent with better gradient estimates for the in-distribution samples
- **val_ood_cond and val_tandem_transfer both regressed** (+16.9% and +11.3%), which is the opposite of what was hoped

The core issue is likely the **gradient update count tradeoff**: with batch_size=8 and 1322 training samples, we get ~166 steps/epoch vs ~331 steps/epoch for batch_size=4. Over 43 vs 47 epochs respectively, this works out to ~7,100 gradient updates vs ~15,500 — roughly half. The increased gradient quality from larger batches didn't compensate for losing 54% of the total update steps within the 30-minute budget.

The VRAM roughly doubled (28.6 GB vs ~14.3 GB for batch_size=4), as expected, but this headroom wasn't turned into better generalization.

The lr linear scaling rule (lr=6e-3) may also be too aggressive combined with fewer steps. The warmup covers the same relative fraction but reaches a higher peak LR.

### Suggested follow-ups
- **Gradient accumulation instead**: accumulate 2 steps at batch_size=4 to get effective batch_size=8 without losing throughput. This preserves the ~15,500 gradient steps while improving gradient quality.
- **Keep batch_size=4, try smaller lr**: since we now know lr=3e-3 with batch_size=4 is already a strong baseline, reducing to lr=1e-3 or 2e-3 might improve OOD generalization.
- **Cosine annealing**: replace linear warmup+constant with cosine decay to benefit more from longer training.