### PR TITLE
Annealing target noise (0.02->0.003, 1.5x on pressure)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -564,7 +564,10 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            noise_start, noise_end = 0.02, 0.003
+            noise_scale = noise_start + (noise_end - noise_start) * (epoch / MAX_EPOCHS)
+            noise_channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
+            y_norm = y_norm + noise_scale * noise_channel_w * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Constant noise=0.01 helps regularization but prevents fine convergence late. An annealing schedule gives strong regularization early (exploring) and precise targets late (converging). Extra noise on pressure channel regularizes where dynamic range is highest.

## Instructions
In `structured_split/structured_train.py`, replace target noise:

```python
# Replace: y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
noise_start, noise_end = 0.02, 0.003
noise_scale = noise_start + (noise_end - noise_start) * (epoch / MAX_EPOCHS)
noise_channel_w = torch.tensor([1.0, 1.0, 1.5], device=device)
y_norm = y_norm + noise_scale * noise_channel_w * torch.randn_like(y_norm)
```

Run with: `--wandb_name "gilbert/noise-sched" --wandb_group noise-schedule --agent gilbert`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `hvlv5oqc` — gilbert/noise-sched

**Best epoch:** 80 of 81 (30.3 min, wall-clock limit)
**Peak memory:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.757 | 0.321 | 0.188 | **23.33** | 1.551 | 0.546 | 31.34 |
| val_ood_cond | 1.586 | — | — | **24.5** | — | — | — |
| val_ood_re | nan | — | — | **33.0** | — | — | — |
| val_tandem_transfer | 4.596 | — | — | **44.0** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.6463** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | 2.6463 | +0.076 ❌ |
| val_in_dist/mae_surf_p | 22.47 | 23.33 | +0.86 ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 24.5 | +0.47 ❌ |
| val_ood_re/mae_surf_p | 32.08 | 33.0 | +0.92 ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 44.0 | +1.87 ❌ |

### What happened

Negative result. The annealing noise schedule performs worse than the constant baseline across all metrics and splits. val/loss is +0.076 worse and all pressure MAE metrics regressed.

Two likely causes:

1. **Starting too high**: The schedule starts at noise=0.02 and only reaches 0.01 (the constant baseline value) around the halfway point. This means the first ~40–50 epochs see more noise than needed, potentially preventing the model from making fast early progress on the learning signal.

2. **Pressure channel upweighting (1.5×) backfires**: Adding more noise to the pressure channel is intended as regularization, but pressure is already the hardest target. More noise on the hardest-to-learn channel may simply make training noisier without improving generalization. Earlier experiments showed that constant 0.02 noise (applied uniformly) helped — but that might have worked because the branch baseline had weaker noise; here the 1.5× factor overloads the pressure channel.

Note: `val_ood_re/loss` is NaN throughout — pre-existing issue.

### Suggested follow-ups

- **Reverse the start/end**: Try noise annealing from 0.01 → 0.005 (anneal down from a moderate level). Starting at 0.02 appears too aggressive.
- **Drop the pressure upweighting**: Test the annealing schedule without the 1.5× pressure factor. The uniform 0.02 result was better.
- **Anneal only the pressure channel**: Keep velocity noise constant at 0.01 and anneal only the pressure noise from 0.02 → 0.005.