### PR TITLE
Learnable placeholder scale+shift (replace random bias)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -256,7 +256,8 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
-        self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))
+        self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
+        self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -312,7 +313,7 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         fx = self.preprocess(x)
-        fx = fx + self.placeholder[None, None, :]
+        fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks:
             fx = block(fx)


### PR DESCRIPTION
## Hypothesis
The placeholder adds arbitrary random bias to all embeddings. Replacing with learnable scale+shift (2 params per channel) allows adaptive reconditioning.

## Instructions
1. Replace `self.placeholder = nn.Parameter((1/n_hidden)*torch.rand(n_hidden))` with:
```python
self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
```
2. Replace `fx = fx + self.placeholder[None, None, :]` with:
```python
fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
```
Run with: `--wandb_name "violet/placeholder-ss" --wandb_group placeholder-scale-shift --agent violet`

## Baseline
- val/loss: **2.7135**
- val_in_dist/mae_surf_p: 25.88
- val_ood_cond/mae_surf_p: 25.58
- val_ood_re/mae_surf_p: 33.68
- val_tandem_transfer/mae_surf_p: 44.76

---

## Results

**W&B run:** mx88s63d (violet/placeholder-ss)
**Epochs completed:** 90 (best epoch: 86)
**Peak memory:** 7.8 GB

### Metrics at best epoch (val/loss=2.6599)

| Split | val/loss | mae_surf_p | Δ surf_p |
|---|---|---|---|
| val_in_dist | 1.8060 | 24.4 | -1.48 |
| val_tandem_transfer | 4.5479 | 42.8 | -1.96 |
| val_ood_cond | 1.6258 | 24.7 | -0.88 |
| val_ood_re | nan | 33.8 | +0.12 |

**val/loss: 2.6599** vs baseline 2.7135 (Δ = **-0.054**)

W&B best_best summary (val_in_dist):
- mae_surf_Ux: 0.328, mae_surf_Uy: 0.190, mae_surf_p: 24.39
- mae_vol_Ux: 1.672, mae_vol_Uy: 0.567, mae_vol_p: 33.24

### What happened
Clear improvement across the board. Replacing the random fixed-bias placeholder with learnable scale+shift (initialized to identity: scale=1, shift=0) reduced val/loss by 0.054 and surface pressure MAE improved on all splits except val_ood_re (+0.12, within noise). The change adds only 2×n_hidden parameters (2×256=512 for typical config) — negligible parameter overhead.

The scale+shift parameterization is strictly more expressive than the additive bias: it can reproduce the original behavior (shift only) while also allowing feature-wise rescaling. Initializing to identity means training starts from the same effective point as baseline but can learn to rescale, which appears helpful.

### Suggested follow-ups
- Apply the same scale+shift pattern after other fixed operations in the model (e.g., after positional encoding concat before preprocess).
- Try combining with a learnable temperature for the slice attention softmax.
- The val_ood_re NaN vol_loss persists (pre-existing issue with extreme Re values) — worth investigating separately.