### PR TITLE
Gradient-norm balanced vol/surf loss (equal gradient signal)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -610,7 +610,24 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
+        # GradNorm-balanced backward
         optimizer.zero_grad()
+        vol_term = vol_loss
+        surf_term = surf_weight * surf_loss
+        # Get gradient norms for each term
+        vol_term.backward(retain_graph=True)
+        vol_gnorm = sum(p.grad.norm()**2 for p in model.parameters() if p.grad is not None).sqrt().item()
+        optimizer.zero_grad()
+        surf_term.backward(retain_graph=True)
+        surf_gnorm = sum(p.grad.norm()**2 for p in model.parameters() if p.grad is not None).sqrt().item()
+        optimizer.zero_grad()
+        # Balance: scale to equal gradient norm
+        target_gnorm = (vol_gnorm + surf_gnorm) / 2
+        vol_scale = target_gnorm / max(vol_gnorm, 1e-8)
+        surf_scale = target_gnorm / max(surf_gnorm, 1e-8)
+        loss = vol_scale * vol_loss + surf_scale * surf_weight * surf_loss
+        if n_groups > 1:
+            loss = loss + 1.0 * coarse_loss
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()


### PR DESCRIPTION
## Hypothesis
Surface and volume losses produce vastly different gradient magnitudes (surface is ~1% of nodes but weighted 20-30x). This causes gradient oscillation. Normalizing each loss term's gradients to have equal norm ensures balanced optimization.

## Instructions
In `structured_split/structured_train.py`, replace the backward/step block (~lines 613-617):
```python
# GradNorm-balanced backward
optimizer.zero_grad()
vol_term = vol_loss
surf_term = surf_weight * surf_loss
# Get gradient norms for each term
vol_term.backward(retain_graph=True)
vol_gnorm = sum(p.grad.norm()**2 for p in model.parameters() if p.grad is not None).sqrt().item()
optimizer.zero_grad()
surf_term.backward(retain_graph=True)
surf_gnorm = sum(p.grad.norm()**2 for p in model.parameters() if p.grad is not None).sqrt().item()
optimizer.zero_grad()
# Balance: scale to equal gradient norm
target_gnorm = (vol_gnorm + surf_gnorm) / 2
vol_scale = target_gnorm / max(vol_gnorm, 1e-8)
surf_scale = target_gnorm / max(surf_gnorm, 1e-8)
loss = vol_scale * vol_loss + surf_scale * surf_weight * surf_loss
if n_groups > 1:
    loss = loss + 1.0 * coarse_loss
loss.backward()
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
optimizer.step()
```

Run with: `--wandb_name "askeladd/gradnorm" --wandb_group gradnorm-balance --agent askeladd`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run:** `3y64ql8h`

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (best) | 2.5700 | **3.7582** | +1.19 |
| val_in_dist/mae_surf_p | 22.47 | **49.14** | +26.67 |
| val_ood_cond/mae_surf_p | 24.03 | **42.27** | +18.24 |
| val_ood_re/mae_surf_p | 32.08 | **48.36** | +16.28 |
| val_tandem_transfer/mae_surf_p | 42.13 | **57.48** | +15.35 |

**Volume MAE (val_in_dist):** Ux=1.640, Uy=0.621, p=42.39

**Peak memory:** 11.5 GB (+2.7 GB vs baseline 8.8 GB)
**Epoch time:** ~47s/epoch vs ~22s baseline (2.1× slower)
**Epochs completed:** 37/100 (30-min timeout — less than half of baseline's 78 epochs)

**Note on val_ood_re:** val_ood_re/loss=NaN is a pre-existing bug present from epoch 1, unrelated to this experiment.

### What happened

This is a clear failure — significantly worse than baseline on every metric.

**Root cause 1: Epoch starvation.** The GradNorm method requires three backward passes per training step: two with `retain_graph=True` to measure per-term gradient norms, plus one final backward for the balanced loss. This approximately doubled per-epoch time (47s vs 22s). As a result, only 37 epochs completed under the 30-minute timeout, vs ~78 for baseline — less than half. The model was nowhere near converged.

**Root cause 2: Memory overhead from retained graphs.** `retain_graph=True` prevents PyTorch from freeing intermediate activations after the backward pass. This pushed peak VRAM from 8.8 GB to 11.5 GB (+31%), a significant and unjustified increase.

**Root cause 3: Dynamic rescaling noise.** The vol_scale and surf_scale factors are computed per batch from instantaneous gradient norms. Early in training these norms are noisy, causing the effective loss weighting to fluctuate unpredictably per step. This is different from a fixed surf_weight which the model can stably optimize against.

The val/loss curve was also still rising at epoch 37 (4.03 vs best 3.76 at epoch 35), suggesting instability rather than premature convergence.

### Suggested follow-ups
- **Static gradient norm ratio as a one-time measurement**: Compute vol_gnorm/surf_gnorm at epoch 5 (once stable), set a fixed correction factor, and use it throughout training. Avoids 3x backward overhead while still correcting the systematic imbalance.
- **Simply tune surf_weight**: The GradNorm hypothesis is that surf_weight=20-30 is wrong relative to gradient magnitudes. Rather than dynamic balancing, just try different fixed surf_weight values (e.g., 5, 10, 50) to empirically find the right ratio.