### PR TITLE
EMA of val_loss for checkpoint selection (decay=0.9)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -536,6 +536,8 @@ best_val = float("inf")
 best_metrics = {}
 global_step = 0
 train_start = time.time()
+ema_val_loss = None
+ema_decay = 0.9
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -762,8 +764,12 @@ for epoch in range(MAX_EPOCHS):
         peak_mem_gb = 0.0
 
     tag = ""
-    if mean_val_loss < best_val:
-        best_val = mean_val_loss
+    if ema_val_loss is None:
+        ema_val_loss = mean_val_loss
+    else:
+        ema_val_loss = ema_decay * ema_val_loss + (1 - ema_decay) * mean_val_loss
+    if ema_val_loss < best_val:
+        best_val = ema_val_loss
         best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss}
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():


### PR DESCRIPTION
## Hypothesis
Smooth checkpoint selection with EMA to avoid epoch-to-epoch variance in val/loss.

## Instructions
Add before training loop:
```python
ema_val_loss = None
ema_decay = 0.9
```
Replace checkpoint selection (line ~765):
```python
if ema_val_loss is None:
    ema_val_loss = mean_val_loss
else:
    ema_val_loss = ema_decay * ema_val_loss + (1 - ema_decay) * mean_val_loss
if ema_val_loss < best_val:
    best_val = ema_val_loss
```

Run: `--wandb_name "askeladd/ema-ckpt" --wandb_group ema-ckpt-select --agent askeladd`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** oc7digym  
**Epochs completed:** 77/100 (30-min timeout)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (best) | 2.4067 | **2.5647** | +0.158 |
| val_in_dist/mae_surf_p | 22.86 | 25.63 | +2.77 |
| val_ood_cond/mae_surf_p | 22.93 | 24.90 | +1.97 |
| val_ood_re/mae_surf_p | 32.68 | 32.93 | +0.25 |
| val_tandem_transfer/mae_surf_p | 44.16 | 48.93 | +4.77 |

**Volume MAE (val_in_dist):** Ux=1.73, Uy=0.63, p=36.32  
**Surface MAE (val_in_dist):** Ux=0.292, Uy=0.187, p=25.63  
**Peak memory:** 8.8 GB (run duration: 1752s)

### What happened

EMA checkpoint selection made results significantly worse. val/loss deteriorated by +0.158, and surface pressure MAE got substantially worse across all splits (in-dist +2.77, ood_cond +1.97, tandem +4.77).

The EMA smoothing itself is not the issue — decay=0.9 is quite responsive (10% weight on new observations), so it barely filters noise. The core problem is that  now tracks the best EMA value rather than the best raw val/loss. Once the EMA drops below a previous EMA minimum, it saves the checkpoint. But the epoch selected by EMA-tracking may not correspond to the epoch with lowest actual val/loss.

With a fast-decaying EMA (decay=0.9), the lag is small but nonzero. In early training when val/loss drops steeply, the EMA lags behind the true minimum and may trigger checkpoint saves at slightly wrong points. More critically, once training converges and the EMA plateaus, small fluctuations in the EMA may save checkpoints at epochs that happen to have a slightly lower EMA reading but a worse actual validation state.

The larger issue may be that the baseline comparison run benefited from later convergence. The noam branch evolves across PRs, and baseline runs reflect that full training. This run trained to a local optimum that happened to be worse.

### Suggested follow-ups

- Try a slower EMA decay (e.g., 0.99 or 0.999) to get more meaningful smoothing over many epochs
- Try N-epoch smoothing: take the average of the last K val/loss values before updating 
- Consider whether checkpoint selection noise is actually a problem — the baseline likely benefits from more recent code improvements (noam branch evolves)
- If the goal is to avoid saving "lucky" checkpoints, consider requiring improvement to persist for 2-3 consecutive epochs before updating best