### PR TITLE
Temporal ensemble (EMA predictions as soft target)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -531,6 +531,7 @@ with open(model_dir / "config.yaml", "w") as f:
 best_val = float("inf")
 best_metrics = {}
 global_step = 0
+ema_pred = None
 train_start = time.time()
 
 for epoch in range(MAX_EPOCHS):
@@ -568,6 +569,11 @@ for epoch in range(MAX_EPOCHS):
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
         pred = pred.float()
+        if ema_pred is None or ema_pred.shape != pred.shape:
+            ema_pred = pred.detach()
+        else:
+            ema_pred = 0.99 * ema_pred + 0.01 * pred.detach()
+        ema_loss = 0.1 * F.mse_loss(pred, ema_pred.detach())
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
@@ -589,7 +595,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + surf_weight * surf_loss
+        loss = vol_loss + surf_weight * surf_loss + ema_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
Maintain EMA of predictions as regularization (temporal ensembling from Laine & Aila 2017).

## Instructions
Maintain ema_pred buffer. Each step: ema_pred=0.99*ema_pred.detach()+0.01*pred.detach(). Add 0.1*F.mse_loss(pred,ema_pred.detach()) to loss. ~8 lines.
Run with: `--wandb_name "haku/temporal-ens" --wandb_group temporal-ensemble --agent haku`

## Baseline
- val/loss: **2.6346**

---

## Results

**W&B run ID:** `ddfnvw2s`  
**Best epoch:** 76 / 78 (30.2 min wall-clock timeout)  
**Peak GPU memory:** 8.8 GB (no change from baseline)

### Metrics at best checkpoint (epoch 76)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.8410 | 0.314 | 0.196 | 25.3 | 1.608 | 0.575 | 34.4 |
| val_tandem_transfer | 4.7065 | 0.677 | 0.357 | 46.0 | 2.490 | 1.135 | 50.1 |
| val_ood_cond | 1.6063 | 0.274 | 0.196 | 24.7 | 1.341 | 0.527 | 25.9 |
| val_ood_re | NaN* | 0.284 | 0.208 | 33.4 | 1.295 | 0.526 | 55.3 |
| **combined val/loss** | **2.7179** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.6346 → This run: 2.7179 — slightly worse (+0.083)**

### What happened

The temporal ensemble did not improve over the baseline. The val/loss of 2.7179 is slightly worse than the 2.6346 baseline.

The core issue is that this implementation applies EMA across **different mini-batches** (different inputs each step), not across repeated passes over the same inputs. With `ema_pred = 0.99 * ema_pred + 0.01 * pred.detach()`, the EMA target at step t is a noisy average of predictions made on different inputs. The MSE between the current batch prediction and this mismatched EMA target is essentially arbitrary — it penalizes the model for being different from stale predictions on unrelated data, which adds incoherent gradient noise rather than useful regularization.

In the original Laine & Aila 2017 paper, temporal ensembling maintains per-sample EMA predictions (the same input seen multiple times across epochs), so the EMA target is genuinely meaningful. That design is incompatible with this loader where batches are not aligned across epochs.

The `ema_loss` term does remain small (predictions stabilize quickly), so the harm is limited — but the signal is also nil.

### Suggested follow-ups

- **Mean teacher (Tarvainen & Valpola 2017)**: Maintain an EMA of *model weights* (not predictions). Use the weight-EMA model to generate soft targets for the current batch. This properly compares predictions on the same inputs, making the regularization meaningful.
- **Proper per-sample temporal ensemble**: Requires tracking which samples have been seen and storing per-sample prediction buffers — more complex but faithful to the original paper.