### PR TITLE
Orthogonal init gain=0.5 (smaller activations)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -265,7 +265,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.orthogonal_(module.weight, gain=0.5)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:


### PR DESCRIPTION
## Hypothesis
Orthogonal init gain=0.5 (smaller activations)

## Instructions
Change nn.init.orthogonal_(module.weight, gain=1.0) to gain=0.5.
Run with: `--wandb_name "alphonse/ortho-gain-05" --wandb_group ortho-gain-05 --agent alphonse`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** y4y4vvph  
**Run stopped at:** epoch 79/100 (30-min timeout, 78 epochs captured in W&B)  
**Peak GPU memory:** 8.8 GB (vs ~7.6 GB on similar runs — this branch has additional model parameters including placeholder_scale/shift)

### Metrics at best checkpoint (epoch 78)

| Metric | This run | Baseline (gain=1.0) | Δ |
|---|---|---|---|
| val/loss | 2.7755 | 2.6492 | +4.8% worse |
| val_in_dist/mae_surf_Ux | 0.317 | — | — |
| val_in_dist/mae_surf_Uy | 0.202 | — | — |
| val_in_dist/mae_surf_p | 26.18 | 24.77 | +5.7% worse |
| val_in_dist/mae_vol_p | 33.40 | — | — |
| val_ood_cond/mae_surf_p | 25.65 | 22.25 | **+15.3% worse** |
| val_ood_re/mae_surf_p | 33.47 | 32.66 | +2.5% worse |
| val_tandem_transfer/mae_surf_p | 47.21 | 44.87 | +5.2% worse |

### What happened

**gain=0.5 is uniformly worse than gain=1.0 baseline, especially on val_ood_cond (+15%).** The run was killed 22 epochs early, but the trend at epoch 78–79 shows the val metrics oscillating rather than improving (epoch 78 val_in_dist=1.84, epoch 79=1.93), suggesting convergence was nearly complete.

The val_ood_cond regression is the clearest signal: halving the orthogonal init scale hurts out-of-distribution condition generalization substantially. This likely happens because smaller initial weights reduce the effective capacity of each layer's projection early in training, causing the network to form weaker feature representations. Orthogonal init with gain=1.0 preserves the norm of forward-propagated signals; gain=0.5 systematically underscales, requiring the optimizer to compensate by growing weights more, which may introduce instability or worse minima.

The run was 22 epochs short, but given the late-epoch behavior (improvement slowing, some regression), the final gap with baseline would likely remain at 4–15%.

### Suggested follow-ups

- **gain=sqrt(2) (~1.41)**: Glorot-scaled orthogonal init, appropriate for ReLU activations. Could be the sweet spot between 1.0 and larger gains.
- **gain=1.0 remains the best tested setting** — negative result, gain=0.5 is worse.