### PR TITLE
Surface weight schedule 3→25 (retest with 5-epoch warmup + L1 vol)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -309,8 +309,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    # Dynamic surface weight: linear ramp from 3 → 25 over training
+    sw_start, sw_end = 3.0, 25.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
The sw-3-25 schedule previously showed best-ever ood_cond=25.7. Retesting on the new baseline (5-epoch warmup + unified L1) to see if improvements compound.

## Instructions
1. Change: `sw_start, sw_end = 3.0, 25.0`
2. Run with `--wandb_group "sw-3-25-v2"`

## Baseline: in=25.8, cond=26.2, tandem=45.1, ood_re=34.4

---
## Results

**W&B run:** `d0pgqyve`
**Best epoch:** 91 / 100 (wall-clock limit at 30.2 min)
**Peak VRAM:** 7.6 GB
**val/loss (best):** 2.836

### Surface MAE (mae_surf_p — primary metric)

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 25.6 | 25.8 | **-0.2** ✓ |
| val_ood_cond | 25.3 | 26.2 | **-0.9** ✓ |
| val_tandem_transfer | 47.0 | 45.1 | **+1.9** ✗ |
| val_ood_re | 34.6 | 34.4 | **+0.2** ~ |

### In-dist detail (best epoch)

| Metric | Value |
|--------|-------|
| val_in_dist/loss | 1.873 |
| mae_surf_Ux | 0.316 |
| mae_surf_Uy | 0.206 |
| mae_surf_p | 25.58 |
| mae_vol_Ux | 1.934 |
| mae_vol_Uy | 0.688 |
| mae_vol_p | 39.28 |

### What happened

Mixed results. The sw-3-25 schedule partially compounds with the 5-epoch warmup + L1 baseline:
- **ood_cond** improved by 0.9 (25.3 vs 26.2) — consistent with the previous best-ever result of 25.7 from this schedule
- **in_dist** marginal improvement (25.6 vs 25.8)
- **tandem** regressed by 1.9 (47.0 vs 45.1) — the lower starting weight (sw_start=3 vs 5) may be insufficient to learn tandem configurations early
- **ood_re** essentially neutral

The lower sw_start=3 may be too gentle initially, leaving tandem transfer cases under-weighted during the critical early epochs.

Note: val_ood_re showed `nan` in the final epoch log (epoch 92) but the best model (epoch 91) had mae_surf_p=34.6 — the nan appears to be an isolated batch issue.

### Suggested follow-ups

- Try sw_start=4 or 5 (e.g. 4→25 or 5→25) to see if a higher starting weight preserves tandem while keeping ood_cond gains
- Investigate occasional nan in val_ood_re — may be a batch normalization issue with sparse surface nodes in the last training epoch
- Test whether warmup duration (5 epochs) interacts with sw_start; a longer warmup with lower sw_start might mitigate the tandem regression