### PR TITLE
Max surface weight 50 (vs current 30)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -546,7 +546,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    sw_start, sw_end = 5.0, 50.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
Higher surface emphasis in later epochs may improve the key metric at slight volume cost.

## Instructions
Change surf_weight ramp (line ~549):
```python
sw_start, sw_end = 5.0, 50.0
```

Run: `--wandb_name "gilbert/sw-50" --wandb_group surf-weight-50 --agent gilbert`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `hxylozfm` (gilbert/sw-50)
**Epochs:** 81 (30.2 min wall-clock limit)
**Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.663 | 0.267 | 0.180 | **22.59** | 1.793 | 0.665 | 37.36 |
| val_ood_cond | 2.173 | 0.294 | 0.201 | **24.36** | 1.552 | 0.591 | 29.23 |
| val_ood_re | NaN | 0.293 | 0.209 | 32.29 | 1.422 | 0.568 | 56.44 |
| val_tandem_transfer | 3.631 | 0.680 | 0.368 | **45.97** | 2.753 | 1.324 | 56.10 |
| **val/loss (mean)** | **2.4892** | | | | | | |

**vs. baseline:**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.4067 | 2.4892 | +0.083 (+3.4%) ❌ |
| val_in_dist/mae_surf_p | 22.86 | 22.59 | -0.27 (-1.2%) ✓ |
| val_ood_cond/mae_surf_p | 22.93 | 24.36 | +1.43 (+6.2%) ❌ |
| val_ood_re/mae_surf_p | 32.68 | 32.29 | -0.39 (-1.2%) ✓ |
| val_tandem_transfer/mae_surf_p | 44.16 | 45.97 | +1.81 (+4.1%) ❌ |

**What happened:** Mixed results — sw_end=50 slightly improves in-distribution surface pressure (-0.27) and ood_re (-0.39), but significantly hurts val_ood_cond (+1.43) and val_tandem_transfer (+1.81). Overall val/loss is worse by 3.4%. The higher surface emphasis may cause the model to overfit to training-distribution surface patterns, reducing generalization to unseen conditions and tandem geometries.

Volume metrics also got worse (val_in_dist/mae_vol_p: 37.36 vs baseline which was presumably lower with sw=30), consistent with trading volume accuracy for surface fitting.

**Suggested follow-ups:**
- Try sw_end=40 as a middle ground between 30 and 50
- Apply higher surf_weight selectively: only when training in-dist samples, not tandem samples
- Try a non-linear (e.g. cosine or step) weight schedule to reach higher emphasis sooner then hold steady