### PR TITLE
Combine cosine similarity loss + surface weight schedule

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -342,14 +342,24 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + surf_weight * surf_loss
+        cos_loss = torch.tensor(0.0, device=device)
+        for b in range(pred.shape[0]):
+            surf_idx = torch.where(surf_mask[b])[0]
+            if len(surf_idx) < 2:
+                continue
+            p_pred = pred[b, surf_idx, 2]  # pressure channel in normalized space
+            p_true = y_norm[b, surf_idx, 2]
+            cos_sim = torch.nn.functional.cosine_similarity(p_pred.unsqueeze(0), p_true.unsqueeze(0))
+            cos_loss = cos_loss + (1 - cos_sim)
+        cos_loss = cos_loss / pred.shape[0]
+        loss = vol_loss + surf_weight * surf_loss + 5.0 * cos_loss
 
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/cos_loss": cos_loss.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Two recent experiments showed complementary strengths:
- **Surface weight schedule** (merged): tandem=45.7 (best ever for tandem)
- **Cosine similarity loss** (closed but promising): cond=26.3 (best ever for ood_cond)

The cosine loss was closed because tandem got slightly worse (49.1). But combined with the sw-schedule (which helps tandem), the two improvements might compound — cosine loss improves cond while sw-schedule maintains tandem.

## Instructions

1. **Add cosine similarity auxiliary loss** on top of the existing sw-schedule code:
   ```python
   # After computing surf_loss (around line 339):
   cos_loss = torch.tensor(0.0, device=device)
   for b in range(pred.shape[0]):
       surf_idx = torch.where(surf_mask[b])[0]
       if len(surf_idx) < 2:
           continue
       p_pred = pred[b, surf_idx, 2]  # pressure channel in normalized space
       p_true = y_norm[b, surf_idx, 2]
       cos_sim = torch.nn.functional.cosine_similarity(p_pred.unsqueeze(0), p_true.unsqueeze(0))
       cos_loss = cos_loss + (1 - cos_sim)
   cos_loss = cos_loss / pred.shape[0]
   
   # Combined loss (sw-schedule already in place):
   loss = vol_loss + surf_weight * surf_loss + 5.0 * cos_loss
   ```

2. **Log it**: `wandb.log({"train/cos_loss": cos_loss.item(), ...})`

3. **Run with**: `--wandb_group "cosine-plus-sw"`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---

## Results

**W&B run ID**: `pof8vzoc`  
**W&B group**: `cosine-plus-sw`  
**Epochs completed**: 89 (best=epoch 88)  
**Best val/loss**: **2.7774**  
**Peak memory**: ~7.5 GB

### Surface MAE — Best Checkpoint (Epoch 88)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.329 | 0.204 | **26.6** | 26.6 → **26.6 (=, unchanged)** |
| val_ood_cond | 0.292 | 0.211 | **26.1** | 27.5 → **26.1 (-5%, better)** |
| val_tandem_transfer | 0.725 | 0.375 | **47.7** | 45.7 → **47.7 (+4%, worse)** |
| val_ood_re | 0.303 | 0.222 | **35.5** | 35.9 → **35.5 (-1%, within noise)** |

### Volume MAE — Best Checkpoint (Epoch 88)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 2.308 | 0.976 | 55.8 |
| val_ood_cond | 2.043 | 0.873 | 46.6 |
| val_tandem_transfer | 2.916 | 1.417 | 63.0 |
| val_ood_re | 1.888 | 0.832 | 73.3 |

### Val Loss — Best Checkpoint (Epoch 88)

| val_in_dist | val_tandem_transfer | val_ood_cond | val_ood_re | mean_val_loss |
|---|---|---|---|---|
| 1.7899 | 4.9283 | 1.6141 | NaN (vol overflow, skipped) | **2.7774** |

### What happened

**Partial positive result — cosine loss strongly improves ood_cond but the sw-schedule doesn't fully recover tandem.** val_ood_cond drops from 27.5→26.1 (-5%, best seen for this split), val_in_dist is unchanged (26.6), and val_ood_re improves slightly (35.9→35.5). However, val_tandem is 47.7 vs baseline 45.7 (+4%), meaning the sw-schedule doesn't fully compensate for tandem regression from the cosine loss.

**Why partial?** The sw-schedule and cosine loss are somewhat orthogonal: the sw-schedule helps tandem by ramping up surface emphasis during training (start soft for broad convergence, finish sharp for surface precision), while cosine loss helps ood_cond by enforcing Cp profile shape agreement. However, the cosine loss appears to impose a structural constraint that conflicts with tandem generalization — tandem cases have dual-foil interactions where the pressure profile shape (cosine similarity) is qualitatively different from single foil.

**Trade-off**: ood_cond: best ever seen (26.1) vs tandem: worse than sw-schedule-only (47.7 vs 45.7). Choosing between them depends on whether generalization to unseen conditions (ood_cond) or tandem foil transfer matters more.

### Suggested follow-ups

1. **Lower cosine weight** (e.g., 2.0 instead of 5.0) — a softer cosine regularizer might preserve the ood_cond gains while reducing tandem regression.
2. **Cosine loss on single-foil only** — apply cosine loss only to non-tandem samples (domain_group filter) to avoid the tandem interference.
3. **Separate hyperparameter search**: sweep cos_weight in {1, 2, 5, 10} to map the accuracy-vs-generalization tradeoff curve.