### PR TITLE
SwiGLU MLP in TransolverBlock (gated FFN, 2/3 scaling)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -179,7 +179,10 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        swiglu_dim = int(hidden_dim * mlp_ratio * 2 / 3)
+        self.mlp_gate = nn.Linear(hidden_dim, swiglu_dim)
+        self.mlp_up = nn.Linear(hidden_dim, swiglu_dim)
+        self.mlp_down = nn.Linear(swiglu_dim, hidden_dim)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -190,7 +193,8 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        h = self.ln_2(fx)
+        fx = self.mlp_down(F.silu(self.mlp_gate(h)) * self.mlp_up(h)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx
@@ -455,6 +459,12 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
+
+# Xavier init for SwiGLU layers (override orthogonal init from initialize_weights)
+for block in model.blocks:
+    for layer in [block.mlp_gate, block.mlp_up, block.mlp_down]:
+        nn.init.xavier_uniform_(layer.weight)
+        nn.init.constant_(layer.bias, 0)
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
SwiGLU replaces the standard FFN with a gated linear unit: SwiGLU(x) = (xW1 * SiLU(xV)) W2. Key innovation in LLaMA/PaLM. Prior GLU on attention output failed; this targets the FFN where gating has strongest support. 2/3 scaling keeps param count similar.

## Instructions
In `structured_split/structured_train.py`, in `TransolverBlock.__init__`:

```python
# Replace: self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
swiglu_dim = int(hidden_dim * mlp_ratio * 2 / 3)
self.mlp_gate = nn.Linear(hidden_dim, swiglu_dim)
self.mlp_up = nn.Linear(hidden_dim, swiglu_dim)
self.mlp_down = nn.Linear(swiglu_dim, hidden_dim)
```

In `TransolverBlock.forward`:
```python
# Replace: fx = self.mlp(self.ln_2(fx)) + fx
h = self.ln_2(fx)
fx = self.mlp_down(F.silu(self.mlp_gate(h)) * self.mlp_up(h)) + fx
```

Apply Xavier init to the new layers. Run with: `--wandb_name "tanjiro/swiglu" --wandb_group swiglu-mlp --agent tanjiro`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `wwanpw8o` | **Epochs:** 78 (clean timeout, ~20s/epoch) | **Peak memory:** 7.6 GB

| Metric | Baseline | SwiGLU | Delta |
|---|---|---|---|
| val/loss | 2.5700 | **2.6489** | +0.079 worse |
| val_in_dist/mae_surf_p | 22.47 | **25.35** | +2.88 worse |
| val_ood_cond/mae_surf_p | 24.03 | **23.93** | -0.10 better |
| val_ood_re/mae_surf_p | 32.08 | **33.13** | +1.05 worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **44.36** | +2.23 worse |

Additional surface metrics (best checkpoint, epoch 78):
- val_in_dist: mae_surf_Ux=0.314, mae_surf_Uy=0.197
- val_ood_cond: mae_surf_Ux=0.267, mae_surf_Uy=0.197
- val_ood_re: mae_surf_Ux=0.280, mae_surf_Uy=0.207
- val_tandem_transfer: mae_surf_Ux=0.651, mae_surf_Uy=0.356

Note: `val_ood_re/loss` remains NaN (pre-existing vol_loss overflow); val/loss is mean over 3 finite splits.

### What happened

**Negative result.** SwiGLU is worse on 3 out of 4 splits, with particularly large degradation on in-dist (+2.9 Pa) and tandem transfer (+2.2 Pa). Only OOD-cond shows marginal improvement (-0.1 Pa).

The 2/3 scaling makes the SwiGLU approximately parameter-equivalent to the standard FFN: with mlp_ratio=2 and hidden_dim=128, the original MLP expands to 256 dims, while SwiGLU with 2/3 scaling uses swiglu_dim=170. Two Linear layers (gate + up) both map 128→170 → ~2×128×170=43k params, plus down 170→128=~22k, total ~65k vs original MLP's ~2×128×256=65k — so roughly the same parameter count.

Despite being parameter-equivalent, SwiGLU underperforms. Possible reasons:

1. **Xavier vs orthogonal init mismatch.** The existing layers use orthogonal init, but the SwiGLU layers use Xavier. This asymmetric initialization might create gradient flow issues at the start of training, slowing convergence. The model has fewer effective epochs to recover.

2. **SwiGLU benefits are most pronounced in deep models.** In LLaMA and PaLM, SwiGLU is used across many layers. With a single TransolverBlock, there's limited opportunity for the gating mechanism to provide benefit — the "gating" advantage is more about gradient flow across many layers.

3. **The attention output (`to_out` projection) may already provide implicit gating.** The Physics Attention mechanism already has a filtering/gating-like property through the slice softmax. Adding an explicit gate in the FFN may be redundant.

### Suggested follow-ups

- **Uniform initialization (all orthogonal):** Try SwiGLU with the same orthogonal init as the rest of the model to rule out the init asymmetry issue.
- **SwiGLU with higher mlp_ratio:** Without the 2/3 scaling (use swiglu_dim = hidden_dim * mlp_ratio), the model has more capacity — may help if the bottleneck is capacity, not gating.