### PR TITLE
Cp pressure channel 1.5x weight in unified L1 loss

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -73,6 +73,9 @@ if cfg.debug:
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
 
+# Channel weighting: 1.5x on pressure (Cp) channel
+channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
+
 # --- Load split manifest and normalization stats ---
 with open(cfg.manifest) as f:
     manifest = json.load(f)
@@ -340,8 +343,9 @@ for epoch in range(MAX_EPOCHS):
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        weighted_abs_err = abs_err * channel_w.unsqueeze(0).unsqueeze(0)
+        vol_loss = (weighted_abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (weighted_abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
Light 1.5x pressure weighting with the current sw-schedule. Previous 2x/3x tests on older baselines hurt tandem. The current sw-schedule may balance it.

## Instructions
1. Add channel weighting:
   \`\`\`python
   channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
   weighted_abs_err = abs_err * channel_w.unsqueeze(0).unsqueeze(0)
   vol_loss = (weighted_abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
   surf_loss = (weighted_abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   \`\`\`
2. Run with \`--wandb_group "cp-1.5x"\`

## Baseline: in=25.8, cond=26.2, tandem=45.1, ood_re=34.4

---
## Results

**W&B run:** mq16uljn  
**Best epoch:** 91/91 (wall-clock limit hit at 30 min)  
**Peak memory:** 7.6 GB

### Surface MAE (pressure, most important)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 25.8 | 26.0 | +0.2 |
| val_ood_cond | 26.2 | 25.6 | **-0.6** |
| val_tandem_transfer | 45.1 | 48.4 | +3.3 |
| val_ood_re | 34.4 | 33.5 | **-0.9** |

### Full metrics at best epoch

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.9921 | 0.346 | 0.214 | 26.0 | 42.8 |
| val_tandem_transfer | 5.0534 | 0.746 | 0.381 | 48.4 | 54.0 |
| val_ood_cond | 1.7583 | 0.295 | 0.224 | 25.6 | 32.4 |
| val_ood_re | NaN* | 0.290 | 0.218 | 33.5 | 59.4 |

\*val_ood_re vol_loss overflows to ~18.9B due to extreme pressure values at Re=4.445M; surface MAE is still valid.

**Overall val/loss:** 2.9346 (mean of 3 finite splits)

### What happened

The hypothesis did not work — tandem got meaningfully worse (+3.3 on mae_surf_p: 45.1→48.4), while the other splits showed only marginal changes (in-dist flat, cond -0.6, ood_re -0.9). The 1.5x pressure weighting continues the pattern seen with 2x/3x: it regresses tandem. This is likely because tandem has inherently different pressure dynamics (two interacting foils, with surface ID 7 missing from SURFACE_IDS), so boosting the pressure channel loss amplifies noise from that mis-labeling. The sw-schedule did not buffer this effect.

The ood_re NaN in vol_loss is a pre-existing numerical issue (Re=4.445M produces extreme volume pressures); it does not reflect on this change.

### Suggested follow-ups

- **Surface-only pressure weighting:** Apply the 1.5x only in surf_loss, not vol_loss. The ood_re vol pressure is already numerically unstable; boosting it may worsen overflow.
- **Investigate tandem surface ID issue:** The known SURFACE_IDS=(5,6) miss boundary ID 7 (foil 2 in tandem). Any pressure weighting will disproportionately penalize the visible foil until this is fixed.
- **Try lower weight (1.2x or 1.25x):** Smaller boost might avoid the tandem regression while still improving cond/ood_re.