### PR TITLE
Gradient matching loss (penalize spatial derivative errors)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -591,6 +591,11 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
+        # Gradient matching: penalize errors in spatial derivatives
+        grad_pred = pred[:, 1:] - pred[:, :-1]
+        grad_true = y_norm[:, 1:] - y_norm[:, :-1]
+        loss = loss + 0.1 * (grad_pred - grad_true).abs().mean()
+
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
         B, N, C = pred.shape


### PR DESCRIPTION
## Hypothesis
Gradient matching loss (penalize spatial derivative errors)

## Instructions
Compute approx spatial gradients: grad_pred=pred[:,1:]-pred[:,:-1], grad_true=y_norm[:,1:]-y_norm[:,:-1]. Add 0.1*(grad_pred-grad_true).abs().mean() to loss. ~8 lines.

Run with: `--wandb_name "gilbert/gradient-matching" --wandb_group gradient-matching --agent gilbert`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** `jjqmp40w` — gilbert/gradient-matching

**Best epoch:** 80 of 81 (30.2 min, wall-clock limit)
**Peak memory:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.701 | 0.288 | 0.192 | **23.36** | 1.556 | 0.567 | 33.26 |
| val_ood_cond | 1.595 | — | — | **24.2** | — | — | — |
| val_ood_re | nan | — | — | **32.6** | — | — | — |
| val_tandem_transfer | 4.644 | — | — | **44.4** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.6469** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.6346 | 2.6469 | +0.012 (≈0) |
| val_in_dist/mae_surf_p | 23.78 | 23.36 | −0.42 ✅ |
| val_ood_cond/mae_surf_p | 25.49 | 24.2 | −1.29 ✅ |
| val_ood_re/mae_surf_p | 33.06 | 32.6 | −0.46 ✅ |
| val_tandem_transfer/mae_surf_p | 43.67 | 44.4 | +0.73 ❌ |

### What happened

Positive result on 3/4 splits. Surface pressure improved meaningfully on val_in_dist (−0.42), val_ood_cond (−1.29), and val_ood_re (−0.46). The tandem split regressed modestly (+0.73). Overall val/loss is essentially unchanged (+0.012).

The gradient matching term penalizes differences between consecutive node predictions relative to their targets, acting as a spatial smoothness regularizer. Unlike the total variation penalty (which just penalizes magnitude), this explicitly matches the derivative profile of the ground truth — giving more physically meaningful supervision.

The val_ood_cond improvement (−1.29) is the largest gain, suggesting the gradient signal helps generalize to extreme AoA/gap/stagger conditions. The tandem regression (+0.73) is the recurring pattern across recent experiments — tandem transfer seems to be in mild tension with improvements on the single-foil splits, possibly because tandem meshes have a different node ordering structure that makes the naive sequential difference (`pred[:,1:]-pred[:,:-1]`) misleading.

Note: `val_ood_re/loss` is NaN throughout — pre-existing issue.

### Suggested follow-ups

- **Surface-only gradient matching**: Apply the gradient penalty only on `surf_mask` nodes for a more targeted signal. The volume gradient penalty may add noise without useful guidance.
- **Larger coefficient**: Try 0.2–0.5 for the gradient term — the current 0.1 may be underweighting the signal.
- **Sorted gradients**: Sort nodes by spatial position before computing the sequential difference, similar to the TV penalty approach. This would give a more physically meaningful "derivative along the surface."
- **Tandem fix**: Apply gradient matching only to single-foil batches, or skip it for batches with tandem geometry detected via the node count.