### PR TITLE
Surface weight warmup from 0 (pure volume for first 5 epochs)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -545,10 +545,11 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
-    surf_weight = sw_start + (sw_end - sw_start) * progress
+    # Surf warmup: 0→5 over first 5 epochs (volume-first), then 5→30 for remainder
+    if epoch < 5:
+        surf_weight = 5.0 * (epoch / 5)
+    else:
+        surf_weight = 5.0 + 25.0 * ((epoch - 5) / (MAX_EPOCHS - 5))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
surf_weight starts at 5.0 from epoch 0. During LR warmup (0-5), model receives both ramping LR and active surface loss. Starting surf_weight at 0 and ramping to 5 over warmup lets model focus purely on volume structure first.

## Instructions
In `structured_split/structured_train.py`:
1. Modify surf_weight calculation: `if epoch < 5: surf_weight = 5.0 * (epoch / 5); else: surf_weight = 5.0 + 25.0 * ((epoch - 5) / (MAX_EPOCHS - 5))`
2. Run with: `--wandb_name "askeladd/surf-warmup" --wandb_group surf-warmup-zero --agent askeladd`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** `bw5tn11h`
**Epochs completed:** 78 (hit 30-min timeout; val/loss was still improving at cutoff)
**Runtime:** 1755s
**Peak memory:** ~9 GB (consistent with prior runs; run crashed before script could log summary)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.4067 | **2.5049** | +0.098 ↑ worse |
| val_in_dist/mae_surf_p | 22.86 | 24.22 | +1.36 ↑ |
| val_ood_cond/mae_surf_p | 22.93 | 24.47 | +1.54 ↑ |
| val_ood_re/mae_surf_p | 32.68 | 33.44 | +0.76 ↑ |
| val_tandem_transfer/mae_surf_p | 44.16 | 45.77 | +1.61 ↑ |

**Volume MAE (val_in_dist):** Ux=1.695, Uy=0.591, p=34.00

Note: `val_ood_re/surf_loss=NaN` is a pre-existing bug unrelated to this change.

### What happened

The hypothesis failed — all surface MAE metrics are worse than baseline across every validation split. Delaying the surface signal for the first 5 epochs (surf_weight=0 during LR warmup) does not help; it hurts.

The baseline already starts at surf_weight=5.0 from epoch 0. The LR warmup ramps the learning rate from 10% to 100% over those same 5 epochs, which already provides a natural softening of early updates. Adding a second warmup on surf_weight means the model receives weaker-than-baseline surface supervision for the first 20 steps (5 epochs × ~330 batches each), apparently at the cost of surface representation quality.

The val/loss curve was still declining at epoch 78 (the final value was also the minimum), so the run was cut off before converging. Even so, the deficit vs. baseline is large enough (~0.1 val/loss) that further training is unlikely to fully close the gap.

### Suggested follow-ups

- The LR warmup + surf_weight ramp is double-softening the early training. If there's benefit to reducing surface loss weight early, a much shorter warmup (1-2 epochs instead of 5) might avoid the surface-learning deficit.
- Alternatively, try the opposite: start with a *higher* surf_weight early (e.g., 10→30 ramp starting from 10 instead of 5) to front-load surface learning.