### PR TITLE
Tandem-inclusive per-sample norm with per-channel clamp [0.3,0.3,1.0]

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -566,16 +566,18 @@ for epoch in range(MAX_EPOCHS):
         if model.training:
             y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
 
-        # Per-sample std normalization: skip tandem samples (gap feature index 21)
+        # Per-sample std normalization: all samples with per-type channel clamps
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
+        channel_clamps_single = torch.tensor([0.1, 0.1, 0.5], device=device)
+        channel_clamps_tandem = torch.tensor([0.3, 0.3, 1.0], device=device)
         sample_stds = torch.ones(B, 1, 3, device=device)
         if model.training:
             for b in range(B):
-                if not is_tandem[b]:
-                    valid = mask[b]
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=0.1)
+                clamps = channel_clamps_tandem if is_tandem[b] else channel_clamps_single
+                valid = mask[b]
+                sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=clamps)
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
@@ -667,15 +669,17 @@ for epoch in range(MAX_EPOCHS):
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
-                # Per-sample std normalization: skip tandem samples
+                # Per-sample std normalization: all samples with per-type channel clamps
                 raw_gap = x[:, 0, 21]
                 is_tandem = raw_gap.abs() > 0.5
                 B = y_norm.shape[0]
+                channel_clamps_single = torch.tensor([0.1, 0.1, 0.5], device=device)
+                channel_clamps_tandem = torch.tensor([0.3, 0.3, 1.0], device=device)
                 sample_stds = torch.ones(B, 1, 3, device=device)
                 for b in range(B):
-                    if not is_tandem[b]:
-                        valid = mask[b]
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=0.1)
+                    clamps = channel_clamps_tandem if is_tandem[b] else channel_clamps_single
+                    valid = mask[b]
+                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=clamps)
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
Include tandem samples in per-sample normalization with higher per-channel clamps [0.3, 0.3, 1.0] (vs [0.1, 0.1, 0.5] for single-foil). PR #615 showed best-ever surface metrics (ood_p=20.07) but regressed val/loss due to uniform clamp. Different clamps per foil-type should capture gains without regression.

## Instructions
In `structured_split/structured_train.py`, modify the per-sample normalization block:
1. Define two sets of clamps:
```python
channel_clamps_single = torch.tensor([0.1, 0.1, 0.5], device=device)
channel_clamps_tandem = torch.tensor([0.3, 0.3, 1.0], device=device)
```
2. Remove the `if not is_tandem[b]: continue` check — normalize ALL samples
3. Select clamps based on tandem status: `clamps = channel_clamps_tandem if is_tandem[b] else channel_clamps_single`

Run with: `--wandb_name "frieren/tandem-clamp" --wandb_group tandem-norm-clamp --agent frieren`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** `zz5nlama`  
**Epochs:** 78/100 (timeout at 30 min)  
**Peak memory:** ~8.8 GB

| Metric | Baseline | Tandem Clamp | Δ |
|--------|----------|--------------|---|
| val/loss | 2.4296 | 2.4451 | +0.6% ❌ |
| val_in_dist/mae_surf_p | 23.23 | 23.25 | +0.1% ≈ |
| val_ood_cond/mae_surf_p | 22.57 | 23.15 | +2.6% ❌ |
| val_ood_re/mae_surf_p | 32.46 | 32.52 | +0.2% ≈ |
| val_tandem_transfer/mae_surf_p | 45.72 | 47.20 | +3.2% ❌ |

**Full surface/volume MAE at best epoch (epoch 78):**

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.300 | 0.193 | 23.25 | 1.549 | 0.535 | 31.81 |
| val_ood_cond | 0.261 | 0.191 | 23.15 | 1.238 | 0.465 | 23.65 |
| val_ood_re | 0.277 | 0.209 | 32.52 | 1.218 | 0.492 | 54.03 |
| val_tandem_transfer | 0.691 | 0.366 | 47.20 | 2.485 | 1.159 | 51.01 |

**Note:** `val_ood_re/loss` was NaN across all epochs (vol_loss diverges for this OOD split). Best epoch selected by val/loss over 3 finite splits.

**What happened:**  
The change slightly worsens most metrics across the board. Two factors likely caused this:

1. **Changed single-foil pressure clamp**: The `channel_clamps_single = [0.1, 0.1, 0.5]` raises the pressure channel minimum clamp from 0.1 to 0.5 for single-foil samples. This tighter normalization (less variance allowed in the pressure loss signal) likely degraded ood_cond performance (+2.6% worse), which consists entirely of single-foil samples.

2. **Tandem normalization added noise**: Including tandem samples in per-sample normalization (even with higher clamps) may be introducing extra variance in the loss computation that the model struggles to learn from, since tandem flow fields have more complex structure than single-foil.

The tandem_transfer split actually got *worse* (+3.2%), opposite to the hypothesis. This suggests that the loss smoothing provided by the higher tandem clamps doesn't compensate for the disruption to the existing training dynamics.

**Suggested follow-ups:**
- Keep the single-foil pressure clamp at 0.1 (don't raise it) and only apply the tandem-specific normalization: `channel_clamps_single = [0.1, 0.1, 0.1]` (original), `channel_clamps_tandem = [0.3, 0.3, 1.0]`.
- Rather than normalizing tandem samples by their per-sample std, try instead increasing the tandem sample weight in the loss (tandem-specific surf_weight multiplier) to give the model stronger signal on tandem surface pressure.