### PR TITLE
Spectral normalization on all Linear layers for OOD robustness

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -451,6 +451,20 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+# Apply spectral normalization to all Linear layers for OOD robustness
+from torch.nn.utils import spectral_norm
+for name, module in model.named_modules():
+    if isinstance(module, nn.Linear):
+        # Get parent module and attribute name
+        parts = name.rsplit('.', 1)
+        if len(parts) == 2:
+            parent = dict(model.named_modules())[parts[0]]
+            attr = parts[1]
+        else:
+            parent = model
+            attr = parts[0]
+        spectral_norm(getattr(parent, attr))
+
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)


### PR DESCRIPTION
## Hypothesis
Spectral normalization constrains the Lipschitz constant of each layer, preventing extreme predictions for OOD inputs. This is particularly relevant for val_ood_re (where predictions diverge) and tandem (novel geometry). Unlike dropout (which was neutral), spectral norm constrains the function space directly, ensuring bounded output changes for bounded input perturbations.

## Instructions
In `structured_split/structured_train.py`, after model creation (after `model = Transolver(**model_config).to(device)`):

```python
# Apply spectral normalization to all Linear layers for OOD robustness
from torch.nn.utils import spectral_norm
for name, module in model.named_modules():
    if isinstance(module, nn.Linear):
        # Get parent module and attribute name
        parts = name.rsplit('.', 1)
        if len(parts) == 2:
            parent = dict(model.named_modules())[parts[0]]
            attr = parts[1]
        else:
            parent = model
            attr = parts[0]
        spectral_norm(getattr(parent, attr))
```

Alternatively, a simpler approach — apply spectral norm during model construction by wrapping the relevant nn.Linear calls. But the post-hoc approach above is less invasive.

IMPORTANT: Spectral norm adds a singular value computation per Linear layer per forward pass. For the small 128-dim model this is cheap, but monitor epoch times to ensure no significant slowdown.

Run with: `--wandb_name "kohaku/spectral-norm" --wandb_group spectral-norm --agent kohaku`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** oy0ap2d3 | **Status:** Crashed at epoch 87/100 | **Peak memory:** 7.6 GB | **Epoch time:** ~20s (no slowdown)

### Metrics at best val/loss (epoch ~84; val/loss computed from 3 splits — val_ood_re excluded due to NaN throughout)

| Split | mae_surf_p | vs baseline | mae_surf_Ux | mae_surf_Uy |
|---|---|---|---|---|
| val_in_dist | 36.92 | 25.77 (+43%) | 0.505 | 0.241 |
| val_ood_cond | 33.04 | 26.21 (+26%) | — | — |
| val_ood_re | 40.17 | 34.38 (+17%) | — | — |
| val_tandem_transfer | 52.64 | 45.10 (+17%) | — | — |

- **val/loss (best): 3.541** vs baseline 2.814 (+26% worse) — excludes val_ood_re since its loss was NaN throughout
- val_in_dist/mae_vol_p: 54.87, val_ood_re/mae_vol_p: 66.96
- **val_ood_re/vol_loss: ~18.9 billion** (catastrophic numerical overflow)

### What happened

Spectral normalization completely failed — it made every metric significantly worse and caused a training crash at epoch 87.

The most critical finding: **val_ood_re/loss was NaN from epoch 1 through the crash**. The vol_loss for the OOD Re split grew to ~18.9 billion by epoch 87, ultimately causing surf_loss to also go NaN and crashing the run. The technique intended to improve OOD Re robustness caused catastrophic failure specifically on that split.

Why it failed:

1. **Capacity collapse**: Constraining every Linear layer's largest singular value to ≤ 1 limits the model's ability to produce large-magnitude outputs. Physics fields like pressure require large dynamic range — the model couldn't represent them at the required scale.

2. **OOD Re overflow**: The OOD Re case (Re=4.445M) requires large-magnitude outputs to capture qualitatively different flow patterns. With spectral norm clamping all layers, the model produced extremely wrong predictions whose squared errors (~18.9B vol_loss) caused numerical overflow.

3. **Global application was too aggressive**: Wrapping all Linear layers reparameterizes weights from scratch (replacing weight with weight_orig * spectral_norm_factor), effectively resetting representational capacity across the entire model from epoch 1. Training never recovered.

Epoch time ~20s (identical to baseline) confirms no computational overhead. But the performance hit was catastrophic.

### Suggested follow-ups
- **Selective spectral norm**: Apply only to output projection layers rather than all Linear layers, avoiding capacity collapse while potentially stabilizing output magnitudes.
- **Gradient clipping**: A softer form of Lipschitz regularization that doesn't globally constrain the function space — may provide some OOD stability without this performance cost.
- **Weight normalization instead**: Decouples magnitude from direction without constraining the maximum singular value, which might be less destructive.