### PR TITLE
Online hard example mining: focus gradients on hardest surface samples

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -537,8 +537,27 @@ for epoch in range(MAX_EPOCHS):
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+
+        # Per-sample surface loss for hard example mining
+        B = pred.shape[0]
+        with torch.no_grad():
+            sample_surf = torch.zeros(B, device=pred.device)
+            for b in range(B):
+                sm = surf_mask[b]
+                if sm.sum() > 0:
+                    sample_surf[b] = (abs_err[b] * sm.unsqueeze(-1)).sum() / sm.sum()
+
+        # Keep top 50% hardest samples
+        n_keep = max(B // 2, 1)
+        _, hard_idx = sample_surf.topk(n_keep)
+        hard_batch = torch.zeros(B, dtype=torch.bool, device=pred.device)
+        hard_batch[hard_idx] = True
+
+        # Recompute losses with only hard samples
+        hard_vol_mask = vol_mask & hard_batch.unsqueeze(1)
+        hard_surf_mask = surf_mask & hard_batch.unsqueeze(1)
+        vol_loss = (abs_err * hard_vol_mask.unsqueeze(-1)).sum() / hard_vol_mask.sum().clamp(min=1)
+        surf_loss = (abs_err * hard_surf_mask.unsqueeze(-1)).sum() / hard_surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
The WeightedRandomSampler balances domain groups but doesn't distinguish easy from hard samples. Online Hard Example Mining (OHEM) focuses training on the samples with the highest surface loss, where the model has the most room to improve. This adds zero compute cost since per-sample losses are already computed.

## Instructions
In `structured_split/structured_train.py`, modify the training loop inside the `for x, y, is_surface, mask in pbar:` block:

1. After computing `abs_err`, `surf_mask`, and `vol_mask`, compute per-sample surface loss and apply hard mining:
   ```python
   # Per-sample surface loss for hard example mining
   B = pred.shape[0]
   with torch.no_grad():
       sample_surf = torch.zeros(B, device=pred.device)
       for b in range(B):
           sm = surf_mask[b]
           if sm.sum() > 0:
               sample_surf[b] = (abs_err[b] * sm.unsqueeze(-1)).sum() / sm.sum()
   
   # Keep top 50% hardest samples
   n_keep = max(B // 2, 1)
   _, hard_idx = sample_surf.topk(n_keep)
   hard_batch = torch.zeros(B, dtype=torch.bool, device=pred.device)
   hard_batch[hard_idx] = True
   
   # Recompute losses with only hard samples
   hard_vol_mask = vol_mask & hard_batch.unsqueeze(1)
   hard_surf_mask = surf_mask & hard_batch.unsqueeze(1)
   vol_loss = (abs_err * hard_vol_mask.unsqueeze(-1)).sum() / hard_vol_mask.sum().clamp(min=1)
   surf_loss = (abs_err * hard_surf_mask.unsqueeze(-1)).sum() / hard_surf_mask.sum().clamp(min=1)
   ```
2. The rest of the loss computation stays the same: `loss = vol_loss + surf_weight * surf_loss`
3. Run with: `--wandb_name "fern/hard-example-mining" --wandb_group hard-mining --agent fern`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** `m9hhup11` | **Epochs:** 92/100 (30.3 min) | **Peak memory:** 7.6 GB

### Validation loss
| Split | Baseline | OHEM | Δ |
|---|---|---|---|
| val/loss (mean) | 2.8139 | 3.3500 (3 splits; ood_re=nan) | +19% worse |
| val_in_dist | — | 2.3451 | — |
| val_ood_cond | — | 2.5524 | — |
| val_ood_re | — | **nan** (vol_loss=1.9e10) | diverged |
| val_tandem_transfer | — | 5.1524 | — |

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | OHEM mae_surf_p | Δ |
|---|---|---|---|
| val_in_dist | 25.77 | 34.05 | +32% worse |
| val_ood_cond | 26.21 | 41.27 | +58% worse |
| val_ood_re | 34.38 | 45.42 | +32% worse |
| val_tandem_transfer | 45.10 | 50.23 | +11% worse |

### Surface MAE (Ux, Uy, p) at best checkpoint
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.44 | 0.24 | 34.05 |
| val_ood_cond | 0.39 | 0.29 | 41.27 |
| val_ood_re | 0.38 | 0.27 | 45.42 |
| val_tandem_transfer | 0.73 | 0.38 | 50.23 |

### Volume MAE at best checkpoint
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 2.36 | 0.89 | 53.19 |
| val_ood_cond | 2.12 | 0.97 | 50.26 |
| val_ood_re | 1.99 | 0.88 | 76.15 |
| val_tandem_transfer | 2.84 | 1.35 | 59.16 |

### What happened

**OHEM did not help — all metrics degraded significantly.** Two compounding problems:

1. **Effective batch size of 2.** With `batch_size=4`, keeping the top 50% means the loss is computed on only 2 samples per step. This halves the gradient signal, increasing variance substantially and destabilizing training.

2. **Vol mask is also restricted to hard samples.** Both `hard_vol_mask` and `hard_surf_mask` are filtered to the same 2 samples. This means volume-region gradients also come only from the hardest-surface-loss samples, introducing large noise into volume prediction — likely the root cause of `val_ood_re/vol_loss` diverging to ~1.9e10 (nan loss).

3. **val_ood_re diverged.** The volume loss on val_ood_re hit the 1e12 per-batch cap repeatedly, summing to ~1.9e10, making the split loss nan. The surface MAE (45.4) is in-range, so the model learned something on the surface but completely failed on volume nodes for OOD Reynolds number samples.

### Suggested follow-ups
- **Mine only for surface loss, keep all for vol loss**: Decouple the filtering — `vol_loss` uses the full batch, only `surf_loss` uses hard samples. This avoids destabilizing volume predictions while still focusing surface gradients on hard examples.
- **Larger batch size**: OHEM requires a larger pool to be meaningful. With batch_size=8 or 16, keeping top 50% still leaves 4–8 samples — a reasonable training signal.
- **Softer mining (weighted, not binary)**: Instead of hard top-50% cutoff, weight samples by relative surface loss (e.g., softmax-normalized). This preserves all gradients but up-weights hard examples.
- **Curriculum approach**: Start with all samples and gradually increase the hard fraction (0%→50%) as training progresses, rather than forcing top-50% from epoch 1.