### PR TITLE
Node dropout: drop 25% of input nodes during training

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -559,6 +559,17 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
+        if model.training:
+            # Node dropout: keep 75% of nodes
+            keep_prob = 0.75
+            node_keep = torch.rand(x.shape[0], x.shape[1], device=device) < keep_prob
+            node_keep = node_keep | is_surface  # ALWAYS keep surface nodes
+            node_keep = node_keep & mask  # Only among valid nodes
+            # Zero out dropped nodes in x (they still exist but carry no signal)
+            x = x * node_keep.unsqueeze(-1).float()
+            # Exclude dropped nodes from loss
+            mask = mask & node_keep
+
         x = (x - stats["x_mean"]) / stats["x_std"]
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
Stochastic subsampling of the input mesh forces robustness to mesh density variation and acts as strong regularization. Different from progressive resolution (which only affects loss computation, not input).

## Instructions
In `structured_split/structured_train.py`, in the training loop, after loading batch:

```python
if model.training:
    # Node dropout: keep 75% of nodes
    keep_prob = 0.75
    node_keep = torch.rand(x.shape[0], x.shape[1], device=device) < keep_prob
    node_keep = node_keep | is_surface  # ALWAYS keep surface nodes
    node_keep = node_keep & mask  # Only among valid nodes
    # Zero out dropped nodes in x (they still exist but carry no signal)
    x = x * node_keep.unsqueeze(-1).float()
    # Exclude dropped nodes from loss
    mask = mask & node_keep
```

Run with: `--wandb_name "gilbert/node-drop" --wandb_group node-dropout --agent gilbert`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 43.67 (note: baseline body says 42.13)

---

## Results

**W&B run:** `9p8hr4ch` — gilbert/node-drop

**Best epoch:** 81 of 81 (30.3 min, wall-clock limit)
**Peak memory:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 2.040 | 0.376 | 0.200 | **28.31** | 2.210 | 0.786 | 46.44 |
| val_ood_cond | 1.639 | — | — | **23.6** | — | — | — |
| val_ood_re | nan | — | — | **33.6** | — | — | — |
| val_tandem_transfer | 4.898 | — | — | **45.0** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.8588** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | 2.8588 | +0.289 ❌ |
| val_in_dist/mae_surf_p | 22.47 | 28.31 | +5.84 ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 23.6 | −0.43 ✅ |
| val_ood_re/mae_surf_p | 32.08 | 33.6 | +1.52 ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 45.0 | +2.87 ❌ |

### What happened

Strong negative result. Node dropout hurt val_in_dist pressure MAE by +5.84 and val/loss by +0.29. Only val_ood_cond showed marginal improvement (−0.43), which appears to be noise given the overall degradation.

Two problems with this approach:

1. **Zeroing before normalization**: The dropout is applied before `x = (x - stats["x_mean"]) / stats["x_std"]`. Dropped nodes receive value `(0 - mean) / std` rather than true zero — they carry a confusing non-zero normalized signal that the physics attention mechanism will try to interpret as a real mesh point. This is worse than masking after normalization.

2. **Physics attention relies on global mesh context**: Transolver's attention mechanism builds physical tokens from the full mesh by learning a soft assignment of nodes to "physics slices". Zeroing 25% of nodes corrupts this global view significantly. Unlike point cloud dropout (where spatial context is well-represented by the remaining points), CFD mesh predictions require accurate global flow information to predict local values.

The val_in_dist volume MAE (2.21 vs ~1.57 baseline) confirms the model struggles to predict volume fields accurately, consistent with the corrupted input hypothesis.

Note: `val_ood_re/loss` is NaN throughout — pre-existing issue.

### Suggested follow-ups

- **Dropout after normalization**: Zero out nodes after normalizing x, so dropped nodes truly carry zero signal (not a spurious mean-offset artifact).
- **Smaller dropout rate**: Try 10% dropout (keep_prob=0.9) instead of 25% — less disruption to the physics context.
- **Volume-only dropout**: Only drop volume nodes (never surface or their immediate neighbors) to preserve the most important parts of the mesh for loss computation.