### PR TITLE
Label smoothing for regression: dead-zone L1 ignoring small errors

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -533,12 +533,16 @@ for epoch in range(MAX_EPOCHS):
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
         pred = pred.float()
-        sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        raw_err = (pred - y_norm).abs()
+
+        # Dead-zone L1 for surface: ignore errors below epsilon in normalized space
+        epsilon = 0.05  # ~5% of typical std
+        surf_err = torch.where(raw_err < epsilon, torch.zeros_like(raw_err), raw_err - epsilon / 2)
+
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-        vol_loss = (abs_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        vol_loss = (raw_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (surf_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
CFD simulation data has inherent discretization error. Training to match exact values forces the model to fit simulation artifacts. A dead-zone L1 loss that ignores errors below a threshold focuses the model on reducing large errors rather than overfitting to noise. This is equivalent to an epsilon-insensitive loss (SVR-style).

## Instructions
In `structured_split/structured_train.py`, modify the loss computation in the training loop:

1. Replace the surface loss abs_err computation with a dead-zone variant:
   ```python
   # Standard abs_err for volume (less precise anyway)
   raw_err = (pred - y_norm).abs()
   
   # Dead-zone L1 for surface: ignore errors below epsilon in normalized space
   epsilon = 0.05  # ~5% of typical std
   surf_err = torch.where(raw_err < epsilon, torch.zeros_like(raw_err), raw_err - epsilon / 2)
   
   vol_mask = mask & ~is_surface
   surf_mask = mask & is_surface
   vol_loss = (raw_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
   surf_loss = (surf_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```

2. Keep the validation loss computation unchanged (still use standard abs_err for fair comparison).
3. Run with: `--wandb_name "edward/deadzone-l1" --wandb_group deadzone-l1 --agent edward`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** 9smbhwi3
**Epochs:** 90 (30-min wall-clock limit)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint (epoch 90)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 2.135 | 0.391 | 0.243 | **28.53** | 37.15 |
| val_ood_cond | 2.102 | 0.387 | 0.281 | **31.30** | 31.18 |
| val_ood_re | NaN | 0.348 | 0.260 | **36.77** | 58.21 |
| val_tandem_transfer | 5.070 | 0.740 | 0.399 | **47.02** | 52.48 |
| **mean val/loss** | **3.102** | | | | |

### vs. Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.8139 | 3.102 | +10.2% worse |
| val_in_dist/mae_surf_p | 25.77 | 28.53 | +10.7% worse |
| val_ood_cond/mae_surf_p | 26.21 | 31.30 | +19.4% worse |
| val_ood_re/mae_surf_p | 34.38 | 36.77 | +7.0% worse |
| val_tandem_transfer/mae_surf_p | 45.10 | 47.02 | +4.3% worse |

### What happened

The dead-zone L1 loss made things worse across all splits. The hypothesis was that ignoring small errors (< epsilon=0.05 in normalized space) would reduce noise-fitting and focus the model on large deviations. In practice it did the opposite.

The most likely reason: the dead zone silences gradient signal for well-predicted surface nodes. Since surf_weight is high (5 to 30 ramp), the surface loss already dominates — removing gradients for small-error nodes reduces the effective training signal in exactly the regions the model is trying to refine. The result is slower convergence and worse final accuracy.

Note: val_ood_re/loss is NaN throughout — this is a pre-existing issue (extreme vol_loss ~1.9e10 in that split), not caused by this change.

### Suggested follow-ups

- Smaller epsilon (e.g. 0.01, ~1% of Cp std) — 0.05 may be silencing too much signal
- Huber loss as a softer alternative: smoothly reduces large-error influence without hard-zeroing small ones; less likely to hurt gradient coverage
- Apply dead-zone only to the p channel, since Ux/Uy predictions may not benefit from noise tolerance