### PR TITLE
Gradient centralization: subtract mean gradient for implicit regularization

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -543,6 +543,10 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
+        # Gradient centralization: subtract mean for weight matrices
+        for p in model.parameters():
+            if p.grad is not None and p.grad.ndim > 1:
+                p.grad.data -= p.grad.data.mean(dim=tuple(range(1, p.grad.ndim)), keepdim=True)
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         global_step += 1


### PR DESCRIPTION
## Hypothesis
Gradient Centralization (Yong et al., ECCV 2020) subtracts the mean of each weight's gradient before the optimizer step. This constrains the weight space, acts as an implicit regularizer, and accelerates convergence — proven on transformers with minimal overhead. It's ~4 lines of code.

## Instructions
In \`structured_split/structured_train.py\`, in the training loop, after \`loss.backward()\` and BEFORE \`torch.nn.utils.clip_grad_norm_()\`:

\`\`\`python
# Gradient centralization: subtract mean for weight matrices
for p in model.parameters():
    if p.grad is not None and p.grad.ndim > 1:
        p.grad.data -= p.grad.data.mean(dim=tuple(range(1, p.grad.ndim)), keepdim=True)
\`\`\`

This applies only to weight matrices (ndim > 1), not biases or LayerNorm parameters. It adds negligible compute.

Run with: \`--wandb_name "askeladd/grad-central" --wandb_group grad-central --agent askeladd\`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** \`qxbl6lp9\`
**Epochs completed:** 85 (terminated at 30-minute timeout)
**Peak GPU memory:** ~24 GB (25% of 96 GB)

### Metrics at best val/loss

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 3.1614 | 2.8139 | **+0.35** |
| val_in_dist/mae_surf_p | 31.44 | 25.77 | **+5.67** |
| val_ood_cond/mae_surf_p | 29.65 | 26.21 | **+3.44** |
| val_ood_re/mae_surf_p | 37.40 | 34.38 | **+3.02** |
| val_tandem_transfer/mae_surf_p | 48.96 | 45.10 | **+3.86** |
| val_in_dist/mae_surf_Ux | 0.41 | — | — |
| val_in_dist/mae_surf_Uy | 0.22 | — | — |
| val_in_dist/mae_vol_Ux | 2.33 | — | — |

### What happened

Gradient centralization did **not** help — all metrics are worse than baseline across every validation split.

There is also a pre-existing numerical issue in the \`val_ood_re\` split: \`val_ood_re/surf_loss\` and \`val_ood_re/loss\` are NaN, and \`val_ood_re/vol_loss\` is a huge constant (~18.87 billion) from the very first epoch. This appears to be a normalization or data-loading problem predating this experiment (present at epoch 1, before GC has any effect). The combined \`val/loss\` is therefore computed from the other three splits only.

The degradation is likely explained by GC interacting with the large \`surf_weight=20\` scaling. Centering gradients across each weight matrix may interfere with the loss-scale-driven optimization balance between vol/surf terms. The model may rely on the natural gradient distribution to properly balance these; GC disrupts it. An additional factor: 85 epochs in 30 minutes may not be enough for this model to converge with a modified gradient flow.

### Suggested follow-ups

- Investigate the \`val_ood_re\` NaN issue independently — the huge vol_loss (~18.87B) from epoch 1 suggests a physics-normalization mismatch for that split, unrelated to this experiment.
- If GC is retried, consider reducing \`surf_weight\` (e.g., 10) to reduce the gradient-scale imbalance that GC disrupts.
- Alternatively, apply GC only to attention projection matrices rather than all weight tensors, to reduce interference with loss-scale balancing.