### PR TITLE
Zone-aware boundary embedding (8-dim boundary type)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -258,6 +258,7 @@ class Transolver(nn.Module):
         self.initialize_weights()
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
+        self.boundary_embed = nn.Embedding(8, 8)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -314,6 +315,19 @@ class Transolver(nn.Module):
                 raise ValueError("Missing required input tensor: pos")
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
+
+        # Zone-aware boundary embedding: derive boundary_id from is_surface and quadrant
+        is_surface_flag = data.get("is_surface")  # [B, N] bool tensor, optional
+        if is_surface_flag is not None:
+            surf_int = is_surface_flag.long()  # 0 or 1
+        else:
+            # Derive from x[:,12] (is_surface feature after normalization — threshold at 0)
+            surf_int = (x[..., 12] > 0).long()
+        # Zone proxy: quadrant based on pos (x[:,0] and x[:,1])
+        zone = (x[..., 0] >= 0).long() * 2 + (x[..., 1] >= 0).long()  # 0-3
+        boundary_id = (surf_int * 4 + zone).clamp(0, 7)  # 0-7
+        embed = self.boundary_embed(boundary_id)  # [B, N, 8]
+        x = torch.cat([x, embed], dim=-1)  # [B, N, X_DIM+8]
 
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
@@ -442,7 +456,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 8,  # X_DIM=24 + 8 boundary embed dims; space_dim=2
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -566,7 +580,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
+            pred = model({"x": x, "is_surface": is_surface})["preds"]
         pred = pred.float()
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
@@ -653,7 +667,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = model({"x": x, "is_surface": is_surface})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()


### PR DESCRIPTION
## Hypothesis
Zone-aware boundary embedding (8-dim boundary type)

## Instructions
Add boundary_embed=nn.Embedding(8,8). Derive boundary_id from existing features (is_surface*5+zone proxy). Concat embed to x before preprocess. Change fun_dim. ~10 lines.

Run with: `--wandb_name "emma/zone-aware-embed" --wandb_group zone-aware-embed --agent emma`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run ID:** ufa83wid  
**Best epoch:** 77/77 (run stopped at epoch 77 by 30-min timeout; ~23s/epoch, down from ~22s)  
**Peak GPU memory:** 9.0 GB (up from 8.8 GB)  

### Implementation
- Added `self.boundary_embed = nn.Embedding(8, 8)` to Transolver
- In forward: `boundary_id = is_surface.long() * 4 + zone` where `zone = (x[...,0]>=0)*2 + (x[...,1]>=0)` (quadrant from pos)
- IDs 0-3 for volume nodes by quadrant, 4-7 for surface nodes by quadrant
- Pass `is_surface` via data dict; fallback to thresholding x[:,12] if absent
- `fun_dim`: 22 → 30 (X_DIM-2+8)

### val/loss (combined)
| | Baseline | Zone-embed | Delta |
|---|---|---|---|
| val/loss | 2.6346 | **2.7470** | +0.112 ❌ |

### Surface MAE
| Split | Metric | Baseline | Zone-embed | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 23.78 | 25.70 | +1.92 ❌ |
| val_ood_cond | mae_surf_p | 25.49 | **23.38** | -2.11 ✅ |
| val_ood_re | mae_surf_p | 33.06 | **32.18** | -0.88 ✅ |
| val_tandem_transfer | mae_surf_p | 43.67 | 47.22 | +3.55 ❌ |

**Surface MAE (Ux, Uy, p) at best epoch:**
- val_in_dist: Ux=0.331, Uy=0.190, p=25.70
- val_ood_cond: Ux=0.284, Uy=0.198, p=23.38
- val_ood_re: Ux=0.298, Uy=0.206, p=32.18
- val_tandem_transfer: Ux=0.683, Uy=0.363, p=47.22

**Volume MAE (Ux, Uy, p) at best epoch:**
- val_in_dist: Ux=1.670, Uy=0.580, p=35.49
- val_ood_cond: Ux=1.324, Uy=0.504, p=25.14
- val_ood_re: Ux=1.275, Uy=0.519, p=54.96
- val_tandem_transfer: Ux=2.517, Uy=1.159, p=51.22

### What happened

Negative result. The zone-aware embedding degraded performance on val/loss (+0.112), in-dist surface pressure (+1.92), and tandem surface pressure (+3.55). It did improve OOD condition (-2.11) and OOD Reynolds (-0.88), suggesting the embedding gives useful boundary-type signals for generalization but at the cost of in-distribution and tandem accuracy.

Two issues:

1. **Epoch budget**: adding the embedding adds compute (23s/epoch vs 22s), giving only 77 epochs vs ~81 in baseline. This likely contributed to the regression.

2. **Tandem geometry mismatch**: the zone proxy uses spatial quadrants (x>=0, y>=0). For tandem configurations, the two foils occupy different spatial regions, so the quadrant-based zones may conflate surface nodes from different foils into the same embedding bucket, confusing the model about which foil it's attending to.

The ood_cond improvement (-2.11) is interesting — it suggests that for OOD conditions, knowing the spatial zone helps generalization. But the tandem regression (+3.55) outweighs this for the combined metric.

### Suggested follow-ups
- **Better zone proxy**: use boundary_id = SURFACE_IDS directly from prepare.py (IDs 5,6,7 for surface; others for volume) — this encodes actual mesh topology rather than a spatial proxy
- **Learnable per-node type**: if boundary_id is stable, learn a per-type bias added to the preprocess output
- **Simpler surface-only flag**: just is_surface → 2-class embedding (skip spatial zone entirely) — reduces tandem confusion risk