### PR TITLE
Deeper output head (2-layer MLP instead of single linear)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -140,7 +140,11 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Linear(hidden_dim, out_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, out_dim),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx


### PR DESCRIPTION
## Hypothesis
The current Transolver output is a single `nn.Linear(n_hidden, out_dim)` in the last TransolverBlock. In the previous (yan) experiment track, replacing this with a 2-layer MLP (Linear→GELU→Linear) improved surface MAE. The richer output projection gives the model more expressiveness for mapping learned representations to physical quantities, which is especially important with only 2 attention layers.

## Instructions

Make this change to `transolver.py` in the `TransolverBlock` class:

1. **Replace the single linear output head** with a 2-layer MLP. In `TransolverBlock.__init__`, change:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Linear(hidden_dim, out_dim)
   ```
   to:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim),
           nn.GELU(),
           nn.Linear(hidden_dim, out_dim),
       )
   ```

2. **No changes needed to structured_train.py** — the model config stays the same.

3. **Run with**: `--wandb_group "deeper-output-head"`

## Baseline (2 layers, single linear output, 47 epochs/30min)
| Val Split | mae_surf_p |
|---|---|
| val_in_dist | 65.3 |
| val_ood_cond | 53.4 |
| val_tandem_transfer | 70.8 |
| val_ood_re | NaN (systemic) |

---

## Results (Revision — 1-layer baseline, after advisor review)

**W&B run ID**: `dmna3zvh`  
**W&B group**: `deeper-output-head-1layer`  
**Epochs completed**: 78 (30 min wall-clock limit hit)  
**Best epoch**: 77  
**Best val/loss** (finite splits only, NaN-robust): **2.6682**  
**Peak memory**: ~8.7 GB (vs ~14.5 GB for 2-layer — much lower due to 1 block)

### Baseline for this run: 1-layer, single-linear output (PR #376)

| Val Split | mae_surf_p (1-layer baseline) |
|---|---|
| val_in_dist | 46.4 |
| val_ood_cond | 46.7 |
| val_tandem_transfer | 65.4 |
| val_ood_re | NaN (systemic) |

### Surface MAE — Best Checkpoint (Epoch 77)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs 1-layer baseline p |
|---|---|---|---|---|
| val_in_dist | 0.467 | 0.247 | **39.0** | 46.4 → **39.0 (-16%, better)** |
| val_ood_cond | 0.440 | 0.266 | **40.1** | 46.7 → **40.1 (-14%, better)** |
| val_tandem_transfer | 0.976 | 0.455 | **59.2** | 65.4 → **59.2 (-9%, better)** |
| val_ood_re | 0.401 | 0.250 | NaN (vol overflow) | NaN (data issue) |

### Volume MAE — Best Checkpoint (Epoch 77)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 3.049 | 1.092 | 68.2 |
| val_ood_cond | 2.759 | 1.002 | 57.6 |
| val_tandem_transfer | 3.767 | 1.676 | 81.0 |
| val_ood_re | 2.461 | 0.902 | Inf (vol overflow) |

### Val Loss — Best Checkpoint (Epoch 77)

| val_in_dist | val_tandem_transfer | val_ood_cond | val_ood_re | mean_val_loss |
|---|---|---|---|---|
| 2.1478 | 3.6895 | 2.1673 | NaN (skipped) | **2.6682** |

### What happened

**Positive result — deeper output head clearly improves on the 1-layer baseline.** With 78 epochs (matching the 1-layer baseline epoch count), the 2-layer MLP output head gives consistent improvements across all evaluable splits: -16% in_dist, -14% ood_cond, -9% tandem. mae_surf_p drops from 46.4/46.7/65.4 to 39.0/40.1/59.2.

**Why does it work on 1-layer but was neutral on 2-layer?** On the 2-layer model, the extra attention block was providing more representational capacity. On the 1-layer model, the single attention block is a tighter bottleneck — the deeper output head helps compensate by learning a richer mapping from the compressed representation to physical quantities. The GELU nonlinearity allows it to model nonlinear interactions in the last projection step.

**Epoch count not significantly affected**: 78 epochs vs ~78 expected for 1-layer (23s/epoch, same as 1-layer baseline). The extra Linear+GELU in the output head adds negligible compute since it only processes the hidden_dim → hidden_dim → out_dim projection, which is tiny relative to the attention operations.

**VRAM**: ~8.7 GB — same as 1-layer baseline (tiny extra parameters from the hidden_dim layer have no measurable impact).

---

## Prior Results (Run 1, before advisor review — 2-layer baseline)

**W&B run ID**: `ytfuy2s2`  
**Epochs**: 46, **Best epoch**: 44  
**Best val/loss**: 3.5981 (vs 2-layer single-linear baseline ~3.60) — essentially neutral  

This run was mixed on the 2-layer baseline. The advisor requested rebase onto 1-layer (PR #376 merged), which was done above.

---

## Suggested follow-ups

1. **Combine with more attention layers** (n_layers=2 or 3) — now that the output head is confirmed useful, test if deeper attention + deeper head stacks additively.
2. **Scale n_hidden** (256 vs 128) — the deeper head may benefit from wider hidden representations.
3. **Multiple runs** — the ~9-16% improvement on a single run is encouraging; 2-3 seeds would confirm it's not noise.