### PR TITLE
Stochastic depth (10% attention block skip)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -188,7 +188,10 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
+        if self.training and torch.rand(1).item() < 0.1:
+            pass  # skip attention (stochastic depth: residual only)
+        else:
+            fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))


### PR DESCRIPTION
## Hypothesis
Stochastic depth (10% attention block skip)

## Instructions
In TransolverBlock.forward: if self.training and torch.rand(1).item()<0.1: skip attention (just residual). else: normal. 3 lines.

Run with: `--wandb_name "senku/stochastic-depth" --wandb_group stochastic-depth --agent senku`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** `5olv8zcj` (senku/stochastic-depth)
**Epochs completed:** 81/100 (30-min timeout; ~21s/epoch)
**Peak memory:** 8.8 GB

### Metrics vs Baseline (best checkpoint, step 79 / epoch 80)

| Metric | Baseline | This run (best) | Delta |
|---|---|---|---|
| val/loss | 2.6346 | 2.7156 | +0.08 (worse) |
| val_in_dist/mae_surf_p | 23.78 | 24.68 | +0.90 (worse) |
| val_ood_cond/mae_surf_p | 25.49 | 24.68 | -0.81 (better) |
| val_ood_re/mae_surf_p | 33.06 | 32.84 | -0.22 (slightly better) |
| val_tandem_transfer/mae_surf_p | 43.67 | 45.22 | +1.55 (worse) |

Last epoch (81) metrics: val/loss=2.7194, val_in_dist/mae_surf_p=25.04, val_ood_cond/mae_surf_p=25.05, val_ood_re/mae_surf_p=33.31, val_tandem_transfer/mae_surf_p=44.96.

Surface MAE (best epoch, val_in_dist): Ux=0.319, Uy=0.189, p=24.68
Volume MAE (last epoch, val_in_dist): Ux=1.60, Uy=0.56, p=33.70

### What happened

Net negative. Val/loss is +0.08 worse than baseline and in-dist surface pressure regresses. The OOD splits (val_ood_cond, val_ood_re) show slight improvement, but the most important split (val_in_dist) and tandem transfer both get worse. The +0.80 surf_p improvement on val_ood_cond doesn't compensate for the degradation elsewhere.

Stochastic depth is typically useful in deep networks (ViT-L, ResNet-110) where it acts as implicit ensembling across depths. With only 5 TransolverBlock layers here, randomly dropping 10% of attention passes more often hurts than helps -- the model is too shallow for the technique to provide meaningful depth regularization. Each attention block carries a larger fraction of the representational capacity in a 5-layer network.

Memory: 8.8 GB -- slightly more than baseline (7.6 GB), likely due to the broader branching in this base branch.

### Suggested follow-ups
- If stochastic depth is revisited, try a lower drop rate (2-3%) on a shallow model -- 10% is likely too aggressive for 5 blocks.
- Block-level dropout might work better if applied only to early blocks (where attention is less critical) rather than uniformly.