### PR TITLE
Spatial-sorted coarse pooling (meaningful multi-scale loss)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -597,10 +597,15 @@ for epoch in range(MAX_EPOCHS):
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask[:, :n_groups * coarse_pool_size]
+            with torch.no_grad():
+                sort_idx = x[:, :, 0].argsort(dim=1)  # sort by x-position
+            pred_sorted = pred.gather(1, sort_idx.unsqueeze(-1).expand_as(pred))
+            y_sorted = y_norm.gather(1, sort_idx.unsqueeze(-1).expand_as(y_norm))
+            mask_sorted = mask.gather(1, sort_idx)
+
+            pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
+            y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
+            mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
             pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
             y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)


### PR DESCRIPTION
## Hypothesis
The multi-scale coarse loss pools over groups of 64 **consecutive** nodes, but node ordering is arbitrary. Sorting by x-position before grouping makes coarse pools spatially coherent, so the loss actually captures multi-scale spatial structure.

## Instructions
In `structured_split/structured_train.py`, replace the coarse loss section (~lines 596-611):
```python
coarse_pool_size = 64
B, N, C = pred.shape
n_groups = N // coarse_pool_size
if n_groups > 1:
    with torch.no_grad():
        sort_idx = x[:, :, 0].argsort(dim=1)  # sort by x-position
    pred_sorted = pred.gather(1, sort_idx.unsqueeze(-1).expand_as(pred))
    y_sorted = y_norm.gather(1, sort_idx.unsqueeze(-1).expand_as(y_norm))
    mask_sorted = mask.gather(1, sort_idx)
    
    pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
    y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
    mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
    
    pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
    y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
    mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
    
    coarse_err = (pred_coarse - y_coarse).abs()
    coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
    loss = loss + 1.0 * coarse_loss
```

Run with: `--wandb_name "alphonse/spatial-coarse" --wandb_group spatial-coarse-pool --agent alphonse`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run ID:** dnx26xyg
**Epochs completed:** 78/100 (30-min timeout; ~22.7s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline | This run (ep78, best) | Delta |
|---|---|---|---|
| val/loss | 2.5700 | **2.7264** | +6.1% worse |
| val_in_dist/mae_surf_p | 22.47 | **24.78** | +10% worse |
| val_ood_cond/mae_surf_p | 24.03 | **24.90** | +3.6% worse |
| val_ood_re/mae_surf_p | 32.08 | **33.95** | +5.8% worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **44.62** | +5.9% worse |

Additional val_in_dist at best epoch:
- mae_surf_Ux: 0.317 | mae_surf_Uy: 0.196
- mae_vol_Ux: 1.672 | mae_vol_Uy: 0.616 | mae_vol_p: 33.91

### What happened

**This did not work.** All metrics are worse than baseline, though the margin is smaller than in some other failed experiments.

The model ran 78 epochs (best at last epoch, still improving), so training time is not the issue.

The spatial sorting hypothesis doesn't pan out. The likely reason: argsort by x-position creates strict spatial bins, which imposes a specific inductive bias — the coarse loss penalizes errors that deviate in x-averaged bins. But the baseline model already has x-position as input and can learn spatial structure directly from the physics loss. The sorted coarse loss adds a constraint that may not align well with how the model represents flow structure, creating a harder-to-optimize objective without meaningful benefit.

The original unsorted coarse loss acts as a noisy mean-regularization over arbitrary groups; spatially sorting removes the noise but may also remove some helpful implicit regularization effect.

### Suggested follow-ups
- The coarse loss benefit may come from the scale regularization rather than spatial coherence — could try fewer but larger groups (e.g., pool_size=128) instead
- If spatial structure matters, sorting by mesh distance from the leading edge might be more physically meaningful than x-position sorting