### PR TITLE
Gentler surf weight ramp 3→35

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -543,7 +543,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    sw_start, sw_end = 3.0, 35.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
Current ramp 5→30 starts high and ends modest. A gentler start (3) with higher end (35) gives the model more time for volume accuracy early, then pushes harder on surface later.

## Instructions
In `structured_split/structured_train.py`, around line 546:
```python
sw_start, sw_end = 3.0, 35.0
```

Run with: `--wandb_name "gilbert/ramp-3-35" --wandb_group surf-ramp-3-35 --agent gilbert`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `9rm5od6l` — gilbert/ramp-3-35

**Best epoch:** 80 of 81 (30.2 min, wall-clock limit)
**Peak memory:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.652 | 0.291 | 0.182 | **23.02** | 1.573 | 0.547 | 33.53 |
| val_ood_cond | 1.583 | — | — | **23.0** | — | — | — |
| val_ood_re | nan | — | — | **33.1** | — | — | — |
| val_tandem_transfer | 4.577 | — | — | **43.8** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.6039** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | 2.6039 | +0.034 ❌ |
| val_in_dist/mae_surf_p | 22.47 | 23.02 | +0.55 ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 23.0 | −1.03 ✅ |
| val_ood_re/mae_surf_p | 32.08 | 33.1 | +1.02 ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 43.8 | +1.67 ❌ |

### What happened

Mixed-to-negative result. val_ood_cond improved substantially (−1.03), which is a recurring pattern across many experiments, but val_in_dist (+0.55), val_ood_re (+1.02), and val_tandem_transfer (+1.67) all regressed. Overall val/loss is worse (+0.034).

The ramp endpoint of 35 (vs 30 baseline) likely explains the regressions: a higher final surface weight creates stronger pressure on the surface loss at the end of training, potentially at the cost of volume accuracy and OOD robustness. The gentler start (3 vs 5) may give slightly more volume flexibility early, but the higher endpoint overrides any benefit for most splits.

The val_ood_cond improvement despite the overall regression may reflect that extreme-condition cases benefit from the late high surface weight, while the more sensitive in-distribution and tandem splits are hurt by it.

### Suggested follow-ups

- **3→30 (gentler start, same end)**: Test just the lower start value (3.0) without changing the endpoint. This might give early volume flexibility without the late penalty of 35.
- **5→25 (lower end)**: Test whether pulling back the final surface weight from 30 helps.
- **Non-linear ramp**: Use an accelerating ramp (e.g., quadratic) that stays low longer then ramps up sharply in the last 20% of training.