### PR TITLE
Higher surface weight (surf_weight=30)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -56,7 +56,7 @@ class Config:
     lr: float = 3e-3
     weight_decay: float = 1e-4
     batch_size: int = 4
-    surf_weight: float = 20.0
+    surf_weight: float = 30.0
     manifest: str = "structured_split/split_manifest.json"
     stats_file: str = "structured_split/split_stats.json"
     wandb_group: str | None = None


### PR DESCRIPTION
## Hypothesis
surf_weight was increased from 10→20 in an earlier PR with good results. The model now has more capacity (deeper output head) and more epochs (78). Pushing surf_weight to 30 may further improve surface metrics at acceptable cost to volume accuracy.

## Instructions
1. Change surf_weight:
   ```python
   parser.add_argument("--surf_weight", type=float, default=30.0)  # was 20.0
   ```
2. Run with `--wandb_group "surf-weight-30"`

## Baseline: in=39.0, cond=40.1, tandem=59.2

---

## Results (v2: slice_num=32 + surf_weight=30, rebased onto latest noam)

**W&B run:** q6olzs3a  
**W&B group:** surf-weight-30-v2  
**Training:** 89 epochs (best), 30.1 min  
**Peak memory:** 8.5 GB  

### mae_surf_p — compared to baselines

| Val Split | noam baseline (slice_num=32, ~33.5 in_dist) | surf_weight=30 v2 | delta vs noam |
|---|---|---|---|
| val_in_dist | ~33.5 | **33.1** | −0.4 (−1.2%) |
| val_ood_cond | — | **40.0** | — |
| val_tandem_transfer | — | **56.6** | — |
| val_ood_re | NaN | NaN | — |

### Full metrics at best epoch (epoch 89)

| Val Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 2.8015 | 0.433 | 0.229 | 33.1 | 3.144 | 1.130 | 67.2 |
| val_tandem_transfer | 5.3170 | 0.998 | 0.446 | 56.6 | 3.908 | 1.720 | 80.4 |
| val_ood_cond | 3.3221 | 0.451 | 0.261 | 40.0 | 2.943 | 1.112 | 63.2 |
| val_ood_re | NaN | 0.378 | 0.242 | NaN | 2.552 | 0.952 | NaN |
| **val/loss (mean of 3)** | **3.8135** | | | | | | |

### What happened

**surf_weight=30 with slice_num=32 narrowly beats the noam baseline on in_dist (33.1 vs ~33.5)**, with 89 epochs in 30 min (vs 77 with slice_num=64). The improvements are consistent but modest:

- The main effect is on val_in_dist: marginally better than baseline.
- val_tandem_transfer: 56.6 — improved from v1 (58.1 at slice_num=64). The faster attention (slice_num=32) allows more epochs which helps.
- val_ood_cond: 40.0 — essentially flat.

**Comparison across v1/v2:**
| | v1 (slice_num=64, 77ep) | v2 (slice_num=32, 89ep) |
|---|---|---|
| val_in_dist | 34.8 | **33.1** |
| val_ood_cond | 39.4 | **40.0** (slight regression) |
| val_tandem_transfer | 58.1 | **56.6** |

The faster-attention architecture (slice_num=32) allows more epochs, which helps in_dist and tandem but slightly hurts ood_cond. Overall: surf_weight=30 delivers consistent small improvements.

**Implementation:** 1-line change: `surf_weight: float = 30.0` (was 20.0).

---

## Previous: Results (v1: slice_num=64, surf_weight=30)

**W&B run:** uy7gnlah  
**W&B group:** surf-weight-30  
**Training:** 77 epochs (best), 30.0 min | **Memory:** 8.7 GB

| Val Split | mae_surf_p (sw=20 baseline) | mae_surf_p (sw=30 v1) | delta |
|---|---|---|---|
| val_in_dist | 39.0 | **34.8** | −4.2 (−10.8%) |
| val_ood_cond | 40.1 | **39.4** | −0.7 (−1.7%) |
| val_tandem_transfer | 59.2 | **58.1** | −1.1 (−1.9%) |

### Suggested follow-ups

1. **Continue to surf_weight=40:** The 20→30 step helped; 30→40 might push further.
2. **Combine with channel weighting:** 3x pressure channel weight (PR #375) stacks well — both improve p metrics.
3. **Tune slice_num × surf_weight jointly:** slice_num=32 helps some splits but regresses ood_cond slightly; the interaction with surf_weight might have a better optimum.