### PR TITLE
Attention temperature annealing (2.0→0.1 over training)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -314,6 +314,11 @@ for epoch in range(MAX_EPOCHS):
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
+    # Attention temperature annealing: exponential decay 2.0 → 0.1 over training
+    temp_start, temp_end = 2.0, 0.1
+    current_temp = temp_start * (temp_end / temp_start) ** progress
+    model.set_temperature(current_temp)
+
     # --- Train ---
     model.train()
     epoch_vol = 0.0
@@ -349,7 +354,7 @@ for epoch in range(MAX_EPOCHS):
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/attn_temp": current_temp, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()

--- a/transolver.py
+++ b/transolver.py
@@ -76,6 +76,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
 
+    def set_temperature(self, temp_value):
+        """Override the learned temperature with a fixed value."""
+        self.temperature.data.fill_(temp_value)
+
     def forward(self, x):
         # x: (B, N, C)
         bsz, num_points, _ = x.shape
@@ -216,6 +220,10 @@ class Transolver(nn.Module):
         )
         self.initialize_weights()
         self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))
+
+    def set_temperature(self, temp_value):
+        for block in self.blocks:
+            block.attn.set_temperature(temp_value)
 
     def initialize_weights(self):
         self.apply(self._init_weights)


### PR DESCRIPTION
## Hypothesis
The physics attention has a learnable temperature parameter (initialized at 0.5) that controls slice assignment softness. But it evolves through gradient descent and may get stuck. A curriculum: start with high temperature (2.0, soft/broad attention) so early training learns coarse flow physics across all slices, then anneal to low temperature (0.1, sharp/specialized) so late training develops specialized boundary-layer vs. wake vs. freestream slices.

## Instructions

1. **In `transolver.py`**, add a method to set temperature:
   ```python
   # In Physics_Attention_Irregular_Mesh, add:
   def set_temperature(self, temp_value):
       """Override the learned temperature with a fixed value."""
       self.temperature.data.fill_(temp_value)
   ```

2. **In `Transolver`, propagate temperature setting:**
   ```python
   def set_temperature(self, temp_value):
       for block in self.blocks:
           block.attn.set_temperature(temp_value)
   ```

3. **In `structured_train.py`**, add temperature schedule:
   ```python
   # In training loop, before model.train():
   temp_start, temp_end = 2.0, 0.1
   progress = epoch / MAX_EPOCHS
   current_temp = temp_start * (temp_end / temp_start) ** progress  # exponential decay
   model.set_temperature(current_temp)
   wandb.log({"train/attn_temp": current_temp, ...})
   ```

4. **Run with**: `--wandb_group "temp-anneal"`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run ID**: `snv2daab`  
**Epochs**: 91 (best at epoch 91)  
**Peak memory**: 7.5 GB (unchanged)

### Metrics vs Baseline (mae_surf_p)

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| val_in_dist | 26.6 | 26.8 | +0.7% |
| val_ood_cond | 27.5 | 28.6 | +4.0% |
| val_tandem | 45.7 | 48.6 | +6.4% |
| val_ood_re | 35.9 | 35.5 | -1.1% |

### Full surface MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 0.343 | 0.212 | 26.8 |
| val_ood_cond | 0.293 | 0.217 | 28.6 |
| val_tandem | 0.732 | 0.382 | 48.6 |
| val_ood_re | 0.305 | 0.216 | 35.5 |

### Volume MAE (val_in_dist)
Ux=2.30, Uy=0.95, p=57.8

**best_val_loss**: 2.821

### What happened

Neutral to slightly negative result. Temperature annealing overrides the learned temperature parameter at every epoch — but the learned temperature is initialized at 0.5 and is allowed to learn freely; we're forcing it through a fixed 2.0→0.1 schedule instead. 

The ood_re split improved marginally (-1.1%), which is consistent with the hypothesis that sharper late-training slices help generalization. However, cond (+4%) and tandem (+6%) regressed. The tandem case is most concerning since it involves unseen foil geometry where broad attention early on may have been beneficial, but the hard constraint overrode whatever the model was learning.

The key issue is that we're **replacing** the learned temperature rather than **guiding** it. The original parameter can adapt to the data; forcing a curriculum schedule prevents it from finding the best value for each problem.

### Suggested follow-ups
- Try a **soft curriculum**: add the schedule as a regularization term pulling the learned temperature toward the target (e.g. `loss += lambda * (temp - current_temp)**2`), so it's guided but not forced.
- Try a **lower starting temp** (e.g. 0.8→0.1) — starting at 2.0 is very soft and may wash out early-training gradients.
- If tandem transfer remains the problem, investigate foil-2 surface encoding (boundary ID 7 is missing from surface mask) as a more targeted fix.