### PR TITLE
Cosine similarity attention (scale-invariant physics clustering)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -117,6 +117,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
         )
+        self.attn_scale = nn.Parameter(torch.tensor(10.0))
 
     def forward(self, x):
         bsz, num_points, _ = x.shape
@@ -142,14 +143,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
         k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
         v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
-        dropout_p = self.dropout.p if self.training else 0.0
-        out_slice_token = F.scaled_dot_product_attention(
-            q_slice_token,
-            k_slice_token,
-            v_slice_token,
-            dropout_p=dropout_p,
-            is_causal=False,
-        )
+        q_norm = F.normalize(q_slice_token, dim=-1)
+        k_norm = F.normalize(k_slice_token, dim=-1)
+        attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
+        attn_weights = F.softmax(attn_logits, dim=-1)
+        out_slice_token = torch.matmul(attn_weights, v_slice_token)
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")


### PR DESCRIPTION
## Hypothesis
Cosine attention normalizes away magnitude differences between boundary layer and far-field nodes, focusing on directional alignment for physically meaningful clustering.

## Instructions
In `structured_split/structured_train.py`, `PhysicsAttention.__init__`, add:
```python
self.attn_scale = nn.Parameter(torch.tensor(10.0))
```

In `forward`, replace F.scaled_dot_product_attention with:
```python
q_norm = F.normalize(q_slice_token, dim=-1)
k_norm = F.normalize(k_slice_token, dim=-1)
attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
attn_weights = F.softmax(attn_logits, dim=-1)
out = torch.matmul(attn_weights, v_slice_token)
```

Run with: `--wandb_name "edward/cos-attn" --wandb_group cosine-attn --agent edward`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---
## Results

**W&B run:** u7o8s4kl | **Epochs:** 81 (30 min wall-clock limit) | **Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 2.4356 | 0.297 | 0.189 | **22.51** | 1.549 | 0.552 | 31.91 |
| ood_cond | — | 0.274 | 0.181 | **21.65** | 1.316 | 0.478 | 23.05 |
| ood_re | NaN | 0.287 | 0.202 | **31.85** | 1.256 | 0.511 | 53.79 |
| tandem | — | 0.663 | 0.354 | **45.43** | 2.481 | 1.143 | 51.21 |

**vs. baseline (val/loss 2.4780, mae_surf_p: in_dist 24.19 / ood_cond 21.87 / ood_re 31.91 / tan 46.41):**
- val/loss: 2.4356 vs 2.4780 (**-1.7%** — better)
- mae_surf_p in_dist: 22.51 vs 24.19 (**-6.9%** — better)
- mae_surf_p ood_cond: 21.65 vs 21.87 (**-1.0%** — better)
- mae_surf_p ood_re: 31.85 vs 31.91 (**-0.2%** — essentially flat)
- mae_surf_p tandem: 45.43 vs 46.41 (**-2.1%** — better)

### What happened

Cosine attention improved across all splits, with the most significant gain on in_dist surface pressure (-6.9%). The hypothesis holds: normalizing Q and K vectors to unit length before computing attention logits removes magnitude-based differences between boundary layer and far-field nodes, allowing the physics slices to cluster by directional alignment (flow direction, pressure gradient) rather than raw feature magnitude. The learnable scale parameter (initialized to 10.0) controls the softmax temperature independently of the Q/K magnitudes.

The ood_re split shows essentially no change (31.85 vs 31.91), consistent with its pre-existing vol_loss NaN issue that makes the split harder to improve. The tandem transfer and ood_cond improvements suggest cosine attention generalizes better to unseen conditions — a good sign for robustness.

### Suggested follow-ups

1. **Tune initial attn_scale**: Starting at 10.0 is arbitrary; a sweep over [5, 10, 20] might find a better initialization.
2. **Cosine attention + other improvements**: Since this is a positive result, stacking with the multi-scale loss or surface weight changes could compound gains.
3. **Analyze learned attn_scale**: Check what value attn_scale converges to — if it drifts far from 10, the initialization matters.