### PR TITLE
Slice attention temperature init 0.25 (sharper assignment)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.25)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
The current temperature init is 0.5. In round 8, init=0.25 showed val/loss 2.6852 (improvement over that round's baseline). This change was merged but the merge was empty — the code change was never applied. Re-testing on the current stronger baseline.

## Instructions
Change temperature initialization in Physics_Attention_Irregular_Mesh from 0.5 to 0.25.

Run with: `--wandb_name "frieren/temp-025" --wandb_group temp-init-025 --agent frieren`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `dkxluapl` (frieren/temp-025)
**Epochs completed:** 78/100 (hit 30-min timeout)
**Peak GPU memory:** ~52.1 GB (54.5% of 96 GB)

### Metrics at best val/loss epoch

| Metric | Baseline | Temp=0.25 | Delta |
|--------|----------|-----------|-------|
| val/loss | 2.5700 | **2.6946** | +4.8% |
| val_in_dist/mae_surf_p | 22.47 | **24.32** | +8.2% |
| val_ood_cond/mae_surf_p | 24.03 | **22.88** | **-4.8%** |
| val_ood_re/mae_surf_p | 32.08 | **33.10** | +3.2% |
| val_tandem_transfer/mae_surf_p | 44.87→42.13 | **46.09** | +9.4% |

Surface MAE (in-dist): Ux=0.32, Uy=0.19, p=24.32
Volume MAE (in-dist): Ux=1.59, Uy=0.57, p=33.62

### What happened

Mixed results on the current baseline. Temperature init=0.25 improved val_ood_cond (-4.8%) but degraded in-distribution surface pressure (+8.2%) and val_tandem_transfer (+9.4%), with overall val/loss worse than baseline (+4.8%).

The result confirms the PR note: in round 8, temp=0.25 beat that round's baseline, but the current baseline is stronger (2.5700 vs presumably a higher value in round 8). The sharper initial attention assignment (lower temperature = more focused slices) may benefit some distribution shifts (ood_cond sees improvement) but hurts generalization to tandem cases and in-distribution accuracy.

The val_tandem_transfer regression (+9.4%) is notable. The tandem foil geometry is more complex than single-foil cases, and sharper slice attention may over-commit to specific mesh regions early, reducing adaptability to the tandem interaction structure.

### Suggested follow-ups

- Try temperature=0.35 as a compromise between 0.25 and 0.5 — might get ood_cond improvement without the tandem regression.
- The temperature parameter is learnable, so the final trained value is more diagnostic than the init. Logging the per-epoch mean temperature would reveal whether the model always converges to similar values from different inits.
- The split in results (better ood_cond but worse tandem) may indicate that temperature controls a geometry-complexity tradeoff in slice assignment.