### PR TITLE
Cosine eta_min=1e-4 (warmer floor)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -490,7 +490,7 @@ class Lookahead:
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
Cosine eta_min=1e-4 (warmer floor)

## Instructions
Change eta_min=1e-5 to eta_min=1e-4 in CosineAnnealingLR.
Run with: `--wandb_name "violet/eta-min-1e-4" --wandb_group eta-min-1e-4 --agent violet`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** tcjgrjq0 (violet/eta-min-1e-4)
**Epochs completed:** 88 (30-min timeout; best epoch: 81)
**Peak memory:** 8.8 GB

### Metrics at best epoch (val/loss=2.6454)

| Split | val/loss | mae_surf_p | Δ vs baseline |
|---|---|---|---|
| val_in_dist | 1.7212 | 23.20 | +0.73 |
| val_tandem_transfer | 4.6114 | 44.55 | +2.42 |
| val_ood_cond | 1.6035 | 23.63 | -0.40 |
| val_ood_re | nan | 32.68 | +0.60 |

**val/loss: 2.6454** vs baseline 2.5756 (Δ = **+0.070**, worse)

W&B best_best (val_in_dist): mae_surf_Ux=0.304, mae_surf_Uy=0.189, mae_surf_p=23.20; mae_vol_Ux=1.541, mae_vol_Uy=0.544, mae_vol_p=31.27

### What happened
Negative result. Raising eta_min from 1e-5 to 1e-4 made performance worse by +0.070 val/loss, with all splits except val_ood_cond worsening. The current baseline uses eta_min=1e-5 with good results, and this experiment confirms that the lower floor is beneficial.

The lower eta_min lets the model do fine-grained updates at the end of training (final LR ~1e-5 instead of ~1e-4). This fine-tuning phase appears important for reaching the best minima — the 10× warmer floor prevents the model from converging as precisely in late epochs.

### Suggested follow-ups
- Try an even colder floor (eta_min=1e-6) to see if more fine-tuning at the end helps.
- The current 1e-5 baseline appears well-calibrated for this architecture and dataset size.