### PR TITLE
Multi-scale coarse pool_size=128

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -592,7 +592,7 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
+        coarse_pool_size = 128
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:


### PR DESCRIPTION
## Hypothesis
Multi-scale coarse pool_size=128

## Instructions
Change coarse_pool_size = 64 to coarse_pool_size = 128.
Run with: `--wandb_name "gilbert/coarse-pool-128" --wandb_group coarse-pool-128 --agent gilbert`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** `5a97sqll` — gilbert/coarse-pool-128

**Best epoch:** 80 of 81 (30.0 min, wall-clock limit)
**Peak memory:** 8.8 GB (vs ~7.8 GB at pool_size=64)

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.778 | 0.316 | 0.190 | **24.37** | 1.610 | 0.573 | 33.05 |
| val_ood_cond | 1.629 | — | — | **25.9** | — | — | — |
| val_ood_re | nan | — | — | **32.9** | — | — | — |
| val_tandem_transfer | 4.643 | — | — | **44.9** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.6833** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.6492 | 2.6833 | +0.034 ❌ |
| val_in_dist/mae_surf_p | 24.77 | 24.37 | −0.40 ✅ |
| val_ood_cond/mae_surf_p | 22.25 | 25.9 | +3.65 ❌ |
| val_ood_re/mae_surf_p | 32.66 | 32.9 | +0.24 (neutral) |
| val_tandem_transfer/mae_surf_p | 44.87 | 44.9 | +0.03 (neutral) |

### What happened

Negative result. The coarser pooling (pool_size=128 vs 64) significantly hurt `val_ood_cond` pressure MAE (+3.65) while providing only a small gain on `val_in_dist` (−0.40). Overall val/loss is slightly worse.

The larger pool groups fewer, coarser tokens from the sequence. This means:
1. The coarse supervision signal captures only very-low-frequency structure — too coarse to guide the model toward smooth field patterns at OOD conditions.
2. With pool_size=128, `n_groups = N // 128` gives fewer coarse tokens, reducing the effective amount of coarse-scale gradient signal.
3. Peak memory increased to 8.8 GB (from ~7.8 GB) due to the larger pool operations, with only 81 epochs completed vs ~88 at pool_size=64.

The pool_size=64 baseline appears to be a better choice — it captures meaningful spatial averaging at a scale that helps rather than hurts generalization.

Note: `val_ood_re/loss` is NaN throughout — pre-existing issue.

### Suggested follow-ups

- **Pool_size=32**: Go the other direction — finer pooling may give more informative coarse supervision. The baseline was 64; smaller may help.
- **Multi-scale at both 32 and 128**: Use two coarse losses at different scales rather than one.
- **Adaptive pooling**: Pool by surface vs volume separately rather than uniform spatial groups.