### PR TITLE
10-epoch warmup (longer stabilization with per-sample norm)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -333,6 +333,7 @@ MAX_EPOCHS = 100
 class Config:
     lr: float = 3e-3
     weight_decay: float = 1e-4
+    eta_min: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"
@@ -484,11 +485,9 @@ class Lookahead:
 
 base_opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 10)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
-)
+warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.05, total_iters=10)
+cosine = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 10, eta_min=cfg.eta_min)
+scheduler = torch.optim.lr_scheduler.SequentialLR(base_opt, [warmup, cosine], milestones=[10])
 
 # --- wandb ---
 run = wandb.init(


### PR DESCRIPTION
## Hypothesis
Per-sample normalization changes the loss landscape — samples with different scales now contribute more equally, making early gradients noisier. A longer warmup (10 epochs instead of 5) with gentler start gives the optimizer more time to find a good trajectory.

## Instructions
In `structured_split/structured_train.py`, change the warmup scheduler:
```python
warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.05, total_iters=10)
```
And adjust the cosine scheduler:
```python
cosine = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 10, eta_min=cfg.eta_min)
```
And the SequentialLR milestone:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(base_opt, [warmup, cosine], milestones=[10])
```

Run with: `--wandb_name "senku/warmup-10" --wandb_group warmup-10 --agent senku`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19
- val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91
- val_tandem_transfer/mae_surf_p: 46.41

---

## Results

**W&B run:** `oelfuegl` — 84 epochs completed (timeout), peak memory 7.6GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.4780 | **2.7614** | +0.283 ↑worse |
| val_in_dist/mae_surf_p | 24.19 | **24.17** | -0.02 ≈same |
| val_ood_cond/mae_surf_p | 21.87 | **25.39** | +3.52 ↑worse |
| val_ood_re/mae_surf_p | 31.91 | **33.47** | +1.56 ↑worse |
| val_tandem_transfer/mae_surf_p | 46.41 | **45.52** | -0.89 ↓better |
| val_in_dist/mae_surf_Ux | — | 0.344 | — |
| val_in_dist/mae_surf_Uy | — | 0.198 | — |
| val_in_dist/mae_vol_p | — | 32.98 | — |

**What happened:** Primarily negative. val/loss worsened by +11.4% overall, driven mainly by ood_cond degrading from 21.87 → 25.39 (+16%). In-distribution surface pressure is essentially unchanged (24.17 vs 24.19), and tandem transfer slightly improved (45.52 vs 46.41), but these bright spots are outweighed by the ood_cond regression.

The changes here are: (1) halving start_factor from 0.1 to 0.05, and (2) adding eta_min=1e-5. The warmup length was already 10 epochs in the base branch. The gentler warmup start means the model trains more slowly in the first 10 epochs, but the baseline's 10% start was evidently already working well for ood splits. Adding eta_min=1e-5 constrains the final LR from decaying below that floor, which can help later epochs but also means later cosine values are slightly higher than without eta_min.

The ood_cond degradation is the main concern — this suggests the reduced warmup LR early is hurting generalization to out-of-distribution conditions, perhaps by converging to a slightly different local minimum.

**Suggested follow-ups:**
- Try restoring start_factor=0.1 but keeping eta_min=1e-5 to isolate which change is responsible
- Try a shorter warmup (5 epochs) with the current baseline start_factor to see if 10 epochs is suboptimal