### PR TITLE
L1 loss for all (surface + volume) instead of MSE volume

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -331,11 +331,10 @@ for epoch in range(MAX_EPOCHS):
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
         pred = pred.float()
-        sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + cfg.surf_weight * surf_loss
 
@@ -385,13 +384,12 @@ for epoch in range(MAX_EPOCHS):
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
                 pred = pred.float()
-                sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
                 val_vol += min(
-                    (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
+                    (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
                     1e12
                 )
                 val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()


### PR DESCRIPTION
## Hypothesis
Currently surface loss uses L1 (directly optimizes MAE) while volume loss uses MSE (penalizes outliers more). With Cp normalization making the prediction task more uniform, MSE's outlier sensitivity on volume predictions may be less important. Using L1 for everything simplifies the loss and directly optimizes MAE for both surface and volume.

In the original experiments, switching surface loss from MSE to L1 was one of the biggest wins. Extending L1 to volume loss is the natural next step.

## Instructions

1. **Change volume loss to L1** in the training loop:

   Replace: vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
   With:    vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)

2. Same change in validation loop (use abs_err instead of sq_err for vol_loss).

3. You can remove the sq_err computation entirely if it's no longer needed.

4. Run with --wandb_group "l1-all"

## Baseline: in=27.6, cond=29.6, tandem=48.0

---
## Results

**W&B run:** p3fmjamm
**Epochs completed:** 92 (30.1 min wall-clock)
**Peak VRAM:** 7.5 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 27.6 | 28.9 | +4.7% |
| val_ood_cond | 29.6 | 28.1 | −5.1% |
| val_tandem | 48.0 | 47.8 | −0.4% |

### Full metrics at best checkpoint (epoch 92)

**val_in_dist**
- mae_surf_p=28.9, mae_surf_Ux=0.360, mae_surf_Uy=0.211
- mae_vol_p=43.5, mae_vol_Ux=2.14, mae_vol_Uy=0.829

**val_ood_cond**
- mae_surf_p=28.1, mae_surf_Ux=0.286, mae_surf_Uy=0.217
- mae_vol_p=36.3, mae_vol_Ux=1.77, mae_vol_Uy=0.722

**val_tandem_transfer**
- mae_surf_p=47.8, mae_surf_Ux=0.716, mae_surf_Uy=0.376
- mae_vol_p=58.3, mae_vol_Ux=2.89, mae_vol_Uy=1.39

**val_ood_re:** nan (float32 overflow, excluded from checkpoint selection)

### What happened

Mixed results. Switching volume loss from MSE to L1 did not produce a consistent improvement:

- **val_in_dist** got slightly worse (+4.7%). With MSE, the model gets stronger gradient signal for large errors in the well-represented in-distribution cases; switching to L1 relaxes that, which may hurt precision on the mode of the distribution.
- **val_ood_cond** improved (−5.1%). L1's robustness to outliers helps on the OOD condition split, where some samples may be harder and MSE would have driven the model to overfit to those large-error cases.
- **val_tandem** is essentially unchanged (−0.4%), within noise.

The Cp normalization does make the prediction task more uniform, but MSE still carries value on in-distribution samples where tighter precision matters. The hypothesis that "L1 for everything simplifies and directly optimizes MAE" holds for surface nodes, but for volume nodes MSE's quadratic penalty may still be useful to drive down large field errors on in-dist samples.

The change does simplify the code (sq_err removed entirely).

### Suggested follow-ups

- **Weighted combination**: Try 0.5*(L1 + MSE) for volume loss — combine direct MAE alignment with MSE's precision pressure on large errors.
- **Different surf_weight with L1 volume**: The optimal surf_weight may shift when vol_loss changes scale (L1 vs MSE produce different magnitudes). Try surf_weight=10 or 30 with L1 volume.
- **Decouple volume and surface**: Surface L1 is clearly good; volume MSE may still be the right choice.