### PR TITLE
Log-cosh loss on surface (smooth L1 with L2 near zero)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -459,6 +459,13 @@ model = Transolver(**model_config).to(device)
 n_params = sum(p.numel() for p in model.parameters())
 
 
+def log_cosh_loss(pred, target, mask, channel_w):
+    err = pred - target
+    lc = err.abs() + torch.log1p(torch.exp(-2.0 * err.abs())) - 0.6931
+    lc = lc * channel_w
+    return (lc * mask.unsqueeze(-1)).sum() / mask.sum().clamp(min=1)
+
+
 class Lookahead:
     def __init__(self, base_optimizer, k=5, alpha=0.5):
         self.base_optimizer = base_optimizer
@@ -589,7 +596,9 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+        surf_channel_w = surf_channel_w / surf_channel_w.mean()
+        surf_loss = log_cosh_loss(pred, y_norm, surf_mask, surf_channel_w)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Log-cosh behaves like L2 for small errors and L1 for large, but is everywhere smooth. Unlike Huber (which failed), log-cosh provides continuous second-order gradient info near zero, helping fine convergence in late epochs.

## Instructions
In `structured_split/structured_train.py`, replace the surface loss:

```python
def log_cosh_loss(pred, target, mask, channel_w):
    err = pred - target
    lc = err.abs() + torch.log1p(torch.exp(-2.0 * err.abs())) - 0.6931
    lc = lc * channel_w
    return (lc * mask.unsqueeze(-1)).sum() / mask.sum().clamp(min=1)

surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
surf_channel_w = surf_channel_w / surf_channel_w.mean()
surf_loss = log_cosh_loss(pred, y_norm, surf_mask, surf_channel_w)
```

Run with: `--wandb_name "alphonse/log-cosh" --wandb_group log-cosh-surf --agent alphonse`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run ID:** t5dv43sf
**Epochs completed:** 77/100 (30-min timeout; ~23.6s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline | Best epoch (75) | Last epoch (77) |
|---|---|---|---|
| val/loss | 2.5700 | **3.0669** (+19%) | 3.0744 |
| val_in_dist/mae_surf_p | 22.47 | **29.88** (+33%) | 29.81 |
| val_ood_cond/mae_surf_p | 24.03 | **28.16** (+17%) | 26.98 |
| val_ood_re/mae_surf_p | 32.08 | **35.60** (+11%) | 34.72 |
| val_tandem_transfer/mae_surf_p | 42.13 | **46.06** (+9%) | 46.81 |

Additional val_in_dist metrics at best epoch:
- mae_surf_Ux: 0.428 | mae_surf_Uy: 0.262
- mae_vol_Ux: 1.301 | mae_vol_Uy: 0.459 | mae_vol_p: 26.98

### What happened

**This did not work.** All metrics are worse than baseline across every val split.

The log-cosh surface loss underperforms the simple MAE surface loss by a consistent margin (+9–33% on surface pressure). The run completed 77/100 epochs (comparable to a normal run in 30 min), so insufficient training time is not the issue.

Two likely causes:
1. **Miscalibrated surf_weight**: The log-cosh loss has smaller gradients near zero (quadratic regime) compared to MAE, so the same surf_weight schedule (5→30) under-penalizes surface errors early in training relative to MAE — the model doesn't learn the surface as aggressively as baseline.
2. **Channel weighting doubles pressure cost**: The [0.75, 0.75, 1.5] weighting doubles the pressure contribution to surf_loss, which inflates the surf_loss value relative to baseline. Since surf_weight ramps to 30, this means pressure gets 45x the vol_loss weight — possibly over-weighting pressure and distorting learning on Ux/Uy.

The combined effect of a softer gradient near zero and the channel weight inflation likely destabilizes the effective surf_weight calibration.

### Suggested follow-ups
- If trying log-cosh, use it without the channel weighting first to isolate the loss function effect from the weight effect
- The channel weighting idea (up-weighting pressure) could be tried standalone with the existing MAE surface loss — that's a simpler change and easier to reason about
- The baseline MAE loss appears well-suited for this task; alternatives need to match its gradient magnitude closely to use the same surf_weight schedule