### PR TITLE
Epoch-aware progressive noise (0.02→0.0 by epoch 60)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -567,7 +567,9 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            y_norm = y_norm + 0.01 * torch.randn_like(y_norm)
+            noise_level = 0.02 * max(1.0 - epoch / 60, 0.0)
+            if noise_level > 0:
+                y_norm = y_norm + noise_level * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
Fixed 0.01 noise persists through fine-tuning. Anneal from 0.02 (stronger early regularization) to 0.0 (clean target for convergence). Follows same logic as LR annealing: early exploration, late exploitation.

## Instructions
In `structured_split/structured_train.py`, replace the noise line:
```python
# Replace: y_norm = y_norm + cfg.target_noise * torch.randn_like(y_norm)
noise_level = 0.02 * max(1.0 - epoch / 60, 0.0)
if noise_level > 0:
    y_norm = y_norm + noise_level * torch.randn_like(y_norm)
```

Run with: `--wandb_name "emma/noise-anneal" --wandb_group noise-anneal --agent emma`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** h6cijus9 | **Epochs:** ~80 (30-min timeout) | **Epoch time:** 22.4 s | **Peak GPU memory:** 48.7 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.720 | 0.326 | 0.172 | 22.19 | 1.709 | 0.620 | 35.66 |
| val_ood_cond | 2.243 | 0.309 | 0.194 | 25.39 | 1.432 | 0.537 | 27.63 |
| val_ood_re | NaN | 0.323 | 0.203 | 32.77 | 1.344 | 0.543 | 56.18 |
| val_tandem_transfer | 3.537 | 0.685 | 0.355 | 44.18 | 2.649 | 1.218 | 51.97 |
| **combined val/loss** | **2.5002** | | | | | | |

**vs baseline (delta surf_p):**
- val_in_dist: 22.19 vs 23.23 → **-1.04 (improved)**
- val_ood_cond: 25.39 vs 22.57 → **+2.82 (worse)**
- val_ood_re: 32.77 vs 32.46 → **+0.31 (marginally worse)**
- val_tandem_transfer: 44.18 vs 45.72 → **-1.54 (improved)**
- val/loss: 2.5002 vs 2.4296 → **+0.0706 (slightly worse)**

### What happened

Mixed result overall. Noise annealing helps in-distribution and tandem accuracy, but hurts OOD condition generalization.

**Why val_in_dist improved:** The 0.0 noise in epochs 60+ allows the model to fit clean targets more precisely during late fine-tuning. val_in_dist benefits from this clean convergence.

**Why val_tandem improved:** Similar reasoning — tandem is a specialized domain where the model benefits from cleaner signal in late epochs.

**Why val_ood_cond degraded (+2.82):** The fixed 0.01 baseline noise persists through all epochs, acting as an ongoing regularizer that prevents overfitting to training distribution. Removing noise entirely at epoch 60+ reduces this late-phase regularization, allowing the model to overfit more to the training distribution. This hurts OOD generalization.

**Why stronger early noise (0.02 vs 0.01) didn't help OOD more:** The early noise only helps while it's active. After epoch 60, the OOD regularization drops to zero, which dominates.

### Suggested follow-ups

- Try **anneal to 0.005** (not 0.0) — keep a small floor of noise throughout late training to maintain OOD robustness.
- Try **0.01→0.005 anneal** (smaller amplitude, same concept) — milder annealing that doesn't fully remove regularization.
- Try **lower start (0.01, same as baseline) with anneal to 0.0** — current PR tests both increasing AND annealing together; hard to isolate which part helps/hurts.