### PR TITLE
Higher learning rate 5e-3 (exploit Lookahead stability)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -336,7 +336,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 5e-3
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
With Lookahead(k=10, alpha=0.8) providing stability, a higher base LR might enable faster convergence and better exploration. 5e-3 is a moderate increase from 3e-3.

## Instructions
In \`structured_split/structured_train.py\`, change the default lr in Config (line 339):

\`\`\`python
lr: float = 5e-3
\`\`\`

Run with: \`--wandb_name "askeladd/lr-5e3" --wandb_group lr-5e3 --agent askeladd\`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** \`cenvity3\`
**Epochs completed:** 78 (terminated at 30-minute timeout)
**Peak GPU memory:** ~23.1 GB (24% of 96 GB)

### Metrics at best val/loss

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.8347 | 2.5700 | **+0.265** ✗ |
| val_in_dist/mae_surf_p | 27.06 | 22.47 | **+4.59** ✗ |
| val_ood_cond/mae_surf_p | 27.53 | 24.03 | **+3.50** ✗ |
| val_ood_re/mae_surf_p | 34.57 | 32.08 | **+2.49** ✗ |
| val_tandem_transfer/mae_surf_p | 47.63 | 42.13 | **+5.50** ✗ |
| val_in_dist/mae_surf_Ux | 0.347 | — | — |
| val_in_dist/mae_vol_p | 33.39 | — | — |

### What happened

lr=5e-3 is a clear negative result. All metrics are substantially worse. The higher learning rate causes too much noise in parameter updates, preventing convergence to low-error solutions within the 30-minute window.

Note: this branch has eta_min=1e-4 (not 1e-5 from the noam baseline). The combination of a warmer LR floor and a higher peak LR means the entire training trajectory is more aggressive, which hurts final performance. The Lookahead stabilizer (k=10, alpha=0.8) smooths but doesn't eliminate the instability from a 5e-3 peak LR.

The 3e-3 baseline appears well-tuned for this model/optimizer/schedule combination. Pushing to 5e-3 clearly over-shoots.

### Suggested follow-ups

- The 3e-3 baseline seems correct. The AdamW default (1e-3) would likely underfit; 5e-3 overshoots. The sweet spot is probably in [3e-3, 4e-3].
- Try 4e-3 for a smaller LR step up.
- Consider a higher LR only for early epochs (warm-up to 5e-3, then decay quickly) if exploration in the first 5 epochs is the goal.