### PR TITLE
Explicit surface pressure loss term (direct gradient for key metric)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -590,7 +590,9 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = vol_loss + surf_weight * surf_loss
+        # Pressure-only surface loss (channel index 2 = pressure)
+        surf_p_loss = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        loss = vol_loss + surf_weight * surf_loss + 5.0 * surf_p_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
@@ -615,7 +617,7 @@ for epoch in range(MAX_EPOCHS):
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/surf_p_loss": surf_p_loss.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Currently surface loss combines Ux, Uy, p equally. Adding an explicit pressure-only surface loss term gives the optimizer a direct gradient signal for our most important metric without dilution from velocity channels.

## Instructions
In `structured_split/structured_train.py`:

After computing surf_loss (line 592), add a pressure-only surface term:
```python
# Pressure-only surface loss (channel index 2 = pressure)
surf_p_loss = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
loss = vol_loss + surf_weight * surf_loss + 5.0 * surf_p_loss
```

Log it: add `"train/surf_p_loss": surf_p_loss.item()` to wandb.log.

Run with: `--wandb_name "askeladd/surf-p" --wandb_group surf-p-term --agent askeladd`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `qyrh73op`

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.5700 | **2.7435** | +0.174 |
| val_in_dist/mae_surf_p | 22.47 | **25.99** | +3.52 |
| val_ood_cond/mae_surf_p | 24.03 | **24.00** | -0.03 |
| val_ood_re/mae_surf_p | 32.08 | **32.61** | +0.53 |
| val_tandem_transfer/mae_surf_p | 42.13 | **46.55** | +4.42 |

**Volume MAE (val_in_dist):** Ux=1.629, Uy=0.574, p=34.37

**Surface MAE (full):**
- val_in_dist: Ux=0.327, Uy=0.190, p=25.99
- val_ood_cond: Ux=0.289, Uy=0.198, p=24.00
- val_ood_re: Ux=0.289, Uy=0.206, p=32.61
- val_tandem_transfer: Ux=0.692, Uy=0.366, p=46.55

**Peak memory:** 8.8 GB (unchanged)
**Epoch time:** ~22s/epoch (same as baseline)
**Epochs completed:** 79/100 (30-min timeout)

**Note on val_ood_re:** val_ood_re/loss=NaN is a pre-existing bug present from epoch 1.

### What happened

The explicit pressure surface term hurt rather than helped. val/loss is worse by +0.174 (6.8% relative), and three of the four pressure MAEs increased substantially — notably val_in_dist/mae_surf_p (+3.52, +15.7%) and val_tandem_transfer/mae_surf_p (+4.42, +10.5%). Only val_ood_cond/mae_surf_p was essentially unchanged (-0.03).

The likely reason: adding `5.0 * surf_p_loss` to the training objective shifts gradient allocation toward pressure at the expense of velocity prediction. This upsets the existing balance established by surf_weight — the model was already paying attention to pressure through the regular surf_loss channel, and the extra term over-penalizes pressure during training, causing it to over-fit pressure at the cost of velocity generalization. The val loss doesn't include this term, so the optimization target during training diverged from what we're measuring.

Additionally, val_loss was still improving at epoch 79 (best = epoch 79 = 2.7435), suggesting the model hadn't converged — but even so, convergence would likely plateau above the baseline given the shifted loss balance.

### Suggested follow-ups
- **Scale down the weight**: Try 1.0 or 2.0 instead of 5.0 for the pressure term — less distortion to the velocity-pressure balance.
- **Replace surf_loss with weighted per-channel surf loss**: Instead of adding a pressure-only term, make the surface loss itself channel-weighted (e.g., Ux×1, Uy×1, p×2). Cleaner than stacking redundant terms.
- **Check if pressure improves earlier in training**: The model may be learning velocity faster while neglecting pressure initially. Plot surf_p_loss trajectory.