### PR TITLE
MoE output head (2 experts, soft gating)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -180,17 +180,17 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.gate = nn.Linear(hidden_dim, 2)
+            self.expert_0 = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
+            self.expert_1 = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            g = F.softmax(self.gate(h), dim=-1)
+            return g[:, :, 0:1] * self.expert_0(h) + g[:, :, 1:2] * self.expert_1(h)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Replace single output MLP with 2 expert MLPs + soft gating. Different experts can specialize in different flow regimes.

## Instructions
In TransolverBlock.__init__ (last_layer section):
```python
self.ln_3 = nn.LayerNorm(hidden_dim)
self.gate = nn.Linear(hidden_dim, 2)
self.expert_0 = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
self.expert_1 = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
```
In forward:
```python
h = self.ln_3(fx)
g = F.softmax(self.gate(h), dim=-1)
return g[:,:,0:1]*self.expert_0(h) + g[:,:,1:2]*self.expert_1(h)
```

Run: `--wandb_name "edward/moe-out" --wandb_group moe-output-head --agent edward`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** r1fy6wba | **Epochs:** 74 (30 min wall-clock limit) | **Peak memory:** 9.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 2.5001 | 0.307 | 0.189 | **24.77** | 1.656 | 0.594 | 34.63 |
| ood_cond | — | 0.295 | 0.196 | **24.49** | 1.373 | 0.518 | 24.63 |
| ood_re | NaN | 0.309 | 0.209 | **33.25** | 1.307 | 0.531 | 54.72 |
| tandem | — | 0.685 | 0.362 | **47.11** | 2.571 | 1.200 | 52.09 |

**vs. baseline (val/loss 2.4067, mae_surf_p: in_dist 22.86 / ood_cond 22.93 / ood_re 32.68 / tan 44.16):**
- val/loss: 2.5001 vs 2.4067 (**+3.9%** — worse)
- mae_surf_p in_dist: 24.77 vs 22.86 (**+8.4%** — worse)
- mae_surf_p ood_cond: 24.49 vs 22.93 (**+6.8%** — worse)
- mae_surf_p ood_re: 33.25 vs 32.68 (**+1.7%** — slightly worse)
- mae_surf_p tandem: 47.11 vs 44.16 (**+6.7%** — worse)

### What happened

MoE output head degraded performance across all splits. Two factors likely contributed:

1. **More parameters, fewer epochs**: The two expert MLPs roughly double the output head parameters (from ~hidden_dim² to ~2×hidden_dim²), increasing memory from 8.8→9.8 GB and slowing per-epoch time, resulting in only 74 epochs vs 81 for baseline runs — less training time.

2. **Soft gating collapse**: With soft gating, both experts receive gradient signal from every sample. Without a diversity-encouraging mechanism (e.g., load balancing loss), the two experts likely converge to similar representations, giving no benefit over a single MLP while paying the parameter cost. The gate may not learn meaningful specialization within the 30-min budget.

The hypothesis that experts can specialize in different flow regimes (e.g., attached vs separated flow) is plausible, but soft gating may not create sufficient specialization pressure. Hard routing or an auxiliary diversity loss might be needed.

### Suggested follow-ups

1. **Smaller experts**: Use hidden_dim//2 intermediate size per expert to keep parameter count similar to baseline, eliminating the memory/speed penalty.
2. **Hard gating (top-1 routing)**: Forces true specialization, prevents expert collapse.
3. **Diversity loss**: Add a small auxiliary loss penalizing gate weight entropy collapse (e.g., encourage ~50/50 usage).