### PR TITLE
Stochastic volume masking (80% random subset post-ramp)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -593,19 +593,14 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
-        # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
-            vol_indices = vol_mask.nonzero(as_tuple=False)
-            n_vol = vol_indices.shape[0]
-            n_keep = max(int(n_vol * vol_keep_ratio), 1)
-            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
-            vol_mask_train = torch.zeros_like(vol_mask)
-            if n_keep > 0:
-                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
-        else:
-            vol_mask_train = vol_mask
+        vol_indices = vol_mask.nonzero(as_tuple=False)
+        n_vol = vol_indices.shape[0]
+        vol_keep_ratio = 0.05 + 0.95 * min(epoch / 40, 1.0) if epoch < 40 else 0.8
+        n_keep = max(int(n_vol * vol_keep_ratio), 1)
+        perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
+        vol_mask_train = torch.zeros_like(vol_mask)
+        if n_keep > 0:
+            vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)


### PR DESCRIPTION
## Hypothesis
After the progressive ramp, continue randomly sampling 80% of volume nodes each step as spatial augmentation.

## Instructions
Replace progressive resolution block (lines ~598-608) to always subsample:
```python
vol_indices = vol_mask.nonzero(as_tuple=False)
n_vol = vol_indices.shape[0]
vol_keep_ratio = 0.05 + 0.95 * min(epoch / 40, 1.0) if epoch < 40 else 0.8
n_keep = max(int(n_vol * vol_keep_ratio), 1)
perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
vol_mask_train = torch.zeros_like(vol_mask)
if n_keep > 0:
    vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
```

Run: `--wandb_name "thorfinn/stoch-vol" --wandb_group stochastic-vol-mask --agent thorfinn`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `9rb92ell` (thorfinn/stoch-vol, group: stochastic-vol-mask)
**Epochs:** 76 (30-min wall clock limit)

| Metric | Baseline | This run (best ep 76) | Δ |
|---|---|---|---|
| val/loss | 2.4067 | **2.5425** | +0.136 ↑ worse |
| val_in_dist/loss | — | 1.8032 | — |
| val_ood_cond/loss | — | 2.2578 | — |
| val_tandem/loss | — | 3.5664 | — |
| in_dist surf_p (Pa) | 22.86 | 24.91 | +2.05 ↑ worse |
| ood_cond surf_p (Pa) | 22.93 | 25.91 | +2.98 ↑ worse |
| ood_re surf_p (Pa) | 32.68 | 35.17 | +2.49 ↑ worse |
| tandem surf_p (Pa) | 44.16 | 46.12 | +1.96 ↑ worse |

Full surface MAE at best epoch:
- val_in_dist: Ux=0.317, Uy=0.194, p=24.91 Pa
- val_ood_cond: Ux=0.298, Uy=0.203, p=25.91 Pa
- val_ood_re: Ux=0.310, Uy=0.217, p=35.17 Pa
- val_tandem: Ux=0.668, Uy=0.361, p=46.12 Pa

**Peak memory:** ~8.8 GB (unchanged)

### What happened

**Negative result.** Continuing 80% random volume subsampling after the progressive ramp made all splits worse. val/loss degraded from 2.4067 to 2.5425 (+5.6%), with surface pressure MAE worsening by 2-3 Pa across single-foil splits.

The reasoning behind the hypothesis is sound (spatial augmentation via dropout regularizes the model), but the 20% volume dropout rate appears too aggressive for this task. The volume nodes carry structural information — even though the primary metric is surface pressure, the volume field provides context about the flow structure that helps the model understand boundary conditions. Permanently dropping 20% of volume supervision noise after the ramp likely removes useful gradient signal rather than providing beneficial regularization.

During the ramp phase (epochs 0-39), subsampling helps by preventing overfitting to fine-grained volume details before coarse flow structure is learned. But after the ramp, the model benefits from full volume supervision to sharpen predictions near the surface.

### Suggested follow-ups
- Try a smaller post-ramp subsample rate (e.g. 90-95%) instead of 80% — less aggressive dropout
- Apply the stochastic masking only to distant-from-surface volume nodes (using dsdf features), keeping near-surface volume nodes fully supervised — this targets the regions where dropping nodes is less harmful