### PR TITLE
Surf weight ramp 3→40 (wider range)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -543,7 +543,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    sw_start, sw_end = 3.0, 40.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
Surf weight ramp 3→40 (wider range)

## Instructions
Change sw_start,sw_end=5.0,30.0 to 3.0,40.0.
Run with: `--wandb_name "senku/surf-ramp-3-40" --wandb_group surf-ramp-3-40 --agent senku`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `wdf3c9u1` (senku/surf-ramp-3-40)
**Epochs completed:** 77/100 (30-min timeout; ~22s/epoch)
**Peak memory:** 8.8 GB

### Metrics vs Baseline (best checkpoint, step 75 / epoch 76)

| Metric | Baseline | This run (best) | Delta |
|---|---|---|---|
| val/loss | 2.5756 | 2.7268 | +0.15 (worse) |
| val_in_dist/mae_surf_p | 22.47 | 24.62 | +2.15 (worse) |
| val_ood_cond/mae_surf_p | 24.03 | 24.11 | +0.08 (similar) |
| val_ood_re/mae_surf_p | 32.08 | 33.33 | +1.25 (worse) |
| val_tandem_transfer/mae_surf_p | 42.13 | 47.16 | +5.03 (much worse) |

Last epoch (77) metrics: val/loss=2.7358, val_in_dist/mae_surf_p=25.88, val_ood_cond/mae_surf_p=23.80.

Surface MAE (best epoch, val_in_dist): Ux=0.337, Uy=0.191, p=24.62
Volume MAE (last epoch, val_in_dist): Ux=1.63, Uy=0.57, p=34.29

### What happened

This did not work. All metrics are worse than baseline, with tandem transfer particularly hurt (+5 on surf_p). The wider 3→40 range appears strictly worse than the 5→30 or 10→40 baselines.

The issue with starting lower (3 instead of 5): in early epochs the model sees very low surface weight, making it relatively indifferent to surface accuracy during the critical early learning phase when representations form. The subsequent ramp to 40 then overcorrects late in training when the representation is already more fixed. The 5→30 range was already well-calibrated; pushing start lower and end higher simultaneously appears to destabilize this balance.

The tandem transfer split showing the largest regression (+5.03) suggests the model is overfitting to volume at the expense of generalization when surface weight starts low.

Memory: 8.8 GB, same as the multi-scale-loss branch it's based on.

### Suggested follow-ups
- The 10→40 range (PR #467) was the winner so far. A targeted search around that: try **8→40** or **10→50** to see if the benefit comes from the start or end of the ramp.
- The start value (sw_start) seems more important than the end -- try keeping sw_start=10 constant and varying sw_end (30, 40, 50).