### PR TITLE
Stochastic Weight Averaging (last 20% of training)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -456,6 +456,9 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+swa_model = torch.optim.swa_utils.AveragedModel(model)
+swa_start = int(0.8 * MAX_EPOCHS)
+
 n_params = sum(p.numel() for p in model.parameters())
 
 
@@ -623,11 +626,14 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    if epoch >= swa_start:
+        swa_model.update_parameters(model)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
     # --- Validate across all splits ---
-    model.eval()
+    eval_model = swa_model if epoch >= swa_start else model
+    eval_model.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -654,7 +660,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()
@@ -733,7 +739,8 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        torch.save(model.state_dict(), model_path)
+        save_state = swa_model.module.state_dict() if epoch >= swa_start else model.state_dict()
+        torch.save(save_state, model_path)
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(
@@ -746,6 +753,8 @@ for epoch in range(MAX_EPOCHS):
         f"val[{split_summary}]{tag}"
     )
 
+
+torch.optim.swa_utils.update_bn(train_loader, swa_model, device=device)
 
 # --- Final summary ---
 total_time = (time.time() - train_start) / 60.0


### PR DESCRIPTION
## Hypothesis
SWA averages model weights over the last training phase, finding wider optima. Complementary to Lookahead (different timescale) and orthogonal to cosine schedule. With ~80 epochs, start SWA at epoch 64.

## Instructions
In `structured_split/structured_train.py`, after model creation:

```python
swa_model = torch.optim.swa_utils.AveragedModel(model)
swa_start = int(0.8 * MAX_EPOCHS)
```

In the training loop after scheduler.step():
```python
if epoch >= swa_start:
    swa_model.update_parameters(model)
```

For validation when epoch >= swa_start, use swa_model for inference. At the end of training, call:
```python
torch.optim.swa_utils.update_bn(train_loader, swa_model, device=device)
```

Run with: `--wandb_name "violet/swa" --wandb_group swa-late-20pct --agent violet`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** 3nryt9l6 (violet/swa)
**Epochs completed:** 82 (30-min timeout; best epoch: 82, SWA from epoch 80)
**Peak memory:** 8.8 GB

### Metrics at best epoch (val/loss≈2.6405, epoch 82 from output log)

| Split | val/loss | mae_surf_p | Δ vs baseline |
|---|---|---|---|
| val_in_dist | 1.7256 | ~24.6 | ~+2.1 |
| val_tandem_transfer | 4.6279 | ~44.4 | ~+2.3 |
| val_ood_cond | 1.5679 | ~24.8 | ~+0.8 |
| val_ood_re | nan | ~32.8 | ~+0.7 |

**val/loss: ≈2.6405** (epoch 82 from output log) vs baseline 2.5700 (Δ = **+0.071**, worse)

W&B last synced (epoch 81): val_in_dist/mae_surf_p=24.57, val_ood_cond/mae_surf_p=24.76, val_tandem_transfer/mae_surf_p=44.41, val_ood_re/mae_surf_p=32.78. Process was killed during epoch 82 validation so best_best values were not logged to W&B.

### What happened
Negative result. SWA (last 20% of training) performed worse than baseline (+0.071 val/loss). The run was timeout-killed at epoch 82, so SWA only accumulated 3 weight averages (epochs 80, 81, 82) — far too few for meaningful averaging. The SWA benefit typically requires 10-20+ updates to produce a noticeably smoother loss landscape.

With the 30-minute cap providing only ~82 epochs total, starting SWA at 80% (epoch 80) leaves only ~2-3 epochs of averaging. The SWA model essentially reflects a noisy average of the last 3 checkpoints rather than a true weight-space ensemble.

Additionally, the AveragedModel holds a copy of all model parameters, adding memory overhead (8.8GB vs typical).

### Suggested follow-ups
- Try starting SWA earlier (e.g., epoch 40, 50% of training) so it can accumulate more averages within the 30-min budget.
- Alternatively, try EMA (exponential moving average) with decay=0.999, which applies smoother averaging throughout training.