### PR TITLE
Target noise 0.015 (between 0.01 and 0.02)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -563,7 +563,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            y_norm = y_norm + 0.015 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Target noise 0.015 (between 0.01 and 0.02)

## Instructions
Change target noise from 0.01 to 0.015.
Run with: `--wandb_name "kohaku/noise-0015" --wandb_group noise-0015 --agent kohaku`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** 3ari0ouh | **Status:** Timed out at epoch 79/100 | **Peak memory:** 8.8 GB | **Epoch time:** ~22s

### Metrics at best val/loss (epoch ~78)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 25.64 | 24.77 (+0.9, **+3.5%**) |
| val_ood_cond | 27.40 | 22.25 (+5.2, **+23% worse**) |
| val_ood_re | 34.64 | 32.66 (+2.0, **+6% worse**) |
| val_tandem_transfer | 45.02 | 44.87 (+0.2, essentially same) |

- **val/loss (best): 2.732** vs baseline 2.649 (+3.1% worse)
- val_in_dist/mae_surf_Ux: 0.323, val_in_dist/mae_surf_Uy: 0.194
- val_in_dist/mae_vol_p: 33.31

### What happened

Noise=0.015 is worse than the baseline (noise=0.01) across all metrics. The most notable regression is val_ood_cond/mae_surf_p (+5.2 Pa, +23%), which is the primary OOD metric the advisor cares about.

The run completed 79 epochs in 30 minutes (~22s/epoch — slightly slower than other runs, likely due to extra features in this branch). The training was still converging at epoch 79, but the gap vs baseline was large enough (especially on val_ood_cond) that more epochs wouldn't close it.

Noise=0.015 injects ~50% more target noise than the baseline 0.01. This causes the model to optimize for a slightly corrupted target distribution, which hurts OOD generalization — particularly for the val_ood_cond distribution where accurate pressure prediction requires precise fitting. The additional noise acts as an overly strong label-smoothing effect, preventing the model from learning sharp pressure gradients.

Combined with the earlier result that noise=0.005 was essentially equivalent to noise=0.01, the data suggests:
- noise ≤ 0.01 → roughly equivalent results
- noise = 0.015 → clearly worse

The sweet spot appears to be at or below 0.01.

### Suggested follow-ups
- **Noise=0.0 re-test**: Prior experiments showed noise=0.0 hurt vs 0.01, but the baseline has improved significantly since then. Worth re-testing whether the current stronger baseline model still benefits from any noise.
- **Noise=0.01 is the current optimum**: Given 0.005 ≈ 0.01 and 0.015 > 0.01 (worse), the noise search around 0.01 seems saturated. Other hyperparameters are likely more impactful.