### PR TITLE
Preprocess MLP with 2 residual layers

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -237,7 +237,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
Deepening the preprocess MLP from 1 to 2 residual layers front-loads more capacity before the attention block.

## Instructions
Change preprocess MLP from n_layers=1 to n_layers=2 in Transolver.__init__.
Run with: `--wandb_name "haku/preprocess-2res" --wandb_group preprocess-2res --agent haku`

## Baseline
- val/loss: **2.5756**

---

## Results

**W&B run ID:** `mqttr52a`  
**Best epoch:** 71 / 72 (30.0 min wall-clock timeout)  
**Peak GPU memory:** 9.8 GB (+~0.7 GB over baseline)

### Metrics at best checkpoint (epoch 71)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.7991 | 0.323 | 0.189 | 25.4 | 1.470 | 0.519 | 32.5 |
| val_tandem_transfer | 4.6228 | 0.656 | 0.353 | 44.5 | 2.345 | 1.087 | 48.0 |
| val_ood_cond | 1.6105 | 0.287 | 0.199 | 24.8 | 1.282 | 0.495 | 24.9 |
| val_ood_re | NaN* | 0.296 | 0.204 | 32.6 | 1.196 | 0.503 | 53.8 |
| **combined val/loss** | **2.6775** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.5756 → This run: 2.6775 — worse (+0.102)**

### What happened

The 2-residual-layer preprocess MLP did not improve over baseline. The result is slightly worse, and the experiment completed only 72 epochs (25 s/epoch) vs ~88 epochs for lighter models (19-20 s/epoch) in the same 30-minute window.

Two plausible explanations:
1. **Training time disadvantage**: The deeper preprocess adds compute, reducing epoch count from ~88 to 72. The model may simply need more iterations to converge.
2. **Representational bottleneck already resolved**: The existing 1-residual-layer preprocess with `n_hidden*2` hidden dimension may already have sufficient capacity to represent the input features. A second residual layer does not add qualitatively different representations.

Memory increased by ~0.7 GB (9.8 GB vs ~9.1 GB baseline), which is a modest cost.

### Suggested follow-ups

- Try a narrower but deeper preprocess (e.g., n_layers=2 with n_hidden instead of n_hidden*2 as hidden dim) to keep the parameter count similar to baseline.
- Test with a longer run or lower per-epoch time to equalize the epoch count comparison.