### PR TITLE
Remove coarse pooling loss (ablation — may be noise now)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -592,24 +592,6 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
-        # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
-        B, N, C = pred.shape
-        n_groups = N // coarse_pool_size
-        if n_groups > 1:
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask[:, :n_groups * coarse_pool_size]
-
-            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
-
-            coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
-
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
The coarse loss pools over consecutive node indices which are arbitrarily ordered (not spatially coherent). It may be adding noise rather than signal. Removing it saves compute time (potentially 1-2 extra epochs in 30 min).

## Instructions
In `structured_split/structured_train.py`:

Comment out or remove the entire multi-scale coarse loss block (lines 596-611). The loss should just be:
```python
loss = vol_loss + surf_weight * surf_loss
```

Remove the coarse_loss addition entirely.

Run with: `--wandb_name "gilbert/no-coarse" --wandb_group no-coarse --agent gilbert`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run**: `39nnllgc` (gilbert/no-coarse)
**Epochs completed**: 81 (30-min wall-clock limit)
**Peak memory**: 8.8 GB

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.5700 | 2.6613 | +0.091 ↑ worse |
| val_in_dist/mae_surf_p | 22.47 | 24.04 | +1.57 ↑ worse |
| val_ood_cond/mae_surf_p | 24.03 | ~24.0 | ~0 |
| val_ood_re/mae_surf_p | 32.08 | ~32.8 | +0.7 ↑ worse |
| val_tandem_transfer/mae_surf_p | 42.13 | ~44.6 | +2.47 ↑ worse |

**val_in_dist detail**:
- mae_surf_Ux: 0.302, mae_surf_Uy: 0.197, mae_surf_p: 24.04
- mae_vol_Ux: 1.731, mae_vol_Uy: 0.640, mae_vol_p: 36.44

**val_ood_re/loss**: NaN (pre-existing issue, unrelated to this change)

### What happened

Removing the coarse loss **slightly hurt** performance across most metrics. val/loss went from 2.5700 → 2.6613 (+0.09), and val_in_dist/mae_surf_p increased from 22.47 → 24.04 (+1.57). The hypothesis that coarse pooling was adding noise was incorrect — the signal appears genuinely helpful despite the non-spatial node ordering.

One possible explanation: even though consecutive node indices aren't spatially coherent, the coarse pooling averages out high-frequency noise in the predictions, providing a smoother training signal. This acts as a useful implicit regularizer regardless of spatial coherence.

The run did reach epoch 81 vs the baseline (which ran similar epochs), so compute savings were minimal — the coarse pooling overhead is negligible.

### Suggested follow-ups

- Try spatially-coherent coarse pooling (e.g. group nodes by proximity using k-d tree clustering) to test whether spatial coherence improves the coarse loss signal further.
- Try a higher coarse weight (e.g. 2.0 or 3.0) since the current 1.0 weight appears to provide modest benefit.
- The tandem split degrades significantly without coarse loss (+2.47 on surf_p), suggesting coarse loss may help generalization to new configurations — worth investigating.