### PR TITLE
Preprocess MLP width 3x (384 hidden)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -229,14 +229,14 @@ class Transolver(nn.Module):
         if self.unified_pos:
             self.preprocess = MLP(
                 fun_dim + self.ref * self.ref * self.ref,
-                n_hidden * 2,
+                n_hidden * 3,
                 n_hidden,
                 n_layers=0,
                 res=False,
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 3, n_hidden, n_layers=1, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
Preprocess MLP width 3x (384 hidden)

## Instructions
In Transolver.__init__, the preprocess MLP uses n_hidden*2 as hidden dim. Change to n_hidden*3.
Run with: `--wandb_name "nezuko/preprocess-3x" --wandb_group preprocess-3x --agent nezuko`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run**: `1bi0py6k` (nezuko/preprocess-3x, group: preprocess-3x)
**Epochs**: 77 (wall-clock stopped at 30.2 min; ~23s/epoch vs ~20s/epoch baseline)
**Peak memory**: 9.8 GB (vs ~7.6 GB baseline, +2.2 GB)

### Metrics at best checkpoint (epoch 74)

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.8529 | 0.324 | 0.199 | **26.5** |
| val_ood_cond | 1.6036 | 0.269 | 0.201 | **24.6** |
| val_ood_re | NaN | 0.291 | 0.211 | **33.6** |
| val_tandem_transfer | 4.6519 | 0.657 | 0.353 | **45.2** |

**val/loss**: 2.7028 vs baseline 2.6492 (+0.054, worse)

### Surface pressure comparison (mae_surf_p)

| Split | Baseline | Ours | Δ |
|---|---|---|---|
| val_in_dist | 24.77 | 26.5 | +1.7 ↑ worse |
| val_ood_cond | 22.25 | 24.6 | +2.4 ↑ **worse** |
| val_ood_re | 32.66 | 33.6 | +0.9 ↑ worse |
| val_tandem_transfer | 44.87 | 45.2 | +0.3 ↑ worse |

### What happened

Negative result. The 3x preprocess width (384 hidden) is worse across all four splits vs. the 2x baseline. It's also heavier (+2.2 GB memory) and slower per epoch (~23s vs ~20s), so the model gets only 77 epochs vs. ~90 for the baseline — less time to converge.

The wider preprocess MLP adds parameters to the input projection but at the cost of fewer training steps in the same wall-clock budget. Since this branch already uses a deeper preprocess (n_layers=1, res=True vs n_layers=0, res=False in vanilla Transolver), going wider on top of that doesn't help. The model is already expressive enough at 2x for this scale (n_hidden=128).

Notably, the worst degradation is on val_ood_cond (22.25 → 24.6, +2.4), the split where the baseline was actually quite strong. This suggests the wider/slower training can't generalize as well on extreme OOD conditions.

### Suggested follow-ups

1. **Undo the width increase, try deeper preprocess**: Instead of wider (2x→3x), try more layers (n_layers=2 or 3) in the preprocess MLP while keeping 2x width — depth may generalize better.
2. **Test 3x with more training budget**: If the run got 90+ epochs (longer T_max), would 3x recover? The 30-min limit may be penalizing larger models unfairly.
3. **Preprocess 1x (narrower)**: It's worth testing if 1x (n_hidden) is competitive — the preprocess might already be the bottleneck in a different way.