### PR TITLE
Higher LR 8e-3 (exploit faster epochs with volume subsampling)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -53,7 +53,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 8e-3
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The current lr=3e-3 was tuned for 92 epochs. If volume subsampling (PR #418) gives 250+ epochs, a higher LR might converge better with the additional training budget. lr=8e-3 with the existing warmup+cosine schedule should reach and exploit the longer training runway.

Even without subsampling, lr=8e-3 is worth testing — the previous LR experiments (5e-3 in PR #379) showed in_dist improvement but cond regression. At 8e-3 with the current Cp normalization and sw-schedule, the dynamics may be different.

## Instructions

1. Increase lr to 8e-3.
2. Run with --wandb_group "lr-8e3"

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run:** g9wfca6o
**Best epoch:** 91 (last checkpoint update)
**Epochs completed:** 92 (30.1 min wall-clock)
**Peak VRAM:** 7.5 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 26.6 | 28.5 | +7.1% |
| val_ood_cond | 27.5 | 33.8 | +22.9% |
| val_tandem | 45.7 | 48.1 | +5.3% |
| val_ood_re | 35.9 | 38.7 | +7.8% |

### What happened

Clear negative result. lr=8e-3 made all splits worse, with val_ood_cond showing the most severe regression (+22.9%).

The LR of 8e-3 appears to be too high for this training setup. With the cosine annealing schedule, the effective LR at epoch 91 is near zero — but the initial 8e-3 (after warmup) is 2.67x larger than the baseline 3e-3. The large initial LR drives the model into a suboptimal basin from which the cosine decay cannot recover.

This is consistent with the earlier LR sweep (PR #379) where lr=5e-3 showed improvement on in_dist but regression on ood_cond. At lr=8e-3 the regression on ood_cond is even more severe — the LR is high enough to disrupt the gradient signals needed for OOD generalization.

Note: The LR hypothesis was partly motivated by a planned volume subsampling change (PR #418) that would provide more epochs. The current 92 epochs with 8e-3 is an apples-to-oranges comparison. If PR #418 does provide 250+ epochs, lr=8e-3 might be re-evaluated in that context.

### Suggested follow-ups

- **lr=4e-3 or 5e-3 on current baseline**: The jump from 3e-3 to 8e-3 is too large. A gentler step (4-5e-3) might improve in_dist without degrading ood_cond.
- **lr=8e-3 with volume subsampling**: If PR #418 gives 250+ epochs, the larger LR might be appropriate with the longer training budget — revisit in that context.
- **LR warmup length**: Current warmup is 3 epochs. Longer warmup (10-15 epochs) might let the model settle before hitting peak LR, reducing the instability from high LR.