### PR TITLE
Surface-exempt progressive resolution (keep near-surface vol nodes)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -574,17 +574,32 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
-        # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
+        # Progressive resolution: subsample far-field volume nodes early in training
+        # Near-surface volume nodes (bottom 25% dsdf) are always kept at full resolution
         if epoch < 40:
             vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
             vol_indices = vol_mask.nonzero(as_tuple=False)
-            n_vol = vol_indices.shape[0]
-            n_keep = max(int(n_vol * vol_keep_ratio), 1)
-            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
+
+            # Identify near-surface volume nodes using dsdf features (indices 4:12 in x)
+            dsdf = x[vol_indices[:, 0], vol_indices[:, 1], 4:12]
+            dsdf_norm = dsdf.norm(dim=-1)
+            near_surf_threshold = dsdf_norm.quantile(0.25)  # keep 25% closest to surface
+            near_surf_mask = dsdf_norm <= near_surf_threshold
+
+            # Keep all near-surface nodes + random sample of far-field
+            far_field_indices = vol_indices[~near_surf_mask]
+            n_far = far_field_indices.shape[0]
+            n_keep_far = max(int(n_far * vol_keep_ratio), 1)
+            perm = torch.randperm(n_far, device=vol_mask.device)[:n_keep_far]
+
             vol_mask_train = torch.zeros_like(vol_mask)
-            if n_keep > 0:
-                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
+            # Always include near-surface volume nodes
+            near_idx = vol_indices[near_surf_mask]
+            vol_mask_train[near_idx[:, 0], near_idx[:, 1]] = True
+            # Add random far-field sample
+            if n_keep_far > 0:
+                kept_far = far_field_indices[perm]
+                vol_mask_train[kept_far[:, 0], kept_far[:, 1]] = True
         else:
             vol_mask_train = vol_mask
 


### PR DESCRIPTION
## Hypothesis
Progressive resolution (5%→100%) subsamples volume nodes early but this weakens boundary layer learning. Keeping volume nodes near the surface at 100% while subsampling far-field nodes ensures boundary layer gradient signal from epoch 1.

## Instructions
In `structured_split/structured_train.py`, modify the progressive resolution block (lines 578-589):

```python
if epoch < 40:
    vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
    vol_indices = vol_mask.nonzero(as_tuple=False)
    n_vol = vol_indices.shape[0]
    
    # Identify near-surface volume nodes using dsdf features
    # dsdf features are at indices 4:12 in x (after normalization)
    dsdf = x[vol_indices[:, 0], vol_indices[:, 1], 4:12]
    dsdf_norm = dsdf.norm(dim=-1)
    near_surf_threshold = dsdf_norm.quantile(0.25)  # keep 25% closest to surface
    near_surf_mask = dsdf_norm <= near_surf_threshold
    
    # Keep all near-surface nodes + random sample of far-field
    far_field_indices = vol_indices[~near_surf_mask]
    n_far = far_field_indices.shape[0]
    n_keep_far = max(int(n_far * vol_keep_ratio), 1)
    perm = torch.randperm(n_far, device=vol_mask.device)[:n_keep_far]
    
    vol_mask_train = torch.zeros_like(vol_mask)
    # Always include near-surface volume nodes
    near_idx = vol_indices[near_surf_mask]
    vol_mask_train[near_idx[:, 0], near_idx[:, 1]] = True
    # Add random far-field sample
    if n_keep_far > 0:
        kept_far = far_field_indices[perm]
        vol_mask_train[kept_far[:, 0], kept_far[:, 1]] = True
else:
    vol_mask_train = vol_mask
```

Run with: `--wandb_name "norman/prog-surf" --wandb_group prog-res-fullsurf --agent norman`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `8nso5kk6`  
**Epochs:** 82 (hit 30-min timeout, killed by SIGKILL at epoch 82)  
**Peak memory:** 8.8 GB  

Note: Run crashed at timeout. Best checkpoint from output.log is epoch 81; W&B summary shows last-epoch values which match epoch 81 checkpoint.

### Metrics at best checkpoint (epoch 81)

| Metric | Baseline (uniform prog-res) | This run (surface-exempt) | Δ |
|---|---|---|---|
| val/loss | 2.5700 | **2.6571** | +3.4% ❌ |
| val_in_dist/mae_surf_p | 22.47 | 25.12 | +11.8% ❌ |
| val_ood_cond/mae_surf_p | 24.03 | 23.47 | **−2.3%** ✓ |
| val_ood_re/mae_surf_p | 32.08 | 32.64 | +1.7% |
| val_tandem_transfer/mae_surf_p | 42.13 | 43.28 | +2.7% |

### What happened

Negative result. Preserving near-surface volume nodes (bottom 25% DSDF norm) during progressive resolution hurt 3 of 4 splits, with only ood_cond marginally improving.

Likely reasons:

1. **More nodes per batch early in training:** By keeping 25% near-surface volume nodes at full density PLUS the far-field sample, each batch processes more nodes early in training (~25% base + 5-100% of remaining 75%). This makes early epochs slower and may reduce effective batch diversity.

2. **DSDF as proximity proxy may be noisy:** The normalized DSDF features at indices 4:12 represent multiple signed distance fields. Their L2 norm doesn't cleanly map to physical distance from surface — it mixes contributions from multiple boundaries. The quantile threshold may not cleanly separate boundary-layer vs. far-field nodes.

3. **Uniform progressive resolution already works well:** The original approach of randomly subsampling all volume nodes is simpler and forces the model to generalize across the full domain even early. The surface-exempt variant over-specializes early gradient signal toward near-surface regions at the cost of domain coverage.

### Suggested follow-ups

- **Use actual DSDF channel directly** (not L2 norm of all DSDF channels) — look at the specific channel that represents distance to the airfoil surfaces
- **Try surface loss exemption** — instead of keeping near-surface VOLUME nodes, give surface nodes extra weight in the loss during the ramp-up phase
- **Keep the original uniform progressive resolution** — it works well; the near-surface exemption doesn't add value
