### PR TITLE
Test-time augmentation: y-flip averaging (free ensemble at val)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -656,6 +656,19 @@ for epoch in range(MAX_EPOCHS):
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
                 pred = pred.float()
+                # Test-time augmentation: y-flip
+                x_flip = x.clone()
+                x_flip[:, :, 1] *= -1  # flip y-coordinate
+                # Also flip AoA features (indices 14 for AoA0_rad, 18 for AoA1_rad)
+                x_flip[:, :, 14] *= -1
+                x_flip[:, :, 18] *= -1
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred_flip = model({"x": x_flip})["preds"]
+                pred_flip = pred_flip.float()
+                # Flip back: negate Uy prediction (channel 1)
+                pred_flip[:, :, 1] *= -1
+                # Average
+                pred = (pred + pred_flip) / 2
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()
 


### PR DESCRIPTION
## Hypothesis
Flow symmetry: flipping y-coordinates and negating Uy produces a valid scenario. Averaging original and flipped predictions at validation is a FREE ensemble (no training cost). Typically 1-3% MAE reduction.

## Instructions
In `structured_split/structured_train.py`, in the validation loop, after computing `pred`:

```python
# Test-time augmentation: y-flip
x_flip = x.clone()
x_flip[:, :, 1] *= -1  # flip y-coordinate
# Also flip AoA features (indices 14 for AoA0_rad, 18 for AoA1_rad)
x_flip[:, :, 14] *= -1
x_flip[:, :, 18] *= -1
with torch.amp.autocast("cuda", dtype=torch.bfloat16):
    pred_flip = model({"x": x_flip})["preds"]
pred_flip = pred_flip.float()
# Flip back: negate Uy prediction (channel 1)
pred_flip[:, :, 1] *= -1
# Average
pred = (pred + pred_flip) / 2
```

This only changes validation, not training. Run with: `--wandb_name "nezuko/tta" --wandb_group tta-yflip --agent nezuko`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run:** `e30egufv` (nezuko/tta)
**Best epoch:** 39 / ~75 (hit 30-min timeout)

### Metrics vs baseline

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| overall | val/loss | 2.5700 | 13.33 | +10.76 |
| val_in_dist | mae_surf_p | 22.47 | 166.9 | +144 |
| val_ood_cond | mae_surf_p | 24.03 | 184.7 | +161 |
| val_ood_re | mae_surf_p | 32.08 | 189.0 | +157 |
| val_tandem_transfer | mae_surf_p | 42.13 | 181.6 | +139 |

### What happened

**Catastrophic failure** — the implementation was done exactly as specified, but the sign-flip in normalized feature space produces out-of-distribution inputs the model cannot handle.

The root cause: the instructions apply `x_flip[:, :, 1] *= -1` to the already-normalized `x` (after `x = (x - stats["x_mean"]) / stats["x_std"]`). Negating a normalized feature is NOT the same as normalizing the negated physical feature, unless the mean is exactly zero:

    negated_normalized != normalized_negated, when mean != 0

For AoA (indices 14, 18), the mean is definitely non-zero (typical AoA range is 0-15 degrees, so mean ~5-7 degrees). For y-coordinate (index 1), the mean may also be non-zero if the mesh is not symmetric around y=0. As a result, `x_flip` doesn't represent any valid physical scenario the model was trained on — it is a truly out-of-distribution input — causing predictions to be ~7x worse than baseline.

The model still trained normally (training loss was reasonable), but validation metrics were catastrophic because the TTA branch fed broken inputs.

### Correct approach

To make the y-flip TTA work, the flip must be performed in raw feature space, then renormalized:

    x_raw = x * stats["x_std"] + stats["x_mean"]
    x_flip_raw = x_raw.clone()
    x_flip_raw[:, :, 1] *= -1    # flip y
    x_flip_raw[:, :, 14] *= -1   # flip AoA0
    x_flip_raw[:, :, 18] *= -1   # flip AoA1
    x_flip = (x_flip_raw - stats["x_mean"]) / stats["x_std"]

This produces a properly flipped input that corresponds to a real physical y-mirrored scenario.

### Suggested follow-ups
- Re-run with the corrected denormalize-flip-renormalize implementation (the hypothesis itself — free TTA ensemble — is still worth testing correctly)
- Check whether the dataset contains negative-AoA samples before assuming y-flip is valid everywhere