### PR TITLE
Higher base LR 4e-3

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -488,12 +488,12 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
+    {'params': attn_params, 'lr': 4e-3 * 0.5},
+    {'params': other_params, 'lr': 4e-3}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1.33e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
With Lookahead dampening and cosine attention, the model may tolerate higher LR for faster convergence.

## Instructions
Change optimizer (lines ~490-493) to use lr=4e-3:
```python
base_opt = torch.optim.AdamW([
    {'params': attn_params, 'lr': 4e-3 * 0.5},
    {'params': other_params, 'lr': 4e-3}
], weight_decay=cfg.weight_decay)
```
Also eta_min -> 1.33e-4 proportionally.

Run: `--wandb_name "senku/lr-4e3" --wandb_group lr-4e3 --agent senku`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `g0oxi9h2` — 74 epochs completed (timeout), peak memory 8.8GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.4067 | **2.6397** | +0.233 ↑worse |
| val_in_dist/mae_surf_p | 22.86 | **25.48** | +2.62 ↑worse |
| val_ood_cond/mae_surf_p | 22.93 | **25.79** | +2.86 ↑worse |
| val_ood_re/mae_surf_p | 32.68 | **33.45** | +0.77 ↑worse |
| val_tandem_transfer/mae_surf_p | 44.16 | **47.16** | +3.00 ↑worse |
| val_in_dist/mae_surf_Ux | — | 0.379 | — |
| val_in_dist/mae_surf_Uy | — | 0.199 | — |
| val_in_dist/mae_vol_p | — | 36.51 | — |

**What happened:** Negative result. Raising LR from 3e-3 to 4e-3 (a 33% increase) worsened all metrics consistently. val/loss increased from 2.4067 → 2.6397 (+9.7%), and surface pressure MAE increased ~11-12% across all splits.

The Lookahead optimizer averages slow and fast weights, which does provide some implicit stabilization — but it doesn't eliminate the fundamental issue that higher LR causes overshooting in later cosine decay stages when the learning rate has already dropped significantly. With the 30-minute training budget and 74 epochs, the model spends most of its time in the cosine decay phase where the proportionally higher LR at each step leads to less stable convergence.

The current 3e-3 baseline appears to be close to optimal for this architecture. Going lower (e.g., 2e-3) might hurt final performance due to insufficient exploration, while going higher (4e-3) overshoots.

**Suggested follow-ups:**
- Try lr=3.5e-3 as a midpoint to see if there's a sweet spot between 3e-3 and 4e-3
- Try a different eta_min (e.g., 3e-4) with the existing lr=3e-3 — the floor of cosine decay may matter more than the peak LR