### PR TITLE
Surf weight ramp 3→25 (gentler)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -542,7 +542,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    sw_start, sw_end = 3.0, 25.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
Surf weight ramp 3→25 (gentler)

## Instructions
Change sw_start, sw_end = 5.0, 30.0 to 3.0, 25.0.
Run with: `--wandb_name "norman/surf-ramp-3-25" --wandb_group surf-ramp-3-25 --agent norman`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** `a3luruym` | 81 epochs | Peak memory: 8.8 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.6492 | **2.6346** | −0.6% ✓ |
| val_in_dist/mae_surf_p | 24.77 | **22.69** | −8.4% ✓ |
| val_ood_cond/mae_surf_p | 22.25 | **25.24** | +13.4% ✗ |
| val_ood_re/mae_surf_p | 32.66 | **31.89** | −2.4% ✓ |
| val_tandem_transfer/mae_surf_p | 44.87 | **44.40** | −1.0% ✓ |
| val_in_dist/mae_surf_Ux | — | 0.289 | |
| val_in_dist/mae_surf_Uy | — | 0.184 | |
| val_ood_cond/mae_surf_Ux | — | 0.299 | |
| val_ood_cond/mae_surf_Uy | — | 0.201 | |
| val_ood_re/mae_surf_Ux | — | 0.287 | |
| val_ood_re/mae_surf_Uy | — | 0.203 | |
| val_tandem_transfer/mae_surf_Ux | — | 0.652 | |
| val_tandem_transfer/mae_surf_Uy | — | 0.348 | |

### What happened

Mixed result. Overall val/loss improved slightly (−0.6%) and 3 of 4 splits showed surface pressure improvement. However, val_ood_cond regressed significantly (+13.4%). The baseline for this split was unusually good (22.25), so some regression may reflect variance, but the magnitude is concerning.

The gentler ramp (starting lower at 3 and ending lower at 25) means surface is weighted less aggressively throughout training compared to the baseline (5→30). This produces a trade-off: val_in_dist benefits (−8.4%, likely because more balanced vol/surf gradient allows better feature learning), while val_ood_cond suffers (the ood_cond split may specifically benefit from strong surface pressure supervision). val_ood_re and val_tandem_transfer improved modestly.

The net effect is a marginal overall improvement, but with an uneven split between the 4 tracks.

### Suggested follow-ups

- The ood_cond degradation with lower surface weight is notable. Try a split ramp — lower start but still reach 30 at the end (e.g., 3→30) to see if the low start alone is beneficial without sacrificing the final push.
- The val_in_dist improvement with lower surface weight contrasts with val_ood_cond degradation — this split-specific behavior suggests the optimal surf_weight may differ by condition type. A validation-driven adaptive surface weight could help.