### PR TITLE
Learned per-head temperature (spread init 0.15-0.40)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.temperature = nn.Parameter(torch.tensor([0.15, 0.20, 0.30, 0.40]).view(1, heads, 1, 1))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
With MQA, each Q-head should specialize differently. Per-head temperature with spread init enables some heads to attend sharply (boundary layer) and others broadly (freestream).

## Instructions
In `structured_split/structured_train.py`, in `Physics_Attention_Irregular_Mesh.__init__`:

```python
# Replace: self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
self.temperature = nn.Parameter(torch.tensor([0.15, 0.20, 0.30, 0.40]).view(1, heads, 1, 1))
```

Run with: `--wandb_name "fern/head-temp" --wandb_group learned-head-temp --agent fern`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `8wj9h91o` | **Epochs:** 81/100 (30.1 min) | **Peak memory:** 8.8 GB

### Validation loss
| Split | Baseline (uniform 0.5) | Spread init (0.15-0.40) | Δ |
|---|---|---|---|
| val/loss (mean 3 splits) | 2.5700 | 2.6771 | +4.2% worse |
| val_in_dist | — | 1.7694 | — |
| val_ood_cond | — | 1.6125 | — |
| val_ood_re | — | nan (vol_loss=1.9e10) | pre-existing |
| val_tandem_transfer | — | 4.6493 | — |

### Surface MAE pressure (primary metric)
| Split | Baseline mae_surf_p | Spread init mae_surf_p | Δ |
|---|---|---|---|
| val_in_dist | 22.47 | 24.74 | +10.0% worse |
| val_ood_cond | 24.03 | 24.05 | +0.1% flat |
| val_ood_re | 32.08 | 32.97 | +2.8% worse |
| val_tandem_transfer | 42.13 | 45.34 | +7.6% worse |

### Surface MAE (Ux, Uy, p) at best checkpoint
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.30 | 0.19 | 24.74 |
| val_ood_cond | 0.28 | 0.19 | 24.05 |
| val_ood_re | 0.29 | 0.20 | 32.97 |
| val_tandem_transfer | 0.66 | 0.35 | 45.34 |

### Volume MAE at best checkpoint
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.53 | 0.54 | 33.13 |
| val_ood_cond | 1.34 | 0.51 | 26.31 |
| val_ood_re | 1.28 | 0.52 | 55.78 |
| val_tandem_transfer | 2.45 | 1.13 | 50.84 |

### What happened

**The spread temperature init performed worse across all splits.** val/loss is +4.2% higher, with val_in_dist (+10%) and val_tandem_transfer (+7.6%) showing the largest regressions. ood_cond is nearly flat.

The hypothesis was that lower temperatures would specialize heads to attend more sharply (boundary layer capture), while higher temperatures maintain broad attention (freestream). However:

1. **Sharpness at 0.15 may over-concentrate**: `slice_weights = softmax(logits / temperature)` — with temperature=0.15, the attention over the 32 slice tokens becomes very concentrated on ~1-2 tokens. This extreme sparsity may prevent heads from learning useful aggregate representations, especially early in training when the model needs to explore.

2. **Optimization instability**: The 4 heads start with very different temperature magnitudes (0.15 vs 0.40 = ~2.7x range). This creates uneven gradient scales and may cause some heads to converge faster than others, leading to suboptimal overall convergence.

3. **The 0.5 uniform init was already well-chosen**: The previous experiments suggest 0.5 is a good balance between sharp and diffuse attention. The spread init breaks this symmetry without benefit.

The model learns the temperatures from initialization — they're still trainable parameters. But the spread initialization pushes heads into different specialization modes before the model has learned meaningful representations, making convergence harder.

### Suggested follow-ups
- **Try narrower spread (0.3-0.7)**: A gentler spread around 0.5 might induce specialization without the instability of 0.15-0.40.
- **Try higher temperature init (0.5-1.0)**: Higher temperatures create softer attention, which might actually help by allowing more gradual specialization.
- **Freeze temperatures for warmup**: Initialize with spread but freeze temperature for the first 10 epochs, then unfreeze. This lets the model learn stable representations before the temperatures diverge.