### PR TITLE
Velocity noise annealing (0.015->0.005)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -567,7 +567,8 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+            vel_noise = 0.015 - 0.01 * min(epoch / 80.0, 1.0)
+            noise_scale = torch.tensor([vel_noise, vel_noise, 0.005], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)


### PR DESCRIPTION
## Hypothesis
Anneal velocity noise from 0.015 to 0.005 over 80 epochs while keeping pressure at 0.005. Early regularization, late precision.

## Instructions
Replace noise_scale (line ~570):
```python
vel_noise = 0.015 - 0.01 * min(epoch / 80.0, 1.0)
noise_scale = torch.tensor([vel_noise, vel_noise, 0.005], device=device)
```

Run: `--wandb_name "tanjiro/noise-anneal" --wandb_group noise-anneal-vel --agent tanjiro`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `ovt56i1s` | **Best epoch:** 80 | **Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.656 | 0.293 | 0.180 | **22.04** | 1.658 | 0.589 | 33.13 |
| val_ood_cond | 2.048 | 0.271 | 0.193 | **22.40** | 1.411 | 0.525 | 25.23 |
| val_ood_re | nan | 0.280 | 0.206 | **32.07** | 1.330 | 0.535 | 55.34 |
| val_tandem_transfer | 3.598 | 0.672 | 0.359 | **45.84** | 2.566 | 1.212 | 52.35 |
| **val (mean)** | **2.4343** | | | | | | |

### vs Baseline

| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|---|---|---|---|
| val_in_dist | 22.86 | 22.04 | **-0.82 ✓** |
| val_ood_cond | 22.93 | 22.40 | **-0.53 ✓** |
| val_ood_re | 32.68 | 32.07 | **-0.61 ✓** |
| val_tandem_transfer | 44.16 | 45.84 | **+1.68 ✗** |
| val/loss | 2.4067 | 2.4343 | +0.028 |

### What happened

Noise annealing gave mixed results. Three of four mae_surf_p metrics improved vs baseline (in_dist −0.82, ood_cond −0.53, ood_re −0.61), but tandem regressed (+1.68 Pa) and overall val/loss is slightly above baseline (2.4343 vs 2.4067) because val/loss is a mean that includes tandem.

The mechanism seems to be: higher velocity noise early (0.015) acts as stronger regularization during the critical convergence phase, helping the model generalize to single-foil OOD splits. But the tandem split suffers — tandem samples are already harder and require the model to learn fine-grained wake interaction features; extra early noise may interfere with that.

One confound: the per-sample norm skips tandem samples, which means tandem does not benefit from the normalizations equalization of sample difficulty. The combination of skipped-norm + higher early noise may be double-penalizing tandem.

### Suggested follow-ups
- **Tandem-aware noise annealing**: Apply separate (slower / lower) noise annealing for tandem samples, e.g. keep tandem at 0.01 the whole time
- **Progressive noise + progressive tandem boost**: Combine noise annealing with the progressive tandem boost from PR #630 to compensate for the tandem regression
- **Per-channel anneal schedule**: Try only annealing velocity noise and leaving pressure noise at 0.005 constant (which is what this PR does), but with the tandem inclusive norm from PR #615