### PR TITLE
Huber(delta=0.1) on surface, L1 on volume

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -589,7 +589,13 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_err = pred - y_norm
+        surf_huber = torch.where(
+            surf_err.abs() < 0.1,
+            0.5 * surf_err ** 2 / 0.1,
+            surf_err.abs() - 0.5 * 0.1,
+        )
+        surf_loss = (surf_huber * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Pure L1 gives constant gradients regardless of error magnitude. For surface nodes where we need precise predictions, Huber(delta=0.1) provides stronger MSE-like gradients near zero while keeping L1 robustness for large errors. Apply only to surface — volume stays L1.

## Instructions
In `structured_split/structured_train.py`, replace the surface loss computation (~line 592):
```python
# OLD: surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
# NEW: Huber on surface for stronger near-zero gradients
surf_err = pred - y_norm
surf_huber = torch.where(
    surf_err.abs() < 0.1,
    0.5 * surf_err ** 2 / 0.1,
    surf_err.abs() - 0.5 * 0.1
)
surf_loss = (surf_huber * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```

Run with: `--wandb_name "edward/huber-surf" --wandb_group huber-surf-01 --agent edward`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run:** di7ay3zr | **Epochs:** 81 (30 min wall-clock limit) | **Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 2.6620 | 0.302 | 0.196 | **23.87** | 1.376 | 0.498 | 29.07 |
| ood_cond | — | 0.300 | 0.214 | **24.87** | 1.203 | 0.453 | 22.67 |
| ood_re | NaN | 0.297 | 0.216 | **33.12** | 1.151 | 0.480 | 52.91 |
| tandem | — | 0.677 | 0.360 | **44.34** | 2.324 | 1.068 | 46.89 |

**vs. baseline (val/loss 2.5700, mae_surf_p: in_dist 22.47 / ood_cond 24.03 / ood_re 32.08 / tan 42.13):**
- val/loss: 2.6620 (+3.6%)
- mae_surf_p in_dist: 23.87 vs 22.47 (**+6.2%** — worse)
- mae_surf_p ood_cond: 24.87 vs 24.03 (**+3.5%** — worse)
- mae_surf_p ood_re: 33.12 vs 32.08 (**+3.2%** — worse)
- mae_surf_p tandem: 44.34 vs 42.13 (**+5.2%** — worse)

### What happened

Huber(delta=0.1) on surface did not improve performance — all splits are uniformly worse than the L1 baseline. The delta=0.1 threshold means any normalized error below 0.1 gets MSE-like treatment. But the current surface loss runs at `surf=0.03` by epoch 81, suggesting most errors are well inside the 0.1 delta region where Huber acts as scaled MSE (gradient magnitude ~err/delta vs 1 for L1). This changes the loss curvature without providing the intended near-zero precision benefit — the optimizer sees weaker gradients for small errors, likely slowing convergence.

The pattern of all splits degrading uniformly (~3-6%) is consistent with other surface loss modifications (asymmetric pressure +3.2%, Xavier init +2.8%). L1 appears well-suited for this problem given the heavy-tailed error distribution in CFD predictions.

### Suggested follow-ups

1. **Huber with smaller delta (e.g., 0.01)**: Tighter delta could better separate the MSE/L1 regimes, though the gain seems unlikely given current results.
2. **Focal loss variant**: Down-weight easy (low-error) examples and focus on hard ones — could help pressure specifically.
3. **Investigate ood_re NaN**: The vol_loss blowup (1.89e10) on ood_re is pre-existing and worth diagnosing.
4. **Accept L1 as the right surface loss**: Multiple experiments (Huber, asymmetric pressure) have tried to improve on pure L1 without success. Architecture or training dynamics may be better levers.