### PR TITLE
SiLU activation in TransolverBlock MLP and output head

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -182,7 +182,7 @@ class TransolverBlock(nn.Module):
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
+                nn.SiLU(),
                 nn.Linear(hidden_dim, out_dim),
             )
 
@@ -448,6 +448,7 @@ model_config = dict(
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,
+    act="silu",
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
SiLU (x*sigmoid(x)) outperforms GELU in physics transformers. Non-monotonicity better captures sharp pressure gradients. Zero-cost change (same compute).

## Instructions
In `structured_split/structured_train.py`:
1. Replace all `nn.GELU()` with `nn.SiLU()` in TransolverBlock MLP and output head (mlp2).
2. Run with: `--wandb_name "frieren/silu" --wandb_group silu-activation --agent frieren`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16

---

## Results

**W&B run:** `sbpc1y33`  
**Epochs:** 77/100 (timeout at 30 min)  
**Peak memory:** ~8.8 GB

| Metric | Baseline | SiLU | Δ |
|--------|----------|------|---|
| val/loss | 2.4067 | 2.5953 | +7.8% ❌ |
| val_in_dist/mae_surf_p | 22.86 | 26.07 | +14.0% ❌ |
| val_ood_cond/mae_surf_p | 22.93 | 25.17 | +9.8% ❌ |
| val_ood_re/mae_surf_p | 32.68 | 33.88 | +3.7% ❌ |
| val_tandem_transfer/mae_surf_p | 44.16 | 45.23 | +2.4% ❌ |

**Full surface/volume MAE at best epoch (epoch 75):**

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.337 | 0.196 | 26.07 | 1.849 | 0.658 | 39.58 |
| val_ood_cond | 0.293 | 0.199 | 25.17 | 1.461 | 0.561 | 27.31 |
| val_ood_re | 0.304 | 0.210 | 33.88 | 1.389 | 0.563 | 56.36 |
| val_tandem_transfer | 0.713 | 0.365 | 45.23 | 2.720 | 1.266 | 52.90 |

**Note:** `val_ood_re/loss` was NaN across all epochs. Best epoch selected by val/loss over 3 finite splits.

**What happened:**  
SiLU activation is worse than GELU across all metrics. The hypothesis that SiLU would improve pressure prediction doesn't hold for this model. The SiLU function's smooth, non-monotonic behavior (negative values for x<0) doesn't provide an advantage here — GELU already provides similar properties. The larger degradation in surface pressure (14% for in_dist) compared to Ux/Uy (5-7%) suggests the activation change particularly affects the final linear layers that predict the pressure channel, possibly because pressure spans a wider range and the SiLU's different saturation behavior interacts poorly with the output scaling.

Note this is the same experiment as a previous PR (#446 in an earlier round), which also showed mixed results. The hypothesis is well-tested now.

**Suggested follow-ups:**
- The preprocess MLP uses `act=act` with `res=True` by default — SiLU might only help in a specific component (e.g., only in the output head or only in the attention projections) rather than globally.
- The activation choice may matter more with deeper networks (n_layers > 1) where activation quality propagates over more layers.