### PR TITLE
Progressive tandem boost (1.0->2.5 over 60 epochs)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -609,7 +609,8 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_mult = 1.0 + 1.5 * min(epoch / 60.0, 1.0)
+        tandem_boost = torch.where(is_tandem, tandem_mult, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Round 19 showed best-ever tandem (43.76) with progressive boost. Wider ramp 1.0->2.5 over 60ep.

## Instructions
Replace tandem boost (line ~611-612):
```python
is_tandem = (x[:, 0, 21].abs() > 0.01)
tandem_mult = 1.0 + 1.5 * min(epoch / 60.0, 1.0)
tandem_boost = torch.where(is_tandem, tandem_mult, 1.0).to(device)
```

Run: `--wandb_name "emma/prog-tandem" --wandb_group prog-tandem-v2 --agent emma`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** c1pzw5ny | **Epochs:** ~81 (30-min cap) | **Epoch time:** 22.4 s | **Peak GPU memory:** 49.8 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.723 | 0.317 | 0.183 | 23.08 | 1.809 | 0.646 | 37.60 |
| val_ood_cond | 2.126 | 0.285 | 0.192 | 22.97 | 1.444 | 0.556 | 28.09 |
| val_ood_re | NaN | 0.289 | 0.205 | 31.94 | 1.375 | 0.557 | 56.86 |
| val_tandem_transfer | 3.539 | 0.656 | 0.347 | 45.95 | 2.641 | 1.271 | 53.58 |
| **combined val/loss** | **2.4626** | | | | | | |

**vs baseline (delta surf_p):**
- val_in_dist: 23.08 vs 22.86 → **+0.22 (marginally worse)**
- val_ood_cond: 22.97 vs 22.93 → **+0.04 (essentially same)**
- val_ood_re: 31.94 vs 32.68 → **-0.74 (improved)**
- val_tandem_transfer: 45.95 vs 44.16 → **+1.79 (worse)**
- val/loss: 2.4626 vs 2.4067 → **+0.0559 (+2.3%, slightly worse)**

### What happened

Slightly negative overall. The progressive boost paradoxically made tandem transfer *worse* (+1.79) despite being designed to improve it.

**Why tandem got worse:**
1. In early epochs (epoch 0-30), tandem_mult is only 1.0-1.75 vs baseline 1.5. For the first ~20 epochs, tandem gets *less* emphasis than baseline, preventing early specialization.
2. In late epochs (epoch 60+), tandem_mult=2.5 vs baseline 1.5. This 67% increase in late tandem weight causes the model to aggressively overfit tandem at the expense of generalization.
3. The fixed 1.5 baseline was apparently well-calibrated. The progressive ramp disrupts a working training regime.

**Why val_ood_re improved:** Less tandem emphasis in early epochs may allow the model to learn more robust velocity representations that generalize to ood Reynolds numbers.

### Suggested follow-ups

- Try **progressive 1.5->2.0** (smaller amplitude): keep fixed start at 1.5, ramp to 2.0 for a milder late boost.
- Try **fixed 2.0** (higher than current 1.5): simpler and avoids the progressive disruption.
- The round 19 tandem improvement (43.76) may have come from other changes (different baseline), not the progressive boost specifically.