### PR TITLE
Longer warmup (10 epochs instead of 5)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -453,10 +453,10 @@ model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=10)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 10)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The 5-epoch warmup improved over 3-epoch (PR #423), with val_ood_re showing the largest gain. More warmup gives the model longer to establish stable representations before full LR. With ~90 epochs, 10 epochs of warmup is only ~11% of budget. Three number changes (5→10).

## Instructions
In `structured_split/structured_train.py`, change the scheduler setup:

```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=10)  # was 5
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 10)  # was -5
scheduler = torch.optim.lr_scheduler.SequentialLR(
    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]  # was 5
)
```

Run with: `--wandb_name "thorfinn/warmup-10" --wandb_group warmup-10 --agent thorfinn`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** `3jp3chs2` (thorfinn/warmup-10)
**Best checkpoint:** epoch 90 / 91 (hit 30-min timeout)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint (val/loss = 2.7755)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.330 | 0.204 | **26.88** | +3.2% worse |
| val_ood_cond | 0.282 | 0.204 | **26.05** | -3.6% better |
| val_ood_re | 0.286 | 0.214 | **34.49** | flat (+0.1%) |
| val_tandem_transfer | 0.693 | 0.363 | **44.85** | -0.3% better |

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.7755 | 2.7927 | -0.6% better |

Volume MAE (pressure): in_dist=36.3, ood_cond=26.9, ood_re=57.4, tandem=49.4

Note: `val_ood_re` had NaN loss every epoch (vol_loss numerically unstable for that split), excluded from mean val/loss. Physical-space MAE metrics for ood_re are valid.

### What happened

Modest improvement overall. Val/loss improved by -0.6%, driven mainly by ood_cond pressure MAE which dropped -3.6% (26.05 vs 27.01). Tandem improved marginally (-0.3%). However, in_dist regressed slightly (+3.2%) and ood_re was flat.

The pattern suggests 10-epoch warmup helps generalization to condition-OOD cases (where establishing stable internal representations before applying full LR matters) but doesn't uniformly help all splits. The in_dist regression may be noise (it's a small split with high variance across runs), or may reflect slightly slower early convergence on in-distribution cases.

This is a minimal change (3 numbers) that delivers a small net improvement and a notable ood_cond gain. Simpler to keep than revert.

### Suggested follow-ups

- **15-epoch warmup:** The trend suggests more warmup may further help ood_cond. With ~90 epochs budget, up to ~15 epochs (~17%) might be worth trying.
- **Longer cosine tail:** The cosine annealer now runs over MAX_EPOCHS-10=90 steps. With more warmup, the cosine phase is compressed. Increasing MAX_EPOCHS or reducing the warmup count (e.g. 8 epochs as a middle ground) could balance warmup benefit vs. longer annealing.
- **Confirm in_dist regression is noise:** Run a second seed with 10-epoch warmup — if in_dist stays near 26.04, the +3.2% is random variation; if it consistently regresses, warmup-10 has a real tradeoff worth considering.