### PR TITLE
Asymmetric pressure loss: 1.5x penalty for underpredicting |p|

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -589,7 +589,11 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        # Asymmetric pressure loss: 1.5x penalty for underpredicting |p|
+        abs_err_asym = abs_err.clone()
+        p_under = (pred[:, :, 2].abs() < y_norm[:, :, 2].abs())
+        abs_err_asym[:, :, 2] = torch.where(p_under, abs_err[:, :, 2] * 1.5, abs_err[:, :, 2])
+        surf_loss = (abs_err_asym * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
In aerodynamics, missing suction peaks (underpredicting |p|) is worse than overpredicting. Asymmetric L1 steers the model toward capturing pressure peaks.

## Instructions
In `structured_split/structured_train.py`, modify the surface loss (around line 592):

```python
# Asymmetric pressure loss
err = pred - y_norm  # signed error
abs_err_asym = abs_err.clone()
# For pressure channel (idx 2): penalize underprediction of magnitude 1.5x
p_under = (pred[:,:,2].abs() < y_norm[:,:,2].abs())  # model underestimates
abs_err_asym[:,:,2] = torch.where(p_under, abs_err[:,:,2] * 1.5, abs_err[:,:,2])
surf_loss = (abs_err_asym * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```

Run with: `--wandb_name "edward/asym-p" --wandb_group asym-pressure --agent edward`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** 7ui2i0j9  
**Best epoch:** 81  
**Peak memory:** 8.8 GB

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6521** | +3.2% ↑ worse |
| val_in_dist/mae_surf_Ux | — | 0.3178 | — |
| val_in_dist/mae_surf_Uy | — | 0.1896 | — |
| val_in_dist/mae_surf_p | 22.47 | **23.98** | +6.7% ↑ worse |
| val_in_dist/mae_vol_Ux | — | 1.6000 | — |
| val_in_dist/mae_vol_Uy | — | 0.5581 | — |
| val_in_dist/mae_vol_p | — | 32.33 | — |
| val_ood_cond/mae_surf_p | 24.03 | **23.07** | -4.0% ↓ better |
| val_ood_re/mae_surf_p | 32.08 | **34.07** | +6.2% ↑ worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **44.26** | +5.1% ↑ worse |

### What happened

Negative result overall. The asymmetric 1.5x penalty for underpredicting pressure magnitude improved ood_cond (-4.0%) but hurt all other splits, especially in-dist (+6.7%) and ood_re (+6.2%). Overall val/loss increased +3.2%. The asymmetric penalty effectively changes the loss landscape so the model optimizes toward a biased target — this appears to hurt calibration on in-distribution and out-of-distribution-Re data while marginally benefiting ood_cond. The pattern of ood_cond improving while others degrade has appeared in other recent experiments (prenorm-postnorm, grad accumulation) and may be an artifact of ood_cond having different pressure scale or sign distribution.

### Suggested follow-ups

- Try a milder asymmetry (1.2x instead of 1.5x) to see if the ood_cond gain can be preserved without hurting in-dist.
- The ood_cond split seems to respond positively to pressure-upweighting changes; investigate if ood_cond has a systematic pressure underprediction bias in the baseline.
- Consider a physics-informed variant: instead of penalizing |p| underprediction, penalize suction-side pressure specifically (where Cp < 0).