### PR TITLE
Dropout 0.05 in attention and MLP

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -253,7 +253,7 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
-model = Transolver(dropout=0.05, **model_config).to(device)
+model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)


### PR DESCRIPTION
## Hypothesis
We have never tried dropout in this model. With only 1 attention layer processing ~200K nodes per sample, the model may be memorizing training patterns rather than learning generalizable flow physics. Even mild dropout (0.05) should improve OOD generalization — particularly tandem_transfer (unseen foil geometry) and ood_re (unseen Reynolds number).

## Instructions

Make this change to \`transolver.py\`:

1. **Add dropout to the Transolver constructor**. Change the model config \`dropout=0.0\` to \`dropout=0.05\`:
   
   In \`structured_split/structured_train.py\`:
   \`\`\`python
   model_config = dict(
       ...,
       # Add dropout parameter (currently not passed, defaults to 0.0 in Physics_Attention)
   )
   \`\`\`
   
   The Physics_Attention_Irregular_Mesh already accepts a \`dropout\` parameter (line 57 of transolver.py). Just pass it through the model config. In the Transolver constructor, \`dropout\` is already forwarded to TransolverBlock. Just set it in the config:
   \`\`\`python
   model = Transolver(**model_config, dropout=0.05).to(device)
   \`\`\`
   
   Wait — \`dropout\` isn't in model_config currently. The simplest approach: pass it directly:
   \`\`\`python
   model = Transolver(dropout=0.05, **model_config).to(device)
   \`\`\`

2. **Run with**: \`--wandb_group "dropout-005"\`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---

## Results

**W&B run:** \`qyfr8ta4\` | **Epochs completed:** 91 in 30.2 min | **Peak memory:** 7.7 GB | **Best epoch:** 89

### Metrics at best checkpoint (epoch 89, val/loss=2.7717)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline (p) |
|---|---|---|---|---|
| val_in_dist | 0.334 | 0.203 | **26.6** | 26.6 → **0%** ~ |
| val_ood_re | 0.286 | 0.221 | **35.5** | 35.9 → **-1%** ~ |
| val_ood_cond | 0.289 | 0.214 | **26.9** | 27.5 → **-2%** ✓ |
| val_tandem_transfer | 0.717 | 0.373 | **47.5** | 45.7 → **+4%** ✗ |

**val/loss: 2.7717** — mixed: ood_cond marginally improved, tandem slightly worse, in_dist and ood_re unchanged.

### Volume MAE at best checkpoint (epoch 89)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 2.30 | 0.97 | 59.6 |
| val_ood_cond | 1.96 | 0.89 | 49.6 |
| val_tandem_transfer | 2.95 | 1.42 | 64.4 |
| val_ood_re | 1.84 | 0.83 | 76.7 |

### What happened

**Hypothesis not confirmed — dropout 0.05 has negligible effect.** Results are essentially at baseline level. The tandem_transfer split got slightly worse (+4%), opposite to what dropout-as-regularizer should do for the hardest generalization task. The ood_cond improvement (-2%) is within noise. val_in_dist is unchanged at 26.6.

**Throughput unchanged:** 20s/epoch, 91 epochs in 30.2 min — identical to no-dropout baseline. Dropout adds zero computational overhead.

**Why it didn't help:** At n_hidden=128 with 1 layer, the model likely has insufficient capacity to benefit from dropout regularization. With ~1M parameters, the model may be underfitting rather than overfitting. Dropout at 0.05 is also very mild — dropping only 5% of activations may be too small to have a meaningful regularization effect here.

**val_ood_re NaN persists:** Pressure channel still NaN in loss (vol_loss=18.87B), but mae_surf_p=35.5 is finite due to robust denormalization (PR #400).

### Suggested follow-ups

1. **Higher dropout (0.1 or 0.2):** If any regularization benefit exists, 0.05 is likely too small to detect it. Worth testing a stronger value.
2. **Dropout only on attention (not MLP):** The attention slice mechanism is the novel part — targeted regularization there might be more effective.
3. **The model may be underfitting, not overfitting:** The consistent result that more epochs always help suggests capacity/convergence is the binding constraint, not overfitting. Weight decay increase might be more relevant than dropout.