### PR TITLE
Surface smoothness penalty: total variation regularization on airfoil

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -541,6 +541,26 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
+        # Surface smoothness penalty (total variation along airfoil)
+        smooth_loss = torch.tensor(0.0, device=pred.device)
+        n_smooth = 0
+        for b_idx in range(pred.shape[0]):
+            s = surf_mask[b_idx]
+            if s.sum() < 3:
+                continue
+            surf_pred = pred[b_idx, s]   # [S, 3]
+            surf_pos = x[b_idx, s, :2]  # [S, 2] — spatial coords (already normalized)
+            # Sort by angle around origin for approximate surface ordering
+            angles = torch.atan2(surf_pos[:, 1], surf_pos[:, 0])
+            sorted_idx = angles.argsort()
+            sorted_pred = surf_pred[sorted_idx]
+            # Total variation: sum of absolute differences between consecutive nodes
+            tv = (sorted_pred[1:] - sorted_pred[:-1]).abs().mean()
+            smooth_loss = smooth_loss + tv
+            n_smooth += 1
+        smooth_loss = smooth_loss / max(n_smooth, 1)
+        loss = loss + 0.5 * smooth_loss
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
Aerodynamic predictions should be smooth along the airfoil surface. A gradient penalty that penalizes large differences between predictions at adjacent surface nodes encourages smooth predictions and reduces high-frequency noise. This is inspired by total variation regularization.

## Instructions
In `structured_split/structured_train.py`, after the existing loss computation, add a surface smoothness penalty:

```python
# Surface smoothness penalty (total variation along airfoil)
smooth_loss = torch.tensor(0.0, device=pred.device)
n_smooth = 0
for b_idx in range(pred.shape[0]):
    s = surf_mask[b_idx]
    if s.sum() < 3:
        continue
    surf_pred = pred[b_idx, s]   # [S, 3]
    surf_pos = x[b_idx, s, :2]  # [S, 2] — spatial coords (already normalized)
    # Sort by angle around origin for approximate surface ordering
    angles = torch.atan2(surf_pos[:, 1], surf_pos[:, 0])
    sorted_idx = angles.argsort()
    sorted_pred = surf_pred[sorted_idx]
    # Total variation: sum of absolute differences between consecutive nodes
    tv = (sorted_pred[1:] - sorted_pred[:-1]).abs().mean()
    smooth_loss = smooth_loss + tv
    n_smooth += 1
smooth_loss = smooth_loss / max(n_smooth, 1)
loss = loss + 0.5 * smooth_loss
```

Note: For tandem configurations with two foils, the angular sort will mix nodes from both foils. This is acceptable — the penalty will be small for nodes that are far apart on different foils (the denominator implicitly accounts for large spatial jumps). If this is a concern, we could add a spatial continuity check, but start simple.

Run with: `--wandb_name "gilbert/smooth-surf" --wandb_group smooth-surf --agent gilbert`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** `8z2pl7e1` — gilbert/smooth-surf

**Best epoch:** 87 of 88 (30.1 min, wall-clock limit)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 2.001 | 0.360 | 0.209 | **27.13** | 2.082 | 0.756 | 41.18 |
| val_ood_cond | 1.749 | — | — | **25.60** | — | — | — |
| val_ood_re | nan | — | — | **34.5** | — | — | — |
| val_tandem_transfer | 4.955 | — | — | **46.7** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.9015** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.8139 | 2.9015 | +0.088 ❌ |
| val_in_dist/mae_surf_p | 25.77 | 27.13 | +1.36 ❌ |
| val_ood_cond/mae_surf_p | 26.21 | 25.60 | −0.61 ✅ |
| val_ood_re/mae_surf_p | 34.38 | 34.5 | ~0 |
| val_tandem_transfer/mae_surf_p | 45.10 | 46.7 | +1.6 ❌ |

Note: `val_ood_re/loss` is NaN from epoch 1 — pre-existing issue, not caused by this change. The baseline val/loss likely also excluded this split.

### What happened

The smoothness penalty did not improve surface accuracy. Results are mixed-to-negative: `val_ood_cond` pressure MAE improved slightly (26.21 → 25.60), but `val_in_dist` and `val_tandem_transfer` both got worse, and the overall val/loss increased (2.8139 → 2.9015).

The TV penalty is applied in the normalized prediction space (after Cp normalization + standardization), so it penalizes smoothness in a space that doesn't directly correspond to physical units. This may be pushing the model toward unrealistically smooth predictions that hurt fit on in-distribution data.

A key concern for tandem cases: the angular sort mixes nodes from both foils, creating "jumps" in the sorted sequence where consecutive nodes actually belong to different foils far apart in space. The penalty treats these cross-foil differences as high-frequency noise and tries to suppress them, which likely hurts the tandem transfer result.

The per-sample Python loop over the batch is clean and fast (no measurable throughput impact — still 88 epochs in 30 min at ~20s/epoch).

### Suggested follow-ups

- **Smaller coefficient**: Try 0.1 instead of 0.5; the current penalty may be over-regularizing.
- **Foil separation for tandem**: Skip the TV term if consecutive sorted nodes are far apart spatially (e.g., `|pos_i - pos_{i-1}| > threshold`). This would avoid penalizing genuine cross-foil discontinuities.
- **Pressure-only TV**: Apply the penalty only to the pressure channel (index 2) since that's what matters most, reducing interference with velocity fitting.
- **Physical-space TV**: Compute TV on denormalized predictions so the penalty is scale-aware and doesn't over-smooth low-magnitude fields.