### PR TITLE
Late-stage EMA (epoch 60+, decay=0.9995, eval on EMA weights)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -458,6 +458,11 @@ model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 
+import copy
+ema_state = copy.deepcopy(model.state_dict())
+ema_decay = 0.9995
+ema_start = 60
+
 
 class Lookahead:
     def __init__(self, base_optimizer, k=5, alpha=0.5):
@@ -640,7 +645,18 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol /= n_batches
     epoch_surf /= n_batches
 
+    if epoch >= ema_start:
+        if epoch == ema_start:
+            ema_state = copy.deepcopy(model.state_dict())
+        else:
+            with torch.no_grad():
+                for key in ema_state:
+                    ema_state[key].mul_(ema_decay).add_(model.state_dict()[key], alpha=1 - ema_decay)
+
     # --- Validate across all splits ---
+    if epoch >= ema_start:
+        orig_state = copy.deepcopy(model.state_dict())
+        model.load_state_dict(ema_state)
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
@@ -752,6 +768,9 @@ for epoch in range(MAX_EPOCHS):
     else:
         peak_mem_gb = 0.0
 
+    if epoch >= ema_start:
+        model.load_state_dict(orig_state)
+
     tag = ""
     if mean_val_loss < best_val:
         best_val = mean_val_loss
@@ -759,7 +778,9 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        torch.save(model.state_dict(), model_path)
+        # Save EMA weights when in EMA phase (they produced the val result)
+        save_state = ema_state if epoch >= ema_start else model.state_dict()
+        torch.save(save_state, model_path)
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(


### PR DESCRIPTION
## Hypothesis
Previous EMA started too early. Starting at epoch 60 with decay=0.9995 only averages well-converged final weights.

## Instructions
After model creation:
```python
import copy
ema_state = copy.deepcopy(model.state_dict())
ema_decay = 0.9995
ema_start = 60
```

End of each training epoch:
```python
if epoch >= ema_start:
    with torch.no_grad():
        for key in ema_state:
            ema_state[key].mul_(ema_decay).add_(model.state_dict()[key], alpha=1-ema_decay)
```

Before validation (swap in EMA):
```python
if epoch >= ema_start:
    orig_state = copy.deepcopy(model.state_dict())
    model.load_state_dict(ema_state)
```
After validation (swap back):
```python
if epoch >= ema_start:
    model.load_state_dict(orig_state)
```

Run with: `--wandb_name "emma/late-ema" --wandb_group late-ema-60 --agent emma`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---

## Results

**W&B run:** 2as2soiq | **Epochs:** ~80 (30-min cap) | **Epoch time:** 22.5 s | **Peak GPU memory:** 46.8 GB

| Split | val/loss (EMA) | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 2.146 | 0.371 | 0.225 | 34.32 | 1.658 | 0.593 | 38.36 |
| val_ood_cond | 2.478 | 0.334 | 0.208 | 26.36 | 1.373 | 0.528 | 24.66 |
| val_ood_re | NaN | 0.340 | 0.220 | 36.17 | 1.297 | 0.535 | 55.63 |
| val_tandem_transfer | 3.882 | 0.741 | 0.387 | 49.10 | 2.556 | 1.189 | 52.63 |
| **combined val/loss** | **2.8355** | | | | | | |

**vs baseline (delta surf_p):**
- val_in_dist: 34.32 vs 24.19 → **+10.13 (+41.9%, much worse)**
- val_ood_cond: 26.36 vs 21.87 → **+4.49 (+20.5%, much worse)**
- val_ood_re: 36.17 vs 31.91 → **+4.26 (+13.4%, much worse)**
- val_tandem_transfer: 49.10 vs 46.41 → **+2.69 (+5.8%, worse)**
- val/loss: 2.8355 vs 2.4780 → **+0.3575 (+14.4%, much worse)**

### Implementation note

The instructions initialized `ema_state = copy.deepcopy(model.state_dict())` at model creation (untrained). This caused catastrophic results (val/loss ~54, surf_p ~800) because epoch-60 validation used the untrained initial weights. Fixed by initializing EMA at `epoch == ema_start` instead.

### What happened

Negative result even after the fix. With decay=0.9995, after n=22 epochs of EMA updates (epochs 60-82), the EMA weight on epoch 60 is 0.9995^21 = 98.9%. The EMA is effectively just the epoch-60 snapshot.

If the model improves between epochs 60-82, using epoch-60 weights for validation is far worse than using the actual trained weights. This explains the +10 surf_p degradation on val_in_dist.

The checkpoint logic also saves ema_state when EMA val/loss is best -- but since EMA = epoch-60 model, the best checkpoint is an early-stage model rather than the final converged model.

**decay=0.9995 is too slow for a ~20-epoch EMA window.** Effective window = 1/(1-decay) = 2000 epochs; we only have ~20.

### Suggested follow-ups

- Use lower decay (0.99) for a ~100-epoch effective window, or 0.9 for ~10-epoch window.
- At decay=0.99 over 20 epochs: epoch-start weight = 0.99^20 = 82% -- still largely the start epoch.
- Realistic sweet spot: decay=0.9, effective window=10 epochs. Would mix last 10 epochs meaningfully.
- Or: start EMA much earlier (e.g., epoch 20) to get more averaging epochs within the 30-min cap.