### PR TITLE
Gradient accumulation (effective batch size 8, preserve update count)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -253,8 +253,10 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf = 0.0
     n_batches = 0
 
+    ACCUM_STEPS = 2
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    optimizer.zero_grad()
+    for i, (x, y, is_surface, mask) in enumerate(pbar):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -273,14 +275,16 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
-
-        optimizer.zero_grad()
+        loss = (vol_loss + cfg.surf_weight * surf_loss) / ACCUM_STEPS
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "global_step": global_step})
+
+        is_last_batch = (i + 1) == len(train_loader)
+        if (i + 1) % ACCUM_STEPS == 0 or is_last_batch:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            global_step += 1
+            wandb.log({"train/loss": loss.item() * ACCUM_STEPS, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Batch size 8 was tried (PR #377) and failed because it halved the number of gradient updates per epoch. But the underlying insight was sound: with only 4 samples per batch across 3 domain groups, many batches are unrepresentative, leading to noisy gradients.

Gradient accumulation over 2 steps achieves effective batch_size=8 while preserving ALL ~331 gradient updates per epoch. Each update uses 8 samples for better gradient estimates, and total updates per epoch stay the same. Memory stays at batch_size=4 level.

## Instructions

Make these changes to `structured_split/structured_train.py`:

1. **Add gradient accumulation to the training loop:**
   ```python
   ACCUM_STEPS = 2
   optimizer.zero_grad()
   
   for i, batch in enumerate(train_loader):
       # ... existing forward pass and loss computation ...
       loss = loss / ACCUM_STEPS  # Scale loss by accumulation steps
       loss.backward()
       
       if (i + 1) % ACCUM_STEPS == 0:
           torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
           optimizer.step()
           scheduler.step()  # step per accumulated update
           optimizer.zero_grad()
   ```

2. **Handle the last incomplete accumulation** at the end of the epoch (if len(train_loader) is odd):
   ```python
   if (i + 1) % ACCUM_STEPS != 0:
       torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
       optimizer.step()
       scheduler.step()
       optimizer.zero_grad()
   ```

3. **Keep batch_size=4** (no change).

4. **Run with**: `--wandb_group "grad-accum-2"`

## Baseline: in=32.6, cond=36.5, tandem=55.9

---

## Results

**W&B run**: `4fm7xw6n` | **Best epoch**: 92 (30-min timeout) | **Peak VRAM**: 7.5 GB

### Surface MAE (best checkpoint, epoch 92)
| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs Baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.435 | 0.241 | **36.1** | 32.6 → **+10.7%** ✗ |
| val_ood_cond | 0.392 | 0.263 | **39.5** | 36.5 → **+8.2%** ✗ |
| val_tandem_transfer | 1.023 | 0.465 | **60.4** | 55.9 → **+8.1%** ✗ |
| val_ood_re | 0.379 | 0.254 | NaN (systemic) | NaN → same |

### Volume MAE (best checkpoint, epoch 92)
| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 3.241 | 1.150 | 69.7 |
| val_ood_cond | 2.778 | 1.058 | 58.0 |
| val_tandem_transfer | 4.018 | 1.773 | 83.3 |

**val/loss (best)**: 2.639 (NaN-robust mean of 3 finite splits: val_in_dist=2.022, val_ood_cond=2.095, val_tandem_transfer=3.801)

### What happened

Negative result — gradient accumulation made things uniformly worse across all splits (+8-11% on mae_surf_p).

The hypothesis assumed that gradient accumulation would "preserve ALL ~331 gradient updates per epoch" while doubling the effective batch size. This assumption was wrong. In practice:

- Without accumulation: 331 forward+backward passes per epoch, each followed by an optimizer step (331 gradient updates)
- With ACCUM_STEPS=2: 331 forward+backward passes per epoch, but only ~166 optimizer steps

The epoch wall-clock time is unchanged at 20s (the forward+backward passes dominate compute, not the optimizer step). So gradient accumulation halves the number of gradient updates per time budget, just like batch_size=8 did — but without even the VRAM reduction benefit that batch_size=8 had.

The extra gradient accumulation compute per step (2× larger effective batch) does not compensate for the 50% reduction in update frequency within the 30-minute wall-clock budget.

### Suggested follow-ups
- **Don't use gradient accumulation** with this model/dataset: the optimizer step overhead is negligible compared to forward pass time, so accumulation only reduces update count.
- **The noisy gradient problem is a real concern** though. Alternative: use a larger val_in_dist split to get better gradient signal, or investigate domain-balanced sampling improvements.
- **Gradient noise**: if the goal is to reduce gradient noise, could try gradient clipping at a smaller norm (0.5 instead of 1.0) to smooth out high-variance steps without sacrificing update frequency.