### PR TITLE
Multi-scale coarse pool_size=32

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -592,7 +592,7 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
+        coarse_pool_size = 32
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:


### PR DESCRIPTION
## Hypothesis
Multi-scale coarse pool_size=32

## Instructions
Change coarse_pool_size = 64 to coarse_pool_size = 32.
Run with: `--wandb_name "senku/coarse-pool-32" --wandb_group coarse-pool-32 --agent senku`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** `0q8knhp5` (senku/coarse-pool-32)
**Epochs completed:** 79/100 (30-min timeout; ~22s/epoch vs ~20s for pool_size=64)
**Peak memory:** 8.8 GB (vs 7.6 GB baseline — +1.2 GB)

### Metrics vs Baseline (best checkpoint, step 76 / epoch 77)

| Metric | Baseline | This run (best) | Delta |
|---|---|---|---|
| val/loss | 2.6492 | 2.6618 | +0.013 (slightly worse) |
| val_in_dist/mae_surf_p | 24.77 | 25.37 | +0.60 (slightly worse) |
| val_ood_cond/mae_surf_p | 22.25 | 23.00 | +0.75 (worse) |
| val_ood_re/mae_surf_p | 32.66 | 32.51 | -0.15 (slightly better) |
| val_tandem_transfer/mae_surf_p | 44.87 | 44.79 | -0.08 (similar) |

Last epoch (79) metrics: val/loss=2.6958, val_in_dist/mae_surf_p=26.06, val_ood_cond/mae_surf_p=22.36

Surface MAE (best epoch, val_in_dist): Ux=0.333, Uy=0.207, p=25.37
Volume MAE (last epoch, val_in_dist): Ux=1.56, Uy=0.56, p=32.95

### What happened

Reducing pool_size from 64 to 32 did not improve results. The baseline (pool_size=64) is slightly better overall, and pool_size=32 costs more memory (+1.2 GB) and more compute per epoch (~22s vs ~20s), resulting in fewer epochs completed within the timeout (79 vs 88).

The smaller pool size creates more coarse groups (more spatial averaging buckets), but each group averages fewer nodes (32 vs 64). This doesn't appear to improve the multi-scale signal quality -- the coarser spatial groupings with 64 nodes per bucket may already capture the relevant large-scale structure in the flow field.

Note: the run only completed 79 epochs at timeout vs 88 for pool_size=64, so comparison is not perfectly fair. However, the trend at epoch 77 (best) is not better than baseline.

Memory cost: +1.2 GB (7.6 → 8.8 GB). Not OOM, but a clear regression without benefit.

### Suggested follow-ups
- Try **pool_size=128** -- perhaps coarser groupings capture larger flow structures better.
- Try **variable coarse_pool_size** that grows with epoch (coarser early, finer late) to match progressive resolution.
- The +1 GB memory cost of any pool_size variant may not be worth it unless it gives >1 point surf_p improvement.