### PR TITLE
Exponential surf_weight ramp 1→30 (slow start, fast finish)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -543,9 +543,9 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    sw_start, sw_end = 1.0, 30.0
     progress = epoch / MAX_EPOCHS
-    surf_weight = sw_start + (sw_end - sw_start) * progress
+    surf_weight = sw_end * (sw_start / sw_end) ** (1 - progress)
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
The current linear ramp goes 5→30. An exponential ramp stays low longer (focus on volume structure) and ramps sharply late (refine surface). This gives the model much more time to learn global flow before surface refinement kicks in.

## Instructions
In `structured_split/structured_train.py`, replace lines 546-548:
```python
sw_start, sw_end = 1.0, 30.0
progress = epoch / MAX_EPOCHS
surf_weight = sw_end * (sw_start / sw_end) ** (1 - progress)
```

This gives: epoch 0: sw=1.0, epoch 40: sw≈3.7, epoch 60: sw≈8.2, epoch 80: sw≈17.8, epoch 100: sw=30.

Run with: `--wandb_name "senku/exp-ramp" --wandb_group exp-sw-ramp --agent senku`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `cfzl1bdh` — 75 epochs completed (timeout), peak memory 8.8GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.5700 | **2.7316** | +0.162 ↑worse |
| val_in_dist/mae_surf_p | 22.47 | **28.29** | +5.82 ↑worse |
| val_ood_cond/mae_surf_p | 24.03 | **24.37** | +0.34 ↑worse |
| val_ood_re/mae_surf_p | 32.08 | **33.96** | +1.88 ↑worse |
| val_tandem_transfer/mae_surf_p | 42.13 | **45.74** | +3.61 ↑worse |
| val_in_dist/mae_surf_Ux | — | 0.333 | — |
| val_in_dist/mae_surf_Uy | — | 0.210 | — |
| val_in_dist/mae_vol_p | — | 28.77 | — |

**What happened:** Negative result. The exponential ramp made all metrics worse. val/loss increased from 2.5700 → 2.7316 (+6.3%) and in-distribution surface pressure MAE rose 26% (22.47 → 28.29).

The exponential schedule keeps surf_weight very low for most of training (1.0 at epoch 0, ~3.7 at epoch 40) compared to the baseline linear ramp (5.0 at epoch 0, ~17 at epoch 40). While the idea was to give the model more time to learn global flow first, in practice this starves the surface loss of gradient signal for too long. The model then can't catch up in the sharp final ramp since by epoch 60+ the hidden representations have already converged to a volume-biased solution that's hard to fine-tune for surface accuracy.

Compare to PR #467 which successfully raised the linear ramp to 10→40 (more surface emphasis throughout), yielding a positive result. The data suggests more surface emphasis earlier helps, not less.

**Suggested follow-ups:**
- Test a "reverse" schedule: start surf_weight high and ramp down (if the model needs surface signal early to learn the right representation)
- Compare the surf_weight curve more carefully with PR #467 to understand the "sweet spot" — the successful range appears to be 5→30 to 10→40, not going below 5 at epoch 0