### PR TITLE
Wider hidden dim (n_hidden=256) with 1-layer model

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -181,7 +181,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=128,
+    n_hidden=256,      # was 128
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=64,


### PR DESCRIPTION
## Hypothesis
With only 1 attention layer, the model's capacity is limited by the hidden dimension (128). Doubling to n_hidden=256 increases the attention dim, FFN width, and output projection — giving the single layer more representational power. The 1-layer model uses only 14.3 GB VRAM at n_hidden=128, so there's room to increase. The key question: does the extra capacity improve accuracy enough to offset potentially slower epochs?

## Instructions

Make this change to `structured_split/structured_train.py`:

1. **Increase hidden dimension:**
   ```python
   model_config = dict(
       space_dim=2,
       fun_dim=X_DIM - 2,
       out_dim=3,
       n_hidden=256,      # was 128
       n_layers=1,
       n_head=4,
       slice_num=64,
       mlp_ratio=2,
       output_fields=["Ux", "Uy", "p"],
       output_dims=[1, 1, 1],
   )
   ```

2. **Everything else stays the same** — 1 layer, L1 surface, surf_weight=20, bf16, lr=3e-3, warmup, gradient clipping, MAX_EPOCHS=100.

3. **Run with**: `--wandb_group "wider-hidden-256"`

4. **Monitor epoch time** — if significantly slower, the throughput loss may negate the capacity gain.

## Baseline (1 layer, n_hidden=128, 78 epochs/30min)
| Val Split | mae_surf_p |
|---|---|
| val_in_dist | 46.4 |
| val_ood_cond | 46.7 |
| val_tandem_transfer | 65.4 |

---

## Results

**W&B run:** `oronnlvh` | **Epochs completed:** 55 in 30 min | **Peak memory:** 14.3 GB | **Best epoch:** 55

### Metrics at best checkpoint (epoch 55, val/loss=4.028)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.727 | 0.300 | **58.3** | 46.4 → **+26%** ✗ |
| val_ood_re | 0.728 | 0.291 | **NaN** ⚠️ | overflow |
| val_ood_cond | 0.819 | 0.317 | **60.0** | 46.7 → **+28%** ✗ |
| val_tandem_transfer | 1.921 | 0.590 | **90.7** | 65.4 → **+39%** ✗ |

### Volume MAE at best checkpoint (epoch 55)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 3.40 | 1.25 | 83.1 |
| val_ood_cond | 3.30 | 1.13 | 76.9 |
| val_tandem_transfer | 5.39 | 1.95 | 105.8 |
| val_ood_re | 2.99 | 1.01 | inf ⚠️ |

### What happened

**Clear negative result: n_hidden=256 is worse than n_hidden=128 on the 1-layer model.**

- **Epoch throughput**: 33s/epoch (256) vs 23s/epoch (128) — 43% slower, completing only 55 epochs vs 80.
- **Memory**: 14.3 GB (256) vs 8.5 GB (128).
- **All metrics worse across all splits**: mae_surf_p increased 26-39% compared to the 128-hidden baseline.

The pattern is consistent with prior findings: **under time-constrained training, epoch count dominates model capacity**. The 43% throughput penalty from doubling the hidden dim translates directly into 25 fewer epochs (~31% less training), which overwhelms any per-epoch capacity benefit. The 256-hidden model at epoch 55 is clearly underfitted compared to the 128-hidden model at epoch 80.

This confirms the 1-layer n_hidden=128 configuration as near-optimal for the 30-minute budget: it's the sweet spot between capacity and throughput.

### Suggested follow-ups

1. **n_hidden=128 is the right choice** for 30-minute training — don't increase.
2. **If more VRAM budget is needed** (e.g., for batch_size experiments), n_hidden=256 could be an option if the epoch budget isn't the constraint.
3. **n_hidden=64 or smaller** would run even faster (potentially 100+ epochs) but capacity might become the bottleneck. Could be worth testing.