### PR TITLE
Surface-only training (remove volume loss entirely)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -326,7 +326,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            y_norm = y_norm + 0.02 * torch.randn_like(y_norm)  # was 0.01 — increased for surface-only training
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
@@ -337,7 +337,7 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        loss = surf_loss  # surface-only — no volume loss, no surf_weight needed
 
         optimizer.zero_grad()
         loss.backward()
@@ -408,7 +408,7 @@ for epoch in range(MAX_EPOCHS):
 
         val_vol /= max(n_vbatches, 1)
         val_surf /= max(n_vbatches, 1)
-        split_loss = val_vol + cfg.surf_weight * val_surf
+        split_loss = val_surf  # surface-only — checkpoint selection on surface loss only
         mae_surf /= max(n_surf, 1)
         mae_vol /= max(n_vol, 1)
 


### PR DESCRIPTION
## Hypothesis
**BOLD EXPERIMENT.** The current loss is `vol_loss + 20 * surf_loss`. Volume nodes make up >95% of the mesh but we ONLY report surface metrics. The model wastes gradient signal on predicting volume quantities that don't affect our metric. Volume loss may be implicitly regularizing (providing context), or it may be competing with surface accuracy by pulling shared representations toward bulk flow features.

Removing volume loss entirely focuses 100% of gradient signal on surface prediction. The model still sees all nodes through attention (volume nodes provide spatial context), but the loss backpropagates ONLY from surface nodes.

## Instructions

Make these changes to `structured_split/structured_train.py`:

1. **Remove volume loss from training:**
   ```python
   # Replace:
   loss = vol_loss + cfg.surf_weight * surf_loss
   
   # With:
   loss = surf_loss  # surface-only — no volume loss, no surf_weight needed
   ```

2. **Keep volume MAE computation in validation** (for diagnostics) but remove `vol_loss` from `split_loss` for checkpoint selection:
   ```python
   split_loss = val_surf  # was: val_vol + cfg.surf_weight * val_surf
   ```

3. **Keep all nodes in input** — the model still processes volume nodes through attention for context.

4. **Increase target noise slightly** to compensate for potential overfitting:
   ```python
   y_norm = y_norm + 0.02 * torch.randn_like(y_norm)  # was 0.01
   ```

5. **Run with**: `--wandb_group "surface-only"`

## Baseline: in=27.6, cond=29.6, tandem=48.0

---

## Results

**W&B run ID**: `qvtcutl5`  
**W&B group**: `surface-only`  
**Epochs completed**: 92 (30 min wall-clock limit hit, best=epoch 92 — still improving at cutoff)  
**Best val/loss** (surf_loss only, finite splits): **0.1355** (note: not comparable to baseline — different loss scale)  
**Peak memory**: ~7.5 GB

### Surface MAE — Best Checkpoint (Epoch 92)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.364 | 0.221 | **28.5** | 27.6 → **28.5 (+3%, slightly worse)** |
| val_ood_cond | 0.314 | 0.237 | **29.8** | 29.6 → **29.8 (+1%, within noise)** |
| val_tandem_transfer | 0.745 | 0.396 | **49.9** | 48.0 → **49.9 (+4%, slightly worse)** |
| val_ood_re | 0.307 | 0.226 | NaN (vol overflow) | NaN (data issue) |

### Volume MAE — Best Checkpoint (Epoch 92)
*Note: Volume not trained — these values are diagnostic only.*

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 18.3 | 4.8 | 732 |
| val_ood_cond | 13.4 | 3.5 | 400 |
| val_tandem_transfer | 14.8 | 4.9 | 411 |
| val_ood_re | 13.8 | 3.3 | Inf (vol overflow) |

### What happened

**Negative result — removing volume loss slightly worsens surface accuracy.** Surface mae_surf_p is +3% worse on val_in_dist (28.5 vs 27.6), +4% worse on tandem (49.9 vs 48.0), and within noise on ood_cond (29.8 vs 29.6). Volume prediction completely collapses as expected (mae_vol_Ux 18.3 vs ~2.4 in baseline).

**Why it fails?** The volume loss acts as an **implicit regularizer** for the shared representation. Volume nodes (95% of the mesh) provide spatial context that constrains the learned features to capture physically consistent bulk flow — this generalizes better to surface predictions than training on surface nodes alone. Without volume supervision, the model's attention mechanism can still "see" volume points as input, but the representation isn't pushed to encode physically meaningful bulk flow patterns. The surface-only gradient signal is sparser (~5% of nodes) and may lead to a less geometrically coherent representation.

**Epoch count**: 92 epochs, same as the slice_num=32 baseline — as expected, removing volume loss doesn't affect epoch speed.

**Conclusion**: Volume loss is important as regularization, not just for volume accuracy. The current surf_weight=20 achieves a good balance — the volume loss acts as a cheap regularizer while surface loss dominates the training signal.

### Suggested follow-ups

1. **Much higher surf_weight** (e.g., 50 or 100) — keep volume as regularizer but reduce its weight further, without removing it entirely.
2. **Surface-only attention** — if volume nodes provide context through attention, what if we mask out volume nodes from the attention Q/K/V computation entirely? Pure surface attention.
3. **Curriculum** — start with volume+surface loss, then anneal volume weight to zero over training. The early epochs benefit from volume regularization, late epochs focus on surface.