### PR TITLE
Fix val_ood_re: fp32 inference for OOD Reynolds number split

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -382,8 +382,11 @@ for epoch in range(MAX_EPOCHS):
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                if split_name == "val_ood_re":
+                    pred = model({"x": x})["preds"]  # fp32, no autocast
+                else:
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        pred = model({"x": x})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()


### PR DESCRIPTION
## Hypothesis
val_ood_re pressure has been NaN throughout all experiments. The Ux/Uy predictions are fine (mae_surf_Ux=0.30, Uy=0.22), but pressure overflows bf16's ±65504 range during the forward pass. Even with Cp normalization, the intermediate activations at Re=4.445M may still overflow in bf16.

Running the val_ood_re evaluation WITHOUT bf16 autocast (in full fp32) should fix the overflow and unlock the 4th validation metric. This doesn't affect training (still bf16) — only validation for that one split.

## Instructions

(see original instructions above)

## Baseline: in=27.6, cond=29.6, tandem=48.0, **ood_re=NaN**

---

## Results

**W&B run:** `ld0ct4fj` | **Epochs completed:** 90 in 30 min | **Peak memory:** 7.5 GB | **Best epoch:** 89

### Metrics at best checkpoint (epoch 89, val/loss=2.806)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.364 | 0.209 | **26.9** | 27.6 → -2% |
| val_ood_re | 0.284 | 0.221 | **NaN** ⚠️ | **fp32 didn't fix it** |
| val_ood_cond | 0.285 | 0.223 | **29.1** | 29.6 → -2% |
| val_tandem_transfer | 0.700 | 0.380 | **47.5** | 48.0 → -1% |

### What happened

**Negative result: fp32 inference for val_ood_re does NOT fix the pressure NaN.**

The other 3 splits improved marginally (1-2%), but within run-to-run noise. The hypothesis was wrong: the NaN is NOT caused by bf16 overflow in the forward pass.

**Root cause analysis**: The Ux/Uy channels give finite predictions for val_ood_re (0.284, 0.221), which means the model forward pass is completing without crashing. Only the pressure channel (channel 2) produces NaN. This rules out:
- Model weight NaN (would affect all channels and all splits)
- bf16 overflow in the forward pass (fp32 doesn't fix it)

The most likely cause: the physics normalization's Cp denormalization for val_ood_re produces extreme values that cause NaN arithmetic. For Re=4.445M with a physically unusual flow regime, some samples may have near-zero mean velocity (from separated flow), making Umag approach the clamp floor, which makes q very small, which makes Cp = p/q very large, and then the denormalized prediction becomes NaN through some overflow→NaN path (inf * anything can produce NaN via inf * 0).

Alternatively: the attention softmax receives extreme logits for val_ood_re inputs (even in fp32), producing exp(x) → inf, inf/inf = NaN in the softmax output, which propagates to only the pressure output channel somehow.

**The fix requires deeper investigation**, not just switching to fp32.

### Suggested follow-ups

1. **Debug val_ood_re sample by sample** — run single samples through the model with detailed intermediate value logging to find exactly where NaN originates.
2. **Clamp predictions before denormalization** — add  before physics denormalization to prevent overflow.
3. **Use abs(Umag) with larger clamp floor** — clamp Umag to min=10.0 (instead of 1.0) to prevent extreme Cp values for near-zero mean velocity samples.
4. **Isolate the problematic val_ood_re samples** — identify which specific samples in val_ood_re produce NaN and what their physical characteristics are.