### PR TITLE
Attention LR 0.25x (7.5e-4 vs 3e-3 base)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -488,7 +488,7 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
+    {'params': attn_params, 'lr': cfg.lr * 0.25},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)


### PR DESCRIPTION
## Hypothesis
Differential LR at 0.5x was a round-18 win. Cosine attention is scale-invariant and may benefit from even more stability at 0.25x. Student in PR #622 suggested trying 0.25x.

## Instructions
In `structured_split/structured_train.py`, change the attention LR multiplier:
- Find: `{'params': attn_params, 'lr': cfg.lr * 0.5}`
- Replace: `{'params': attn_params, 'lr': cfg.lr * 0.25}`

Run with: `--wandb_name "alphonse/attn-025" --wandb_group attn-lr-025 --agent alphonse`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run ID:** webf4mgf
**Epochs completed:** 77/100 (30-min timeout; ~23.0s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline (0.5x) | This run (0.25x, ep77) | Delta |
|---|---|---|---|
| val/loss | 2.4296 | **2.5332** | +4.3% worse |
| val_in_dist/mae_surf_p | 23.23 | **24.10** | +3.7% worse |
| val_ood_cond/mae_surf_p | 22.57 | **23.60** | +4.6% worse |
| val_ood_re/mae_surf_p | 32.46 | **33.52** | +3.3% worse |
| val_tandem_transfer/mae_surf_p | 45.72 | **45.44** | -0.6% (noise) |

Additional val_in_dist at best epoch:
- mae_surf_Ux: 0.325 | mae_surf_Uy: 0.192
- mae_vol_Ux: 1.699 | mae_vol_Uy: 0.612 | mae_vol_p: 34.88

### What happened

**This did not work.** Reducing attention LR from 0.5x to 0.25x makes all metrics slightly worse across every split.

The 0.5x multiplier was optimal — halving it again to 0.25x over-constrains the attention module. At 7.5e-4 effective LR for attention parameters, the model converges too slowly in the 30-minute window: the best val/loss is at the very last epoch (still improving), but from a worse learning curve than the 0.5x baseline.

The hypothesis that "more LR stability helps scale-invariant cosine attention" doesn't hold here. The attention module at 0.5x LR already found a good trade-off; pushing further doesn't help.

### Suggested follow-ups
- 0.5x appears to be the sweet spot for differential LR on this task — further tuning in either direction seems unlikely to help
- The consistent improvement from 0.5x attn LR (baseline) vs uniform LR suggests the attention parameters benefit from slightly slower learning; but the benefit saturates before 0.25x