### PR TITLE
Learnable per-channel output scaling (scale + bias)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -454,6 +454,9 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+output_scale = nn.Parameter(torch.ones(3, device=device))
+output_bias = nn.Parameter(torch.zeros(3, device=device))
+
 n_params = sum(p.numel() for p in model.parameters())
 
 
@@ -486,7 +489,7 @@ class Lookahead:
 
 
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight'])] + [output_scale, output_bias]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
@@ -585,6 +588,7 @@ for epoch in range(MAX_EPOCHS):
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             pred = model({"x": x})["preds"]
         pred = pred.float()
+        pred = pred * output_scale[None, None, :] + output_bias[None, None, :]
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -689,6 +693,7 @@ for epoch in range(MAX_EPOCHS):
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = model({"x": x})["preds"]
                 pred = pred.float()
+                pred = pred * output_scale[None, None, :] + output_bias[None, None, :]
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis
Ux, Uy, and p have very different scales. Learnable per-channel output scaling gives the model a calibration knob without changing learned features. Only 6 extra parameters.

## Instructions
In `structured_split/structured_train.py`, add to the model (after model creation, before optimizer):
```python
output_scale = nn.Parameter(torch.ones(3, device=device))
output_bias = nn.Parameter(torch.zeros(3, device=device))
```
Add these to the optimizer's other_params group.

In the training loop, after `pred = model(x, mask)`, apply:
```python
pred = pred * output_scale[None, None, :] + output_bias[None, None, :]
```
Apply the same in the validation loop.

Run with: `--wandb_name "senku/out-scale" --wandb_group output-scale --agent senku`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** `vu609qsx` — 74 epochs completed (timeout), peak memory 8.8GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.4296 | **2.6115** | +0.182 ↑worse |
| val_in_dist/mae_surf_p | 23.23 | **25.16** | +1.93 ↑worse |
| val_ood_cond/mae_surf_p | 22.57 | **25.90** | +3.33 ↑worse |
| val_ood_re/mae_surf_p | 32.46 | **33.56** | +1.10 ↑worse |
| val_tandem_transfer/mae_surf_p | 45.72 | **46.84** | +1.12 ↑worse |
| val_in_dist/mae_surf_Ux | — | 0.360 | — |
| val_in_dist/mae_surf_Uy | — | 0.189 | — |
| val_in_dist/mae_vol_p | — | 36.02 | — |

**What happened:** Negative result. Adding learnable per-channel output scale and bias (initialised to ones/zeros, so a no-op at init) worsened all metrics. val/loss increased from 2.4296 → 2.6115 (+7.5%), ood_cond surface pressure rose from 22.57 → 25.90 (+14.8%).

The scale/bias parameters are applied before the per-sample normalization division, which means they interact with that normalisation in a way that might confuse learning. Additionally, these 6 parameters create a direct path to shift the output distribution, but the model already has this capability implicitly: the final MLP output layer can learn any affine transform. Explicit per-channel parameters may introduce a redundant degree of freedom that destabilizes early training, particularly since they're applied outside the autocast context (float32) while the model runs in bfloat16.

**Suggested follow-ups:**
- Try zero-initializing output_bias while keeping output_scale=1 (so only the bias is added, and it starts as a pure no-op)
- Try applying the scale/bias inside the model (as a learned final layer), so it participates in the autocast context and gradient flow is more uniform
- Try using a very small LR multiplier (0.1x) for these parameters so they change slowly relative to the rest of the network