### PR TITLE
Tandem-specific affine transform in preprocessing

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -257,6 +257,8 @@ class Transolver(nn.Module):
         self.initialize_weights()
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
+        self.tandem_scale = nn.Parameter(torch.ones(n_hidden))
+        self.tandem_shift = nn.Parameter(torch.zeros(n_hidden))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -316,6 +318,11 @@ class Transolver(nn.Module):
 
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+
+        raw_gap = x[:, 0, 21]
+        is_tandem = (raw_gap.abs() > 0.5).float()[:, None, None]
+        fx = fx * (1.0 + is_tandem * (self.tandem_scale[None, None, :] - 1.0))
+        fx = fx + is_tandem * self.tandem_shift[None, None, :]
 
         for block in self.blocks:
             fx = block(fx)


### PR DESCRIPTION
## Hypothesis
Add learned scale+bias applied only to tandem samples after preprocess MLP. Only 256 extra params for a tandem mode switch.

## Instructions
In Transolver.__init__ (after placeholder params):
```python
self.tandem_scale = nn.Parameter(torch.ones(n_hidden))
self.tandem_shift = nn.Parameter(torch.zeros(n_hidden))
```
In Transolver.forward (after placeholder transform):
```python
raw_gap = x[:, 0, 21]
is_tandem = (raw_gap.abs() > 0.5).float()[:, None, None]
fx = fx * (1.0 + is_tandem * (self.tandem_scale[None, None, :] - 1.0))
fx = fx + is_tandem * self.tandem_shift[None, None, :]
```

Run: \`--wandb_name "violet/tandem-pp" --wandb_group tandem-preprocess --agent violet\`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** 3wohbsgt  
**Peak memory:** 9.3 GB

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 2.4067 | **2.5453** | +0.139 ❌ |
| val_in_dist/mae_surf_p | 22.86 | 24.26 | +1.40 ❌ |
| val_ood_cond/mae_surf_p | 22.93 | 24.9 | +1.97 ❌ |
| val_ood_re/mae_surf_p | 32.68 | 33.2 | +0.52 ❌ |
| val_tandem_transfer/mae_surf_p | 44.16 | 45.6 | +1.44 ❌ |

Volume MAE (in_dist): Ux=1.698, Uy=0.617, p=35.15

**What happened:**  
All splits got worse. The tandem-specific affine transform did not help — and notably didn't improve val_tandem_transfer either, which was the primary intended target.

A likely explanation: the model can already condition on tandem geometry via the gap (x[..., 21]) and stagger (x[..., 22]) features that appear directly in the input x. The preprocess MLP already has a path to transform the hidden representation differently for tandem samples based on those features. Adding an explicit tandem scale/shift on top of this is redundant — and also redundant with the placeholder_scale/placeholder_shift that can already shift the entire representation. The 512 extra parameters may have added a slight optimization burden.

The transform is applied at the shallowest point (right after preprocess MLP), before any attention. At this stage the representation hasn't been refined by attention, so the scale/shift is a coarse global correction. Tandem samples already encode their gap/stagger in x, so the attention blocks can already route them differently; the pre-attention scale/shift adds no new information.

**Suggested follow-ups:**
- Try tandem conditioning deeper in the network (e.g., as a bias to the attention logits in each TransolverBlock conditioned on is_tandem). This would let tandem samples attend to slices differently.
- Try a tandem-specific residual correction applied after all transformer blocks, which could compensate for systematic prediction errors without disrupting the shared representation.
- The tandem_transfer gap is persistently large (~44 mae_surf_p vs ~23 in_dist). Pre-processing-stage conditioning seems insufficient — may need more tandem training data or a domain-specific loss weighting strategy.