### PR TITLE
Lookahead k=5 alpha=0.8 (frequent sync + strong interpolation)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -488,7 +488,7 @@ class Lookahead:
 
 
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=5, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Combining more frequent sync (k=5) with the current strong interpolation (alpha=0.8). This untested combination might find better flat minima.

## Instructions
In `structured_split/structured_train.py`, line 491:
```python
optimizer = Lookahead(base_opt, k=5, alpha=0.8)
```

Run with: `--wandb_name "chihiro/la-k5a08" --wandb_group la-k5-a08-v2 --agent chihiro`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run:** `m4jheuet` | **Best epoch:** 80 | **Peak VRAM:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.814 | 0.341 | 0.191 | **25.00** | — |
| val_ood_cond | 1.542 | 0.276 | 0.187 | **22.92** | — |
| val_ood_re | NaN | 0.306 | 0.201 | **32.46** | — |
| val_tandem_transfer | 4.566 | 0.653 | 0.346 | **43.75** | — |
| **combined** | **2.6407** | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6407** | +0.071 (worse) |
| val_in_dist/mae_surf_p | 22.47 | **25.00** | +2.53 (regression) |
| val_ood_cond/mae_surf_p | 24.03 | **22.92** | **-1.11 (improvement)** |
| val_ood_re/mae_surf_p | 32.08 | **32.46** | +0.38 (slight regression) |
| val_tandem_transfer/mae_surf_p | 42.13 | **43.75** | +1.62 (regression) |

### What happened

**k=5 (more frequent sync) with alpha=0.8 does not beat the baseline.** Combined val/loss is worse (+0.071), with val_in_dist showing a large regression (+2.53 Pa) and tandem regressing (+1.62 Pa). The ood_cond split shows the only improvement (-1.11 Pa), suggesting the faster sync may help OOD generalization but at the cost of in-distribution accuracy.

With k=5, slow weights are synchronized every 5 gradient steps vs every 10 at baseline. This means the slow-weight averaging happens more frequently, potentially forcing the fast weights closer to the slow weights more often and disrupting the exploration phase. Strong interpolation (alpha=0.8) moves the fast weights far toward the slow weights on each sync; doing this twice as often may over-constrain optimization.

Compared to the baseline (k=10, alpha=0.8), the Lookahead benefit appears to come primarily from the 10-step averaging interval, not from more frequent syncing.

### Suggested follow-ups

- **Try k=5, alpha=0.5**: Lower interpolation with more frequent sync — might find a sweet spot that avoids over-constraining while still benefiting from faster sync.
- **Try k=3, alpha=0.8**: Even more frequent sync to understand the k sensitivity more fully.
- **The ood_cond improvement with k=5 is interesting**: May reflect more conservative slow weights helping OOD generalization. Worth exploring dedicated OOD regularization.