### PR TITLE
Lookahead k=5 alpha=0.5 (more frequent sync)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -488,7 +488,7 @@ class Lookahead:
 
 
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=5, alpha=0.5)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
The current code has k=10, alpha=0.8. Round 12 tested k=5/alpha=0.5 and got val/loss 2.5700 but the change was labeled differently. Testing this properly: more frequent slow-weight updates with lighter interpolation.

## Instructions
In `structured_split/structured_train.py`, line 491:

```python
# Change: optimizer = Lookahead(base_opt, k=10, alpha=0.8)
# To:
optimizer = Lookahead(base_opt, k=5, alpha=0.5)
```

Run with: `--wandb_name "nezuko/la-k5a05" --wandb_group la-k5-a05-v3 --agent nezuko`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run:** `ldn99dsi` (nezuko/la-k5a05)
**Best epoch:** 80 / ~80 (hit 30-min timeout)

### Metrics vs baseline

| Split | Metric | Baseline | This run | Δ |
|---|---|---|---|---|
| — | val/loss | 2.5700 | **2.5595** | ↓0.011 |
| val_in_dist | mae_surf_p | 22.47 | 23.43 | ↑0.96 |
| val_ood_cond | mae_surf_p | 24.03 | **21.65** | ↓2.38 |
| val_ood_re | mae_surf_p | 32.08 | **31.53** | ↓0.55 |
| val_tandem_transfer | mae_surf_p | 42.13 | 42.29 | ↑0.16 |

Detailed best-epoch metrics:
- **val_in_dist**: loss=1.6863, mae_surf_Ux=0.297, mae_surf_Uy=0.183, mae_surf_p=23.43, mae_vol_Ux=1.602, mae_vol_Uy=0.549, mae_vol_p=31.81
- **val_ood_cond**: loss=1.4890, mae_surf_Ux=0.268, mae_surf_Uy=0.183, mae_surf_p=21.65, mae_vol_Ux=1.320, mae_vol_Uy=0.503, mae_vol_p=24.79
- **val_ood_re**: mae_surf_p=31.53 (loss=NaN — vol overflow on extreme Re, pre-existing issue)
- **val_tandem_transfer**: loss=4.5032, mae_surf_Ux=0.642, mae_surf_Uy=0.340, mae_surf_p=42.29

### What happened

Mixed results. Overall val/loss improved slightly (2.5595 vs 2.5700), driven primarily by a strong improvement on val_ood_cond (21.65 vs 24.03, −2.38). However, val_in_dist pressure got worse (23.43 vs 22.47, +0.96), and tandem/val_ood_re were essentially flat.

The k=5/alpha=0.5 setting means slow weights are updated more frequently (every 5 steps instead of 10) but with less aggressive interpolation (50% blend instead of 80%). This may favour the OOD condition split — more frequent sync could reduce variance in generalisation — but it costs some in-distribution accuracy, possibly because the lighter alpha=0.5 interpolation makes the slow weights track less closely, slightly underfitting in-distribution.

The run reached epoch 80 before the 30-min timeout, matching the baseline epoch count.

**Peak VRAM:** not logged explicitly; same model architecture as baseline, expected ~same.

### Suggested follow-ups
- Try k=5, alpha=0.7 (frequent sync but stronger interpolation) to see if we can recover the in-dist regression while keeping the OOD gains
- The ood_cond improvement (+2.38 pressure units) is worth investigating — it may be the more frequent sync that helps, not the lighter alpha