### PR TITLE
Proximity-weighted volume loss (dsdf-based, 3x near surface)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -602,7 +602,12 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        dsdf_features = x[:, :, 2:10]
+        dsdf_norm = dsdf_features.norm(dim=-1)
+        prox_weight = 1.0 + 2.0 * torch.exp(-dsdf_norm * 5.0)
+        prox_weight = prox_weight * vol_mask
+        prox_weight = prox_weight / prox_weight.sum(dim=1, keepdim=True).clamp(min=1) * vol_mask.sum(dim=1, keepdim=True).clamp(min=1)
+        vol_loss = (abs_err * prox_weight.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
         surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Near-surface volume nodes carry boundary-layer physics. Weight them 3x using dsdf features.

## Instructions
In training loop, after vol_mask, before vol_loss:
```python
dsdf_features = x[:, :, 2:10]
dsdf_norm = dsdf_features.norm(dim=-1)
prox_weight = 1.0 + 2.0 * torch.exp(-dsdf_norm * 5.0)
prox_weight = prox_weight * vol_mask
prox_weight = prox_weight / prox_weight.sum(dim=1, keepdim=True).clamp(min=1) * vol_mask.sum(dim=1, keepdim=True).clamp(min=1)
vol_loss = (abs_err * prox_weight.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
```

Run with: `--wandb_name "askeladd/dsdf-w" --wandb_group dsdf-vol --agent askeladd`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---
## Results

**W&B run:** `3czyhtx1`

| Metric | Baseline | This run (best epoch 77) | Delta |
|--------|----------|----------|-------|
| val/loss | 2.4780 | **2.5646** | +0.087 |
| val_in_dist/mae_surf_p | 24.19 | **24.52** | +0.33 |
| val_ood_cond/mae_surf_p | 21.87 | **23.15** | +1.28 |
| val_ood_re/mae_surf_p | 31.91 | **33.31** | +1.40 |
| val_tandem_transfer/mae_surf_p | 46.41 | **46.46** | +0.05 |

**Volume MAE (val_in_dist, best epoch):** Ux=1.592, Uy=0.557, p=32.67

**Surface MAE (full, best epoch):**
- val_in_dist: Ux=0.315, Uy=0.197, p=24.52
- val_ood_cond: Ux=0.284, Uy=0.202, p=23.15
- val_ood_re: Ux=0.306, Uy=0.210, p=33.31
- val_tandem_transfer: Ux=0.701, Uy=0.374, p=46.46

**Peak memory:** 8.9 GB (unchanged)
**Epoch time:** ~22s/epoch (unchanged)
**Epochs completed:** 78/100 (30-min timeout)

**Note on val_ood_re:** val_ood_re/loss=NaN is a pre-existing bug unrelated to this experiment.

### What happened

The proximity-weighted volume loss hurt performance across all splits. Val/loss at best epoch is 3.5% worse than baseline (2.5646 vs 2.4780). Surface pressure MAEs are worse on in_dist (+0.33), ood_cond (+1.28), and ood_re (+1.40), with tandem_transfer essentially unchanged (+0.05).

The near-surface weighting re-distributes training gradient toward boundary-layer nodes at the expense of far-field nodes. While boundary-layer physics are important, the model appears to already capture them reasonably via the surface loss term (which directly supervises airfoil surface nodes). Adding a secondary upweight near the surface in the volume loss may cause the model to over-focus on a small subset of volume nodes, degrading generalization.

Note: this implementation bypasses the progressive volume resolution schedule (vol_mask_train) since prox_weight uses vol_mask directly. It's not clear whether this was intentional or contributed to the performance gap.

### Suggested follow-ups
- **Apply prox_weight to vol_mask_train instead of vol_mask**: Preserve the progressive resolution schedule during early epochs while still upweighting near-surface volume nodes.
- **Lower the contrast**: Try weight multiplier 1.5x instead of 3x (i.e., `1.0 + 0.5 * torch.exp(...)`) to more gently emphasize boundary layer nodes.
- **Use dsdf magnitude directly**: The dsdf distance field may not be the right proxy for boundary layer importance. Pressure gradient magnitude might better identify physically interesting volume nodes.