### PR TITLE
Split surface/volume decoders (specialized output heads)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -182,17 +182,19 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.mlp2_vol = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
+            self.mlp2_surf = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
 
-    def forward(self, fx):
+    def forward(self, fx, is_surface=None):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            out = self.mlp2_vol(h)
+            if is_surface is not None:
+                surf_h = h[is_surface]
+                out[is_surface] = self.mlp2_surf(surf_h)
+            return out
         return fx
 
 
@@ -257,6 +259,14 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
+        # Xavier init for split decoder heads
+        last_block = self.blocks[-1]
+        for seq in [last_block.mlp2_vol, last_block.mlp2_surf]:
+            for m in seq.modules():
+                if isinstance(m, nn.Linear):
+                    nn.init.xavier_uniform_(m.weight)
+                    if m.bias is not None:
+                        nn.init.constant_(m.bias, 0)
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
 
@@ -319,8 +329,9 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
+        is_surface = data.get("is_surface", None) if isinstance(data, Mapping) else None
         for block in self.blocks:
-            fx = block(fx)
+            fx = block(fx, is_surface=is_surface)
         self._validate_output_dims(fx)
         return {"preds": fx}
 
@@ -567,7 +578,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
+            pred = model({"x": x, "is_surface": is_surface})["preds"]
         pred = pred.float()
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
@@ -654,7 +665,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = model({"x": x, "is_surface": is_surface})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()


### PR DESCRIPTION
## Hypothesis
Surface nodes (~5%) have fundamentally different physics from volume nodes. A dedicated surface decoder can specialize without compromise. The shared Transolver encodes both; decoding is split.

## Instructions
In `structured_split/structured_train.py`, in `TransolverBlock.__init__` (when last_layer=True):

```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.mlp2_vol = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
    self.mlp2_surf = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
```

In forward:
```python
if self.last_layer:
    h = self.ln_3(fx)
    out = self.mlp2_vol(h)  # default: volume head
    if is_surface is not None:
        surf_h = h[is_surface]
        out[is_surface] = self.mlp2_surf(surf_h)
    return out
```

Pass `is_surface` mask through the model forward call. Apply Xavier init to both heads.

Run with: `--wandb_name "fern/split-dec" --wandb_group split-decoder --agent fern`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**Run ID**: l5umo7hq  
**Epochs**: 77 best, 79 total (wall-clock 30.2 min)  
**Peak memory**: 9.0 GB  

### Val/loss
| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.5700 | **2.6911** | +4.7% (worse) |

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|-------|---------------------|---------------------|-------|
| val_in_dist | 22.47 | 24.30 | +8.1% (worse) |
| val_ood_cond | 24.03 | 24.38 | +1.5% (worse) |
| val_ood_re | 32.08 | 32.87 | +2.5% (worse) |
| val_tandem_transfer | 42.13 | 45.33 | +7.6% (worse) |

### Full Surface MAE
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|-------------|-------------|------------|
| val_in_dist | 0.329 | 0.192 | 24.30 |
| val_ood_cond | 0.284 | 0.199 | 24.38 |
| val_ood_re | 0.294 | 0.206 | 32.87 |
| val_tandem_transfer | 0.678 | 0.354 | 45.33 |

### Full Volume MAE
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.564 | 0.521 | 30.50 |
| val_ood_cond | 1.331 | 0.511 | 25.37 |
| val_ood_re | 1.277 | 0.512 | 53.68 |
| val_tandem_transfer | 2.392 | 1.091 | 47.16 |

Note: val_ood_re/loss = nan (pre-existing issue — vol_loss blows up due to extreme Re extrapolation; surface MAEs are still valid).

### What happened

Negative result across all splits. The split decoder hypothesis did not improve surface predictions — in fact all surface pressure metrics are worse than baseline, with in-dist and tandem transfer suffering the most (+8.1%, +7.6%).

The likely cause: the encoder (attention) layers are where surface/volume specialization actually needs to happen, not the decoder. Both node types share the same sequence of Transolver blocks, so the encoder representations don't differentiate surface vs volume during the forward pass — only the final MLP is split. With only ~5% of nodes being surface nodes, the `mlp2_surf` decoder sees very few training examples per batch compared to `mlp2_vol`, making it harder to train effectively.

Additionally, splitting the decoder doubles the output parameter count for the last block without adding representational capacity in the encoder, which could hurt by reducing shared statistical strength (the shared decoder sees all nodes, giving more gradient signal per update).

### Suggested follow-ups

- Inject surface/volume signal earlier: add a learned surface embedding (0/1 flag → embedding) to the input features alongside the node coordinates, so the encoder can learn to specialize
- Try a shallower surface head (single linear layer) to reduce overfitting risk while still allowing specialization
- The channel weighting approach from PR #549 (ood_cond -7.8%) may be a simpler, more effective way to push the model toward surface pressure accuracy