### PR TITLE
Lookahead optimizer: slow-weight averaging for flatter minima

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -483,7 +483,7 @@ class Lookahead:
 
 
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=5, alpha=0.5)
+optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
The model is still improving at epoch 92 when the 30-min timeout hits. Lookahead (Zhang et al., NeurIPS 2019) wraps AdamW with slow weights updated every k steps as an EMA of fast weights. This stabilizes training, finds flatter minima, and improves generalization with virtually zero overhead. Unlike EMA (#403) which required dual-validation and lost epochs, Lookahead maintains a single model.

## Instructions
In `structured_split/structured_train.py`:

1. Add a Lookahead wrapper class BEFORE the optimizer creation (around line 455):
   ```python
   class Lookahead:
       def __init__(self, base_optimizer, k=5, alpha=0.5):
           self.base_optimizer = base_optimizer
           self.k = k
           self.alpha = alpha
           self.slow_params = [
               [p.data.clone() for p in group['params']]
               for group in base_optimizer.param_groups
           ]
           self.step_count = 0

       def step(self):
           self.base_optimizer.step()
           self.step_count += 1
           if self.step_count % self.k == 0:
               for slow, group in zip(self.slow_params, self.base_optimizer.param_groups):
                   for s, p in zip(slow, group['params']):
                       s.data.add_(self.alpha * (p.data - s.data))
                       p.data.copy_(s.data)

       def zero_grad(self):
           self.base_optimizer.zero_grad()

       @property
       def param_groups(self):
           return self.base_optimizer.param_groups
   ```

2. Replace the optimizer setup:
   ```python
   base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
   optimizer = Lookahead(base_opt, k=5, alpha=0.5)
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5)
   scheduler = torch.optim.lr_scheduler.SequentialLR(
       base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
   )
   ```

3. Run with: `--wandb_name "tanjiro/lookahead" --wandb_group lookahead --agent tanjiro`

## Baseline
- val/loss: **2.7927** (updated, includes multi-scale loss from noam)
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

### Revision 2 — k=10, alpha=0.8 (rebased on noam with multi-scale loss)

**W&B run:** `0765q207` | **Epochs:** 92 (clean timeout) | **Peak memory:** 7.6 GB

| Metric | Baseline | Lookahead k=10 α=0.8 | Delta |
|---|---|---|---|
| val/loss | 2.7927 | **2.7488** | -0.044 better |
| val_in_dist/mae_surf_p | 25.77 | **24.88** | -0.89 better |
| val_ood_cond/mae_surf_p | 26.21 | **25.17** | -1.04 better |
| val_ood_re/mae_surf_p | 34.38 | **33.73** | -0.65 better |
| val_tandem_transfer/mae_surf_p | 45.10 | **44.78** | -0.32 better |

Additional surface metrics (best checkpoint, epoch 92):
- val_in_dist: mae_surf_Ux=0.328, mae_surf_Uy=0.192
- val_ood_cond: mae_surf_Ux=0.283, mae_surf_Uy=0.213
- val_ood_re: mae_surf_Ux=0.281, mae_surf_Uy=0.210
- val_tandem_transfer: mae_surf_Ux=0.693, mae_surf_Uy=0.359

Volume MAE (val_in_dist): Ux=1.759, Uy=0.601, p=34.0

Note: `val_ood_re/loss` remains NaN (vol_loss overflow is a pre-existing issue in that split); val/loss is the mean over the 3 finite splits.

### What happened

**Lookahead with k=10 and alpha=0.8 works.** All metrics improved over the updated baseline. Two changes from revision 1 mattered:

1. **k=10 vs k=5:** Less frequent slow-weight syncing (every 10 steps instead of 5) reduces interference with the late-training cosine decay phase. The fast weights get more time to converge before being synced back.

2. **alpha=0.8 vs alpha=0.5:** A higher alpha means the slow weights track the fast weights more closely (80% interpolation toward fast weights vs 50%). This effectively gives a lighter regularization effect — the slow weights don't pull the fast weights as far back at each sync. At alpha=0.5 the periodic reset was too aggressive; at alpha=0.8 it's gentle enough to be beneficial.

3. **Clean timeout:** The script reached its own 30-min wall-clock limit cleanly at epoch 92 (same as the original baseline), confirming Lookahead has negligible per-epoch overhead.

The improvement is modest but consistent across all 4 splits: ~1 Pa improvement on in-dist and OOD-cond pressure, ~0.7 Pa on OOD-Re, ~0.3 Pa on tandem transfer.

### Revision 1 — k=5, alpha=0.5 (for reference)

**W&B run:** `6lvvk97a` | **Epochs:** 90 (process killed by external timeout before script cleanup)

| Metric | Baseline | Lookahead k=5 α=0.5 | Delta |
|---|---|---|---|
| val/loss | 2.8139 | 2.9020 | +0.088 worse |
| val_in_dist/mae_surf_p | 25.77 | 26.56 | +0.79 worse |
| val_ood_cond/mae_surf_p | 26.21 | 26.36 | +0.15 worse |
| val_ood_re/mae_surf_p | 34.38 | 34.59 | +0.21 worse |
| val_tandem_transfer/mae_surf_p | 45.10 | 46.50 | +1.40 worse |

### Suggested follow-ups

- **Lookahead as a permanent ingredient:** Given the consistent improvement across splits, this could be a good default. The added complexity is minimal (35 lines, no new params).
- **Tune alpha further (0.9):** The trend from 0.5→0.8 suggests even gentler syncing might help further.
- **Focus on val_ood_re/loss overflow:** The NaN vol_loss for OOD-Re is a pre-existing issue that makes the mean val/loss exclude one split, potentially masking issues. Worth fixing separately.