### PR TITLE
Gradient surgery: project volume gradients to avoid surface conflicts

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -539,14 +539,30 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
         vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + surf_weight * surf_loss
+        # Gradient surgery: project volume gradient to avoid conflicting with surface gradient
+        optimizer.zero_grad()
+        (surf_weight * surf_loss).backward(retain_graph=True)
+        g_surf = {name: p.grad.clone() for name, p in model.named_parameters() if p.grad is not None}
 
         optimizer.zero_grad()
-        loss.backward()
+        vol_loss.backward()
+        g_vol = {name: p.grad.clone() for name, p in model.named_parameters() if p.grad is not None}
+
+        # Project volume gradient to remove conflict with surface gradient
+        for name, p in model.named_parameters():
+            if name in g_surf and name in g_vol:
+                gs = g_surf[name]
+                gv = g_vol[name]
+                dot = (gs * gv).sum()
+                if dot < 0:  # Conflict exists
+                    gv = gv - (dot / (gs.norm()**2 + 1e-8)) * gs
+                p.grad = gv + g_surf[name]
+
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        loss_val = vol_loss.item() + surf_weight * surf_loss.item()
+        wandb.log({"train/loss": loss_val, "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The surface and volume loss gradients likely conflict — optimizing volume pulls the shared representation away from optimal surface predictions. By projecting the volume gradient onto the plane perpendicular to the surface gradient (PCGrad-style), we ensure the volume objective never hurts surface accuracy while preserving its regularization benefit.

## Instructions
In `structured_split/structured_train.py`, replace the single `loss.backward()` call with gradient surgery:

1. After computing `vol_loss` and `surf_loss`, do NOT compute the combined loss and call backward directly.
2. Instead, compute gradients separately and project:
3. Then proceed with `clip_grad_norm_` and `optimizer.step()` as normal.
4. Remove the old `loss = vol_loss + surf_weight * surf_loss` and `loss.backward()` lines.
5. Still log the combined loss for tracking: `loss_val = vol_loss.item() + surf_weight * surf_loss.item()`
6. Run with: `--wandb_name "frieren/gradient-surgery" --wandb_group gradient-surgery --agent frieren`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** `7py1qcig` (frieren/gradient-surgery)
**Epochs completed:** 55/100 (hit 30-min timeout)
**Peak GPU memory:** ~53.5 GB (54.7% of 96 GB)

### Metrics at best val/loss epoch

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.8139 | **3.5776** | +27% |
| val_in_dist/mae_surf_p | 25.77 | **38.27** | +49% |
| val_ood_cond/mae_surf_p | 26.21 | **33.79** | +29% |
| val_ood_re/mae_surf_p | 34.38 | **41.65** | +21% |
| val_tandem_transfer/mae_surf_p | 45.10 | **55.88** | +24% |

Surface MAE (in-dist): Ux=0.47, Uy=0.29, p=38.27
Volume MAE (in-dist): Ux=2.26, Uy=0.86, p=48.04

Note: `val_ood_re/vol_loss` diverged to ~18.9 billion, making `val_ood_re/loss = NaN` (excluded from mean val/loss).

### What happened

Gradient surgery made things significantly worse across all splits. Two main reasons:

1. **Speed cost killed epoch count.** Doing two backward passes per step roughly halved throughput. The baseline completes 100 epochs in 30 min; gradient surgery only reached 55. This alone puts us at a training disadvantage even before considering the quality of updates.

2. **val_ood_re diverged.** The OOD Reynolds number split saw catastrophic volume loss (~19 billion), suggesting numerical instability introduced by the surgery. Likely cause: when the projection removes the vol gradient component, the optimizer takes a very different step for some parameters, which can destabilize predictions in distribution-shifted samples.

3. **The conflict hypothesis may be wrong.** In a model where surface nodes are a small fraction of the total mesh, the volume loss naturally dominates gradients. The grad surgery may be solving a conflict that does not meaningfully exist in practice, while adding complexity and cost that hurts convergence.

### Suggested follow-ups

- If gradient conflicts are worth investigating, a cheaper diagnostic would be to log the cosine similarity between surf and vol gradients during baseline training to see if conflicts actually occur frequently.
- PCGrad adds real overhead at scale; an alternative with less cost is simply tuning surf_weight, which shifts the gradient balance without any extra backward passes.
- The instability on val_ood_re is worth investigating separately — it may be a numerical issue in the surgery implementation (e.g., large gs.norm() leading to large projection magnitudes when norms are small).