### PR TITLE
Cosine eta_min=5e-5 (middle ground)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -493,7 +493,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
Between 1e-4 (current) and 1e-5 (previously merged then overridden). 5e-5 may be the sweet spot.

## Instructions
Change cosine scheduler:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=5e-5)
```

Run: `--wandb_name "norman/eta-5e5" --wandb_group cosine-eta-5e5 --agent norman`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `3l9tzgvn` | 80 epochs completed (killed during epoch 81 validation at 30-min timeout) | Peak memory: 8.8 GB

| Split | val/loss (ep80) | mae_surf_p | mae_vol |
|---|---|---|---|
| val_in_dist | 1.721 | **23.38** | Ux=1.67, Uy=0.61, p=34.22 |
| val_ood_cond | 2.111 | **23.55** | Ux=1.43, Uy=0.53, p=25.89 |
| val_ood_re | nan | **32.03** | Ux=1.34, Uy=0.54, p=55.52 |
| val_tandem_transfer | 3.513 | **44.62** | Ux=2.58, Uy=1.20, p=50.54 |
| **val/loss (mean, ep80)** | **2.4485** | | |

_Note: Run killed during epoch 81 validation. val/loss from epoch 80 output log; MAE from W&B summary (last logged state)._

**vs baseline (val/loss 2.4067):**
| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 22.86 | 23.38 | **+2.3% ✗** |
| val_ood_cond | 22.93 | 23.55 | **+2.7% ✗** |
| val_ood_re | 32.68 | 32.03 | **-2.0% ✓** |
| val_tandem_transfer | 44.16 | 44.62 | **+1.0% ✗** |
| val/loss | 2.4067 | 2.4485 | **+1.7%** |

### What happened

Negative result. val/loss is 1.7% worse than baseline, with surface pressure regressing on 3 of 4 splits. Only ood_re improved marginally (-2.0%). 

The current eta_min=1e-4 appears to be better than 5e-5. With a lower floor, the LR decays to a smaller value late in training, which may limit the model's ability to take meaningful gradient steps in the final epochs. The 1e-4 baseline appears to provide better final-phase learning. The hypothesis that 5e-5 is a "sweet spot" between 1e-4 and 1e-5 is not supported by this run.

### Suggested follow-ups
- Try higher eta_min (e.g. 2e-4 or 3e-4) — the model may benefit from keeping LR higher throughout
- Combine eta_min tuning with T_max tuning (the cosine schedule may reach its minimum too early at epoch 95)
- Check if the baseline val/loss improvement came from another change on the noam branch rather than the scheduler