### PR TITLE
Deeper output MLP (3-layer with extra GELU)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -185,6 +185,8 @@ class TransolverBlock(nn.Module):
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
 


### PR DESCRIPTION
## Hypothesis
The output head is a simple 2-layer MLP (hidden→GELU→3). A deeper output head could better translate latent representations to physical quantities. The extra ~16K parameters are minimal.

## Instructions
In `structured_split/structured_train.py`, in `TransolverBlock.__init__` (around line 185):

Change:
```python
self.mlp2 = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim),
    nn.GELU(),
    nn.Linear(hidden_dim, out_dim),
)
```
to:
```python
self.mlp2 = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim),
    nn.GELU(),
    nn.Linear(hidden_dim, hidden_dim),
    nn.GELU(),
    nn.Linear(hidden_dim, out_dim),
)
```

Run with: `--wandb_name "chihiro/deep-out" --wandb_group deeper-output --agent chihiro`

## Baseline
- val/loss: **2.5700**
- val_in_dist/mae_surf_p: 22.47
- val_ood_cond/mae_surf_p: 24.03
- val_ood_re/mae_surf_p: 32.08
- val_tandem_transfer/mae_surf_p: 42.13

---

## Results

**W&B run:** `v3qsvkmq`
**Best epoch:** 78 (wall-clock limit: 30.3 min)
**VRAM:** ~8.8 GB (minimal increase from baseline; +16K params)

### val/loss

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.6799** | 2.5700 | +0.1099 (worse) |

Note: val_ood_re loss = NaN (vol_loss exploded to ~18.9B for that split); val/loss is the mean over the remaining 3 non-NaN splits.

### Surface MAE (mae_surf_p, Pa)

| Split | This run | Baseline | Δ |
|-------|----------|----------|---|
| val_in_dist | 25.93 | 22.47 | +3.46 (worse) |
| val_ood_cond | 23.79 | 24.03 | **-0.24 (better)** |
| val_ood_re | 32.64 | 32.08 | +0.56 (worse) |
| val_tandem_transfer | 43.67 | 42.13 | +1.54 (worse) |

### Volume MAE (val_in_dist)

| Channel | MAE |
|---------|-----|
| Ux | 1.53 |
| Uy | 0.56 |
| p | 31.88 |

### What happened

The deeper output head did not improve results — val/loss is 2.6799 vs baseline 2.5700 (+0.11 worse). Three of four splits regressed, with the in_dist surface pressure error jumping by +3.46 Pa. A notable anomaly: val_ood_re vol_loss diverged to ~18.9B (NaN loss), though its surface MAE remained near-baseline (32.64 vs 32.08). This NaN may indicate numerical instability in the extra linear layer for high-Re flows.

The deeper head hypothesis didn't pan out for two likely reasons: (1) the Transolver attention mechanism is the bottleneck — the output head maps well-structured slot representations to field values, and a 2-layer MLP is already sufficient for that; (2) the extra parameters without careful initialization (e.g., zero-init final layer) may have slightly destabilized optimization. Epoch time stayed at ~22.6 s, so budget wasn't the issue.

### Suggested follow-ups
- Investigate the ood_re vol_loss NaN — if it's reproducible across runs, it could be silently hurting other experiments where it might not overflow but still produces outlier gradients.
- If a deeper head is revisited, try zero-initializing the final linear layer so it starts as identity-like behavior rather than random.
- Consider whether the output head bottleneck could be more impactful with a hidden→hidden/2→3 shape (reduce, not expand) to force compression.