### PR TITLE
Orthogonal init gain=sqrt(2) (ReLU-optimal)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -265,7 +265,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.orthogonal_(module.weight, gain=1.4142)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:


### PR DESCRIPTION
## Hypothesis
Orthogonal init gain=sqrt(2) (ReLU-optimal)

## Instructions
Change nn.init.orthogonal_(module.weight, gain=1.0) to gain=1.4142.
Run with: `--wandb_name "edward/ortho-gain-141" --wandb_group ortho-gain-141 --agent edward`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** kpu2pdny
**Epochs:** 81 (30-min wall-clock limit; slightly slower at 22s/epoch due to deeper preprocess MLP on this branch)
**Peak memory:** 8.8 GB

### Metrics at best checkpoint (epoch 80)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.684 | 0.294 | 0.184 | **23.18** | 33.75 |
| val_ood_cond | 1.639 | 0.286 | 0.202 | **24.00** | 25.56 |
| val_ood_re | NaN | 0.283 | 0.207 | **32.25** | 55.23 |
| val_tandem_transfer | 4.748 | 0.678 | 0.355 | **45.51** | 50.65 |
| **mean val/loss** | **2.690** | | | | |

### vs. Baseline (gain=1.0)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.6492 | 2.690 | +1.5% worse |
| val_in_dist/mae_surf_p | 24.77 | 23.18 | -6.4% better |
| val_ood_cond/mae_surf_p | 22.25 | 24.00 | +7.9% worse |
| val_ood_re/mae_surf_p | 32.66 | 32.25 | -1.3% better |
| val_tandem_transfer/mae_surf_p | 44.87 | 45.51 | +1.4% worse |

### What happened

Mixed result. In-distribution pressure improved by 6.4% and OOD Re by 1.3%, but OOD condition regressed 7.9%. Overall val/loss is 1.5% worse. The gain=sqrt(2) is theoretically motivated for ReLU-based networks (doubles variance to compensate for the ~50% dead neurons), but this network uses GELU activations. GELU kills fewer units than ReLU, so the sqrt(2) correction over-scales the initialization, which may explain the inconsistent performance across splits.

The split-dependent behavior (in-dist improves, ood_cond regresses) suggests the higher gain creates a more aggressive initial feature extractor that fits in-distribution patterns better but generalizes less well to the extreme AoA/gap/stagger conditions in ood_cond.

Note: val_ood_re/loss is NaN throughout — pre-existing issue.

### Suggested follow-ups

- Try gain=1.2 as a compromise between 1.0 and sqrt(2) — GELU has less dead-unit suppression than ReLU so a smaller correction may be more appropriate
- The inconsistency between splits (in-dist improved, ood_cond regressed) suggests this is marginal and may not be worth pursuing further
- If the goal is purely in-dist improvement, gain=1.4142 is promising, but for generalization gain=1.0 appears more stable