### PR TITLE
Cosine eta_min=1e-6 (colder floor for finer convergence)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -490,7 +490,7 @@ class Lookahead:
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-6)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
eta_min=1e-5 was merged and improved. eta_min=1e-4 was too warm. 1e-6 allows 10x finer updates in the final epochs while still being nonzero. Strong directional evidence from prior experiments.

## Instructions
In \`structured_split/structured_train.py\`, change the cosine scheduler:

\`\`\`python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-6)
\`\`\`

Run with: \`--wandb_name "askeladd/eta-1e6" --wandb_group eta-min-1e6 --agent askeladd\`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** \`ooxcza73\`
**Epochs completed:** 78 (terminated at 30-minute timeout)
**Peak GPU memory:** ~37.0 GB (38% of 96 GB)

### Metrics at best val/loss

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.6749 | 2.5700 | **+0.105** ✗ |
| val_in_dist/mae_surf_p | 24.92 | 22.47 | **+2.45** ✗ |
| val_ood_cond/mae_surf_p | 24.01 | 24.03 | -0.02 (~tie) |
| val_ood_re/mae_surf_p | 33.32 | 32.08 | **+1.24** ✗ |
| val_tandem_transfer/mae_surf_p | 44.25 | 42.13 | **+2.12** ✗ |
| val_in_dist/mae_surf_Ux | 0.306 | — | — |
| val_in_dist/mae_surf_Uy | 0.197 | — | — |
| val_in_dist/mae_vol_p | 32.04 | — | — |

### What happened

eta_min=1e-6 is a negative result — all metrics are worse than the baseline (which was set at eta_min=1e-5). The directional progression (1e-4 → 1e-5 improved, 1e-5 → 1e-6 did not) suggests we've already passed the optimal floor.

Note: this branch started from eta_min=1e-4, so the actual change made was 1e-4 → 1e-6. The baseline (val/loss 2.5700) was measured with eta_min=1e-5 on the main noam branch. The result confirms that 1e-6 is worse than 1e-5.

Mechanistically, an extremely low eta_min means the cosine schedule converges to near-zero LR toward the end of training, leaving the model unable to escape local minima or respond to the loss landscape in the final epochs. With only 78 epochs in 30 minutes (the 100-epoch budget requires faster-than-1-min/epoch), the tail of the cosine schedule at 1e-6 may be too aggressive.

### Suggested follow-ups

- The sweet spot may be eta_min=1e-5 — this appears to be the best value found so far.
- Try eta_min=5e-6 to check if the transition is sharp (1e-6 bad, 1e-5 good) or gradual.
- Explore WSD (warmup-stable-decay) schedules that keep LR stable in the middle epochs and only decay at the end.