### PR TITLE
Replace GELU with SiLU activation everywhere

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -183,7 +183,7 @@ class TransolverBlock(nn.Module):
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
+                nn.SiLU(),
                 nn.Linear(hidden_dim, out_dim),
             )
 
@@ -445,6 +445,7 @@ model_config = dict(
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,
+    act="silu",
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
SiLU (Swish) has smoother gradients near zero than GELU — it never fully kills negative activations. Modern transformers (LLaMA, PaLM) consistently use SiLU. This is a zero-cost change since SiLU is already in the ACTIVATION dict. ~3 line changes.

## Instructions
In `structured_split/structured_train.py`:

1. Add `act="silu"` to `model_config`
2. Change the hard-coded `nn.GELU()` in `mlp2` (TransolverBlock last layer output head) to `nn.SiLU()`
3. Run with: `--wandb_name "frieren/silu" --wandb_group silu-activation --agent frieren`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** `t25hxy81` (frieren/silu)
**Epochs completed:** 86/100 (hit 30-min timeout at ~28.6 min)
**Peak GPU memory:** ~38.2 GB (40.0% of 96 GB)

### Metrics at best val/loss epoch

| Metric | Baseline | SiLU | Delta |
|--------|----------|------|-------|
| val/loss | 2.7927 | **3.0008** | +7.4% |
| val_in_dist/mae_surf_p | 26.04 | **28.95** | +11% |
| val_ood_cond/mae_surf_p | 27.01 | **27.99** | +4% |
| val_ood_re/mae_surf_p | 34.46 | **37.04** | +7% |
| val_tandem_transfer/mae_surf_p | 44.98 | **49.14** | +9% |

Surface MAE (in-dist): Ux=0.40, Uy=0.22, p=28.95
Volume MAE (in-dist): Ux=1.89, Uy=0.66, p=38.20

### What happened

SiLU performed uniformly worse than the GELU baseline across all splits — a clear negative result. The hypothesis that SiLU's smoother gradient near zero would help here did not hold.

Possible reasons:
1. **GELU may suit this architecture better.** Transolver's attention mechanism already normalizes features via LayerNorm at each block; the zero-masking property of GELU may act as a useful implicit regularizer in that context, whereas SiLU's always-nonzero activations could leak noisy features through more easily.
2. **Hyperparameters tuned for GELU.** The learning rate, weight decay, and initialization were never tuned for SiLU. GELU and SiLU have different output scales that could interact with the 0.003 learning rate.
3. **Small model, small dataset.** The gap in behavior between GELU and SiLU tends to show up in larger models with more data. With 177k parameters and 1322 training samples, the advantage of SiLU's smoother gradients may simply not materialize.

The epoch counts are reasonably comparable (86 vs baseline's ~100), so the result is not primarily a training length effect.

### Suggested follow-ups

- Testing SiLU with a tuned LR (possibly lower, e.g., 0.001) might close the gap.
- Checking whether GELU's zero-masking behavior correlates with better surface prediction specifically (e.g., surface nodes near stagnation points where activations near zero are common) would be an interesting diagnostic.