### PR TITLE
Multi-scale loss: coarse spatial pooling for large-scale flow patterns

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -541,6 +541,24 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
+        # Multi-scale loss: coarse spatial pooling
+        coarse_pool_size = 64
+        B, N, C = pred.shape
+        n_groups = N // coarse_pool_size
+        if n_groups > 1:
+            # Pool predictions and targets over groups of 64 nodes
+            pred_trunc = pred[:, :n_groups * coarse_pool_size]
+            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
+            mask_trunc = mask[:, :n_groups * coarse_pool_size]
+
+            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
+
+            coarse_err = (pred_coarse - y_coarse).abs()
+            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+            loss = loss + 2.0 * coarse_loss
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
The current L1 loss treats all spatial scales equally. Aerodynamic predictions have multi-scale structure: large-scale (freestream, circulation) and small-scale (boundary layer, separation). Adding a coarse-scale loss that pools predictions over spatial neighborhoods helps the model capture large-scale flow patterns first, then refine details.

## Instructions
In `structured_split/structured_train.py`, after computing the standard loss (`loss = vol_loss + surf_weight * surf_loss`), add a coarse-scale auxiliary loss:

\`\`\`python
# Multi-scale loss: coarse spatial pooling
coarse_pool_size = 64
B, N, C = pred.shape
n_groups = N // coarse_pool_size
if n_groups > 1:
    # Pool predictions and targets over groups of 64 nodes
    pred_trunc = pred[:, :n_groups * coarse_pool_size]
    y_trunc = y_norm[:, :n_groups * coarse_pool_size]
    mask_trunc = mask[:, :n_groups * coarse_pool_size]
    
    pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
    y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
    mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
    
    coarse_err = (pred_coarse - y_coarse).abs()
    coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
    loss = loss + 2.0 * coarse_loss
\`\`\`

Note: The nodes are not sorted spatially, so the "coarse" pooling is over arbitrary groups. This still provides a useful signal because it captures whether the mean prediction in each region is correct, even if the spatial grouping is random.

Run with: \`--wandb_name "norman/multi-scale" --wandb_group multi-scale --agent norman\`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** [m9wxqi76](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/m9wxqi76)
**Epochs completed:** 90 (30-min wall-clock limit hit)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint (val/loss = 2.7737)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ vs baseline |
|---|---|---|---|---|
| val_in_dist | 0.348 | 0.200 | **25.25** | −0.52 ✓ |
| val_ood_cond | 0.291 | 0.209 | **26.91** | +0.70 ✗ |
| val_ood_re | 0.291 | 0.214 | **34.01** | −0.37 ✓ |
| val_tandem_transfer | 0.685 | 0.354 | **44.80** | −0.30 ✓ |

**val/loss: 2.7737** vs baseline 2.8139 (−0.04, −1.4%)

Note: val_ood_re vol_loss was very large/NaN in some epochs; this split was excluded from mean val/loss when NaN.

### What happened

The coarse-scale pooling loss provides a modest but consistent improvement on 3 of 4 splits. val_in_dist/mae_surf_p improved by 0.52 (25.25 vs 25.77) and overall val/loss improved by 1.4%.

However, val_ood_cond/mae_surf_p slightly worsened (26.91 vs 26.21, +0.70). This may be because the pooling groups are arbitrary (nodes aren't sorted spatially), so the "coarse" signal is really just a mean-field constraint over random node sets — it doesn't actually capture spatial structure. The weight=2.0 may be pulling training slightly in the wrong direction for extreme-condition OOD cases.

The PR note is correct: this still provides a useful signal because it penalizes incorrect global means across arbitrary groups. But the lack of spatial structure limits how much multi-scale information is actually being captured.

### Suggested follow-ups

1. **Spatially-sorted coarse pooling**: Sort nodes by x-coordinate before pooling, so groups are actually spatial neighbors. This would give genuine multi-scale spatial structure to the coarse loss.
2. **Lower coarse weight**: Try weight=0.5 or 1.0 instead of 2.0 — the val_ood_cond regression suggests the auxiliary loss may be over-regularizing.
3. **Surface-only coarse pooling**: Apply the coarse loss only to surface nodes (using \`surf_mask\`), since surface accuracy matters most. Volume coarse pooling may be adding noise.