### PR TITLE
Deeper output head (3-layer narrowing MLP: 128→64→64→3)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -182,9 +182,11 @@ class TransolverBlock(nn.Module):
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
+                nn.Linear(hidden_dim, hidden_dim // 2),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
+                nn.Linear(hidden_dim // 2, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, out_dim),
             )
 
     def forward(self, fx):


### PR DESCRIPTION
## Hypothesis
The output head is a 2-layer MLP (128→128→3). Adding a third layer with narrowing dims (128→64→64→3) gives more capacity to learn the nonlinear mapping to predictions without touching attention. The narrower dims keep parameter cost small (~12K extra).

## Instructions
In `structured_split/structured_train.py`, in TransolverBlock.__init__, replace the mlp2 definition:

```python
# Old (~line 184):
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.mlp2 = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim),
        nn.GELU(),
        nn.Linear(hidden_dim, out_dim),
    )

# New:
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.mlp2 = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim // 2),
        nn.GELU(),
        nn.Linear(hidden_dim // 2, hidden_dim // 2),
        nn.GELU(),
        nn.Linear(hidden_dim // 2, out_dim),
    )
```

Run with: `--wandb_name "gilbert/deep-output" --wandb_group output-head-depth --agent gilbert`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** `tf0eqiqe` — gilbert/deep-output

**Best epoch:** 91 of 91 (30.1 min, wall-clock limit)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.914 | 0.342 | 0.206 | **25.76** | 1.744 | 0.632 | 34.50 |
| val_ood_cond | 1.683 | — | — | **26.5** | — | — | — |
| val_ood_re | nan | — | — | **34.5** | — | — | — |
| val_tandem_transfer | 4.923 | — | — | **47.6** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.8397** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.7927 | 2.8397 | +0.047 ❌ |
| val_in_dist/mae_surf_p | 26.04 | 25.76 | −0.28 ✅ |
| val_ood_cond/mae_surf_p | 27.01 | 26.5 | −0.51 ✅ |
| val_ood_re/mae_surf_p | 34.46 | 34.5 | ~0 |
| val_tandem_transfer/mae_surf_p | 44.98 | 47.6 | +2.62 ❌ |

Note: `val_ood_re/loss` is NaN throughout — pre-existing issue, not caused by this change.

### What happened

Mixed results. Surface pressure MAE improved on `val_in_dist` (26.04 → 25.76) and `val_ood_cond` (27.01 → 26.5), but `val_tandem_transfer` degraded significantly (44.98 → 47.6) and overall val/loss is slightly worse (2.7927 → 2.8397).

Note: the new head (128→64→64→3 = 12,611 params) is actually *smaller* than the old head (128→128→3 = 16,899 params), so this is a narrowing + deepening change, not purely additive capacity. The bottleneck at 64 dims may be limiting the model's ability to decode tandem configurations which require more representational richness.

The throughput is unchanged (~20s/epoch, 91 epochs in 30 min), confirming the head is not a compute bottleneck.

### Suggested follow-ups

- **Wider bottleneck**: Try 128→96→96→3 to keep more capacity while still adding depth.
- **Skip connection in head**: Add a residual from the input to the output of mlp2 to ease optimization of the deeper head.
- **Per-field heads**: Give each output field (Ux, Uy, p) its own 2-layer head. Pressure and velocity may benefit from decoupled capacity.
- **Keep depth, restore width**: Try 128→128→64→3 to get the extra layer without narrowing.