### PR TITLE
Temperature annealing schedule (1.0→0.1 over training)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,6 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
@@ -118,7 +117,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
 
-    def forward(self, x):
+    def forward(self, x, temperature=None):
+        if temperature is None:
+            temperature = 0.5
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -133,7 +134,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
+        slice_weights = self.softmax(self.in_project_slice(x_mid) / temperature)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -188,8 +189,8 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
+    def forward(self, fx, temperature=None):
+        fx = self.attn(self.ln_1(fx), temperature=temperature) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
@@ -316,11 +317,13 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        temperature = data.get("temperature", None) if isinstance(data, Mapping) else None
+
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks:
-            fx = block(fx)
+            fx = block(fx, temperature=temperature)
         self._validate_output_dims(fx)
         return {"preds": fx}
 
@@ -547,6 +550,9 @@ for epoch in range(MAX_EPOCHS):
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
+    # Temperature annealing: 1.0 → 0.1 over training
+    temp = max(0.1, 1.0 - 0.9 * epoch / MAX_EPOCHS)
+
     # --- Train ---
     model.train()
     epoch_vol = 0.0
@@ -567,7 +573,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
+            pred = model({"x": x, "temperature": temp})["preds"]
         pred = pred.float()
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
@@ -654,7 +660,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = model({"x": x, "temperature": temp})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()


### PR DESCRIPTION
## Hypothesis
Fix temperature on a schedule instead of learning it. Early: high temp (broad attention, exploration). Late: low temp (sharp specialization). Prevents temperature from getting stuck in a local optimum.

## Instructions
In \`structured_split/structured_train.py\`, remove the learnable temperature parameter. In \`Physics_Attention_Irregular_Mesh.__init__\`, remove \`self.temperature\`. In forward, accept temperature as an argument:

\`\`\`python
def forward(self, x, temperature=None):
    ...
    if temperature is None:
        temperature = 0.5
    slice_weights = self.softmax(self.in_project_slice(x_mid) / temperature)
    ...
\`\`\`

In the training loop, compute and pass temperature:
\`\`\`python
temp = max(0.1, 1.0 - 0.9 * epoch / MAX_EPOCHS)
# Pass through model to attention (modify model forward to pass temp)
\`\`\`

Run with: \`--wandb_name "violet/temp-anneal" --wandb_group temp-anneal --agent violet\`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run**: xuq838l2  
**Best epoch**: 83  
**Peak memory**: 8.6 GB  

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6829 | 0.291 | 0.186 | 23.20 | 1.510 | 0.541 | 31.11 |
| val_tandem_transfer | 4.7310 | 0.673 | 0.353 | 46.94 | 2.407 | 1.109 | 50.27 |
| val_ood_cond | 1.5984 | 0.292 | 0.193 | 23.54 | 1.333 | 0.499 | 25.19 |
| val_ood_re | nan | 0.291 | 0.203 | 32.25 | — | — | — |

**val/loss (mean non-nan)**: 2.6708 vs baseline 2.5700 → **Δ=+0.101 (worse)**

**Surface MAE (p) comparison**:
| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 22.47 | 23.20 | +0.73 ↑ worse |
| val_ood_cond | 24.03 | 23.54 | **-0.49 better** |
| val_ood_re | 32.08 | 32.25 | +0.17 ≈ same |
| val_tandem_transfer | 42.13 | 46.94 | +4.81 ↑ much worse |

### What happened

Temperature annealing (1.0→0.1) did not help. Overall val/loss is 0.101 worse than baseline. The most striking regression is val_tandem_transfer mae_surf_p (+4.81), suggesting the high initial temperature (1.0) harms early-epoch specialization for out-of-distribution generalization.

The learned temperature (baseline ≈0.5) appears to be a well-calibrated value. Starting at 1.0 makes attention slices too diffuse early in training, while 0.1 at the end may over-sharpen. val_ood_cond improved slightly (-0.49), but the other splits regressed.

The only clear improvement over the fixed-temperature schedule would be if the learned temperature converged to something clearly suboptimal. Here it appears the model learns a good temperature on its own.

### Suggested follow-ups
- Try a narrower schedule: 0.5→0.1 (same endpoint, less disruption to early training)
- Try starting from a checkpoint with a warmup phase: keep learned temperature for first N epochs, then switch to annealing
- Investigate the learned temperature value at convergence — if it settles at ~0.5, fixed 0.5 baseline might be fine