### PR TITLE
Checkpoint by mean surface pressure MAE (direct metric optimization)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -533,6 +533,7 @@ with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
 best_val = float("inf")
+best_mean_surf_p = float("inf")
 best_metrics = {}
 global_step = 0
 train_start = time.time()
@@ -761,10 +762,17 @@ for epoch in range(MAX_EPOCHS):
     else:
         peak_mem_gb = 0.0
 
+    mean_surf_p = sum(
+        val_metrics_per_split[name][f"{name}/mae_surf_p"]
+        for name in ["val_in_dist", "val_ood_cond", "val_tandem_transfer"]
+    ) / 3.0
+
     tag = ""
     if mean_val_loss < best_val:
         best_val = mean_val_loss
-        best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss}
+    if mean_surf_p < best_mean_surf_p:
+        best_mean_surf_p = mean_surf_p
+        best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss, "mean_surf_p": mean_surf_p}
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v


### PR DESCRIPTION
## Hypothesis
Checkpoint selection by val/loss doesn't perfectly align with surface pressure MAE (proven in round 16). Select checkpoint by mean surface pressure MAE across in_dist, ood_cond, tandem (skip ood_re which can have NaN).

## Instructions
In `structured_split/structured_train.py`:
1. After computing all val metrics, compute: `mean_surf_p = mean(val_in_dist_surf_p, val_ood_cond_surf_p, val_tandem_surf_p)`
2. Track `best_mean_surf_p` alongside `best_val_loss`. Save checkpoint when `mean_surf_p < best_mean_surf_p`.
3. Still log val/loss for comparison, but use mean_surf_p for checkpoint selection.
4. Run with: `--wandb_name "thorfinn/ckpt-surfp" --wandb_group ckpt-surfp-v2 --agent thorfinn`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** `d5ejgv37` (thorfinn/ckpt-surfp, group: ckpt-surfp-v2)
**Epochs:** 77 (30-min wall clock limit)

Checkpoint selected by: mean_surf_p = mean(in_dist, ood_cond, tandem mae_surf_p)
Best epoch by both val/loss and mean_surf_p: epoch 77 (still improving at timeout)

| Metric | Baseline | This run (epoch 77) | Δ |
|---|---|---|---|
| val/loss | 2.4067 | **2.5989** | +0.193 ↑ worse |
| mean_surf_p (ckpt criterion) | — | 33.64 Pa | — |
| in_dist surf_p (Pa) | 22.86 | 26.03 | +3.17 ↑ worse |
| ood_cond surf_p (Pa) | 22.93 | 26.66 | +3.73 ↑ worse |
| ood_re surf_p (Pa) | 32.68 | 34.40 | +1.72 ↑ worse |
| tandem surf_p (Pa) | 44.16 | 48.22 | +4.06 ↑ worse |

Full surface MAE at best epoch:
- val_in_dist: Ux=0.349, Uy=0.205, p=26.03 Pa
- val_ood_cond: Ux=0.294, Uy=0.203, p=26.66 Pa
- val_ood_re: Ux=0.298, Uy=0.210, p=34.40 Pa
- val_tandem: Ux=0.688, Uy=0.372, p=48.22 Pa

**Peak memory:** ~8.8 GB

### What happened

**Negative result.** All metrics are substantially worse than baseline. Importantly, the best epoch by both val/loss and mean_surf_p is epoch 77 (the last epoch) — the model was still improving at the 30-minute timeout, suggesting it's simply converging slower rather than converging to a different optimum.

The checkpoint selection by mean_surf_p worked correctly — it selects the same epoch as val/loss selection would (since both are monotonically improving). But the overall training performance is worse than the baseline, likely because this branch includes other modifications (tandem_boost on surf_loss, prediction normalization during training) that interact differently with the training dynamics.

Changing checkpoint selection criterion alone cannot improve training quality — it only affects which saved weights are used. Since the best epoch here is the final epoch (still improving), the checkpoint selection doesn't differ from val/loss-based selection.

### Suggested follow-ups
- The baseline improvement (val/loss 2.4067 vs this run's 2.5989) is likely due to other changes in the baseline branch — investigate what modifications in the advisor's branch account for the gap
- If checkpoint divergence between val/loss and mean_surf_p is common in the baseline, applying this change there might yield small improvements