### PR TITLE
GLU gated output projection in attention

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -113,10 +113,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
-        self.to_out = nn.Sequential(
-            nn.Linear(inner_dim, dim),
-            nn.Dropout(dropout),
-        )
+        self.to_out_gate = nn.Linear(inner_dim, dim)
+        self.to_out_val = nn.Linear(inner_dim, dim)
 
     def forward(self, x):
         bsz, num_points, _ = x.shape
@@ -153,7 +151,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
-        return self.to_out(out_x)
+        return self.to_out_val(out_x) * torch.sigmoid(self.to_out_gate(out_x))
 
 
 class TransolverBlock(nn.Module):


### PR DESCRIPTION
## Hypothesis
GLU gated output projection in attention

## Instructions
Replace to_out with GLU: self.to_out_gate=Linear(inner_dim,dim), self.to_out_val=Linear(inner_dim,dim). Return to_out_val(x)*sigmoid(to_out_gate(x)). ~4 lines.
Run with: \`--wandb_name "askeladd/attn-glu-out" --wandb_group attn-glu-out --agent askeladd\`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** \`jit2wbik\`
**Epochs completed:** 75 (terminated at 30-minute timeout)
**Peak GPU memory:** ~37.3 GB (38% of 96 GB — slightly higher than baseline due to extra linear)

### Metrics at best val/loss

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.7150 | 2.5756 | **+0.139** ✗ |
| val_in_dist/mae_surf_p | 25.25 | 22.47 | **+2.78** ✗ |
| val_ood_cond/mae_surf_p | 24.20 | 24.03 | +0.17 (~tie) |
| val_ood_re/mae_surf_p | 33.49 | 32.08 | **+1.41** ✗ |
| val_tandem_transfer/mae_surf_p | 45.36 | 42.13 | **+3.23** ✗ |
| val_in_dist/mae_surf_Ux | 0.315 | — | — |
| val_in_dist/mae_surf_Uy | 0.197 | — | — |
| val_in_dist/mae_vol_Ux | 1.508 | — | — |
| val_in_dist/mae_vol_p | 33.11 | — | — |

### What happened

The GLU output projection is a clear negative result. All metrics are worse than baseline, with val/loss up +0.14 and surface pressure up 2-3 Pa across splits. Only ood_cond is essentially unchanged.

The GLU doubles the output projection parameter count (two \`inner_dim→dim\` matrices instead of one), which could increase optimization difficulty for a 1-layer model. The sigmoid gate may be hindering gradient flow in early training — sigmoidal gates are known to have vanishing gradient issues and are often better served by SiLU (swish) gating. The original linear + dropout appears simpler and sufficient.

There's also no specific reason to expect GLU to help in the output projection specifically. GLU is most effective when there's a benefit to selectively gating information flow in the network's intermediate representations, but the output projection is already at the final aggregation step.

### Suggested follow-ups

- If gating is desired in the attention output, try SiLU gating (x * silu(gate)) instead of sigmoid — it doesn't saturate and has better gradient properties.
- Apply GLU/SiLU gating inside the MLP (FFN) of TransolverBlock instead, where gating over intermediate features has a longer track record (e.g., SwiGLU).
- The added parameters from the double linear might work better if the model dimension were increased correspondingly (e.g., n_hidden → 96 to keep total params similar).