### PR TITLE
Wider FFN (mlp_ratio=4) in single attention layer

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -185,7 +185,7 @@ model_config = dict(
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=64,
-    mlp_ratio=2,
+    mlp_ratio=4,  # was 2 — wider FFN for more nonlinear capacity
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
With only 1 attention layer, the FFN (mlp_ratio=2, so 256-dim) may be a bottleneck. Increasing to mlp_ratio=4 (512-dim FFN) gives the model more nonlinear transformation capacity per token. Unlike wider hidden dim, wider FFN doesn't increase attention cost — only the feedforward computation, which is relatively cheap.

## Instructions
1. Change mlp_ratio in model config:
   ```python
   model_config = dict(
       ...,
       mlp_ratio=4,  # was 2
       ...,
   )
   ```
2. Run with `--wandb_group "mlp-ratio-4"`

## Baseline: in=39.0, cond=40.1, tandem=59.2

---
## Results

**W&B run:** `jnir2g0b` | **Peak memory:** 9.8 GB (vs 8.5 GB baseline) | **Duration:** 30.1 min | **Epochs:** 74

| Val Split | Baseline (mlp_ratio=2) | mlp_ratio=4 | Delta |
|---|---|---|---|
| val_in_dist | 39.0 | **39.4** | +1% ✗ |
| val_ood_cond | 40.1 | 42.9 | +7% ✗ |
| val_tandem_transfer | 59.2 | **59.4** | +0.3% ✗ |
| val_ood_re | — | NaN | — |

**Full surface MAE breakdown:**

| Split | surf_p | surf_Ux | surf_Uy |
|---|---|---|---|
| val_in_dist | 39.4 | 0.505 | 0.248 |
| val_ood_cond | 42.9 | 0.455 | 0.262 |
| val_tandem_transfer | 59.4 | 1.010 | 0.453 |
| val_ood_re | NaN | 0.415 | 0.258 |

**best_val_loss:** 2.709 | **Best epoch:** 74

### What happened

mlp_ratio=4 does not improve over the baseline. Results are essentially tied (+0.3–7%) within run-to-run variance, with a slight regression on ood_cond (+7%). The wider FFN adds 1.3 GB of VRAM (9.8 vs 8.5 GB) and reduces epochs from ~80 to 74 (slightly slower), but does not produce a commensurate accuracy improvement.

The epoch count is slightly lower (74 vs 80), likely because larger FFN computations take marginally more time per epoch (~24s vs ~23s). The best epoch moves from 79 to 74.

The hypothesis that the 256-dim FFN was a bottleneck appears to be incorrect. With a 1-layer model and n_hidden=128, the attention mechanism's 128-dim processing is likely the capacity constraint, not the 256-dim FFN. Doubling the FFN without changing n_hidden adds parameters in a part of the model that is already over-sized relative to the bottleneck.

### Suggested follow-ups

1. **No improvement** — mlp_ratio=4 is not worth the extra VRAM. Keep mlp_ratio=2 as default.
2. **Wider hidden dim** (n_hidden=256) might help more than wider FFN, since n_hidden is the actual information bottleneck.
3. **The 1-layer model with n_hidden=128 may be at capacity** — further improvement may require either more layers or wider hidden dim rather than wider FFN.