### PR TITLE
Multi-query attention (shared K,V across heads)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -139,8 +139,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
 
         q_slice_token = self.to_q(slice_token)
-        k_slice_token = self.to_k(slice_token)
-        v_slice_token = self.to_v(slice_token)
+        slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
+        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
+        v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
         dropout_p = self.dropout.p if self.training else 0.0
         out_slice_token = F.scaled_dot_product_attention(
             q_slice_token,


### PR DESCRIPTION
## Hypothesis
Multi-query attention (shared K,V across heads)

## Instructions
In attention, share K and V across heads: compute k,v once with dim_head, broadcast to all heads. Keep separate Q per head. ~6 lines changed.

Run with: `--wandb_name "norman/multi-query-attn" --wandb_group multi-query-attn --agent norman`

## Baseline
- val/loss: **2.6346**
- val_in_dist/mae_surf_p: 23.78
- val_ood_cond/mae_surf_p: 25.49
- val_ood_re/mae_surf_p: 33.06
- val_tandem_transfer/mae_surf_p: 43.67

---

## Results

**W&B run:** `1alc5n9r` | 81 epochs | Peak memory: 8.8 GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.6346 | **2.5756** | −2.2% ✓ |
| val_in_dist/mae_surf_p | 23.78 | **22.47** | −5.5% ✓ |
| val_ood_cond/mae_surf_p | 25.49 | **24.03** | −5.7% ✓ |
| val_ood_re/mae_surf_p | 33.06 | **32.08** | −3.0% ✓ |
| val_tandem_transfer/mae_surf_p | 43.67 | **42.13** | −3.5% ✓ |
| val_in_dist/mae_surf_Ux | — | 0.304 | |
| val_in_dist/mae_surf_Uy | — | 0.179 | |
| val_ood_cond/mae_surf_Ux | — | 0.282 | |
| val_ood_cond/mae_surf_Uy | — | 0.191 | |
| val_ood_re/mae_surf_Ux | — | 0.290 | |
| val_ood_re/mae_surf_Uy | — | 0.205 | |
| val_tandem_transfer/mae_surf_Ux | — | 0.646 | |
| val_tandem_transfer/mae_surf_Uy | — | 0.344 | |
| val_in_dist/loss | — | 1.672 | |
| val_ood_cond/loss | — | 1.580 | |
| val_tandem_transfer/loss | — | 4.475 | |

### Implementation

In `forward`, after computing `slice_token` (shape `bsz × heads × slice_num × dim_head`), averaged across heads to get a single shared representation for K and V:

```python
q_slice_token = self.to_q(slice_token)
slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
```

`to_k` and `to_v` weight shapes are unchanged (dim_head → dim_head).

### What happened

Clear positive result. All 4 splits improved, with surface pressure MAE dropping 3–6% across the board. val/loss improved by 2.2% overall.

The improvement makes sense: forcing all heads to share the same K,V representation means each Q-head must find a distinct query specialization rather than different heads learning redundant full-attention patterns. With only 4 heads and a 128-dim hidden dimension (32 dims per head), the standard independent-QKV attention may have been over-parameterizing the K,V representations. The shared K,V also acts as a regularizer, which helps OOD generalization (all 4 splits improved, including the harder OOD ones).

### Suggested follow-ups

- Try Grouped Query Attention (GQA) with 2 K,V groups for 4 Q-heads — a middle ground between MQA and full MHA.
- The mean-pooling of slice_token for shared K,V is simple but arbitrary. Try using a dedicated single-head projection (`in_project_fx_kv: Linear(dim, dim_head)`) for a learned shared K,V rather than the mean.