### PR TITLE
Multi-scale coarse loss weight 1.0 (halved from 2.0)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -607,7 +607,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 2.0 * coarse_loss
+            loss = loss + 1.0 * coarse_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Halving coarse loss weight to 1.0 reduces pull away from fine-scale surface accuracy.

## Instructions
Change `loss = loss + 2.0 * coarse_loss` to `loss = loss + 1.0 * coarse_loss`.
Run with: `--wandb_name "tanjiro/ms-wt-1" --wandb_group multiscale-wt-1 --agent tanjiro`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** `3h3shh2n` | **Epochs:** 87 (clean timeout) | **Peak memory:** 7.6 GB

| Metric | Baseline | Coarse wt=1.0 | Delta |
|---|---|---|---|
| val/loss | 2.6604 | **2.6543** | -0.006 better |
| val_in_dist/mae_surf_p | 24.04 | **24.78** | +0.74 worse |
| val_ood_cond/mae_surf_p | 24.27 | **22.52** | -1.75 better |
| val_ood_re/mae_surf_p | 33.79 | **32.18** | -1.61 better |
| val_tandem_transfer/mae_surf_p | 43.62 | **43.55** | -0.07 better |

Additional surface metrics (best checkpoint, epoch 87):
- val_in_dist: mae_surf_Ux=0.335, mae_surf_Uy=0.190
- val_ood_cond: mae_surf_Ux=0.271, mae_surf_Uy=0.188
- val_ood_re: mae_surf_Ux=0.281, mae_surf_Uy=0.205
- val_tandem_transfer: mae_surf_Ux=0.646, mae_surf_Uy=0.345

Note: `val_ood_re/loss` remains NaN (pre-existing vol_loss overflow); val/loss is the mean over the 3 finite splits.

### What happened

**Mixed but broadly positive.** Halving the coarse loss weight from 2.0 to 1.0 improves OOD generalization substantially (OOD-cond -1.75 Pa, OOD-Re -1.61 Pa) and keeps tandem transfer flat, but costs a small amount on val_in_dist (+0.74 Pa). Overall val/loss improves marginally (-0.006).

The result aligns with the hypothesis: at weight 2.0, the coarse-scale pooling loss was pulling too hard on the optimization, competing with fine-scale surface accuracy. Reducing it to 1.0 lets the surface loss dominate more, which appears to especially benefit OOD conditions where the model needs to generalize across different Reynolds numbers and angles of attack rather than just fitting the training distribution.

The in-distribution degradation (+0.74 Pa) suggests the coarse loss at weight 2.0 was still contributing useful low-frequency structure for the training distribution. There may be an optimal value between 1.0 and 2.0.

### Suggested follow-ups

- **Coarse weight 1.5:** Try a middle ground that might balance in-dist and OOD performance.
- **Coarse weight 0.5 or 0.0:** Explore whether the coarse loss helps at all, or whether it's net negative at any weight.
- **Per-condition coarse weight:** Higher weight for in-dist (where it helps), but applied differently for OOD — though this would complicate the loss and likely isn't worth it.