### PR TITLE
Multi-scale loss: finer pool (32) and lower weight (1.0)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -542,11 +542,11 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
+        coarse_pool_size = 32
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:
-            # Pool predictions and targets over groups of 64 nodes
+            # Pool predictions and targets over groups of 32 nodes
             pred_trunc = pred[:, :n_groups * coarse_pool_size]
             y_trunc = y_norm[:, :n_groups * coarse_pool_size]
             mask_trunc = mask[:, :n_groups * coarse_pool_size]
@@ -557,7 +557,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 2.0 * coarse_loss
+            loss = loss + 1.0 * coarse_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The merged multi-scale loss uses pool_size=64 and weight=2.0. A smaller pool_size=32 creates 2x as many groups for finer granularity, while weight=1.0 reduces the coarse loss influence (since ood_cond regressed slightly with weight=2.0). Two number changes.

## Instructions
In `structured_split/structured_train.py`, in the multi-scale loss block:

```python
# Change these two values:
coarse_pool_size = 32   # was 64
...
loss = loss + 1.0 * coarse_loss  # was 2.0
```

Run with: `--wandb_name "fern/ms-pool32" --wandb_group multiscale-pool32 --agent fern`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** `fc9kdbzb` | **Epochs:** 91/100 (30.2 min) | **Peak memory:** 7.6 GB

### Validation loss
| Split | Baseline | pool32/w1.0 | Δ |
|---|---|---|---|
| val/loss (mean 3 splits) | 2.7927 | 2.8161 | +0.8% |
| val_in_dist | — | 1.9280 | — |
| val_ood_cond | — | 1.6829 | — |
| val_ood_re | — | **nan** (vol_loss=1.9e10) | still diverged |
| val_tandem_transfer | — | 4.8374 | — |

Note: val_ood_re/loss is nan in both baseline and this run — same pre-existing issue with extreme vol_loss for OOD Reynolds numbers.

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | pool32/w1.0 mae_surf_p | Δ |
|---|---|---|---|
| val_in_dist | 26.04 | 26.27 | +0.9% flat |
| val_ood_cond | 27.01 | 25.01 | **-7.4% better** |
| val_ood_re | 34.46 | 34.14 | -0.9% flat |
| val_tandem_transfer | 44.98 | 46.06 | +2.4% slightly worse |

### Surface MAE (Ux, Uy, p) at best checkpoint
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.35 | 0.20 | 26.27 |
| val_ood_cond | 0.28 | 0.21 | 25.01 |
| val_ood_re | 0.28 | 0.22 | 34.14 |
| val_tandem_transfer | 0.70 | 0.36 | 46.06 |

### Volume MAE at best checkpoint
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.84 | 0.64 | 36.86 |
| val_ood_cond | 1.55 | 0.58 | 28.42 |
| val_ood_re | 1.45 | 0.57 | 57.71 |
| val_tandem_transfer | 2.57 | 1.19 | 50.71 |

### What happened

**Mixed but directionally positive.** The pool_size=32 + weight=1.0 change produces a clear improvement on val_ood_cond (25.01 vs 27.01, -7.4%), slight improvement on val_ood_re, near-flat on val_in_dist, and slightly worse on val_tandem_transfer (+2.4%).

The val/loss aggregate is nominally +0.8% worse (2.8161 vs 2.7927), but this includes tandem_transfer which is the highest-loss split and dominates the average. The ood_cond gain is the most notable result — lower coarse loss weight seems to prevent the coarse pooling from over-smoothing OOD condition features.

Finer pooling (32 vs 64) creates 2x as many coarse groups, so the coarse loss is more sensitive to local structure. Combined with a lower weight (1.0 vs 2.0), this seems to improve OOD generalization without destabilizing in-distribution performance.

The val_ood_re/vol_loss divergence (1.9e10) is a pre-existing issue inherited from the parent multi-scale-loss branch and is unrelated to this change.

### Suggested follow-ups
- **Try weight=0.5 with pool32**: If lowering weight from 2.0→1.0 already helped ood_cond, reducing further to 0.5 might help tandem_transfer too while preserving the ood_cond gain.
- **Decouple pool size from weight search**: Try pool32/weight=2.0 and pool64/weight=1.0 separately to isolate which factor drives the ood_cond improvement.
- **Investigate val_ood_re vol_loss divergence**: The 1.9e10 vol_loss for val_ood_re is a pre-existing issue — possibly extreme predictions on OOD Reynolds number samples. Worth investigating but not related to the pool size/weight change.