### PR TITLE
Learned per-channel weights for multi-scale coarse loss

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -455,6 +455,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
+coarse_channel_w = nn.Parameter(torch.tensor([1.0, 1.0, 2.0], device=device))
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -487,7 +488,10 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+base_opt = torch.optim.AdamW(
+    list(model.parameters()) + [coarse_channel_w],
+    lr=cfg.lr, weight_decay=cfg.weight_decay
+)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
@@ -607,6 +611,7 @@ for epoch in range(MAX_EPOCHS):
             mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
             coarse_err = (pred_coarse - y_coarse).abs()
+            coarse_err = coarse_err * F.softmax(coarse_channel_w, dim=0) * 3
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 


### PR DESCRIPTION
## Hypothesis
The coarse loss uses uniform channel weights, but pressure has different error scale than velocity. 3 learnable parameters let the model auto-balance the coarse signal per channel.

## Instructions
In `structured_split/structured_train.py`, add learnable coarse channel weights:

After model creation:
```python
coarse_channel_w = nn.Parameter(torch.tensor([1.0, 1.0, 2.0])).to(device)
base_opt = torch.optim.AdamW(
    list(model.parameters()) + [coarse_channel_w],
    lr=cfg.lr, weight_decay=cfg.weight_decay
)
```

In coarse loss computation:
```python
coarse_err = (pred_coarse - y_coarse).abs()
coarse_err = coarse_err * F.softmax(coarse_channel_w, dim=0) * 3
coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
```

Run with: `--wandb_name "emma/learned-coarse" --wandb_group learned-coarse-w --agent emma`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** hlxour8f | **Epochs:** ~83 (30-min cap) | **Epoch time:** 22.0 s | **Peak GPU memory:** 23.3 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.750 | 0.332 | 0.184 | 24.21 | 1.725 | 0.618 | 29.65 |
| val_ood_cond | 1.600 | 0.283 | 0.188 | 23.53 | 1.474 | 0.564 | 23.01 |
| val_ood_re | NaN | 0.300 | 0.205 | 32.38 | 1.384 | 0.562 | 53.27 |
| val_tandem_transfer | 4.649 | 0.662 | 0.346 | 43.96 | 2.599 | 1.185 | 46.82 |
| **combined val/loss** | **2.6666** | | | | | | |

**vs baseline (Δ surf_p):**
- val_in_dist: 24.21 vs 22.47 → **+1.74 (↑7.7%, worse)**
- val_ood_cond: 23.53 vs 24.03 → **-0.50 (↓2.1%, better)**
- val_ood_re: 32.38 vs 32.08 → **+0.30 (↑0.9%, marginally worse)**
- val_tandem_transfer: 43.96 vs 42.13 → **+1.83 (↑4.3%, worse)**
- val/loss: 2.6666 vs 2.5700 → **+0.0966 (↑3.8%, worse)**

### What happened

Negative result overall. The learnable coarse channel weights did not help — val/loss is 3.8% higher than baseline and most splits are worse. Only val_ood_cond showed a small improvement (-0.50 on surf_p), which may be within noise.

Two likely causes:

1. **Softmax forces weight competition.** The softmax normalization means boosting pressure weight (channel 2) reduces Ux and Uy weights proportionally. Since pressure errors dominate in absolute scale, the model may already get more gradient signal from pressure — explicitly down-weighting velocity in the coarse loss hurts velocity accuracy without helping pressure enough.

2. **Coarse loss is a secondary signal.** The coarse loss is added at weight 1.0 to the main loss (vol_loss + surf_weight×surf_loss where surf_weight ramps up to ~30). At late training surf_weight is large, so the coarse loss contributes ~3% of total loss. Re-weighting 3 channels within that 3% has minimal effect on overall training dynamics.

Note: The  on  returns a non-leaf tensor — had to fix by creating with  directly. The PR instructions would have failed out of the box; the fix was mechanical.

### Suggested follow-ups

- Try **fixed manual weights** (e.g. [1, 1, 3] without learnable) — simpler and no optimizer interference.
- Try **separate coarse loss scale per channel** as a config hyperparameter (search [1.5, 2.0, 3.0] for pressure multiplier).
- The vol MAE for this run (vol_Ux ~1.7 vs baseline likely ~1.3) is notably worse — the learned weights may be hurting the volume field. Worth investigating if the coarse loss is over-weighting surface-irrelevant nodes.