### PR TITLE
Subsample volume nodes during training (keep all surface, 25% volume)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -338,8 +338,20 @@ for epoch in range(MAX_EPOCHS):
         pred = pred.float()
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
+        if model.training:
+            vol_subsample_ratio = 0.25
+            train_mask = mask.clone()
+            for b_idx in range(x.shape[0]):
+                vol_nodes = torch.where(train_mask[b_idx] & ~is_surface[b_idx])[0]
+                n_keep = max(int(len(vol_nodes) * vol_subsample_ratio), 1)
+                perm = torch.randperm(len(vol_nodes), device=device)
+                drop_nodes = vol_nodes[perm[n_keep:]]
+                train_mask[b_idx, drop_nodes] = False
+            vol_mask = train_mask & ~is_surface
+            surf_mask = train_mask & is_surface  # unchanged — all surface kept
+        else:
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
         vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
**PARADIGM SHIFT: Trade mesh resolution for epoch count.** Each training sample has ~200K nodes, of which only ~5K are surface nodes (our metric). The remaining ~195K volume nodes provide context but dominate compute. By randomly subsampling to 25% of volume nodes while keeping ALL surface nodes, we reduce per-sample node count from ~200K to ~54K — making each forward pass ~3-4x faster.

With 3-4x speedup, we'd get **250-350 epochs** instead of 92. The model still sees all surface nodes (100% of our metric target) and a representative sample of volume context. This extends the "maximize epochs" strategy that has been our #1 winning approach.

## Instructions

Make these changes to `structured_split/structured_train.py`:

1. **Add volume subsampling in the training loop**, after loading the batch.

2. **Keep validation at full resolution** (no subsampling).

3. **Run with**: `--wandb_group "subsample-vol-25pct"`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9 (92 epochs/30min)

---

## Results

**W&B run ID**: `47i7ezu9`  
**W&B group**: `subsample-vol-25pct`  
**Epochs completed**: 90 (best=epoch 89)  
**Best val/loss**: **2.7811**  
**Peak memory**: ~7.6 GB

### Surface MAE — Best Checkpoint (Epoch 89)

| Val Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.338 | 0.212 | **27.4** | 26.6 → **27.4 (+3%, slightly worse)** |
| val_ood_cond | 0.297 | 0.223 | **29.2** | 27.5 → **29.2 (+6%, worse)** |
| val_tandem_transfer | 0.717 | 0.373 | **47.3** | 45.7 → **47.3 (+4%, slightly worse)** |
| val_ood_re | 0.299 | 0.220 | **36.1** | 35.9 → **36.1 (+1%, within noise)** |

### Volume MAE — Best Checkpoint (Epoch 89)

| Val Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 2.354 | 0.937 | 61.1 |
| val_ood_cond | 1.989 | 0.911 | 51.3 |
| val_tandem_transfer | 2.891 | 1.410 | 63.3 |
| val_ood_re | 1.844 | 0.829 | 75.1 |

### Val Loss — Best Checkpoint (Epoch 89)

| val_in_dist | val_tandem_transfer | val_ood_cond | val_ood_re | mean_val_loss |
|---|---|---|---|---|
| 1.8130 | 4.8287 | 1.7017 | NaN (vol overflow, skipped) | **2.7811** |

### What happened

**Negative result — volume subsampling fails to provide speedup and worsens accuracy.** All four evaluable splits show worse accuracy vs baseline (in_dist +3%, ood_cond +6%, tandem +4%, ood_re +1%). Epoch count is 90 vs 92 — no speedup despite the subsampling.

**Why no speedup?** The implementation subsamples only the **loss mask**, not the **forward pass**. The Transolver attention still processes all ~200K nodes in `x` — the expensive O(N×G) attention computation is unchanged. The only computational "savings" come from computing the vol_loss over fewer nodes (minor). But the per-batch Python loop (`for b_idx in range(B)`) with `torch.randperm` adds CPU overhead that roughly cancels even these savings.

**Why does accuracy worsen?** With 25% volume subsampling, the effective volume loss is computed on fewer nodes, making vol_loss noisier and less stable. The gradient signal from volume nodes is weaker and more random, effectively reducing the regularization benefit of volume supervision. This is similar to the "surface-only loss" experiment (PR #398), where removing volume loss also hurt accuracy.

**Conclusion**: The "maximize epochs" strategy works when epoch speedup is achieved by reducing the attention computation (e.g., fewer slices, fewer layers). Simply subsampling the loss mask doesn't reduce compute and introduces gradient noise that hurts accuracy. To truly speed up training, subsampling would need to be applied to the input tensor `x` as well.

### Suggested follow-ups

1. **True node subsampling** — subset both `x` and the targets so the model processes only N' = 5K surf + 12K vol nodes per forward pass. This would need careful handling of the batch collation (variable-length meshes are already padded).
2. **Importance-weighted subsampling** — weight volume nodes by their distance to the surface (near-surface volume nodes are more important for pressure prediction).
3. **Patch-based training** — divide the mesh into patches, train on surface-centered patches with limited local volume context.