### PR TITLE
Gradient accumulation (effective batch 8, accumulate 2 steps)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -332,6 +332,7 @@ class Transolver(nn.Module):
 
 MAX_TIMEOUT = 30.0  # minutes
 MAX_EPOCHS = 100
+accum_steps = 2
 
 
 @dataclass
@@ -553,6 +554,7 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf = 0.0
     n_batches = 0
 
+    optimizer.zero_grad()
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
@@ -610,17 +612,25 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        scaled_loss = loss / accum_steps
+        scaled_loss.backward()
+        if (n_batches + 1) % accum_steps == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            global_step += 1
+            wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
+
+    if n_batches % accum_steps != 0:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        optimizer.step()
+        optimizer.zero_grad()
+        global_step += 1
 
     scheduler.step()
     epoch_vol /= n_batches


### PR DESCRIPTION
## Hypothesis
Current batch_size=4 with variable mesh sizes (85K-210K nodes) gives noisy gradients. Accumulating over 2 steps gives effective batch 8, reducing variance without increasing peak memory. Previous grad-accum (#537) may have had implementation issues.

## Instructions
In `structured_split/structured_train.py`:

1. Add after line 333: `accum_steps = 2`

2. Replace lines 613-617 (the optimizer step block):
```python
scaled_loss = loss / accum_steps
scaled_loss.backward()
if (n_batches + 1) % accum_steps == 0:
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    optimizer.step()
    optimizer.zero_grad()
    global_step += 1
    wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
```

3. After the training pbar loop, flush any remaining accumulated gradients:
```python
if n_batches % accum_steps != 0:
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    optimizer.step()
    optimizer.zero_grad()
    global_step += 1
```

Run with: `--wandb_name "emma/grad-accum" --wandb_group grad-accum-8 --agent emma`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** 6bsr8t14 | **Epochs:** ~83 (killed by 30-min timeout) | **Epoch time:** 21.8 s | **Peak GPU memory:** 35.7 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 2.120 | 0.354 | 0.227 | 33.19 | 1.684 | 0.588 | 35.48 |
| val_ood_cond | 1.613 | 0.277 | 0.202 | 23.41 | 1.390 | 0.533 | 25.98 |
| val_ood_re | NaN | 0.287 | 0.211 | 33.36 | 1.341 | 0.535 | 55.59 |
| val_tandem_transfer | 4.722 | 0.671 | 0.366 | 45.25 | 2.545 | 1.182 | 49.49 |
| **combined val/loss** | **2.8183** | | | | | | |

**vs baseline (Δ surf_p):**
- val_in_dist: 33.19 vs 22.47 → **+10.72 (↑47.7%, much worse)**
- val_ood_cond: 23.41 vs 24.03 → **-0.62 (↓2.6%, better)**
- val_ood_re: 33.36 vs 32.08 → **+1.28 (↑4.0%, worse)**
- val_tandem_transfer: 45.25 vs 42.13 → **+3.12 (↑7.4%, worse)**
- val/loss: 2.8183 vs 2.5700 → **+0.2483 (↑9.7%, much worse)**

### What happened

Strong negative result. Gradient accumulation (2 steps, effective batch 8) hurt performance severely, with val_in_dist surf_p degrading by +47%.

**Root cause: halved optimizer updates per epoch.** With accum_steps=2, the model makes only ~165 optimizer steps per epoch instead of ~331. The cosine LR schedule and the 30-min wall clock cap are both epoch-based, so the model receives the same number of epochs (~83) but only half as many weight updates total. This causes significant underfitting — the model doesn't converge as well within the time budget.

**Lookahead amplifies the problem.** The Lookahead wrapper triggers every k=10 optimizer steps. With gradient accumulation, slow weights update every 20 batches (instead of 10), effectively halving the slow-weight refresh rate. This means the Lookahead stabilization mechanism is much less active.

The val_ood_cond result (-0.62) may be a positive signal that gradient accumulation can help with OOD generalization once convergence is addressed, but the convergence cost is too high.

### Suggested follow-ups

- To compensate for halved updates, **double the learning rate** (3e-3 → 6e-3) when using accum_steps=2.
- Or: **double MAX_EPOCHS** to 200 with accum_steps=2, though this conflicts with the 30-min cap.
- Or simply: gradient accumulation is not beneficial when the bottleneck is optimizer steps (not memory or batch diversity).