### PR TITLE
Per-group gradient clipping (0.5 attn, 2.0 MLP)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -634,7 +634,8 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(attn_params, max_norm=0.5)
+        torch.nn.utils.clip_grad_norm_(other_params, max_norm=2.0)
         optimizer.step()
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})


### PR DESCRIPTION
## Hypothesis
Differential LR worked (round 18). Extending to gradient clipping: attention needs stability (lower clip 0.5), MLP tolerates larger gradients (clip 2.0). Same principle, zero speed cost.

## Instructions
In `structured_split/structured_train.py`:
1. Replace the single `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)` with two calls:
   - `torch.nn.utils.clip_grad_norm_(attn_params, max_norm=0.5)` (use the same attn_params list from differential LR)
   - `torch.nn.utils.clip_grad_norm_(other_params, max_norm=2.0)` (all other model params)
2. Run with: `--wandb_name "edward/pergroup-clip" --wandb_group pergroup-clip --agent edward`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** 81rs9gp2 | **Epochs:** 81 (30 min wall-clock limit) | **Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 2.4521 | 0.290 | 0.190 | **23.21** | 1.716 | 0.608 | 35.58 |
| ood_cond | — | 0.281 | 0.198 | **23.89** | 1.439 | 0.544 | 27.48 |
| ood_re | NaN | 0.301 | 0.208 | **32.75** | 1.365 | 0.543 | 56.63 |
| tandem | — | 0.646 | 0.351 | **43.75** | 2.631 | 1.229 | 52.18 |

**vs. baseline (val/loss 2.4067, mae_surf_p: in_dist 22.86 / ood_cond 22.93 / ood_re 32.68 / tan 44.16):**
- val/loss: 2.4521 vs 2.4067 (**+1.9%** — slightly worse)
- mae_surf_p in_dist: 23.21 vs 22.86 (**+1.5%** — slightly worse)
- mae_surf_p ood_cond: 23.89 vs 22.93 (**+4.2%** — worse)
- mae_surf_p ood_re: 32.75 vs 32.68 (**+0.2%** — essentially flat)
- mae_surf_p tandem: 43.75 vs 44.16 (**-0.9%** — marginally better)

### What happened

Per-group gradient clipping did not improve performance — results are modestly worse than baseline. The analogy with differential LR doesn't fully carry over: differential LR gives attention parameters slower, more stable updates relative to MLP parameters. Per-group clipping with max_norm=0.5 for attention and 2.0 for MLP has a more irregular effect — it depends on the actual gradient magnitudes at each step, which can vary significantly.

The issue is that with max_norm=0.5 for attention (half of the previous 1.0 uniform clip) and 2.0 for MLP (double), we're effectively cutting attention gradient steps while allowing larger MLP steps. If attention gradients are typically small relative to MLP gradients, the lower clip may be overly restrictive; if they're large, the lower clip may improve stability but at the cost of slower convergence. Without knowing the actual gradient magnitude distributions per group, the chosen values (0.5 / 2.0) are essentially a guess.

### Suggested follow-ups

1. **Profile gradient magnitudes**: Log per-group gradient norms to understand the actual baseline — this would reveal whether attention gradients are typically larger or smaller than MLP gradients.
2. **Equal clip at 1.0**: Keep the current uniform clip if per-group clipping doesn't help, since the evidence suggests the uniform approach is more reliable.
3. **clip attn at 1.0, MLP at 2.0**: Try a less aggressive version — keep attention at baseline and only relax MLP.