### PR TITLE
SwiGLU gated MLP in TransolverBlock

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -177,7 +177,9 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.w1 = nn.Linear(hidden_dim, hidden_dim * mlp_ratio)
+        self.w_gate = nn.Linear(hidden_dim, hidden_dim * mlp_ratio)
+        self.w2 = nn.Linear(hidden_dim * mlp_ratio, hidden_dim)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -188,7 +190,8 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        normed = self.ln_2(fx)
+        fx = fx + self.w2(self.w1(normed) * F.silu(self.w_gate(normed)))
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx


### PR DESCRIPTION
## Hypothesis
SwiGLU (Shazeer 2020, used in LLaMA/PaLM) replaces standard FFN: SwiGLU(x) = (xW1 * SiLU(xW_gate)) W2. Gating enables selective information passing, separating pressure from velocity features.

## Instructions
In `structured_split/structured_train.py`, replace the TransolverBlock MLP with SwiGLU:
1. Add three linear layers: `w1 = nn.Linear(n_hidden, n_hidden*mlp_ratio)`, `w_gate = nn.Linear(n_hidden, n_hidden*mlp_ratio)`, `w2 = nn.Linear(n_hidden*mlp_ratio, n_hidden)`
2. Forward: `self.w2(self.w1(x) * F.silu(self.w_gate(x)))`
3. Replace the existing MLP block with this SwiGLU variant.
4. Run with: `--wandb_name "nezuko/swiglu" --wandb_group swiglu-mlp --agent nezuko`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** `r2k1wn8k` (nezuko/swiglu)
**Best epoch:** 71 / ~71 (hit 30-min timeout)

### Metrics vs baseline

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| overall | val/loss | 2.4067 | 2.5334 | +0.127 |
| val_in_dist | mae_surf_p | 22.86 | 24.67 | +1.81 |
| val_ood_cond | mae_surf_p | 22.93 | 26.40 | +3.47 |
| val_ood_re | mae_surf_p | 32.68 | 33.94 | +1.26 |
| val_tandem_transfer | mae_surf_p | 44.16 | 45.73 | +1.57 |

Detailed best-epoch metrics:
- **val_in_dist**: loss=1.788, mae_surf_Ux=0.319, mae_surf_Uy=0.187, mae_surf_p=24.67
- **val_ood_cond**: loss=2.272, mae_surf_Ux=0.307, mae_surf_Uy=0.208, mae_surf_p=26.40
- **val_ood_re**: mae_surf_p=33.94 (loss=NaN, pre-existing)
- **val_tandem_transfer**: loss=3.541, mae_surf_Ux=0.671, mae_surf_Uy=0.357, mae_surf_p=45.73

### What happened

**Regression across all splits.** SwiGLU degraded performance by 1.3-3.5 pressure units, most notably on val_ood_cond (+3.47). The model also converged to its best epoch at 71 (vs baseline ~80), suggesting slower optimization.

Several likely reasons:

1. **Model is too small to benefit**: The model has n_hidden=128, n_layers=1, mlp_ratio=2. SwiGLU adds 50% more MLP parameters (adds an extra w_gate: 128→256), increasing model complexity. With only 1 Transolver block, this extra capacity may not be usable and instead adds optimization difficulty.

2. **Initialization issues**: The gating linear layer (w_gate) is initialized orthogonally like other linear layers. With SwiGLU, the gate starts at high norm, causing erratic gradient flow early in training. The LLaMA-style zero-init of the gate (or careful fan-in scaling) is often used but not applied here.

3. **Interference between branches**: The orthogonal initialization of w1 and w_gate creates high-dimensional projections that may be nearly orthogonal to each other, making the initial gating behavior near-constant rather than informative. The model needs more epochs to learn meaningful gate patterns.

4. **The "gating separates pressure from velocity" hypothesis** assumes the model needs to route different physics to different channels. With mlp_ratio=2 and n_hidden=128, the feature space may already be too compressed for meaningful gating to help.

### Suggested follow-ups
- Try with larger mlp_ratio (e.g., 4) to give SwiGLU more room: the expanded space (128→512) may provide enough capacity for gating to be useful
- Initialize w_gate weights to zero (standard in LLaMA) so that gating starts near-neutral and is learned progressively