### PR TITLE
AdamW with β2=0.95 (more aggressive momentum decay)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -255,7 +255,8 @@ model_config = dict(
 model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
+                               betas=(0.9, 0.95))
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=3)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 3)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
The default AdamW uses β2=0.999, which maintains a very long-term estimate of squared gradients. For a small 1-layer model trained for 92 epochs on heterogeneous CFD data, this long-term average may not adapt quickly enough to changing gradient scales across domain groups. β2=0.95 makes the optimizer more responsive to recent gradient magnitudes, potentially improving convergence in the later epochs where the LR is low.

## Instructions

1. Change optimizer β2 to 0.95 (default is 0.999).
2. Run with --wandb_group "beta2-095"

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run:** 4yafj52z
**Best epoch:** 90 (val/loss=2.7733)
**Epochs completed:** 92 (30.3 min wall-clock)
**Peak VRAM:** 7.5 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 26.6 | 29.5 | +10.9% |
| val_ood_cond | 27.5 | 26.6 | −3.3% |
| val_tandem | 45.7 | 44.7 | −2.2% |
| val_ood_re | 35.9 | 35.7 | −0.6% |

### What happened

Negative result overall. β2=0.95 significantly degraded val_in_dist (+10.9%), while giving small improvements on val_ood_cond (−3.3%) and val_tandem (−2.2%).

The tradeoff is unfavorable: in_dist accuracy is the primary metric, and losing 3 points (26.6→29.5) outweighs gaining ~1 point on ood_cond (27.5→26.6). The total surface MAE picture is worse.

**Why val_in_dist degraded**: β2=0.95 makes the second-moment estimate noisier — it forgets old gradient scale information every ~20 steps (1/(1-0.95)) instead of every ~1000 steps (1/(1-0.999)). For in-distribution samples where the optimizer has established stable gradient scale estimates, this aggressive forgetting introduces noise into parameter updates, particularly in the late low-LR regime where precise gradient scaling matters most.

**Why ood_cond/tandem slightly improved**: OOD samples benefit from faster adaptation of gradient scales. When the model encounters samples from conditions it hasn't seen as often, β2=0.95 allows the optimizer to quickly re-estimate the appropriate step sizes. This is the intended benefit of lower β2.

The problem is that in this training setup, in-distribution samples vastly outnumber OOD samples in terms of signal, so the optimizer's instability on in-dist outweighs the OOD benefits.

### Suggested follow-ups

- **Per-group betas**: Could try different β2 for different parameter groups, but this adds complexity without clear benefit.
- **β2=0.98**: A less aggressive compromise between 0.95 and 0.999 — may retain the OOD adaptation benefit with less in-dist instability.
- **LR schedule interaction**: The β2=0.95 instability is worse at low LR (late training). Could try warmup + constant LR with β2=0.95 to avoid the late-epoch noise amplification.