### PR TITLE
Channel dropout (5% per-channel feature masking)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -559,6 +559,10 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        if model.training:
+            chan_mask = (torch.rand(1, 1, x.shape[-1], device=x.device) > 0.05).float()
+            chan_mask[:, :, :2] = 1.0
+            x = x * chan_mask / 0.95
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Channel dropout (5% per-channel feature masking)

## Instructions
After x normalization, add: chan_mask=(torch.rand(1,1,x.shape[-1],device=x.device)>0.05).float(); chan_mask[:,:,:2]=1.0; x=x*chan_mask/0.95. 4 lines.

Run with: `--wandb_name "edward/channel-dropout" --wandb_group channel-dropout --agent edward`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** e5kdl3fu
**Epochs:** 81 (30-min wall-clock limit)
**Peak memory:** 8.8 GB

### Metrics at best checkpoint (epoch 80)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 2.323 | 0.418 | 0.231 | **36.02** | 42.70 |
| val_ood_cond | 1.809 | 0.291 | 0.213 | **29.44** | 27.22 |
| val_ood_re | NaN | 0.313 | 0.227 | **38.22** | 57.14 |
| val_tandem_transfer | 4.879 | 0.661 | 0.369 | **47.77** | 49.79 |
| **mean val/loss** | **3.004** | | | | |

### vs. Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.6346 | 3.004 | +14.1% worse |
| val_in_dist/mae_surf_p | 23.78 | 36.02 | +51.5% worse |
| val_ood_cond/mae_surf_p | 25.49 | 29.44 | +15.5% worse |
| val_ood_re/mae_surf_p | 33.06 | 38.22 | +15.6% worse |
| val_tandem_transfer/mae_surf_p | 43.67 | 47.77 | +9.4% worse |

### What happened

Strong negative result. Channel dropout at 5% significantly hurts performance across all splits, with in-distribution surface pressure degrading by 51.5%. The input features (X_DIM=24) encode critical physical information — geometry descriptors, distance-to-surface fields, signed-distance functions, flow conditions — and randomly dropping any of them disrupts the physical signal the model relies on.

This is different from the usual dropout scenario where features are somewhat redundant. Each of the 24 input channels carries distinct physics information (e.g., there's only one NACA encoding channel, one Re channel, etc.), so masking any one of them leaves the model without that physics information rather than just forcing it to use other redundant representations. The result is noisier training and worse generalization.

The unusually bad val_in_dist/mae_surf_p (+51%) compared to the other splits suggests the model learned to rely heavily on the in-distribution geometry channels and is particularly sensitive to their dropout.

Note: val_ood_re/loss is NaN throughout — pre-existing issue.

### Suggested follow-ups

- Much lower dropout rate (0.5-1%) might work if the goal is regularization, but the per-channel design is likely ill-suited for this physics encoding
- Standard spatial/point-wise dropout after the first MLP projection would be safer — it operates in feature space rather than on raw physics channels
- This approach might work better with redundant feature encodings, not with distinct single-channel physics descriptors