### PR TITLE
Fix val_ood_re NaN via abs_err clamping (include 4th split in checkpoint)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -23,6 +23,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import sys
 from pathlib import Path
 
@@ -658,13 +659,15 @@ for epoch in range(MAX_EPOCHS):
                 pred = pred.float()
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()
+                abs_err = abs_err.clamp(max=1e6)
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
-                val_vol += min(
-                    (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
-                    1e12
-                )
+                batch_vol = (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+                if math.isfinite(batch_vol):
+                    val_vol += min(batch_vol, 1e6)
+                else:
+                    val_vol += 0.0
                 val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 


### PR DESCRIPTION
## Hypothesis
val_ood_re/loss is NaN in every run (all ~230 experiments), so checkpoint selection ignores the OOD-Re split entirely. The NaN comes from extreme values in the Re=4.445M data causing inf in abs_err. Clamping abs_err before accumulation will make val_ood_re/loss finite, including it in checkpoint selection and providing better optimization signal.

## Instructions
In `structured_split/structured_train.py`:

1. Add `import math` at the top if not present.

2. In the validation loop, after line 660 (`abs_err = (pred - y_norm).abs()`), add:
```python
abs_err = abs_err.clamp(max=1e6)
```

3. Replace lines 664-666 with more robust accumulation:
```python
batch_vol = (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
if math.isfinite(batch_vol):
    val_vol += min(batch_vol, 1e6)
else:
    val_vol += 0.0
```

Run with: `--wandb_name "nezuko/fix-nan" --wandb_group fix-ood-re-nan --agent nezuko`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `okdostiz` (nezuko/fix-nan)
**Best epoch:** 81 / ~81 (hit 30-min timeout)

### Metrics vs baseline

Note: val/loss is not directly comparable — baseline excluded ood_re (NaN), this run includes it.

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| overall | val/loss | 2.5700 | 6.9638 | +4.39 (incomparable*) |
| val_in_dist | mae_surf_p | 22.47 | 23.69 | +1.22 |
| val_ood_cond | mae_surf_p | 24.03 | 24.36 | +0.33 |
| val_ood_re | mae_surf_p | 32.08 | 33.17 | +1.09 |
| val_tandem_transfer | mae_surf_p | 42.13 | 44.67 | +2.54 |

*val/loss is now averaged over 4 splits instead of 3, so the numbers are incomparable.

Detailed best-epoch metrics:
- **val_in_dist**: loss=1.766, surf_loss=0.0775, mae_surf_Ux=0.318, mae_surf_Uy=0.191, mae_surf_p=23.69
- **val_ood_cond**: loss=1.584, surf_loss=0.0698, mae_surf_Ux=0.285, mae_surf_Uy=0.192, mae_surf_p=24.36
- **val_ood_re**: loss=19.92, surf_loss=0.0673, vol_loss=18.57, mae_surf_p=33.17 (NaN fixed!)
- **val_tandem_transfer**: loss=4.590, surf_loss=0.2056, mae_surf_Ux=0.657, mae_surf_Uy=0.356, mae_surf_p=44.67

### What happened

The NaN fix works technically — val_ood_re/loss is now 19.92 (finite). The clamping keeps the abs_err bounded so accumulation doesn't overflow.

However, all splits got worse. The core issue: the ood_re split's volume loss (18.57) dominates the val/loss average. With 4 splits averaged, ood_re contributes ~20/4 = 5.0 to the total, vs the other 3 splits contributing ~8.0/4 = 2.0. This means checkpoint selection is now heavily biased toward reducing the ood_re volume loss, which comes at the expense of in-dist and tandem performance.

Notably, val_ood_re/surf_loss=0.067 is actually good (comparable to other splits). The problem is purely the volume prediction on extreme Reynolds numbers — the physical flow is fundamentally different from training distribution, and clamping the normalized error doesn't help the model learn it better; it just suppresses the NaN.

The hypothesis was correct in identifying the problem (NaN excludes ood_re from checkpoint selection), but the cure may be worse than the disease: including a very high-loss split in the average destabilizes checkpoint selection.

### Suggested follow-ups
- Use a weighted val/loss that down-weights ood_re: e.g., val/loss = mean([in_dist, tandem, ood_cond]) + 0.1 * ood_re (treat it as a secondary metric)
- Or track val_ood_re/surf_loss as the checkpoint criterion for ood_re (since surf prediction is fine, it's only volume that's extreme)
- Or clip the ood_re split's contribution to val/loss: `split_loss = min(split_loss, some_cap)` for the ood_re split specifically