### PR TITLE
Gated residual output head (sigmoid gate, bias init +2.0)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -185,12 +185,19 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.output_gate = nn.Sequential(
+                nn.Linear(hidden_dim, out_dim),
+                nn.Sigmoid(),
+            )
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            ln3_fx = self.ln_3(fx)
+            fx_out = self.mlp2(ln3_fx)
+            gate = self.output_gate(ln3_fx)
+            return fx_out * gate
         return fx
 
 
@@ -255,6 +262,10 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
+        # Re-initialize gate bias to +2.0 for near-identity start
+        for block in self.blocks:
+            if block.last_layer:
+                block.output_gate[0].bias.data.fill_(2.0)
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
 


### PR DESCRIPTION
## Hypothesis
Add a learned gate to the output head that can suppress noisy predictions per-channel/per-node. Starts near identity (bias=+2.0). Split heads failed because they break shared representations; gating preserves them while adding adaptive control. Only ~387 extra parameters.

## Instructions
In \`structured_split/structured_train.py\`, in \`TransolverBlock.__init__\`:
\`\`\`python
self.output_gate = nn.Sequential(
    nn.Linear(hidden_dim, out_dim),
    nn.Sigmoid(),
)
# Initialize gate bias to +2.0 for near-identity start
self.output_gate[0].bias.data.fill_(2.0)
\`\`\`

In \`TransolverBlock.forward\`, after computing \`fx = self.mlp2(self.ln_3(fx))\`:
\`\`\`python
gate = self.output_gate(self.ln_3(fx_before_mlp2))  # use pre-mlp2 features
fx = fx * gate
\`\`\`
(Save the \`ln_3(fx)\` output before mlp2 to use for gating)

Note: gate bias is re-set to +2.0 after \`initialize_weights()\` in Transolver to avoid it being zeroed by the weight init.

Run with: \`--wandb_name "violet/gated-out" --wandb_group gated-output --agent violet\`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run**: 8lbrw8ug  
**Best epoch**: 78  
**Peak memory**: 9.1 GB (+0.2 GB vs baseline)  

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.7631 | 0.301 | 0.195 | 24.43 | 1.701 | 0.604 | 34.00 |
| val_tandem_transfer | 3.5158 | 0.669 | 0.358 | 44.55 | 2.620 | 1.198 | 51.81 |
| val_ood_cond | 2.1004 | 0.270 | 0.194 | 23.47 | 1.391 | 0.513 | 25.00 |
| val_ood_re | nan | 0.283 | 0.207 | 32.94 | — | — | — |

**val/loss (mean non-nan)**: 2.4597 vs baseline 2.4296 → **Δ=+0.030 (slightly worse)**

**Surface MAE (p) comparison**:
| Split | Baseline | This run | Δ |
|---|---|---|---|
| val_in_dist | 23.23 | 24.43 | +1.20 ↑ worse |
| val_ood_cond | 22.57 | 23.47 | +0.90 ↑ worse |
| val_ood_re | 32.46 | 32.94 | +0.48 ↑ slightly worse |
| val_tandem_transfer | 45.72 | 44.55 | **-1.17 better** |

### What happened

Gated output head marginally hurts performance. val/loss is 0.030 worse, and surface pressure metrics regress on all splits except tandem_transfer (-1.17 in mae_surf_p). The gate introduces ~387 extra parameters and a small memory overhead (+0.2GB).

The near-identity initialization (sigmoid(2.0) ≈ 0.88 at start) means predictions are slightly suppressed from the beginning. While this helps tandem (which benefits from more regularized prediction), it seems to suppress too aggressively for the other splits where the baseline predictions are already well-calibrated.

The extra layer of computation may also slightly slow convergence within the 30-minute budget, with best epoch at 78 vs ~80 for the baseline.

### Suggested follow-ups
- Try a larger gate bias (e.g. +4.0) to start closer to identity (sigmoid(4.0) ≈ 0.98)
- Apply gate only for tandem samples (where it seems to help) while bypassing for single-foil
- Try gate with a per-node rather than per-channel design to be more selective