### PR TITLE
Surf weight ramp 8→35 (more aggressive)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -541,8 +541,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    # Dynamic surface weight: linear ramp from 8 → 35 over training
+    sw_start, sw_end = 8.0, 35.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
Surf weight ramp 8→35 (more aggressive)

## Instructions
Change sw_start, sw_end = 5.0, 30.0 to 8.0, 35.0.
Run with: `--wandb_name "chihiro/surf-ramp-8-35" --wandb_group surf-ramp-8-35 --agent chihiro`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** `tw1vf1d8` | **Best epoch:** 79 | **Peak VRAM:** 7.6 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.664 | 0.276 | 0.190 | **22.34** | 32.67 |
| val_ood_cond | 1.614 | 0.280 | 0.201 | **23.68** | 26.29 |
| val_ood_re | NaN | 0.286 | 0.209 | **32.57** | 55.91 |
| val_tandem_transfer | 4.621 | 0.665 | 0.351 | **44.52** | 49.92 |
| **combined** | **2.6330** | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.6492 | **2.6330** | **-0.016 (beats baseline ✓)** |
| val_in_dist/mae_surf_p | 24.77 | **22.34** | **-2.43 (large improvement)** |
| val_ood_cond/mae_surf_p | 22.25 | **23.68** | +1.43 (regression) |
| val_ood_re/mae_surf_p | 32.66 | **32.57** | -0.09 (essentially same) |
| val_tandem_transfer/mae_surf_p | 44.87 | **44.52** | -0.35 (slight improvement) |

### What happened

**The more aggressive ramp beats the baseline.** val/loss improves from 2.6492 → 2.6330 and val_in_dist pressure improves substantially (22.34 vs 24.77, -2.43 Pa). Val_ood_re and val_tandem also slightly improve.

The val_ood_cond regression (+1.43 Pa) is the main downside. The more aggressive surface emphasis starting higher (8 vs 5) and ending higher (35 vs 30) pushes the model to fit surface nodes harder, which helps the interpolation regime (val_in_dist) but slightly hurts the OOD conditioning split. This tradeoff suggests the two splits prefer different surface weight levels: ood_cond does well with the old 5→30 schedule, while in_dist improves with the more aggressive 8→35.

Overall, val/loss and surface pressure averaged across splits favor the 8→35 ramp.

Val_ood_re NaN persists (pre-existing issue).

### Suggested follow-ups

- **Try 5→35** (keep the low start, push the end higher) to get in_dist improvement without the ood_cond regression
- **Try 8→30** (raise start only) to see which end of the ramp matters more for ood_cond
- **Per-dataset-type surface weights**: the regression on ood_cond with the more aggressive ramp confirms that different regimes prefer different weights — this motivates the learned SW idea