### PR TITLE
Asymmetric output heads (deeper pressure head, simple velocity head)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -140,17 +140,25 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
+            # Simple velocity head (Ux, Uy)
+            self.vel_head = nn.Linear(hidden_dim, 2)
+            # Deeper pressure head (p) - more capacity for the harder task
+            self.p_head = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
+                nn.Linear(hidden_dim, 64),
+                nn.GELU(),
+                nn.Linear(64, 1),
             )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            vel_out = self.vel_head(h)   # [B, N, 2] for Ux, Uy
+            p_out = self.p_head(h)       # [B, N, 1] for pressure
+            return torch.cat([vel_out, p_out], dim=-1)  # [B, N, 3]
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The current shared output head (Linear→GELU→Linear) maps 128-dim features to 3 outputs (Ux, Uy, p). But pressure and velocity have fundamentally different error scales: pressure errors are 80x larger (mae_surf_p=32.6 vs mae_surf_Ux=0.4). The shared head forces a single nonlinear transformation to serve both regimes simultaneously.

By splitting into a **deeper pressure head** (3-layer MLP) and a **simple velocity head** (single linear), we match architectural capacity to task difficulty. The extra parameters (~12K) are negligible and won't impact epoch time.

## Instructions

Make these changes to `transolver.py` in the `TransolverBlock` class:

1. **Replace the shared output head** with two asymmetric heads. In `__init__`, when `last_layer=True`:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       # Simple velocity head (Ux, Uy)
       self.vel_head = nn.Linear(hidden_dim, 2)
       # Deeper pressure head (p) - more capacity for the harder task
       self.p_head = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim),
           nn.GELU(),
           nn.Linear(hidden_dim, 64),
           nn.GELU(),
           nn.Linear(64, 1),
       )
   ```

2. **Update the forward method** for the last layer:
   ```python
   if self.last_layer:
       h = self.ln_3(fx)
       vel_out = self.vel_head(h)   # [B, N, 2] for Ux, Uy
       p_out = self.p_head(h)       # [B, N, 1] for pressure
       return torch.cat([vel_out, p_out], dim=-1)  # [B, N, 3]
   ```

3. **No changes to structured_train.py** — the output shape stays [B, N, 3].

4. **Run with**: `--wandb_group "asymmetric-heads"`

## Baseline: in=32.6, cond=36.5, tandem=55.9 (1 layer, deeper shared head, slice_num=32, 91 epochs/30min)

---

## Results

**W&B run ID**: `6f5d5nnw`  
**W&B group**: `asymmetric-heads`  
**Epochs completed**: 87 (30 min wall-clock limit hit, best=epoch 87 — still improving at cutoff)  
**Best val/loss** (finite splits only, NaN-robust): **2.7716**  
**Peak memory**: ~8.0 GB

### Surface MAE — Best Checkpoint (Epoch 87)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.476 | 0.263 | **37.5** | 32.6 → **37.5 (+15%, worse)** |
| val_ood_cond | 0.442 | 0.292 | **41.2** | 36.5 → **41.2 (+13%, worse)** |
| val_tandem_transfer | 1.040 | 0.488 | **60.1** | 55.9 → **60.1 (+7%, worse)** |
| val_ood_re | 0.383 | 0.263 | NaN (vol overflow) | NaN (data issue) |

### Volume MAE — Best Checkpoint (Epoch 87)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 3.410 | 1.261 | 67.9 |
| val_ood_cond | 2.921 | 1.170 | 58.7 |
| val_tandem_transfer | 4.068 | 1.851 | 83.0 |
| val_ood_re | 2.672 | 1.026 | Inf (vol overflow) |

### Val Loss — Best Checkpoint (Epoch 87)

| val_in_dist | val_tandem_transfer | val_ood_cond | val_ood_re | mean_val_loss |
|---|---|---|---|---|
| 2.1676 | 3.8735 | 2.2738 | NaN (skipped) | **2.7716** |

### What happened

**Negative result — asymmetric heads are consistently worse than the shared deeper head across all splits.** mae_surf_p increases by +15% in_dist (32.6→37.5), +13% ood_cond (36.5→41.2), and +7% tandem (55.9→60.1). Best val_loss of 2.7716 vs ~2.52 for baseline.

**Why it failed?** The hypothesis was that more pressure-specific capacity would help. But the 3-layer pressure head introduces much more network depth: the gradient now flows through 3 linear+activation layers to reach the shared representation. This makes training harder — the pressure head is effectively a different optimization problem than the velocity head. In 87 epochs, the pressure head doesn't fully converge, while the shared head's simpler 2-layer design trains more uniformly across all outputs. Both also share the same shared 128-dim representation — the pressure head can't "ask for" different features than the velocity head.

**Epoch count roughly similar**: 87 vs 91 for baseline (same 21s/epoch). The extra layers in the pressure head are negligible in cost.

**Conclusion**: The shared head architecture (Linear→GELU→Linear applied to all outputs jointly) is better for this task. The different scales between Ux/Uy and p are already handled by the L1 surface loss and surf_weight=20, not by architectural differentiation at the output stage.

### Suggested follow-ups

1. **Per-output loss weighting** — instead of architecture asymmetry, try separate loss weights for p vs Ux/Uy (e.g., pressure_weight=2.0 within surf_loss).
2. **Shared deeper head** — the current (Linear→GELU→Linear) may not be the optimal shared architecture; a 3-layer shared head (all outputs together) could be better than splitting.
3. **Feature normalization** — normalize the 128-dim representation differently before projecting to p vs velocity (e.g., separate LayerNorms for velocity and pressure) without splitting the actual projection depth.