### PR TITLE
ReZero gate (zero-init scalar gate on attention/MLP output)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -178,6 +178,8 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.alpha_attn = nn.Parameter(torch.zeros(1))
+        self.alpha_mlp = nn.Parameter(torch.zeros(1))
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -187,8 +189,10 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        attn_output = self.attn(self.ln_1(fx))
+        fx = self.alpha_attn * attn_output + fx
+        mlp_output = self.mlp(self.ln_2(fx))
+        fx = self.alpha_mlp * mlp_output + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx
@@ -485,8 +489,8 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'alpha_attn', 'alpha_mlp'])]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'alpha_attn', 'alpha_mlp'])]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}


### PR DESCRIPTION
## Hypothesis
ReZero (Bachlechner 2020): add zero-initialized scalar gate on sublayer outputs. Model starts as pure preprocess MLP (gate=0 kills attention), gradually learns to incorporate attention. Simpler than layer scale, accelerates training.

## Instructions
In `structured_split/structured_train.py`, in `TransolverBlock.__init__`:
1. Add: `self.alpha_attn = nn.Parameter(torch.zeros(1))` and `self.alpha_mlp = nn.Parameter(torch.zeros(1))`
2. In forward: `fx = self.alpha_attn * attn_output + fx` and `fx = self.alpha_mlp * mlp_output + fx`
3. Add alpha params to attn_params group for differential LR.
4. Run with: `--wandb_name "gilbert/rezero" --wandb_group rezero-gate --agent gilbert`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** `di1n3oby` (gilbert/rezero)
**Epochs:** 76 (30.4 min wall-clock limit)
**Peak memory:** 9.3 GB (+0.5 GB vs baseline)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.828 | 0.305 | 0.193 | **24.96** | 1.842 | 0.643 | 36.66 |
| val_ood_cond | 2.259 | 0.301 | 0.202 | **26.86** | 1.505 | 0.557 | 28.48 |
| val_ood_re | NaN | 0.300 | 0.212 | 34.64 | 1.383 | 0.553 | 56.72 |
| val_tandem_transfer | 3.691 | 0.696 | 0.371 | **46.96** | 2.669 | 1.268 | 54.37 |
| **val/loss (mean)** | **2.5927** | | | | | | |

**vs. baseline:**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.4067 | 2.5927 | +0.186 (+7.7%) ❌ |
| val_in_dist/mae_surf_p | 22.86 | 24.96 | +2.10 (+9.2%) ❌ |
| val_ood_cond/mae_surf_p | 22.93 | 26.86 | +3.93 (+17.1%) ❌ |
| val_ood_re/mae_surf_p | 32.68 | 34.64 | +1.96 (+6.0%) ❌ |
| val_tandem_transfer/mae_surf_p | 44.16 | 46.96 | +2.80 (+6.3%) ❌ |

**What happened:** ReZero gating significantly hurt performance across all splits — val/loss is 7.7% worse and surface pressure degrades by 9–17%. This is a clear failure.

The likely cause: with both alpha_attn and alpha_mlp initialized to zero, the TransolverBlock starts as an identity function. The attention and MLP outputs are gated out entirely at epoch 1, so the model initially provides no contribution to the residual stream — the network effectively trains as a pure input-passthrough. This is very different from standard transformer training where attention contributes immediately. The alpha params must learn to increase from zero, but with the low Lookahead learning rate, they learn too slowly. Compared to a non-gated start, the network wastes training steps building up the alpha values rather than learning physics.

Also: slightly higher memory (9.3 vs 8.8 GB) due to storing attn_output and mlp_output tensors separately, and 5 fewer epochs completed (76 vs 81) due to the ~2s/epoch overhead.

**Suggested follow-ups:**
- Try initializing alpha to 1.0 instead of 0 (learned scale rather than gate) — this preserves the standard training dynamics while adding a per-layer learnable scale
- Try only gating the attention (not MLP): alpha_attn starts at 0, but no gating on MLP output, so training starts with MLP-only then learns when to add attention