### PR TITLE
Per-sample std normalization (skip tandem to preserve dual-foil learning)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -566,9 +566,23 @@ for epoch in range(MAX_EPOCHS):
         if model.training:
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
+        # Per-sample std normalization: skip tandem samples (gap feature index 21)
+        raw_gap = x[:, 0, 21]
+        is_tandem = raw_gap.abs() > 0.5
+        B = y_norm.shape[0]
+        sample_stds = torch.ones(B, 1, 3, device=device)
+        if model.training:
+            for b in range(B):
+                if not is_tandem[b]:
+                    valid = mask[b]
+                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=0.1)
+            y_norm = y_norm / sample_stds
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
         pred = pred.float()
+        if model.training:
+            pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
@@ -653,11 +667,23 @@ for epoch in range(MAX_EPOCHS):
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
+                # Per-sample std normalization: skip tandem samples
+                raw_gap = x[:, 0, 21]
+                is_tandem = raw_gap.abs() > 0.5
+                B = y_norm.shape[0]
+                sample_stds = torch.ones(B, 1, 3, device=device)
+                for b in range(B):
+                    if not is_tandem[b]:
+                        valid = mask[b]
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=0.1)
+                y_norm_scaled = y_norm / sample_stds
+
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
                 pred = pred.float()
-                sq_err = (pred - y_norm) ** 2
-                abs_err = (pred - y_norm).abs()
+                pred_loss = pred / sample_stds
+                sq_err = (pred_loss - y_norm_scaled) ** 2
+                abs_err = (pred_loss - y_norm_scaled).abs()
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface


### PR DESCRIPTION
## Hypothesis
Per-sample normalization (PR #594) achieved ood_p=20.49 (best ever, -15%) but tandem regressed from 42.13 to 46.58. Tandem samples have higher variance from two-foil interaction, so dividing by per-sample std underweights them. Skipping normalization for tandem samples should preserve the ood/re gains without tandem regression.

## Instructions
In `structured_split/structured_train.py`:

After computing y_norm (line 565), add per-sample std normalization for non-tandem samples only:

```python
# Detect tandem samples: gap feature (index ~21 in normalized x) is non-zero for tandem
# Use raw x before normalization to check; or check multiple dsdf features
# Tandem samples have foil-2 geometry features that are non-zero
raw_gap = x[:, 0, 21]  # gap feature after x normalization
is_tandem = raw_gap.abs() > 0.5  # threshold for normalized gap

# Compute per-sample std of y_norm for non-tandem samples
if model.training:
    for b in range(y_norm.shape[0]):
        if not is_tandem[b]:
            valid = mask[b]
            sample_std = y_norm[b, valid].std(dim=0).clamp(min=0.1)  # [3]
            y_norm[b] = y_norm[b] / sample_std
```

Apply the same scaling to pred before loss computation for non-tandem samples. In validation, use the same logic.

Run with: `--wandb_name "fern/ps-norm" --wandb_group ps-norm-notandem --agent fern`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**Run ID**: cb1e4mqj  
**Epochs**: 81 best (wall-clock limit ~30 min)  
**Peak memory**: ~8.8 GB (same model size)  

### Val/loss
| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.5700 | **2.478** | -3.5% (note: loss scale changed by normalization) |

Note: the val/loss change is not directly comparable to baseline — per-sample normalization changes the scale of the normalized loss metric. The mae_surf_p values (in original units) are the true comparison.

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|-------|---------------------|---------------------|-------|
| val_in_dist | 22.47 | 24.19 | +7.6% (worse) |
| val_ood_cond | 24.03 | **21.87** | **-9.0% (better) — best ood_cond ever** |
| val_ood_re | 32.08 | 31.91 | -0.5% (flat) |
| val_tandem_transfer | 42.13 | 46.41 | +10.2% (worse) |

### Full Surface MAE
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|-------------|-------------|------------|
| val_in_dist | 0.310 | 0.186 | 24.19 |
| val_ood_cond | 0.279 | 0.186 | 21.87 |
| val_ood_re | 0.290 | 0.203 | 31.91 |
| val_tandem_transfer | 0.674 | 0.356 | 46.41 |

### Full Volume MAE
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.554 | 0.557 | 32.34 |
| val_ood_cond | 1.247 | 0.474 | 22.13 |
| val_ood_re | 1.213 | 0.494 | 53.15 |
| val_tandem_transfer | 2.465 | 1.141 | 50.34 |

Note: val_ood_re/loss = nan (pre-existing issue — vol_loss blows up due to extreme Re; surface MAEs are still valid).

### What happened

Mixed results. Despite skipping tandem samples in the normalization, tandem transfer still regressed significantly (+10.2%). val_ood_cond showed the best improvement (-9.0%, best ever seen), but val_in_dist degraded (+7.6%) and tandem got worse.

The gap-feature detection for tandem (x[:, 0, 21] > 0.5) likely works to identify tandem samples, but the regression in tandem suggests the issue is more indirect: by training non-tandem samples with per-sample normalization, the model's learned representations shift in a way that hurts tandem generalization, even though tandem samples themselves are trained without normalization.

There's a fundamental tension: the normalization makes the model optimize relative error (error/std), which improves ood_cond (diverse flow conditions) but shifts in-dist optimization in a way that hurts absolute accuracy there.

### Suggested follow-ups

- The ood_cond gain (-9.0%) is promising. Try applying per-sample normalization with a softer version (e.g., only for samples where std is very large, using a high min clamp like 0.5 instead of 0.1) 
- The tandem regression may be addressable by also including tandem normalization (since skipping it didn't help)
- Combining the ood_cond gains from per-sample norm and channel weighting [1,1,2] could potentially compound