### PR TITLE
EMA decay=0.999 from epoch 0 (eval+checkpoint on EMA weights)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -456,6 +456,9 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+ema_decay = 0.999
+ema_state = {k: v.clone() for k, v in model.state_dict().items()}
+
 n_params = sum(p.numel() for p in model.parameters())
 
 
@@ -614,6 +617,9 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        with torch.no_grad():
+            for k, v in model.state_dict().items():
+                ema_state[k].mul_(ema_decay).add_(v, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -627,6 +633,8 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf /= n_batches
 
     # --- Validate across all splits ---
+    fast_state = {k: v.clone() for k, v in model.state_dict().items()}
+    model.load_state_dict(ema_state)
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
@@ -699,6 +707,8 @@ for epoch in range(MAX_EPOCHS):
         }
         val_loss_sum += split_loss
 
+    model.load_state_dict(fast_state)
+
     # val/loss = mean across finite splits; NaN-robust for checkpoint selection
     finite_losses = [val_metrics_per_split[name][f"{name}/loss"]
                      for name in VAL_SPLIT_NAMES
@@ -733,7 +743,7 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        torch.save(model.state_dict(), model_path)
+        torch.save(ema_state, model_path)
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(


### PR DESCRIPTION
## Hypothesis
EMA from epoch 0 with decay=0.999 smooths training noise. Previous EMA tests (rounds 13, 16) either started too late or evaluated on fast weights. This tests EMA properly: evaluate and checkpoint using EMA weights throughout.

## Instructions
In `structured_split/structured_train.py`:

1. After model creation (line 457), create EMA state:
```python
ema_decay = 0.999
ema_state = {k: v.clone() for k, v in model.state_dict().items()}
```

2. After each optimizer step (after line 616), update EMA:
```python
with torch.no_grad():
    for k, v in model.state_dict().items():
        ema_state[k].mul_(ema_decay).add_(v, alpha=1 - ema_decay)
```

3. Before validation loop (before line 631), swap in EMA weights:
```python
fast_state = {k: v.clone() for k, v in model.state_dict().items()}
model.load_state_dict(ema_state)
```

4. After validation loop (after line 700), restore fast weights:
```python
model.load_state_dict(fast_state)
```

5. In checkpoint saving (line 736), save EMA weights: `torch.save(ema_state, model_path)`

Run with: `--wandb_name "thorfinn/ema" --wandb_group ema-999 --agent thorfinn`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `llu2esv7` (thorfinn/ema, group: ema-999)
**Epochs:** 78 (30-min wall clock limit, run finished)

| Metric | Baseline | This run (best ep 78) | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.5956** | +0.026 ↑ slightly worse |
| val_in_dist/loss | — | 1.6308 | — |
| val_ood_cond/loss | — | 1.5721 | — |
| val_tandem/loss | — | 4.5838 | — |
| in_dist surf_p (Pa) | 22.47 | **21.79** | −0.68 ↓ better |
| ood_cond surf_p (Pa) | 24.03 | **23.85** | −0.18 ↓ slightly better |
| ood_re surf_p (Pa) | 32.08 | 32.35 | +0.27 ↑ slightly worse |
| tandem surf_p (Pa) | 42.13 | 44.00 | +1.87 ↑ worse |

Full surface MAE at best epoch:
- val_in_dist: Ux=0.285, Uy=0.179, p=21.79 Pa
- val_ood_cond: Ux=0.262, Uy=0.194, p=23.85 Pa
- val_ood_re: Ux=0.279, Uy=0.204, p=32.35 Pa
- val_tandem: Ux=0.657, Uy=0.348, p=44.00 Pa

**Peak memory:** ~8.8 GB (GPU), no overhead from EMA (state dict copies, not model parameters)

### What happened

**Mixed result, slightly negative overall.** EMA decay=0.999 with full evaluation on EMA weights from epoch 0:
- **Improved** on the single-foil splits: in_dist surf_p −0.68 Pa (−3.0%), ood_cond surf_p −0.18 Pa (−0.8%)
- **Hurt** tandem transfer: +1.87 Pa (+4.4%) — the tandem domain appears to require sharper, faster-adapting weights than EMA provides
- val/loss slightly worse (2.5956 vs 2.5700) due to the tandem penalty dominating the mean

The in-distribution and conditioning-OOD improvements align with the hypothesis: EMA smooths noise in well-represented domains. But tandem transfer suffers — plausibly because the model sees tandem samples less frequently (domain imbalance) and EMA with 0.999 decay moves slowly enough that the EMA weights lag the fast weights more on underrepresented domains.

### Suggested follow-ups
- Try a faster EMA (decay=0.99 or 0.995): would track faster on tandem samples while still smoothing single-foil noise
- Domain-specific EMA: maintain separate EMA states per domain group and blend by domain affinity — more complex but targets the tandem lag problem
- EMA warmup: start EMA accumulation after epoch 10-20 when model has converged from random init, avoiding contamination from noisy early updates