### PR TITLE
Dual-phase training (vol-first then surf-heavy at epoch 40)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -545,10 +545,13 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
-    surf_weight = sw_start + (sw_end - sw_start) * progress
+    # Dual-phase surface weight: vol-first (2→10) for ep 0-40, surf-heavy (20→40) for ep 40+
+    if epoch < 40:
+        surf_weight = 2.0 + (10.0 - 2.0) * min(epoch / 40, 1.0)
+        tandem_boost_factor = 1.0
+    else:
+        surf_weight = 20.0 + (40.0 - 20.0) * min((epoch - 40) / 40, 1.0)
+        tandem_boost_factor = 2.0
 
     # --- Train ---
     model.train()
@@ -608,7 +611,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_boost = torch.where(is_tandem, tandem_boost_factor, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Split training into vol-focused and surf-focused phases. Phase 1 (ep 0-40): surf_weight 2→10, no tandem boost. Phase 2 (ep 40+): surf_weight 20→40, tandem boost 2.0. Lets model learn global flow first.

## Instructions
In `structured_split/structured_train.py`, replace the surf_weight computation:
```python
if epoch < 40:
    surf_weight = 2.0 + (10.0 - 2.0) * min(epoch / 40, 1.0)
    tandem_boost_factor = 1.0
else:
    surf_weight = 20.0 + (40.0 - 20.0) * min((epoch - 40) / 40, 1.0)
    tandem_boost_factor = 2.0
tandem_boost = torch.where(is_tandem, tandem_boost_factor, 1.0)
```
Remove the existing surf_weight ramp and tandem boost code.

Run with: `--wandb_name "askeladd/dual-phase" --wandb_group dual-phase --agent askeladd`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** mjxgzsim  
**Epochs completed:** 78/100 (30-min timeout)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.4296 | **2.4628** | +0.033 |
| val_in_dist/mae_surf_p | 23.23 | 23.13 | -0.10 |
| val_ood_cond/mae_surf_p | 22.57 | 23.24 | +0.67 |
| val_ood_re/mae_surf_p | 32.46 | 32.78 | +0.32 |
| val_tandem_transfer/mae_surf_p | 45.72 | **44.82** | -0.90 |

**Volume MAE (val_in_dist):** Ux=1.69, Uy=0.61, p=37.37  
**Surface MAE (val_in_dist):** Ux=0.322, Uy=0.185, p=23.13  
**Peak memory:** ~29 GB (similar to baseline, run duration: 1762s)

### What happened

Dual-phase training did not improve over baseline. val/loss is slightly worse (+0.033), and surface pressure accuracy is mixed — slightly better on in-dist (-0.10) and tandem transfer (-0.90), but worse on ood_cond (+0.67) and ood_re (+0.32). No consistent improvement.

The intuition behind learning "global flow first" is reasonable, but the sudden jump from surf_weight=10 at epoch 39 to surf_weight=20 at epoch 40 (plus activating the 2x tandem boost simultaneously) may be too abrupt. The baseline ramp (5→30 linearly) provides smoother conditioning throughout. The model at epoch 40 likely hasn't fully converged on volume structure yet, so the abrupt surf-heavy pivot disrupts what was learned.

The tandem_boost doubling to 2.0 in phase 2 may also over-weight tandem cases relative to single-foil cases, which slightly helps tandem transfer but hurts ood_cond.

### Suggested follow-ups

- Try a softer transition: rather than jumping at epoch 40, use a sigmoid or longer blend window
- Try decoupling the tandem boost from the phase change — just increase surf_weight without changing tandem boost
- Try starting phase 2 later (e.g., epoch 60) to give more time for vol convergence in phase 1
- Try just surf_weight 2→30 with a plateau rather than the double-ramp structure