### PR TITLE
Input mixup for mesh data (Beta(0.2,0.2) interpolation)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -523,6 +523,16 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
+        # Mixup augmentation
+        if model.training:
+            lam = torch.distributions.Beta(0.2, 0.2).sample().item()
+            idx = torch.randperm(x.size(0), device=x.device)
+            x = lam * x + (1 - lam) * x[idx]
+            y = lam * y + (1 - lam) * y[idx]
+            # Mix masks: use intersection (both samples must have real nodes)
+            mask = mask & mask[idx]
+            is_surface = is_surface & is_surface[idx]
+
         x = (x - stats["x_mean"]) / stats["x_std"]
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
Data augmentation has never been tried. Mixup creates virtual training samples by linearly interpolating between pairs. For mesh data, meshes are already padded to the same size via pad_collate. Mixup regularizes the model to predict smooth interpolations between flow states, which is physically meaningful. With Beta(0.2,0.2), lambda is almost always >0.9 or <0.1, so mixing is very mild.

## Instructions
In `structured_split/structured_train.py`, in the training loop, right after moving tensors to device and BEFORE x normalization (before `x = (x - stats["x_mean"]) / stats["x_std"]`):

```python
# Mixup augmentation
if model.training:
    lam = torch.distributions.Beta(0.2, 0.2).sample().item()
    idx = torch.randperm(x.size(0), device=x.device)
    x = lam * x + (1 - lam) * x[idx]
    y = lam * y + (1 - lam) * y[idx]
    # Mix masks: use intersection (both samples must have real nodes)
    mask = mask & mask[idx]
    is_surface = is_surface & is_surface[idx]
```

This is ~6 lines of code with zero compute overhead. The Beta(0.2,0.2) distribution keeps most samples near-pure, avoiding catastrophic mixing.

Run with: `--wandb_name "alphonse/mixup" --wandb_group mixup --agent alphonse`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** ccoiwq7n  
**Run stopped at:** epoch 87/100 (30-min timeout)  
**Peak GPU memory:** 7.6 GB (unchanged — mixup is compute-free)

### Metrics at best checkpoint (epoch 85)

| Metric | This run | Baseline | Δ |
|---|---|---|---|
| val/loss | 3.7924 | 2.8139 | +35% worse |
| val_in_dist/mae_surf_Ux | 0.519 | — | — |
| val_in_dist/mae_surf_Uy | 0.266 | — | — |
| val_in_dist/mae_surf_p | 42.17 | 25.77 | +64% worse |
| val_in_dist/mae_vol_Ux | 1.923 | — | — |
| val_in_dist/mae_vol_Uy | 0.716 | — | — |
| val_in_dist/mae_vol_p | 43.81 | — | — |
| val_ood_cond/mae_surf_p | 42.82 | 26.21 | +63% worse |
| val_ood_re/mae_surf_p | 45.77 | 34.38 | +33% worse |
| val_tandem_transfer/mae_surf_p | 55.41 | 45.10 | +23% worse |

### What happened

**Mixup significantly hurt performance across all splits.** Surface pressure MAE is 23–64% worse than baseline. This is a clear negative result.

The most likely cause is the interaction with the **physics-based label normalization**. Mixup is applied on raw y labels, then immediately after we call `_umag_q(y, mask)` and `_phys_norm(y, Umag, q)` using per-sample statistics derived from the already-mixed y. When y is a linear combination of two different flow states, the resulting Umag is neither state's true reference velocity. This makes the normalization inconsistent—the training targets are neither properly normalized nor physically interpretable. In standard image mixup, no such nonlinear preprocessing is applied to the labels, so the linearity holds end-to-end.

A secondary issue: the mask intersection (`mask & mask[idx]`) can silently drop surface nodes if two samples have non-overlapping padding patterns. Fewer surface nodes per batch means noisier surf_loss estimates.

The hypothesis that "mixing is physically meaningful" turns out not to hold in this context—unlike mixing pixel values, mixing flow velocity/pressure fields from different simulations creates non-physical states that don't satisfy Navier-Stokes.

### Suggested follow-ups

- **Mixup in normalized space**: Apply mixup *after* x and y normalization rather than before. This avoids the physics-normalization inconsistency. The mixed targets would be linear combinations of properly normalized values, which is the standard formulation.
- **Input-only mixup**: Mix only x (geometry/conditions) without mixing y, using the original label of one of the pair. This adds diversity to inputs while keeping targets physically valid.
- **Cutmix**: Rather than blending samples, replace node subsets. For mesh data this might be more natural than linear interpolation.
- **Noise augmentation on inputs only**: The existing Gaussian noise on y_norm (0.01) seems more appropriate for CFD data than label mixing.