### PR TITLE
Target noise 0.005 (half current for finer convergence)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -564,7 +564,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            y_norm = y_norm + 0.005 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Current noise=0.01 might be too much with eta_min=1e-4 (warmer floor means more LR in final epochs → noise becomes more disruptive). Halving to 0.005.

## Instructions
In `structured_split/structured_train.py`, line 567:
```python
y_norm = y_norm + 0.005 * torch.randn_like(y_norm)
```

Run with: `--wandb_name "senku/noise-005" --wandb_group noise-005 --agent senku`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `ifdf7a4v` (senku/noise-005)
**Epochs completed:** 78/100 (30-min timeout; ~22s/epoch)
**Peak memory:** 8.8 GB

### Metrics vs Baseline (best checkpoint, step 77 / epoch 78)

| Metric | Baseline | This run (best) | Delta |
|---|---|---|---|
| val/loss | 2.5700 | 2.6993 | +0.13 (worse) |
| val_in_dist/mae_surf_p | 22.47 | 24.03 | +1.56 (worse) |
| val_ood_cond/mae_surf_p | 24.03 | 24.86 | +0.83 (worse) |
| val_ood_re/mae_surf_p | 32.08 | 33.20 | +1.12 (worse) |
| val_tandem_transfer/mae_surf_p | 42.13 | 47.73 | +5.60 (much worse) |

Surface MAE (best epoch, val_in_dist): Ux=0.313, Uy=0.196, p=24.03
Volume MAE (best epoch, val_in_dist): Ux=1.59, Uy=0.56, p=33.04

### What happened

Halving the noise from 0.01 to 0.005 made things worse, not better. All metrics regressed relative to baseline, with tandem transfer particularly hurt (+5.60 on surf_p). This rules out the hypothesis that the current noise level was too high for the warmer LR floor.

The correct interpretation is the opposite: the 0.01 noise level in baseline is already well-calibrated and provides the right amount of regularization. Reducing it weakens the smoothing effect without enough benefit. The larger tandem transfer regression may indicate the model is slightly overfitting to the training distribution without sufficient noise regularization.

This result, combined with the earlier noise=0 ablation (PR #452, also worse), establishes that 0.01 is closer to optimal than either 0 or 0.005. The noise is serving a genuine regularization purpose.

Memory: 8.8 GB, no change.

### Suggested follow-ups
- The noise=0.01 baseline appears to be near-optimal. If the advisor wants to explore further, try 0.02 to test whether more noise helps.
- Alternatively, test adaptive noise (higher early, lower late) -- annealing noise similar to how surface weight is annealed.