### PR TITLE
Progressive tandem boost (1.0→2.0 ramp over 50 epochs)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -608,7 +608,8 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_factor = 1.0 + 1.0 * min(epoch / 50, 1.0)
+        tandem_boost = torch.where(is_tandem, tandem_factor, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Ramp tandem boost from 1.0 to 2.0 over 50 epochs instead of fixed 1.5x. Early epochs learn general flow; later epochs increasingly focus on tandem accuracy. Higher final boost (2.0 vs 1.5) may further improve tandem.

## Instructions
In \`structured_split/structured_train.py\`, replace the fixed tandem boost:
\`\`\`python
# Replace: tandem_boost = torch.where(is_tandem, 1.5, 1.0)
tandem_factor = 1.0 + 1.0 * min(epoch / 50, 1.0)
tandem_boost = torch.where(is_tandem, tandem_factor, 1.0)
\`\`\`

Run with: \`--wandb_name "tanjiro/prog-tandem" --wandb_group prog-tandem --agent tanjiro\`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23 | val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46 | val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**Does not beat baseline val/loss**, but significantly improves tandem surface pressure (-1.96 Pa). Mixed results on other splits.

- **W&B run**: \`f5vw0pcg\` (tanjiro/prog-tandem, group: prog-tandem)
- **Epochs**: 81 of 100 (30.3 min wall clock)
- **Best epoch**: 81
- **Peak memory**: 8.8 GB

### Validation losses (best checkpoint, epoch 81)

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6634 | 0.276 | 0.178 | 22.73 | 1.738 | 0.638 | 35.43 |
| val_ood_cond | 2.1801 | 0.309 | 0.195 | 23.42 | 1.485 | 0.547 | 27.53 |
| val_ood_re | nan | 0.307 | 0.211 | 32.45 | 1.371 | 0.553 | 56.09 |
| val_tandem_transfer | 3.4824 | 0.671 | 0.348 | 43.76 | 2.670 | 1.231 | 51.75 |
| **val/loss** | **2.4420** | | | | | | |

### Comparison vs baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.4296 | 2.4420 | +0.012 (slightly worse) |
| mae_surf_p in_dist | 23.23 | **22.73** | **-0.50 (improvement)** |
| mae_surf_p ood_cond | 22.57 | 23.42 | +0.85 (regression) |
| mae_surf_p ood_re | 32.46 | **32.45** | -0.01 (same) |
| mae_surf_p tandem | 45.72 | **43.76** | **-1.96 (large improvement)** |
| mean_surf_p | 31.00 | **30.59** | **-0.41 (improvement)** |

### What happened

The progressive ramp (1.0→2.0) successfully improved tandem transfer (-1.96 Pa) compared to the fixed 1.5x baseline. This validates the hypothesis that ramping into higher tandem boost helps — early epochs learn general flow before increasingly focusing on tandem geometry. The in_dist split also slightly improved (-0.50).

However, val/loss is slightly worse (2.4420 vs 2.4296) because ood_cond regressed (+0.85). This may be because the higher final boost (2.0 vs 1.5) over-emphasizes tandem in later epochs, slightly starving ood_cond gradient.

The mean surface pressure MAE improved slightly (30.59 vs 31.00), suggesting the progression approach is directionally correct even if not an overall win by the val/loss metric.

### Suggested follow-ups

- Try a final boost of 1.75 instead of 2.0 to find a better balance between tandem and ood_cond.
- Try a shorter ramp (e.g., 30 epochs instead of 50) to establish the higher boost earlier while LR is still high.