### PR TITLE
mlp_ratio=1 (regularize via less MLP capacity)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -448,7 +448,7 @@ model_config = dict(
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
-    mlp_ratio=2,
+    mlp_ratio=1,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
Halving mlp_ratio to 1 acts as regularization through reduced capacity.

## Instructions
Change `mlp_ratio=2` to `mlp_ratio=1` in model_config.
Run with: `--wandb_name "kohaku/mlp-ratio-1" --wandb_group mlp-ratio-1 --agent kohaku`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** kkfqko1f | **Status:** Timed out at epoch 88/100 | **Peak memory:** 7.3 GB (vs 7.6 GB, slightly smaller model) | **Epoch time:** ~20s (unchanged)

### Metrics at best val/loss (epoch ~85)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 27.14 | 24.04 (+3.1, **13% worse**) |
| val_ood_cond | 24.01 | 24.27 (−0.3, marginally better) |
| val_ood_re | 33.68 | 33.79 (−0.1, essentially the same) |
| val_tandem_transfer | 43.48 | 43.62 (−0.1, essentially the same) |

- **val/loss (best): 2.757** vs baseline 2.660 (+3.6% worse)
- val_in_dist/mae_surf_Ux: 0.381, val_in_dist/mae_surf_Uy: 0.197
- val_in_dist/mae_vol_p: 35.65

### What happened

Reducing mlp_ratio from 2 to 1 is a negative result overall. The val/loss is 3.6% worse than baseline, driven primarily by a significant degradation in in-distribution surface pressure (+3.1 Pa, 13%).

The OOD metrics show no meaningful benefit:
- val_ood_cond is marginally better by 0.3 Pa, but this is within single-run noise
- val_ood_re and val_tandem are essentially unchanged (< 0.2 Pa improvement)

The regularization hypothesis was that reduced capacity would prevent overfitting and improve OOD generalization. The data instead shows the model simply has insufficient capacity to model in-distribution pressure accurately. The MLP at mlp_ratio=1 has an intermediate dimension of 128×1=128, vs 128×2=256 for the baseline — halving the width of each MLP block.

Notably, memory decreased only slightly (7.3 GB vs 7.6 GB), confirming the MLP is not the memory bottleneck. The epoch time was unchanged at ~20s.

The training was still improving at epoch 88 (best at epoch 85, some noise afterward). With 100 epochs the val/loss would likely reach ~2.74 — still noticeably worse than baseline 2.66.

### Suggested follow-ups
- **mlp_ratio=4**: If mlp_ratio=1 is underpowered and mlp_ratio=2 is the current baseline, mlp_ratio=4 (more capacity) is the natural opposite test. Though memory use would increase modestly.
- **Dropout inside MLP**: The real hypothesis behind this experiment was regularization. Applying dropout (e.g. 0.1) to the MLP layers would test regularization without sacrificing capacity.
- **Conclusion**: mlp_ratio=2 is better than mlp_ratio=1. The capacity reduction acts as underfitting, not useful regularization.