### PR TITLE
Gradient accumulation (2 steps, effective batch 8)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -553,8 +553,10 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf = 0.0
     n_batches = 0
 
+    accum_steps = 2
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    optimizer.zero_grad()
+    for step_idx, (x, y, is_surface, mask) in enumerate(pbar):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -610,12 +612,14 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        (loss / accum_steps).backward()
+
+        if (step_idx + 1) % accum_steps == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            global_step += 1
+            wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Batch 8 failed because it doubled memory and halved updates. Gradient accumulation achieves the same noise reduction while keeping memory constant and maintaining epoch count.

## Instructions
In `structured_split/structured_train.py`, modify the training loop:

```python
accum_steps = 2
optimizer.zero_grad()
for step_idx, (x, y, is_surface, mask) in enumerate(pbar):
    # ... existing forward pass and loss computation ...
    (loss / accum_steps).backward()
    
    if (step_idx + 1) % accum_steps == 0:
        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
        optimizer.step()
        optimizer.zero_grad()
        global_step += 1
```

Remove existing optimizer.zero_grad() and optimizer.step() calls from the inner loop.

Run with: `--wandb_name "edward/grad-accum" --wandb_group grad-accum-2 --agent edward`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** bfjdw957  
**Best epoch:** 80  
**Peak memory:** 8.8 GB

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6277** | +2.2% |
| val_in_dist/mae_surf_Ux | — | 0.3079 | — |
| val_in_dist/mae_surf_Uy | — | 0.1956 | — |
| val_in_dist/mae_surf_p | 22.47 | **23.49** | +4.5% ↑ worse |
| val_in_dist/mae_vol_Ux | — | 1.6249 | — |
| val_in_dist/mae_vol_Uy | — | 0.5687 | — |
| val_in_dist/mae_vol_p | — | 34.31 | — |
| val_ood_cond/mae_surf_p | 24.03 | **23.45** | -2.4% ↓ better |
| val_ood_re/mae_surf_p | 32.08 | **33.04** | +3.0% |
| val_tandem_transfer/mae_surf_p | 42.13 | **43.94** | +4.3% ↑ worse |

### What happened

Slightly negative result. Gradient accumulation (accum_steps=2, effective batch 8) didn't improve over baseline — in-dist and tandem pressure got slightly worse while ood_cond improved marginally. The key issue: with accumulation, the model performs only half as many gradient updates in the same wall-clock time (~13k steps vs ~26k at best epoch). Since training is time-capped at 30 minutes, gradient accumulation trades update frequency for larger effective batches, and that trade-off is unfavorable here — the model benefits more from frequent updates than from smoother gradients. The existing Lookahead optimizer (k=10) already provides gradient smoothing, so the marginal benefit of accumulation is minimal.

### Suggested follow-ups

- Try a lower accumulation factor (accum_steps=2 but with a proportionally higher learning rate to compensate for smoother gradients).
- Investigate whether removing Lookahead (which does its own slow-weights averaging) and relying on gradient accumulation instead gives better results.
- If gradient noise is the concern, stochastic weight averaging (SWA) over late epochs may be more efficient than accumulation.