### PR TITLE
Surface-aware coarse pooling (separate surf and vol groups)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -610,6 +610,20 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
+        # Surface-specific coarse loss
+        surf_pool_size = 32
+        B, N, C = pred.shape
+        surf_indices = surf_mask.nonzero(as_tuple=False)
+        if surf_indices.shape[0] > surf_pool_size * 2:
+            surf_pred = pred[surf_indices[:, 0], surf_indices[:, 1]]
+            surf_target = y_norm[surf_indices[:, 0], surf_indices[:, 1]]
+            n_sg = surf_pred.shape[0] // surf_pool_size
+            if n_sg > 1:
+                sp = surf_pred[:n_sg * surf_pool_size].reshape(n_sg, surf_pool_size, C).mean(dim=1)
+                st = surf_target[:n_sg * surf_pool_size].reshape(n_sg, surf_pool_size, C).mean(dim=1)
+                surf_coarse_loss = (sp - st).abs().mean()
+                loss = loss + 2.0 * surf_coarse_loss
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
Current coarse loss pools all nodes uniformly — surface nodes are ~5% of total so most groups are dominated by volume. A surface-specific coarse loss provides a stronger multi-scale signal for the most important region. Prior surface-only coarse used pool=16/wt=1.0; this uses pool=32/wt=2.0 while keeping volume coarse.

## Instructions
In `structured_split/structured_train.py`, after the existing coarse loss computation, add:

```python
# Surface-specific coarse loss
surf_pool_size = 32
B, N, C = pred.shape
surf_indices = surf_mask.nonzero(as_tuple=False)
if surf_indices.shape[0] > surf_pool_size * 2:
    surf_pred = pred[surf_indices[:, 0], surf_indices[:, 1]]
    surf_target = y_norm[surf_indices[:, 0], surf_indices[:, 1]]
    n_sg = surf_pred.shape[0] // surf_pool_size
    if n_sg > 1:
        sp = surf_pred[:n_sg * surf_pool_size].reshape(n_sg, surf_pool_size, C).mean(dim=1)
        st = surf_target[:n_sg * surf_pool_size].reshape(n_sg, surf_pool_size, C).mean(dim=1)
        surf_coarse_loss = (sp - st).abs().mean()
        loss = loss + 2.0 * surf_coarse_loss
```

Run with: `--wandb_name "chihiro/surf-coarse" --wandb_group surf-aware-pool --agent chihiro`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `x3v5vbpl` | **Best epoch:** 80 | **Peak VRAM:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.735 | 0.312 | 0.192 | **23.88** | — |
| val_ood_cond | 1.565 | 0.277 | 0.190 | **23.52** | — |
| val_ood_re | NaN | 0.297 | 0.206 | **32.60** | — |
| val_tandem_transfer | 4.594 | 0.653 | 0.352 | **43.81** | — |
| **combined** | **2.6315** | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6315** | +0.061 (worse) |
| val_in_dist/mae_surf_p | 22.47 | **23.88** | +1.41 (regression) |
| val_ood_cond/mae_surf_p | 24.03 | **23.52** | **-0.51 (slight improvement)** |
| val_ood_re/mae_surf_p | 32.08 | **32.60** | +0.52 (slight regression) |
| val_tandem_transfer/mae_surf_p | 43.67→42.13 | **43.81** | +1.68 (regression) |

### What happened

**Hypothesis does not hold — surface-specific coarse pooling hurts overall performance.** Combined val/loss is worse (+0.061) and 3 of 4 splits regress. Only ood_cond shows a slight improvement (-0.51 Pa).

The likely reason the loss is counterproductive: `surf_indices = surf_mask.nonzero()` returns all surface node indices from the batch flattened together. When these are grouped into coarse pools of 32, the groups contain surface nodes from **different physical samples** (different AoA, Re, geometry). Averaging predictions and targets across cross-sample groups creates a meaningless multi-scale target — you're asking the model to match the average of a NACA0012 at AoA=5° with a NACA4412 at AoA=15°. This corrupts the gradient signal rather than enriching it.

The volume coarse loss avoids this problem to some extent because the spatial indexing (truncation to ) at least keeps nodes from roughly the same region of the padded tensor, though it also cross-mixes batches.

### Suggested follow-ups

- **Per-sample surface coarse pooling**: Compute coarse pools within each sample separately (loop over batch), then average the losses. This avoids cross-sample mixing and would be a fair test of the hypothesis.
- **Sort surface nodes by x-coord before pooling**: Groups nodes by spatial location within a sample before grouping, giving a more coherent coarse signal.
- **Reduce weight**: Try 0.5 instead of 2.0 — the strong 2.0 weight amplifies any noise in the signal.