### PR TITLE
Cross-attention surface refinement

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -254,6 +254,10 @@ class Transolver(nn.Module):
                 for idx in range(n_layers)
             ]
         )
+        self.surf_q = nn.Linear(n_hidden, 32)
+        self.surf_k = nn.Linear(n_hidden, 32)
+        self.surf_v = nn.Linear(n_hidden, 32)
+        self.surf_out = nn.Linear(32, n_hidden)
         self.initialize_weights()
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
@@ -317,7 +321,15 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
-        for block in self.blocks:
+        for i, block in enumerate(self.blocks):
+            if i == len(self.blocks) - 1:
+                # Cross-attention before final projection; subsample K,V to cap memory
+                max_kv = 2048
+                q = self.surf_q(fx)
+                k = self.surf_k(fx[:, :max_kv])
+                v = self.surf_v(fx[:, :max_kv])
+                attn = F.softmax(torch.matmul(q, k.transpose(-2, -1)) / 5.66, dim=-1)
+                fx = fx + self.surf_out(torch.matmul(attn, v))
             fx = block(fx)
         self._validate_output_dims(fx)
         return {"preds": fx}


### PR DESCRIPTION
## Hypothesis
Lightweight cross-attention where surface queries attend to volume context. Models boundary-layer physics.

## Instructions
Add to Transolver.__init__:
```python
self.surf_q = nn.Linear(n_hidden, 32)
self.surf_k = nn.Linear(n_hidden, 32)
self.surf_v = nn.Linear(n_hidden, 32)
self.surf_out = nn.Linear(32, n_hidden)
```
In forward, before the last block's output:
```python
q = self.surf_q(fx)
k = self.surf_k(fx)
v = self.surf_v(fx)
attn = F.softmax(torch.matmul(q, k.transpose(-2,-1)) / 5.66, dim=-1)
fx = fx + self.surf_out(torch.matmul(attn, v))
```
WARNING: N*N attention may OOM. If so, subsample to first 2048 nodes for K,V.

Run: `--wandb_name "haku/cross-attn" --wandb_group cross-attn-surf --agent haku`

## Baseline
- val/loss: **2.4067**
- val_in_dist/mae_surf_p: 22.86
- val_ood_cond/mae_surf_p: 22.93
- val_ood_re/mae_surf_p: 32.68
- val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run ID:** `3ms1e9t4`  
**Best epoch:** 30 / 30 (30.5 min wall-clock timeout)  
**Peak GPU memory:** 34.2 GB (was 8.8 GB — 3.9x increase)

### Metrics at best checkpoint (epoch 30)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 3.1891 | 0.637 | 0.310 | 49.2 | 2.338 | 0.879 | 53.4 |
| val_tandem_transfer | 4.8487 | 0.978 | 0.500 | 61.6 | 3.171 | 1.499 | 63.6 |
| val_ood_cond | 3.4156 | 0.431 | 0.308 | 40.5 | 1.684 | 0.706 | 36.1 |
| val_ood_re | NaN* | 0.397 | 0.289 | 45.7 | 1.552 | 0.677 | 64.5 |
| **combined val/loss** | **3.8178** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.4067 → This run: 3.8178 — dramatically worse (+1.41, ~59% worse)**

Surface pressure MAE vs baseline:
- val_in_dist: 49.2 vs 22.86 (+26.4, much worse)
- val_ood_cond: 40.5 vs 22.93 (+17.6, much worse)
- val_ood_re: 45.7 vs 32.68 (+13.0, much worse)
- val_tandem_transfer: 61.6 vs 44.16 (+17.5, much worse)

### What happened

The cross-attention addition badly hurt performance, with results far worse than baseline across all metrics.

Two major problems:

1. **Massive memory increase**: Capping K,V to max_kv=2048 still resulted in 34.2GB peak memory (vs 8.8GB baseline — 3.9x increase). This is because the attention matrix has shape [B=4, N~5000, 2048] in float32, which creates large activations and gradients that need to be stored for backprop.

2. **Severe epoch reduction**: Each epoch took ~57-64 seconds (vs ~23 seconds baseline) due to the O(N × 2048) attention computation, leaving only 30 epochs to train instead of 77. The model didn't converge — with a typical CFD surrogate needing 60-80 epochs, 30 epochs is clearly insufficient.

The actual cross-attention mechanism may have merit, but it's not usable in this form: the memory and compute cost are too high relative to what the 30-minute budget allows.

The subsample to K,V=2048 from "first 2048 nodes" is also conceptually wrong — nodes are not ordered by significance, so the first 2048 are arbitrary. A proper implementation might sort by distance to surface, but that would require additional tracking.

### Suggested follow-ups

- If cross-attention is worth exploring, it needs to be much cheaper: use only surface nodes as queries (typically <200 nodes per sample) and surface+near-surface nodes as K,V. This would reduce attn to [B, ~200, ~500] — manageable.
- Alternatively, a per-slot interaction in the slice space (32 slices × 256-dim) could capture similar "global context" without N×N cost, since Transolver already aggregates nodes into slices.
- The memory overhead of N×N attention makes this approach incompatible with the 30-minute budget unless N is much smaller or attention is sparse.
