### PR TITLE
Surface weight schedule 3→25 (gentler ramp)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -309,8 +309,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    # Dynamic surface weight: linear ramp from 3 → 25 over training
+    sw_start, sw_end = 3.0, 25.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
The current sw-schedule ramps from 5→30. With unified L1 loss (which has different gradient magnitudes than MSE for volume), the optimal ramp range may differ. A gentler schedule (3→25) starts with even more volume emphasis and ends with less extreme surface focus. This tests whether the current 5→30 range is optimal or if the L1 volume loss prefers a different balance.

## Instructions
1. Change the sw-schedule parameters:
   ```python
   sw_start, sw_end = 3.0, 25.0  # was 5.0, 30.0
   ```
2. Run with `--wandb_group "sw-3-25"`

## Baseline: in=26.0, cond=26.1, tandem=45.8, ood_re=35.5

---
## Results

**W&B run**: `xmo95i0u`
**Peak memory**: ~7 GB (epoch time: 20s, best epoch: 91)

### Best checkpoint (epoch 91)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 26.1 | +0.4% ≈neutral |
| val_ood_cond | 25.7 | -1.5% ✅ |
| val_tandem_transfer | 45.9 | +0.2% ≈neutral |
| val_ood_re | 34.3 | -3.4% ✅ |

val/loss: in_dist=1.931, ood_cond=1.752, tandem=4.937

Surface MAE (val_in_dist): Ux=0.344, Uy=0.206, p=26.1

### What happened

**Positive result — ood splits improve with gentler ramp, in_dist and tandem essentially unchanged.**

The 3→25 schedule improves ood_re by -3.4% (35.5→34.3) and ood_cond by -1.5% (26.1→25.7). In_dist (+0.4%) and tandem (+0.2%) are essentially flat — within noise.

The gentler ramp means:
- **Early training** (epochs 1-50): sw goes from 3→14 vs 5→17.5 — slightly less surface emphasis early on, which appears to help generalization.
- **Late training** (epochs 50-100): sw goes from 14→25 vs 17.5→30 — less aggressive surface focus, which may avoid overfitting the surface distribution.

The improvement on ood splits at no cost to in_dist/tandem suggests the 5→30 schedule was slightly over-emphasizing the surface loss and hurting generalization. The 3→25 schedule is a better default.

### Suggested follow-ups

- **Try 3→20 or 2→20**: If softer endings help ood generalization, a lower ceiling might help further.
- **Try non-linear ramp (e.g., cosine or slow-start fast-finish)**: A linear ramp is arbitrary — a schedule that stays near sw=3 for longer then ramps up quickly late might help even more.