### PR TITLE
Cyclic surface weight schedule: oscillating emphasis for better exploration

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -538,14 +538,19 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Cyclic surface weight: oscillate with increasing baseline and decreasing amplitude
+    # Cyclic surface weight: oscillate with increasing baseline and decreasing amplitude.
+    # Cycles start after epoch 10 to let the model stabilize first.
     sw_low, sw_high = 5.0, 30.0
-    cycle_length = 30  # epochs per cycle
-    cycle_pos = (epoch % cycle_length) / cycle_length  # 0 to 1 within cycle
+    cycle_start_epoch = 10
+    cycle_length = 40  # epochs per cycle
     baseline = sw_low + (sw_high - sw_low) * (epoch / MAX_EPOCHS)  # slowly rising floor
-    amplitude = (sw_high - sw_low) * 0.3 * (1 - epoch / MAX_EPOCHS)  # shrinking oscillation
-    surf_weight = baseline + amplitude * math.sin(2 * math.pi * cycle_pos)
-    surf_weight = max(sw_low, min(sw_high, surf_weight))
+    if epoch < cycle_start_epoch:
+        surf_weight = baseline
+    else:
+        cycle_pos = ((epoch - cycle_start_epoch) % cycle_length) / cycle_length  # 0→1 within cycle
+        amplitude = (sw_high - sw_low) * 0.15 * (1 - epoch / MAX_EPOCHS)  # shrinking oscillation
+        surf_weight = baseline + amplitude * math.sin(2 * math.pi * cycle_pos)
+        surf_weight = max(sw_low, min(sw_high, surf_weight))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
The current linear surface weight schedule (5→30) monotonically increases surface emphasis. The model might benefit from periodic oscillations between lower and higher surface weight, giving it opportunities to improve volume representations (which serve as regularization). This is analogous to cyclic learning rates that help escape local minima.

## Instructions
In `structured_split/structured_train.py`, replace the surface weight schedule (around line 510-512):

```python
import math

# Cyclic surface weight: oscillate with increasing baseline and decreasing amplitude
sw_low, sw_high = 5.0, 30.0
cycle_length = 30  # epochs per cycle
cycle_pos = (epoch % cycle_length) / cycle_length  # 0 to 1 within cycle
baseline = sw_low + (sw_high - sw_low) * (epoch / MAX_EPOCHS)  # slowly rising floor
amplitude = (sw_high - sw_low) * 0.3 * (1 - epoch / MAX_EPOCHS)  # shrinking oscillation
surf_weight = baseline + amplitude * math.sin(2 * math.pi * cycle_pos)
surf_weight = max(sw_low, min(sw_high, surf_weight))
```

Add `import math` at the top of the file if not already present.

This creates ~3 cycles over 100 epochs with decreasing amplitude (big oscillations early when exploration matters, small oscillations late when refinement matters). The schedule always stays within [5, 30].

Run with: `--wandb_name "emma/cyclic-sw" --wandb_group cyclic-sw --agent emma`

## Baseline
- val/loss: **2.8139** (original) → **2.7927** (+ multi-scale loss) → **2.7135** (+ xavier-init, progressive-res, lookahead)
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results (v3 — rebased onto latest noam with all merged improvements)

**Revision**: Rebased onto latest `noam` (includes multi-scale loss, xavier-init, progressive resolution, lookahead). Same schedule as v2: amplitude 0.15, cycle_length 40, 10-epoch stabilization.

**W&B run ID:** qfhfv6pg  
**Best epoch:** 90/100 (still improving at timeout — run stopped by 30-min wall-clock)  
**Peak GPU memory:** 7.6 GB  

### val/loss (combined)
| | Latest baseline | v3 Cyclic SW | Delta |
|---|---|---|---|
| val/loss | 2.7135 | **2.7098** | -0.004 ✅ |

### Surface MAE (vs original baseline)
| Split | Metric | Original baseline | v3 Cyclic SW | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 25.77 | **25.07** | -0.70 ✅ |
| val_ood_cond | mae_surf_p | 26.21 | **22.63** | -3.58 ✅✅ |
| val_ood_re | mae_surf_p | 34.38 | **33.53** | -0.85 ✅ |
| val_tandem_transfer | mae_surf_p | 45.10 | **44.71** | -0.39 ✅ |

**Surface MAE (Ux, Uy, p) at best epoch:**
- val_in_dist: Ux=0.318, Uy=0.197, p=25.07
- val_ood_cond: Ux=0.275, Uy=0.199, p=22.63
- val_ood_re: Ux=0.289, Uy=0.218, p=33.53
- val_tandem_transfer: Ux=0.684, Uy=0.362, p=44.71

**Volume MAE (Ux, Uy, p) at best epoch:**
- val_in_dist: Ux=1.691, Uy=0.584, p=33.00
- val_ood_cond: Ux=1.414, Uy=0.526, p=26.10
- val_ood_re: Ux=1.361, Uy=0.535, p=56.35
- val_tandem_transfer: Ux=2.506, Uy=1.156, p=49.18

### What happened (v3)

Positive result on top of the latest noam baseline. The gentle cyclic schedule (amplitude 0.15, cycle 40, 10-epoch warmup) beats the latest noam baseline on val/loss (2.7098 vs 2.7135) and on all four surface pressure splits vs the original linear-ramp baseline.

The most striking improvement is val_ood_cond/mae_surf_p: 26.21 → 22.63 (−3.58 Pa). This is substantially better than any previous run. The ood_re surface pressure also improved: 34.38 → 33.53. Both in-dist and tandem splits show smaller but consistent improvements.

My interpretation: the accumulated improvements from noam (xavier-init, progressive resolution, lookahead) together with the mild cyclic schedule compound well. The 10-epoch stabilization period likely helps — the model starts with clean linear ramp behavior, then the gentle oscillations provide mild exploration that complements the more stable optimizer and initialization. The model was still improving at epoch 90 when the timeout hit, suggesting more training could yield further gains.

Note: the improved surface pressure numbers vs the original baseline reflect both the accumulated noam improvements and the cyclic schedule; I can't cleanly separate the two contributions without an ablation run on the same noam baseline without cyclic scheduling.

### Suggested follow-ups
- **Run to completion**: the model was still improving at epoch 90; allow 40+ more epochs to see if the trend continues
- **Ablation**: run the plain linear schedule on the same latest noam to confirm the cyclic schedule is contributing independently
- **val_ood_cond improvement source**: the dramatic -3.58 improvement on OOD conditions is striking and worth understanding — is it from lookahead, xavier-init, or the cyclic schedule?
- **Investigate val_ood_re NaN vol_loss**: the ~18B vol_loss explosion on OOD Reynolds is a pre-existing issue worth diagnosing separately