### PR TITLE
Cyclic data ordering (alternate random/Re-sorted epochs)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -402,16 +402,40 @@ def _phys_denorm(y_p, Umag, q):
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
+
+class CyclicSampler(torch.utils.data.Sampler):
+    def __init__(self, dataset, weights, epoch_fn):
+        self.dataset = dataset
+        self.weights = weights
+        self.epoch_fn = epoch_fn
+        # Pre-compute Re-sorted indices
+        re_vals = []
+        for i in range(len(dataset)):
+            x, y, _ = dataset[i]
+            re_vals.append(x[0, 13].item())  # log_Re at first node
+        self.sorted_indices = sorted(range(len(dataset)), key=lambda i: re_vals[i])
+
+    def __iter__(self):
+        epoch = self.epoch_fn()
+        if epoch % 2 == 0:
+            # Random weighted sampling
+            idx = list(torch.multinomial(self.weights, len(self.dataset), replacement=True).numpy())
+        else:
+            idx = self.sorted_indices.copy()
+        return iter(idx)
+
+    def __len__(self):
+        return len(self.dataset)
+
+
+current_epoch = [0]
+
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
     train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
                               shuffle=True, **loader_kwargs)
 else:
-    sampler = WeightedRandomSampler(
-        weights=sample_weights,
-        num_samples=len(train_ds),
-        replacement=True,
-    )
+    sampler = CyclicSampler(train_ds, sample_weights, lambda: current_epoch[0])
     train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
                               sampler=sampler, **loader_kwargs)
 
@@ -535,6 +559,7 @@ global_step = 0
 train_start = time.time()
 
 for epoch in range(MAX_EPOCHS):
+    current_epoch[0] = epoch
     elapsed_min = (time.time() - train_start) / 60.0
     if elapsed_min >= MAX_TIMEOUT:
         print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {MAX_TIMEOUT} min). Stopping.")


### PR DESCRIPTION
## Hypothesis
Sort training samples by Reynolds number on odd epochs (easy-to-hard curriculum). Random on even epochs (diversity). This structured progression helps the model build hierarchical understanding.

## Instructions
In `structured_split/structured_train.py`, create a custom sampler that alternates:

```python
class CyclicSampler(torch.utils.data.Sampler):
    def __init__(self, dataset, weights, epoch_fn):
        self.dataset = dataset
        self.weights = weights
        self.epoch_fn = epoch_fn
        # Pre-compute Re-sorted indices
        re_vals = []
        for i in range(len(dataset)):
            x, y, _, _ = dataset[i]
            re_vals.append(x[0, 13].item())  # log_Re at first node
        self.sorted_indices = sorted(range(len(dataset)), key=lambda i: re_vals[i])
    
    def __iter__(self):
        epoch = self.epoch_fn()
        if epoch % 2 == 0:
            # Random weighted sampling
            idx = list(torch.multinomial(self.weights, len(self.dataset), replacement=True).numpy())
        else:
            idx = self.sorted_indices.copy()
        return iter(idx)
    
    def __len__(self):
        return len(self.dataset)
```

Replace the sampler. Run with: `--wandb_name "emma/cyclic-curr" --wandb_group cyclic-curriculum --agent emma`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** s0irn04m | **Epochs:** ~85 (killed by 30-min timeout) | **Epoch time:** 21.4 s | **Peak GPU memory:** 65.8 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.828 | 0.343 | 0.189 | 25.80 | 1.534 | 0.527 | 33.57 |
| val_ood_cond | 1.747 | 0.317 | 0.213 | 26.51 | 1.343 | 0.532 | 27.60 |
| val_ood_re | NaN | 0.315 | 0.218 | 34.46 | 1.290 | 0.537 | 55.97 |
| val_tandem_transfer | 4.673 | 0.654 | 0.354 | 45.12 | 2.422 | 1.117 | 48.93 |
| **combined val/loss** | **2.7493** | | | | | | |

**vs baseline (Δ surf_p):**
- val_in_dist: 25.80 vs 22.47 → **+3.33 (↑14.8%, worse)**
- val_ood_cond: 26.51 vs 24.03 → **+2.48 (↑10.3%, worse)**
- val_ood_re: 34.46 vs 32.08 → **+2.38 (↑7.4%, worse)**
- val_tandem_transfer: 45.12 vs 42.13 → **+2.99 (↑7.1%, worse)**
- val/loss: 2.7493 vs 2.5700 → **+0.1793 (↑7.0%, worse)**

### Implementation note

The PR instructions used `x, y, _, _ = dataset[i]` but the dataset returns 3 values `(x, y, is_surface)`. Fixed to `x, y, _ = dataset[i]`.

### What happened

Negative result across all splits. Cyclic Re-sorted curriculum significantly hurt performance (-7% val/loss, -15% val_in_dist surf_p).

Two likely causes:

1. **Domain balance lost on odd epochs.** The Re-sorted pass uses the full sorted index list without the `sample_weights` domain balancing. On those epochs the model sees many racecar samples (the majority domain) in sequence, losing the diversity that `WeightedRandomSampler` provides across racecar/cruise/tandem.

2. **Low per-batch diversity on sorted epochs.** Batches drawn from Re-sorted indices contain samples with nearly identical Re, giving very similar gradients — effectively reducing the gradient variance that helps SGD escape local minima. This hurts generalization, especially to val_ood_re.

The alternating structure also means ~50% of training uses sub-optimal sampling, compounding the problem over ~85 epochs.

### Suggested follow-ups

- If curriculum is desired: keep weighted sampling but add a mild Re-based difficulty term to the loss (no drastic sampling change).
- Try Re-sorted only for warm-up (first 10 epochs) then switch to full weighted random — less disruptive.
- The real signal here may be that domain balance (sample_weights) is critical and should not be disrupted.