### PR TITLE
mlp_ratio=4 (2x MLP capacity per token)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -448,7 +448,7 @@ model_config = dict(
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
-    mlp_ratio=2,
+    mlp_ratio=4,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
Doubling mlp_ratio to 4 increases per-token capacity without changing attention.

## Instructions
Change `mlp_ratio=2` to `mlp_ratio=4` in model_config.
Run with: `--wandb_name "haku/mlp-ratio-4" --wandb_group mlp-ratio-4 --agent haku`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** l0pcnyj1  
**Epochs completed:** 80/100 (30-minute timeout; larger model → fewer epochs)  
**Peak GPU memory:** 8.9 GB (vs ~7.6 GB baseline, +1.3 GB / +17%)  
**Model params:** 242,599 (vs ~154k at mlp_ratio=2)

### Metrics at best checkpoint (epoch 80, val/loss = 2.7007)

| Metric | mlp_ratio=4 | Baseline (mlp_ratio=2) | Delta |
|--------|------------|------------------------|-------|
| val/loss | **2.7007** | 2.6604 | +1.5% worse |
| val_in_dist/mae_surf_p | 24.73 | 24.04 | +2.9% worse |
| val_ood_cond/mae_surf_p | 26.10 | 24.27 | +7.5% worse |
| val_ood_re/mae_surf_p | **33.47** | 33.79 | -0.9% better |
| val_tandem_transfer/mae_surf_p | 44.41 | 43.62 | +1.8% worse |
| val_in_dist/mae_surf_Ux | 0.3333 | — | — |
| val_in_dist/mae_surf_Uy | 0.1882 | — | — |
| val_in_dist/mae_vol_p | 31.10 | — | — |

### What happened

**Inconclusive / likely negative given fixed time budget.** The larger model used more memory (+1.3 GB) and ran slower (21-22s/epoch vs 19-20s), completing only 80 epochs vs ~88 for the baseline. It was still improving at cutoff (epoch 80 = best checkpoint), suggesting it hadn't fully converged.

Key observations:
- Most metrics degraded vs baseline, with the largest regression on val_ood_cond/mae_surf_p (+7.5%). Only val_ood_re/mae_surf_p improved slightly (-0.9%).
- The model has ~57% more parameters but achieved comparable (slightly worse) performance with 10% fewer epochs. This suggests the capacity increase did not provide proportional benefit for this problem size.
- Memory cost is significant: 8.9 GB vs 7.6 GB. Not dangerous (well within 96 GB), but notable.
- The result might reverse with more epochs — the model was still actively improving at epoch 80 — but within the 30-minute budget it doesn't pay off.

Given the memory cost, slower epochs, and worse metrics within the fixed budget, mlp_ratio=4 is not recommended over mlp_ratio=2.

### Suggested follow-ups

1. **mlp_ratio=1** — test if the MLP is actually needed (attention-only Transolver); probably a separate branch
2. **Compare at fixed epoch count** — if you run to epoch 100 explicitly, does mlp_ratio=4 eventually win?
3. **Wider hidden_dim instead** — increasing n_hidden from 128→192 might be more efficient than deeper MLPs for this 1-layer architecture