### PR TITLE
Cosine similarity loss on velocity channels only (avoid tandem regression)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -541,6 +541,22 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
+        # Auxiliary cosine similarity on velocity channels at surface nodes
+        cos_loss = torch.tensor(0.0, device=pred.device)
+        n_cos = 0
+        for b_idx in range(pred.shape[0]):
+            s = surf_mask[b_idx]
+            if s.sum() < 2:
+                continue
+            pred_vel = pred[b_idx, s, :2]   # [S, 2] — Ux, Uy predictions
+            tgt_vel = y_norm[b_idx, s, :2]  # [S, 2] — Ux, Uy targets
+            # Flatten to 1D vectors and compute cosine similarity
+            cos_sim = F.cosine_similarity(pred_vel.reshape(1, -1), tgt_vel.reshape(1, -1))
+            cos_loss = cos_loss + (1 - cos_sim)
+            n_cos += 1
+        cos_loss = cos_loss / max(n_cos, 1)
+        loss = loss + 3.0 * cos_loss  # lighter weight than previous pressure version (5.0)
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
The cosine similarity loss (PR #407) showed the best-ever ood_cond improvement (-8.4%) but regressed tandem because the pressure-channel cosine constraint conflicted with tandem dual-foil pressure patterns. Applying cosine similarity to velocity channels (Ux, Uy) only avoids this — velocity flow patterns are more universal across single/tandem geometries.

## Instructions
In `structured_split/structured_train.py`, after the existing loss computation (`loss = vol_loss + surf_weight * surf_loss`), add an auxiliary cosine similarity loss:

```python
# Auxiliary cosine similarity on velocity channels at surface nodes
import torch.nn.functional as F
cos_loss = torch.tensor(0.0, device=pred.device)
n_cos = 0
for b_idx in range(pred.shape[0]):
    s = surf_mask[b_idx]
    if s.sum() < 2:
        continue
    pred_vel = pred[b_idx, s, :2]   # [S, 2] — Ux, Uy predictions
    tgt_vel = y_norm[b_idx, s, :2]  # [S, 2] — Ux, Uy targets
    # Flatten to 1D vectors and compute cosine similarity
    cos_sim = F.cosine_similarity(pred_vel.reshape(1, -1), tgt_vel.reshape(1, -1))
    cos_loss = cos_loss + (1 - cos_sim)
    n_cos += 1
cos_loss = cos_loss / max(n_cos, 1)
loss = loss + 3.0 * cos_loss  # lighter weight than previous pressure version (5.0)
```

Run with: `--wandb_name "thorfinn/cosine-vel-only" --wandb_group cosine-vel-only --agent thorfinn`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** `wbd31nh9` (thorfinn/cosine-vel-only)
**Best checkpoint:** epoch 84 / 87 (hit 30-min timeout)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint (val/loss = 2.9351)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.343 | 0.202 | **27.15** | +5.4% worse |
| val_ood_cond | 0.308 | 0.219 | **28.44** | +8.5% worse |
| val_ood_re | 0.296 | 0.215 | **35.85** | +4.3% worse |
| val_tandem_transfer | 0.722 | 0.377 | **48.24** | +7.0% worse |

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.9351 | 2.8139 | +4.3% worse |

Volume MAE (pressure): in_dist=41.1, ood_cond=33.0, ood_re=60.1, tandem=54.7

Note: `val_ood_re` had NaN loss every epoch (vol_loss ~19 billion due to numerical overflow in that split's normalization), so it was excluded from the mean val/loss. The physical-space MAE metrics for ood_re were still finite and valid.

### What happened

The hypothesis failed — velocity-only cosine similarity hurt performance on every split compared to baseline, with ood_cond regressing the most (-8.5% on pressure MAE). Tandem also regressed (-7.0%), not improved as hoped.

The original PR #407 motivation was that pressure was the problematic channel for tandem, so dropping it would help. But even with velocity-only, the constraint appears to interfere with training. Two likely causes:

1. **Conflicting gradients with the surf_weight ramp.** The cosine loss provides a fixed-scale directional signal while the MAE loss ramp grows from surf_weight=5 to 30. The cosine term's relative influence changes throughout training in a way that may destabilize the pressure predictions (since Ux/Uy and p are physically coupled — constraining velocity direction also indirectly constrains pressure).

2. **The flattened 1D cosine is too coarse.** Flattening all surface node velocities into a single 1D vector loses spatial structure. This measures whether the overall velocity patterns point in the same direction, not whether they match locally — a weak signal that may not provide meaningful gradient information.

### Suggested follow-ups

- **Much smaller weight (0.5 or 1.0):** Weight=3.0 adds ~3x the baseline loss magnitude at early epochs. A lighter signal might provide directional guidance without overriding MAE gradients.
- **Node-wise cosine rather than flattened:** Compute cosine similarity per surface node (each node is a 2D velocity vector) instead of flattening all nodes. This preserves spatial structure.
- **Accept that cosine constraints don't help here:** Both PR #407 (all channels, weight=5) and this run (velocity only, weight=3) hurt performance. The directional constraint may be fundamentally at odds with learning accurate magnitudes under physics normalization.