### PR TITLE
Warmup-Stable-Decay LR schedule (hold peak LR for 50 epochs)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -492,10 +492,11 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
+warmup_sched = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
+stable_sched = torch.optim.lr_scheduler.ConstantLR(base_opt, factor=1.0, total_iters=50)
+decay_sched = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=1.0, end_factor=1e-4/cfg.lr, total_iters=45)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_sched, stable_sched, decay_sched], milestones=[5, 55]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Cosine annealing starts decaying LR immediately after warmup, wasting productive learning time. WSD holds peak LR for 50 epochs (62% of training), then linearly decays. Used in modern LLM training (Llama, GPT-4).

## Instructions
In `structured_split/structured_train.py`, replace the cosine scheduler with a WSD schedule:
```python
from torch.optim.lr_scheduler import SequentialLR, LinearLR, ConstantLR
warmup_sched = LinearLR(base_opt, start_factor=0.1, total_iters=5)
stable_sched = ConstantLR(base_opt, factor=1.0, total_iters=50)
decay_sched = LinearLR(base_opt, start_factor=1.0, end_factor=1e-4/cfg.lr, total_iters=45)
scheduler = SequentialLR(base_opt, schedulers=[warmup_sched, stable_sched, decay_sched], milestones=[5, 55])
```
Remove the old CosineAnnealingLR scheduler.

Run with: `--wandb_name "nezuko/wsd" --wandb_group wsd-sched --agent nezuko`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** `6hiy84ja` (nezuko/wsd)
**Best epoch:** 80 / ~80 (hit 30-min timeout)

### Metrics vs baseline

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| overall | val/loss | 2.4296 | 2.7729 | +0.34 |
| val_in_dist | mae_surf_p | 23.23 | 31.55 | +8.32 |
| val_ood_cond | mae_surf_p | 22.57 | 27.76 | +5.19 |
| val_ood_re | mae_surf_p | 32.46 | 35.83 | +3.37 |
| val_tandem_transfer | mae_surf_p | 45.72 | 48.75 | +3.03 |

Detailed best-epoch metrics:
- **val_in_dist**: loss=2.089, mae_surf_Ux=0.340, mae_surf_Uy=0.224, mae_surf_p=31.55
- **val_ood_cond**: loss=2.373, mae_surf_Ux=0.301, mae_surf_Uy=0.206, mae_surf_p=27.76
- **val_ood_re**: mae_surf_p=35.83 (loss=NaN, pre-existing)
- **val_tandem_transfer**: loss=3.857, mae_surf_Ux=0.718, mae_surf_Uy=0.386, mae_surf_p=48.75

### What happened

**Significant regression across all splits.** WSD is worse than cosine annealing by 3-8 pressure units on every split.

The root cause is the 30-minute budget constraint. WSD is designed to let the model train aggressively at peak LR for a long stable phase, then converge rapidly during the decay. However:

- With the cosine schedule, by epoch 80 the LR has decayed to ~1.9e-4 (94% of the way to eta_min), so the model is in a well-converged regime.
- With WSD, at epoch 80 (25/45 through the decay phase), LR is still ~5e-4 — 2.5x higher than cosine. The model is still in "coarse optimization" mode and hasn't converged.

WSD requires the full 100-epoch budget to realize its benefits. The 50-epoch stable phase front-loads the high-LR exploration, and the 45-epoch decay is needed for final convergence. Hitting the timeout at epoch 80 means only 55% of the decay phase completed, leaving the model underconverged compared to cosine.

The cosine schedule's continuous annealing is a better fit for the 30-minute/~80-epoch budget because it's always gradually reducing the LR, making each epoch progressively more convergent.

### Suggested follow-ups
- WSD with shorter stable phase: e.g., stable=20 epochs, decay=75 epochs — this would make WSD converge faster and be more timeout-robust
- WSD may show improvement if the budget is increased to 120+ epochs, where the full decay phase can complete