### PR TITLE
Cosine T_max=75 (match actual epoch count)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -493,7 +493,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
T_max=95 but training reaches only ~80 epochs in 30 min. LR never reaches eta_min. Setting T_max=75 (+ 5 warmup = 80 total) completes the cosine cycle for proper final convergence.

## Instructions
In `structured_split/structured_train.py`:
1. Find `CosineAnnealingLR` and change T_max to 75 (from MAX_EPOCHS - 5).
2. Run with: `--wandb_name "tanjiro/tmax75" --wandb_group tmax-75 --agent tanjiro`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16

---
## Results

**W&B run:** `w4kchas8` | **Best epoch:** 78 | **Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_p | mae_surf_Ux | mae_surf_Uy | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.629 | **21.07** (−1.79 ✓) | 0.288 | 0.178 | 1.697 | 0.596 | 34.01 |
| ood_cond | 2.054 | **23.02** (+0.09) | 0.281 | 0.196 | 1.430 | 0.531 | 26.07 |
| ood_re | — | **31.79** (−0.89 ✓) | 0.281 | 0.200 | 1.336 | 0.532 | 55.13 |
| tandem_transfer | 3.498 | **44.99** (+0.83) | 0.651 | 0.352 | 2.592 | 1.226 | 52.08 |
| **combined** | **2.3940** | — | — | — | — | — | — |

**Baseline val/loss:** 2.4067 → **2.3940 (−0.013 ✓)**

### What happened
Clear win for in-distribution and OOD Reynolds: setting T_max=75 means the cosine cycle completes right at the end of the ~80-epoch run (best epoch was 78), so the final learning rate reaches eta_min=1e-4 for a proper convergence phase. The old T_max=95 left LR at ~2.7×10⁻⁴ at epoch 80 — too high for fine-grained weight refinement.

OOD condition is nearly unchanged (+0.09 Pa). Tandem regresses slightly (+0.83 Pa), likely because tandem benefits from continued exploration at a slightly higher LR that the shorter cosine cycle cuts off early. Overall val/loss improvement of −0.013 is a net positive.

No complexity added — one-line parameter change.

### Suggested follow-ups
- Try T_max=70 to see if an even earlier convergence point helps tandem while keeping single-foil gains.
- Investigate tandem specifically: it may benefit from a separate warm-restart schedule (CosineAnnealingWarmRestarts) to maintain exploration longer.