### PR TITLE
Pressure-focused noise (0.005 for p, 0.01 for vel)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -567,7 +567,8 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
Per-channel noise: halve noise on pressure channel (0.005) while keeping velocity at 0.01. Pressure is the key metric and has different characteristics. Per-channel treatment worked well for clamps.

## Instructions
In `structured_split/structured_train.py`, replace the noise line:
```python
# Replace: y_norm = y_norm + cfg.target_noise * torch.randn_like(y_norm)
noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
```

Run with: `--wandb_name "edward/p-noise" --wandb_group pressure-noise --agent edward`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** wbd0j4rp | **Epochs:** 80 (30 min wall-clock limit) | **Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 2.3944 | 0.285 | 0.179 | **22.55** | 1.711 | 0.592 | 33.21 |
| ood_cond | — | 0.281 | 0.193 | **22.50** | 1.413 | 0.527 | 24.96 |
| ood_re | NaN | 0.293 | 0.205 | **32.27** | 1.350 | 0.538 | 55.37 |
| tandem | — | 0.646 | 0.354 | **43.91** | 2.608 | 1.200 | 51.35 |

**vs. baseline (val/loss 2.4296, mae_surf_p: in_dist 23.23 / ood_cond 22.57 / ood_re 32.46 / tan 45.72):**
- val/loss: 2.3944 vs 2.4296 (**-1.4%** — better)
- mae_surf_p in_dist: 22.55 vs 23.23 (**-2.9%** — better)
- mae_surf_p ood_cond: 22.50 vs 22.57 (**-0.3%** — marginally better)
- mae_surf_p ood_re: 32.27 vs 32.46 (**-0.6%** — slightly better)
- mae_surf_p tandem: 43.91 vs 45.72 (**-4.0%** — better)

### What happened

Reducing pressure noise from 0.01 to 0.005 while keeping velocity noise at 0.01 improved all splits. The largest gain was on tandem transfer (-4.0%), with in_dist also meaningfully improved (-2.9%). The hypothesis holds: pressure has different scale and distribution characteristics than velocity components, and the current uniform noise level was degrading pressure predictions more than velocity ones. Halving pressure noise gives the model cleaner pressure supervision while still maintaining regularization via the velocity noise.

The consistent improvement across all splits (including ood_re despite the NaN vol_loss issue) suggests this is a genuine signal, not overfitting to in-distribution data.

### Suggested follow-ups

1. **Further reduce pressure noise (0.001 or 0)**: The improvement suggests even less noise might be better — though zero noise could lead to overfitting.
2. **Per-channel noise as a function of channel std**: Adaptive noise scaling proportional to the per-channel std of y_norm rather than fixed values.
3. **Stack with cosine attention**: Both cosine attention and pressure noise reduction showed positive results — combining them could compound gains.