### PR TITLE
Split output head: separate velocity and pressure decoders

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -182,17 +182,15 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.vel_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 2))
+            self.p_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 1))
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            return torch.cat([self.vel_head(h), self.p_head(h)], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The current output MLP predicts Ux, Uy, p jointly. But velocity and pressure have different physics (divergence-free vs Poisson equation). Splitting only the final output projection (not entire decoder) allows specialization with minimal overhead.

## Instructions
In `structured_split/structured_train.py`, modify `TransolverBlock`:

1. In `__init__` (~line 183), replace the output head:
```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.vel_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 2))
    self.p_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 1))
```

2. In `forward` (~line 194), replace the output:
```python
if self.last_layer:
    h = self.ln_3(fx)
    return torch.cat([self.vel_head(h), self.p_head(h)], dim=-1)
```

3. Remove the old `self.mlp2` definition.

Run with: `--wandb_name "gilbert/split-head" --wandb_group split-vel-pressure-head --agent gilbert`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run:** `tdgrycud` — gilbert/split-head

**Best epoch:** 77 of 77 (30.4 min, wall-clock limit)
**Peak memory:** 9.5 GB (vs ~8.8 GB baseline)

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.828 | 0.325 | 0.204 | **27.23** | 1.506 | 0.560 | 33.63 |
| val_ood_cond | 1.604 | — | — | **23.1** | — | — | — |
| val_ood_re | nan | — | — | **33.0** | — | — | — |
| val_tandem_transfer | 4.629 | — | — | **45.5** | — | — | — |
| **val/loss (mean, 3 finite splits)** | **2.6870** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | 2.6870 | +0.117 ❌ |
| val_in_dist/mae_surf_p | 22.47 | 27.23 | +4.76 ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 23.1 | −0.93 ✅ |
| val_ood_re/mae_surf_p | 32.08 | 33.0 | +0.92 ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 45.5 | +3.37 ❌ |

### What happened

Negative result. Splitting the output into separate velocity and pressure heads hurts val_in_dist pressure MAE significantly (+4.76) and val_tandem_transfer (+3.37). Only val_ood_cond improved (−0.93). Overall val/loss is +0.117 worse.

The split head increases capacity (two full hidden→hidden→out MLPs instead of one hidden→hidden→3) but the results are worse. The most likely explanation: the joint output MLP allows the model to share intermediate representations between Ux, Uy, and p, which turns out to be beneficial. The shared hidden layer likely learns common flow features (e.g., no-slip boundary conditions affect both velocity and pressure). Splitting forces independent learning of these shared patterns.

Additionally, the larger output heads slow down training (~23-24s/epoch vs ~22s/epoch), resulting in fewer epochs (77 vs ~82) in the 30-minute budget.

Peak memory increased to 9.5 GB from ~8.8 GB.

Note: `val_ood_re/loss` is NaN throughout — pre-existing issue.

### Suggested follow-ups

- **Shared trunk, split final**: Keep a shared hidden layer but split only the last linear (hidden→2 and hidden→1 with no intermediate layer). Minimal overhead while still allowing some specialization.
- **Pressure-only separate head**: Keep velocity in the joint head, only separate pressure into its own 2-layer MLP. This targets the most important output without fully splitting the representation.
- **Weighted output loss**: Rather than structural splitting, try re-weighting the loss to put more emphasis on pressure prediction error.