### PR TITLE
Asymmetric coarse loss (3x weight on surface-containing groups)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -628,7 +628,9 @@ for epoch in range(MAX_EPOCHS):
             mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
             coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+            surf_in_group = surf_mask[:, :n_groups * coarse_pool_size].reshape(B, n_groups, coarse_pool_size).any(dim=2)
+            coarse_wt = torch.where(surf_in_group, 3.0, 1.0).unsqueeze(-1)
+            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1) * coarse_wt).sum() / (mask_coarse.unsqueeze(-1) * coarse_wt).sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
         optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis
Coarse loss treats all node groups equally. Upweighting groups containing surface nodes provides multi-scale supervision where it matters most. Coarse loss was confirmed helpful (removing it hurt).

## Instructions
In `structured_split/structured_train.py`, in the coarse loss block, after computing `coarse_err`:
```python
# After: mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
# Add surface detection per group
surf_in_group = surf_mask[:, :n_groups * coarse_pool_size].reshape(B, n_groups, coarse_pool_size).any(dim=2)
coarse_wt = torch.where(surf_in_group, 3.0, 1.0).unsqueeze(-1)
# Modify coarse_loss to use weights
coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1) * coarse_wt).sum() / (mask_coarse.unsqueeze(-1) * coarse_wt).sum().clamp(min=1)
```

Run with: `--wandb_name "chihiro/asym-coarse" --wandb_group asym-coarse --agent chihiro`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run:** `9s3a3zmd`
**Best epoch:** 80 (wall-clock limit: 30.3 min)
**VRAM:** ~8.8 GB (negligible change)

### val/loss

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.4786** | 2.4296 | +0.049 (slightly worse) |

Note: val_ood_re loss = NaN (vol_loss = 18.9B, same as seen in other recent runs — pre-existing issue); val/loss is mean of 3 non-NaN splits.

### Surface MAE (mae_surf_p, Pa)

| Split | This run | Baseline | Δ |
|-------|----------|----------|---|
| val_in_dist | 22.68 | 23.23 | **-0.55 (better)** |
| val_ood_cond | 23.32 | 22.57 | +0.75 (worse) |
| val_ood_re | 32.84 | 32.46 | +0.38 (worse) |
| val_tandem_transfer | 45.63 | 45.72 | **-0.09 (better)** |

### Volume MAE (val_in_dist)

| Channel | MAE |
|---------|-----|
| Ux | 1.73 |
| Uy | 0.61 |
| p | 33.77 |

### What happened

Mixed results. The asymmetric coarse loss helped in_dist surface pressure by -0.55 Pa and made tandem_transfer negligibly better (-0.09 Pa), but ood_cond regressed by +0.75 Pa and ood_re by +0.38 Pa. Overall val/loss is slightly worse (+0.049).

The in_dist improvement makes sense: surface groups get more gradient signal in the coarse loss, which helps for in-distribution samples where surface node positions are consistent with training. The ood_cond regression is harder to explain, but may indicate that the asymmetric weighting fits the surface locations for one regime at the cost of another — coarse pooling groups aren't aligned with physical surfaces, so which nodes fall into surface vs. non-surface groups varies by sample type.

The approach is theoretically sound but the 3x weight may be too aggressive, causing the optimization to over-fit surface groups in the coarse loss at the expense of out-of-distribution generalization.

### Suggested follow-ups
- Try a softer asymmetry (2x instead of 3x) — the regression on ood_cond suggests 3x is too strong
- The pre-existing NaN in val_ood_re (vol_loss = 18.9B) is worth investigating — it likely represents a numerical instability that's been present since earlier experiments and may be silently impacting gradient stability during training