### PR TITLE
Tandem-specific channel weight [1,1,3] (extra pressure for dual-foil)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -603,7 +603,11 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        surf_loss = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        # Per-sample channel weighting: heavier pressure weight for tandem samples
+        channel_w = torch.ones(B, 1, 3, device=device)
+        channel_w[is_tandem, :, 2] = 3.0
+        channel_w = channel_w / channel_w.mean(dim=-1, keepdim=True)
+        surf_loss = (abs_err * channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Tandem has worst surface pressure (46.41). Apply heavier pressure weight [1,1,3] for tandem while [1,1,1] for single.

## Instructions
Detect tandem: `is_tandem = (x[:, 0, 21].abs() > 0.01)`

Create per-sample channel weighting:
```python
channel_w = torch.ones(B, 1, 3, device=device)
channel_w[is_tandem, :, 2] = 3.0
channel_w = channel_w / channel_w.mean(dim=-1, keepdim=True)
surf_loss = (abs_err * channel_w * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
```

Run with: `--wandb_name "norman/tandem-ch" --wandb_group tandem-ch --agent norman`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---
## Results

**W&B run:** `aaw5zum4` | 81 epochs (30.2 min, wall-clock timeout) | Peak memory: 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol |
|---|---|---|---|---|---|
| val_in_dist | 1.728 | 0.314 | 0.208 | **22.58** | Ux=1.60, Uy=0.58, p=32.47 |
| val_ood_cond | 2.114 | 0.287 | 0.200 | **20.71** | Ux=1.35, Uy=0.49, p=22.49 |
| val_ood_re | nan | 0.303 | 0.207 | **30.93** | Ux=1.27, Uy=0.50, p=52.88 |
| val_tandem_transfer | 3.659 | 0.709 | 0.382 | **48.38** | Ux=2.54, Uy=1.17, p=51.57 |
| **val/loss (mean)** | **2.5002** | | | | |

**vs baseline (val/loss 2.4780):**
| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 24.19 | 22.58 | **-6.7% ✓** |
| val_ood_cond | 21.87 | 20.71 | **-5.3% ✓** |
| val_ood_re | 31.91 | 30.93 | **-3.1% ✓** |
| val_tandem_transfer | 46.41 | 48.38 | **+4.3% ✗** |
| val/loss | 2.4780 | 2.5002 | **+0.9%** |

### What happened

Negative result on the primary target. The channel weighting improved surface pressure on 3 of 4 splits (in-dist −6.7%, ood_cond −5.3%, ood_re −3.1%), but tandem_transfer — the split this was designed to help — got worse (+4.3%). Overall val/loss regressed slightly (+0.9%).

The normalization `channel_w / channel_w.mean()` scales the weights to `[3/5, 3/5, 9/5]` for tandem. This slightly downweights Ux and Uy for tandem, and the model may be adapting to the loss signal in a way that hurts tandem velocity prediction, which in turn cascades to worse pressure via the physics coupling. Alternatively, the existing `is_tandem` detection (threshold 0.5 on normalized feature) may interact with the new 0.01 threshold in subtle ways — though in practice both should correctly classify samples.

The improvements on non-tandem splits are likely noise from a marginally different random trajectory rather than a genuine effect of the channel weighting.

### Suggested follow-ups
- Try a lighter pressure boost (e.g. `[1, 1, 1.5]` or `[1, 1, 2]`) — 3× may be too aggressive
- Apply the boost only in the later training stages (after surf_weight ramp completes, epoch >50) when the model is already fitting reasonably
- Instead of per-sample weighting, try a separate tandem-specific loss term added as a regularizer, rather than modifying the existing surf_loss normalization