### PR TITLE
SmoothL1 loss (beta=0.5) on surface nodes

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -610,7 +610,8 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        smooth_err = F.smooth_l1_loss(pred, y_norm, beta=0.5, reduction='none')
+        surf_per_sample = (smooth_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Standard L1 has constant gradient regardless of error size. SmoothL1(beta=0.5) gives quadratic gradients near zero for better fine-tuning of near-converged predictions.

## Instructions
In training loop (~line 610-614), compute surface loss with SmoothL1:
```python
smooth_err = F.smooth_l1_loss(pred_loss, y_norm_scaled, beta=0.5, reduction='none')
surf_per_sample = (smooth_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
```
Keep volume loss as L1.

Run: `--wandb_name "frieren/smooth-l1" --wandb_group smooth-l1-05 --agent frieren`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `k4jntyfn`  
**Epochs:** 76/100 (timeout at 30 min)  
**Peak memory:** ~8.8 GB

| Metric | Baseline | SmoothL1 | Δ |
|--------|----------|----------|---|
| val/loss | 2.4067 | 2.7205 | +13.1% ❌ |
| val_in_dist/mae_surf_p | 22.86 | 29.02 | +27.0% ❌ |
| val_ood_cond/mae_surf_p | 22.93 | 28.25 | +23.2% ❌ |
| val_ood_re/mae_surf_p | 32.68 | 34.98 | +7.0% ❌ |
| val_tandem_transfer/mae_surf_p | 44.16 | 49.33 | +11.7% ❌ |

**Full surface/volume MAE at best epoch (epoch 76):**

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.356 | 0.217 | 29.02 | 1.395 | 0.508 | 29.95 |
| val_ood_cond | 0.374 | 0.230 | 28.25 | 1.195 | 0.439 | 22.39 |
| val_ood_re | 0.343 | 0.232 | 34.98 | 1.163 | 0.466 | 52.66 |
| val_tandem_transfer | 0.731 | 0.394 | 49.33 | 2.332 | 1.079 | 49.22 |

**Note:** `val_ood_re/loss` was NaN across all epochs. Best epoch selected by val/loss over 3 finite splits.

**What happened:**  
SmoothL1 substantially hurts performance — all surface pressure metrics are 7-27% worse. The root cause is a **loss scaling problem**: SmoothL1(beta=0.5) for errors < 0.5 gives `err^2` (quadratic), which is much smaller than L1 for the same error (e.g., error=0.1 → SmoothL1=0.01 vs L1=0.1). Once the model is converging with typical per-sample-normalized errors in the 0.05-0.3 range, the SmoothL1 surf_loss becomes ~10-100x smaller than the L1 vol_loss. This effectively makes `surf_weight=20` act like `surf_weight=~1-2`, dramatically reducing the surface gradient signal relative to volume.

The training log confirms this: `train/surf` drops to ~0.02 with SmoothL1 vs ~0.09 with L1, while `train/vol` stays similar. The surf_weight multiplier on a 0.02-scale loss provides insufficient gradient signal compared to the 0.2-scale vol_loss.

**Suggested follow-ups:**
- If SmoothL1 is desired for its quadratic near-zero behavior, scale up the surf_weight proportionally (e.g., surf_weight=200 instead of 20) to compensate for the loss magnitude reduction.
- Alternatively, normalize the SmoothL1 output to match L1 scale: `smooth_err * (abs_err / (smooth_err + 1e-8)).detach()` for relative magnitude matching.
- The underlying goal (better convergence for near-zero errors) might be better served by continuing with L1 and reducing the noise augmentation in later training epochs.