### PR TITLE
Grouped-query attention (2 K,V groups for 4 heads)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -139,9 +139,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
 
         q_slice_token = self.to_q(slice_token)
-        slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
-        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
-        v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
+        # GQA: 2 K,V groups for 4 Q heads (2 heads share each K,V group)
+        slice_token_kv = slice_token.reshape(bsz, 2, 2, slice_token.shape[2], self.dim_head).mean(2).repeat_interleave(2, 1)
+        k_slice_token = self.to_k(slice_token_kv)
+        v_slice_token = self.to_v(slice_token_kv)
         dropout_p = self.dropout.p if self.training else 0.0
         out_slice_token = F.scaled_dot_product_attention(
             q_slice_token,


### PR DESCRIPTION
## Hypothesis
Grouped-query attention (2 K,V groups for 4 heads)

## Instructions
In Physics_Attention_Irregular_Mesh.forward, after computing slice_token, average K,V over groups of 2 heads: slice_token_kv=slice_token.reshape(bsz,2,2,slice_num,dim_head).mean(2).repeat_interleave(2,1). Use for K,V computation. ~5 lines.
Run with: `--wandb_name "fern/gqa-2groups" --wandb_group gqa-2groups --agent fern`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `eucymuub` | **Epochs:** 82/100 (30.1 min) | **Peak memory:** 8.8 GB

Note: baseline already uses MQA (single shared K,V group). GQA increases sharing granularity to 2 groups (2 heads per K,V group).

### Validation loss
| Split | Baseline (MQA) | GQA 2-groups | Δ |
|---|---|---|---|
| val/loss (mean 3 splits) | 2.5756 | 2.6252 | +1.9% worse |
| val_in_dist | — | 1.7084 | — |
| val_ood_cond | — | 1.5329 | — |
| val_ood_re | — | nan (vol_loss=1.9e10) | pre-existing |
| val_tandem_transfer | — | 4.6343 | — |

### Surface MAE pressure (primary metric)
| Split | Baseline mae_surf_p | GQA mae_surf_p | Δ |
|---|---|---|---|
| val_in_dist | 22.47 | 23.19 | +3.2% worse |
| val_ood_cond | 24.03 | **23.39** | **-2.7% better** |
| val_ood_re | 32.08 | **32.00** | **-0.2% flat** |
| val_tandem_transfer | 42.13 | 45.03 | +6.8% worse |

### Surface MAE (Ux, Uy, p) at best checkpoint
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.31 | 0.18 | 23.19 |
| val_ood_cond | 0.26 | 0.19 | 23.39 |
| val_ood_re | 0.27 | 0.20 | 32.00 |
| val_tandem_transfer | 0.65 | 0.35 | 45.03 |

### Volume MAE at best checkpoint
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.54 | 0.55 | 31.34 |
| val_ood_cond | 1.29 | 0.50 | 26.06 |
| val_ood_re | 1.24 | 0.51 | 54.45 |
| val_tandem_transfer | 2.44 | 1.11 | 48.82 |

### What happened

**GQA (2 groups) is slightly worse than MQA (1 group) overall.** val/loss degraded by +1.9%, driven mainly by tandem_transfer (+6.8% worse). ood_cond improved modestly (-2.7%), ood_re is flat, in_dist is slightly worse (+3.2%).

The baseline already uses MQA (complete K,V sharing across all 4 heads). Moving to GQA (2 K,V groups of 2 heads each) reduces parameter sharing, giving each head-pair its own K,V projection. This adds more expressiveness in principle, but the result is the model doesn't consistently outperform MQA.

The tandem_transfer regression is notable: with 210 tandem samples (foil-2 transfer), more K,V sharing (MQA) seems to help generalization to unseen tandem configurations. GQA's less-constrained K,V representation may overfit more to the training distribution.

With only 4 heads and n_hidden=128, the model may be too small for GQA to show benefits over MQA. GQA typically shines in larger models with many heads where MQA is overly aggressive.

### Suggested follow-ups
- **Revert to MQA for production**: The baseline MQA is better overall (val/loss 2.5756 vs 2.6252) — no reason to prefer GQA.
- **Try GQA with more heads (n_head=8)**: With 8 heads and 2-group GQA, there are 4 heads per K,V group — more room for the benefits to show.
- **Try GQA with 4 groups**: With 4 heads and 4 K,V groups, each head gets its own K,V (standard multi-head attention). This would show whether any sharing helps vs none.