### PR TITLE
Asymmetric loss: MSE on surface pressure, L1 elsewhere

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -589,7 +589,11 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+        surf_channel_w = surf_channel_w / surf_channel_w.mean()
+        surf_err = torch.cat([abs_err[..., :2], sq_err[..., 2:3]], dim=-1)
+        surf_err = surf_err * surf_channel_w
+        surf_loss = (surf_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
MSE penalizes large surface pressure errors quadratically (stagnation point, suction peak), while L1 keeps velocity robust. Prior Huber failed due to delta=0.5 kink; pure MSE on pressure is cleaner.

## Instructions
Replace the surface loss computation with asymmetric MSE: L1 for Ux/Uy, MSE for pressure, with channel weights [1.0, 1.0, 2.0] normalized to mean=1.

Run with: `--wandb_name "frieren/asymmetric-mse" --wandb_group asymmetric-mse --agent frieren`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `wktbnm4x` (frieren/asymmetric-mse)
**Epochs completed:** 78/100 (hit 30-min timeout)
**Peak GPU memory:** ~52.5 GB (54.9% of 96 GB, vs ~33 GB baseline)

### Metrics at best val/loss epoch

| Metric | Baseline | Asymmetric MSE | Delta |
|--------|----------|----------------|-------|
| val/loss | 2.5700 | **2.9867** | +16.3% |
| val_in_dist/mae_surf_p | 22.47 | **32.57** | +45% |
| val_ood_cond/mae_surf_p | 24.03 | **32.79** | +36% |
| val_ood_re/mae_surf_p | 32.08 | **38.22** | +19% |
| val_tandem_transfer/mae_surf_p | 42.13 | **49.77** | +18% |

Surface MAE (in-dist): Ux=0.33, Uy=0.20, p=32.57
Volume MAE (in-dist): Ux=1.62, Uy=0.58, p=37.87

### What happened

The asymmetric MSE approach made things dramatically worse, particularly for pressure (+45% on in-dist surface pressure MAE). This is a strong negative result against the hypothesis.

Several failure modes explain this:

1. **Train/val metric mismatch**: The training objective changed to MSE for pressure, but the validation checkpoint selection still uses MAE (abs_err in the validation loop). This means we're optimizing one metric while selecting checkpoints by another — the model may be overfitting to minimize squared errors that don't translate to better MAE.

2. **MSE scaling in normalized space**: Normalized pressure residuals can be large (the std is not 1 in original space). Switching to squared errors for pressure creates a much larger loss scale for outlier samples. The gradient signal from a few high-error cases dominates training, pulling the model away from the average-case solution.

3. **Memory spike**: GPU memory went from ~33 GB to ~52.5 GB. This suggests that the larger gradient graph (squaring creates an extra term in the backward pass) is being retained, or the computation graph is larger due to maintaining both sq_err and abs_err paths.

4. **Channel weight interaction**: The [1.0, 1.0, 2.0] channel weights combined with switching to squared error for pressure essentially applies 4x more pressure focus in gradient magnitude terms (2x weight * ~2x MSE gradient). This may cause the optimizer to ignore Ux/Uy gradients almost entirely.

### Suggested follow-ups

- If MSE on pressure is to be explored, the train/val loss should be aligned (use MSE-based val metric for checkpoint selection).
- A softer version — e.g., Huber loss with large delta (e.g., 5.0) — might get the asymptotic MSE behavior for large errors without the quadratic explosion.
- The dramatic memory increase (54.9% vs 34%) warrants investigation — `sq_err` is already computed so this likely indicates gradient graph issues from combining sq and abs paths.