### PR TITLE
Checkpoint by mean surface pressure MAE (align metric with goal)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -530,6 +530,7 @@ with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
 best_val = float("inf")
+best_surf_p = float("inf")
 best_metrics = {}
 global_step = 0
 train_start = time.time()
@@ -752,8 +753,15 @@ for epoch in range(MAX_EPOCHS):
     else:
         peak_mem_gb = 0.0
 
+    # Checkpoint by mean surface pressure MAE across all splits
+    surf_p_vals = [val_metrics_per_split[s][f"{s}/mae_surf_p"]
+                   for s in VAL_SPLIT_NAMES
+                   if s in val_metrics_per_split]
+    mean_surf_p = sum(surf_p_vals) / max(len(surf_p_vals), 1)
+
     tag = ""
-    if mean_val_loss < best_val:
+    if mean_surf_p < best_surf_p:
+        best_surf_p = mean_surf_p
         best_val = mean_val_loss
         best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss}
         for split_metrics in val_metrics_per_split.values():


### PR DESCRIPTION
## Hypothesis
Checkpointing by val/loss doesn't perfectly target surface pressure. Selecting checkpoints by mean surface pressure MAE across all 4 splits aligns selection with the engineering goal.

## Instructions
Track `best_surf_p = float('inf')`, compute `mean_surf_p` from per-split `mae_surf_p`, and save checkpoint when `mean_surf_p` improves (instead of val/loss).

Run with: `--wandb_name "haku/ckpt-surfp" --wandb_group ckpt-surfp --agent haku`

## Baseline
- val/loss: **2.4780**
- val_in_dist/mae_surf_p: 24.19 | val_ood_cond/mae_surf_p: 21.87
- val_ood_re/mae_surf_p: 31.91 | val_tandem_transfer/mae_surf_p: 46.41

---

## Results

**W&B run ID:** `tfmg2g88`  
**Best epoch:** 77 / 77 (30.1 min wall-clock timeout)  
**Peak GPU memory:** 8.8 GB (no change)

### Metrics at best checkpoint (epoch 77)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.7576 | 0.315 | 0.194 | 25.0 | 1.575 | 0.566 | 32.8 |
| val_tandem_transfer | 3.5523 | 0.681 | 0.366 | 46.1 | 2.496 | 1.159 | 49.7 |
| val_ood_cond | 2.1873 | 0.288 | 0.194 | 21.7 | 1.319 | 0.497 | 22.9 |
| val_ood_re | NaN* | 0.301 | 0.210 | 31.8 | 1.263 | 0.517 | 53.7 |
| **combined val/loss** | **2.4991** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.4780 → This run: 2.4991 — slightly worse (+0.021)**

Surface pressure MAE vs baseline:
- val_in_dist: 25.0 vs 24.19 (+0.8, slightly worse)
- val_ood_cond: 21.7 vs 21.87 (-0.17, slightly better)
- val_tandem_transfer: 46.1 vs 46.41 (-0.31, slightly better)
- val_ood_re: 31.8 vs 31.91 (-0.11, slightly better)
- **mean surf_p: 31.15 vs 31.10 — essentially identical (+0.05)**

### What happened

The checkpoint selection criterion change produces results that are essentially identical to the baseline. The combined val/loss and mean surface pressure MAE differ by less than 1%. This is expected: `val/loss` is a weighted sum of surface and volume MAEs (with surf_weight 5–30 over training), and this already highly correlates with surface accuracy.

The slight difference in final metrics comes from selecting epoch 77 (by surf_p criterion) instead of whatever epoch the baseline selected by val/loss. Both criteria essentially track the same quantity — as surface MAE improves, val/loss also improves, so the checkpoint candidates are largely the same.

One subtlety: at epoch 77, the val_ood_cond/loss (2.19) is higher than what a pure val/loss criterion might prefer, but the surf_p for that split (21.7) is lower. This is likely why 3 out of 4 splits show slightly better surf_p, while the val/loss is slightly higher.

### Suggested follow-ups

- This change is nearly cost-free and shifts selection toward a physically meaningful metric. Even without improvement, it avoids edge cases where val/loss improvement is driven by volume MAE reduction without surface improvement.
- Consider weighted mean_surf_p that gives extra weight to val_in_dist and val_ood_cond (most reliable splits), or exclude val_ood_re (noisy from the NaN vol_loss).
