### PR TITLE
Value residual in slice attention (identity shortcut)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -150,6 +150,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             dropout_p=dropout_p,
             is_causal=False,
         )
+        out_slice_token = out_slice_token + slice_token  # identity shortcut
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")


### PR DESCRIPTION
## Hypothesis
Adding identity skip from input slice tokens to attention output adds a direct gradient path, preventing attention from collapsing to low-rank subspace. Critical for our 1-layer model where attention is the only feature mixing operation.

## Instructions
In `structured_split/structured_train.py`, in `Physics_Attention_Irregular_Mesh.forward`, after computing out_slice_token:

```python
# After: out_slice_token = F.scaled_dot_product_attention(...)
out_slice_token = out_slice_token + slice_token  # identity shortcut
```

This is a single-line change. Run with: `--wandb_name "senku/val-residual" --wandb_group value-residual --agent senku`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `6woosawl` (senku/val-residual)
**Epochs completed:** 78/100 (30-min timeout; ~22s/epoch)
**Peak memory:** 8.8 GB

### Metrics vs Baseline (best checkpoint, step 77 / epoch 78)

| Metric | Baseline | This run (best) | Delta |
|---|---|---|---|
| val/loss | 2.5700 | 2.6466 | +0.077 (worse) |
| val_in_dist/mae_surf_p | 22.47 | 25.56 | +3.09 (worse) |
| val_ood_cond/mae_surf_p | 24.03 | 24.70 | +0.67 (worse) |
| val_ood_re/mae_surf_p | 32.08 | 32.73 | +0.65 (worse) |
| val_tandem_transfer/mae_surf_p | 42.13 | 44.71 | +2.58 (worse) |

Surface MAE (best epoch, val_in_dist): Ux=0.285, Uy=0.190, p=25.56
Volume MAE (best epoch, val_in_dist): Ux=1.54, Uy=0.55, p=33.93

### What happened

This did not work. Adding the identity shortcut (`out_slice_token = out_slice_token + slice_token`) made all metrics worse than baseline, with val_in_dist/mae_surf_p going from 22.47 to 25.56 (+3.09).

The problem: `slice_token` is not a residual from the same representation space as `out_slice_token`. The attention mechanism transforms `slice_token` through learned projections (to_q, to_k, to_v) and applies multi-head attention; adding the original `slice_token` back introduces a shortcut that bypasses the attention's learned mixing. This effectively adds noise from the pre-attention token representation into the post-attention output, diluting the attention's learned signal.

This is different from a standard residual connection (which adds `fx` before the attention block, not inside it). A true value-residual would require adding the value projection output to the attention output, not the raw slice token.

Memory cost: same 8.8 GB.

### Suggested follow-ups
- If attention-level residuals are worth exploring, try `out_slice_token = out_slice_token + v_slice_token.mean(dim=1, keepdim=True)` (add the averaged value) instead.
- Or simply keep the existing `fx = self.attn(...) + fx` block-level residual -- it already provides the gradient path the hypothesis was targeting.