### PR TITLE
Tighter gradient clipping (max_norm=0.5)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -561,7 +561,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
         optimizer.step()
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})


### PR DESCRIPTION
## Hypothesis
With the multi-scale loss adding an extra term (coarse_loss * 2.0), effective gradient magnitude is larger. Tighter clipping (0.5 vs 1.0) stabilizes training, especially in early epochs when surface weight is low and coarse loss dominates. One number change.

## Instructions
In `structured_split/structured_train.py`, change the grad clipping line:

```python
# Old:
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
# New:
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
```

Run with: `--wandb_name "edward/grad-clip-05" --wandb_group grad-clip-05 --agent edward`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** 7r1j9cmz
**Epochs:** 91 (30-min wall-clock limit)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint (epoch 90)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.894 | 0.344 | 0.204 | **26.73** | 36.29 |
| val_ood_cond | 1.712 | 0.291 | 0.210 | **26.27** | 28.62 |
| val_ood_re | NaN | 0.291 | 0.214 | **34.99** | 57.36 |
| val_tandem_transfer | 4.861 | 0.706 | 0.362 | **46.13** | 49.66 |
| **mean val/loss** | **2.822** | | | | |

### vs. Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.7927 | 2.822 | +1.0% worse |
| val_in_dist/mae_surf_p | 26.04 | 26.73 | +2.6% worse |
| val_ood_cond/mae_surf_p | 27.01 | 26.27 | -2.7% better |
| val_ood_re/mae_surf_p | 34.46 | 34.99 | +1.5% worse |
| val_tandem_transfer/mae_surf_p | 44.98 | 46.13 | +2.6% worse |

### What happened

Effectively a wash. Tighter clipping (0.5) produced no meaningful change — the differences are within run-to-run noise. The hypothesis that multi-scale gradients would be large enough to destabilize training with max_norm=1.0 didn't hold: the coarse loss (pool-64 mean) produces gradients of similar magnitude to the surface loss, so the original clip threshold was already adequate.

The val_ood_cond mae_surf_p improved slightly (27.01 → 26.27) but val_in_dist and val_tandem_transfer regressed by similar amounts. Overall val/loss is ~1% worse.

Note: val_ood_re/loss is NaN throughout — pre-existing issue unrelated to this change.

### Suggested follow-ups

- The multi-scale loss itself (coarse_pool_size=64, weight=2.0) is the more important variable to tune — worth trying different pool sizes or weights
- If gradient norms are genuinely the problem, logging grad norm before clipping would confirm whether clipping is active at all
- max_norm=0.25 might show more differentiation, but given the negligible effect of 0.5, this seems unlikely to matter