### PR TITLE
Kaiming fan-out initialization (better for GELU networks)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -263,7 +263,7 @@ class Transolver(nn.Module):
 
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
-            nn.init.xavier_uniform_(module.weight)
+            nn.init.kaiming_normal_(module.weight, mode="fan_out", nonlinearity="relu")
             if module.bias is not None:
                 nn.init.constant_(module.bias, 0)
         elif isinstance(module, (nn.LayerNorm, nn.BatchNorm1d)):


### PR DESCRIPTION
## Hypothesis
Kaiming init accounts for nonlinear activation variance, while Xavier assumes linear. For GELU-activated MLPs, Kaiming fan_out may be a better match.

## Instructions
In `_init_weights`, replace `nn.init.xavier_uniform_(module.weight)` with `nn.init.kaiming_normal_(module.weight, mode="fan_out", nonlinearity="relu")`. Keep bias/LayerNorm unchanged.
Run with: `--wandb_name "haku/kaiming-init" --wandb_group kaiming-fan-out --agent haku`

## Baseline
- val/loss: **2.7135**
- val_in_dist/mae_surf_p: 25.88
- val_ood_cond/mae_surf_p: 25.58
- val_ood_re/mae_surf_p: 33.68
- val_tandem_transfer/mae_surf_p: 44.76

---

## Results

**W&B run:** pr2tawwy  
**Epochs completed:** 88/100 (30-minute timeout hit during epoch 89)  
**Peak GPU memory:** 7.6 GB

### Metrics at best checkpoint (epoch 88, val/loss = 3.1772)

| Metric | Kaiming fan_out | Baseline (Xavier) | Delta |
|--------|----------------|-------------------|-------|
| val/loss | **3.1772** | 2.7135 | +17.1% worse |
| val_in_dist/mae_surf_p | 29.16 | 25.88 | +12.7% worse |
| val_ood_cond/mae_surf_p | 33.82 | 25.58 | +32.2% worse |
| val_ood_re/mae_surf_p | 37.89 | 33.68 | +12.5% worse |
| val_tandem_transfer/mae_surf_p | 52.10 | 44.76 | +16.4% worse |
| val_in_dist/mae_surf_Ux | 0.3883 | — | — |
| val_in_dist/mae_surf_Uy | 0.2150 | — | — |
| val_in_dist/mae_vol_p | 38.62 | — | — |

### What happened

**Kaiming fan_out is clearly worse than Xavier on every metric — negative result.**

The key observation is that Kaiming fan_out starts much worse: epoch 1 val_in_dist = 40.44, vs Xavier's 14.46. The larger initial weights (Kaiming scales by sqrt(2/fan_out), which is larger than Xavier's sqrt(2/(fan_in+fan_out)) for typical layer sizes) produce large initial activations and unstable early gradients.

Despite still improving at epoch 88 (the model was converging), it hadn't caught up to Xavier after the same 88-epoch budget:
- val_in_dist/mae_surf_p: 29.16 vs Xavier 25.88 (+12.7%)
- val_ood_cond/mae_surf_p: 33.82 vs Xavier 25.58 — the worst gap (+32%)

The `relu` nonlinearity flag for a GELU network is also not ideal. Kaiming for relu assumes it discards 50% of activations (to normalize variance), but GELU preserves more of the distribution. The correct nonlinearity would be `leaky_relu` with a=0 or a custom GELU approximation. However, even correcting this is unlikely to match Xavier given the slower convergence trajectory.

Xavier remains the better choice: it provides well-calibrated initial weights without assuming a specific nonlinearity, which suits this mixed-activation architecture (GELU in MLPs, softmax in attention).

### Suggested follow-ups

1. **Kaiming fan_in** — the fan_in mode gives smaller weights (more conservative), which might be better than fan_out; worth a quick test
2. **Xavier + lower weight_decay** — Xavier may allow reducing weight_decay (currently 1e-4) since it already regularizes initial scale
3. **Orthogonal init for attention weights** — try orthogonal init specifically for to_q, to_k, to_v while keeping Xavier for the rest