### PR TITLE
Relative position encoding in slice attention

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -117,8 +117,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
         )
+        self.pos_bias_net = nn.Sequential(nn.Linear(1, 16), nn.GELU(), nn.Linear(16, heads))
 
-    def forward(self, x):
+    def forward(self, x, pos=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -141,14 +142,18 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         q_slice_token = self.to_q(slice_token)
         k_slice_token = self.to_k(slice_token)
         v_slice_token = self.to_v(slice_token)
-        dropout_p = self.dropout.p if self.training else 0.0
-        out_slice_token = F.scaled_dot_product_attention(
-            q_slice_token,
-            k_slice_token,
-            v_slice_token,
-            dropout_p=dropout_p,
-            is_causal=False,
-        )
+        attn_logits = torch.einsum("bhgd,bhtd->bhgt", q_slice_token, k_slice_token) * (self.dim_head ** -0.5)
+        if pos is not None:
+            # Compute mean position per slice: [bsz, heads, slice_num, 2]
+            slice_pos = torch.einsum("bnc,bhng->bhgc", pos, slice_weights) / (slice_norm + 1e-5).unsqueeze(-1)
+            slice_pos_mean = slice_pos.mean(1)  # [bsz, slice_num, 2]
+            diff = slice_pos_mean.unsqueeze(2) - slice_pos_mean.unsqueeze(1)  # [bsz, S, S, 2]
+            dist = diff.norm(dim=-1, keepdim=True)  # [bsz, S, S, 1]
+            attn_logits = attn_logits + self.pos_bias_net(dist).permute(0, 3, 1, 2)
+        attn_weights = F.softmax(attn_logits, dim=-1)
+        if self.training and self.dropout.p > 0:
+            attn_weights = F.dropout(attn_weights, p=self.dropout.p, training=self.training)
+        out_slice_token = attn_weights @ v_slice_token
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
@@ -187,8 +192,8 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
+    def forward(self, fx, pos=None):
+        fx = self.attn(self.ln_1(fx), pos=pos) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
@@ -315,11 +320,12 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        pos = x[:, :, :self.space_dim]  # spatial coordinates for relative position encoding
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks:
-            fx = block(fx)
+            fx = block(fx, pos=pos)
         self._validate_output_dims(fx)
         return {"preds": fx}
 


### PR DESCRIPTION
## Hypothesis
Relative position encoding in slice attention

## Instructions
Add pos_bias_net=nn.Sequential(Linear(1,16),GELU(),Linear(16,heads)) in attention. Compute mean pos per slice, pairwise dist, add bias to attention logits. ~15 lines.

Run with: `--wandb_name "kohaku/rel-pos-encoding" --wandb_group rel-pos-encoding --agent kohaku`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** 1a22woze | **Status:** Timed out at epoch 72/100 | **Peak memory:** 8.8 GB | **Epoch time:** ~24s (vs ~22s baseline, +10% overhead)

### Metrics at best val/loss (epoch 72 — last epoch)

| Split | mae_surf_p | vs baseline |
|---|---|---|
| val_in_dist | 25.58 | 23.78 (+1.8, **+7.6% worse**) |
| val_ood_cond | 25.94 | 25.49 (+0.5, **+1.8% worse**) |
| val_ood_re | 33.73 | 33.06 (+0.7, **+2.0% worse**) |
| val_tandem_transfer | 45.14 | 43.67 (+1.5, **+3.4% worse**) |

- **val/loss (best): 2.751** vs baseline 2.635 (+4.4% worse)
- val_in_dist/mae_surf_Ux: 0.323, val_in_dist/mae_surf_Uy: 0.200
- val_in_dist/mae_vol_p: 33.85

### What happened

Relative position encoding did not help — all metrics are worse than baseline. There are two compounding issues:

**1. Computational overhead:** The pairwise distance computation and pos_bias_net add ~10% per-epoch cost (24s vs ~22s). With a 30-minute budget, this yields only 72 epochs vs ~79-88 for similar runs. The model gets ~10-20% less training.

**2. Potentially redundant information:** The spatial coordinates are already in the first 2 dimensions of , which gets processed by the preprocess MLP and is available throughout the network. The slice assignment mechanism in Transolver implicitly groups spatially and semantically similar points. Adding explicit pairwise position biases to the slice-level attention may conflict with or duplicate the existing position encoding.

**Implementation details:**
- Extracted  from normalized input (before preprocess)
- Computed weighted slice centroids: 
- Averaged over heads to get  centroid positions
- Computed pairwise L2 distances, fed through  →  bias
- Replaced  with manual softmax attention + bias

The manual attention path also loses flash attention optimization, contributing to the slowdown.

### Suggested follow-ups
- **Detached pos_bias_net**: The distance matrix computation at every forward pass is expensive. A cached or approximate version might help.
- **Absolute positional embedding instead**: Adding a learned 2D positional embedding to the input features before the preprocess MLP (rather than in attention) might capture similar position information with less overhead.
- **Conclusion**: The spatial position information is likely already well-encoded through the input features. The complexity of in-attention positional biases isn't justified by any performance gain.