### PR TITLE
Y-flip augmentation (physical symmetry of 2D flow)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -558,6 +558,13 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
+        # Y-flip augmentation (50% probability): negate y-pos and Uy
+        if model.training and torch.rand(1).item() < 0.5:
+            x = x.clone()
+            x[:, :, 1] = -x[:, :, 1]  # negate y-position
+            y = y.clone()
+            y[:, :, 1] = -y[:, :, 1]  # negate Uy
+
         x = (x - stats["x_mean"]) / stats["x_std"]
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
Y-flip augmentation (physical symmetry of 2D flow)

## Instructions
In training loop with 50% prob: negate x[:,:,1] (y-pos) and y[:,:,1] (Uy). This is a valid symmetry for 2D flow. ~5 lines before x normalization.

Run with: `--wandb_name "alphonse/y-flip-augment" --wandb_group y-flip-augment --agent alphonse`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** 7toyaxyl  
**Run stopped at:** epoch 79/100 (30-min timeout)  
**Peak GPU memory:** 8.8 GB (same as baseline — no architecture change)

### Metrics at best checkpoint (epoch 79)

| Metric | This run | Baseline | Δ |
|---|---|---|---|
| val/loss | 2.8092 | 2.6346 | **+6.6% worse** |
| val_in_dist/mae_surf_Ux | 0.337 | — | — |
| val_in_dist/mae_surf_Uy | 0.211 | — | — |
| val_in_dist/mae_surf_p | 26.68 | 23.78 | **+12.2% worse** |
| val_in_dist/mae_vol_p | 34.08 | — | — |
| val_ood_cond/mae_surf_p | 25.25 | 25.49 | -1% (negligible) |
| val_ood_re/mae_surf_p | 34.32 | 33.06 | +3.8% worse |
| val_tandem_transfer/mae_surf_p | 45.48 | 43.67 | +4.1% worse |

### What happened

**Y-flip augmentation hurts performance, with val_in_dist/mae_surf_p 12% worse than baseline.** The run was killed at epoch 79/100 and was still improving (epoch 79 saved a new best), so the final gap would likely be smaller — but the in-dist regression is persistent enough that it's unlikely to fully close.

The y-flip is physically valid for symmetric airfoils in isolation, but has two issues in this context:

1. **Normalization mismatch**: The input normalization statistics (, ) are computed on the original dataset. After flipping x[:,:,1], the y-position distribution is shifted/negated relative to these statistics. The normalized y-coordinate is now out-of-distribution from the perspective of the model's learned representation. Doing the flip after normalization (i.e., flipping the normalized coordinate) would avoid this.

2. **Dataset asymmetry**: The TandemFoilSet likely includes configurations with asymmetric angle-of-attack or stagger, where a y-flip is not a valid symmetry. The model may see contradictory flipped/unflipped examples for cases where the physics doesn't respect this symmetry, creating confusion.

The near-neutral result on val_ood_cond (-1%) but regression on val_in_dist (+12%) and val_ood_re (+3.8%) reinforces that the augmentation is adding noise rather than generalizable signal.

### Suggested follow-ups

- **Flip after normalization**: Apply  on the already-normalized x (i.e., after ). This avoids the normalization mismatch and may be more effective.
- **Verify y-flip validity per sample**: Only apply flip to samples where the configuration is approximately symmetric (e.g., single-foil cases). Skip for tandem configurations with asymmetric geometry.
- **Rotate augmentation**: A small random rotation might be more effective than a fixed axis flip, since it doesn't require strict symmetry.