### PR TITLE
Val surf_weight=30 (align eval with late training objective)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -682,7 +682,7 @@ for epoch in range(MAX_EPOCHS):
 
         val_vol /= max(n_vbatches, 1)
         val_surf /= max(n_vbatches, 1)
-        split_loss = val_vol + cfg.surf_weight * val_surf
+        split_loss = val_vol + 30.0 * val_surf
         mae_surf /= n_surf.clamp(min=1)
         mae_vol /= n_vol.clamp(min=1)
 


### PR DESCRIPTION
## Hypothesis
Training ramps surf_weight to 30 by the end, but validation uses a fixed surf_weight=20 (cfg.surf_weight). This misalignment means the model's late-training optimization target (surf_weight=30) doesn't match how checkpoints are selected (surf_weight=20). Aligning them should select better checkpoints.

## Instructions
In `structured_split/structured_train.py`, change the validation loss computation (line ~685):
```python
# OLD: split_loss = val_vol + cfg.surf_weight * val_surf
# NEW: match the training endpoint for aligned checkpoint selection
split_loss = val_vol + 30.0 * val_surf
```

Run with: `--wandb_name "nezuko/val-sw30" --wandb_group val-sw-30 --agent nezuko`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run:** `dg1hsc77` (nezuko/val-sw30)
**Best epoch:** 81 / ~81 (hit 30-min timeout)

### Metrics vs baseline

Note: val/loss is not directly comparable to baseline — this run uses sw=30 in the loss formula, baseline uses sw=20.

| Split | Metric | Baseline (sw=20) | This run (sw=30) | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 22.47 | 23.21 | +0.74 |
| val_ood_cond | mae_surf_p | 24.03 | 23.54 | -0.49 |
| val_ood_re | mae_surf_p | 32.08 | 32.13 | +0.05 |
| val_tandem_transfer | mae_surf_p | 42.13 | 45.13 | +3.00 |

Detailed best-epoch metrics:
- **val_in_dist**: loss=2.453 (sw=30), mae_surf_Ux=0.298, mae_surf_Uy=0.191, mae_surf_p=23.21, mae_vol_Ux=1.556, mae_vol_Uy=0.554, mae_vol_p=31.89
- **val_ood_cond**: loss=2.271 (sw=30), mae_surf_Ux=0.273, mae_surf_Uy=0.194, mae_surf_p=23.54, mae_vol_Ux=1.316, mae_vol_Uy=0.505, mae_vol_p=25.38
- **val_ood_re**: mae_surf_p=32.13 (loss=NaN — vol overflow, pre-existing)
- **val_tandem_transfer**: loss=6.665 (sw=30), mae_surf_Ux=0.651, mae_surf_Uy=0.351, mae_surf_p=45.13

### What happened

The hypothesis did not work. The change only affects checkpoint selection (which epoch's weights get saved), not training. Despite using sw=30 in the checkpoint selection criterion (aligned with the late-training objective), the selected checkpoint had worse surface accuracy than the baseline across most splits. Notably:

- **Tandem transfer degraded by +3 pressure units** — a meaningful regression
- In-dist and OOD-re were essentially flat to slightly worse
- Only OOD-cond showed minor improvement (-0.49)

Why it likely failed: The val/loss with sw=30 heavily penalizes surface error, so it selects checkpoints that minimized the surface term. But minimizing the surface loss in isolation doesn't always correspond to minimum surface MAE in physical units — the model may have selected a checkpoint where surface features overfit at the expense of generalization (especially on tandem, the most diverse split).

Additionally, the sw ramp means the model is optimized with sw=30 only at the very end of training. Checkpoints selected with sw=30 may favor later epochs that haven't fully converged on volume accuracy, hurting the combined metric.

The surf_loss at best checkpoint: 0.0746 vs baseline 0.0734 — slightly higher despite the stronger penalty, suggesting the alignment didn't help select a better checkpoint.

### Suggested follow-ups
- Try a smooth sw ramp in validation to match training (e.g., sw = sw_start + (sw_end - sw_start) * epoch/MAX_EPOCHS), making the selection criterion continuously aligned rather than snapping to the endpoint
- Alternatively, keep val sw=20 but track separate metrics for checkpoint selection vs reporting