### PR TITLE
EMA model (exponential moving average of weights)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -254,6 +254,11 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+ema_decay = 0.999
+ema_model = Transolver(**model_config).to(device)
+ema_model.load_state_dict(model.state_dict())
+ema_model.eval()
+
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=3)
@@ -286,6 +291,8 @@ wandb.define_metric("train/*", step_metric="global_step")
 wandb.define_metric("val/*", step_metric="global_step")
 for _sname in VAL_SPLIT_NAMES:
     wandb.define_metric(f"{_sname}/*", step_metric="global_step")
+    wandb.define_metric(f"ema_{_sname}/*", step_metric="global_step")
+wandb.define_metric("ema_val/*", step_metric="global_step")
 wandb.define_metric("lr", step_metric="global_step")
 wandb.define_metric("epoch_time_s", step_metric="global_step")
 wandb.define_metric("val_predictions", step_metric="global_step")
@@ -300,6 +307,79 @@ best_val = float("inf")
 best_metrics = {}
 global_step = 0
 train_start = time.time()
+
+
+def _run_validation(mdl, prefix=""):
+    """Run validation loop for mdl. Returns (metrics_per_split, mean_val_loss)."""
+    mdl.eval()
+    metrics_per_split = {}
+    for split_name, vloader in val_loaders.items():
+        val_vol = 0.0
+        val_surf = 0.0
+        mae_surf = torch.zeros(3, device=device)
+        mae_vol = torch.zeros(3, device=device)
+        n_surf = torch.zeros(3, device=device)
+        n_vol = torch.zeros(3, device=device)
+        n_vbatches = 0
+        with torch.no_grad():
+            for x, y, is_surface, mask in tqdm(
+                vloader, desc=f"[{prefix}{split_name}]", leave=False
+            ):
+                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                is_surface = is_surface.to(device, non_blocking=True)
+                mask = mask.to(device, non_blocking=True)
+                x = (x - stats["x_mean"]) / stats["x_std"]
+                Umag, q = _umag_q(y, mask)
+                y_phys = _phys_norm(y, Umag, q)
+                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred = mdl({"x": x})["preds"]
+                pred = pred.float()
+                sq_err = (pred - y_norm) ** 2
+                abs_err = (pred - y_norm).abs()
+                vol_mask = mask & ~is_surface
+                surf_mask = mask & is_surface
+                val_vol += min(
+                    (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
+                    1e12
+                )
+                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                n_vbatches += 1
+                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_orig = _phys_denorm(pred_phys, Umag, q)
+                y_clamped = y.clamp(-1e6, 1e6)
+                err = (pred_orig - y_clamped).abs()
+                finite = err.isfinite()
+                err = err.where(finite, torch.zeros_like(err))
+                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+                n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+        val_vol /= max(n_vbatches, 1)
+        val_surf /= max(n_vbatches, 1)
+        split_loss = val_vol + cfg.surf_weight * val_surf
+        mae_surf /= n_surf.clamp(min=1)
+        mae_vol /= n_vol.clamp(min=1)
+        key = f"{prefix}{split_name}"
+        metrics_per_split[key] = {
+            f"{key}/vol_loss":    val_vol,
+            f"{key}/surf_loss":   val_surf,
+            f"{key}/loss":        split_loss,
+            f"{key}/mae_vol_Ux":  mae_vol[0].item(),
+            f"{key}/mae_vol_Uy":  mae_vol[1].item(),
+            f"{key}/mae_vol_p":   mae_vol[2].item(),
+            f"{key}/mae_surf_Ux": mae_surf[0].item(),
+            f"{key}/mae_surf_Uy": mae_surf[1].item(),
+            f"{key}/mae_surf_p":  mae_surf[2].item(),
+        }
+    finite_losses = [
+        metrics_per_split[f"{prefix}{name}"][f"{prefix}{name}/loss"]
+        for name in VAL_SPLIT_NAMES
+        if not (torch.tensor(metrics_per_split[f"{prefix}{name}"][f"{prefix}{name}/loss"]).isnan() or
+                torch.tensor(metrics_per_split[f"{prefix}{name}"][f"{prefix}{name}/loss"]).isinf())
+    ]
+    mean_loss = sum(finite_losses) / max(len(finite_losses), 1)
+    return metrics_per_split, mean_loss
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -343,6 +423,9 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        with torch.no_grad():
+            for ema_p, m_p in zip(ema_model.parameters(), model.parameters()):
+                ema_p.data.mul_(ema_decay).add_(m_p.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "global_step": global_step})
 
@@ -355,85 +438,11 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
-    # --- Validate across all splits ---
-    model.eval()
-    val_metrics_per_split: dict[str, dict] = {}
-    val_loss_sum = 0.0
+    # --- Validate: regular model ---
+    val_metrics_per_split, mean_val_loss = _run_validation(model)
 
