### PR TITLE
Input-to-output skip connection (geometry shortcut)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -259,6 +259,7 @@ class Transolver(nn.Module):
         self.initialize_weights()
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -321,6 +322,7 @@ class Transolver(nn.Module):
 
         for block in self.blocks:
             fx = block(fx)
+        fx = fx + self.input_skip(x)  # geometry shortcut: linear skip from input to output
         self._validate_output_dims(fx)
         return {"preds": fx}
 


### PR DESCRIPTION
## Hypothesis
The input x contains position and geometric features (dsdf, saf) strongly correlated with output. A lightweight linear skip from input to output lets the model learn a local baseline from geometry alone, with attention refining the residual. Similar to U-Net skip connections.

## Instructions
In `structured_split/structured_train.py`:

1. In `Transolver.__init__` (~line 260), after `self.placeholder_shift`, add:
```python
self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
```

2. In `Transolver.forward` (~line 319-325), modify the end:
```python
fx = self.preprocess(x)
fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
for block in self.blocks:
    fx = block(fx)
fx = fx + self.input_skip(x)  # ADD THIS LINE
self._validate_output_dims(fx)
return {"preds": fx}
```

Run with: `--wandb_name "senku/input-skip" --wandb_group input-skip-output --agent senku`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run:** `mn4txyll` — 74 epochs completed (timeout), peak memory 8.8GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.5700 | **2.8028** | +0.233 ↑worse |
| val_in_dist/mae_surf_p | 22.47 | **26.55** | +4.08 ↑worse |
| val_ood_cond/mae_surf_p | 24.03 | **24.90** | +0.87 ↑worse |
| val_ood_re/mae_surf_p | 32.08 | **34.18** | +2.10 ↑worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **46.40** | +4.27 ↑worse |
| val_in_dist/mae_surf_Ux | — | 0.358 | — |
| val_in_dist/mae_surf_Uy | — | 0.217 | — |
| val_in_dist/mae_vol_p | — | 33.96 | — |

**What happened:** Negative result. The linear input-to-output skip connection made all metrics worse across every split. val/loss increased from 2.5700 → 2.8028 (+9.1%) and in-distribution surface pressure MAE rose 18% (22.47 → 26.55).

The linear skip adds a shortcut path that bypasses the attention mechanism. Rather than helping the model "learn a residual," it appears to hurt optimization — the skip creates a gradient path that competes with the learned representations, making it harder to converge. The baseline model's preprocess MLP + single attention block already handles feature compression well; the extra linear term adds noise to the output rather than a useful bias.

An alternative explanation: the orthogonal initialization of `input_skip` creates a random projection from input (24-dim) to output (3-dim) that interferes with the early training dynamics, before the skip weights can be learned down to zero.

**Suggested follow-ups:**
- Try initializing `input_skip` weights to zero (so it starts as identity) — zero-init shortcuts are standard in ResNets and would start as a no-op
- Try a learnable scalar gate on the skip (e.g., `self.skip_gate = nn.Parameter(torch.zeros(1))`) so the model can choose how much skip to use
- If skip connections help, a richer skip (e.g., through the MLP preprocess layer rather than directly from raw x) might work better