### PR TITLE
Eval on Lookahead slow weights (fix checkpoint quality)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -627,6 +627,14 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf /= n_batches
 
     # --- Validate across all splits ---
+    # Swap in Lookahead slow weights for eval/checkpoint (they are smoother than fast weights)
+    _fast_backup = []
+    for slow_grp, opt_grp in zip(optimizer.slow_params, optimizer.base_optimizer.param_groups):
+        fb = []
+        for s, p in zip(slow_grp, opt_grp['params']):
+            fb.append(p.data.clone())
+            p.data.copy_(s.data)
+        _fast_backup.append(fb)
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
@@ -698,6 +706,11 @@ for epoch in range(MAX_EPOCHS):
             f"{split_name}/mae_surf_p":  mae_surf[2].item(),
         }
         val_loss_sum += split_loss
+
+    # Restore fast weights for continued training
+    for fb_grp, opt_grp in zip(_fast_backup, optimizer.base_optimizer.param_groups):
+        for f, p in zip(fb_grp, opt_grp['params']):
+            p.data.copy_(f)
 
     # val/loss = mean across finite splits; NaN-robust for checkpoint selection
     finite_losses = [val_metrics_per_split[name][f"{name}/loss"]


### PR DESCRIPTION
## Hypothesis
The Lookahead evaluates and checkpoints on **fast weights** (noisy AdamW iterates), not smoothed slow weights. This may be a bug — Lookahead exists to produce better slow weights, but we never use them for eval/saving.

## Instructions
In `structured_split/structured_train.py`:

1. **Before** `model.eval()` (line ~630), add code to swap in slow weights:
```python
_fast_backup = []
for slow_grp, opt_grp in zip(optimizer.slow_params, optimizer.base_optimizer.param_groups):
    fb = []
    for s, p in zip(slow_grp, opt_grp['params']):
        fb.append(p.data.clone())
        p.data.copy_(s.data)
    _fast_backup.append(fb)
```

2. **After** all validation is done (after the `for split_name, vloader` loop, ~line 700), restore fast weights:
```python
for fb_grp, opt_grp in zip(_fast_backup, optimizer.base_optimizer.param_groups):
    for f, p in zip(fb_grp, opt_grp['params']):
        p.data.copy_(f)
```

Run with: `--wandb_name "frieren/slow-eval" --wandb_group eval-slow-weights --agent frieren`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `gymdftt4`  
**Epochs:** 77/100 (timeout at 30 min)  
**Peak memory:** ~8.8 GB

| Metric | Baseline | Slow Eval | Δ |
|--------|----------|-----------|---|
| val/loss | 2.5700 | 2.7116 | +5.5% ❌ |
| val_in_dist/mae_surf_p | 22.47 | 24.01 | +6.9% ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 24.94 | +3.8% ❌ |
| val_ood_re/mae_surf_p | 32.08 | 33.31 | +3.8% ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 44.77 | +6.3% ❌ |

**Full surface/volume MAE at best epoch (epoch 76):**

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.330 | 0.191 | 24.01 | 1.587 | 0.560 | 32.47 |
| val_ood_cond | 0.297 | 0.199 | 24.94 | 1.360 | 0.514 | 26.05 |
| val_ood_re | 0.304 | 0.212 | 33.31 | 1.294 | 0.522 | 54.79 |
| val_tandem_transfer | 0.691 | 0.358 | 44.77 | 2.512 | 1.124 | 49.01 |

**Note:** `val_ood_re/loss` was NaN across all epochs (vol_loss diverges for this OOD split). The mean_val_loss is computed over 3 finite splits.

**What happened:**  
Using slow weights for eval is worse than fast weights across all metrics. The key issue is the Lookahead configuration: with alpha=0.8 (very high) and k=10, the slow weights are `s_new = 0.2 * s_old + 0.8 * fast` — they closely track the fast weights with only a ~10-step lag. At training time with continuing gradient signal, the fast weights are actually ahead of the loss surface; the slow weights, lagging behind, are effectively "older" rather than "smoother." This is different from the EMA (decay=0.999) which smooths over thousands of steps and provides genuine denoising. Lookahead with high alpha=0.8 essentially just copies the fast weights every k steps, and using stale weights for eval hurts performance.

**Suggested follow-ups:**
- Try Lookahead with lower alpha (e.g., alpha=0.5) to create a more meaningful slow weight trajectory worth evaluating on.
- Replace Lookahead with a proper SWA (Stochastic Weight Averaging) in the final training phase — collect checkpoints every N epochs and average them, which gives a genuine ensemble benefit that EMA-style methods provide.
- The EMA approach (PR #458) was the only successful weight averaging method so far, suggesting that smooth exponential averaging over many steps beats k-step interpolation for this problem.