### PR TITLE
Lookahead k=5 alpha=0.8 (frequent sync, strong interpolation)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -488,7 +488,7 @@ class Lookahead:
 
 
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=5, alpha=0.8)  # was k=10 — more frequent sync with proven alpha
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
k=5/alpha=0.5 was just merged. k=10/alpha=0.8 was the previous baseline. The untested combo k=5 (more frequent sync) + alpha=0.8 (stronger interpolation) combines faster synchronization with proven interpolation strength. With MQA reducing parameters, frequent steps keep slow weights closer to the trajectory.

## Instructions
In `structured_split/structured_train.py`, change:

```python
optimizer = Lookahead(base_opt, k=5, alpha=0.8)
```

Run with: `--wandb_name "norman/la-k5a08" --wandb_group la-k5a08 --agent norman`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `0mu041fs`  
**Epochs:** 81 (hit 30-min timeout at 1815s)  
**Peak memory:** 8.8 GB  

### Metrics at best checkpoint (epoch 81)

| Metric | Baseline (k=10, α=0.8) | This run (k=5, α=0.8) | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.5761** | +0.24% (flat) |
| val_in_dist/mae_surf_p | 22.47 | 22.97 | +2.2% |
| val_ood_cond/mae_surf_p | 24.03 | 23.13 | **−3.7%** ✓ |
| val_ood_re/mae_surf_p | 32.08 | 31.91 | **−0.5%** ✓ |
| val_tandem_transfer/mae_surf_p | 42.13 | 44.11 | +4.7% |

### What happened

Neutral/mixed result. Doubling sync frequency (k=10→5) with the same interpolation strength (α=0.8) produced a near-identical val/loss (+0.24%). Two splits improved (ood_cond −3.7%, ood_re −0.5%) while two degraded (in_dist +2.2%, tandem_transfer +4.7%).

The frequent sync may slightly over-regularize in-distribution and tandem transfer performance while helping OOD generalization by smoothing the loss landscape more aggressively. The tradeoff is essentially zero-sum at the overall val/loss level.

Note: epoch 81 was both the last and best epoch in this run, so W&B last-epoch summary equals best-checkpoint metrics.

### Suggested follow-ups

- **Try k=5, alpha=0.5** (the recently merged default) — need to verify the actual performance of that config  
- **Try k=3, alpha=0.8** — push frequency further to see if there's a trend  
- **Try k=5, alpha=0.9** — increase interpolation strength along with frequency  
- The ood_cond improvement is worth exploring further; frequent sync may genuinely help OOD generalization
