### PR TITLE
Remove target noise (0.01 noise may hurt fine convergence)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -527,8 +527,6 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Target noise (0.01 * randn) was added as regularization but was never ablated against zero on the current baseline with Cp normalization. With weight decay, surface weight ramp, and cosine LR already providing regularization, the noise may be hurting late-epoch convergence. One line deletion.

## Instructions
In `structured_split/structured_train.py`, remove the target noise line (~line 531):

```python
# Remove or comment out:
if model.training:
    y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
```

Just delete those two lines entirely.

Run with: `--wandb_name "senku/noise-zero" --wandb_group noise-zero --agent senku`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** `kxe88mru` (senku/noise-zero)
**Epochs completed:** 88/100 (30-min timeout)
**Peak memory:** 7.6 GB

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.7927 | 2.8332 | +0.04 (worse) |
| val_in_dist/mae_surf_p | 26.04 | 27.48 | +1.44 (worse) |
| val_ood_cond/mae_surf_p | 27.01 | 27.27 | +0.26 (worse) |
| val_ood_re/mae_surf_p | 34.46 | 34.97 | +0.51 (worse) |
| val_tandem_transfer/mae_surf_p | 44.98 | 46.30 | +1.32 (worse) |

Surface MAE (last epoch, val_in_dist): Ux=0.340, Uy=0.200, p=27.48
Volume MAE (last epoch, val_in_dist): Ux=1.78, Uy=0.63, p=35.66

### What happened

Removing the target noise made things slightly worse across all metrics. The hypothesis that the noise was hurting convergence did not hold -- it appears to be providing genuine regularization benefit.

The differences are small (val/loss +0.04, surf_p in-dist +1.44), which suggests the noise is a mild but consistently helpful regularizer. This makes sense: with 0.01 standard deviations of noise added to normalized targets (which have unit variance), the noise-to-signal ratio is about 1%, small enough to not distort learning but large enough to prevent the model from memorizing exact target values.

The run was still improving at the timeout (epoch 88 was the new best checkpoint), so the model had not fully converged. At 100 epochs the gap might narrow slightly, but given the consistent direction of all metrics, the conclusion is clear: the noise is helping, not hurting.

val_ood_re continues to be NaN throughout -- this appears to be a pre-existing issue with that validation split unrelated to this change.

Memory cost: no change from baseline (7.6 GB).

### Suggested follow-ups
- The noise magnitude (0.01) was never swept. A lower value (0.005) might be a better balance -- enough regularization without slightly biasing the learned solution.
- The noise is currently applied uniformly across all 3 output channels (Ux, Uy, p). Pressure-specific noise magnitude could be tuned separately since pressure has much larger absolute errors.
- Keep the noise in -- this ablation confirms it is earning its place.