### PR TITLE
Per-channel adaptive loss weighting (auto-balance Ux/Uy/p)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -254,8 +254,14 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+# Learnable per-channel log-variance for uncertainty weighting (Kendall et al. 2018)
+log_vars = torch.zeros(3, device=device, requires_grad=True)  # [Ux, Uy, p]
+
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+optimizer = torch.optim.AdamW(
+    list(model.parameters()) + [log_vars],
+    lr=cfg.lr, weight_decay=cfg.weight_decay
+)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=3)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 3)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
@@ -341,15 +347,26 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        # Per-channel uncertainty weighting (Kendall et al. 2018)
+        precision = torch.exp(-log_vars)  # [3]
+        weighted_abs_err = abs_err * precision.unsqueeze(0).unsqueeze(0)  # [B, N, 3]
+        surf_loss = (weighted_abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = surf_loss + log_vars.sum()  # regularization: prevent precision collapse
         loss = vol_loss + surf_weight * surf_loss
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(list(model.parameters()) + [log_vars], max_norm=1.0)
         optimizer.step()
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({
+            "train/loss": loss.item(),
+            "train/surf_weight": surf_weight,
+            "train/weight_Ux": precision[0].item(),
+            "train/weight_Uy": precision[1].item(),
+            "train/weight_p": precision[2].item(),
+            "global_step": global_step,
+        })
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The current loss treats all 3 output channels equally in normalized space. But the channels have different error magnitudes and learning dynamics. Pressure (p) has the largest absolute error and dominates the gradient. Using learnable per-channel weights (Kendall et al., "Multi-Task Learning Using Uncertainty to Weigh Losses", CVPR 2018) lets the model automatically balance the channels based on their uncertainty.

## Instructions

1. **Add learnable log-variance parameters** in structured_train.py:
   ```python
   # After model creation:
   log_vars = torch.zeros(3, device=device, requires_grad=True)  # [Ux, Uy, p]
   optimizer = torch.optim.AdamW(
       list(model.parameters()) + [log_vars],
       lr=cfg.lr, weight_decay=cfg.weight_decay
   )
   ```

2. **Modify the loss computation** to use uncertainty weighting:
   ```python
   # Surface loss with per-channel uncertainty weighting:
   precision = torch.exp(-log_vars)  # [3]
   weighted_abs_err = abs_err * precision.unsqueeze(0).unsqueeze(0)  # [B, N, 3]
   surf_loss = (weighted_abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   surf_loss = surf_loss + log_vars.sum()  # regularization to prevent all-zero
   ```

3. **Log the learned weights**: 
   ```python
   wandb.log({
       "train/weight_Ux": precision[0].item(),
       "train/weight_Uy": precision[1].item(),
       "train/weight_p": precision[2].item(),
       ...
   })
   ```

4. **Run with**: `--wandb_group "adaptive-weights"`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run:** `42sd1kjm` | **Peak memory:** 7.6 GB | **Duration:** 30.2 min | **Epochs:** 91

| Val Split | Baseline | Adaptive weights | Delta |
|---|---|---|---|
| val_in_dist | 26.6 | 27.9 | +4.9% ✗ |
| val_ood_cond | 27.5 | 28.5 | +3.6% ✗ |
| val_tandem_transfer | 45.7 | 49.9 | +9.2% ✗ |
| val_ood_re | 35.9 | 36.5 | +1.7% ✗ |

**Final learned channel weights (precision = exp(-log_var)):**
- weight_Ux: 35.7 (high confidence)
- weight_Uy: 41.4 (highest confidence)
- weight_p: 20.4 (lowest confidence)

**best_val_loss:** 2.970 | **Best epoch:** 91

### What happened

Adaptive per-channel weighting substantially **hurts** performance — tandem gets 9.2% worse, in_dist +4.9%, ood_cond +3.6%. This is a clear negative result.

**Why it fails:** The Kendall et al. framework is designed to balance channels with different variance. The model correctly learns that pressure has the highest uncertainty (lowest precision: 20.4 vs 41.4 for Uy). However, this means the model **reduces its emphasis on pressure** relative to the baseline. In the baseline, all channels are weighted equally — effectively giving pressure equal training signal. Under adaptive weighting, pressure gets weight 20.4 vs Uy's 41.4, meaning pressure errors contribute only ~half as much to the loss gradient. This is the opposite of what we want, since pressure (mae_surf_p) is the primary metric.

The Kendall framework works well when channels are of equal importance (e.g., multi-task learning where all tasks matter). When we have a primary metric that we want to optimize (pressure MAE), automatic uncertainty weighting can work against us by deprioritizing the hardest channels.

**Note on branch context**: This branch includes surf_weight schedule (5→30, linear ramp) from noam PR #405. The interaction between the ramp schedule and adaptive weighting is uncertain, but the ramp starts low (sw=5 at epoch 0), which reduces early emphasis on surface losses and may have amplified the adaptive weighting's negative effect early in training.

### Suggested follow-ups

1. **Negative result** — Adaptive uncertainty weighting hurts by deprioritizing pressure, which is the primary metric.
2. **Alternative**: If per-channel balance is desired, use a fixed weight that upweights pressure (e.g., loss = abs_err_Ux + abs_err_Uy + 2*abs_err_p) rather than learned uncertainty.
3. **Asymmetric Kendall**: Apply Kendall weighting only to Ux/Uy channels (auto-balance between them) while keeping pressure at a fixed higher weight.