### PR TITLE
Weight decay 2e-4 (slightly stronger regularization)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -336,7 +336,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 2e-4
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
Weight decay 2e-4 provides a middle ground between current 1e-4 (too weak?) and previously failed 3e-4 (too strong).

## Instructions
Change `weight_decay: float = 1e-4` to `weight_decay: float = 2e-4` in Config.
Run with: `--wandb_name "haku/wd-2e4" --wandb_group wd-2e4 --agent haku`

## Baseline
- val/loss: **2.6492**
- val_in_dist/mae_surf_p: 24.77
- val_ood_cond/mae_surf_p: 22.25
- val_ood_re/mae_surf_p: 32.66
- val_tandem_transfer/mae_surf_p: 44.87

---

## Results

**W&B run:** mxla57q4  
**Epochs completed:** 78/100 (30-minute timeout hit during epoch 79)  
**Peak GPU memory:** 8.8 GB

### Metrics at best checkpoint (epoch 77, val/loss = 2.6675)

| Metric | wd=2e-4 | Baseline (wd=1e-4) | Delta |
|--------|---------|-------------------|-------|
| val/loss | **2.6675** | 2.6492 | +0.7% worse |
| val_in_dist/mae_surf_p | **24.57** | 24.77 | -0.8% better |
| val_ood_cond/mae_surf_p | 23.78 | **22.25** | +6.9% worse |
| val_ood_re/mae_surf_p | 33.21 | **32.66** | +1.7% worse |
| val_tandem_transfer/mae_surf_p | **44.19** | 44.87 | -1.5% better |
| val_in_dist/mae_surf_Ux | 0.2964 | — | — |
| val_in_dist/mae_surf_Uy | 0.1872 | — | — |
| val_in_dist/mae_vol_p | 32.94 | — | — |

### What happened

**Negative result overall.** The combined val/loss is slightly worse, and the critical val_ood_cond/mae_surf_p degraded by 6.9% (23.78 vs 22.25). The in-distribution and tandem splits improved marginally, but the OOD splits got worse.

Key observations:
- The val_ood_cond regression (+6.9%) is the most concerning finding. This is a generalization metric, and the stronger weight decay appears to over-regularize the model for out-of-distribution conditions. The model becomes more conservative in-distribution but less adaptive OOD.
- val_in_dist/mae_surf_p improved slightly (24.57 vs 24.77, -0.8%) — the stronger regularization does help in-distribution slightly.
- The asymmetry between in-dist improvement and OOD degradation suggests wd=2e-4 pushes the model toward the in-distribution manifold at the expense of OOD generalization.
- The run reached only 78 epochs vs the baseline's ~88 epochs (epochs take 22s vs ~20s due to the additional coarse_loss computation), so direct comparison is slightly unfair — but the trend at the best checkpoint is clearly unfavorable.

The current wd=1e-4 remains the better choice. The hypothesis that 1e-4 is "too weak" is not supported.

### Suggested follow-ups

1. **wd=5e-5** — test if even lighter regularization helps OOD generalization further
2. **Decoupled weight decay** — apply stronger wd only to the embedding layers, not the prediction head
3. **L1 regularization on the output head** — might be more appropriate than L2 for surface pressure prediction