### PR TITLE
Per-head learnable attn_scale (4 independent scale params)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -117,7 +117,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
         )
-        self.attn_scale = nn.Parameter(torch.tensor(10.0))
+        self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
     def forward(self, x):
         bsz, num_points, _ = x.shape
@@ -485,8 +485,8 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}


### PR DESCRIPTION
## Hypothesis
Replace single shared attn_scale with per-head versions. Different heads capture different physics and may benefit from different attention sharpness.

## Instructions
In `structured_split/structured_train.py`, in `Physics_Attention_Irregular_Mesh.__init__`:
- Replace: `self.attn_scale = nn.Parameter(torch.tensor(10.0))`
- With: `self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)`

Broadcasting in forward pass should work without changes. Ensure attn_scale stays in attn param group for differential LR.

Run with: `--wandb_name "fern/perhead-scale" --wandb_group perhead-scale --agent fern`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**Run ID**: zvtl8vqx  
**Epochs**: 81 (wall-clock limit ~30 min)  
**Peak memory**: ~8.8 GB  

**Implementation note**: Changed `self.attn_scale` from shape `()` (scalar) to `[1, heads, 1, 1]`. Also had to add `attn_scale` to BOTH the `attn_params` filter (for 0.5x LR) AND the `other_params` exclusion filter to avoid duplicate param groups error.

### Val/loss
| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.4296 | **2.411** | -0.8% (slight improvement) |

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|-------|---------------------|---------------------|-------|
| val_in_dist | 23.23 | **22.32** | **-3.9% (better)** |
| val_ood_cond | 22.57 | 23.09 | +2.3% (slightly worse) |
| val_ood_re | 32.46 | 32.21 | -0.8% (flat) |
| val_tandem_transfer | 45.72 | **44.88** | **-1.8% (better)** |

3 of 4 splits improved vs baseline.

### Full Surface MAE
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|-------------|-------------|------------|
| val_in_dist | 0.278 | 0.185 | 22.32 |
| val_ood_cond | 0.269 | 0.194 | 23.09 |
| val_ood_re | 0.279 | 0.206 | 32.21 |
| val_tandem_transfer | 0.643 | 0.353 | 44.88 |

### Full Volume MAE
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.680 | 0.595 | 33.82 |
| val_ood_cond | 1.421 | 0.521 | 26.94 |
| val_ood_re | 1.336 | 0.533 | 55.72 |
| val_tandem_transfer | 2.572 | 1.211 | 52.49 |

Note: val_ood_re/loss = nan (pre-existing issue).

### What happened

Mostly positive result. The per-head `attn_scale` change (scalar → [1, heads, 1, 1]) improved val/loss slightly (-0.8%) and improved 3 of 4 surface pressure splits vs the baseline. The in_dist improvement (-3.9%) is solid. The ood_cond slight regression (+2.3%) may be noise or reflect that the flexible per-head scale introduces slightly more variance in attention patterns that helps some splits but not others.

The change is minimal (one param → 4 params, initialized identically) but allows the model to learn different attention sharpness per head, which is physically motivated — different heads may specialize for boundary layer, wake, or pressure recovery regions.

### Suggested follow-ups

- Per-head scale appeared to help in_dist and tandem; could combine with per-channel clamp adjustments or channel weighting to see if the gains compound
- Investigate what values the 4 per-head scale parameters converge to — if they diverge significantly, it confirms heads are specializing