### PR TITLE
Stochastic depth (drop TransolverBlock with p=0.1)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -187,8 +187,13 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        if self.training and torch.rand(1).item() < 0.1:
+            # Stochastic depth: skip attention+MLP, go directly to output
+            if self.last_layer:
+                return self.mlp2(self.ln_3(fx))
+            return fx
+        fx = self.attn(self.ln_1(fx)) * (1.0 / 0.9) + fx
+        fx = self.mlp(self.ln_2(fx)) * (1.0 / 0.9) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx


### PR DESCRIPTION
## Hypothesis
With 1 layer, stochastic depth forces model to occasionally rely on preprocess MLP + placeholder pathway. Regularizes attention without reducing capacity. Saves ~10% compute, potentially gaining extra epochs.

## Instructions
In `structured_split/structured_train.py`, in `TransolverBlock.forward`:
1. At the start, if `self.training and torch.rand(1).item() < 0.1`, skip the attention+MLP block and go directly to the output projection (mlp2). Scale the non-dropped path by `1.0 / 0.9`.
2. Run with: `--wandb_name "alphonse/stoch-depth" --wandb_group stochastic-depth --agent alphonse`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run ID:** x463mgp0
**Epochs completed:** 80/100 (30-min timeout; ~22.3s/epoch)
**Peak VRAM:** ~8.8 GB (architecture unchanged)

| Metric | Baseline | This run (ep80, best) | Delta |
|---|---|---|---|
| val/loss | 2.4067 | **2.5204** | +4.7% worse |
| val_in_dist/mae_surf_p | 22.86 | **23.30** | +1.9% worse |
| val_ood_cond/mae_surf_p | 22.93 | **26.14** | +14% worse |
| val_ood_re/mae_surf_p | 32.68 | **33.85** | +3.6% worse |
| val_tandem_transfer/mae_surf_p | 44.16 | **46.76** | +5.9% worse |

Additional val_in_dist at best epoch:
- mae_surf_Ux: 0.306 | mae_surf_Uy: 0.181
- mae_vol_Ux: 1.717 | mae_vol_Uy: 0.608 | mae_vol_p: 34.22

### What happened

**This did not work.** All metrics are worse, with val_ood_cond notably degraded (+14%).

The core problem with stochastic depth in a 1-layer model: in multi-layer networks, dropping one layer still leaves the other layers to process features. With only 1 attention layer, dropping it means 10% of training batches pass from raw preprocess features directly to the output MLP, bypassing all attention-based spatial mixing. These "dropped" batches produce poor loss signals that may actively mislead the network.

The val_ood_cond regression (+14%) suggests the attention mechanism is critical for out-of-distribution conditions — the model can't generalize to new conditions without spatial feature mixing. Forcing it to occasionally skip attention learning hurts OOD performance disproportionately.

The "saves ~10% compute" hypothesis was also not realized in practice: 80 epochs completed vs baseline ~80 epochs, suggesting the compute savings are within run-to-run variance.

### Suggested follow-ups
- Stochastic depth makes more sense with multiple layers (n_layers=2+) where dropping one layer still preserves most processing
- A lighter regularization approach would be to increase the existing dropout instead
- The 1-layer architecture may simply not have enough redundancy to benefit from stochastic depth