### PR TITLE
Lower weight decay (1e-5) for less regularization

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -54,7 +54,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
The current weight_decay=1e-4 was a default setting. With only 1 attention layer and 78 epochs, the model may be underfitting rather than overfitting. Reducing weight decay to 1e-5 allows the model to fit the data more aggressively. This was a successful change in the previous (yan) experiment track.

## Instructions

1. **Change weight decay:**
   ```python
   parser.add_argument("--weight_decay", type=float, default=1e-5)  # was 1e-4
   ```

2. **Everything else stays the same.**

3. **Run with**: `--wandb_group "wd-1e5"`

## Baseline (1 layer, deeper head, wd=1e-4, 78 epochs/30min)
| Val Split | mae_surf_p |
|---|---|
| val_in_dist | 39.0 |
| val_ood_cond | 40.1 |
| val_tandem_transfer | 59.2 |

---

## Results (run 1 — pre-rebase, slice_num=64, wd=1e-5)

**W&B run**: `f0guy1tg` | **Best epoch**: 78 | **Peak VRAM**: 8.7 GB

| Val Split | mae_surf_p | vs Baseline |
|---|---|---|
| val_in_dist | **38.0** | 39.0 → -2.6% ✓ |
| val_ood_cond | **38.4** | 40.1 → -4.2% ✓ |
| val_tandem_transfer | **59.0** | 59.2 → -0.3% ✓ |
| val_ood_re | NaN | NaN |

---

## Results (run 2 — after rebase onto slice_num=32 baseline, 92 epochs/30min)

**W&B run**: `e0herl8x` | **Best epoch**: 92 (30-min timeout) | **Peak VRAM**: 7.5 GB

**New baseline** (slice_num=32, wd=1e-4, 92 epochs): val_in_dist=33.5, val_ood_cond=38.0, val_tandem_transfer=58.4

### Surface MAE (best checkpoint, epoch 92)
| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs New Baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.436 | 0.234 | **34.1** | 33.5 → **+1.8%** ✗ |
| val_ood_cond | 0.384 | 0.255 | **38.8** | 38.0 → **+2.1%** ✗ |
| val_tandem_transfer | 0.993 | 0.455 | **59.4** | 58.4 → **+1.7%** ✗ |
| val_ood_re | 0.361 | 0.243 | NaN (systemic) | NaN → same |

### Volume MAE (best checkpoint, epoch 92)
| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 3.053 | 1.086 | 63.6 |
| val_ood_cond | 2.761 | 1.007 | 56.7 |
| val_tandem_transfer | 3.740 | 1.660 | 79.4 |

**val/loss (best)**: 2.570 (NaN-robust mean of 3 finite splits: val_in_dist=1.948, val_ood_cond=2.043, val_tandem_transfer=3.720)

### What happened

Mixed result relative to the new baseline. Against the original slice_num=64 baseline, wd=1e-5 was a clear win (-2.6% to -4.2%). But against the slice_num=32 baseline, wd=1e-5 is slightly *worse* (+1.7% to +2.1%).

The reversal suggests the benefit of lower weight decay is tied to model capacity: with slice_num=64 (higher capacity), the model was over-regularized. With slice_num=32 (lower capacity), wd=1e-4 appears to be an appropriate amount of regularization — or perhaps even slightly insufficient.

The differences are small (1-2%) and may partly reflect run-to-run variance, but the direction is consistently negative across all three splits.

Conclusion: **wd=1e-5 does not improve over wd=1e-4 when combined with slice_num=32.**

### Suggested follow-ups
- **Try wd=1e-6 or wd=0 with slice_num=32** to check if the trend continues, but current evidence suggests diminishing returns.
- **Combine wd=1e-5 with larger model** (slice_num=64 or n_hidden=192): the wd reduction is helpful when model has more capacity to exploit.
- **Accept wd=1e-4 as appropriate for 1-layer + slice_num=32 setup** and focus on other levers (lr, architecture).