### PR TITLE
Late-epoch pressure channel weight [1,1,1.5] after epoch 40

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -610,7 +610,12 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        if epoch >= 40:
+            channel_weight = torch.tensor([1.0, 1.0, 1.5], device=device)
+            abs_err_surf = abs_err * channel_weight[None, None, :]
+        else:
+            abs_err_surf = abs_err
+        surf_per_sample = (abs_err_surf * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Channel [1,1,2] improved all surface metrics but hurt val/loss (round 18). Apply pressure emphasis only after epoch 40 when shared velocity-pressure structure is learned. Early epochs need balanced channels.

## Instructions
In `structured_split/structured_train.py`:
1. Before computing surf_loss, if epoch >= 40, multiply the pressure channel of abs_err by 1.5:
   ```python
   if epoch >= 40:
       channel_weight = torch.tensor([1.0, 1.0, 1.5], device=device)
       abs_err_surf = abs_err * channel_weight[None, None, :]  # apply to surface loss computation
   ```
2. Use the weighted abs_err only for surf_loss, not vol_loss.
3. Run with: `--wandb_name "emma/late-pressure" --wandb_group late-pressure-wt --agent emma`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** 1k2yiybl  
**Runtime:** 30.2 min | **Best epoch:** 80 | **Epoch time:** 22.3s | **Peak GPU:** ~50 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 2.4780 | 2.4067 | +0.0713 ↑ worse |
| val_in_dist/mae_surf_Ux | 0.3096 | — | |
| val_in_dist/mae_surf_Uy | 0.1853 | — | |
| val_in_dist/mae_surf_p | 23.10 | 22.86 | +0.24 ↑ worse |
| val_in_dist/mae_vol_Ux | 1.7409 | — | |
| val_in_dist/mae_vol_Uy | 0.6201 | — | |
| val_in_dist/mae_vol_p | 38.55 | — | |
| val_ood_cond/mae_surf_p | 23.98 | 22.93 | +1.05 ↑ worse |
| val_ood_re/mae_surf_p | 33.78 | 32.68 | +1.10 ↑ worse |
| val_tandem_transfer/mae_surf_p | 44.89 | 44.16 | +0.73 ↑ worse |

**What happened:** Negative result across all metrics. Late-epoch pressure weighting hurts rather than helps. The [1,1,1.5] multiplier applied from epoch 40 inflates the surface loss pressure channel, which reshapes the training signal but does not translate to improved physical accuracy. Likely causes: (1) the discontinuous loss change at epoch 40 destabilizes late-stage optimization; (2) the pressure channel weight makes the training and validation loss scales inconsistent — validation still measures unweighted MAE, so optimizing a weighted version misleads the model. The earlier [1,1,2] result that motivated this idea may also have been noise.

**Suggested follow-ups:**
- Try the channel weighting applied from epoch 0 (constant throughout), which avoids the epoch-40 discontinuity and is simpler.
- If pressure weighting is to be re-explored, apply it to the *metric used for model selection* (best checkpoint), not just to training loss.
- Investigate whether the cross-split pressure variance suggests a normalization issue rather than a loss weighting issue.