### PR TITLE
Progressive resolution transition at epoch 50

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -574,9 +574,9 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
 
         # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+        # Ramps from 10% → 100% of volume nodes over first 50 epochs
+        if epoch < 50:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / 50)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
Progressive resolution transition at epoch 50

## Instructions
Change the progressive resolution epoch threshold from 40 to 50.
Run with: `--wandb_name "violet/progres-ep50" --wandb_group progres-ep50 --agent violet`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** l8w8qp2m (violet/progres-ep50)
**Epochs completed:** 88 (30-min timeout; best epoch: 80)
**Peak memory:** 7.8 GB

### Metrics at best epoch (val/loss=2.6601)

| Split | mae_surf_p | Δ vs baseline |
|---|---|---|
| val_in_dist | 23.71 | **-1.06** |
| val_tandem_transfer | 44.69 | -0.18 |
| val_ood_cond | 24.22 | +1.97 |
| val_ood_re | 32.17 | -0.49 |

**val/loss: 2.6601** vs baseline 2.6492 (Δ = **+0.011**, slightly worse)

W&B best_best summary (val_in_dist): mae_surf_Ux=0.308, mae_surf_Uy=0.187, mae_surf_p=23.71; mae_vol_Ux=1.584, mae_vol_Uy=0.569, mae_vol_p=34.00

### What happened
Extending the transition from 40→50 epochs did not improve overall val/loss (+0.011 vs baseline). The results are mixed: val_in_dist surface pressure improved notably (-1.06 Pa) but val_ood_cond got worse (+1.97 Pa), which is unusual since the two often move together. This may be noise — the difference from baseline is small in both val/loss and per-split MAEs.

The longer progressive window keeps the model in a lower-fidelity regime for more of training, which may slightly hurt OOD generalization (the model sees less full-volume signal during conditioning phases). Epoch 40 appears to be near the sweet spot for this dataset and model size.

### Suggested follow-ups
- Try epoch 30 threshold (shorter transition) to see if faster full-resolution convergence helps.
- The mixed split results suggest this hyperparameter may interact with other settings; could be worth revisiting once other improvements (e.g., placeholder scale+shift) are merged.