### PR TITLE
Temperature init 0.25 (apply confirmed-empty merge)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.25)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
PR #468 showed temp=0.25 improved 3/4 splits but merged as empty commit. Code still has * 0.5. This is a validated change never actually applied.

## Instructions
In `structured_split/structured_train.py`, find `PhysicsAttention.__init__` temperature init:
```python
self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
```
Change to:
```python
self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.25)
```

Run with: `--wandb_name "frieren/temp-025" --wandb_group temp-025 --agent frieren`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---

## Results

**W&B run:** `vberni4b`  
**Epochs:** 77/100 (timeout at 30 min)  
**Peak memory:** ~8.8 GB

| Metric | Baseline | Temp 0.25 | Δ |
|--------|----------|-----------|---|
| val/loss | 2.4780 | 2.5277 | +2.0% ❌ |
| val_in_dist/mae_surf_p | 24.19 | 25.39 | +5.0% ❌ |
| val_ood_cond/mae_surf_p | 21.87 | 22.35 | +2.2% ❌ |
| val_ood_re/mae_surf_p | 31.91 | 32.20 | +0.9% ❌ |
| val_tandem_transfer/mae_surf_p | 46.41 | 48.23 | +3.9% ❌ |

**Full surface/volume MAE at best epoch (epoch 77):**

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.308 | 0.190 | 25.39 | 1.555 | 0.548 | 33.75 |
| val_ood_cond | 0.278 | 0.189 | 22.35 | 1.299 | 0.490 | 23.68 |
| val_ood_re | 0.302 | 0.208 | 32.20 | 1.277 | 0.515 | 54.15 |
| val_tandem_transfer | 0.703 | 0.366 | 48.23 | 2.532 | 1.170 | 51.16 |

**Note:** `val_ood_re/loss` was NaN across all epochs (vol_loss diverges for this OOD split). Best epoch selected by val/loss over 3 finite splits.

**What happened:**  
Temperature init 0.25 is worse than the new baseline (val/loss 2.5277 vs 2.4780, all surface pressure metrics higher). The original PR #548 showed marginal improvement on some splits against the old baseline (2.5700), but that baseline has since been improved to 2.4780 by the advisor — and against this stronger baseline, temp=0.25 does not hold up.

The lower temperature (0.25 vs 0.5) makes the slice attention softmax distribution sharper (since `score / temperature` is scaled up), reducing the number of physics slices that each point attends to. This may have been beneficial when the training dynamics needed more focused attention, but with the improved baseline (which may have other architectural/training changes), this constraint appears to hurt.

**Suggested follow-ups:**
- Try temperature as a learnable per-head scalar starting at 0.25 but allowed to increase — this would let the model find its own temperature during training rather than fixing it.
- The val_ood_cond/surf_p=22.35 is very close to the baseline's 21.87 — the OOD condition split seems most robust to this change. Exploring what the improved baseline changed architecturally could provide more signal.