### PR TITLE
Random Fourier Features on spatial coordinates (NeRF-style encoding)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -30,6 +30,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import json
+import math
 import os
 import time
 import torch
@@ -72,6 +73,11 @@ if cfg.debug:
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
+
+# Random Fourier Features — fixed (not learned), applied to raw spatial coords
+N_FOURIER = 32
+SIGMA = 10.0  # frequency scale
+B_matrix = (torch.randn(2, N_FOURIER) * SIGMA).to(device)
 
 # --- Load split manifest and normalization stats ---
 with open(cfg.manifest) as f:
@@ -179,7 +185,7 @@ val_loaders = {
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=(X_DIM + 2 * N_FOURIER) - 2,  # 24 + 64 Fourier dims - 2 space = 86
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -259,7 +265,13 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
-        x = (x - stats["x_mean"]) / stats["x_std"]
+        # Fourier features from raw spatial coords (before normalization)
+        pos = x[:, :, :2]  # [B, N, 2]
+        fourier = torch.cat([
+            torch.sin(2 * math.pi * pos @ B_matrix),
+            torch.cos(2 * math.pi * pos @ B_matrix),
+        ], dim=-1)  # [B, N, 64]
+        x = torch.cat([(x - stats["x_mean"]) / stats["x_std"], fourier], dim=-1)  # [B, N, 88]
         y_norm = (y - stats["y_mean"]) / stats["y_std"]
         if model.training:
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
@@ -313,7 +325,13 @@ for epoch in range(MAX_EPOCHS):
                 is_surface = is_surface.to(device, non_blocking=True)
                 mask = mask.to(device, non_blocking=True)
 
-                x = (x - stats["x_mean"]) / stats["x_std"]
+                # Fourier features from raw spatial coords (before normalization)
+                pos = x[:, :, :2]  # [B, N, 2]
+                fourier = torch.cat([
+                    torch.sin(2 * math.pi * pos @ B_matrix),
+                    torch.cos(2 * math.pi * pos @ B_matrix),
+                ], dim=-1)  # [B, N, 64]
+                x = torch.cat([(x - stats["x_mean"]) / stats["x_std"], fourier], dim=-1)  # [B, N, 88]
                 y_norm = (y - stats["y_mean"]) / stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
The model receives raw (x, z) coordinates that are normalized to zero-mean unit-variance. A linear input MLP can only learn linear spatial features from these. But surface pressure has sharp local features: stagnation point spikes, suction peaks with steep gradients, trailing edge discontinuities.

Random Fourier Features (Tancik et al., NeurIPS 2020) project coordinates through fixed sinusoidal bases, enabling the model to resolve high-frequency spatial patterns. This has been transformative in NeRFs and physics-informed neural networks.

Previous Fourier features attempt (PR #296 on yan track) failed because it injected at intermediate layers and used learnable frequencies. This proposal uses FIXED random features applied ONLY at the input level.

## Instructions

Make these changes to `structured_split/structured_train.py`:

1. **Generate fixed random Fourier features** before training:
   ```python
   # Random Fourier Features for spatial coordinates
   N_FOURIER = 32
   SIGMA = 10.0  # frequency scale
   B_matrix = torch.randn(2, N_FOURIER) * SIGMA  # fixed, not learned
   B_matrix = B_matrix.to(device)
   ```

2. **Apply to input features** in the training loop, after loading x but before normalization:
   ```python
   # Extract spatial coords (first 2 dims), compute Fourier features
   pos = x[:, :, :2]  # [B, N, 2]
   fourier = torch.cat([
       torch.sin(2 * 3.14159 * pos @ B_matrix),
       torch.cos(2 * 3.14159 * pos @ B_matrix),
   ], dim=-1)  # [B, N, 64]
   x = torch.cat([x, fourier], dim=-1)  # [B, N, 24+64=88]
   ```

3. **Apply the same in validation** (before x normalization).

4. **Update model config**:
   ```python
   model_config = dict(
       space_dim=2,
       fun_dim=88 - 2,  # was X_DIM - 2, now includes Fourier features
       ...
   )
   ```

5. **Update x normalization stats** — compute x_mean and x_std over the augmented 88-dim features (or skip normalization for the Fourier dims since they're already in [-1, 1]).

6. **Run with**: `--wandb_group "fourier-features"`

## Baseline: in=32.6, cond=36.5, tandem=55.9

---

## Results

**W&B run:** `hxqgpzcp` | **Peak memory:** 8.2 GB | **Duration:** 30.3 min | **Epochs:** 90

Note: this branch includes target noise regularization (0.01σ on y_norm during training) from noam #386.

| Val Split | Baseline | Fourier (N=32, σ=10) | Delta |
|---|---|---|---|
| val_in_dist | 32.6 | 39.6 | +21% ✗ |
| val_ood_cond | 36.5 | 41.5 | +14% ✗ |
| val_tandem_transfer | 55.9 | 64.2 | +15% ✗ |
| val_ood_re | — | NaN | — |

**Full surface MAE breakdown:**

| Split | surf_p | surf_Ux | surf_Uy |
|---|---|---|---|
| val_in_dist | 39.6 | 0.505 | 0.258 |
| val_ood_cond | 41.5 | 0.431 | 0.265 |
| val_tandem_transfer | 64.2 | 1.083 | 0.484 |
| val_ood_re | NaN | 0.390 | 0.258 |

**best_val_loss:** 2.803 | **Best epoch:** 90

**Note on visualization error**: The `visualize()` function at the end called the model without Fourier augmentation (24-dim input), causing a shape mismatch. Training metrics are correct; only the final plot generation failed.

### What happened

Fourier features substantially hurt performance across all three finite splits (+14-21%). This is a clear negative result.

**Root cause analysis:**

1. **sigma=10.0 is likely mismatched to coordinate scale.** The raw (x, z) coordinates in the TandemFoilSet are in physical space (~chord lengths ≈ 1 unit). The Fourier frequencies are sampled from N(0, σ²=100), giving very high-frequency features. At sigma=10 on coordinates in [-5, 5], the projections `pos @ B_matrix` range over ~[-50, 50], creating features that oscillate far more than needed to capture aerodynamic boundary layer gradients. The model may be confusing noise from over-oscillation.

2. **Fixed random B_matrix introduces run-to-run variance.** Each run draws a different B_matrix. The useful "low-frequency envelope" requires luck in the random draw.

3. **Fun_dim increased from 22 to 86**, making the model wider at the input. This slightly slows down training (20.1s/epoch vs ~19.6s for baseline) and may cause the model to require more epochs to converge.

4. **The visualization crash** indicates the saved model can't be loaded and used without Fourier augmentation, reducing utility.

### Suggested follow-ups

1. **Negative result** — Fourier features at sigma=10 hurt. Not worth keeping.
2. **If revisiting**: try sigma=1.0-2.0 (appropriate for unit-normalized coordinates), or apply Fourier features to already-normalized coords (eliminating the scale mismatch).
3. **Alternative** for high-frequency spatial encoding: positional encodings relative to airfoil surface could be more principled (e.g., distance-to-wall, angular position on airfoil).