### PR TITLE
Longer warmup (5 epochs) with cosine annealing

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -194,10 +194,10 @@ model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=3)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 3)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[3]
+    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The current 3-epoch warmup may be too short for the 1-layer model running 78 epochs. A 5-epoch warmup (6.4% of training) gives the model more time to stabilize before reaching peak LR. With cosine decay over the remaining 95 epochs, the model gets a gentler ramp-up and more refined annealing.

## Instructions
1. Change warmup from 3 to 5 epochs in the SequentialLR:
   ```python
   warmup = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)  # was 3
   cosine = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)
   scheduler = torch.optim.lr_scheduler.SequentialLR(optimizer, [warmup, cosine], [5])
   ```
2. Run with `--wandb_group "warmup-5ep"`

## Baseline: in=39.0, cond=40.1, tandem=59.2

---
## Results

**W&B run:** `dmaliims` | **Epochs completed:** 78 in 30 min | **Peak memory:** 8.7 GB | **Best epoch:** 78

### Metrics at best checkpoint (epoch 78, val/loss=2.640)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.492 | 0.242 | **38.2** | 39.0 → **-2%** |
| val_ood_re | 0.392 | 0.254 | **NaN** ⚠️ | overflow |
| val_ood_cond | 0.397 | 0.258 | **39.8** | 40.1 → **-1%** |
| val_tandem_transfer | 0.970 | 0.452 | **59.7** | 59.2 → **+1%** |

| Val Split | mae_vol_p |
|---|---|
| val_in_dist | 64.7 |
| val_ood_cond | 58.7 |
| val_tandem_transfer | 81.6 |

### What happened

**Essentially neutral result** — the 5-epoch warmup is within noise of the 3-epoch warmup. All differences are ≤2%, and tandem_transfer is very slightly worse.

- **val_in_dist**: 39.0 → 38.2 (-2%) — marginal improvement, could be run-to-run variance
- **val_ood_cond**: 40.1 → 39.8 (-1%) — marginal, within noise
- **val_tandem_transfer**: 59.2 → 59.7 (+1%) — slightly worse

Same epoch count (78) as the 3-warmup baseline. The additional 2 warmup epochs don't change throughput meaningfully.

The 3-epoch warmup is already sufficient for the 1-layer model. The warming phase (10% to 100% LR over 3 epochs) is enough to stabilize the optimizer before peak LR, and extending it to 5 epochs doesn't provide meaningful additional stability at the cost of 2 fewer cosine epochs.

### Suggested follow-ups

1. **Not worth merging** — the improvement is within noise and the change adds complexity for no clear benefit.
2. **The 3-epoch warmup is fine** for this architecture. Warmup tuning is low-priority.
3. **More impactful levers** to explore: LR value, batch size, per-channel weighting scale, or data augmentation.