### PR TITLE
Remove training target noise (0.01 may prevent convergence)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -563,8 +563,7 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]


### PR DESCRIPTION
## Hypothesis
Adding 0.01 Gaussian noise to regression targets during L1 training creates a perpetually moving target. At the current plateau, the bottleneck may be underfitting, not overfitting — removing noise allows the model to fit training targets precisely.

## Instructions
In \`structured_split/structured_train.py\`, **delete or comment out** line 567:
\`\`\`python
# DELETE THIS LINE:
# y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
\`\`\`

That's it — single line removal.

Run with: \`--wandb_name "tanjiro/no-noise" --wandb_group remove-target-noise --agent tanjiro\`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**Did not beat baseline.** val/loss=2.6922 vs baseline 2.5700 (worse by +5%).

- **W&B run**: \`pnjis87i\` (tanjiro/no-noise, group: remove-target-noise)
- **Epochs**: 81 of 100 (30.1 min wall clock)
- **Best epoch**: 81
- **Peak memory**: 8.8 GB

### Validation losses (best checkpoint, epoch 81)

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.7343 | 0.305 | 0.192 | 24.38 | 1.573 | 0.564 | 33.10 |
| val_ood_cond | 1.6065 | 0.274 | 0.193 | 25.80 | 1.358 | 0.523 | 26.37 |
| val_ood_re | nan | 0.285 | 0.204 | 32.97 | 1.286 | 0.530 | 55.46 |
| val_tandem_transfer | 4.7359 | 0.682 | 0.365 | 45.80 | 2.486 | 1.148 | 49.65 |
| **val/loss** | **2.6922** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.5700 | 2.6922 | +0.12 (+5%) |
| mae_surf_p in_dist | 22.47 | 24.38 | +1.91 (+9%) |
| mae_surf_p ood_cond | 24.03 | 25.80 | +1.77 (+7%) |
| mae_surf_p ood_re | 32.08 | 32.97 | +0.89 (+3%) |
| mae_surf_p tandem | 42.13 | 45.80 | +3.67 (+9%) |

### What happened

Removing the 0.01 target noise slightly degraded performance. The hypothesis assumed underfitting, but the data suggests otherwise: train loss (vol=0.23, surf=0.076) is much lower than val loss (~2.69), indicating the model is already overfitting. In that regime, the small amount of label smoothing from noise actually helps regularize, preventing the model from over-memorizing training targets.

On the positive side: 81 epochs completed in 30 min (22s/epoch) — significantly more than many other experiments, confirming that this configuration is fast.

### Suggested follow-ups

- If underfitting is actually a concern (e.g. after capacity increases), this change is worth revisiting.
- Alternatively, try **reducing** noise to 0.005 or applying it only to pressure channel (which has higher variance), rather than removing it entirely.