### PR TITLE
Layer Scale (learnable residual scaling, init 0.1)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -178,6 +178,8 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.gamma_1 = nn.Parameter(0.1 * torch.ones(hidden_dim))
+        self.gamma_2 = nn.Parameter(0.1 * torch.ones(hidden_dim))
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -187,8 +189,8 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        fx = self.gamma_1 * self.attn(self.ln_1(fx)) + fx
+        fx = self.gamma_2 * self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx
@@ -485,8 +487,8 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'gamma'])]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'gamma'])]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}


### PR DESCRIPTION
## Hypothesis
CaiT/DeiT-III layer scale: learnable per-channel scaling on sublayer outputs before residual add. Init to 0.1 so residual dominates early, attention/MLP grow gradually. Only 256 extra params.

## Instructions
In `structured_split/structured_train.py`, in `TransolverBlock.__init__`:
1. Add: `self.gamma_1 = nn.Parameter(0.1 * torch.ones(n_hidden))` and `self.gamma_2 = nn.Parameter(0.1 * torch.ones(n_hidden))`
2. In forward, scale sublayer outputs before residual: `fx = self.gamma_1 * attn_out + fx` and `fx = self.gamma_2 * mlp_out + fx`
3. Add gamma params to attn_params group for differential LR.
4. Run with: `--wandb_name "fern/layer-scale" --wandb_group layer-scale --agent fern`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16

---
## Results

**Run ID**: r4n8shsl  
**Epochs**: 76 best (wall-clock limit ~30 min)  
**Peak memory**: ~8.8 GB  

### Val/loss
| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.4067 | **2.5328** | +5.2% (worse) |

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|-------|---------------------|---------------------|-------|
| val_in_dist | 22.86 | 23.92 | +4.6% (worse) |
| val_ood_cond | 22.93 | 23.85 | +4.0% (worse) |
| val_ood_re | 32.68 | 32.70 | +0.1% (flat) |
| val_tandem_transfer | 44.16 | 47.31 | +7.1% (worse) |

All splits worse than baseline.

### Full Surface MAE
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|-------------|-------------|------------|
| val_in_dist | 0.307 | 0.190 | 23.92 |
| val_ood_cond | 0.291 | 0.196 | 23.85 |
| val_ood_re | 0.301 | 0.206 | 32.70 |
| val_tandem_transfer | 0.696 | 0.372 | 47.31 |

### Full Volume MAE
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.679 | 0.620 | 36.57 |
| val_ood_cond | 1.451 | 0.541 | 25.98 |
| val_ood_re | 1.366 | 0.540 | 55.82 |
| val_tandem_transfer | 2.607 | 1.224 | 52.15 |

Note: val_ood_re/loss = nan (pre-existing issue).

### What happened

Negative result. Layer scale (init 0.1) degraded all splits vs baseline. The gamma_1/gamma_2 init at 0.1 means only 10% of the attention/MLP outputs contribute to the residual stream early in training. This likely slows feature learning too much for the 30-minute experiment window — the model may not have enough epochs to warm up these scale parameters to useful values. The baseline (no layer scale) effectively uses gamma=1.0, which was already working well.

The best epoch being 76 (slightly earlier than typical 81) suggests the model also converged slightly worse: it stopped improving earlier.

In vision transformers (CaiT, DeiT-III), layer scale is applied to much deeper models where gradient vanishing is a real problem. The 5-layer Transolver baseline doesn't appear to suffer from depth-related issues, making layer scale unnecessary.

### Suggested follow-ups

- Try higher init (0.5 or 1.0 equivalent to no-op) if layer scale is still desired
- The baseline's implicit gamma=1.0 appears better for this model depth