### PR TITLE
Progressive resolution: surface-focused loss early, full field later

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -539,9 +539,9 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
 
         # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 20% → 100% of volume nodes over first 60 epochs
-        if epoch < 60:
-            vol_keep_ratio = 0.2 + 0.8 * (epoch / 60)
+        # Ramps from 10% → 100% of volume nodes over first 40 epochs
+        if epoch < 40:
+            vol_keep_ratio = 0.1 + 0.9 * (epoch / 40)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
The model processes ~200K nodes per sample, spending most loss compute on far-field volume nodes. Progressive resolution training starts by computing loss only on nodes near the surface (plus all surface nodes), then gradually includes all nodes. Early epochs focus entirely on surface physics, later epochs refine the full field. The forward pass still sees all nodes.

## Instructions
In `structured_split/structured_train.py`, modify the training loop. After computing masks but before computing losses:

```python
if epoch < 40:
    vol_keep_ratio = 0.1 + 0.9 * (epoch / 40)  # 10% → 100% over 40 epochs
    vol_indices = vol_mask.nonzero(as_tuple=False)
    n_vol = vol_indices.shape[0]
    n_keep = max(int(n_vol * vol_keep_ratio), 1)
    perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
    vol_mask_train = torch.zeros_like(vol_mask)
    if n_keep > 0:
        vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
else:
    vol_mask_train = vol_mask

vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
```

Run with: `--wandb_name "violet/prog-resolution" --wandb_group prog-resolution --agent violet`

## Baseline
- val/loss: **2.7927** (updated baseline, includes multi-scale loss)
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results (v2 — revised parameters, rebased onto noam with multi-scale loss)

**W&B run:** `660kx60h` | **Epochs:** 90 (30.2 min) | **Peak memory:** 7.6 GB

### Metrics at best checkpoint (epoch 90)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ p vs original baseline |
|---|---|---|---|---|
| val_in_dist | 0.326 | 0.200 | 25.71 | -0.06 ✅ |
| val_ood_cond | 0.— | — | 26.47 | +0.26 ≈ |
| val_ood_re | — | — | 34.53 | +0.15 ≈ |
| val_tandem_transfer | — | — | 44.04 | -1.06 ✅ |

**val/loss:** 2.7421 (updated baseline: 2.7927, Δ = **-0.051** — better ✅)

Volume MAE (val_in_dist): Ux=1.73, Uy=0.60, p=35.77

Note: val_ood_re/loss = NaN (pre-existing vol_loss overflow at extreme Re); excluded from val/loss mean.

### What happened

**Improvement over updated baseline.** This v2 run (10% start, 40-epoch transition, rebased onto noam with multi-scale loss) achieves val/loss 2.7421 vs updated baseline 2.7927 (−0.051). Key observations:

1. **More aggressive early subsampling helped slightly.** The 10%/40-epoch schedule focuses surface learning more sharply in early epochs. Combined with the multi-scale loss already capturing coarse spatial patterns, the model converges faster.

2. **Still no epoch-speed benefit.** Each epoch is still ~20s. The speedup hypothesis remains falsified — the gain, if any, is purely from gradient signal prioritization, not more epochs.

3. **Tandem transfer improved notably** (mae_surf_p 44.0 vs 45.1 original). The multi-scale loss from the rebase likely contributes here.

4. **Caution on attribution.** It's hard to separate the effect of the 10%/40-epoch parameter change from the multi-scale loss included in the rebase. The v1 run (20%/60-epoch, without multi-scale) scored 2.8674, while v2 (10%/40-epoch, with multi-scale) scores 2.7421. Most of the gain may be from multi-scale loss.

### Suggested follow-ups

- **Ablation:** Run 20%/60-epoch on the updated noam base (with multi-scale) to isolate the parameter effect from the multi-scale contribution.
- **Dsdf-based near-surface filtering:** Use the signed-distance features (dsdf) to preferentially keep volume nodes close to the surface instead of random subsampling, which may provide more signal-consistent gradients.
- **Shorter transition (20 epochs):** If focusing early is the mechanism, an even shorter ramp might help.