### PR TITLE
Coordinate-aware slice assignment

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -108,7 +108,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
-        self.in_project_slice = nn.Linear(dim_head, slice_num)
+        self.in_project_slice = nn.Linear(dim_head + 2, slice_num)
         torch.nn.init.orthogonal_(self.in_project_slice.weight)
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
@@ -119,7 +119,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
-    def forward(self, x):
+    def forward(self, x, pos_2d=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -134,7 +134,12 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
+        if pos_2d is not None:
+            pos_h = pos_2d.unsqueeze(1).expand(-1, self.heads, -1, -1)
+            slice_input = torch.cat([x_mid, pos_h], dim=-1)
+        else:
+            slice_input = x_mid
+        slice_weights = self.softmax(self.in_project_slice(slice_input) / self.temperature)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -186,8 +191,8 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
+    def forward(self, fx, pos_2d=None):
+        fx = self.attn(self.ln_1(fx), pos_2d=pos_2d) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
@@ -314,11 +319,12 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        pos_2d = x[:, :, :2]
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks:
-            fx = block(fx)
+            fx = block(fx, pos_2d=pos_2d)
         self._validate_output_dims(fx)
         return {"preds": fx}
 


### PR DESCRIPTION
## Hypothesis
Add x,y position to slice projection input for spatially-coherent slices. Different from failed cosine slice (changes WHAT goes in, not HOW).

## Instructions
1. Change in_project_slice to accept dim_head+2:
```python
self.in_project_slice = nn.Linear(dim_head + 2, slice_num)
```
2. In Transolver.forward, extract pos_2d = x[:,:,:2] before preprocess, pass through blocks.
3. In Physics_Attention forward, concat pos to x_mid before slice projection:
```python
if pos_2d is not None:
    pos_h = pos_2d.unsqueeze(1).expand(-1, self.heads, -1, -1)
    slice_input = torch.cat([x_mid, pos_h], dim=-1)
else:
    slice_input = x_mid
slice_weights = self.softmax(self.in_project_slice(slice_input) / self.temperature)
```

Run: `--wandb_name "nezuko/pos-slice" --wandb_group pos-in-slice --agent nezuko`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `16renhg9` (nezuko/pos-slice)
**Best epoch:** 77 / ~77 (hit 30-min timeout)

### Metrics vs baseline

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| overall | val/loss | 2.4067 | 2.5350 | +0.128 |
| val_in_dist | mae_surf_p | 22.86 | 23.04 | +0.18 |
| val_ood_cond | mae_surf_p | 22.93 | 26.84 | +3.91 |
| val_ood_re | mae_surf_p | 32.68 | 34.09 | +1.41 |
| val_tandem_transfer | mae_surf_p | 44.16 | 46.39 | +2.23 |

Detailed best-epoch metrics:
- **val_in_dist**: loss=1.714, mae_surf_Ux=0.306, mae_surf_Uy=0.187, mae_surf_p=23.04
- **val_ood_cond**: loss=2.288, mae_surf_Ux=0.304, mae_surf_Uy=0.202, mae_surf_p=26.84
- **val_ood_re**: mae_surf_p=34.09 (loss=NaN, pre-existing)
- **val_tandem_transfer**: loss=3.604, mae_surf_Ux=0.677, mae_surf_Uy=0.362, mae_surf_p=46.39

### What happened

**Regression across all splits.** The coordinate-aware slice assignment degraded performance, most notably on val_ood_cond (+3.91 pressure units).

Several likely causes:

1. **Redundant position encoding**: The input `x` already contains x,y mesh node coordinates as the first two features (indices 0,1), which flow through the preprocess MLP and into the attention layers. The model already has access to spatial position implicitly in its feature embeddings. Adding raw normalized coordinates directly to the slice projection creates a conflicting/redundant signal.

2. **Scale mismatch**: The pos_2d values are normalized coordinates (mean ~0, std ~1), while x_mid values are dim_head-dimensional embeddings that have been linearly projected from a hidden_dim=128 embedding. The two coordinate dimensions may have a very different effective scale relative to the 32 feature dimensions, causing either domination or drowning-out of positional information in the slice projection.

3. **Initialization**: The orthogonal initialization of `in_project_slice` expects a near-square matrix. Changing from (32, 32) to (34, 32) disrupts the orthogonal structure, potentially weakening the initial diversity of slice assignments.

4. **OOD generalization**: The OOD-cond split (different angle-of-attack/conditions) is particularly sensitive. If the model relies more on spatial coordinates for slice assignment, it may overfit the seen spatial patterns and fail to generalize to different flow conditions.

### Suggested follow-ups
- Try using unnormalized (raw) position before the stats normalization to avoid scale mismatches
- Instead of concatenating to the linear input, try adding a learned positional bias to the slice logits (position-dependent offset without changing the linear layer dimensions)