### PR TITLE
Deeper preprocess MLP (1 residual hidden layer)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -236,7 +236,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
The preprocess MLP has 0 hidden layers (linear→act→linear). Adding 1 residual layer gives it capacity to learn nonlinear input features.

## Instructions
In model_config or Transolver init, the preprocess uses `n_layers=0`. This is in Transolver.__init__ where MLP is called with n_layers=0. We cannot easily change this without modifying the MLP call. Instead: in the `Transolver.__init__`, change the preprocess MLP call from `n_layers=0, res=False` to `n_layers=1, res=True`.
Run with: `--wandb_name "chihiro/deep-preprocess" --wandb_group preprocess-deeper --agent chihiro`

## Baseline
- val/loss: **2.6604**
- val_in_dist/mae_surf_p: 24.04
- val_ood_cond/mae_surf_p: 24.27
- val_ood_re/mae_surf_p: 33.79
- val_tandem_transfer/mae_surf_p: 43.62

---

## Results

**W&B run:** `ymsozmey` | **Best epoch:** 81 | **Peak VRAM:** 7.6 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.705 | 0.307 | 0.184 | **23.29** | 30.54 |
| val_ood_cond | 1.542 | 0.269 | 0.192 | **22.61** | 23.06 |
| val_ood_re | NaN | 0.289 | 0.203 | **32.58** | 53.74 |
| val_tandem_transfer | 4.616 | 0.647 | 0.352 | **44.65** | 48.32 |
| **combined** | **2.6211** | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.6604 | **2.6211** | **-0.039 (beats baseline ✓)** |
| val_in_dist/mae_surf_p | 24.04 | **23.29** | **-0.75** |
| val_ood_cond/mae_surf_p | 24.27 | **22.61** | **-1.66 (large improvement)** |
| val_ood_re/mae_surf_p | 33.79 | **32.58** | **-1.21** |
| val_tandem_transfer/mae_surf_p | 43.62 | **44.65** | +1.03 (slight regression) |

### What happened

**The deeper preprocess MLP works well.** val/loss improves from 2.6604 → 2.6211 (-1.5%), and 3 of the 4 pressure splits improve meaningfully. The ood_cond split in particular sees a large improvement (-1.66 Pa), suggesting nonlinear feature interactions in flow conditions (Re, AoA) are beneficial.

The tandem split regresses slightly (+1.03 Pa). This may be because the additional hidden layer adds ~16K parameters (128×128 weight matrix) to the preprocess MLP, which slightly changes the implicit regularization. With only 30 min of training, the model may not have fully converged with the deeper preprocess.

The change is minimal in code complexity (1 parameter change) for a meaningful metric gain — fits the simplicity criterion well.

Val_ood_re NaN persists (pre-existing issue).

### Suggested follow-ups

- **Try n_layers=2** to see if more depth continues to help, or if 1 layer is the sweet spot
- **Investigate tandem regression**: the deeper preprocess may benefit from longer training (more epochs) since it has more parameters to optimize
- **Combine with learned SW**: the deep preprocess and learned surface weights both improved in_dist pressure substantially; combining them may stack well