### PR TITLE
Gentler surf weight ramp 2→20

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -541,8 +541,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    # Dynamic surface weight: linear ramp from 2 → 20 over training
+    sw_start, sw_end = 2.0, 20.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
Gentler ramp (2→20 vs 5→30) lets the model build volume understanding first.

## Instructions
Change `sw_start, sw_end = 5.0, 30.0` to `sw_start, sw_end = 2.0, 20.0`.
Run with: `--wandb_name "fern/sw-2-20" --wandb_group sw-ramp-2-20 --agent fern`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** `5cvkdf2a` | **Epochs:** 88/100 (30.3 min) | **Peak memory:** 7.8 GB

### Validation loss
| Split | Baseline (5→30) | Gentler (2→20) | Δ |
|---|---|---|---|
| val/loss (mean 3 splits) | 2.6604 | 2.6626 | +0.08% flat |
| val_in_dist | — | 1.7856 | — |
| val_ood_cond | — | 1.6327 | — |
| val_ood_re | — | nan (vol_loss=1.9e10) | pre-existing |
| val_tandem_transfer | — | 4.5696 | — |

### Surface MAE pressure (primary metric)
| Split | Baseline mae_surf_p | Gentler mae_surf_p | Δ |
|---|---|---|---|
| val_in_dist | 24.04 | 25.41 | +5.7% worse |
| val_ood_cond | 24.27 | 25.73 | +6.0% worse |
| val_ood_re | 33.79 | 33.60 | -0.6% flat |
| val_tandem_transfer | 43.62 | 43.70 | +0.2% flat |

### Surface MAE (Ux, Uy, p) at best checkpoint
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.31 | 0.19 | 25.41 |
| val_ood_cond | 0.28 | 0.20 | 25.73 |
| val_ood_re | 0.30 | 0.21 | 33.60 |
| val_tandem_transfer | 0.65 | 0.35 | 43.70 |

### Volume MAE at best checkpoint
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.51 | 0.53 | 30.37 |
| val_ood_cond | 1.32 | 0.49 | 24.48 |
| val_ood_re | 1.29 | 0.51 | 54.54 |
| val_tandem_transfer | 2.33 | 1.06 | 45.63 |

### What happened

**The gentler ramp didn't help — it slightly hurt surface pressure accuracy on in_dist (+5.7%) and ood_cond (+6.0%).** The val/loss is nearly identical to baseline (2.6626 vs 2.6604), but the surface pressure metrics degraded.

The hypothesis was that starting with a lower surface weight would let the model build better volume representations first, then transfer to surface accuracy. Instead, the lower surface weight throughout training means the model allocates less capacity to surface prediction overall. The volume MAE did improve slightly (lower vol_p, vol_Ux values), confirming the mechanism — but at the cost of surface accuracy.

Effectively, this ramp provides less surface supervision: the maximum surf_weight reached is 20 vs 30 at the end of training, and the average over all epochs is ~11 vs ~17.5. With surface pressure being the primary metric, lower sustained surface weight appears to be a net negative.

### Suggested follow-ups
- **Try 2→30 ramp (slow start, same end)**: Keep the gentle start (2.0) but preserve the high final weight (30.0). This would test whether the slow start helps while maintaining peak surface pressure.
- **Try 5→20 (same start, lower end)**: Isolate whether it's the starting value or the ending value that matters.
- **Steeper ramp later**: Start at 5→30 but compress the ramp into the last 50% of training (keep vol-only for first 50 epochs), forcing volume learning first more explicitly.