### PR TITLE
Separate pressure output head

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -180,17 +180,15 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.vel_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 2))
+            self.p_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 1))
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            return torch.cat([self.vel_head(h), self.p_head(h)], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Dedicated linear layers for velocity (128->2) and pressure (128->1) instead of shared 128->3.

## Instructions
Replace output head in TransolverBlock (last_layer section):
```python
self.ln_3 = nn.LayerNorm(hidden_dim)
self.vel_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 2))
self.p_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 1))
```
In forward: `return torch.cat([self.vel_head(h), self.p_head(h)], dim=-1)`

Run: `--wandb_name "chihiro/sep-p" --wandb_group separate-p-head --agent chihiro`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `ttmkcbm5`
**Best epoch:** 73 (wall-clock limit: 30.1 min)
**VRAM:** ~8.8 GB (~same as baseline; extra params negligible)

### val/loss

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.5288** | 2.4067 | +0.1221 (worse) |

Note: val_ood_re loss = NaN (vol_loss = 18.9B, pre-existing issue); val/loss is mean of 3 non-NaN splits.

### Surface MAE (mae_surf_p, Pa)

| Split | This run | Baseline | Δ |
|-------|----------|----------|---|
| val_in_dist | 25.11 | 22.86 | +2.25 (worse) |
| val_ood_cond | 24.27 | 22.93 | +1.34 (worse) |
| val_ood_re | 34.03 | 32.68 | +1.35 (worse) |
| val_tandem_transfer | 46.71 | 44.16 | +2.55 (worse) |

### Volume MAE (val_in_dist)

| Channel | MAE |
|---------|-----|
| Ux | 1.72 |
| Uy | 0.62 |
| p | 35.41 |

### What happened

The separate pressure head consistently hurt all splits (all surface MAEs worse, val/loss +0.12). Best epoch was 73 instead of the usual 80, suggesting the split head architecture converges a bit more slowly. The p_head and vel_head each have hidden_dim→hidden_dim→1(or 2) which is the same total parameter count as the original shared mlp2, but by splitting the capacity the model loses the benefit of shared representation learning in the final projection. Velocity and pressure are physically coupled (Bernoulli's principle, momentum equations), so forcing them to be decoded with independent heads may actually hurt by preventing the model from learning their joint relationships in the final layer.

### Suggested follow-ups
- Try a smaller shared trunk with separate output layers: hidden→hidden/2 shared, then split to vel (hidden/2→2) and p (hidden/2→1) — retain coupling but allow specialization
- Or try loss-weighting rather than architecture changes: up-weight the p channel in the MAE loss directly