### PR TITLE
Huber loss (delta=0.5) on surface nodes

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -589,7 +589,8 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        huber_err = torch.where(abs_err < 0.5, sq_err, abs_err - 0.25)  # Huber delta=0.5
+        surf_loss = (huber_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Huber loss (delta=0.5) on surface nodes

## Instructions
Replace surface abs_err with Huber: huber_err=where(abs_err<0.5, 0.5*(pred-y_norm)**2/0.5, abs_err-0.25). ~2 lines.
Run with: `--wandb_name "emma/huber-surf" --wandb_group huber-surf --agent emma`

## Baseline
- val/loss: **2.5756**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** 2fs9y4er | **Epochs:** 78 (30-min cap) | **Epoch time:** 22.3 s | **Peak GPU memory:** ~59.9 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.934 | 0.390 | 0.233 | 26.65 | 1.289 | 0.456 | 27.01 |
| val_ood_cond | 1.808 | 0.354 | 0.236 | 26.69 | 1.071 | 0.411 | 21.15 |
| val_ood_re | NaN | 0.333 | 0.234 | 34.19 | 1.041 | 0.448 | 51.60 |
| val_tandem_transfer | 4.755 | 0.692 | 0.382 | 45.52 | 2.139 | 0.995 | 44.62 |
| **combined val/loss** | **2.8323** | | | | | | |

**vs baseline (Δ surf_p):**
- val_in_dist: 26.65 vs 22.47 → **+4.18 (↑18.6%, worse)**
- val_ood_cond: 26.69 vs 24.03 → **+2.66 (↑11.1%, worse)**
- val_ood_re: 34.19 vs 32.08 → **+2.11 (↑6.6%, worse)**
- val_tandem_transfer: 45.52 vs 42.13 → **+3.39 (↑8.0%, worse)**
- val/loss: 2.8323 vs 2.5756 → **+0.2567 (↑10.0%, worse)**

### What happened

Negative result across all metrics. Huber loss (delta=0.5) on surface nodes performed significantly worse than plain MAE.

Two likely causes:

1. **Training/eval metric mismatch.** Validation still uses MAE, but training optimizes Huber. The model learns to minimize Huber but gets evaluated on MAE — gradients point in a different direction than what the evaluation metric measures.

2. **Huber too aggressive at delta=0.5.** Surface pressure errors in normalized space frequently exceed 0.5, placing most training samples in the linear (MAE) regime — so the model loses the quadratic smoothing benefit near zero while getting no extra penalty for large outliers. Effectively, Huber with delta=0.5 provides *less* signal on large errors than plain MAE, which hurts pressure accuracy.

The vol_loss uses MAE unchanged, creating an inconsistency between the two components that may also hurt optimization.

### Suggested follow-ups

- Try **larger delta** (1.0, 2.0) so more samples stay in the quadratic regime and the smoothing benefit is actually realized.
- Try **MSE** (squared loss) on surface nodes instead of Huber — stronger penalty for large errors, which might push the model harder on the surface pressure outliers.
- If trying Huber again, consider **using Huber in validation too** to align training and evaluation metrics.