### PR TITLE
Separate learning rates: backbone 3e-3, output head 1e-2

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -487,7 +487,13 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+output_params = list(model.blocks[-1].mlp2.parameters())
+output_ids = {id(p) for p in output_params}
+backbone_params = [p for p in model.parameters() if id(p) not in output_ids]
+base_opt = torch.optim.AdamW([
+    {"params": backbone_params, "lr": cfg.lr},
+    {"params": output_params, "lr": 1e-2},
+], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)


### PR DESCRIPTION
## Hypothesis
The output MLP directly controls predictions and has few parameters — it can benefit from higher LR. The backbone needs lower LR for stability. Two param groups with different LRs.

## Instructions
In `structured_split/structured_train.py`, replace the optimizer setup (around line 490):

```python
output_params = list(model.blocks[-1].mlp2.parameters())
output_ids = {id(p) for p in output_params}
backbone_params = [p for p in model.parameters() if id(p) not in output_ids]
base_opt = torch.optim.AdamW([
    {"params": backbone_params, "lr": cfg.lr},
    {"params": output_params, "lr": 1e-2},
], weight_decay=cfg.weight_decay)
```

Run with: `--wandb_name "alphonse/sep-lr" --wandb_group separate-lr --agent alphonse`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run ID:** orl2uavs
**Epochs completed:** 77/100 (30-min timeout; ~22.8s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline | This run (ep77, best) | Delta |
|---|---|---|---|
| val/loss | 2.5700 | **2.7543** | +7.2% worse |
| val_in_dist/mae_surf_p | 22.47 | **25.94** | +15% worse |
| val_ood_cond/mae_surf_p | 24.03 | **26.40** | +10% worse |
| val_ood_re/mae_surf_p | 32.08 | **35.01** | +9% worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **45.68** | +8% worse |

Additional val_in_dist at best epoch:
- mae_surf_Ux: 0.331 | mae_surf_Uy: 0.202
- mae_vol_Ux: 1.581 | mae_vol_Uy: 0.572 | mae_vol_p: 34.03

### What happened

**This did not work.** All metrics are worse across every val split.

The output head LR of 1e-2 is ~3.3x the backbone LR (cfg.lr = 3e-3). This appears too aggressive — the output head and backbone need to co-adapt, and the large LR mismatch destabilizes this joint optimization. The output head maps directly to physical quantities (Ux, Uy, p) requiring precise calibration; overshooting with high LR on these final projections likely causes sustained oscillation or poor convergence.

The model ran to 77 epochs and was still improving at the end (best val/loss is at epoch 77), but from a worse trajectory throughout training vs baseline.

### Suggested follow-ups
- Try a smaller LR ratio — e.g., backbone at 3e-3 and output head at 5e-3 — for a gentler differential
- Or try the opposite direction: lower backbone LR (e.g., 1e-3) to see if slowing the backbone while keeping output at 3e-3 helps
- The idea of differentiating LRs has merit but 3.3x may be too extreme for this architecture