### PR TITLE
Lower learning rate 2e-3 (finer convergence)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -335,7 +335,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 2e-3
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
Lower LR (2e-3 vs 3e-3) may find a deeper minimum with more precise gradient steps. Xavier init and Lookahead provide enough exploration.

## Instructions
Change `lr: float = 3e-3` to `lr: float = 2e-3` in Config.
Run with: `--wandb_name "violet/lr-2e3" --wandb_group lr-2e3 --agent violet`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** r3bymlxz (violet/lr-2e3)
**Epochs completed:** 88 (run hit 30-min timeout; best model: epoch 87)
**Peak memory:** 7.8 GB

### Metrics at best epoch (val/loss=2.6732)

| Split | mae_surf_p | Δ vs baseline |
|---|---|---|
| val_in_dist | 24.23 | +0.19 |
| val_tandem_transfer | 43.79 | +0.17 |
| val_ood_cond | 23.57 | **-0.70** |
| val_ood_re | 33.40 | -0.39 |

**val/loss: 2.6732** vs baseline 2.6604 (Δ = **+0.013**, slightly worse)

Full MAE summary (val_in_dist): mae_surf_Ux=0.332, mae_surf_Uy=0.192, mae_surf_p=24.23; mae_vol_Ux=1.695, mae_vol_Uy=0.586, mae_vol_p=33.17

### What happened
Lower LR underperformed slightly on overall val/loss (+0.013). The 30-minute cap limits training to ~88 epochs, which may not be enough for lr=2e-3 to catch up — lower learning rates typically require more steps to converge. The mixed signal across splits (val_ood_cond improved by 0.70 Pa but val_in_dist and tandem_transfer worsened slightly) suggests the lower LR is still in a less-converged state rather than finding a better minimum.

Given more epochs, lr=2e-3 might eventually outperform lr=3e-3, but within the 30-minute budget it does not.

### Suggested follow-ups
- Try lr=2e-3 with a longer run (if timeout can be extended) to test if convergence is the issue.
- Try a warmup + cosine schedule that starts at 3e-3 but decays to 1e-3 or lower, to get the best of both regimes.
- Alternatively, try 2.5e-3 as a compromise.