### PR TITLE
Tandem surface weight 1.5x boost (address tandem regression)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -603,7 +603,10 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        is_tandem = (x[:, 0, 21].abs() > 0.01)
+        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Tandem split regressed to 46.41 after per-sample norm. Give tandem samples 1.5x surface weight to compensate.

## Instructions
In `structured_split/structured_train.py`, detect tandem samples and boost their surface loss:
```python
is_tandem = (x[:, 0, 21].abs() > 0.01)
tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
```
Apply boost to per-sample surface loss before averaging. The exact location depends on how surf_loss is structured in the per-sample normalization code — multiply each sample's surface loss contribution by tandem_boost[b].

Run with: `--wandb_name "nezuko/tandem-boost" --wandb_group tandem-boost --agent nezuko`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---
## Results

**W&B run:** `4yxulgb3` (nezuko/tandem-boost)
**Best epoch:** 80 / ~80 (hit 30-min timeout)

### Metrics vs baseline

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| overall | val/loss | 2.4780 | **2.4381** | -0.040 |
| val_in_dist | mae_surf_p | 24.19 | **21.72** | -2.47 |
| val_ood_cond | mae_surf_p | 21.87 | 22.88 | +1.01 |
| val_ood_re | mae_surf_p | 31.91 | 32.10 | +0.19 |
| val_tandem_transfer | mae_surf_p | 46.41 | **43.75** | -2.66 |

Detailed best-epoch metrics:
- **val_in_dist**: loss=1.662, mae_surf_Ux=0.293, mae_surf_Uy=0.180, mae_surf_p=21.72, mae_vol_Ux=1.678, mae_vol_Uy=0.586, mae_vol_p=34.59
- **val_ood_cond**: loss=2.171, mae_surf_Ux=0.268, mae_surf_Uy=0.195, mae_surf_p=22.88, mae_vol_Ux=1.317, mae_vol_Uy=0.522, mae_vol_p=24.24
- **val_ood_re**: mae_surf_p=32.10 (loss=NaN — vol overflow, pre-existing)
- **val_tandem_transfer**: loss=3.482, mae_surf_Ux=0.656, mae_surf_Uy=0.355, mae_surf_p=43.75

### What happened

**Positive result.** The tandem boost achieved its primary goal — tandem transfer improved by 2.66 units (46.41 → 43.75). The boost works by weighting tandem samples' surface loss 1.5x higher during training, pushing the model to fit tandem surface predictions more carefully.

Additionally, val_in_dist pressure improved by 2.47 (24.19 → 21.72), which is a notable bonus. This may be because the per-sample approach (computing surf_loss per sample then averaging) provides more uniform gradient signal across the batch, benefiting all samples — not just tandem ones.

The only regressor is val_ood_cond (+1.01), which was the standout improvement from the per-sample normalization experiment. This is a typical trade-off: improving tandem slightly hurts OOD-cond, possibly because boosting tandem samples steers the model toward a different equilibrium.

Overall val/loss improved from 2.4780 → 2.4381 (best epoch at 80).

Implementation note: The surf_loss was rewritten as a per-sample mean (equal weight per sample) rather than node-count-weighted average. This is a mild change in semantics but enabled the per-sample boosting. The boost variable `is_tandem` (threshold 0.01 in normalized space) correctly identifies tandem configurations.

### Suggested follow-ups
- Try boost = 2.0 for tandem — the 2.66 improvement suggests there may be more gain available
- Investigate whether the per-sample mean surf_loss (independent of PR) alone improves over node-count-weighted — the in-dist improvement might come from that change rather than the tandem boost specifically