### PR TITLE
Multi-scale coarse loss weight 0.5 (lighter regularization)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -608,7 +608,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 0.5 * coarse_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Current coarse loss weight=1.0 might be too strong with the improved model. Reducing to 0.5 lets the fine-grained loss dominate more.

## Instructions
In `structured_split/structured_train.py`, around line 611:
```python
loss = loss + 0.5 * coarse_loss
```

Run with: `--wandb_name "emma/coarse-05" --wandb_group coarse-wt-05 --agent emma`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** bkxk0muq | **Epochs:** ~83 (30-min cap) | **Epoch time:** 22.0 s | **Peak GPU memory:** 60.4 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.688 | 0.295 | 0.184 | 23.53 | 1.631 | 0.585 | 33.22 |
| val_ood_cond | 1.618 | 0.278 | 0.195 | 25.13 | 1.464 | 0.550 | 27.06 |
| val_ood_re | NaN | 0.285 | 0.204 | 33.22 | 1.353 | 0.546 | 56.31 |
| val_tandem_transfer | 4.593 | 0.667 | 0.346 | 43.76 | 2.513 | 1.145 | 49.39 |
| **combined val/loss** | **2.6332** | | | | | | |

**vs baseline (Δ surf_p):**
- val_in_dist: 23.53 vs 22.47 → **+1.06 (↑4.7%, worse)**
- val_ood_cond: 25.13 vs 24.03 → **+1.10 (↑4.6%, worse)**
- val_ood_re: 33.22 vs 32.08 → **+1.14 (↑3.6%, worse)**
- val_tandem_transfer: 43.76 vs 42.13 → **+1.63 (↑3.9%, worse)**
- val/loss: 2.6332 vs 2.5700 → **+0.0632 (↑2.5%, worse)**

### What happened

Negative result. Reducing the coarse loss weight from 1.0 to 0.5 made all metrics slightly worse. The coarse pooling loss at weight=1.0 appears to provide a useful regularization signal — halving it lets the fine-grained loss dominate more but at the cost of accuracy.

This suggests the multi-scale coarse signal contributes meaningfully at weight=1.0. The model apparently benefits from explicit coarse-scale consistency constraints, and weakening them hurts generalization.

### Suggested follow-ups

- Try **weight > 1.0** (e.g. 1.5 or 2.0) to see if the coarse signal can be strengthened further.
- Try **weight=0** (ablation) to confirm the coarse loss is net-positive at 1.0.
- Since both 0.5 (this run) and the learned-weight experiment (#544) degraded performance, the current 1.0 fixed weight appears well-calibrated.