### PR TITLE
Surface attention bias (dedicated surface clusters)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -105,6 +105,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.surface_bias = nn.Parameter(torch.ones(1, 1, 1, slice_num) * 1.0)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
@@ -118,7 +119,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
 
-    def forward(self, x):
+    def forward(self, x, is_surface=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -133,7 +134,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
+        slice_logits = self.in_project_slice(x_mid) / self.temperature
+        if is_surface is not None:
+            slice_logits = slice_logits + self.surface_bias * is_surface.unsqueeze(1).unsqueeze(-1).float()
+        slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -188,8 +192,8 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
+    def forward(self, fx, is_surface=None):
+        fx = self.attn(self.ln_1(fx), is_surface=is_surface) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
@@ -316,11 +320,13 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        is_surface = data.get("is_surface", None) if isinstance(data, Mapping) else None
+
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks:
-            fx = block(fx)
+            fx = block(fx, is_surface=is_surface)
         self._validate_output_dims(fx)
         return {"preds": fx}
 
@@ -567,7 +573,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
+            pred = model({"x": x, "is_surface": is_surface})["preds"]
         pred = pred.float()
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
@@ -654,7 +660,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = model({"x": x, "is_surface": is_surface})["preds"]
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()


### PR DESCRIPTION
## Hypothesis
Surface nodes are ~1-2% of total nodes — they get diluted across many clusters in the slice attention, losing boundary layer information. Adding a learnable bias to slice logits for surface nodes encourages dedicated surface clusters.

## Instructions
In \`structured_split/structured_train.py\`:

1. In \`Physics_Attention_Irregular_Mesh.__init__\` (~line 99), add after the existing parameters:
\`\`\`python
self.surface_bias = nn.Parameter(torch.ones(1, 1, 1, slice_num) * 1.0)
\`\`\`

2. Change the \`forward\` signature to accept \`is_surface\`:
\`\`\`python
def forward(self, x, is_surface=None):
\`\`\`

3. In the forward method, after computing slice logits but before softmax (~line 136), replace:
\`\`\`python
# OLD: slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
# NEW:
slice_logits = self.in_project_slice(x_mid) / self.temperature
if is_surface is not None:
    slice_logits = slice_logits + self.surface_bias * is_surface.unsqueeze(1).unsqueeze(-1).float()
slice_weights = self.softmax(slice_logits)
\`\`\`

4. Thread \`is_surface\` through the model: In \`TransolverBlock.forward\`, accept and pass \`is_surface\`:
\`\`\`python
def forward(self, fx, is_surface=None):
    fx = self.attn(self.ln_1(fx), is_surface=is_surface) + fx
    ...
\`\`\`

5. In \`Transolver.forward\`, pass \`is_surface\` from the data dict:
\`\`\`python
is_surface = data.get("is_surface", None)
# ... in the loop:
for block in self.blocks:
    fx = block(fx, is_surface=is_surface)
\`\`\`

6. In the training loop, pass \`is_surface\` to the model:
\`\`\`python
pred = model({"x": x, "is_surface": is_surface})["preds"]
\`\`\`

Run with: \`--wandb_name "violet/surf-bias" --wandb_group surface-attn-bias --agent violet\`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run**: 76naekjk  
**Best epoch**: 80  
**Peak memory**: 8.8 GB  

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6907 | 0.302 | 0.188 | 22.84 | 1.503 | 0.552 | 31.84 |
| val_tandem_transfer | 4.6351 | 0.660 | 0.353 | 45.71 | 2.433 | 1.126 | 49.62 |
| val_ood_cond | 1.5652 | 0.277 | 0.192 | 23.64 | 1.289 | 0.509 | 25.36 |
| val_ood_re | nan | 0.284 | 0.203 | 32.44 | — | — | — |

**val/loss (mean non-nan)**: 2.6303 vs baseline 2.5700 → **Δ=+0.060 (worse)**

**Surface MAE (p) comparison**:
| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 22.47 | 22.84 | +0.37 ↑ slightly worse |
| val_ood_cond | 24.03 | 23.64 | **-0.39 better** |
| val_ood_re | 32.08 | 32.44 | +0.36 ≈ same |
| val_tandem_transfer | 42.13 | 45.71 | +3.58 ↑ worse |

### What happened

Surface attention bias did not help overall. val/loss is 0.060 worse than baseline. val_ood_cond improved slightly (-0.39 in mae_surf_p), but in-dist regressed (+0.37) and tandem_transfer regressed significantly (+3.58).

The tandem_transfer regression suggests the bias encourages the model to over-specialize on surface node patterns from the training distribution, at the cost of generalization to new foil geometries. Rather than creating "dedicated surface clusters," the bias may be creating spurious separation between surface and volume nodes that hurts generalization.

A secondary issue: the bias is applied uniformly across all blocks, which may be too aggressive. Applying it only to the first block, or using a smaller initial value, might be worth trying.

### Suggested follow-ups
- Try a smaller initial surface_bias (e.g. 0.1 instead of 1.0) to provide a gentler nudge
- Apply bias only in the first block (where geometry encoding is most relevant)
- Try a negative bias to push surface nodes away from volume clusters (inverse hypothesis)