### PR TITLE
Channel-specific learning rate: 2x LR for output head

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -452,7 +452,15 @@ model_config = dict(
 model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
-optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+# Split parameters: higher LR for output head
+output_params = list(model.blocks[-1].mlp2.parameters())
+output_param_ids = {id(p) for p in output_params}
+base_params = [p for p in model.parameters() if id(p) not in output_param_ids]
+
+optimizer = torch.optim.AdamW([
+    {"params": base_params, "lr": cfg.lr},
+    {"params": output_params, "lr": cfg.lr * 2.0},
+], weight_decay=cfg.weight_decay)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Pressure has ~80x larger absolute error than velocity, suggesting the output head parameters need different learning dynamics. A separate parameter group for the output head with 2x learning rate can accelerate pressure convergence without destabilizing the representation layers.

## Instructions
In `structured_split/structured_train.py`, replace the optimizer creation (around line 455):

```python
# Split parameters: higher LR for output head
output_params = list(model.blocks[-1].mlp2.parameters())
output_param_ids = {id(p) for p in output_params}
base_params = [p for p in model.parameters() if id(p) not in output_param_ids]

optimizer = torch.optim.AdamW([
    {"params": base_params, "lr": cfg.lr},
    {"params": output_params, "lr": cfg.lr * 2.0},
], weight_decay=cfg.weight_decay)
```

The schedulers should use the same optimizer object (they apply to all param groups):
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)
scheduler = torch.optim.lr_scheduler.SequentialLR(
    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
)
```

The output head has ~16K parameters out of ~1M total, so this is a targeted intervention.

Run with: `--wandb_name "senku/channel-lr" --wandb_group channel-lr --agent senku`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** `9mi0m8v5` (senku/channel-lr)
**Epochs completed:** 87/100 (30-min timeout)
**Peak memory:** 7.6 GB

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.8139 | 2.9185 | +0.10 (worse) |
| val_in_dist/mae_surf_p | 25.77 | 28.86 | +3.09 (worse) |
| val_ood_cond/mae_surf_p | 26.21 | 26.64 | +0.43 (worse) |
| val_ood_re/mae_surf_p | 34.38 | 34.76 | +0.38 (worse) |
| val_tandem_transfer/mae_surf_p | 45.10 | 46.42 | +1.32 (worse) |

Surface MAE (last epoch, val_in_dist): Ux=0.364, Uy=0.204, p=28.86
Volume MAE (last epoch, val_in_dist): Ux=2.04, Uy=0.74, p=42.01

### What happened

This did not work. Every metric is worse than baseline. The 2x LR on the output head (~16K params out of ~1M) degraded rather than accelerated convergence.

The most likely explanation: the output head LR is coupled to the representation via the loss signal. When the output head takes larger gradient steps, it overshoots around good solutions rather than settling -- the representation then tries to compensate for a moving target, destabilizing the whole system. This is the opposite of what was hoped.

Also notable: `val_ood_re/vol_loss` shows a large numerical instability (~18.9 billion). This appears to be pre-existing (val_ood_re was NaN throughout training epoch summaries from early on), so it is not caused by this change, but the higher output-head LR may have made it marginally worse.

Memory cost: negligible -- same 7.6 GB. Splitting params into two groups adds no extra parameters.

### Suggested follow-ups
- If channel-specific learning is still worth exploring, try **lower LR (0.5x) on the output head** rather than higher -- the pressure head might be overshooting with the current LR, not undershooting.
- Alternatively, try a separate parameter group for **pressure-only output weights** (a sub-slice of mlp2 outputs) with a tuned LR.
- The val_ood_re NaN issue is worth investigating independently -- it looks like a pre-existing numerical problem in that validation split.