### PR TITLE
Slice temperature init 0.3 (decouple from attn_scale)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.3)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
The model now has TWO sharpness controls: temperature (slice assignment) and attn_scale (inter-cluster attention). Lowering temperature init to 0.3 (from 0.5) creates sharper slice assignment while keeping attn_scale at 10.0. Gentle init change that still allows learning.

## Instructions
In `structured_split/structured_train.py`, in `Physics_Attention_Irregular_Mesh.__init__`:
- Change temperature initialization from 0.5 to 0.3:
```python
# Replace: self.temperature = nn.Parameter(torch.ones([1, self.heads, 1, 1]) * 0.5)
self.temperature = nn.Parameter(torch.ones([1, self.heads, 1, 1]) * 0.3)
```
Also ensure temperature is in the attn param group (lower LR).

Run with: `--wandb_name "norman/temp-03" --wandb_group temp-decouple --agent norman`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** `a85a7qxt` | 80 epochs completed (killed during epoch 81 validation at 30-min timeout) | Peak memory: 8.8 GB

| Split | val/loss (ep80) | mae_surf_p | mae_vol |
|---|---|---|---|
| val_in_dist | 1.699 | **22.78** | Ux=1.73, Uy=0.61, p=35.21 |
| val_ood_cond | 2.136 | **24.10** | Ux=1.41, Uy=0.54, p=25.97 |
| val_ood_re | nan | **32.39** | Ux=1.33, Uy=0.53, p=55.27 |
| val_tandem_transfer | 3.545 | **45.75** | Ux=2.64, Uy=1.22, p=52.00 |
| **val/loss (mean, ep80)** | **2.4602** | | |

_Note: Run killed during epoch 81 validation (val_in_dist/tandem/ood_cond validated, val_ood_re in progress). val/loss computed from epoch 80 output log; MAE values from W&B summary reflect last logged state (epoch 81 partial for in_dist/tandem/ood_cond, epoch 80 for ood_re)._

**vs baseline (val/loss 2.4296):**
| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 23.23 | 22.78 | **-1.9% ✓** |
| val_ood_cond | 22.57 | 24.10 | **+6.8% ✗** |
| val_ood_re | 32.46 | 32.39 | **-0.2% ≈** |
| val_tandem_transfer | 45.72 | 45.75 | **+0.1% ≈** |
| val/loss | 2.4296 | 2.4602 | **+1.3%** |

### What happened

Negative result. val/loss is 1.3% worse than baseline, and the surface pressure metric is mixed: ood_cond notably regressed (+6.8%), tandem_transfer barely moved (+0.1%), ood_re essentially unchanged, in_dist marginally improved (-1.9%).

The sharper initial slice assignment (temp=0.3 vs 0.5) does not appear to help. The temperature is a learned parameter, so the model can freely adjust it — the init only affects the optimization trajectory. With lower init, the softmax assignments start very peaked (each point strongly committed to one slice), which may prevent the early stages of training from smoothly exploring the representational space. The baseline (0.5) appears to be a better initialization that allows more flexible early-epoch learning.

The temperature is already in the lower-LR attn param group, so the change was correctly scoped.

### Suggested follow-ups
- Try temp init higher than 0.5 (e.g. 0.7 or 1.0) — softer initial assignments might give more training signal early
- Freeze temperature for first N epochs, then unfreeze — decouple the learning schedule from architecture init
- Investigate whether temperature actually converges to different values at the end of training (log it to W&B)