### PR TITLE
Combo: temperature 0.25 + surface pressure 2x channel weight

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.25)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
@@ -589,7 +589,9 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+        surf_channel_w = surf_channel_w / surf_channel_w.mean()
+        surf_loss = (abs_err * surf_channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Both temp=0.25 and channel [1,1,2] showed independent improvement. Testing them together since they're orthogonal (attention sharpness vs loss weighting).

## Instructions
In `structured_split/structured_train.py`:

1. Line 107 — change temperature init:
```python
self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.25)
```

2. Around line 592 — add channel weighting to surface loss:
```python
surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
surf_channel_w = surf_channel_w / surf_channel_w.mean()
surf_loss = (abs_err * surf_channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```

Run with: `--wandb_name "alphonse/temp-channel" --wandb_group temp-025-plus-channel --agent alphonse`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run ID:** xtfmhqyw
**Epochs completed:** 77/100 (30-min timeout; ~23.1s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline | This run (ep77, best) | Delta |
|---|---|---|---|
| val/loss | 2.5700 | **2.7588** | +7.3% worse |
| val_in_dist/mae_surf_p | 22.47 | **26.06** | +16% worse |
| val_ood_cond/mae_surf_p | 24.03 | **22.67** | **-5.7% better** |
| val_ood_re/mae_surf_p | 32.08 | **32.55** | +1.5% (noise) |
| val_tandem_transfer/mae_surf_p | 42.13 | **44.71** | +6% worse |

Additional val_in_dist at best epoch:
- mae_surf_Ux: 0.371 | mae_surf_Uy: 0.213
- mae_vol_Ux: 1.616 | mae_vol_Uy: 0.573 | mae_vol_p: 33.87

### What happened

**Mixed result — not a clear win.** Overall val/loss is worse (+7.3%), val_in_dist surface pressure is notably worse (+16%), and val_tandem_transfer is slightly worse. The one bright spot: val_ood_cond surface pressure improved from 24.03 to 22.67 (-5.7%), and val_ood_re is essentially unchanged.

The model was still improving at epoch 77 (best val/loss is the very last epoch, no sign of flattening), so the 30-minute timeout may be partially responsible. However, even given more time, the large regression on val_in_dist/mae_surf_p (22.47→26.06) is concerning.

The channel weighting [0.75, 0.75, 1.5] inflates the surf_loss value by ~12.5% on average vs uniform weighting, and doubles pressure's gradient contribution. Combined with surf_weight ramping to 30, pressure receives ~45x more gradient than volume — which may over-regularize the in-distribution pressure predictions while still struggling on in-distribution geometry.

The temp=0.25 component sharpens attention, which seems to help OOD conditions (ood_cond improved) but the channel weighting negates or reverses that benefit on in-distribution.

### Suggested follow-ups
- Test temp=0.25 alone (without channel weighting) to isolate whether the attention sharpening independently helps
- The channel weighting consistently makes things worse when combined with other changes (also failed in the log-cosh experiment) — may not be worth pursuing further
- The val_ood_cond improvement from temp=0.25 is interesting and worth following up without the confounding channel weight change