### PR TITLE
Preprocess MLP width 3x (n_hidden*3=384)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -237,7 +237,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 3, n_hidden, n_layers=1, res=True, act=act)  # was n_hidden*2
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
The preprocess MLP is the bottleneck: it compresses 24-dim input to 128. A wider intermediate (384 vs 256) gives more capacity for the initial feature extraction.

## Instructions
In `structured_split/structured_train.py`, in Transolver.__init__, around line 240:
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 3, n_hidden, n_layers=1, res=True, act=act)
```

Run with: `--wandb_name "norman/preproc-3x" --wandb_group preprocess-width-3x --agent norman`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run:** `1ldie023`  
**Epochs:** 76 (30.3 min, completed normally)  
**Peak memory:** 9.8 GB  

### Metrics at best checkpoint (epoch 76)

| Metric | Baseline (n_hidden*2) | This run (n_hidden*3) | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6739** | +4.1% ❌ |
| val_in_dist/mae_surf_p | 22.47 | 25.3 | +12.6% ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 24.6 | +2.4% ❌ |
| val_ood_re/mae_surf_p | 32.08 | 33.8 | +5.4% ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 45.4 | +7.7% ❌ |

### What happened

Negative result. Widening the preprocess MLP from 2x→3x intermediate width hurt all splits.

Two factors explain this:

1. **Slower training, fewer epochs:** Each epoch took ~23-24s (vs ~22s baseline), yielding 76 epochs in 30 min vs 81. The extra parameters (~16K more) in the preprocess MLP slightly slowed each epoch.

2. **Preprocess is not the bottleneck:** The preprocess MLP compresses 24 input dims to 128. At 2x width (256 intermediate), it has more than enough capacity for this. Widening to 3x (384) adds parameters without benefit — the compression task is already well-served at 2x. The attention layers (slice_num=32, 4 heads) are likely the limiting factor, not preprocessing.

The result confirms that the architecture's primary constraint is in the physics-attention mechanism, not feature extraction.

### Suggested follow-ups

- **Try n_hidden=192 or 256** — increase the main hidden dimension rather than intermediate widths to give the full model more capacity
- **Try 2-layer preprocess MLP** — depth rather than width might help if feature extraction needs more non-linearity
- **Skip the hypothesis, focus on attention capacity** — the attention slots (slice_num) and head count seem to be the bottleneck based on the MQA results
