### PR TITLE
2-layer model with Cp normalization (revisit capacity with better representation)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -244,7 +244,7 @@ model_config = dict(
     fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_layers=2,       # 2 layers — revisiting capacity with Cp normalization
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
When we first reduced layers (5→2→1), the model was predicting raw physical values with massive cross-Re variance. The "maximize epochs" strategy dominated. Now with Cp normalization, the prediction target is bounded O(1) with much less variance. The 1-layer model may be capacity-limited for the harder tandem transfer task (48 vs 27). A 2-layer model with Cp normalization might find a better capacity/epochs tradeoff.

Expected: ~45 epochs (vs 91 for 1-layer). But if Cp normalization makes convergence faster, 45 epochs might be enough.

## Instructions

1. **Change to 2 layers:**
   ```python
   model_config = dict(
       ...,
       n_layers=2,  # was 1
       ...,
   )
   ```

2. **Everything else stays the same** — Cp normalization, L1 surface, slice_num=32, deeper head.

3. **Run with**: `--wandb_group "2-layer-cp"`

## Baseline: in=27.6, cond=29.6, tandem=48.0 (1 layer, 91 epochs)

---

## Results

**W&B run**: `mjy0alcj`
**Peak memory**: ~7 GB (epoch time: 32s)

### Best checkpoint (epoch 56 of 100)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 40.7 | +47.5% ❌ |
| val_ood_cond | 35.1 | +18.6% ❌ |
| val_tandem_transfer | 52.8 | +10.0% ❌ |
| val_ood_re | NaN | — |

val/loss = 2.528 (in_dist)

### What happened

**Negative result — epoch budget matters more than capacity, even with Cp normalization.**

The 2-layer model reaches epoch 56 within 30 minutes (32s/epoch vs ~20s for 1-layer), compared to epoch 91 for the 1-layer model. The result is uniformly worse: +47.5% on in_dist, +18.6% on ood_cond, +10.0% on tandem.

The hypothesis was that Cp normalization's bounded targets might allow a 2-layer model to converge in fewer epochs and still match the 1-layer model at 91 epochs. This didn't happen. The 2-layer model is still converging at epoch 56 (it hasn't plateaued), confirming that the epoch gap is the dominant factor — the 1-layer model gets ~62% more training steps, which more than compensates for its lower per-epoch capacity.

Interestingly, the tandem gap is smaller (+10% vs +47% for in_dist), suggesting that the 2-layer model does learn tandem geometry somewhat more efficiently per epoch. But the overall epoch budget penalty is too steep.

### Suggested follow-ups

- **The 1-layer model is the right architecture for this 30-minute budget.** The epoch efficiency advantage outweighs the capacity disadvantage.
- **If the timeout were extended to 60 minutes**, 2-layer training could reach ~100 epochs, making this a fair comparison. The tandem improvement hint suggests it might win at equal epochs.
- **n_hidden=192 or 256 with 1 layer**: Add capacity without doubling epoch time — a lighter parameter increase that stays within the 30-minute budget.