### PR TITLE
Shared-Q attention (invert MQA: shared Q, separate K,V)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -138,10 +138,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
 
-        q_slice_token = self.to_q(slice_token)
-        slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
-        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
-        v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
+        q_slice_token = self.to_q(slice_token.mean(1, keepdim=True)).expand(-1, self.heads, -1, -1)
+        k_slice_token = self.to_k(slice_token)
+        v_slice_token = self.to_v(slice_token)
         dropout_p = self.dropout.p if self.training else 0.0
         out_slice_token = F.scaled_dot_product_attention(
             q_slice_token,


### PR DESCRIPTION
## Hypothesis
Shared-Q attention (invert MQA: shared Q, separate K,V)

## Instructions
In forward, compute shared Q: q_shared=self.to_q(slice_token.mean(1,keepdim=True)).expand(-1,self.heads,-1,-1). Keep per-head K,V. ~4 lines.
Run with: `--wandb_name "tanjiro/mqa-shared-q" --wandb_group mqa-shared-q --agent tanjiro`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `iibuftpy` | **Epochs:** 80 (clean timeout, ~20s/epoch) | **Peak memory:** 7.6 GB

| Metric | Baseline | Shared-Q | Delta |
|---|---|---|---|
| val/loss | 2.5756 | **2.5992** | +0.024 worse |
| val_in_dist/mae_surf_p | 22.47 | **24.51** | +2.04 worse |
| val_ood_cond/mae_surf_p | 24.03 | **23.14** | -0.89 better |
| val_ood_re/mae_surf_p | 32.08 | **31.79** | -0.29 better |
| val_tandem_transfer/mae_surf_p | 42.13 | **43.49** | +1.36 worse |

Additional surface metrics (best checkpoint, epoch 80):
- val_in_dist: mae_surf_Ux=0.314, mae_surf_Uy=0.184
- val_ood_cond: mae_surf_Ux=0.268, mae_surf_Uy=0.194
- val_ood_re: mae_surf_Ux=0.277, mae_surf_Uy=0.204
- val_tandem_transfer: mae_surf_Ux=0.643, mae_surf_Uy=0.340

Note: `val_ood_re/loss` remains NaN (pre-existing vol_loss overflow); val/loss is mean over 3 finite splits.

### What happened

**Negative result overall.** Shared-Q (per-head K,V) improves OOD-cond and OOD-Re slightly but degrades in-distribution (+2 Pa) and tandem transfer (+1.4 Pa). The overall val/loss is slightly worse (+0.024).

Contrast with the baseline's shared-K,V (per-head Q): the baseline inverted-MQA had per-head Q projections providing diversity in query perspectives, while K and V were averaged across heads. Flipping this to shared Q means all heads query the same features but distinguish in how they attend (K) and what they extract (V). 

The result suggests that **diversity in Q is more important than diversity in K,V** for this task. When each head has its own Q, they can specialize in finding different aspects of the slice representation to attend to. With a shared Q, this specialization is lost, and the model relies entirely on per-head K,V diversity — which is apparently less effective for in-distribution accuracy and complex geometries like tandem foils.

The small improvement in OOD splits may reflect that shared-Q provides implicit regularization (fewer effective degrees of freedom in the attention), but this comes at too high a cost for in-distribution accuracy.

### Suggested follow-ups

- **Standard full per-head Q,K,V:** Compare against the original (non-MQA) setup to quantify how much the various shared-head variants each cost/gain.
- **Group Query Attention (GQA):** Use groups of 2 heads sharing K,V, with per-head Q — a middle ground between full multi-head and full MQA.