### PR TITLE
Temperature anneal 0.5→0.1 (warm explore, cold exploit)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -547,6 +547,12 @@ for epoch in range(MAX_EPOCHS):
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
+    # Temperature annealing: 0.5 -> 0.1 over training
+    target_temp = 0.5 - 0.4 * progress  # 0.5 at epoch 0, 0.1 at epoch MAX
+    with torch.no_grad():
+        for block in model.blocks:
+            block.attn.temperature.fill_(target_temp)
+
     # --- Train ---
     model.train()
     epoch_vol = 0.0


### PR DESCRIPTION
## Hypothesis
The attention temperature controls cluster sharpness. Warm (0.5) allows exploration early — nodes participate in many clusters. Annealing to cold (0.1) makes clusters sharp for specialization. Previous fixed temp experiments tried single values; annealing combines exploration+exploitation.

## Instructions
In `structured_split/structured_train.py`, at the start of the training epoch loop (after computing `progress` ~line 547), add:
```python
# Temperature annealing: 0.5 -> 0.1 over training
target_temp = 0.5 - 0.4 * progress  # 0.5 at epoch 0, 0.1 at epoch MAX
with torch.no_grad():
    for block in model.blocks:
        block.attn.temperature.fill_(target_temp)
```

Run with: `--wandb_name "haku/temp-anneal" --wandb_group temp-anneal-05-01 --agent haku`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47, ood: 24.03, re: 32.08, tan: 42.13

---

## Results

**W&B run ID:** `1s0qfyb8`  
**Best epoch:** 70 / 78 (30.2 min wall-clock timeout)  
**Peak GPU memory:** 8.8 GB (no change from baseline)

### Metrics at best checkpoint (epoch 70)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.8358 | 0.348 | 0.195 | 25.7 | 1.606 | 0.566 | 33.6 |
| val_tandem_transfer | 4.6773 | 0.669 | 0.358 | 44.9 | 2.517 | 1.134 | 49.2 |
| val_ood_cond | 1.7160 | 0.314 | 0.201 | 25.3 | 1.433 | 0.527 | 26.0 |
| val_ood_re | NaN* | 0.332 | 0.209 | 33.8 | 1.347 | 0.536 | 55.9 |
| **combined val/loss** | **2.7430** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.5700 → This run: 2.7430 — worse (+0.173)**

Surface pressure MAE vs baseline:
- val_in_dist: 25.7 vs 22.47 (+14% worse)
- val_ood_cond: 25.3 vs 24.03 (+5% worse)
- val_tandem_transfer: 44.9 vs 42.13 (+7% worse)
- val_ood_re: 33.8 vs 32.08 (+5% worse)

### What happened

Temperature annealing did not improve over baseline. The main issue is that `temperature` is an `nn.Parameter` (a learnable parameter), and by calling `block.attn.temperature.fill_(target_temp)` each epoch we override what the optimizer learned during the previous epoch. This creates a conflict: the optimizer adjusts temperature toward a learned optimum, but at the start of each epoch we reset it to a predetermined schedule.

With this override, the model can never adapt the temperature based on the loss landscape — we're forcing a hard schedule on top of what would otherwise be a flexible learned parameter. For each of the 8 attention blocks (which may need different temperatures for different physical scales), we set the same temperature, removing potentially useful per-block specialization.

The annealing schedule itself might be reasonable, but the interaction with the AdamW optimizer (which maintains per-parameter momentum and adaptive step sizes for temperature) creates stale gradient corrections that are now applied to a mis-set temperature.

### Suggested follow-ups

- Convert temperature from a learned parameter to a pure schedule (remove it from the optimizer parameter groups) to avoid the conflict.
- Try non-uniform annealing (e.g., step-decay or cosine annealing from 0.5 to 0.1).
- Allow each block to anneal independently from its learned starting point, rather than resetting to a fixed schedule.
