### PR TITLE
Surface refinement head (two-stage prediction with surface specialist)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -254,8 +254,21 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
-n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+# Surface refinement head: lightweight MLP that refines surface predictions
+# using both the model's output and original normalized input features (skip connection).
+# Only ~1600 parameters, adds <1% compute (runs only on surface nodes conceptually,
+# but applied to all nodes since masking comes from surf_mask in the loss).
+surf_refine = torch.nn.Sequential(
+    torch.nn.Linear(3 + X_DIM, 64),
+    torch.nn.GELU(),
+    torch.nn.Linear(64, 3),
+).to(device)
+
+n_params = sum(p.numel() for p in model.parameters()) + sum(p.numel() for p in surf_refine.parameters())
+optimizer = torch.optim.AdamW(
+    list(model.parameters()) + list(surf_refine.parameters()),
+    lr=cfg.lr, weight_decay=cfg.weight_decay
+)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=3)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 3)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
@@ -316,6 +329,7 @@ for epoch in range(MAX_EPOCHS):
 
     # --- Train ---
     model.train()
+    surf_refine.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
@@ -336,17 +350,21 @@ for epoch in range(MAX_EPOCHS):
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
         pred = pred.float()
+        surf_delta = surf_refine(torch.cat([pred, x], dim=-1))
+        pred_for_surf = pred + surf_delta
         sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        abs_err_surf = (pred_for_surf - y_norm).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = (abs_err_surf * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(
+            list(model.parameters()) + list(surf_refine.parameters()), max_norm=1.0
+        )
         optimizer.step()
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
@@ -362,6 +380,7 @@ for epoch in range(MAX_EPOCHS):
 
     # --- Validate across all splits ---
     model.eval()
+    surf_refine.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -390,8 +409,10 @@ for epoch in range(MAX_EPOCHS):
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
                 pred = pred.float()
+                surf_delta = surf_refine(torch.cat([pred, x], dim=-1))
+                pred_for_surf = pred + surf_delta
                 sq_err = (pred - y_norm) ** 2
-                abs_err = (pred - y_norm).abs()
+                abs_err_surf = (pred_for_surf - y_norm).abs()
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
@@ -399,20 +420,26 @@ for epoch in range(MAX_EPOCHS):
                     (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
                     1e12
                 )
-                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                val_surf += (abs_err_surf * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
                 # Denormalize: phys_stats → Cp space → original scale
-                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
-                pred_orig = _phys_denorm(pred_phys, Umag, q)
+                # Surface uses refined prediction; volume uses original prediction
+                pred_phys_surf = pred_for_surf * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_orig_surf = _phys_denorm(pred_phys_surf, Umag, q)
+                pred_phys_vol = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_orig_vol = _phys_denorm(pred_phys_vol, Umag, q)
                 y_clamped = y.clamp(-1e6, 1e6)
-                err = (pred_orig - y_clamped).abs()
-                finite = err.isfinite()
-                err = err.where(finite, torch.zeros_like(err))
-                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
-                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
-                n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
-                n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+                err_surf = (pred_orig_surf - y_clamped).abs()
+                err_vol = (pred_orig_vol - y_clamped).abs()
+                finite_surf = err_surf.isfinite()
+                finite_vol = err_vol.isfinite()
+                err_surf = err_surf.where(finite_surf, torch.zeros_like(err_surf))
+                err_vol = err_vol.where(finite_vol, torch.zeros_like(err_vol))
+                mae_surf += (err_surf * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                mae_vol += (err_vol * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                n_surf += (surf_mask.unsqueeze(-1) * finite_surf).sum(dim=(0, 1)).float()
+                n_vol += (vol_mask.unsqueeze(-1) * finite_vol).sum(dim=(0, 1)).float()
 
         val_vol /= max(n_vbatches, 1)
         val_surf /= max(n_vbatches, 1)
@@ -467,7 +494,7 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        torch.save(model.state_dict(), model_path)
+        torch.save({"model": model.state_dict(), "surf_refine": surf_refine.state_dict()}, model_path)
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(
@@ -500,7 +527,9 @@ if best_metrics:
     wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})
 
     print("\nGenerating flow field plots...")
-    model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
+    _ckpt = torch.load(model_path, map_location=device, weights_only=True)
+    model.load_state_dict(_ckpt["model"])
+    surf_refine.load_state_dict(_ckpt["surf_refine"])
     plot_dir = Path("plots") / run.id
     # Visualize from val_in_dist — same distribution as original val_ds
     images = visualize(model, val_splits["val_in_dist"], stats, device,


### PR DESCRIPTION
## Hypothesis
**BOLD ARCHITECTURE CHANGE.** The current model makes a single prediction pass for ALL nodes. But surface nodes (~5% of mesh) are our primary metric. After the Transolver block predicts for all nodes, add a lightweight surface-specialist MLP that refines surface predictions using both the hidden features AND original input features (skip connection).

This two-stage approach: (1) coarse prediction for all nodes, (2) specialist refinement for surface only. The refinement MLP adds ~5% compute (only runs on surface nodes) and zero epoch reduction. Critically, it allocates dedicated capacity to surface accuracy without affecting the attention computation.

## Instructions

(see original PR body for full instructions)

**Run with**: `--wandb_group "surf-refinement"`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run**: `12zhniay`  
**Epochs**: 88 (30 min, best at epoch 88)  
**Peak memory**: 8.0 GB (+0.5 GB vs baseline, ~6% increase)

### Surface MAE (best epoch)

| Split | mae_surf_p | Δ vs baseline |
|-------|-----------|--------------|
| val_in_dist | **26.2** | -1.5% (26.6) |
| val_ood_cond | **27.1** | -1.5% (27.5) |
| val_tandem_transfer | **47.0** | +2.8% worse (45.7) |
| val_ood_re | **34.6** | **-3.6%** (35.9) |

### val/loss (best epoch)

| Split | loss |
|-------|------|
| val_in_dist | 1.805 |
| val_tandem_transfer | 4.817 |
| val_ood_cond | 1.622 |
| val_ood_re | nan (physical MAE=34.6 finite) |

### What happened

**Mixed but lean positive.** The surface refinement head improves 3 of 4 splits:
- val_in_dist: -1.5% (26.6 → 26.2)
- val_ood_cond: -1.5% (27.5 → 27.1)  
- val_ood_re: -3.6% (35.9 → 34.6) — most notable gain

The tandem_transfer split regresses slightly (+2.8%, 45.7 → 47.0). This may be because the refinement head learns surface patterns specific to single-foil geometry (which dominates training) and generalizes less well to tandem geometries.

The approach works as intended: a tiny 2-layer MLP (27→64→3) that takes normalized predictions + input features and predicts a residual correction. Memory overhead is small (+0.5 GB). Epoch count is maintained (88 vs ~90 for baseline).

The residual formulation (pred + surf_delta) is important — it ensures the base model predictions are always used as a starting point, preventing the refinement head from dominating.

### Suggested follow-ups
- **Tandem-aware refinement**: The tandem regression might be addressed by conditioning the refinement head on foil count or NACA code — it currently can't distinguish single vs tandem scenarios
- **Surface-only compute**: Instead of applying refinement to all nodes and masking in the loss, apply it only to actual surface nodes to save some compute
- **Combined with dropout**: Dropout 0.05 showed similar OOD gains — combining both might compound