### PR TITLE
Cosine similarity in slice assignment (extend scale-invariance)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -110,6 +110,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.in_project_fx = nn.Linear(dim, inner_dim)
         self.in_project_slice = nn.Linear(dim_head, slice_num)
         torch.nn.init.orthogonal_(self.in_project_slice.weight)
+        self.slice_scale = nn.Parameter(torch.tensor(5.0))
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
@@ -134,7 +135,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
+        x_mid_norm = F.normalize(x_mid, dim=-1)
+        slice_w = self.in_project_slice.weight
+        slice_w_norm = F.normalize(slice_w, dim=-1)
+        slice_logits = F.linear(x_mid_norm, slice_w_norm, self.in_project_slice.bias) * self.slice_scale
+        slice_weights = self.softmax(slice_logits / self.temperature)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -485,8 +490,8 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'slice_scale'])]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'slice_scale'])]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}


### PR DESCRIPTION
## Hypothesis
Cosine attention (Q-K) was a round-18 breakthrough by removing magnitude bias. The same bias exists in slice assignment. Normalizing the slice projection makes assignment purely direction-based.

## Instructions
In `structured_split/structured_train.py`, in `Physics_Attention_Irregular_Mesh`:
1. Add in __init__: `self.slice_scale = nn.Parameter(torch.tensor(5.0))`
2. In forward, replace the slice weight computation:
```python
x_mid_norm = F.normalize(x_mid, dim=-1)
slice_w = self.in_project_slice.weight
slice_w_norm = F.normalize(slice_w, dim=-1)
slice_logits = F.linear(x_mid_norm, slice_w_norm, self.in_project_slice.bias) * self.slice_scale
slice_weights = self.softmax(slice_logits / self.temperature)
```
Add `slice_scale` to the attn param group for differential LR.

Run with: `--wandb_name "thorfinn/cos-slice" --wandb_group cosine-slice --agent thorfinn`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** `7n9sgc9t` (thorfinn/cos-slice, group: cosine-slice)
**Epochs:** 68 (30-min wall clock limit)

| Metric | Baseline | This run (best ep 68) | Δ |
|---|---|---|---|
| val/loss | 2.4296 | **2.6610** | +0.231 ↑ worse |
| val_in_dist/loss | — | 2.0249 | — |
| val_ood_cond/loss | — | 2.2468 | — |
| val_tandem/loss | — | 3.7112 | — |
| in_dist surf_p (Pa) | 23.23 | 28.11 | +4.88 ↑ worse |
| ood_cond surf_p (Pa) | 22.57 | 25.59 | +3.02 ↑ worse |
| ood_re surf_p (Pa) | 32.46 | 35.24 | +2.78 ↑ worse |
| tandem surf_p (Pa) | 45.72 | 47.04 | +1.32 ↑ worse |

Full surface MAE at best epoch:
- val_in_dist: Ux=0.379, Uy=0.211, p=28.11 Pa
- val_ood_cond: Ux=0.282, Uy=0.211, p=25.59 Pa
- val_ood_re: Ux=0.301, Uy=0.219, p=35.24 Pa
- val_tandem: Ux=0.697, Uy=0.375, p=47.04 Pa

**Peak memory:** ~9.5 GB (unchanged)

### What happened

**Negative result.** Cosine normalization in slice assignment made things substantially worse across all 4 splits. val/loss degraded from 2.4296 to 2.6610 (+9.5%), and surface pressure MAE worsened by +4.88 Pa in-distribution (+21%).

The key difference from the round-18 cosine attention success: cosine attention normalized *token-to-token* Q-K dot products where magnitude truly was noise (scale-invariant features should compare only directions). Slice assignment is different — it maps mesh points to physics groups (slices). Here, magnitude *carries information*: how strongly a mesh node belongs to a physics regime is not just a matter of direction. Normalizing  removes the activation magnitude that distinguishes, e.g., high-velocity from low-velocity regions.

The  learnable parameter was intended to compensate for this, but the per-instance magnitude information is gone after normalization — a global scale cannot recover it.

Also notable: the best epoch is 68 vs 73+ in the baseline, suggesting the normalization makes the loss landscape harder to optimize.

### Suggested follow-ups
- If normalization bias reduction is desired in slice assignment, try layer normalization on  instead of L2 normalization — this preserves relative magnitudes within a sample while removing cross-sample scale drift
- Per-head learnable scaling (instead of global scalar) might better compensate for the loss of magnitude information