### PR TITLE
EMA model averaging (decay=0.999, eval on EMA weights)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -456,6 +456,16 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+import copy
+ema_model = copy.deepcopy(model)
+ema_model.eval()
+ema_decay = 0.999
+
+@torch.no_grad()
+def update_ema(ema, student, decay):
+    for ep, sp in zip(ema.parameters(), student.parameters()):
+        ep.data.mul_(decay).add_(sp.data, alpha=1 - decay)
+
 n_params = sum(p.numel() for p in model.parameters())
 
 
@@ -614,6 +624,7 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        update_ema(ema_model, model, ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -628,6 +639,7 @@ for epoch in range(MAX_EPOCHS):
 
     # --- Validate across all splits ---
     model.eval()
+    ema_model.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -654,7 +666,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = ema_model({"x": x})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()


### PR DESCRIPTION
## Hypothesis
EMA smooths weights exponentially for wider optima. Complementary to Lookahead (coarse periodic avg vs continuous smoothing). Previously showed strong surface pressure improvement but branch diverged.

## Instructions
In `structured_split/structured_train.py`, after model creation:

```python
import copy
ema_model = copy.deepcopy(model)
ema_model.eval()
ema_decay = 0.999

@torch.no_grad()
def update_ema(ema, student, decay):
    for ep, sp in zip(ema.parameters(), student.parameters()):
        ep.data.mul_(decay).add_(sp.data, alpha=1 - decay)
```

After each optimizer.step(): `update_ema(ema_model, model, ema_decay)`
During validation: use `ema_model` instead of `model` for inference.

Run with: `--wandb_name "nezuko/ema" --wandb_group ema-weights --agent nezuko`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 43.67 (note: PR body shows 42.13 — using PR body value)

---

## Results

**W&B run**: `gimiqsmp` (nezuko/ema, group: ema-weights)
**Epochs**: 81 (wall-clock stopped at 30.0 min; ~22s/epoch vs ~20s baseline)
**Peak memory**: 8.8 GB (vs ~7.6 GB baseline, +1.2 GB for EMA copy)

### Metrics at best checkpoint (epoch 81)

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.6734 | 0.301 | 0.180 | **23.0** |
| val_ood_cond | 1.5603 | 0.286 | 0.190 | **23.0** |
| val_ood_re | NaN | 0.295 | 0.203 | **32.4** |
| val_tandem_transfer | 4.5323 | 0.639 | 0.339 | **43.5** |

**val/loss**: 2.5887 vs baseline 2.5700 (+0.019, essentially flat)

### Surface pressure comparison (mae_surf_p)

| Split | Baseline | Ours | Δ |
|---|---|---|---|
| val_in_dist | 22.47 | 23.0 | +0.5 ↑ slightly worse |
| val_ood_cond | 24.03 | 23.0 | **−1.0 ↓ better** |
| val_ood_re | 32.08 | 32.4 | +0.3 ↑ neutral |
| val_tandem_transfer | 42.13 | 43.5 | +1.4 ↑ worse |

### What happened

EMA (decay=0.999) gives a mixed result. val_ood_cond shows a clear improvement (24.03 → 23.0, −1.0), but val_tandem_transfer degrades (+1.4), and val_in_dist is slightly worse (+0.5). The combined val/loss is essentially the same as baseline (2.5887 vs 2.5700).

The EMA model adds overhead: a deep copy of the model (+1.2 GB) and extra parameter updates after each step (~10% slower per epoch). This causes the run to complete 81 epochs instead of ~90, which partially limits performance.

The EMA validation metrics are from the ema_model which is a 0.999-decay running average of all training checkpoints. At epoch 81, the EMA model has been updating for ~31K steps (331 batches × 81 epochs × correction for 0.999^31K ≈ ∞ convergence to recent weights). With high decay (0.999), the EMA model closely tracks the current model — the difference from the instantaneous checkpoint is small.

The small overall improvement on val_ood_cond and slight degradation on val_tandem_transfer is within noise for this architecture. EMA at 0.999 may be too slow to meaningfully differ from the current model within ~80 epochs of training.

### Suggested follow-ups

1. **Lower decay (0.99 or 0.995)**: A faster EMA would diverge more from the current model and could show clearer smoothing benefits, especially in earlier epochs.
2. **EMA validation only at final epoch**: Skip EMA validation during training (removes ~10% overhead) and only evaluate the EMA model at the very end — similar to the SWA approach.
3. **EMA + 2 heads**: Combining EMA with n_head=2 (which improved val_ood_cond) might be additive.