### PR TITLE
Slice temperature init 0.1 (sharper specialization)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.1)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
Lower temp init (0.1 vs current 0.25) forces sharper slice specialization from the start.

## Instructions
Change `torch.ones([1, heads, 1, 1]) * 0.25` to `torch.ones([1, heads, 1, 1]) * 0.1` in Physics_Attention_Irregular_Mesh.__init__.
Run with: `--wandb_name "edward/temp-01" --wandb_group temp-init-01 --agent edward`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** t71bxwle
**Epochs:** 88 (30-min wall-clock limit)
**Peak memory:** 7.8 GB

### Metrics at best checkpoint (epoch 88)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.789 | 0.335 | 0.198 | **24.21** | 34.33 |
| val_ood_cond | 1.655 | 0.283 | 0.203 | **24.91** | 27.33 |
| val_ood_re | NaN | 0.290 | 0.211 | **33.86** | 56.50 |
| val_tandem_transfer | 4.772 | 0.697 | 0.364 | **45.64** | 50.01 |
| **mean val/loss** | **2.739** | | | | |

### vs. Baseline (temp=0.25)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.6604 | 2.739 | +3.0% worse |
| val_in_dist/mae_surf_p | 24.04 | 24.21 | +0.7% worse |
| val_ood_cond/mae_surf_p | 24.27 | 24.91 | +2.6% worse |
| val_ood_re/mae_surf_p | 33.79 | 33.86 | +0.2% (flat) |
| val_tandem_transfer/mae_surf_p | 43.62 | 45.64 | +4.6% worse |

### What happened

Temperature 0.1 is worse than 0.25 across all splits. The hypothesis that sharper initial specialization would help did not hold. Starting too sharp apparently constrains slice routing too early and prevents the network from finding good attention patterns during the critical early training phase when gradients are large. The 0.25 value already provided more focused attention than the original 0.5, and going to 0.1 over-constrains it.

The tandem transfer split regressed most strongly (-4.6%), suggesting that overly sharp initial routing hurts generalization to novel configurations.

Note: the branch starting point had temperature=0.5 (not 0.25 as the PR baseline implies), so the change was 0.5 → 0.1. The comparison to baseline is still valid since the baseline val/loss of 2.6604 represents the branch context with temperature=0.25.

Note: val_ood_re/loss is NaN throughout — pre-existing issue.

### Suggested follow-ups

- Temperature 0.25 appears to be a sweet spot — confirm by trying 0.15 or 0.2 to bracket the optimum
- The temperature parameter is learned (nn.Parameter), so the init value mainly sets the starting point; larger datasets or more training steps might reduce sensitivity to init
- Could try freezing temperature for the first N epochs to allow other params to warm up before letting temperature adapt