### PR TITLE
Predict residual from spatial mean (anomaly prediction)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -565,11 +565,15 @@ for epoch in range(MAX_EPOCHS):
         if model.training:
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
+        # Predict residual from spatial mean (anomaly prediction)
+        y_mean_spatial = (y_norm * mask.unsqueeze(-1)).sum(1, keepdim=True) / mask.float().sum(1, keepdim=True).unsqueeze(-1).clamp(min=1)
+        y_target = y_norm - y_mean_spatial
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
         pred = pred.float()
-        sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        sq_err = (pred - y_target) ** 2
+        abs_err = (pred - y_target).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -598,7 +602,7 @@ for epoch in range(MAX_EPOCHS):
         if n_groups > 1:
             # Pool predictions and targets over groups of 64 nodes
             pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
+            y_trunc = y_target[:, :n_groups * coarse_pool_size]
             mask_trunc = mask[:, :n_groups * coarse_pool_size]
 
             pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
@@ -652,11 +656,15 @@ for epoch in range(MAX_EPOCHS):
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
+                # Predict residual from spatial mean (anomaly prediction)
+                y_mean_spatial = (y_norm * mask.unsqueeze(-1)).sum(1, keepdim=True) / mask.float().sum(1, keepdim=True).unsqueeze(-1).clamp(min=1)
+                y_target = y_norm - y_mean_spatial
+
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
                 pred = pred.float()
-                sq_err = (pred - y_norm) ** 2
-                abs_err = (pred - y_norm).abs()
+                sq_err = (pred - y_target) ** 2
+                abs_err = (pred - y_target).abs()
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
@@ -667,8 +675,8 @@ for epoch in range(MAX_EPOCHS):
                 val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
-                # Denormalize: phys_stats → Cp space → original scale
-                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                # Denormalize: add spatial mean back to pred, then phys_stats → Cp space → original scale
+                pred_phys = (pred + y_mean_spatial) * phys_stats["y_std"] + phys_stats["y_mean"]
                 pred_orig = _phys_denorm(pred_phys, Umag, q)
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()


### PR DESCRIPTION
## Hypothesis
Predict residual from spatial mean (anomaly prediction)

## Instructions
After y_norm, compute y_mean_spatial=(y_norm*mask.unsqueeze(-1)).sum(1,keepdim=True)/mask.sum(1,keepdim=True).clamp(min=1). Train on y_target=y_norm-y_mean_spatial. At val time, add y_mean_spatial back for denorm. ~10 lines.

Run with: `--wandb_name "fern/predict-residual" --wandb_group predict-residual --agent fern`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** `wmqszqd0` | **Epochs:** 81/100 (30.1 min) | **Peak memory:** 8.8 GB (vs ~7.8 GB baseline, +1 GB)

**Implementation note:** The PR instruction had a broadcasting bug: `mask.sum(1, keepdim=True)` gives shape `[B, 1]` but the numerator is `[B, 1, C]`. Fixed to `mask.float().sum(1, keepdim=True).unsqueeze(-1).clamp(min=1)`.

### Validation loss
| Split | Baseline | Residual | Δ |
|---|---|---|---|
| val/loss (mean 3 splits) | 2.6346 | 2.8369 | +7.7% worse |
| val_in_dist | — | 1.8465 | — |
| val_ood_cond | — | 1.6573 | — |
| val_ood_re | — | nan (vol_loss=1.9e10) | pre-existing |
| val_tandem_transfer | — | 5.0069 | — |

### Surface MAE pressure (primary metric)
| Split | Baseline mae_surf_p | Residual mae_surf_p | Δ |
|---|---|---|---|
| val_in_dist | 23.78 | 26.13 | +9.9% worse |
| val_ood_cond | 25.49 | 25.17 | -1.3% flat |
| val_ood_re | 33.06 | **931.8** | **+2715% catastrophic failure** |
| val_tandem_transfer | 43.67 | 46.50 | +6.5% worse |

### Surface MAE (Ux, Uy, p) at best checkpoint
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.30 | 0.22 | 26.13 |
| val_ood_cond | 0.28 | 0.21 | 25.17 |
| val_ood_re | 0.29 | 0.24 | **931.8** |
| val_tandem_transfer | 0.64 | 0.46 | 46.50 |

### Volume MAE at best checkpoint
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.62 | 0.59 | 37.17 |
| val_ood_cond | 1.36 | 0.54 | 27.88 |
| val_ood_re | 1.28 | 0.53 | **1026.9** |
| val_tandem_transfer | 2.46 | 1.18 | 52.50 |

### What happened

**Residual prediction completely failed for val_ood_re (mae_surf_p=932 vs baseline 33).** In-dist and ood_cond are slightly worse; only ood_cond is approximately flat.

**Root cause**: For val_ood_re (Re=4.445M, well out-of-distribution), the model cannot predict the spatial residuals correctly. The approach removes the spatial mean from the target, so the model must predict the deviation from the flow's mean state. For in-distribution samples, this simplifies the task (smaller prediction range). For val_ood_re, however, the spatial structure of residuals is completely different (high Re creates different pressure gradients and velocity profiles), and the model predicts wrong residuals. When `y_mean_spatial` is added back at denorm time, the errors compound rather than cancel.

Without residual prediction (baseline), the model can partially generalize to OOD Re by predicting the bulk flow values, even if imperfectly. With residual prediction, the model only predicts deviations, losing the ability to anchor predictions to the correct magnitude.

**Also notable**: the approach uses 1 GB more memory (8.8 vs 7.8 GB) due to storing `y_mean_spatial` and `y_target`.

### Suggested follow-ups
- **Provide mean as auxiliary input**: Instead of using spatial mean as a target transform, pass `y_mean_spatial` as a conditioning input to the model (`x` features). This lets the model use the mean as context without losing it from the target.
- **Instance normalization as the mean**: Rather than spatial mean per sample, use a learned or statistics-based mean per domain/dataset. This would be more stable for OOD samples.
- **Restrict residual to surface nodes only**: Compute `y_mean_spatial` only from surface nodes (surf_mask), then subtract only for surface loss. This avoids the OOD failure mode while potentially improving surface prediction.