### PR TITLE
Target noise decay (0.01→0.002 cosine schedule)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -31,6 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import json
 import os
+import math
 import time
 import torch
 import wandb
@@ -330,8 +331,10 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+        noise_start, noise_end = 0.01, 0.002
+        noise_std = noise_end + (noise_start - noise_end) * 0.5 * (1 + math.cos(math.pi * progress))
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            y_norm = y_norm + noise_std * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Constant target noise 0.01 prevents fine fitting in late epochs. Cosine decay to 0.002 gives strong regularization early, precise fitting late.

## Instructions
1. Add `import math` at top.
2. Replace constant noise:
   \`\`\`python
   noise_start, noise_end = 0.01, 0.002
   progress = epoch / MAX_EPOCHS
   noise_std = noise_end + (noise_start - noise_end) * 0.5 * (1 + math.cos(math.pi * progress))
   if model.training:
       y_norm = y_norm + noise_std * torch.randn_like(y_norm)
   \`\`\`
3. Run with \`--wandb_group "noise-decay-v2"\`

## Baseline: in=25.8, cond=26.2, tandem=45.1, ood_re=34.4

---
## Results

**W&B run:** \`fm8nybuv\`
**Best epoch:** 92 (hit 30 min wall-clock limit)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint (mae_surf_p, vs baseline)

| Split | val_loss | surf_p MAE | vs baseline |
|---|---|---|---|
| val_in_dist | 1.9701 | 27.3 | 25.8 → +1.5 worse |
| val_ood_cond | 1.7487 | 27.3 | 26.2 → +1.1 worse |
| val_tandem_transfer | 5.0331 | 48.1 | 45.1 → +3.0 worse |
| val_ood_re | nan | 34.4 | 34.4 → same (loss nan) |

### val_in_dist detailed MAE

| Channel | Surface MAE | Volume MAE |
|---|---|---|
| Ux | 0.341 | 2.049 |
| Uy | 0.198 | 0.746 |
| p | 27.3 | 42.5 |

### What happened

Negative result. Cosine noise decay made all surface metrics slightly worse across in-dist, OOD condition, and tandem splits compared to baseline. More concerning: val_ood_re loss became nan starting around epoch 72, suggesting numerical instability on some OOD Reynolds number samples.

The hypothesis was that reducing noise in late epochs would allow finer surface fitting. In practice, the opposite occurred — metrics degraded modestly (~5-7%) relative to the constant-noise baseline. Possible explanations:

1. The constant 0.01 noise acts as implicit data augmentation helping generalization; reducing it in late epochs allows slight overfitting.
2. The cosine schedule decays slowly at first (noise stays near 0.01 for the first ~50% of training), so early-epoch regularization is not actually stronger than baseline.
3. The nan in val_ood_re may indicate the model fitting too tightly to normalized targets at very low noise late in training, leading to instability on OOD samples.

### Suggested follow-ups

- Try **noise=0** (removing target noise entirely) to test whether any amount of noise hurts vs. helps.
- Investigate the **val_ood_re nan** — check if this also happens in the baseline run, or if it was triggered by the noise change.
- Try **input-space noise** (perturb x instead of y_norm) as a different regularization strategy that doesn't interfere with target precision.