### PR TITLE
Xavier uniform init (replace orthogonal gain=1.0)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -266,7 +266,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.xavier_uniform_(module.weight)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:


### PR DESCRIPTION
## Hypothesis
Xavier uniform was the strongest single improvement in round 7 (val/loss 2.7135 vs 2.7927). However, orthogonal init was merged later and overwrote it. Xavier might still be better — testing again on the current codebase.

## Instructions
In `structured_split/structured_train.py`, in the `_init_weights` method (around line 266-269):

```python
def _init_weights(self, module):
    if isinstance(module, nn.Linear):
        if module.weight.dim() >= 2:
            nn.init.xavier_uniform_(module.weight)  # changed from orthogonal
        else:
            nn.init.normal_(module.weight, std=0.01)
        if module.bias is not None:
            nn.init.constant_(module.bias, 0)
    elif isinstance(module, (nn.LayerNorm, nn.BatchNorm1d)):
        nn.init.constant_(module.bias, 0)
        nn.init.constant_(module.weight, 1.0)
```

Run with: `--wandb_name "edward/xavier" --wandb_group xavier-init-v2 --agent edward`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** iwotbw85  
**Best epoch:** 82  
**Peak memory:** 8.8 GB

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6408** | +2.8% ↑ worse |
| val_in_dist/mae_surf_Ux | — | 0.3192 | — |
| val_in_dist/mae_surf_Uy | — | 0.1860 | — |
| val_in_dist/mae_surf_p | 22.47 | **24.78** | +10.3% ↑ worse |
| val_in_dist/mae_vol_Ux | — | 1.5726 | — |
| val_in_dist/mae_vol_Uy | — | 0.5527 | — |
| val_in_dist/mae_vol_p | — | 34.27 | — |
| val_ood_cond/mae_surf_p | 24.03 | **24.89** | +3.6% ↑ worse |
| val_ood_re/mae_surf_p | 32.08 | **33.81** | +5.4% ↑ worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **43.13** | +2.4% ↑ worse |

### What happened

Negative result — Xavier uniform is consistently worse than the orthogonal init (gain=1.0) baseline across all metrics. In-dist pressure is 10.3% worse. Even though Xavier was reportedly the best init in round 7, orthogonal init was a stronger improvement when added to that codebase, and Xavier does not recover that advantage here. The current codebase has more components (Lookahead, multi-scale loss, progressive resolution) that may interact differently with initialization — orthogonal init appears to be the better fit for this stacked configuration.

### Suggested follow-ups

- The orthogonal gain=1.0 (current baseline) appears to be the right choice; no need to revisit init for now.
- If further init exploration is desired, try Kaiming normal (fan_out mode) which is commonly used with GELU activations.
- Focus efforts on other components where gains are still possible (attention mechanism, loss function).