### PR TITLE
Cosine annealing with warm restarts (T_0=30, T_mult=2)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -454,7 +454,7 @@ model = Transolver(**model_config).to(device)
 n_params = sum(p.numel() for p in model.parameters())
 optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=30, T_mult=2)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
The current cosine schedule decays LR monotonically. CosineAnnealingWarmRestarts resets the LR at epoch 35 (after 30 cosine epochs post-warmup), then does another 60-epoch cycle. The restart at epoch 35 can escape local minima. First cycle provides rapid convergence, second cycle provides long fine-tuning.

## Instructions
In `structured_split/structured_train.py`, replace the cosine scheduler:

\`\`\`python
# Old:
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS - 5)

# New:
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=30, T_mult=2)
\`\`\`

Keep the warmup and SequentialLR unchanged. The first cosine cycle runs 30 epochs (5-35), then restarts and runs 60 epochs (35-95).

Run with: \`--wandb_name "norman/cosine-restart" --wandb_group cosine-restart --agent norman\`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** [d31048am](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/d31048am)
**Epochs completed:** 90 (30-min wall-clock limit hit)
**Peak memory:** 7.6 GB

### Metrics at best checkpoint (val/loss = 2.8788)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ vs baseline |
|---|---|---|---|---|
| val_in_dist | 0.352 | 0.204 | **27.48** | +1.44 ✗ |
| val_ood_cond | 0.309 | 0.220 | **28.93** | +1.92 ✗ |
| val_ood_re | 0.305 | 0.219 | **35.11** | +0.65 ✗ |
| val_tandem_transfer | 0.718 | 0.365 | **45.92** | +0.94 ✗ |

**val/loss: 2.8788** vs baseline 2.7927 (+0.09, +3.2%) — **negative result**

### What happened

The warm restart at epoch 35 caused severe disruption to training. Val loss jumped from ~2.63 (epoch 35) to ~3.89 (epoch 36) when the LR reset to its initial value. The model spent the next 30+ epochs just recovering from the restart.

By epoch 90 the model had recovered to val/loss ~2.865 but still hadn't surpassed the baseline (2.7927). All surface MAE metrics are worse than baseline.

The core problem: T_0=30 means the restart happens at epoch 35 (after the 5-epoch warmup). At that point, the model has learned meaningful weights and resetting the LR to the maximum value is too disruptive. With only 90 epochs available in 30 minutes, the recovery from restart is too costly.

### Suggested follow-ups

1. **Later restart or no restart**: T_0=50 would push the restart to epoch 55, leaving less time for it to disrupt training. Or avoid restarts entirely.
2. **Lower restart LR**: Use `eta_min` on the second cycle to prevent a full reset to max LR.
3. **Longer run needed**: Warm restarts may work with more epochs (200+) but not in the 30-minute budget we have.