### PR TITLE
Gradient accumulation 2-step with 2x LR compensation

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -330,11 +330,12 @@ class Transolver(nn.Module):
 
 MAX_TIMEOUT = 30.0  # minutes
 MAX_EPOCHS = 100
+accum_steps = 2  # gradient accumulation steps
 
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 6e-3
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -491,7 +492,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=20, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
@@ -555,6 +556,8 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
+    step = 0
+    optimizer.zero_grad()
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
@@ -631,17 +634,28 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
-        optimizer.zero_grad()
+        loss_val = loss.item()
+        loss = loss / accum_steps
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        if (step + 1) % accum_steps == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            global_step += 1
+        step += 1
+        wandb.log({"train/loss": loss_val, "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
+
+    # Flush any remaining accumulated gradients at end of epoch
+    if step % accum_steps != 0:
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        optimizer.step()
+        optimizer.zero_grad()
+        global_step += 1
 
     scheduler.step()
     epoch_vol /= n_batches


### PR DESCRIPTION
## Hypothesis
PR #608 tested grad accum but failed because it halved optimizer steps without compensating. The fix: double the LR (6e-3 base, 1.5e-3 attn) and adjust Lookahead k=20. Effective batch 8 provides more stable gradients.

## Instructions
In `structured_split/structured_train.py`:
1. Set `accum_steps = 2`
2. Double LR: `cfg.lr = 6e-3` (change the default)
3. Attention LR: `cfg.lr * 0.5 = 3e-3` (automatically follows)
4. Adjust Lookahead: `optimizer = Lookahead(base_opt, k=20, alpha=0.8)`
5. In training loop, divide loss by accum_steps before backward:
```python
loss = loss / accum_steps
loss.backward()
if (step + 1) % accum_steps == 0:
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    optimizer.step()
    optimizer.zero_grad()
```

Run with: `--wandb_name "haku/grad-accum-2x" --wandb_group grad-accum-2xlr --agent haku`

## Baseline
- val/loss: **2.4296**
- val_in_dist/mae_surf_p: 23.23
- val_ood_cond/mae_surf_p: 22.57
- val_ood_re/mae_surf_p: 32.46
- val_tandem_transfer/mae_surf_p: 45.72

---

## Results

**W&B run ID:** `lz64eujc`  
**Best epoch:** 77 / 77 (30.2 min wall-clock timeout)  
**Peak GPU memory:** 8.8 GB (no change)

### Metrics at best checkpoint (epoch 77)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.8520 | 0.328 | 0.208 | 24.8 | 1.819 | 0.659 | 38.1 |
| val_tandem_transfer | 3.7370 | 0.708 | 0.380 | 47.9 | 2.723 | 1.277 | 54.5 |
| val_ood_cond | 2.3442 | 0.302 | 0.210 | 26.7 | 1.528 | 0.575 | 28.2 |
| val_ood_re | NaN* | 0.316 | 0.221 | 36.0 | 1.435 | 0.587 | 58.4 |
| **combined val/loss** | **2.6444** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.4296 → This run: 2.6444 — worse (+0.215, ~9%)**

Surface pressure MAE vs baseline:
- val_in_dist: 24.8 vs 23.23 (+1.6, worse)
- val_ood_cond: 26.7 vs 22.57 (+4.1, worse)
- val_ood_re: 36.0 vs 32.46 (+3.5, worse)
- val_tandem_transfer: 47.9 vs 45.72 (+2.2, worse)
- **All splits worse than baseline**

### What happened

The 2x LR compensation failed — all metrics are significantly worse than baseline. The hypothesis that doubling LR would neutralize the effect of halving optimizer steps does not hold for AdamW with warmup/cosine schedule.

Two factors likely contributed:
1. **LR instability**: At LR=6e-3, even with a 5-epoch warmup, the initial updates are too large. AdamW's adaptive step sizes don't scale linearly with LR — the effective learning rate is already tuned to 3e-3, and doubling it causes overshooting in the momentum accumulators.
2. **Lookahead k=20 slows correction**: Increasing k from 10 to 20 means the slow-weight interpolation happens half as often. Combined with the larger LR, the Lookahead correction mechanism doesn't have enough frequency to dampen the instability introduced by the higher LR.

The original grad accum without LR compensation also failed (PR #608). Both approaches — no compensation and 2x compensation — underperform the baseline, suggesting that with batch_size=4 the gradient signal is already good enough, and accumulation offers no benefit regardless of LR adjustment.

### Suggested follow-ups

- Grad accumulation is unlikely to help for this problem at batch_size=4 — skip further exploration.
- The 3e-3 baseline LR appears to be well-calibrated; larger LR values destabilize training.
- If stable training with more gradient diversity is desired, try increasing batch_size from 4 to 8 directly (without accumulation), which may be feasible within 96GB VRAM.
