### PR TITLE
Dynamic val surf_weight matching training ramp (fix eval misalignment)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -682,7 +682,7 @@ for epoch in range(MAX_EPOCHS):
 
         val_vol /= max(n_vbatches, 1)
         val_surf /= max(n_vbatches, 1)
-        split_loss = val_vol + cfg.surf_weight * val_surf
+        split_loss = val_vol + surf_weight * val_surf
         mae_surf /= n_surf.clamp(min=1)
         mae_vol /= n_vol.clamp(min=1)
 


### PR DESCRIPTION
## Hypothesis
Training ramps surf_weight 5→30, but validation uses fixed cfg.surf_weight=20. This means checkpoint selection optimizes a different objective than training. Making validation loss use the same dynamic surf_weight as training should improve checkpoint selection.

## Instructions
In `structured_split/structured_train.py`:

Change line 685 from:
```python
split_loss = val_vol + cfg.surf_weight * val_surf
```
to:
```python
split_loss = val_vol + surf_weight * val_surf
```

This uses the same dynamic `surf_weight` variable computed at line 548 (which ramps from 5 to 30 during training).

Run with: `--wandb_name "edward/dyn-sw" --wandb_group val-sw-dynamic --agent edward`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** 8jvhwz99 | **Epochs:** 81 (30 min wall-clock limit) | **Peak memory:** 8.8 GB

### Best checkpoint (epoch 19, selected by dynamic val loss)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 2.3852 | 0.731 | 0.379 | **57.40** | 2.422 | 0.974 | 59.32 |
| ood_cond | — | 0.471 | 0.346 | **46.33** | 1.720 | 0.763 | 40.32 |
| ood_re | NaN | 0.456 | 0.332 | **50.35** | 1.657 | 0.748 | 66.83 |
| tandem | — | 1.180 | 0.533 | **67.74** | 3.252 | 1.549 | 68.05 |

### Last epoch (epoch 81, for reference)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 3.2346 | 0.338 | 0.191 | **23.74** | 1.580 | 0.547 | 32.02 |
| ood_cond | — | 0.285 | 0.190 | **23.51** | 1.383 | 0.504 | 24.47 |
| ood_re | NaN | 0.307 | 0.206 | **32.88** | 1.297 | 0.525 | 54.72 |
| tandem | — | 0.647 | 0.344 | **44.18** | 2.465 | 1.130 | 48.40 |

**vs. baseline (val/loss 2.5700, mae_surf_p: in_dist 22.47 / ood_cond 24.03 / ood_re 32.08 / tan 42.13):**

Best-checkpoint mae_surf_p: in_dist **57.40 (+155%)**, ood_cond **46.33 (+93%)**, ood_re **50.35 (+57%)**, tandem **67.74 (+61%)** — catastrophically worse.

### What happened

The hypothesis backfired severely. Using the dynamic surf_weight for checkpoint selection caused epoch 19 (early training, surf_weight≈13) to be chosen as the best model, even though its actual surface accuracy is terrible. The reason: with a low surf_weight at epoch 19, the validation loss formula heavily under-penalizes surface errors, making early underfitted checkpoints appear better than late well-converged ones.

The last epoch (81) actually achieves near-baseline MAE (in_dist: 23.74 vs 22.47, ood_cond: 23.51 vs 24.03), suggesting the model trained fine — the only problem was checkpoint selection. The fixed cfg.surf_weight=20 for validation loss acts as a stable selection criterion and is the right approach.

The training-vs-validation objective mismatch noted in the hypothesis is real (training ramps to 30, val uses 20), but it's a feature, not a bug: the fixed validation weight provides a consistent comparator across epochs, preventing early low-surf-weight epochs from being falsely preferred.

### Suggested follow-ups

1. **Use val surf_weight = sw_end (30)**: If any alignment change is desired, use the final training value (30) as a fixed constant for validation, not the dynamic ramp — this keeps checkpoint selection stable while better reflecting the end-of-training objective.
2. **Checkpoint on mae_surf_p directly**: Skip the composite loss and select checkpoints based on raw surface MAE, which is the true metric of interest.
3. **Keep cfg.surf_weight=20 for validation**: The current fixed-20 setting works well (it's close to the ramp midpoint) and should not be changed.