-    for split_name, vloader in val_loaders.items():
-        val_vol = 0.0
-        val_surf = 0.0
-        mae_surf = torch.zeros(3, device=device)
-        mae_vol = torch.zeros(3, device=device)
-        n_surf = torch.zeros(3, device=device)
-        n_vol = torch.zeros(3, device=device)
-        n_vbatches = 0
-
-        with torch.no_grad():
-            for x, y, is_surface, mask in tqdm(
-                vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
-            ):
-                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
-                is_surface = is_surface.to(device, non_blocking=True)
-                mask = mask.to(device, non_blocking=True)
-
-                x = (x - stats["x_mean"]) / stats["x_std"]
-                Umag, q = _umag_q(y, mask)
-                y_phys = _phys_norm(y, Umag, q)
-                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
-                pred = pred.float()
-                sq_err = (pred - y_norm) ** 2
-                abs_err = (pred - y_norm).abs()
-
-                vol_mask = mask & ~is_surface
-                surf_mask = mask & is_surface
-                val_vol += min(
-                    (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
-                    1e12
-                )
-                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
-                n_vbatches += 1
-
-                # Denormalize: phys_stats → Cp space → original scale
-                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
-                pred_orig = _phys_denorm(pred_phys, Umag, q)
-                y_clamped = y.clamp(-1e6, 1e6)
-                err = (pred_orig - y_clamped).abs()
-                finite = err.isfinite()
-                err = err.where(finite, torch.zeros_like(err))
-                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
-                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
-                n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
-                n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
-
-        val_vol /= max(n_vbatches, 1)
-        val_surf /= max(n_vbatches, 1)
-        split_loss = val_vol + cfg.surf_weight * val_surf
-        mae_surf /= n_surf.clamp(min=1)
-        mae_vol /= n_vol.clamp(min=1)
-
-        val_metrics_per_split[split_name] = {
-            f"{split_name}/vol_loss":    val_vol,
-            f"{split_name}/surf_loss":   val_surf,
-            f"{split_name}/loss":        split_loss,
-            f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
-            f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
-            f"{split_name}/mae_vol_p":   mae_vol[2].item(),
-            f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
-            f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
-            f"{split_name}/mae_surf_p":  mae_surf[2].item(),
-        }
-        val_loss_sum += split_loss
-
-    # val/loss = mean across finite splits; NaN-robust for checkpoint selection
-    finite_losses = [val_metrics_per_split[name][f"{name}/loss"]
-                     for name in VAL_SPLIT_NAMES
-                     if not (torch.tensor(val_metrics_per_split[name][f"{name}/loss"]).isnan() or
-                             torch.tensor(val_metrics_per_split[name][f"{name}/loss"]).isinf())]
-    mean_val_loss = sum(finite_losses) / max(len(finite_losses), 1)
+    # --- Validate: EMA model ---
+    ema_val_metrics_per_split, ema_mean_val_loss = _run_validation(ema_model, prefix="ema_")
 
     dt = time.time() - t0
 
@@ -442,10 +451,13 @@ for epoch in range(MAX_EPOCHS):
         "train/vol_loss": epoch_vol,
         "train/surf_loss": epoch_surf,
         "val/loss": mean_val_loss,
+        "ema_val/loss": ema_mean_val_loss,
         "lr": scheduler.get_last_lr()[0],
         "epoch_time_s": dt,
     }
     for split_metrics in val_metrics_per_split.values():
+        metrics.update(split_metrics)
+    for split_metrics in ema_val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
     wandb.log(metrics)
@@ -455,24 +467,33 @@ for epoch in range(MAX_EPOCHS):
     else:
         peak_mem_gb = 0.0
 
+    # Checkpoint: save the better of model vs ema_model
+    best_loss = min(mean_val_loss, ema_mean_val_loss)
     tag = ""
-    if mean_val_loss < best_val:
-        best_val = mean_val_loss
-        best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss}
-        for split_metrics in val_metrics_per_split.values():
+    if best_loss < best_val:
+        best_val = best_loss
+        use_ema = ema_mean_val_loss <= mean_val_loss
+        save_metrics = ema_val_metrics_per_split if use_ema else val_metrics_per_split
+        best_metrics = {"epoch": epoch + 1, "val_loss": best_loss, "use_ema": use_ema}
+        for split_metrics in save_metrics.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        torch.save(model.state_dict(), model_path)
-        tag = f" * -> {model_path}"
+        state = ema_model.state_dict() if use_ema else model.state_dict()
+        torch.save(state, model_path)
+        tag = f" * (ema={use_ema}) -> {model_path}"
 
     split_summary = "  ".join(
         f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
         for name in VAL_SPLIT_NAMES
     )
+    ema_summary = "  ".join(
+        f"{name}={ema_val_metrics_per_split[f'ema_{name}'][f'ema_{name}/loss']:.4f}"
+        for name in VAL_SPLIT_NAMES
+    )
     print(
         f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
         f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
-        f"val[{split_summary}]{tag}"
+        f"val[{split_summary}]  ema[{ema_summary}]{tag}"
     )
 
 
@@ -482,10 +503,12 @@ print("\n" + "=" * 70)
 print(f"TRAINING COMPLETE ({total_time:.1f} min)")
 print("=" * 70)
 if best_metrics:
