### PR TITLE
R-Drop consistency regularization (dual forward pass)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -449,6 +449,7 @@ model_config = dict(
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,
+    dropout=0.02,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )
@@ -566,8 +567,11 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
-        pred = pred.float()
+            pred1 = model({"x": x})["preds"]
+            pred2 = model({"x": x})["preds"]
+        pred1 = pred1.float()
+        pred2 = pred2.float()
+        pred = (pred1 + pred2) / 2
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
@@ -608,6 +612,10 @@ for epoch in range(MAX_EPOCHS):
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
+
+        # R-Drop: consistency regularization between two forward passes
+        rdrop_loss = F.mse_loss(pred1, pred2)
+        loss = loss + 0.5 * rdrop_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
R-Drop consistency regularization (dual forward pass)

## Instructions
Set dropout=0.02 in model_config. In training: pred1=model(x), pred2=model(x), rdrop=F.mse_loss(pred1,pred2), loss=main_loss(mean)+0.5*rdrop. ~10 lines, ~2x forward cost.

Run with: \`--wandb_name "askeladd/r-drop" --wandb_group r-drop --agent askeladd\`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** \`bd1yn769\`
**Epochs completed:** 43 (terminated at 30-minute timeout — half of baseline)
**Peak GPU memory:** ~56.7 GB (59% of 96 GB — doubled due to two activation graphs)

### Metrics at best val/loss

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 3.4994 | 2.6346 | **+0.86** ✗ |
| val_in_dist/mae_surf_p | 41.04 | 23.78 | **+17.26** ✗ |
| val_ood_cond/mae_surf_p | 39.26 | 25.49 | **+13.77** ✗ |
| val_ood_re/mae_surf_p | 42.23 | 33.06 | **+9.17** ✗ |
| val_tandem_transfer/mae_surf_p | 54.97 | 43.67 | **+11.30** ✗ |
| val_in_dist/mae_surf_Ux | 0.510 | — | — |
| val_in_dist/mae_vol_p | 46.61 | — | — |

### What happened

R-Drop is a clear failure in this training budget. The dual forward pass roughly halves the number of training epochs (43 vs ~85 for single-pass runs), and the model is far under-trained at the 30-minute cutoff — all metrics are dramatically worse.

The doubled GPU memory (56.7 GB vs ~24 GB baseline) reflects two activation graphs being retained for backprop.

Even ignoring the epoch count, R-Drop with only 2% dropout is likely a poor fit here: the two predictions from such a small dropout fraction would be nearly identical, making the consistency loss near zero and providing minimal regularization benefit while paying the full 2x compute cost.

R-Drop was designed for classification tasks where dropout creates meaningful distribution differences between passes. For regression with tiny dropout, this doesn't hold.

### Suggested follow-ups

- If consistency regularization is desired, test it with significantly higher dropout (10-20%) to create meaningful diversity between the two passes.
- Alternatively, drop the R-Drop and try a simpler consistency approach: gradient noise or stochastic depth, which have much lower compute cost.
- The epoch-budget issue is fundamental — any method that doubles per-step compute will be penalized by ~50% fewer epochs in the 30-min window.