### PR TITLE
Surface channel weight [1,1,2] for pressure (re-apply confirmed empty merge)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -588,8 +588,10 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
+        surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+        surf_channel_w = surf_channel_w / surf_channel_w.mean()  # normalize to mean=1
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = (abs_err * surf_channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
@@ -665,7 +667,9 @@ for epoch in range(MAX_EPOCHS):
                     (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
                     1e12
                 )
-                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                val_surf_ch_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+                val_surf_ch_w = val_surf_ch_w / val_surf_ch_w.mean()
+                val_surf += (abs_err * val_surf_ch_w * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
                 # Denormalize: phys_stats → Cp space → original scale


### PR DESCRIPTION
## Hypothesis
PR #459 merged channel weight [1,1,2] but the merge was EMPTY — no code change was applied. PR #549 re-tested it independently and showed ood_cond=22.15 (-7.8% vs 24.03 baseline). The improvement was real but never made it into the codebase.

## Instructions
In `structured_split/structured_train.py`:

1. After line 574, define channel weights:
```python
surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
surf_channel_w = surf_channel_w / surf_channel_w.mean()  # normalize to mean=1
```

2. Change the surface loss computation (line 592) to use channel weights:
```python
surf_loss = (abs_err * surf_channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```

3. Apply the same weighting in validation surface loss (line 668).

Run with: `--wandb_name "alphonse/ch-112" --wandb_group channel-112 --agent alphonse`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run ID:** d6ovil5z
**Epochs completed:** 77/100 (30-min timeout; ~23.3s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

**Note:** val/loss here uses channel-weighted surface loss (1.5x pressure), making it directly incomparable to baseline val/loss which uses unweighted MAE. Physical MAE metrics (mae_surf_p etc.) are unweighted and directly comparable.

| Metric | Baseline | Best val/loss epoch (76) | Last epoch (77) |
|---|---|---|---|
| val/loss | 2.5700 | 3.0589 (*) | 3.0616 (*) |
| val_in_dist/mae_surf_p | 22.47 | 26.67 | **24.44** |
| val_ood_cond/mae_surf_p | 24.03 | 24.50 | **24.26** |
| val_ood_re/mae_surf_p | 32.08 | 32.75 | **32.66** |
| val_tandem_transfer/mae_surf_p | 42.13 | 43.82 | **44.64** |

(*) val/loss is channel-weighted, not directly comparable to baseline.

Using last epoch (77) physical MAE for comparison:
- val_in_dist: +8.8% worse | val_ood_cond: +1% worse | val_ood_re: +1.8% worse | val_tandem_transfer: +5.9% worse

Additional val_in_dist at last epoch:
- mae_surf_Ux: 0.352 | mae_surf_Uy: 0.209
- mae_vol_Ux: 1.670 | mae_vol_Uy: 0.601 | mae_vol_p: 33.85

### What happened

**This did not work as intended.** All physical MAE metrics are worse than baseline, though the margin is smaller than previous channel-weighting attempts (the worst being the log-cosh combo).

A key issue surfaced: applying channel weights in the validation loss inflates val/loss relative to baseline (3.06 vs 2.57), making epoch checkpointing based on val/loss unreliable — the "best" checkpoint selected by val/loss (epoch 76) actually has *worse* mae_surf_p than the final epoch (26.67 vs 24.44). This means the channel-weighted val/loss is selecting the wrong checkpoint.

The model appears to be improving at epoch 77 (mae_surf_p still declining), so incomplete convergence is a partial factor. But even so, val_in_dist/mae_surf_p at 24.44 is 8.8% above baseline.

### Suggested follow-ups
- The checkpoint selection issue is important: if channel weighting is used in the loss, val/loss metric should NOT be used for checkpointing; instead checkpoint by mae_surf_p directly
- The channel weighting in training has consistently failed in multiple experiments — it may be worth dropping this direction
- The only case where channel weighting showed benefit was in a combined experiment (PR #549 which may have confounded other changes)