### PR TITLE
Deeper preprocess MLP (2 hidden layers instead of 1)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -195,7 +195,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
The preprocess MLP maps raw 24-dim input features to 128-dim hidden representations using: Linear(24, 256) → GELU → Linear(256, 128). This single-hidden-layer MLP is the model's first and only chance to extract meaningful features from the input geometry and flow conditions BEFORE the attention layer.

With only 1 attention layer and 32 slices, the preprocess MLP is the bottleneck for feature extraction. Adding a second hidden layer (Linear(24, 256) → GELU → Linear(256, 256) → GELU → Linear(256, 128)) gives the model more capacity to learn nonlinear input-feature interactions without affecting the attention computation.

The extra compute is negligible (~32K params, <1ms per forward pass).

## Instructions

Make this change to `transolver.py` in the `Transolver.__init__` method:

1. **Change preprocess MLP depth** from `n_layers=0` to `n_layers=1`:
   ```python
   # In Transolver.__init__, change:
   self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
   
   # To:
   self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
   ```
   
   This adds one residual hidden layer: Linear(24,256) → GELU → [Linear(256,256) → GELU + residual] → Linear(256,128).

2. **No changes to structured_train.py.**

3. **Run with**: `--wandb_group "deeper-preprocess"`

## Baseline: in=27.0, cond=28.7, tandem=48.4, ood_re=35.7

---

## Results

**W&B run ID**: `5n7ph9eo`  
**W&B group**: `deeper-preprocess`  
**Epochs completed**: 85 (best=epoch 84 — converged slightly before wall-clock limit)  
**Best val/loss**: **2.8554**  
**Peak memory**: ~8.5 GB (vs ~7.5 GB for baseline — +1 GB from extra MLP layer)

### Surface MAE — Best Checkpoint (Epoch 84)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.334 | 0.207 | **27.2** | 27.0 → **27.2 (±1%, within noise)** |
| val_ood_cond | 0.293 | 0.213 | **29.2** | 28.7 → **29.2 (+2%, within noise)** |
| val_tandem_transfer | 0.713 | 0.383 | **50.5** | 48.4 → **50.5 (+4%, slightly worse)** |
| val_ood_re | 0.292 | 0.213 | **35.0** | 35.7 → **35.0 (-2%, slightly better)** |

### Volume MAE — Best Checkpoint (Epoch 84)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 2.251 | 0.926 | 54.2 |
| val_ood_cond | 1.967 | 0.865 | 45.2 |
| val_tandem_transfer | 2.924 | 1.421 | 61.9 |
| val_ood_re | 1.792 | 0.801 | 70.8 |

### Val Loss — Best Checkpoint (Epoch 84)

| val_in_dist | val_tandem_transfer | val_ood_cond | val_ood_re | mean_val_loss |
|---|---|---|---|---|
| 1.8085 | 5.0632 | 1.6944 | NaN (vol overflow, skipped) | **2.8554** |

### What happened

**Neutral result — deeper preprocess MLP produces mixed changes within noise.** val_in_dist and val_ood_cond are essentially unchanged (±1-2%), val_tandem worsens by +4%, and val_ood_re improves by -2%. All differences are within typical run-to-run variability. Best val_loss of 2.8554 is nearly identical to baseline (~2.85).

**Why no improvement?** The preprocess MLP (24→256→128) is already sufficient to learn the input geometry and flow condition embeddings. The additional residual hidden layer doesn't provide meaningfully new representational capacity for this task, since the input features are relatively low-dimensional (24 dim) and the mapping to 128-dim embeddings is not the bottleneck. The single-layer MLP already captures the key input geometry transformations.

**Epoch count**: 85 epochs, same throughput as baseline (~21s/epoch). The extra ~32K parameters from the residual layer have no measurable impact on training speed.

**VRAM**: ~8.5 GB vs ~7.5 GB baseline (+1 GB) — modest increase from the extra hidden layer (256×256 weight matrix).

### Suggested follow-ups

1. **Wider preprocess MLP** (n_hidden*4=512 instead of n_hidden*2=256) — the intermediate representation might be too narrow to benefit from depth.
2. **Dedicated geometry encoder** — separate preprocess branches for spatial coordinates (x, y) vs functional features (Re, AoA, chord, etc.) before merging.
3. **Remove the placeholder parameter** — the current architecture adds a learnable scalar offset to all nodes' embeddings; testing without it might free capacity.