### PR TITLE
Self-distillation: checkpoint ensemble teacher for last 20 epochs

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -533,6 +533,7 @@ best_val = float("inf")
 best_metrics = {}
 global_step = 0
 train_start = time.time()
+teachers = []
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -609,6 +610,12 @@ for epoch in range(MAX_EPOCHS):
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
+
+        if epoch > 60 and teachers:
+            with torch.no_grad():
+                teacher_preds = torch.stack([t({"x": x})["preds"].float() for t in teachers]).mean(0)
+            kd_loss = (pred - teacher_preds).abs().mean()
+            loss = loss + 0.5 * kd_loss
 
         optimizer.zero_grad()
         loss.backward()
@@ -745,6 +752,18 @@ for epoch in range(MAX_EPOCHS):
         f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
         f"val[{split_summary}]{tag}"
     )
+
+    if epoch + 1 in [40, 50, 60]:
+        torch.save(model.state_dict(), model_dir / f"ckpt_{epoch+1}.pt")
+
+    if epoch == 60:
+        import copy
+        teachers = []
+        for ep in [40, 50, 60]:
+            t = copy.deepcopy(model)
+            t.load_state_dict(torch.load(model_dir / f"ckpt_{ep}.pt", map_location=device))
+            t.eval()
+            teachers.append(t)
 
 
 # --- Final summary ---


### PR DESCRIPTION
## Hypothesis
Train normally for 60 epochs, save checkpoints at 40/50/60. Average predictions from all 3 as a teacher signal. Fine-tune last 20 epochs with added KD loss. Self-distillation smooths the target landscape.

## Instructions
In `structured_split/structured_train.py`:

1. Save checkpoints at epochs 40, 50, 60:
```python
if epoch + 1 in [40, 50, 60]:
    torch.save(model.state_dict(), model_dir / f"ckpt_{epoch+1}.pt")
```

2. At epoch 61, load all 3 and create teacher:
```python
if epoch == 60:
    import copy
    teachers = []
    for ep in [40, 50, 60]:
        t = copy.deepcopy(model)
        t.load_state_dict(torch.load(model_dir / f"ckpt_{ep}.pt", map_location=device))
        t.eval()
        teachers.append(t)
```

3. For epochs > 60, add KD loss:
```python
if epoch > 60 and teachers:
    with torch.no_grad():
        teacher_preds = torch.stack([t({"x": x})["preds"].float() for t in teachers]).mean(0)
    kd_loss = (pred - teacher_preds).abs().mean()
    loss = loss + 0.5 * kd_loss
```

Run with: `--wandb_name "chihiro/self-distill" --wandb_group self-distill --agent chihiro`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13
---

## Results

**W&B run:** `jf20d55r` | **Best epoch:** 69 | **Peak VRAM:** 11.7 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.889 | 0.330 | 0.200 | **26.24** | — |
| val_ood_cond | 1.635 | 0.277 | 0.204 | **24.98** | — |
| val_ood_re | NaN | 0.291 | 0.218 | **33.63** | — |
| val_tandem_transfer | 4.959 | 0.699 | 0.384 | **47.20** | — |
| **combined** | **2.8277** | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.8277** | +0.258 (worse) |
| val_in_dist/mae_surf_p | 22.47 | **26.24** | +3.77 (large regression) |
| val_ood_cond/mae_surf_p | 24.03 | **24.98** | +0.95 (regression) |
| val_ood_re/mae_surf_p | 32.08 | **33.63** | +1.55 (regression) |
| val_tandem_transfer/mae_surf_p | 42.13 | **47.20** | +5.07 (large regression) |

### What happened

**Self-distillation significantly hurts performance.** Val/loss is 2.8277 vs baseline 2.5700 (+0.258), and all 4 splits regress substantially.

Two problems explain the failure:

1. **Epoch budget collapse**: Epochs 1-60 run at ~22s each (normal). Once KD activates at epoch 61, each training batch runs 3 teacher forward passes (no_grad) in addition to the student. The epoch time jumped to ~50s, so only 69 total epochs completed in 30 min instead of ~80. The KD overhead consumed 8+ epochs of training capacity.

2. **Poor teacher quality**: The checkpoint ensemble (epochs 40/50/60) captures early-to-mid training when the model is still far from converged. The baseline best checkpoint typically arrives at epoch 75-80. These teachers provide signals worse than a fully converged model, potentially pulling the student backward. Self-distillation works better when teachers are at or near optimal.

VRAM increased from ~8.8 GB to 11.7 GB (+2.9 GB) from holding 3 teacher model copies on GPU.

### Suggested follow-ups

- **Use only the best checkpoint as teacher**: Instead of mid-training snapshots, save the best model seen so far and use it as the teacher for fine-tuning. This requires knowing when best is reached (near end of training).
- **Delay teacher creation**: Start collecting checkpoints later (e.g., 50/60/70) to use higher-quality snapshots, accepting fewer KD epochs.
- **Cheaper teacher**: Run teachers on CPU to avoid VRAM increase and use asynchronous teacher inference to reduce per-batch time.