### PR TITLE
Separate velocity and pressure output heads

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -181,17 +181,23 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
+            self.vel_head = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
+                nn.Linear(hidden_dim, 2),
+            )
+            self.pres_head = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, 1),
             )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            ln3_fx = self.ln_3(fx)
+            return torch.cat([self.vel_head(ln3_fx), self.pres_head(ln3_fx)], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Separate velocity and pressure output heads

## Instructions
In TransolverBlock last_layer, replace mlp2 with vel_head(hidden->hidden->2) + pres_head(hidden->hidden->1). Concat outputs: cat([vel_head(ln3(fx)), pres_head(ln3(fx))], dim=-1). ~8 lines.

Run with: `--wandb_name "tanjiro/separate-pressure-head" --wandb_group separate-pressure-head --agent tanjiro`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** `vaubgjad` | **Epochs:** 77 (clean timeout, ~20s/epoch) | **Peak memory:** 7.6 GB

| Metric | Baseline | Separate heads | Delta |
|---|---|---|---|
| val/loss | 2.6346 | **2.6955** | +0.061 worse |
| val_in_dist/mae_surf_p | 23.78 | **23.66** | -0.12 better |
| val_ood_cond/mae_surf_p | 25.49 | **25.46** | -0.03 better |
| val_ood_re/mae_surf_p | 33.06 | **34.08** | +1.02 worse |
| val_tandem_transfer/mae_surf_p | 43.67 | **44.30** | +0.63 worse |

Additional surface metrics (best checkpoint, epoch 77):
- val_in_dist: mae_surf_Ux=0.329, mae_surf_Uy=0.193
- val_ood_cond: mae_surf_Ux=0.292, mae_surf_Uy=0.205
- val_ood_re: mae_surf_Ux=0.291, mae_surf_Uy=0.213
- val_tandem_transfer: mae_surf_Ux=0.665, mae_surf_Uy=0.354

Note: `val_ood_re/loss` remains NaN (pre-existing vol_loss overflow); val/loss is mean over 3 finite splits.

### What happened

**The separate heads do not help.** In-dist and OOD-cond pressure barely change (improvements of ~0.1 Pa and ~0.03 Pa respectively), but OOD-Re pressure degrades by 1 Pa and tandem transfer by 0.6 Pa. Overall val/loss is worse by 0.061.

The hypothesis that separate decoders would specialize — velocity heads learning velocity patterns, pressure head learning pressure patterns — is not confirmed. A few possible reasons:

1. **More parameters, same budget.** The separate heads add one extra `Linear(hidden_dim, hidden_dim)` block (vs the original shared head). With 128 hidden dim and 4+1 output dims, the shared head has ~16k output params while the separate heads have ~33k. These extra parameters may need more epochs to converge, but the run reached timeout after 77 epochs (vs baseline's ~88 epochs), slightly fewer due to the added compute.

2. **The bottleneck is not the output head.** If the main limit on pressure accuracy is how well the shared representation captures physics, splitting the output head doesn't help — it's the upstream representation that matters.

3. **Pressure and velocity are physically coupled.** The shared head may actually benefit from joint training because the pressure and velocity fields are related through the Navier-Stokes equations. Separating them at the output layer removes this implicit coupling in the loss.

### Suggested follow-ups

- **Pressure-only auxiliary loss:** Instead of separate output heads, add an explicit pressure reconstruction auxiliary loss with higher weight on surface nodes — this is less invasive than structural changes.
- **Weighted output loss:** Apply different loss weights to pressure vs velocity components without changing the architecture.