### PR TITLE
Cosine eta_min=1e-5 (productive final epochs)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -489,7 +489,7 @@ class Lookahead:
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
Cosine eta_min=1e-5 (productive final epochs)

## Instructions
Add eta_min=1e-5 to CosineAnnealingLR constructor.
Run with: `--wandb_name "thorfinn/eta-min-1e5" --wandb_group eta-min-1e5 --agent thorfinn`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** `c6p7asf0` (thorfinn/eta-min-1e5)
**Best checkpoint:** epoch 81 / 81 (hit 30-min timeout)
**Peak memory:** 8.8 GB (vs 7.6 GB typical — this branch has a deeper preprocessor MLP)

### Metrics at best checkpoint (val/loss = 2.6346)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 0.318 | 0.184 | **23.78** | -4.0% better |
| val_ood_cond | 0.284 | 0.194 | **25.49** | +14.5% worse |
| val_ood_re | — | — | **33.06** | +1.2% worse |
| val_tandem_transfer | 0.651 | 0.345 | **43.67** | -2.7% better |

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.6346 | 2.6492 | -0.6% better |

Volume MAE (pressure): in_dist=32.3, ood_re=55.5, tandem=48.0

Note: `val_ood_re` had NaN loss every epoch, excluded from mean val/loss.

### What happened

Mixed result. The val/loss improved marginally (-0.6%), and in_dist (-4.0%) and tandem (-2.7%) pressure MAEs improved. However, ood_cond pressure regressed sharply (+14.5%, from 22.25 → 25.49). The model ran only 81 epochs due to the 30-min timeout — this branch's deeper preprocessor (MLP with n_layers=1, res=True vs default 0/False) uses more memory (8.8 GB vs 7.6 GB) and is slightly slower, reducing the epoch count.

The ood_cond regression is the main concern. The eta_min=1e-5 is intended to keep the LR productive in the final epochs rather than decaying to near-zero. However, a non-zero LR floor can cause oscillation near the final optimum, which hurts generalization on challenging OOD splits. It's also possible the 81 vs 87-91 epoch difference accounts for the ood_cond degradation — the model simply had fewer epochs to optimize.

The 8.8 GB memory usage is notably higher than baseline. This appears to be due to architectural changes on this branch, not the eta_min change itself.

### Suggested follow-ups

- **Combine eta_min with more epochs:** If the 30-min limit allows ~85+ epochs on the faster baseline architecture, eta_min=1e-5 might show cleaner improvements. The fewer epochs here confound the result.
- **eta_min=1e-4 as a compromise:** A slightly higher floor might avoid the oscillation issue while still preventing near-zero LR.
- **Isolate the memory increase:** The deeper preprocessor adds 1.2 GB of memory. Confirming this is the architecture's doing (not eta_min) would clarify the tradeoff.