### PR TITLE
Per-sample mean subtraction (predict spatial deviations, not absolute values)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -218,9 +218,9 @@ val_loaders = {
     for name, subset in val_splits.items()
 }
 
-# --- Physics normalization stats (computed over training set) ---
-# Compute mean/std of Cp-normalized targets so the model sees O(1) values.
-print("Computing physics normalization stats...")
+# --- Physics normalization stats (computed over training set residuals) ---
+# Compute mean/std of per-sample-mean-subtracted Cp targets.
+print("Computing physics normalization stats (residual)...")
 _phys_sum = torch.zeros(3, device=device)
 _phys_sq_sum = torch.zeros(3, device=device)
 _phys_n = 0.0
@@ -230,14 +230,17 @@ with torch.no_grad():
         _y, _mask = _y.to(device), _mask.to(device)
         _Um, _q = _umag_q(_y, _mask)
         _yp = _phys_norm(_y, _Um, _q)
-        _m = _mask.float().unsqueeze(-1)  # [B, N, 1]
-        _phys_sum += (_yp * _m).sum(dim=(0, 1))
-        _phys_sq_sum += (_yp ** 2 * _m).sum(dim=(0, 1))
+        _n_valid = _mask.float().sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1]
+        _yp_mean = (_yp * _mask.unsqueeze(-1).float()).sum(dim=1, keepdim=True) / _n_valid.unsqueeze(-1)  # [B, 1, 3]
+        _yp_residual = _yp - _yp_mean  # deviations from per-sample spatial mean
+        _m = _mask.float().unsqueeze(-1)
+        _phys_sum += (_yp_residual * _m).sum(dim=(0, 1))
+        _phys_sq_sum += (_yp_residual ** 2 * _m).sum(dim=(0, 1))
         _phys_n += _mask.float().sum().item()
 _pmean = (_phys_sum / _phys_n).float()
 _pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
 phys_stats = {"y_mean": _pmean, "y_std": _pstd}
-print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
+print(f"  Residual Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
@@ -329,7 +332,11 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
-        y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+        # Per-sample mean subtraction: model predicts spatial deviations
+        n_valid = mask.float().sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1]
+        y_mean_per_sample = (y_phys * mask.unsqueeze(-1).float()).sum(dim=1, keepdim=True) / n_valid.unsqueeze(-1)  # [B, 1, 3]
+        y_residual = y_phys - y_mean_per_sample
+        y_norm = (y_residual - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
@@ -385,7 +392,11 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
-                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                # Per-sample mean subtraction
+                n_valid = mask.float().sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1]
+                y_mean_per_sample = (y_phys * mask.unsqueeze(-1).float()).sum(dim=1, keepdim=True) / n_valid.unsqueeze(-1)  # [B, 1, 3]
+                y_residual = y_phys - y_mean_per_sample
+                y_norm = (y_residual - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
@@ -402,8 +413,9 @@ for epoch in range(MAX_EPOCHS):
                 val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
-                # Denormalize: phys_stats → Cp space → original scale
+                # Denormalize: residual → add back spatial mean → Cp space → original scale
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_phys = pred_phys + y_mean_per_sample  # add back per-sample spatial mean
                 pred_orig = _phys_denorm(pred_phys, Umag, q)
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()


### PR DESCRIPTION
## Hypothesis
Before normalization, the model predicts absolute Cp values. But much of the signal is the spatial mean (dominated by freestream), and the interesting variation is how Cp deviates from this mean at the surface. By subtracting the per-sample spatial mean of each channel, the model predicts DEVIATIONS — which are smaller, more zero-centered, and more focused on spatial variation (where surface features live).

For pressure, the spatial mean is close to freestream stagnation. Deviations highlight suction peaks and stagnation points — exactly what we care about. At denormalization, add the mean back.

## Instructions

1. **In the training loop**, after computing `y_phys` but before global normalization:
   ```python
   # Per-sample mean subtraction (over valid nodes)
   n_valid = mask.float().sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1]
   y_mean_per_sample = (y_phys * mask.unsqueeze(-1).float()).sum(dim=1, keepdim=True) / n_valid.unsqueeze(-1)  # [B, 1, 3]
   y_residual = y_phys - y_mean_per_sample  # deviations from spatial mean
   
   # Now normalize the residuals
   y_norm = (y_residual - phys_stats["y_mean"]) / phys_stats["y_std"]
   ```

2. **Recompute phys_stats** over the residuals (not absolute Cp).

3. **At denormalization**, add back per-sample means:
   ```python
   pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]  # in residual Cp space
   pred_phys = pred_phys + y_mean_per_sample  # add back spatial mean → absolute Cp
   pred_orig = _phys_denorm(pred_phys, Umag, q)
   ```

4. **CRITICAL**: The per-sample mean `y_mean_per_sample` is computed from GROUND TRUTH at both train and val time. At real inference, you'd need to estimate it (e.g., from the model's own coarse prediction). But for this experiment, using GT is fine since we're testing if the representation helps training.

5. **Run with**: `--wandb_group "residual-mean-sub"`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run**: `agsq27pi`
**Peak memory**: ~7 GB (epoch time: 20s, best epoch: 92)

### Best checkpoint (epoch 92)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 29.3 | +10.2% ❌ |
| val_ood_cond | 26.8 | -2.5% ✅ |
| val_tandem_transfer | 49.7 | +8.8% ❌ |
| val_ood_re | 934.7 | catastrophic ❌ |

val/loss: in_dist=1.929, ood_cond=1.721, tandem=5.298

### What happened

**Negative result — catastrophic failure on val_ood_re, regressions on in_dist and tandem.**

The ood_re split shows a catastrophic mae_surf_p of 934 (vs baseline 35.9). This makes the overall result clearly negative despite a slight improvement on ood_cond (-2.5%).

The root cause of the ood_re failure: per-sample mean subtraction introduces a sample-specific context that the model can't generalize to unseen Re values. At out-of-distribution Reynolds numbers, the spatial mean of Cp has different structure (different free-stream pressure/velocity ratios), so adding the GT mean back in denormalization restores absolute values — but the model has learned to predict residuals from the training distribution, which don't match the ood_re residual distribution. The discrepancy compounds at denormalization.

Even ignoring ood_re, the in_dist (+10.2%) and tandem (+8.8%) regressions suggest the mean-subtraction adds unnecessary complexity to the prediction task. The model must now predict deviations AND implicitly recover the mean, which is harder than predicting absolute Cp directly when the global stats are already well-normalized.

The tiny ood_cond improvement (-2.5%) does not compensate for the ood_re catastrophe.

### Suggested follow-ups

- **Do not pursue per-sample mean subtraction**: The ood_re failure reveals a fundamental incompatibility between this scheme and OOD generalization. The absolute Cp representation is more robust.
- **If mean subtraction is desired**: Only subtract the training-set global mean (which is already done by phys_stats), not a per-sample mean that changes at inference time.