-    print(f"Best model at epoch {best_metrics['epoch']}  (val/loss={best_metrics['val_loss']:.4f})")
+    use_ema = best_metrics.get("use_ema", False)
+    pfx = "ema_" if use_ema else ""
+    print(f"Best model at epoch {best_metrics['epoch']}  (val/loss={best_metrics['val_loss']:.4f}, use_ema={use_ema})")
     for split_name in VAL_SPLIT_NAMES:
-        k_p = f"best_{split_name}/mae_surf_p"
-        k_l = f"best_{split_name}/loss"
+        k_p = f"best_{pfx}{split_name}/mae_surf_p"
+        k_l = f"best_{pfx}{split_name}/loss"
         if k_p in best_metrics:
             print(f"  {split_name:30s}  loss={best_metrics[k_l]:.4f}  mae_surf_p={best_metrics[k_p]:.1f}")
 else:


### PR DESCRIPTION
## Hypothesis
Exponential Moving Average (EMA) maintains a shadow copy of model weights that is a running average of training weights. Unlike SWA (which averages at specific epochs), EMA continuously smooths weight trajectories, finding flatter minima that generalize better. This is standard in diffusion models (DDPM), GANs, and modern vision transformers.

EMA adds zero computational overhead during training (just weight copying) and should improve OOD generalization (tandem_transfer, ood_re) because flatter minima are more robust to distribution shift.

## Instructions

Make these changes to `structured_split/structured_train.py`:

1. **Create EMA model** after model initialization:
   ```python
   # After: model = Transolver(**model_config).to(device)
   ema_decay = 0.999
   ema_model = Transolver(**model_config).to(device)
   ema_model.load_state_dict(model.state_dict())
   ema_model.eval()
   ```

2. **Update EMA after each optimizer step** in training loop:
   ```python
   optimizer.step()
   # EMA update
   with torch.no_grad():
       for ema_p, model_p in zip(ema_model.parameters(), model.parameters()):
           ema_p.data.mul_(ema_decay).add_(model_p.data, alpha=1 - ema_decay)
   ```

3. **Evaluate both models** during validation. After the regular model validation, also run the EMA model through the same val loop and log with prefix `ema_`:
   ```python
   # After regular validation, evaluate EMA model on same splits
   ema_model.eval()
   # ... same validation loop but using ema_model ...
   # Log: f"ema_{split_name}/mae_surf_p"
   ```

4. **Use EMA model's metrics for checkpoint selection** if they're better:
   ```python
   ema_val = ...  # mean EMA val loss
   best_to_save = min(mean_val_loss, ema_val)
   if best_to_save < best_val:
       if ema_val < mean_val_loss:
           torch.save(ema_model.state_dict(), model_path)
       else:
           torch.save(model.state_dict(), model_path)
   ```

5. **Run with**: `--wandb_group "ema-model"`

## Baseline: in=27.0, cond=28.7, tandem=48.4, ood_re=35.7

---
## Results

**W&B run**: `859q0dne`  
**Epochs**: 79 (30 min, best at epoch 79, EMA selected)  
**Peak memory**: 7.5 GB

### Surface MAE (best epoch, EMA model selected)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ vs baseline |
|-------|------------|------------|-----------|--------------|
| val_in_dist | 0.356 | 0.208 | **28.4** | +5% worse (27.0) |
| val_ood_cond | — | — | **28.1** | -2% better (28.7) |
| val_tandem_transfer | — | — | **48.2** | -0.4% better (48.4) |
| val_ood_re | — | — | **35.5** | -0.6% better (35.7) |

### EMA vs regular model (same run, epoch 79)

| Split | Regular val/loss | EMA val/loss |
|-------|-----------------|-------------|
| val_in_dist | 2.029 | **1.922** |
| val_tandem_transfer | 5.111 | **5.005** |
| val_ood_cond | 1.750 | **1.738** |
| val_ood_re | nan | nan |

EMA consistently outperformed the regular model on all finite splits within the same run.

### What happened

**Mixed result.** EMA does what it's supposed to — within this run, the EMA model is consistently better than the regular model on all finite splits (1–7% lower loss). This validates the mechanism.

However, comparing to the baseline run, val_in_dist regressed from 27.0 to 28.4 (+5%). The main cause is **epoch count**: dual validation (running both regular and EMA val loops) reduces epochs from ~91 to ~79, a 15% reduction in training time. With a 1-layer model where more epochs = better, this overhead costs meaningful training progress.

The OOD splits (ood_cond, tandem, ood_re) are marginally better than baseline, consistent with EMA's stated benefit for generalization.

**val_ood_re**: Finite (35.5) — the NaN was fixed by PR #400's robust denorm clamping (this branch is based on that fix). EMA doesn't hurt or help val_ood_re specifically.

### Suggested follow-ups
- **EMA-only validation**: Instead of running both regular and EMA val each epoch, only validate the EMA model. This would recover the epoch overhead and test EMA at equal epoch count.
- **Lower EMA decay** (0.99 or 0.995): With 79 epochs, decay=0.999 is very slow — needs >1000 steps to stabilize. Lower decay might converge faster within our budget.
- **EMA as test-time only**: Train with regular model, then apply EMA as a post-processing step on the saved checkpoint (load weights and manually apply EMA over saved checkpoints). Zero training overhead.