### PR TITLE
Surface channel weight [1,1,2] for pressure (apply confirmed-empty merge)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -360,6 +360,8 @@ train_ds, val_splits, stats, sample_weights = load_structured_split(
     cfg.manifest, cfg.stats_file, debug=cfg.debug,
 )
 stats = {k: v.to(device) for k, v in stats.items()}
+surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
+surf_channel_w = surf_channel_w / surf_channel_w.mean()
 
 
 def _umag_q(y, mask):
@@ -603,7 +605,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        surf_loss = (abs_err * surf_channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
@@ -691,7 +693,7 @@ for epoch in range(MAX_EPOCHS):
                     (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
                     1e12
                 )
-                val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                val_surf += (abs_err * surf_channel_w * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
                 # Denormalize: phys_stats → Cp space → original scale


### PR DESCRIPTION
## Hypothesis
PR #459 showed [1,1,2] improved all splits but merged empty. Weight pressure 2x in surface loss.

## Instructions
In `structured_split/structured_train.py`, add channel weighting to training and validation surface loss:
```python
surf_channel_w = torch.tensor([1.0, 1.0, 2.0], device=device)
surf_channel_w = surf_channel_w / surf_channel_w.mean()
```
Change surf_loss from:
```python
surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```
to:
```python
surf_loss = (abs_err * surf_channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```
Apply same in validation.

Run with: `--wandb_name "fern/ch-112" --wandb_group surf-ch-112 --agent fern`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---
## Results

**Run ID**: 5at8f6e2  
**Epochs**: 81 (wall-clock limit ~30 min)  
**Peak memory**: ~8.8 GB  

### Val/loss
| Metric | Baseline (ps-norm) | This run | Delta |
|--------|-------------------|----------|-------|
| val/loss | 2.478 | **2.737** | +10.5% (note: loss scale changed by channel weighting) |

### Surface MAE vs ps-norm baseline
| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|-------|---------------------|---------------------|-------|
| val_in_dist | 24.19 | **21.89** | **-9.5% (better)** |
| val_ood_cond | 21.87 | **21.34** | **-2.4% (better)** |
| val_ood_re | 31.91 | **31.22** | **-2.2% (better)** |
| val_tandem_transfer | 46.41 | **44.36** | **-4.4% (better)** |

All four splits improved vs the ps-norm baseline.

### Surface MAE vs original baseline (2.57)
| Split | Original baseline | This run | Delta |
|-------|-------------------|----------|-------|
| val_in_dist | 22.47 | **21.89** | **-2.6% (better)** |
| val_ood_cond | 24.03 | **21.34** | **-11.2% (better)** |
| val_ood_re | 32.08 | **31.22** | **-2.7% (better)** |
| val_tandem_transfer | 42.13 | 44.36 | +5.3% (worse) |

Three of four splits improved vs the original baseline. Tandem transfer remains the challenge.

### Full Surface MAE
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|-------------|-------------|------------|
| val_in_dist | 0.337 | 0.193 | 21.89 |
| val_ood_cond | 0.297 | 0.200 | 21.34 |
| val_ood_re | 0.306 | 0.207 | 31.22 |
| val_tandem_transfer | 0.708 | 0.370 | 44.36 |

### Full Volume MAE
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.661 | 0.582 | 32.30 |
| val_ood_cond | 1.350 | 0.492 | 22.80 |
| val_ood_re | 1.291 | 0.513 | 53.84 |
| val_tandem_transfer | 2.555 | 1.182 | 49.77 |

Note: val_ood_re/loss = nan (pre-existing issue).

### What happened

Strong positive result. The combination of per-sample std normalization (from the ps-norm baseline branch) and [1,1,2] channel weighting improved all four splits vs the ps-norm baseline, and improved three of four splits vs the original baseline.

The [1,1,2] channel weight (normalized to mean=1, effective weights [0.75, 0.75, 1.5]) fixed the val_in_dist regression from ps-norm alone (+7.6% → -2.6% vs original). The in_dist pressure improved from 24.19 to 21.89, now better than the original baseline (22.47). val_ood_cond improved further to 21.34 (-11.2% vs original baseline, best ood_cond yet).

The tandem transfer at 44.36 is still worse than the original 42.13 baseline. This seems to be a fundamental challenge: the combination of per-sample normalization (which skips tandem) and channel weighting pushes the model toward single-foil surface physics in a way that hurts tandem generalization.

### Suggested follow-ups

- Try tandem-specific channel weighting: apply the [1,1,2] weight to tandem samples too, potentially recovering some tandem accuracy
- The original baseline had better tandem (42.13) — this combination still has a tandem deficit. Consider whether tandem can be addressed separately (e.g., tandem-specific loss boost)
- The ood_cond at 21.34 is now excellent. The main remaining gap is tandem.