### PR TITLE
Dual-scale coarse loss (pool64 + pool256)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -632,6 +632,14 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
+        coarse2_size = 256
+        n_g2 = N // coarse2_size
+        if n_g2 > 1:
+            p2 = pred[:, :n_g2*coarse2_size].reshape(B, n_g2, coarse2_size, C).mean(2)
+            y2 = y_norm[:, :n_g2*coarse2_size].reshape(B, n_g2, coarse2_size, C).mean(2)
+            m2 = mask[:, :n_g2*coarse2_size].reshape(B, n_g2, coarse2_size).any(2)
+            loss = loss + 0.5 * ((p2-y2).abs() * m2.unsqueeze(-1)).sum() / m2.sum().clamp(1)
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
Adding a second coarser scale at pool256 captures global flow features. Two-level hierarchy may compound benefit.

## Instructions
After existing coarse loss (line ~633), add:
```python
coarse2_size = 256
n_g2 = N // coarse2_size
if n_g2 > 1:
    p2 = pred[:, :n_g2*coarse2_size].reshape(B,n_g2,coarse2_size,C).mean(2)
    y2 = y_norm[:, :n_g2*coarse2_size].reshape(B,n_g2,coarse2_size,C).mean(2)
    m2 = mask[:, :n_g2*coarse2_size].reshape(B,n_g2,coarse2_size).any(2)
    loss = loss + 0.5 * ((p2-y2).abs() * m2.unsqueeze(-1)).sum() / m2.sum().clamp(1)
```

Run: `--wandb_name "fern/dual-coarse" --wandb_group multi-coarse-256 --agent fern`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**Run ID**: 1dxl4tmk  
**Epochs**: 80 best (wall-clock limit ~30 min)  
**Peak memory**: ~8.8 GB  

### Val/loss
| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.4067 | **2.5085** | +4.2% (worse) |

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|-------|---------------------|---------------------|-------|
| val_in_dist | 22.86 | 23.29 | +1.9% (worse) |
| val_ood_cond | 22.93 | 24.22 | +5.6% (worse) |
| val_ood_re | 32.68 | 32.87 | +0.6% (flat) |
| val_tandem_transfer | 44.16 | 47.37 | +7.3% (worse) |

All splits worse than baseline.

### Full Surface MAE
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|-------------|-------------|------------|
| val_in_dist | 0.325 | 0.181 | 23.29 |
| val_ood_cond | 0.297 | 0.193 | 24.22 |
| val_ood_re | 0.300 | 0.206 | 32.87 |
| val_tandem_transfer | 0.701 | 0.364 | 47.37 |

### Full Volume MAE
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.703 | 0.597 | 35.39 |
| val_ood_cond | 1.454 | 0.530 | 26.62 |
| val_ood_re | 1.348 | 0.537 | 55.82 |
| val_tandem_transfer | 2.672 | 1.244 | 54.55 |

Note: val_ood_re/loss = nan (pre-existing issue).

### What happened

Negative result. Adding a pool256 coarse loss at 0.5x weight made all splits worse. The volume MAEs also increased, suggesting the coarser-scale auxiliary loss is pulling the model away from fine-grained accuracy.

The 0.5x weight may be too large for a global-pooling loss: each pool256 group averages 256 nodes, smoothing out all local variation including boundary layers. Optimizing for this coarse representation may discourage the model from maintaining sharp gradients at the surface.

Alternatively, the pool64 loss is already capturing sufficient multi-scale information; adding pool256 may be redundant or contradictory. The pool256 groups likely contain both surface and interior nodes averaged together, which creates a mixed signal that confuses surface-specific learning.

### Suggested follow-ups

- Try pool256 with much smaller weight (0.1x or 0.2x) to see if the global signal helps without hurting fine-grained accuracy
- Pool surface nodes only at the coarser scale (separate surface coarse loss from volume coarse loss)