### PR TITLE
Fixed (non-learnable) temperature 0.25 (eliminate optimizer noise)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.register_buffer('temperature', torch.ones([1, heads, 1, 1]) * 0.25)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
Making temperature a fixed buffer at 0.25 removes optimizer momentum noise and locks in the validated value.

## Instructions
In `structured_split/structured_train.py`, `PhysicsAttention.__init__`, change:
```python
self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
```
to:
```python
self.register_buffer('temperature', torch.ones([1, heads, 1, 1]) * 0.25)
```

Run with: `--wandb_name "alphonse/fixed-temp" --wandb_group fixed-temp --agent alphonse`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---
## Results

**W&B run ID:** kkx31tc0
**Epochs completed:** 80/100 (30-min timeout; ~22.3s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline | This run (ep80, best) | Delta |
|---|---|---|---|
| val/loss | 2.4780 | **2.5153** | +1.5% worse |
| val_in_dist/mae_surf_p | 24.19 | **25.41** | +5.0% worse |
| val_ood_cond/mae_surf_p | 21.87 | **22.24** | +1.7% worse |
| val_ood_re/mae_surf_p | 31.91 | **31.93** | +0.1% (noise) |
| val_tandem_transfer/mae_surf_p | 46.41 | **47.30** | +1.9% worse |

Additional val_in_dist at best epoch:
- mae_surf_Ux: 0.340 | mae_surf_Uy: 0.196
- mae_vol_Ux: 1.651 | mae_vol_Uy: 0.577 | mae_vol_p: 33.23

### What happened

**Marginal negative result.** All metrics are slightly worse than baseline, but the margins are small (1.5–5%). val_ood_re is essentially identical (31.93 vs 31.91).

The fixed temperature at 0.25 doesn't help vs the learnable temperature initialized at 0.5. The learnable parameter presumably adapts during training and ends up near an effective value for the task — fixing it at 0.25 removes this adaptivity without providing a clear benefit.

The model ran 80 epochs (best at last epoch, still converging), so some of the deficit could shrink with more training, but this doesn't look like a meaningful win.

The close proximity to baseline (vs the larger regressions seen in other experiments) suggests that temperature=0.25 is *not actively harmful* as a fixed value, but removing the learnable degree of freedom doesn't help.

### Suggested follow-ups
- If temperature matters, testing intermediate fixed values (0.3, 0.4) might find a sweet spot
- A learnable temperature initialized at 0.25 (rather than 0.5) was not tested here — could be useful if the initial value matters for convergence dynamics
- Given that multiple temperature experiments show small effects, temperature tuning may not be a high-leverage direction