### PR TITLE
FiLM: coordinate-conditioned output (position modulates output MLP)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -182,17 +182,23 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
+            self.film_gen = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * hidden_dim))
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx):
+    def forward(self, fx, pos=None):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            film = self.film_gen(pos)
+            gamma, beta = film.chunk(2, dim=-1)
+            h_first = self.mlp2[0](h)
+            h_act = self.mlp2[1](gamma * h_first + beta)
+            return self.mlp2[2](h_act)
         return fx
 
 
@@ -319,8 +325,9 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
-        for block in self.blocks:
+        for block in self.blocks[:-1]:
             fx = block(fx)
+        fx = self.blocks[-1](fx, pos=x[:, :, :2])
         self._validate_output_dims(fx)
         return {"preds": fx}
 


### PR DESCRIPTION
## Hypothesis
The output MLP has no access to original coordinates. Surface pressure is highly position-dependent (leading edge vs trailing edge). FiLM conditioning generates scale/shift from (x,y) to modulate output activations. Standard in NeRF/neural implicit representations.

## Instructions
In `structured_split/structured_train.py`, in `TransolverBlock.__init__` (when last_layer=True), add:

```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.film_gen = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * hidden_dim))
    self.mlp2 = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
```

In `TransolverBlock.forward`, when last_layer, accept pos as argument and apply FiLM:
```python
if self.last_layer:
    h = self.ln_3(fx)
    film = self.film_gen(pos)  # pos is x[:,:,:2] passed from parent
    gamma, beta = film.chunk(2, dim=-1)
    h_first = self.mlp2[0](h)  # First linear
    h_act = self.mlp2[1](gamma * h_first + beta)  # GELU with FiLM
    return self.mlp2[2](h_act)  # Final linear
```

Pass position through the model: in `Transolver.forward`, pass `pos=data["x"][:,:,:2]` to the last block.

Run with: `--wandb_name "frieren/film" --wandb_group film-output --agent frieren`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `ecrd827e`  
**Epochs:** 73/100 (timeout at 30 min)  
**Peak memory:** ~9.8 GB

| Metric | Baseline | FiLM | Δ |
|--------|----------|------|---|
| val/loss | 2.5700 | 2.7987 | +8.9% ❌ |
| val_in_dist/mae_surf_p | 22.47 | 27.36 | +21.7% ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 25.52 | +6.2% ❌ |
| val_ood_re/mae_surf_p | 32.08 | 32.69 | +1.9% ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 45.40 | +7.8% ❌ |

**Full surface/volume MAE at best epoch (epoch 73):**

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.333 | 0.197 | 27.36 | 1.637 | 0.604 | 34.93 |
| val_ood_cond | 0.329 | 0.211 | 25.52 | 1.440 | 0.558 | 29.66 |
| val_ood_re | 0.322 | 0.212 | 32.69 | 1.311 | 0.539 | 56.11 |
| val_tandem_transfer | 0.693 | 0.354 | 45.40 | 2.503 | 1.165 | 49.46 |

**Note:** `val_ood_re/loss` was NaN in all epochs (vol_loss diverges to ±inf for this OOD split). The mean_val_loss is computed over the 3 finite splits.

**What happened:**  
FiLM conditioning made things worse across all metrics. The surface pressure MAE on val_in_dist increased by 22%, which is the most important metric. This is likely because the model receives normalized (x,y) coordinates (passed through `stats["x_mean"]`/`stats["x_std"]` normalization), so the FiLM generator sees already-preprocessed values that include the position as part of the 24-dim feature vector anyway — position information was already available to the model implicitly through the `fun_dim + space_dim` input. The FiLM conditioning may be adding noise to the gradient signal or the `gamma * h + beta` modulation is destabilizing the learned representation without learning useful position structure.

**Suggested follow-ups:**
- Try using the unnormalized (x,y) coordinates for FiLM (extract before `x = (x - stats["x_mean"]) / stats["x_std"]` normalization). The normalized coordinates have reduced spatial distinctiveness.
- Try a simpler position injection: concatenate (x,y) to the hidden state just before the output MLP instead of multiplicative modulation (additive residual may be easier to optimize).
- Revisit with a deeper model (n_layers>1) where the final block's representation is more abstract and coordinate conditioning could provide more additive value.