### PR TITLE
CosineAnnealingWarmRestarts T_0=25 (escape local minima)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -490,7 +490,7 @@ class Lookahead:
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=25, T_mult=1, eta_min=1e-4)  # was CosineAnnealingLR
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
The current cosine schedule decays monotonically. With ~85 epochs, LR is very low for the last 30+ epochs. Warm restarts with T_0=25 give 3 full cycles (5-30, 30-55, 55-80), re-injecting energy to escape local minima. Previous restart experiments may have used wrong periods.

## Instructions
In `structured_split/structured_train.py`, replace the cosine scheduler (~line 493):
```python
# OLD: cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
# NEW:
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=25, T_mult=1, eta_min=1e-4)
```

Note: `SequentialLR` should still work with this — warmup runs for 5 epochs, then the warm-restart cosine takes over.

Run with: `--wandb_name "norman/cosine-restart" --wandb_group cosine-warm-restart-25 --agent norman`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run:** `2nt218we`  
**Epochs:** 81 (30.2 min, completed normally)  
**Peak memory:** 8.8 GB  

### Metrics at best checkpoint (epoch 80)

| Metric | Baseline (mono cosine) | This run (warm restart T_0=25) | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6151** | +1.8% ❌ |
| val_in_dist/mae_surf_p | 22.47 | 23.4 | +4.1% ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 24.2 | +0.7% ❌ |
| val_ood_re/mae_surf_p | 32.08 | 33.2 | +3.5% ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 44.4 | +5.4% ❌ |

### What happened

Negative result. Warm restarts with T_0=25 hurt all splits vs. monotonic cosine decay.

Several factors may explain this:

1. **Lookahead + warm restarts interaction:** Lookahead maintains slow weights averaged over k=10 steps. When LR resets to a high value after each cycle, the fast weights jump away from the slow weights, undermining Lookahead's smoothing effect. The two mechanisms conflict.

2. **Model already well-trained:** The monotonic schedule's low LR in later epochs serves as effective implicit regularization. The warm restarts disrupt this by repeatedly re-introducing high LR noise in epochs 30-55 and 55-80 when the model needs fine-grained refinement.

3. **Attention slot specialization:** The physics-attention slices may need stable, monotonically decreasing LR to complete slot specialization. Periodic resets scramble the learned specialization.

### Suggested follow-ups

- **Monotonic cosine is already well-suited** to this model/task — likely not worth further restarts experiments
- **Try WSD schedule (warm-stable-decay)** — step down LR at 60-70 epochs rather than cyclic resets
- **Try T_0=40 with T_mult=1** — only 1 restart total might be less disruptive than 3
