### PR TITLE
Noise schedule (decay target noise from 0.03→0.001 over training)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -30,6 +30,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import json
+import math
 import os
 import time
 import torch
@@ -326,7 +327,10 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            noise_start, noise_end = 0.03, 0.001
+            progress = epoch / MAX_EPOCHS
+            noise_std = noise_end + (noise_start - noise_end) * 0.5 * (1 + math.cos(math.pi * progress))
+            y_norm = y_norm + noise_std * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
@@ -441,6 +445,7 @@ for epoch in range(MAX_EPOCHS):
     metrics = {
         "train/vol_loss": epoch_vol,
         "train/surf_loss": epoch_surf,
+        "train/noise_std": noise_std,
         "val/loss": mean_val_loss,
         "lr": scheduler.get_last_lr()[0],
         "epoch_time_s": dt,


### PR DESCRIPTION
## Hypothesis
The constant target noise 0.01 applies the same regularization throughout training. In early epochs, stronger noise (0.03) prevents premature memorization of training samples. In late epochs, lower noise (0.001) allows the model to fit fine-grained surface details. This is analogous to learning rate scheduling — aggressive exploration early, precise refinement late.

## Instructions

1. **Replace constant noise** with a cosine decay schedule:
   ```python
   # In the training loop, compute dynamic noise:
   noise_start, noise_end = 0.03, 0.001
   progress = epoch / MAX_EPOCHS
   # Cosine decay: smooth transition
   noise_std = noise_end + (noise_start - noise_end) * 0.5 * (1 + math.cos(math.pi * progress))
   
   if model.training:
       y_norm = y_norm + noise_std * torch.randn_like(y_norm)
   ```

2. **Add `import math`** at the top.

3. **Log noise level**: `wandb.log({"train/noise_std": noise_std, ...})`

4. **Run with**: `--wandb_group "noise-schedule"`

## Baseline: in=27.0, cond=28.7, tandem=48.4, ood_re=35.7

---
## Results

**W&B run:** `dt2cg7o0` | **Peak memory:** 7.5 GB | **Duration:** 30.1 min | **Epochs:** 91

| Val Split | Baseline (const 0.01) | Noise schedule (0.03→0.001) | Delta |
|---|---|---|---|
| val_in_dist | 27.0 | 27.3 | +1.1% |
| val_ood_cond | 28.7 | **28.6** | -0.3% |
| val_tandem_transfer | 48.4 | 49.2 | +1.6% |
| val_ood_re | 35.7 | 35.9 | +0.6% |

**Full surface MAE breakdown:**

| Split | surf_p | surf_Ux | surf_Uy |
|---|---|---|---|
| val_in_dist | 27.3 | 0.347 | 0.207 |
| val_ood_cond | 28.6 | 0.293 | 0.214 |
| val_tandem_transfer | 49.2 | 0.720 | 0.382 |
| val_ood_re | 35.9 | 0.287 | 0.219 |

**best_val_loss:** 2.811 | **Best epoch:** 91

### What happened

The noise schedule produces a neutral result. All deltas vs. constant 0.01 noise are within ±2% and mixed in direction, consistent with run-to-run variance rather than a systematic effect.

The cosine decay from 0.03 to 0.001 over 100 epochs means:
- Epoch 0: noise = 0.030
- Epoch 45: noise ≈ 0.016 (midpoint)
- Epoch 91: noise ≈ 0.001

The starting value of 0.03 is 3× the baseline constant (0.01). In Cp space (std ≈ 2.5 for pressure), even 0.03 is just 1.2% of the Cp range — relatively mild regularization. The model does not appear sensitive to noise level in this range.

**Note on val_ood_re**: This run achieves a finite val_ood_re score (35.9) thanks to PR #400 (robust denormalization), which is included in this branch. This is the first time val_ood_re pressure is measurable. The result (35.9) closely matches the baseline (35.7), confirming the noise schedule has no special effect on OOD Re predictions.

### Suggested follow-ups

1. **Neutral result** — Noise schedule doesn't improve over constant 0.01. The training appears insensitive to noise level in the 0.001-0.03 range.
2. **Larger noise range**: Try starting at 0.1 or higher to see if the model benefits from stronger early regularization.
3. **Channel-specific noise**: Apply different noise levels to Ux/Uy vs. Cp channels, targeting the pressure channel's larger std.