### PR TITLE
Lookahead k=5 alpha=0.5 (tighter sync with MQA)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -488,7 +488,7 @@ class Lookahead:
 
 
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=5, alpha=0.5)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Lookahead k=5 alpha=0.5 (tighter sync with MQA)

## Instructions
Change Lookahead(base_opt, k=10, alpha=0.8) to k=5, alpha=0.5.
Run with: `--wandb_name "gilbert/la-k5a05-v2" --wandb_group la-k5a05-v2 --agent gilbert`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 43.67 (note: baseline title says 42.13)

---

## Results

**W&B run:** `wnepug7e` — gilbert/la-k5a05-v2

**Best epoch:** 81 of 81 (30.1 min, wall-clock limit)
**Peak memory:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.691 | 0.291 | 0.184 | **23.38** | 1.573 | 0.547 | 30.97 |
| val_ood_cond | 1.525 | — | — | **22.7** | — | — | — |
| val_ood_re | nan | — | — | **31.9** | — | — | — |
| val_tandem_transfer | 4.494 | — | — | **42.9** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.5700** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5756 | 2.5700 | −0.006 ✅ |
| val_in_dist/mae_surf_p | 22.47 | 23.38 | +0.91 ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 22.7 | −1.33 ✅ |
| val_ood_re/mae_surf_p | 32.08 | 31.9 | −0.18 ✅ |
| val_tandem_transfer/mae_surf_p | 42.13 | 42.9 | +0.77 ❌ |

### What happened

Mixed results. The overall val/loss improved very slightly (−0.006, likely within noise). OOD condition pressure improved significantly (−1.33). But the in-distribution split regressed (+0.91) and tandem worsened slightly (+0.77).

Tighter Lookahead sync (k=5 vs k=10) means the slow weights are updated more frequently, and the smaller alpha (0.5 vs 0.8) means the slow weights move less aggressively toward the fast weights. This combination should theoretically provide more stable optimization, but the result is ambiguous — it helps generalization to OOD conditions while hurting in-distribution accuracy.

The val/loss improvement is tiny and could easily be noise across runs. The shift from val_in_dist improvement to val_ood_cond improvement suggests the optimizer change is altering which regime the model optimizes toward.

Note: `val_ood_re/loss` is NaN throughout — pre-existing issue.

### Suggested follow-ups

- **k=5, alpha=0.8**: Keep the tighter sync but use the original interpolation strength to see if alpha matters more.
- **k=10, alpha=0.5**: Try the converse — original sync frequency with weaker slow-weight pull.
- **No Lookahead**: Test without Lookahead entirely to establish whether it helps at all vs base AdamW on this configuration.