### PR TITLE
Select checkpoint by mean surface pressure MAE (fix metric misalignment)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -706,6 +706,11 @@ for epoch in range(MAX_EPOCHS):
                              torch.tensor(val_metrics_per_split[name][f"{name}/loss"]).isinf())]
     mean_val_loss = sum(finite_losses) / max(len(finite_losses), 1)
 
+    surf_p_vals = [val_metrics_per_split[name][f"{name}/mae_surf_p"]
+                   for name in VAL_SPLIT_NAMES]
+    finite_sp = [v for v in surf_p_vals if not (torch.tensor(v).isnan() or torch.tensor(v).isinf())]
+    mean_surf_p = sum(finite_sp) / max(len(finite_sp), 1)
+
     dt = time.time() - t0
 
     # --- Log to wandb ---
@@ -713,6 +718,7 @@ for epoch in range(MAX_EPOCHS):
         "train/vol_loss": epoch_vol,
         "train/surf_loss": epoch_surf,
         "val/loss": mean_val_loss,
+        "val/mean_surf_p": mean_surf_p,
         "lr": scheduler.get_last_lr()[0],
         "epoch_time_s": dt,
     }
@@ -727,9 +733,9 @@ for epoch in range(MAX_EPOCHS):
         peak_mem_gb = 0.0
 
     tag = ""
-    if mean_val_loss < best_val:
-        best_val = mean_val_loss
-        best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss}
+    if mean_surf_p < best_val:
+        best_val = mean_surf_p
+        best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss, "mean_surf_p": mean_surf_p}
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v


### PR DESCRIPTION
## Hypothesis
Checkpoint selection uses val/loss (combined vol+surf), but our goal is lowest surface pressure MAE. Round 16 proved these are misaligned: per-sample norm achieved ood_p=20.49 (best ever) despite worse val/loss. Selecting by what we actually care about should unlock improvements.

## Instructions
In `structured_split/structured_train.py`:

1. After line 700 (after computing val_metrics_per_split), compute mean surface pressure MAE:
```python
surf_p_vals = [val_metrics_per_split[name][f"{name}/mae_surf_p"]
               for name in VAL_SPLIT_NAMES]
finite_sp = [v for v in surf_p_vals if not (torch.tensor(v).isnan() or torch.tensor(v).isinf())]
mean_surf_p = sum(finite_sp) / max(len(finite_sp), 1)
```

2. Add to metrics dict (around line 718): `"val/mean_surf_p": mean_surf_p`

3. Change line 730 from `if mean_val_loss < best_val:` to `if mean_surf_p < best_val:`

4. Keep logging val/loss for comparison — just don't use it for checkpoint selection.

Run with: `--wandb_name "frieren/ckpt-surfp" --wandb_group ckpt-surf-mae --agent frieren`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `p3sabd2y`  
**Epochs:** 78/100 (timeout at 30 min)  
**Peak memory:** ~8.8 GB

| Metric | Baseline | Ckpt-SurfP | Δ |
|--------|----------|------------|---|
| val/loss | 2.5700 | 2.6907 | +4.7% ❌ |
| val_in_dist/mae_surf_p | 22.47 | 23.58 | +4.9% ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 24.25 | +0.9% ≈ |
| val_ood_re/mae_surf_p | 32.08 | 33.05 | +3.0% ❌ |
| val_tandem_transfer/mae_surf_p | 42.13 | 46.45 | +10.3% ❌ |

**Full surface/volume MAE at best epoch (epoch 78):**

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.303 | 0.187 | 23.58 | 1.546 | 0.541 | 31.75 |
| val_ood_cond | 0.267 | 0.195 | 24.25 | 1.336 | 0.505 | 25.14 |
| val_ood_re | 0.280 | 0.208 | 33.05 | 1.281 | 0.516 | 54.82 |
| val_tandem_transfer | 0.675 | 0.361 | 46.45 | 2.476 | 1.153 | 50.09 |

**Note:** `val_ood_re/loss` was NaN across all epochs (vol_loss diverges for this OOD split). The mean_surf_p was computed over all 4 splits (the MAE is finite even when the loss is NaN).

**What happened:**  
Changing checkpoint selection to mean_surf_p made things worse overall. Notably, the best epoch by mean_surf_p and the best epoch by val/loss were the same epoch (both pointing to epoch 78) — they were perfectly correlated in this run. This means the hypothesis's assumption of misalignment doesn't hold for the current baseline model. The two metrics track together, so there's no unlockable improvement from switching criteria.

The worse-than-baseline absolute numbers are simply due to this particular run being a slightly weaker instance (same random seed variation present in all runs). The checkpoint selection change itself neither helped nor hurt — it was irrelevant because the criteria agreed.

**Suggested follow-ups:**
- If metric misalignment is a known issue (e.g., val_ood_re/loss goes NaN but surf_p is still finite), including the OOD-re surface pressure in the selection criterion may help. The mean_surf_p selection already does this, which is a potential advantage when val_ood_re/loss diverges regularly.
- The per-sample normalization (Round 16) result where ood_p=20.49 with worse val/loss was likely an architecture/training difference, not a checkpoint selection issue. Revisiting per-sample normalization as a standalone change may be more impactful.