### PR TITLE
Random Fourier features on position (multi-scale spatial encoding)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -23,6 +23,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import sys
 from pathlib import Path
 
@@ -440,9 +441,12 @@ _pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min
 phys_stats = {"y_mean": _pmean, "y_std": _pstd}
 print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
+# Random Fourier Features: project 2D position into 64-dim frequency space
+fourier_B = torch.randn(2, 32) * 10  # frozen, shape [2, 32]
+
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 64,  # 22 + 64 RFF features; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -454,6 +458,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
+fourier_B = fourier_B.to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -559,6 +564,10 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        pos = x[:, :, :2]
+        ff = torch.cat([torch.sin(2 * math.pi * pos @ fourier_B),
+                        torch.cos(2 * math.pi * pos @ fourier_B)], dim=-1)
+        x = torch.cat([x, ff], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -648,6 +657,10 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
+                pos = x[:, :, :2]
+                ff = torch.cat([torch.sin(2 * math.pi * pos @ fourier_B),
+                                torch.cos(2 * math.pi * pos @ fourier_B)], dim=-1)
+                x = torch.cat([x, ff], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Random Fourier features on position (multi-scale spatial encoding)

## Instructions
Before preprocess MLP, add random Fourier features on pos (x[:,:,:2]): create frozen B=torch.randn(2,32)*10, compute ff=cat(sin(2pi*pos@B), cos(2pi*pos@B)), concat to x, update fun_dim from 22 to 86.

Run with: `--wandb_name "frieren/fourier-features" --wandb_group fourier-features --agent frieren`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** `ergflryh` (frieren/fourier-features)
**Epochs completed:** 76/100 (hit 30-min timeout)
**n_params:** 258,983 (vs ~176,679 baseline; +47% from larger preprocess MLP)
**Peak GPU memory:** ~36.6 GB (38.2% of 96 GB)

### Metrics at best val/loss epoch

| Metric | Baseline | RFF | Delta |
|--------|----------|-----|-------|
| val/loss | 2.6346 | **2.8875** | +9.6% |
| val_in_dist/mae_surf_p | 23.78 | **27.99** | +17.7% |
| val_ood_cond/mae_surf_p | 25.49 | **27.94** | +9.6% |
| val_ood_re/mae_surf_p | 33.06 | **35.92** | +8.6% |
| val_tandem_transfer/mae_surf_p | 43.67 | **47.43** | +8.6% |

Surface MAE (in-dist): Ux=0.34, Uy=0.21, p=27.99
Volume MAE (in-dist): Ux=1.81, Uy=0.67, p=36.85

### What happened

Random Fourier features made things worse across all splits. There are a few contributing factors:

1. **Epoch count penalty**: Adding 64 RFF dims to x expands the preprocess MLP input from 24 to 88, increasing its parameter count. The model became ~47% larger (258k vs 177k params), and only reached 76/100 epochs vs baseline's ~88.

2. **Redundant position encoding**: The raw xy coordinates are already in x[:,:,:2]. Transolver's slice-based attention mechanism is designed to learn spatial structure from these. Adding an explicit frequency expansion of the same coordinates may cause the model to learn competing representations rather than benefiting from the additional frequencies.

3. **Scale factor sensitivity**: The B matrix scale of 10 is a hyperparameter that was not tuned. In normalized coordinate space (roughly [-2, 2] for this dataset), frequencies of 10 may produce aliased features or saturate the sin/cos encodings. The optimal scale depends on the actual spatial frequency content of the CFD fields.

4. **Frozen B is a design choice**: Unlike learnable positional encodings (e.g., rotary PE), the random frozen B can't adapt to the data. A random seed that happens to misalign with the mesh structure would consistently add noise.

### Suggested follow-ups

- If RFF encoding is worth exploring, tuning the scale factor (e.g., B*1, B*5, B*20) or using a learnable linear projection instead of random frozen B would be stronger variants.
- The Transolver architecture may already be effectively computing spatial embeddings through its attention mechanism — the marginal value of explicit positional encodings may be low here.
- Using a smaller fun_dim expansion (e.g., 8 or 16 frequencies instead of 32) would reduce the epoch penalty while still testing the hypothesis.