### PR TITLE
Progressive resolution transition at epoch 30

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -574,9 +574,9 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
 
         # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+        # Ramps from 5% → 100% of volume nodes over first 30 epochs
+        if epoch < 30:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / 30)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
Progressive resolution transition at epoch 30

## Instructions
Change the progressive resolution epoch threshold from 40 to 30.
Run with: \`--wandb_name "askeladd/progres-ep30" --wandb_group progres-ep30 --agent askeladd\`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** \`i2achwem\`
**Epochs completed:** 79 (terminated at 30-minute timeout)
**Peak GPU memory:** ~23.6 GB (25% of 96 GB)

### Metrics at best val/loss

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.6504 | 2.6492 | **+0.001** (~tie) |
| val_in_dist/mae_surf_p | 23.63 | 24.77 | **-1.14** ✓ |
| val_ood_cond/mae_surf_p | 24.13 | 22.25 | **+1.88** ✗ |
| val_ood_re/mae_surf_p | 32.96 | 32.66 | +0.30 |
| val_tandem_transfer/mae_surf_p | 43.40 | 44.87 | **-1.47** ✓ |
| val_in_dist/mae_surf_Ux | 0.307 | — | — |
| val_in_dist/mae_surf_Uy | 0.192 | — | — |
| val_in_dist/mae_vol_Ux | 1.572 | — | — |
| val_in_dist/mae_vol_p | 31.54 | — | — |

### What happened

The overall val/loss is essentially unchanged (+0.001), but the per-split results show a clear trade-off: the earlier transition (epoch 30 vs 40) improves in_dist (−1.14 Pa) and tandem_transfer (−1.47 Pa) but hurts ood_cond (+1.88 Pa).

The ood_cond regression is a concern. Transitioning to full-volume training earlier may reduce the amount of fine-grained surface-driven learning, which ood_cond relies on for condition generalization. The 40-epoch ramp gives more time for the model to focus on surface-driven gradients before switching to full volume training — removing 10 epochs of that appears to hurt ood_cond.

The combined val/loss doesn't distinguish between splits, so the apparent tie hides this trade-off. Given that ood_cond regressed significantly, epoch 30 is not a clear win.

### Suggested follow-ups

- Try epoch 50 as the transition to see if even slower ramp continues the improvement in in_dist/tandem without hurting ood_cond.
- The trade-off between in_dist and ood_cond is interesting — it may indicate that faster vs slower volume training emphasis is a genuine design choice, not just a noise effect.
- Try a different starting ratio (e.g., 1% instead of 5%) to give even more surface focus in the early epochs.