### PR TITLE
Higher target noise (0.01 → 0.02) with Cp normalization

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -326,7 +326,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            y_norm = y_norm + 0.02 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Target noise of 0.01 std was tuned before Cp normalization. In Cp space, the target values have different variance (std ~1.1 for Ux/Umag, ~2.5 for Cp). The 0.01 noise may be too small relative to the Cp channel's std, providing insufficient regularization for pressure predictions.

Increasing to 0.02 should provide stronger regularization, particularly for the pressure coefficient channel which dominates our metric.

## Instructions

1. Change target noise:
   ```python
   # Replace:
   y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
   
   # With:
   y_norm = y_norm + 0.02 * torch.randn_like(y_norm)
   ```

2. Run with `--wandb_group "target-noise-002"`

## Baseline: in=27.6, cond=29.6, tandem=48.0

---
## Results

**W&B run:** `hjjqx9hl` | **Peak memory:** 7.5 GB | **Duration:** 30.1 min | **Epochs:** 91

| Val Split | Baseline (noise=0.01) | noise=0.02 | Delta |
|---|---|---|---|
| val_in_dist | 27.6 | **26.6** | -3.6% ✓ |
| val_ood_cond | 29.6 | 30.8 | +4.0% ✗ |
| val_tandem_transfer | 48.0 | **47.6** | -0.8% ✓ |
| val_ood_re | — | NaN | — |

**Full surface MAE breakdown:**

| Split | surf_p | surf_Ux | surf_Uy |
|---|---|---|---|
| val_in_dist | 26.6 | 0.334 | 0.206 |
| val_ood_cond | 30.8 | 0.307 | 0.226 |
| val_tandem_transfer | 47.6 | 0.727 | 0.379 |
| val_ood_re | NaN | 0.294 | 0.219 |

**best_val_loss:** 2.827 | **Best epoch:** 91

### What happened

Increasing target noise from 0.01 to 0.02 produces a neutral result: in_dist improves slightly (-3.6%), tandem is essentially unchanged (-0.8%), but ood_cond regresses (+4%). All deltas are within the expected run-to-run variance for this experiment, making it impossible to conclusively attribute any change to the noise increase.

The hypothesis that 0.01 noise was "too small" relative to Cp std ≈ 2.5 appears to hold for in_dist (slight improvement), but the ood_cond regression suggests that stronger noise may be over-regularizing on OOD conditions where the model needs to capture more precise physics.

The 0.02 noise doesn't appear to harm or help meaningfully compared to 0.01.

### Suggested follow-ups

1. **Neutral result** — 0.02 noise isn't clearly better than 0.01. The difference is within noise.
2. **Channel-specific noise**: applying larger noise only to the pressure channel (e.g., 0.01 for Ux/Uy, 0.02 for Cp) would be a more targeted approach. This aligns with the hypothesis that Cp needs more regularization.
3. **Noise search**: if noise level is important, a range sweep (0.005, 0.01, 0.02, 0.05) would identify the optimal value more definitively.