### PR TITLE
Project attn_scale to [5,20] after each step

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -636,6 +636,10 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        with torch.no_grad():
+            for block in model.blocks:
+                block.attn.attn_scale.data.clamp_(5.0, 20.0)
+                block.attn.temperature.data.clamp_(0.2, 1.0)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 


### PR DESCRIPTION
## Hypothesis
Prevent attn_scale from drifting to extreme values. Simple param clamping after optimizer step.

## Instructions
After optimizer.step() (line ~638):
```python
with torch.no_grad():
    for block in model.blocks:
        block.attn.attn_scale.data.clamp_(5.0, 20.0)
        block.attn.temperature.data.clamp_(0.2, 1.0)
```

Run: `--wandb_name "alphonse/proj-scale" --wandb_group proj-grad-scale --agent alphonse`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run ID:** y6ny6b1t
**Epochs completed:** 77/100 (30-min timeout; ~23.1s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline | Best epoch (73) | Last epoch (77) |
|---|---|---|---|
| val/loss | 2.4067 | **2.5278** (+4.6%) | 2.5432 |
| val_in_dist/mae_surf_p | 22.86 | **25.89** (+13%) | 24.29 |
| val_ood_cond/mae_surf_p | 22.93 | **23.89** (+4.2%) | 24.01 |
| val_ood_re/mae_surf_p | 32.68 | **33.20** (+1.6%) | 34.10 |
| val_tandem_transfer/mae_surf_p | 44.16 | **45.11** (+2.2%) | 47.40 |

Additional val_in_dist at best epoch (73):
- mae_surf_Ux: 0.314 | mae_surf_Uy: 0.195
- mae_vol_Ux: 1.700 | mae_vol_Uy: 0.632 | mae_vol_p: 36.14

### What happened

**This did not work.** All metrics are worse than baseline, with val_in_dist surface pressure notably worse (+13% at best epoch).

Notable: the best val/loss occurs at epoch 73, not at the final epoch 77 — unusual for this setup where models typically still improve at epoch 77. The late-training regression suggests the clamping may be destabilizing: after the unconstrained parameters find good values, the clamp occasionally forces them to a bound and the optimizer momentum (from Lookahead) continues pushing, causing oscillation. This would explain the slight late-epoch deterioration.

Both parameters start within their respective clamp ranges (attn_scale=10.0 in [5,20], temperature=0.5 in [0.2,1.0]), so the constraints are only relevant if the optimizer tries to push them out of range. The constraints may be limiting beneficial adaptation or causing the momentum-clamp oscillation.

### Suggested follow-ups
- The hypothesis that attn_scale drifts to harmful extremes may be wrong — if it doesn't drift, the clamps are unnecessary overhead
- Could log attn_scale during training to verify if it actually leaves [5,20] in the baseline
- If attn_scale stability is a concern, a softer approach like adding L2 regularization on attn_scale would avoid hard boundary effects