### PR TITLE
Pressure channel 2x weight in surface L1 loss

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -340,8 +340,10 @@ for epoch in range(MAX_EPOCHS):
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
+        channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+        weighted_abs_err = abs_err * channel_w.unsqueeze(0).unsqueeze(0)
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = (weighted_abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         optimizer.zero_grad()
@@ -392,6 +394,8 @@ for epoch in range(MAX_EPOCHS):
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()
+                channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+                weighted_abs_err = abs_err * channel_w.unsqueeze(0).unsqueeze(0)
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
@@ -399,7 +403,7 @@ for epoch in range(MAX_EPOCHS):
                     (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
                     1e12
                 )
-                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                val_surf += (weighted_abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
                 # Denormalize: phys_stats → Cp space → original scale


### PR DESCRIPTION
## Hypothesis
Within the surface L1 loss, all 3 channels (Ux, Uy, p) contribute equally. But pressure is our PRIMARY metric. Weighting pressure 2x in the surface loss directly steers more gradient toward pressure accuracy.

PR #375 tested 3x pressure weighting on an earlier baseline (before Cp norm and sw-schedule) and showed improvement. On the current baseline with Cp normalization making pressure predictions more uniform, a lighter 2x should compound with the existing improvements.

## Instructions

1. Add channel_w = [1.0, 1.0, 2.0] weights to surface loss (training + validation).
2. Run with --wandb_group "pressure-2x"

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run:** gyxandu6
**Best epoch:** 91 (val/loss=4.14, inflated — see note below)
**Epochs completed:** 92 (30.1 min wall-clock)
**Peak VRAM:** ~7.5 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 26.6 | 26.0 | −2.3% |
| val_ood_cond | 27.5 | 27.2 | −1.1% |
| val_tandem | 45.7 | 46.9 | +2.6% |
| val_ood_re | 35.9 | 34.2 | −4.7% |

**Note on val/loss**: The checkpoint selection uses `val_surf` with the 2x pressure weight, making the loss values ~1.33x higher than the baseline (not directly comparable). The mae_surf_p metric (computed in original units via denormalization) is the right comparison.

### Full metrics at best checkpoint

**val_in_dist**
- mae_surf_p=26.0, mae_surf_Ux=0.364, mae_surf_Uy=0.221
- mae_vol_p=62.7, mae_vol_Ux=2.51, mae_vol_Uy=1.01

**val_ood_cond**
- mae_surf_p=27.2, mae_surf_Ux=0.333, mae_surf_Uy=0.236
- mae_vol_p=52.4, mae_vol_Ux=2.08, mae_vol_Uy=0.950

**val_tandem_transfer**
- mae_surf_p=46.9, mae_surf_Ux=0.767, mae_surf_Uy=0.397
- mae_vol_p=64.0, mae_vol_Ux=3.08, mae_vol_Uy=1.45

**val_ood_re**
- mae_surf_p=34.2, mae_surf_Ux=0.313, mae_surf_Uy=0.225
- mae_vol_p=75.7, mae_vol_Ux=1.93, mae_vol_Uy=0.851

### What happened

Mostly positive. Weighting pressure 2x in surface loss directly improved the primary metric on 3 of 4 splits:

- **val_in_dist**: -2.3% (26.0 vs 26.6) — consistent improvement on the most important split.
- **val_ood_cond**: -1.1% (27.2 vs 27.5) — small but positive.
- **val_ood_re**: -4.7% (34.2 vs 35.9) — largest gain; the OOD high-Re split benefits most from the pressure focus.
- **val_tandem**: +2.6% (46.9 vs 45.7) — slightly worse. Tandem foil geometry may need the Ux/Uy velocity channels for good surface pressure predictions (interference effects between foils), and de-weighting them hurts.

The 2x weighting is a lighter touch than the 3x from PR #375 and is clearly better aligned with the current Cp-normalized regime (where the scale of Cp predictions is already more uniform than before).

### Suggested follow-ups

- **Tune the pressure weight**: Try 1.5x (lighter) or 3x (heavier). 2x improved in_dist but hurt tandem — a different weight might find a better tradeoff.
- **Per-split channel weights**: The tandem penalty suggests tandem geometry cares more about velocity. A split-conditioned weighting (if geometry metadata is available) could help.
- **Apply to volume loss too**: Currently vol_loss uses uniform channel weight. Adding a pressure 2x to volume loss might improve volume pressure MAE (now 62.7).
- **Checkpoint selection with pressure-weighted loss**: If the val/loss for checkpoint selection also emphasizes pressure, it might select a checkpoint that's better for pressure specifically rather than the current combined metric.