### PR TITLE
Weight decay 3e-4 (stronger regularization)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -337,7 +337,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 3e-4
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
With 1-layer model and MQA reducing effective parameters, current wd=1e-4 may under-regularize. 3e-4 provides more regularization for OOD generalization.

## Instructions
In \`structured_split/structured_train.py\`, change Config default (line 340):
\`\`\`python
weight_decay: float = 3e-4
\`\`\`

Run with: \`--wandb_name "violet/wd-3e4" --wandb_group wd-3e4-v2 --agent violet\`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run**: fsinusn0  
**Best epoch**: 80  
**Peak memory**: 8.8 GB  

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.7132 | 0.301 | 0.188 | 23.72 | 1.507 | 0.541 | 32.36 |
| val_tandem_transfer | 4.5765 | 0.661 | 0.344 | 43.20 | 2.431 | 1.103 | 48.08 |
| val_ood_cond | 1.5954 | 0.279 | 0.196 | 24.03 | 1.307 | 0.511 | 24.95 |
| val_ood_re | nan | 0.283 | 0.202 | 32.20 | — | — | — |

**val/loss (mean non-nan)**: 2.6284 vs baseline 2.5700 → **Δ=+0.058 (worse)**

**Surface MAE (p) comparison**:
| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 22.47 | 23.72 | +1.25 ↑ worse |
| val_ood_cond | 24.03 | 24.03 | 0.00 same |
| val_ood_re | 32.08 | 32.20 | +0.12 ≈ same |
| val_tandem_transfer | 42.13 | 43.20 | +1.07 ↑ worse |

### What happened

Higher weight decay (3e-4 vs 1e-4) did not help. Overall val/loss is 0.058 worse than baseline. The hypothesis that the model was under-regularizing doesn't appear to hold — the stronger regularization hurt in-distribution accuracy (val_in_dist mae_surf_p +1.25) without providing meaningful OOD benefit. val_ood_cond pressure is identical to baseline (24.03), and val_ood_re is nearly unchanged (+0.12). tandem transfer also regressed slightly (+1.07).

The current wd=1e-4 seems appropriate for this model size. With a 1-layer architecture, the model has relatively few parameters and the existing weight decay appears sufficient.

### Suggested follow-ups
- Try wd=5e-5 (less regularization) to check if the baseline wd=1e-4 is already slightly over-regularizing
- Try combining wd with dropout on the MLP layers if more regularization is needed for OOD
- Investigate why val_ood_cond is insensitive to wd (both 1e-4 and 3e-4 give 24.03) — possibly hitting a different bottleneck there