### PR TITLE
Surface-only coarse loss (multi-scale targeting surface nodes)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -559,6 +559,25 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 2.0 * coarse_loss
 
+        # Surface-only coarse loss
+        surf_pool_size = 16
+        pred_surf = pred * surf_mask.unsqueeze(-1).float()
+        y_surf = y_norm * surf_mask.unsqueeze(-1).float()
+        n_surf_groups = N // surf_pool_size
+        if n_surf_groups > 1:
+            ps = pred_surf[:, :n_surf_groups * surf_pool_size]
+            ys = y_surf[:, :n_surf_groups * surf_pool_size]
+            ms = surf_mask[:, :n_surf_groups * surf_pool_size]
+            ps_c = ps.reshape(B, n_surf_groups, surf_pool_size, C).sum(dim=2)
+            ys_c = ys.reshape(B, n_surf_groups, surf_pool_size, C).sum(dim=2)
+            ms_c = ms.reshape(B, n_surf_groups, surf_pool_size).sum(dim=2).clamp(min=1).unsqueeze(-1)
+            ps_c = ps_c / ms_c
+            ys_c = ys_c / ms_c
+            mask_c = ms.reshape(B, n_surf_groups, surf_pool_size).any(dim=2)
+            sc_err = (ps_c - ys_c).abs()
+            sc_loss = (sc_err * mask_c.unsqueeze(-1)).sum() / mask_c.sum().clamp(min=1)
+            loss = loss + 1.0 * sc_loss
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
The multi-scale coarse loss pools over ALL nodes (surface + volume). Adding a surface-specific coarse loss directly targets our key metric. Surface nodes are ~5K per sample; pool_size=16 gives ~300 groups — a reasonable coarse surface representation.

## Instructions
In `structured_split/structured_train.py`, after the existing multi-scale loss block, add:

```python
# Surface-only coarse loss
surf_pool_size = 16
pred_surf = pred * surf_mask.unsqueeze(-1).float()
y_surf = y_norm * surf_mask.unsqueeze(-1).float()
n_surf_groups = N // surf_pool_size
if n_surf_groups > 1:
    ps = pred_surf[:, :n_surf_groups * surf_pool_size]
    ys = y_surf[:, :n_surf_groups * surf_pool_size]
    ms = surf_mask[:, :n_surf_groups * surf_pool_size]
    ps_c = ps.reshape(B, n_surf_groups, surf_pool_size, C).sum(dim=2)
    ys_c = ys.reshape(B, n_surf_groups, surf_pool_size, C).sum(dim=2)
    ms_c = ms.reshape(B, n_surf_groups, surf_pool_size).sum(dim=2).clamp(min=1).unsqueeze(-1)
    ps_c = ps_c / ms_c
    ys_c = ys_c / ms_c
    mask_c = ms.reshape(B, n_surf_groups, surf_pool_size).any(dim=2)
    sc_err = (ps_c - ys_c).abs()
    sc_loss = (sc_err * mask_c.unsqueeze(-1)).sum() / mask_c.sum().clamp(min=1)
    loss = loss + 1.0 * sc_loss
```

Run with: `--wandb_name "alphonse/surf-coarse" --wandb_group surf-coarse-loss --agent alphonse`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** o17rb3t8  
**Run stopped at:** epoch 89/100 (30-min timeout, 87 epochs captured in W&B)  
**Peak GPU memory:** 7.6 GB (unchanged — no model size change)

### Metrics at best checkpoint (epoch 87, last logged)

| Metric | This run | Baseline | Δ |
|---|---|---|---|
| val/loss | **2.8732** | 2.7927 | +3% worse |
| val_in_dist/mae_surf_Ux | 0.353 | — | — |
| val_in_dist/mae_surf_Uy | 0.207 | — | — |
| val_in_dist/mae_surf_p | 26.83 | 26.04 | +3% worse |
| val_in_dist/mae_vol_Ux | 1.800 | — | — |
| val_in_dist/mae_vol_p | 37.00 | — | — |
| val_ood_cond/mae_surf_p | 27.82 | 27.01 | +3% worse |
| val_ood_re/mae_surf_p | **34.22** | 34.46 | -1% (marginal) |
| val_tandem_transfer/mae_surf_p | 47.00 | 44.98 | +4.5% worse |

### What happened

**Approximately equivalent to baseline — no significant improvement.** Surface pressure MAE is within ~3% of baseline on in-dist and ood splits, with negligible gains on val_ood_re. The run was killed 11 epochs early (89/100), so the gap is likely even smaller at full convergence.

The training dynamics look healthy — loss was still decreasing at epoch 89 (val_in_dist dropped from 1.94 to 1.91 in the final epochs), and the model learned well. The surface-only coarse loss doesn't hurt training but doesn't provide a meaningful signal advantage. The likely reason: the existing coarse loss (pool_size=64, weight=2.0) already captures inter-region consistency across the full mesh, and the very high surf_weight (up to 30) already provides strong surface supervision. Adding a second surface-specific coarse term with weight 1.0 appears redundant — it's asking the model to do something the surf_loss already rewards.

Note: val_tandem_transfer/mae_surf_p (47.00 vs 44.98) is slightly worse, which may indicate the coarse pooling over surface groups doesn't transfer to the tandem configuration as well. This is a hint that the surface nodes in tandem cases may have a different spatial distribution that isn't well-captured by position-agnostic pooling.

### Suggested follow-ups

- **Higher weight**: Try sc_loss weight 2.0 or 3.0 — with weight 1.0 it may be too weak to meaningfully shift gradients given the already large surf_weight term.
- **Larger pool_size**: pool_size=16 creates ~300 surface groups, which may add noise from sparse surface coverage. pool_size=32 or 64 (matching the existing coarse loss scale) might be more stable.
- **Remove the existing coarse loss as a control**: If both coarse losses are present, it's unclear which one is doing the work. Testing with only the surface coarse loss (removing the all-node coarse loss) would isolate the effect.
- **Surface-aware normalization**: Rather than masking all non-surface nodes to zero before pooling (which distorts group means), restrict the pooling to surface-only node indices explicitly. The current implementation includes all N nodes in the reshape, which may scatter surface nodes across groups that are mostly empty.