### PR TITLE
Target noise regularization (0.01 std Gaussian noise on targets)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -261,6 +261,8 @@ for epoch in range(MAX_EPOCHS):
 
         x = (x - stats["x_mean"]) / stats["x_std"]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
+        if model.training:
+            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Adding small Gaussian noise (std=0.01) to normalized training targets prevents the model from overfitting to exact values and acts as a form of label smoothing. This was a successful technique in the previous (yan) experiment track, where it improved surface MAE by preventing memorization of high-frequency noise in the CFD data.

## Instructions
1. Add target noise in the training loop, after normalizing targets:
   ```python
   y_norm = (y - stats["y_mean"]) / stats["y_std"]
   if model.training:
       y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
   ```
2. Only apply during training, NOT validation.
3. Run with `--wandb_group "target-noise-001"`

## Baseline: in=33.5, cond=38.0, tandem=58.4 (1 layer, deeper head, slice_num=32, 92 epochs/30min)

---
## Results

**W&B run:** `v10t4fwz` | **Epochs completed:** 91 in 30 min | **Peak memory:** 7.5 GB | **Best epoch:** 88

### Metrics at best checkpoint (epoch 88, val/loss=2.493)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.422 | 0.234 | **33.7** | 33.5 → **+1%** ~ |
| val_ood_re | 0.361 | 0.245 | **NaN** ⚠️ | overflow |
| val_ood_cond | 0.394 | 0.259 | **37.2** | 38.0 → **-2%** ✓ |
| val_tandem_transfer | 0.946 | 0.443 | **56.4** | 58.4 → **-3%** ✓ |

| Val Split | mae_vol_p |
|---|---|
| val_in_dist | 61.8 |
| val_ood_cond | 56.8 |
| val_tandem_transfer | 76.2 |

### What happened

**Marginally positive: target noise helps OOD splits slightly but doesn't improve in-distribution accuracy.**

- **val_in_dist**: 33.5 → 33.7 (+1%) — essentially neutral, within run-to-run variance
- **val_ood_cond**: 38.0 → 37.2 (-2%) — slight improvement
- **val_tandem_transfer**: 58.4 → 56.4 (-3%) — modest but consistent improvement

The pattern matches the hypothesis: regularization via label noise reduces memorization of training-set specifics, which helps OOD generalization (tandem_transfer, ood_cond) at the cost of in-distribution accuracy. The effect is small (1-3%) — the model is not significantly overfitting at 91 epochs, so there's less room for the noise to help.

Velocity channels (Ux, Uy) improved slightly across all splits, suggesting the noise also helps velocity prediction.

val_ood_re overflow persists regardless of regularization.

### Suggested follow-ups

1. **Try std=0.05 or 0.1** — the 0.01 noise is very small relative to the normalized target distribution. A larger noise floor might provide stronger regularization for OOD splits.
2. **Combine with other improvements** — target noise is orthogonal to per-channel weighting and architecture changes. Could be worth combining.
3. **More epochs** — if the model is at epoch 91 and still improving, the noise may help more with additional training time.