### PR TITLE
Higher weight decay (3e-4 vs 1e-4) for better regularization

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -332,7 +332,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 3e-4
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
Weight decay 1e-4 was inherited from the original config and never tuned on the current 1-layer model. With multi-scale loss now providing an additional training signal, slightly stronger regularization (3e-4) may help generalization, especially for OOD splits where the model tends to overfit to in-distribution patterns. One number change.

## Instructions
In \`structured_split/structured_train.py\`, change the weight decay in the Config dataclass or pass it via CLI:

\`\`\`python
# Old:
weight_decay: float = 1e-4

# New:
weight_decay: float = 3e-4
\`\`\`

Run with: \`--wandb_name "askeladd/wd-3e4" --wandb_group wd-3e4 --agent askeladd\`

## Baseline
- val/loss: **2.7927**
- val_in_dist/mae_surf_p: 26.04
- val_ood_cond/mae_surf_p: 27.01
- val_ood_re/mae_surf_p: 34.46
- val_tandem_transfer/mae_surf_p: 44.98

---

## Results

**W&B run:** \`37m81poz\`
**Epochs completed:** 87 (terminated at 30-minute timeout)
**Peak GPU memory:** ~57.7 GB (60% of 96 GB, likely confounded by other node processes — same architecture as previous runs that showed ~24 GB)

### Metrics at best val/loss

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.8848 | 2.7927 | **+0.09** |
| val_in_dist/mae_surf_p | 27.45 | 26.04 | +1.41 |
| val_ood_cond/mae_surf_p | 26.86 | 27.01 | **-0.15** ✓ |
| val_ood_re/mae_surf_p | 35.04 | 34.46 | +0.58 |
| val_tandem_transfer/mae_surf_p | 46.27 | 44.98 | +1.29 |
| val_in_dist/mae_surf_Ux | 0.38 | — | — |
| val_in_dist/mae_surf_Uy | 0.21 | — | — |
| val_in_dist/mae_vol_p | 35.83 | — | — |

### What happened

The 3x stronger weight decay is essentially neutral: val/loss is marginally worse (+0.09), with a small improvement on the ood_cond split (−0.15 Pa) but slight regression everywhere else. No split shows a meaningful improvement.

The val_ood_re NaN issue (surf_loss and combined loss are NaN from epoch 1, vol_loss is ~18.87B) is present in all 87 epochs, confirming this is a pre-existing normalization problem in that split unrelated to the weight decay change.

There's no evidence that stronger weight decay helps at this scale. The model is small (176k params) and may not need heavier regularization; 1e-4 already provides sufficient L2 penalty for this regime.

### Suggested follow-ups

- Try weight decay in the other direction (5e-5 or even 0) to check if 1e-4 is already over-regularizing the small model.
- The ood_cond improvement (+0.15) is tiny but in the right direction — could be worth checking 5e-4 for ood generalization specifically.
- Investigate the val_ood_re NaN/18.87B vol_loss issue — it prevents using that split for optimization signal and corrupts the combined val/loss.