### PR TITLE
Surface pressure 4x channel weight (up from 2x)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -588,7 +588,8 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_channel_w = torch.tensor([1.0, 1.0, 4.0], device=abs_err.device)
+        surf_loss = ((abs_err * surf_channel_w) * surf_mask.unsqueeze(-1)).sum() / (surf_mask.sum().clamp(min=1) * surf_channel_w.sum() / 3)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Doubling surface pressure weight to 4x further concentrates gradient on the primary metric.

## Instructions
Change `surf_channel_w = torch.tensor([1.0, 1.0, 2.0], ...)` to `torch.tensor([1.0, 1.0, 4.0], ...)`.
Run with: `--wandb_name "thorfinn/surf-4x" --wandb_group surf-channel-4x --agent thorfinn`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** `q8iivlma` (thorfinn/surf-4x)
**Best checkpoint:** epoch 86 / 87 (hit 30-min timeout)
**Peak memory:** 7.8 GB

### Metrics at best checkpoint (val/loss = 2.8411)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.402 | 0.219 | **23.49** | -2.3% better |
| val_ood_cond | 0.316 | 0.225 | **22.58** | -7.0% better |
| val_ood_re | 0.312 | 0.231 | **32.44** | -4.0% better |
| val_tandem_transfer | 0.757 | 0.391 | **42.97** | -1.5% better |

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.8411 | 2.6604 | +6.7% worse |

Volume MAE (pressure): in_dist=34.9, ood_re=55.9, tandem=48.9

Note: `val_ood_re` had NaN loss every epoch (vol_loss numerically unstable for that split), excluded from mean val/loss. Physical-space MAE metrics for ood_re are valid.

### What happened

Mixed result: every pressure MAE improved (ood_cond down -7.0%, ood_re down -4.0%, in_dist down -2.3%, tandem down -1.5%), but the overall val/loss regressed by +6.7% because velocity MAEs (Ux, Uy) got significantly worse. The 4x channel weight forces the model to focus almost exclusively on pressure accuracy at the cost of velocity field accuracy.

The validation loss is unweighted across channels, so the strong velocity regression (e.g. tandem Ux: 0.757 vs ~0.662 in baseline) shows up directly in the loss calculation. The training objective diverges too far from the evaluation metric.

The 2x weight (PR that established the baseline) appears to be a better balance: pressure improves while velocity doesn't regress much. Going to 4x is too aggressive.

The ood_cond pressure gain (-7.0%) is notable, but it comes at the cost of velocity accuracy that the physics requires. In CFD, velocity and pressure are coupled through Navier-Stokes; a model that accurately predicts pressure but not velocity is not physically consistent.

### Suggested follow-ups

- **3x as a middle ground:** Between 2x and 4x might find the sweet spot where pressure gains without meaningful velocity regression.
- **Separate velocity and pressure surface weights:** Rather than a multiplicative channel weight, use separate terms:  where . This decouples the two objectives and allows independent tuning.
- **Accept that 2x is optimal:** The baseline's 2x weight may already be at the Pareto frontier for this architecture/dataset combination.