### PR TITLE
Wider preprocess MLP only (256→128→128 instead of 256→128)

### DIFF
--- a/transolver.py
+++ b/transolver.py
@@ -195,7 +195,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 4, n_hidden, n_layers=0, res=False, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
Previous "wider" experiments increased n_hidden (the attention dimension), which slowed the attention computation and reduced epochs. But the PREPROCESS MLP (which maps 24-dim input to 128-dim hidden) is independent of the attention computation. Making only the preprocess wider gives more capacity for input feature extraction without slowing the attention bottleneck.

Currently: Linear(24, 256) → GELU → Linear(256, 128). This is a 2-layer MLP with hidden_dim=256.

Change to: Linear(24, 512) → GELU → Linear(512, 128). This doubles the preprocess hidden width, giving 2x more capacity for learning input feature interactions, while the attention layer stays at 128-dim (same speed).

## Instructions

1. **In `transolver.py`**, modify the preprocess MLP width. Change `n_hidden * 2` to `n_hidden * 4`:
   ```python
   # In Transolver.__init__, change:
   self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
   
   # To:
   self.preprocess = MLP(fun_dim + space_dim, n_hidden * 4, n_hidden, n_layers=0, res=False, act=act)
   ```

2. **No changes to structured_train.py.**

3. **Run with**: `--wandb_group "wider-preprocess"`

## Baseline: in=26.6, cond=27.5, tandem=45.7, ood_re=35.9

---
## Results

**W&B run**: `y89s5qbf`
**Peak memory**: ~7 GB (epoch time: 21s, best epoch: 86)

### Best checkpoint (epoch 86)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 26.5 | -0.4% ✅ |
| val_ood_cond | 28.7 | +4.4% ❌ |
| val_tandem_transfer | 46.9 | +2.6% ❌ |
| val_ood_re | 34.9 | -2.8% ✅ |

val/loss: in_dist=1.747, ood_cond=1.683, tandem=4.856

Surface MAE (val_in_dist): Ux=0.313, Uy=0.197, p=26.5

### What happened

**Mixed/neutral result — ood_re improves modestly, but ood_cond and tandem regress.**

The wider preprocess MLP (512 hidden vs 256 baseline) gives ood_re a small improvement (-2.8%) and in_dist is essentially unchanged (-0.4%). However, ood_cond regresses by +4.4% and tandem by +2.6%.

The hypothesis was that more preprocess capacity would help feature extraction without slowing attention. The epoch time increased slightly (21s vs 20s for baseline) — small enough to not be the bottleneck. So the extra parameters don't cause an epoch penalty, but they also don't clearly help.

The ood_cond and tandem regressions are unexpected given that the preprocess MLP is upstream of the attention, which should benefit from richer features. A possible explanation: the larger preprocess MLP overfits more to the training distribution, hurting OOD generalization. The best epoch is 86 (vs baseline's ~92+), suggesting the wider model converges faster but to a slightly worse generalization minimum on the harder splits.

### Suggested follow-ups

- **n_hidden * 3 (intermediate width)**: 512 may be too wide, causing slight overfitting. A 384-dim preprocess might find the sweet spot.
- **The current 256 preprocess is a good default**: Results confirm the preprocess width is not a major bottleneck — both directions (wider or narrower) give mixed results.