### PR TITLE
Reduce target noise from 0.01 to 0.005

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -559,7 +559,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            y_norm = y_norm + 0.005 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Removing noise entirely hurt (+0.12), but 0.01 may be too much. Halving to 0.005 reduces signal corruption while preserving regularization.

## Instructions
Change `y_norm = y_norm + 0.01 * torch.randn_like(y_norm)` to `y_norm = y_norm + 0.005 * torch.randn_like(y_norm)`. One number change.
Run with: `--wandb_name "kohaku/noise-0005" --wandb_group target-noise-0005 --agent kohaku`

## Baseline
- val/loss: **2.7135**
- val_in_dist/mae_surf_p: 25.88
- val_ood_cond/mae_surf_p: 25.58
- val_ood_re/mae_surf_p: 33.68
- val_tandem_transfer/mae_surf_p: 44.76

---

## Results

**W&B run:** 30p9ju52 | **Status:** Timed out at epoch 88/100 (~29.3 min) | **Peak memory:** 7.6 GB | **Epoch time:** ~20s

### Metrics at best val/loss (epoch 87 of 88)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 25.80 | 25.88 (−0.3%, marginally better) |
| val_ood_cond | 25.49 | 25.58 (−0.4%, marginally better) |
| val_ood_re | 33.56 | 33.68 (−0.4%, marginally better) |
| val_tandem_transfer | 45.17 | 44.76 (+0.9%, marginally worse) |

- **val/loss (best): 2.729** vs baseline 2.714 (+0.5% — essentially the same, computed from 3 splits with val_ood_re excluded due to NaN loss)
- val_in_dist/mae_surf_Ux: 0.334, val_in_dist/mae_surf_Uy: 0.197
- val_in_dist/mae_vol_p: 34.28

### What happened

Halving the target noise (0.01→0.005) produces results essentially indistinguishable from the 0.01 baseline. All differences are within single-run noise:
- 3 of 4 surface pressure metrics are marginally better (by ≤0.4%)
- Tandem is marginally worse (by 0.9%)
- val/loss is +0.5% worse, but training was still converging at epoch 88

The run timed out at 88/100 epochs. The val/loss trend at the last 4 epochs (2.759→2.744→2.729→2.732) suggests the model had nearly converged. At 100 epochs, it likely would have reached ~2.72, which could marginally beat the baseline.

Key observation: the target noise level makes very little difference in this range (0.005 vs 0.01). Both are small enough that they don't dominate the loss signal — they're essentially equivalent levels of regularization for this model size and dataset.

The val_ood_re/loss NaN is a pre-existing issue unrelated to this change (overflow in vol_loss normalization for the Re=4.445M distribution).

### Suggested follow-ups
- **Try noise=0.0 vs 0.005 directly**: The PR mentions noise=0.0 hurt (+0.12 val/loss). With 0.005 being equivalent to 0.01, the sweet spot may actually be 0.0 with better regularization elsewhere (e.g., dropout, weight decay).
- **Try noise=0.02**: If 0.005 and 0.01 are equivalent, checking a larger value would help characterize the sensitivity curve. If 0.02 is also neutral, noise is simply not an important hyperparameter here.
- **Try per-channel noise**: The current noise is applied uniformly to all output fields. Pressure (p) may benefit from different noise than velocity (Ux, Uy) given their different dynamic ranges.