### PR TITLE
Surface weight schedule (ramp from 5→30 over training)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -309,6 +309,11 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
+    # Dynamic surface weight: linear ramp from 5 → 30 over training
+    sw_start, sw_end = 5.0, 30.0
+    progress = epoch / MAX_EPOCHS
+    surf_weight = sw_start + (sw_end - sw_start) * progress
+
     # --- Train ---
     model.train()
     epoch_vol = 0.0
@@ -337,14 +342,14 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + cfg.surf_weight * surf_loss
+        loss = vol_loss + surf_weight * surf_loss
 
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The constant surf_weight=20 forces the model to focus on surface accuracy from the very start, when it hasn't yet learned basic flow physics. A schedule that starts low (sw=5) and ramps to high (sw=30) lets the model first learn volume physics (establishing flow field understanding) then gradually shift focus to surface accuracy.

This curriculum approach has been successful in multi-task learning: start with the easier task to build shared representations, then specialize.

## Instructions

1. Replace constant surf_weight with a linear ramp (sw_start=5, sw_end=30).
2. Log train/surf_weight to wandb.
3. Run with --wandb_group "sw-schedule"

## Baseline: in=27.0, cond=28.7, tandem=48.4, ood_re=35.7

---
## Results

**W&B run:** dwhjhjix
**Epochs completed:** 92 (30.1 min wall-clock)
**Peak VRAM:** ~7.5 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 27.0 | 26.6 | −1.5% |
| val_ood_cond | 28.7 | 27.5 | −4.2% |
| val_tandem | 48.4 | 45.7 | −5.6% |
| val_ood_re | 35.7 | 35.9 | +0.6% |

### Full metrics at best checkpoint

**val_in_dist**
- mae_surf_p=26.6, mae_surf_Ux=0.332, mae_surf_Uy=0.206
- mae_vol_p=56.7, mae_vol_Ux=2.35, mae_vol_Uy=0.985

**val_ood_cond**
- mae_surf_p=27.5, mae_surf_Ux=0.299, mae_surf_Uy=0.218
- mae_vol_p=50.1, mae_vol_Ux=1.93, mae_vol_Uy=0.901

**val_tandem_transfer**
- mae_surf_p=45.7, mae_surf_Ux=0.700, mae_surf_Uy=0.368
- mae_vol_p=61.3, mae_vol_Ux=2.89, mae_vol_Uy=1.44

**val_ood_re**
- mae_surf_p=35.9, mae_surf_Ux=0.305, mae_surf_Uy=0.217
- mae_vol_p=75.4, mae_vol_Ux=1.85, mae_vol_Uy=0.841

### What happened

The schedule worked well. Consistent improvement across in-dist, ood-cond, and notably tandem:

- **val_in_dist**: -1.5% (26.6 vs 27.0). Modest improvement — the curriculum helps but in-dist cases are already well-covered by the standard regime.
- **val_ood_cond**: -4.2% (27.5 vs 28.7). Better OOD generalization — starting with volume-first learning builds more robust flow representations.
- **val_tandem**: -5.6% (45.7 vs 48.4). Largest gain. The tandem foil geometry is structurally different; the model benefits most from first learning general flow physics before specializing on surface accuracy.
- **val_ood_re**: essentially unchanged (+0.6%), within noise. The high-Re split's difficulty is dominated by the physical regime, not the surface weight schedule.

The curriculum interpretation makes sense: early in training, the model doesn't have a good flow field representation, so penalizing surface errors heavily (sw=20 from epoch 1) may force it to overfit surface patterns before learning volume physics. The ramp gives the model space to learn volume physics first, then refine surface predictions.

Note: vol_loss uses MSE in this branch (sq_err), so the volume training objective is stronger than the surface objective at sw=5 in early epochs.

### Suggested follow-ups

- **Tune the ramp endpoints**: sw_start=5, sw_end=30 was chosen as specified. Try sw_start=2, sw_end=40 (more aggressive curriculum) or sw_start=10, sw_end=25 (gentler).
- **Non-linear schedule**: Cosine or logarithmic ramp instead of linear — ramp slowly at first, faster near end.
- **Combine with L1 volume loss**: This branch uses MSE for volume. Pairing the schedule with L1 volume loss (from exp/l1-all-loss) might compound the gains.
- **val_loss for checkpoint selection**: Currently checkpoint selection uses cfg.surf_weight=20 for val split_loss. Consider using the same dynamic surf_weight for val as well.