### PR TITLE
Trapezoidal LR schedule: hold peak LR longer, brief cooldown

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -453,11 +453,17 @@ model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
-)
+# Trapezoidal LR: warmup 5 epochs, hold until epoch 80, linear decay to 1e-5
+def trapezoid_lr(epoch):
+    if epoch < 5:
+        return 0.1 + 0.9 * (epoch / 5)  # warmup from 0.1x to 1.0x
+    elif epoch < 80:
+        return 1.0  # constant peak LR
+    else:
+        # Linear decay from 1.0x to 0.003x over epochs 80-100
+        return 1.0 - 0.997 * (epoch - 80) / 20
+
+scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, trapezoid_lr)
 
 # --- wandb ---
 run = wandb.init(


### PR DESCRIPTION
## Hypothesis
The cosine annealing schedule decays LR from 3e-3 toward zero, effectively wasting the final ~15 epochs with near-zero learning rate. A trapezoidal schedule — warmup, hold at peak LR for most of training, then brief cooldown — keeps the LR productive for longer. The model gets ~80% of training at peak LR instead of ~50%.

## Instructions
In `structured_split/structured_train.py`, replace the scheduler setup (around lines 456-460):

```python
# Trapezoidal LR: warmup 5 epochs, hold until epoch 80, linear decay to 1e-5
def trapezoid_lr(epoch):
    if epoch < 5:
        return 0.1 + 0.9 * (epoch / 5)  # warmup from 0.1x to 1.0x
    elif epoch < 80:
        return 1.0  # constant peak LR
    else:
        # Linear decay from 1.0x to 0.003x over epochs 80-100
        return 1.0 - 0.997 * (epoch - 80) / 20

scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, trapezoid_lr)
```

Remove the `warmup_scheduler`, `cosine_scheduler`, and `SequentialLR` setup. Replace with this single LambdaLR.

This keeps lr=3e-3 for 75 epochs (vs cosine which decays continuously after warmup), then drops to ~9e-6 by epoch 100 for fine convergence.

Run with: `--wandb_name "haku/trapezoid-lr" --wandb_group trapezoid-lr --agent haku`

## Baseline
- val/loss: **2.8139**
- val_in_dist/mae_surf_p: 25.77
- val_ood_cond/mae_surf_p: 26.21
- val_ood_re/mae_surf_p: 34.38
- val_tandem_transfer/mae_surf_p: 45.10

---

## Results

**W&B run:** m3e2nps3  
**Epochs completed:** 88/100 (30-minute timeout hit during epoch 89)  
**Peak GPU memory:** 7.6 GB

### Metrics at best checkpoint (epoch 85, val/loss = 3.4056)

| Metric | Trapezoid | Baseline | Delta |
|--------|-----------|----------|-------|
| val/loss | **3.4056** | 2.8139 | +21% worse |
| val_in_dist/mae_surf_p | 39.22 | 25.77 | +52% worse |
| val_ood_cond/mae_surf_p | 33.29 | 26.21 | +27% worse |
| val_ood_re/mae_surf_p | 38.70 | 34.38 | +13% worse |
| val_tandem_transfer/mae_surf_p | 54.42 | 45.10 | +21% worse |
| val_in_dist/mae_surf_Ux | 0.4511 | — | — |
| val_in_dist/mae_surf_Uy | 0.2719 | — | — |
| val_in_dist/mae_vol_p | 50.26 | — | — |

### What happened

**The trapezoidal schedule hurt on every metric — clearly a negative result.**

Holding lr=3e-3 for 75 epochs appears to prevent the fine-grained convergence that continuous cosine decay provides. The val/loss curve shows steady improvement throughout training (still improving at epoch 85), but the final values are substantially worse than cosine's baseline.

Key observations:
- The model never reached the quality the cosine baseline achieved. At epoch 85 (best), val/loss = 3.41, still 21% above baseline 2.81.
- val_in_dist/mae_surf_p degraded most severely (39.22 vs 25.77, +52%). The high sustained LR appears to destabilize the surface pressure predictions specifically.
- The improvement only accelerates once the LR decay kicks in at epoch 80 — epochs 80–85 show the steepest drop — but there isn't enough time to recover.
- val_ood_re/vol_loss spiked to ~19 billion by the final epoch. The MAE metrics are still finite (38.70), but the volume loss exploded. This appears to be numerical instability from the sustained high LR acting on the high-Re test cases.
- The hypothesis that cosine "wastes" the final 15 epochs is incorrect. Continuous LR decay provides a beneficial implicit regularization/convergence effect throughout training, not just at the end.

### Suggested follow-ups

1. **Lower peak LR with plateau** — try lr=1e-3 (instead of 3e-3) during the plateau phase to reduce instability while still testing the trapezoid concept
2. **Shorter plateau** — hold for 40 epochs (epochs 5–45) then cosine decay, to get the best of both: productive high-LR phase without over-extending it
3. **Investigate val_ood_re vol_loss explosion** — this overflow appears in combined loss but MAE is finite, suggesting a pre-existing normalization issue in the ood_re split