### PR TITLE
8 MQA heads with n_hidden=192 (wider+more heads)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -445,9 +445,9 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=128,
+    n_hidden=192,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
-    n_head=4,
+    n_head=8,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],


### PR DESCRIPTION
## Hypothesis
8 MQA heads with n_hidden=192 (wider+more heads)

## Instructions
Change n_hidden=128 to 192 and n_head=4 to 8 in model_config.
Run with: `--wandb_name "alphonse/mqa-8heads-dim192" --wandb_group mqa-8heads-dim192 --agent alphonse`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run ID:** ardwey64
**Epochs completed:** 52/100 (30-min timeout; 32.5s/epoch vs ~22s for base model)
**Peak VRAM:** 13.6 GB (vs ~8.8 GB base)

| Metric | Baseline | This run (best, ep51) | Delta |
|---|---|---|---|
| val/loss | 2.5756 | **3.1318** | +22% worse |
| val_in_dist/mae_surf_p | 22.47 | **41.68** | +85% worse |
| val_ood_cond/mae_surf_p | 24.03 | **30.81** | +28% worse |
| val_ood_re/mae_surf_p | 32.08 | **38.54** | +20% worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **52.72** | +25% worse |

Additional val_in_dist metrics at best epoch:
- mae_surf_Ux: 0.405 | mae_surf_Uy: 0.233
- mae_vol_Ux: 1.660 | mae_vol_Uy: 0.599 | mae_vol_p: 40.51

### What happened

**This did not work.** All metrics are significantly worse than baseline across all val splits.

The core problem is that n_hidden=192 + n_head=8 slows each epoch from ~22s to ~32.5s, so only 52 of 100 scheduled epochs complete within the 30-minute cap. Even accounting for this, the model appears behind baseline at comparable training fractions — it is a larger model that needs more training time to converge, but the timeout prevents it from doing so.

The val/loss curve is still declining at epoch 52 (best was epoch 51 at 3.1318 vs. 3.1594 at epoch 52, with no sign of flattening), confirming the model has not converged. Surface pressure MAE is 40-53 vs. baseline 22-42 — a clear regression, not just an artifact of early stopping.

Memory cost is also significant: 13.6 GB vs. 8.8 GB base (+55%), with no benefit.

### Suggested follow-ups
- Test MQA with only the head count change (n_head=8, n_hidden=128) to isolate whether more heads help independently of width
- If testing wider models, reduce to n_hidden=160 or similar to stay within the epoch budget
- The slow convergence suggests the existing n_hidden=128 model may be well-matched to dataset complexity — larger capacity does not automatically help