### PR TITLE
Denoising pretraining for preprocess MLP (first 5 epochs)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -227,8 +227,9 @@ class Transolver(nn.Module):
         self.output_dims = output_dims
 
         if self.unified_pos:
+            preprocess_in = fun_dim + self.ref * self.ref * self.ref
             self.preprocess = MLP(
-                fun_dim + self.ref * self.ref * self.ref,
+                preprocess_in,
                 n_hidden * 2,
                 n_hidden,
                 n_layers=0,
@@ -236,7 +237,9 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            preprocess_in = fun_dim + space_dim
+            self.preprocess = MLP(preprocess_in, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+        self.decoder = nn.Linear(n_hidden, preprocess_in)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim
@@ -608,6 +611,16 @@ for epoch in range(MAX_EPOCHS):
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
+
+        # Denoising pretraining for preprocess MLP (epochs 0-4)
+        if epoch < 5:
+            recon_weight = max(0.0, 1.0 - epoch / 5)
+            x_corrupt = x + 0.1 * torch.randn_like(x)
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                fx_noisy = model.preprocess(x_corrupt)
+            x_recon = model.decoder(fx_noisy.float())
+            recon_loss = (x_recon - x).abs().mean()
+            loss = loss + recon_weight * recon_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Denoising pretraining for preprocess MLP (first 5 epochs)

## Instructions
Add decoder=nn.Linear(n_hidden,X_DIM). For epochs 0-4: corrupt x with 0.1*randn, pass through preprocess, decode, add recon_loss*max(0,1-epoch/5). ~12 lines.

Run with: `--wandb_name "violet/denoise-pretrain" --wandb_group denoise-pretrain --agent violet`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** jckj2sse (violet/denoise-pretrain)
**Epochs completed:** 80 (30-min timeout; best epoch: 79)
**Peak memory:** 11.8 GB (vs typical 7.8 GB — see note)

### Metrics at best epoch (val/loss=2.6781)

| Split | val/loss | mae_surf_p | Δ vs baseline |
|---|---|---|---|
| val_in_dist | 1.7831 | 24.06 | +0.28 |
| val_tandem_transfer | 4.6639 | 45.04 | +1.37 |
| val_ood_cond | 1.5873 | 23.59 | **-1.90** |
| val_ood_re | nan | 32.72 | -0.34 |

**val/loss: 2.6781** vs baseline 2.6346 (Δ = **+0.043**, worse)

W&B summary (final epoch ≈ best): mae_surf_Ux=0.320/0.279, mae_surf_Uy=0.200/0.202 (in_dist/ood_cond)

### What happened
Negative result. The denoising pretraining auxiliary loss hurt overall performance (+0.043 on val/loss). Results are mixed across splits: val_ood_cond surface pressure improved notably (-1.90 Pa) but val_tandem_transfer worsened (+1.37 Pa) and val_in_dist also worsened slightly.

**Memory spike:** Training used 11.8 GB vs the typical 7.8 GB. The decoder linear layer itself is tiny (128×24=3072 params) so this is unexpected. The additional forward pass through  for the corrupted input (even with autocast) may be retaining extra activations, or something changed in the noam branch between runs. Regardless, the 4 GB increase is a significant cost.

Only 80 epochs were completed vs the typical 88+, suggesting each epoch took slightly longer (likely from the denoising forward pass in epochs 0-4 keeping the GPU warm for later epochs, plus more memory pressure).

### Suggested follow-ups
- The memory issue should be investigated before this approach is reconsidered.
- The val_ood_cond improvement might be real — denoising could help OOD generalization specifically. Could try a weaker noise (0.01 instead of 0.1) or fewer warm-up epochs (1-2 instead of 5).
- Alternatively, apply denoising only at inference time (test-time corruption averaging) rather than training time.