### PR TITLE
Correct y-flip TTA at validation (denorm→flip→renorm)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -656,6 +656,21 @@ for epoch in range(MAX_EPOCHS):
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
                 pred = pred.float()
+
+                # TTA: y-flip augmentation
+                x_denorm = x * stats["x_std"] + stats["x_mean"]
+                x_flip = x_denorm.clone()
+                x_flip[:, :, 1] *= -1   # flip y coordinate (index 1)
+                for aidx in [14, 18]:   # AoA foil1 and foil2
+                    if aidx < x_flip.shape[-1]:
+                        x_flip[:, :, aidx] *= -1
+                x_flip = (x_flip - stats["x_mean"]) / stats["x_std"]
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred_flip = model({"x": x_flip})["preds"]
+                pred_flip = pred_flip.float()
+                pred_flip[:, :, 1] *= -1  # flip Uy back
+                pred = (pred + pred_flip) / 2
+
                 sq_err = (pred - y_norm) ** 2
                 abs_err = (pred - y_norm).abs()
 


### PR DESCRIPTION
## Hypothesis
PR #567 tested TTA with y-flip but got catastrophic results (167 vs 22.47) because the flip was applied in normalized space. The correct approach: denormalize x, flip y-coordinate and AoA, renormalize, run forward pass, flip Uy back, average with original. This gives a free improvement at validation time.

## Instructions
In \`structured_split/structured_train.py\`, in the validation loop only (inside the \`with torch.no_grad():\` block, after line 658):

After computing \`pred = model({"x": x})["preds"]\` and converting to float, add:
\`\`\`python
# TTA: y-flip augmentation
x_denorm = x * stats["x_std"] + stats["x_mean"]
x_flip = x_denorm.clone()
x_flip[:, :, 1] *= -1   # flip y coordinate (index 1)
# Flip AoA features (indices may vary — check prepare_multi.py)
# AoA is typically at index 14 and 18 for foil1 and foil2
for aidx in [14, 18]:
    if aidx < x_flip.shape[-1]:
        x_flip[:, :, aidx] *= -1
# Re-normalize
x_flip = (x_flip - stats["x_mean"]) / stats["x_std"]
with torch.amp.autocast("cuda", dtype=torch.bfloat16):
    pred_flip = model({"x": x_flip})["preds"]
pred_flip = pred_flip.float()
pred_flip[:, :, 1] *= -1  # flip Uy back
pred = (pred + pred_flip) / 2
\`\`\`

Note: This doubles validation forward passes (~8s extra per epoch, may lose 2-3 epochs). The TTA benefit should outweigh.

Run with: \`--wandb_name "violet/tta" --wandb_group tta-fixed --agent violet\`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run**: vqwc4gpt  
**Best epoch**: 9  
**Peak memory**: 8.9 GB  

| Split | val/loss | mae_surf_p |
|---|---|---|
| val_in_dist | 13.18 | 245.06 |
| val_tandem_transfer | 22.41 | 250.05 |
| val_ood_cond | 10.91 | 194.39 |
| val_ood_re | nan | 157.02 |

**val/loss (mean non-nan)**: 15.50 vs baseline 2.5700 → **CATASTROPHIC FAILURE (~11x worse)**

### What happened

The y-flip TTA fails catastrophically for the second time (same as PR #567). The implementation correctly denormalizes x, flips y and AoA, then renormalizes. However, the results are far worse than baseline (mae_surf_p 245 vs 22.47).

**Root cause**: y-flip is NOT a valid symmetry operation for this dataset's feature encoding, for two reasons:

1. **Domain asymmetry**: Mesh y-coordinates range roughly from 0 to 2 (the flow domain has y ≥ 0). Flipping y as `y → -y` maps all mesh nodes to negative y, which is far outside the training distribution. Flipping should be about the domain midpoint (y → 2-y), but that is not what `x_flip[:, :, 1] *= -1` does.

2. **Geometry-derived features**: Indices 2-11 contain SAF (shape-aware features) and DSDF (distance function to boundary) features that are precomputed from the mesh geometry. These depend on y-coordinates in a complex, non-linear way and are NOT simply negated by a y-flip. After flipping position index 1, these features become physically inconsistent.

The validation is also corrupted: since TTA changes the val metrics, the model's checkpoint selection uses corrupted TTA metrics throughout training, choosing a suboptimal checkpoint (epoch 9 rather than epoch 70-80).

This approach cannot work with the current feature encoding without recomputing DSDF/SAF features post-flip, which is not feasible at inference time.

### Suggested follow-ups
- TTA is not viable with pre-computed geometric features (DSDF, SAF); skip this approach
- If TTA is desired, a valid symmetry must be identified — e.g. minor perturbations of Re or AoA (not geometric flips)
- Alternatively, apply TTA only to conditions where the flip gives a valid in-distribution sample (very restrictive)