### PR TITLE
n_hidden=192 (50% more capacity)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -444,7 +444,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=128,
+    n_hidden=192,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs


### PR DESCRIPTION
## Hypothesis
n_hidden=192 (50% more capacity)

## Instructions
Change n_hidden=128 to n_hidden=192 in model_config.
Run with: `--wandb_name "frieren/n-hidden-192" --wandb_group n-hidden-192 --agent frieren`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** `oideqfeg` (frieren/n-hidden-192)
**Epochs completed:** 60/100 (hit 30-min timeout)
**n_params:** 538,215 (vs ~176,679 for n_hidden=128, ~3x larger)
**Peak GPU memory:** ~57.4 GB (60.1% of 96 GB)

### Metrics at best val/loss epoch

| Metric | Baseline | n_hidden=192 | Delta |
|--------|----------|--------------|-------|
| val/loss | 2.6492 | **2.8564** | +7.8% |
| val_in_dist/mae_surf_p | 24.77 | **29.21** | +17.9% |
| val_ood_cond/mae_surf_p | 22.25 | **27.59** | +24.0% |
| val_ood_re/mae_surf_p | 32.66 | **34.98** | +7.1% |
| val_tandem_transfer/mae_surf_p | 44.87 | **47.83** | +6.6% |

Surface MAE (in-dist): Ux=0.34, Uy=0.20, p=29.21
Volume MAE (in-dist): Ux=1.61, Uy=0.58, p=34.39

### What happened

n_hidden=192 performed worse than baseline across all metrics. The primary cause is the 30-minute epoch count penalty: the 3x larger model only reached 60 epochs vs the baseline's ~88 epochs. With fewer epochs, the larger model simply hasn't converged as far.

This is a classic capacity-vs-epochs tradeoff under a wall-clock budget. The larger model has more expressive power, but it needs more steps to use it. The baseline (n_hidden=128) trains faster and reaches a better-converged state within the time limit.

It's plausible that n_hidden=192 could outperform n_hidden=128 with more training (e.g., 150+ epochs), but under the current 30-minute constraint, smaller is better.

### Suggested follow-ups

- Try n_hidden=160 as a middle ground — it would be faster per epoch than 192 while adding some capacity.
- The baseline (n_hidden=128) already achieves good results; the bottleneck may not be model capacity but rather data diversity or architecture choices.
- If the budget constraint were relaxed (e.g., 1-hour runs), n_hidden=192 might close the gap.