### PR TITLE
Placeholder shift init=0.1 (nonzero bias)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -257,7 +257,7 @@ class Transolver(nn.Module):
         )
         self.initialize_weights()
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
-        self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
+        self.placeholder_shift = nn.Parameter(torch.full((n_hidden,), 0.1))
 
     def initialize_weights(self):
         self.apply(self._init_weights)


### PR DESCRIPTION
## Hypothesis
Placeholder shift init=0.1 (nonzero bias)

## Instructions
Change placeholder_shift init from torch.zeros to torch.full(..., 0.1).
Run with: `--wandb_name "emma/placeholder-shift-01" --wandb_group placeholder-shift-01 --agent emma`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run ID:** 20nq2r24  
**Best epoch:** 81 (run completed 81 epochs in 30 min; ~22s/epoch)  
**Peak GPU memory:** 8.8 GB  

### val/loss (combined)
| | Baseline | Shift=0.1 | Delta |
|---|---|---|---|
| val/loss | 2.6492 | **2.6570** | +0.008 ❌ |

### Surface MAE
| Split | Metric | Baseline | Shift=0.1 | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 24.77 | **23.62** | -1.15 ✅ |
| val_ood_cond | mae_surf_p | 22.25 | 25.21 | +2.96 ❌ |
| val_ood_re | mae_surf_p | 32.66 | **32.51** | -0.15 ✅ |
| val_tandem_transfer | mae_surf_p | 44.87 | **43.68** | -1.19 ✅ |

**Surface MAE (Ux, Uy, p) at best epoch:**
- val_in_dist: Ux=0.313, Uy=0.183, p=23.62
- val_ood_cond: Ux=0.291, Uy=0.199, p=25.21
- val_ood_re: Ux=0.295, Uy=0.205, p=32.51
- val_tandem_transfer: Ux=0.651, Uy=0.348, p=43.68

**Volume MAE (Ux, Uy, p) at best epoch:**
- val_in_dist: Ux=1.601, Uy=0.566, p=32.54
- val_ood_cond: Ux=1.397, Uy=0.531, p=26.80
- val_ood_re: Ux=1.288, Uy=0.528, p=55.07
- val_tandem_transfer: Ux=2.431, Uy=1.124, p=48.96

### What happened

Mixed result, slightly negative overall. The val/loss of 2.6570 is 0.008 worse than baseline. Three of four surface pressure splits improved (in_dist -1.15, ood_re -0.15, tandem -1.19), but val_ood_cond regressed significantly (+2.96). The combined val/loss is slightly worse.

The divergence in val_ood_cond is concerning and hard to explain from initialization alone. Possible explanations: (1) the nonzero bias breaks the symmetry differently across training runs and the baseline happened to be favorable for ood_cond; (2) the initial placeholder_shift=0.1 biases the feature space in a direction that helps in-distribution but hurts out-of-distribution generalization; (3) run-to-run variance — with only 81 epochs completed there's noise in the final metrics.

The 8.8 GB peak memory is higher than expected for a pure initialization change. This likely reflects the updated noam architecture (the branch was rebased onto a more recent noam that includes more features), not the shift init itself.

### Suggested follow-ups
- **Rerun to check variance**: the ood_cond regression may be noise; a second run with shift=0.1 would confirm
- **Smaller init**: try shift=0.01 — a smaller but nonzero bias might help without breaking ood generalization
- **Negative init**: try shift=-0.1 to explore the direction space
- **scale_init**: instead of (or in addition to) shift, try initializing placeholder_scale to something other than ones, e.g., 1.1 or 0.9