### PR TITLE
Per-sample target std normalization in loss (equalize samples)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -570,7 +570,19 @@ for epoch in range(MAX_EPOCHS):
             pred = model({"x": x})["preds"]
         pred = pred.float()
         sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        with torch.no_grad():
+            # Per-sample, per-channel std of targets (only valid nodes)
+            y_std_per_sample = []
+            for b in range(y_norm.shape[0]):
+                valid = mask[b]
+                if valid.sum() > 1:
+                    y_std_per_sample.append(y_norm[b, valid].std(dim=0).clamp(min=0.1))
+                else:
+                    y_std_per_sample.append(torch.ones(3, device=device))
+            y_std_ps = torch.stack(y_std_per_sample).unsqueeze(1)  # [B, 1, 3]
+
+        # Normalize residuals by per-sample std
+        abs_err = ((pred - y_norm) / y_std_ps).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 


### PR DESCRIPTION
## Hypothesis
Different samples have different residual scales even after Cp + z-score normalization. High-magnitude samples dominate the loss. Dividing both pred and target by per-sample target std equalizes sample contributions regardless of magnitude.

## Instructions
In `structured_split/structured_train.py`, before the abs_err computation (~line 573), add:
```python
with torch.no_grad():
    # Per-sample, per-channel std of targets (only valid nodes)
    y_std_per_sample = []
    for b in range(y_norm.shape[0]):
        valid = mask[b]
        if valid.sum() > 1:
            y_std_per_sample.append(y_norm[b, valid].std(dim=0).clamp(min=0.1))
        else:
            y_std_per_sample.append(torch.ones(3, device=device))
    y_std_ps = torch.stack(y_std_per_sample).unsqueeze(1)  # [B, 1, 3]

# Normalize residuals by per-sample std
abs_err = ((pred - y_norm) / y_std_ps).abs()
```

Run with: `--wandb_name "chihiro/ps-norm" --wandb_group per-sample-norm-loss --agent chihiro`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run:** `0miosvsf` | **Best epoch:** 80 | **Peak VRAM:** 8.8 GB

### Metrics at best checkpoint

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 1.666 | 0.308 | 0.190 | **22.13** | — |
| val_ood_cond | 1.480 | 0.274 | 0.185 | **20.49** | — |
| val_ood_re | NaN | 0.292 | 0.200 | **30.98** | — |
| val_tandem_transfer | 4.792 | 0.682 | 0.366 | **46.58** | — |
| **combined** | **2.6459** | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6459** | +0.074 (worse) |
| val_in_dist/mae_surf_p | 22.47 | **22.13** | **-0.34 (improvement)** |
| val_ood_cond/mae_surf_p | 24.03 | **20.49** | **-3.54 (large improvement)** |
| val_ood_re/mae_surf_p | 32.08 | **30.98** | **-1.10 (improvement)** |
| val_tandem_transfer/mae_surf_p | 42.13 | **46.58** | +4.45 (large regression) |

### What happened

**Combined val/loss does not beat the baseline (+0.074), but the split-level results are striking.** Three of four splits show substantial surface pressure improvements — ood_cond improves by 3.54 Pa (the best single-metric improvement across all experiments), in_dist by 0.34 Pa, and ood_re by 1.10 Pa. However, val_tandem_transfer regresses severely (+4.45 Pa), dragging the combined metric down.

The mechanism explains this split behavior: per-sample std normalization scales the loss by 1/(sample_std). For single-foil samples (in_dist, ood_cond, ood_re), where high-magnitude samples likely have large std and were previously dominating the loss, normalization reduces their outsized influence and gives more weight to harder-to-fit average samples. This works well.

For tandem samples, the two interacting foils create complex flow patterns with intrinsically larger field variance. The per-sample std for tandem samples is high, so dividing by it shrinks the tandem loss contribution and effectively underweights tandem samples in each batch. The model learns less about tandem geometry and fails on that split.

### Suggested follow-ups

- **Apply per-sample normalization only to single-foil batches**: Skip the normalization when tandem geometry is detected (e.g., via the boundary ID features).
- **Per-split std normalization**: Normalize by split-level std (computed offline) rather than per-sample std, which would avoid the tandem underweighting.
- **Combine with tandem oversampling**: The weighted sampler already upweights tandem, but the per-sample std normalization works against this. Try increasing tandem weight in the sampler when using this loss.