### PR TITLE
Multi-scale coarse loss weight 2.0 (double current)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -608,7 +608,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 2.0 * coarse_loss  # was 1.0 — testing stronger coarse supervision
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The coarse loss was halved from 2.0 to 1.0 in round 9 and merged. But the model has changed significantly since (MQA, eta_min change). Testing weight=2.0 again on the current much-stronger baseline.

## Instructions
In `structured_split/structured_train.py`, around line 611:
```python
loss = loss + 2.0 * coarse_loss
```

Run with: `--wandb_name "norman/coarse-2" --wandb_group coarse-wt-2 --agent norman`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run:** `5rob18si`  
**Epochs:** 81 (30.0 min, completed normally)  
**Peak memory:** 8.8 GB  

### Metrics at best checkpoint (epoch 80)

| Metric | Baseline (coarse_wt=1.0) | This run (coarse_wt=2.0) | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.5996** | +1.2% ❌ |
| val_in_dist/mae_surf_p | 22.47 | 22.79 | +1.4% |
| val_ood_cond/mae_surf_p | 24.03 | 23.83 | **−0.8%** ✓ |
| val_ood_re/mae_surf_p | 32.08 | 32.85 | +2.4% ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 43.74 | +3.8% ❌ |

### What happened

Slightly negative result. Doubling the coarse loss weight from 1.0→2.0 caused a modest overall degradation (+1.2% val/loss), with only ood_cond improving slightly (-0.8%).

The coarse loss (multi-scale downsampled predictions) provides additional gradient signal for low-frequency structure. At weight=1.0 this appears to be near-optimal for the current model — increasing it to 2.0 slightly over-regularizes the coarse structure at the expense of fine-grained surface accuracy (tandem_transfer +3.8%, ood_re +2.4%).

The model has improved substantially since the weight was last tuned (MQA, eta_min, Lookahead changes). The current 1.0 weight seems appropriate for the stronger baseline.

### Suggested follow-ups

- **Try coarse_wt=0.5** — the current trend suggests the coarse loss might benefit from being reduced further on the improved model
- **Try coarse_wt=0.0 (disable)** — ablation to see whether coarse loss helps at all on the current baseline
- **Adaptive coarse weight** — ramp from higher to lower values during training (start 2.0, end 0.5) to give coarse structure supervision early when it's most useful
