### PR TITLE
Layer-normalized slice tokens before Q/K/V projection

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -118,6 +118,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.tensor(10.0))
+        self.slice_token_norm = nn.LayerNorm(self.dim_head)
 
     def forward(self, x):
         bsz, num_points, _ = x.shape
@@ -138,6 +139,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+        slice_token = self.slice_token_norm(slice_token)
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)


### PR DESCRIPTION
## Hypothesis
Slice tokens are weighted averages of features with varying magnitudes. LayerNorm after aggregation ensures consistent statistics before Q/K/V projections, complementing cosine attention. Analogous to pre-norm in transformers but at the physics token level.

## Instructions
In `structured_split/structured_train.py`, in `Physics_Attention_Irregular_Mesh.__init__`:
```python
self.slice_token_norm = nn.LayerNorm(self.dim_head)
```

In the forward pass, after `slice_token = slice_token / (slice_norm + 1e-5)[:, :, :, None]`, add:
```python
slice_token = self.slice_token_norm(slice_token)
```

Run with: `--wandb_name "gilbert/slice-ln" --wandb_group slice-ln --agent gilbert`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** `fktvm7i4` (gilbert/slice-ln)
**Epochs:** 81 (30.2 min wall-clock limit)
**Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.732 | 0.301 | 0.188 | **23.49** | 1.700 | 0.607 | 34.91 |
| val_ood_cond | 2.115 | 0.281 | 0.193 | **24.23** | 1.392 | 0.531 | 26.18 |
| val_ood_re | NaN | 0.286 | 0.208 | 32.41 | 1.317 | 0.539 | 55.78 |
| val_tandem_transfer | 3.534 | 0.682 | 0.358 | **45.19** | 2.575 | 1.230 | 51.98 |
| **val/loss (mean)** | **2.4601** | | | | | | |

**vs. baseline:**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.4296 | 2.4601 | +0.031 (+1.3%) ❌ |
| val_in_dist/mae_surf_p | 23.23 | 23.49 | +0.26 (+1.1%) ❌ |
| val_ood_cond/mae_surf_p | 22.57 | 24.23 | +1.66 (+7.4%) ❌ |
| val_ood_re/mae_surf_p | 32.46 | 32.41 | -0.05 (~same) |
| val_tandem_transfer/mae_surf_p | 45.72 | 45.19 | -0.53 (-1.2%) ✓ |

**What happened:** The hypothesis did not work — slice token LayerNorm hurt performance. Overall val/loss is 1.3% worse and val_ood_cond mae_surf_p regressed by 7.4% (22.57 → 24.23). Only tandem transfer showed a marginal improvement.

The likely reason: the slice token already goes through explicit weighted-average normalization (`slice_token / (slice_norm + 1e-5)`), which already controls the scale. Adding LayerNorm then re-scales and re-centers via learned gamma/beta, potentially discarding useful magnitude information from the aggregation weights. The cosine normalization in Q/K projections already handles scale invariance downstream.

**Suggested follow-ups:**
- Try LayerNorm on x_mid (before projection to slice weights) rather than on the aggregated token
- Try RMSNorm (no bias/centering) instead of LayerNorm — less aggressive normalization
- Investigate why val_ood_cond regressed so much — it may indicate the normalization disrupts generalization to unseen conditions