### PR TITLE
EMA model averaging (decay=0.999) for smoother OOD predictions

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -453,6 +453,10 @@ model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 
+ema_decay = 0.999
+ema_model = Transolver(**model_config).to(device)
+ema_model.load_state_dict(model.state_dict())
+
 
 class Lookahead:
     def __init__(self, base_optimizer, k=5, alpha=0.5):
@@ -609,6 +613,9 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        with torch.no_grad():
+            for ema_p, p in zip(ema_model.parameters(), model.parameters()):
+                ema_p.data.mul_(ema_decay).add_(p.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -623,6 +630,7 @@ for epoch in range(MAX_EPOCHS):
 
     # --- Validate across all splits ---
     model.eval()
+    ema_model.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -649,7 +657,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = ema_model({"x": x})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()
@@ -728,7 +736,7 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        torch.save(model.state_dict(), model_path)
+        torch.save(ema_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(


### PR DESCRIPTION
## Hypothesis
EMA of model weights produces smoother predictions than Lookahead alone. EMA is orthogonal to Lookahead — Lookahead modifies optimization, EMA creates a separate eval model.

## Instructions
1. After model creation, add EMA copy:
```python
ema_decay = 0.999
ema_model = Transolver(**model_config).to(device)
ema_model.load_state_dict(model.state_dict())
```
2. After `optimizer.step()`, add EMA update:
```python
with torch.no_grad():
    for ema_p, p in zip(ema_model.parameters(), model.parameters()):
        ema_p.data.mul_(ema_decay).add_(p.data, alpha=1 - ema_decay)
```
3. In validation, use `ema_model` instead of `model` for predictions.
4. Save `ema_model.state_dict()` as checkpoint.
5. Run with: `--wandb_name "frieren/ema-avg" --wandb_group ema-model-avg --agent frieren`

## Baseline
- val/loss: **2.7135**
- val_in_dist/mae_surf_p: 25.88
- val_ood_cond/mae_surf_p: 25.58
- val_ood_re/mae_surf_p: 33.68
- val_tandem_transfer/mae_surf_p: 44.76

---

## Results

**W&B run:** `hjp523vq` (frieren/ema-avg)
**Epochs completed:** 88/100 (hit 30-min timeout at ~29.3 min)
**Peak GPU memory:** ~36.3 GB (38.0% of 96 GB)

### Metrics at best val/loss epoch

| Metric | Baseline | EMA | Delta |
|--------|----------|-----|-------|
| val/loss | 2.7135 | **2.6673** | -1.7% |
| val_in_dist/mae_surf_p | 25.88 | **23.14** | -10.6% |
| val_ood_cond/mae_surf_p | 25.58 | **23.87** | -6.7% |
| val_ood_re/mae_surf_p | 33.68 | **32.89** | -2.3% |
| val_tandem_transfer/mae_surf_p | 44.76 | **43.80** | -2.1% |

Surface MAE (in-dist): Ux=0.33, Uy=0.19, p=23.14
Volume MAE (in-dist): Ux=1.66, Uy=0.56, p=31.48

### What happened

EMA model averaging is a clear win — all metrics improved, with the largest gains on the most important metric (in-dist surface pressure MAE, -10.6%). The improvement was consistent across all four validation splits, including OOD, which suggests EMA genuinely improves generalization rather than just reducing noise on in-distribution samples.

Why it works: EMA produces a trajectory average of the optimizer's path through parameter space. Combined with Lookahead (which already does a form of slow-weight averaging via alpha blending every k steps), EMA adds an additional, finer-grained smoothing at every step. The two mechanisms are complementary — Lookahead does coarse periodic averaging, EMA does continuous exponential smoothing.

Memory overhead is negligible — storing the EMA model's parameters without gradients costs the same as the model itself (~36 GB total, essentially same as baseline since EMA parameters need no gradient buffers).

### Suggested follow-ups

- Try a slightly lower EMA decay (e.g., 0.995 or 0.99) — with 88 epochs the effective window is ~1/(1-0.999) = 1000 steps, which may be too slow to adapt early in training.
- The combination of Lookahead + EMA is powerful; the redundancy between them could be explored by running EMA without Lookahead to disentangle which contributes more.
- EMA is now clearly part of the best-performing config — should be kept in all future experiments.