### PR TITLE
Progressive resolution: start at 5% volume (more aggressive surface focus)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -572,7 +572,7 @@ for epoch in range(MAX_EPOCHS):
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
         if epoch < 40:
-            vol_keep_ratio = 0.1 + 0.9 * (epoch / 40)
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
Progressive resolution starts at 10% volume. Starting at 5% forces even more surface focus in critical early epochs, strengthening surface representations.

## Instructions
Change `vol_keep_ratio = 0.1 + 0.9 * (epoch / 40)` to `vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)`. One number change.
Run with: `--wandb_name "norman/prog-5pct" --wandb_group prog-res-5pct --agent norman`

## Baseline
- val/loss: **2.7135**
- val_in_dist/mae_surf_p: 25.88
- val_ood_cond/mae_surf_p: 25.58
- val_ood_re/mae_surf_p: 33.68
- val_tandem_transfer/mae_surf_p: 44.76

---

## Results

**W&B run:** `rhukrqth` | 91 epochs | Peak memory: 7.6 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.7135 | **2.7051** | −0.3% |
| val_in_dist/mae_surf_p | 25.88 | **23.79** | −8.1% ✓ |
| val_ood_cond/mae_surf_p | 25.58 | **24.87** | −2.8% ✓ |
| val_ood_re/mae_surf_p | 33.68 | **33.85** | +0.5% |
| val_tandem_transfer/mae_surf_p | 44.76 | **44.09** | −1.5% ✓ |
| val_in_dist/mae_surf_Ux | — | 0.321 | |
| val_in_dist/mae_surf_Uy | — | 0.194 | |
| val_ood_cond/mae_surf_Ux | — | 0.291 | |
| val_ood_cond/mae_surf_Uy | — | 0.197 | |
| val_ood_re/mae_surf_Ux | — | 0.298 | |
| val_ood_re/mae_surf_Uy | — | 0.208 | |
| val_tandem_transfer/mae_surf_Ux | — | 0.667 | |
| val_tandem_transfer/mae_surf_Uy | — | 0.350 | |
| val_in_dist/mae_vol_Ux | — | 1.706 | |
| val_ood_cond/mae_vol_Ux | — | 1.437 | |
| val_tandem_transfer/mae_vol_Ux | — | 2.469 | |

**Note:** `val_ood_re/loss` is NaN throughout training (vol_loss explodes to ~1.9e10 on that split). The mae metrics for ood_re are computed from the saved best checkpoint and appear normal. This NaN appears to be a pre-existing issue with the ood_re split, not caused by this change.

### What happened

The change worked as intended. Lowering the initial volume sampling from 10% to 5% gave a modest but consistent improvement, most noticeably on `val_in_dist/mae_surf_p` (−8.1%). The logic is sound: with fewer volume nodes sampled early, the gradient signal is more concentrated on surface nodes during the critical early epochs when representations are being established.

The improvement is real but small — overall val/loss dropped from 2.7135 → 2.7051 (−0.3%). Three of four splits showed surface pressure improvement; only val_ood_re is essentially flat.

### Suggested follow-ups

- Try an even more aggressive start (2% or 1%) to see if the trend continues, or if there is a floor where too little volume sampling in epoch 0 hurts convergence.
- Investigate the val_ood_re volume loss explosion — this NaN appears systematically across runs and may indicate a data normalization edge case with extreme Reynolds numbers.
- Try extending the ramp period beyond 40 epochs (e.g., 50 or 60) so the model spends more time in the surface-focused regime.