### PR TITLE
Lookahead k=5 alpha=0.8 (more frequent sync)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -491,7 +491,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=5, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=MAX_EPOCHS - 5, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
k=5 with alpha=0.5 showed ood_cond improvement (21.65). Testing k=5 with existing alpha=0.8 provides more frequent stabilization while keeping strong interpolation. 1-line change.

## Instructions
In `structured_split/structured_train.py`:
1. Change `Lookahead(base_opt, k=10, alpha=0.8)` to `Lookahead(base_opt, k=5, alpha=0.8)`
2. Run with: `--wandb_name "norman/la-k5" --wandb_group la-k5-a08 --agent norman`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** `y4zdfy4s` | 81 epochs (30.2 min, wall-clock timeout) | Peak memory: 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol |
|---|---|---|---|---|---|
| val_in_dist | 1.681 | 0.310 | 0.180 | **23.16** | Ux=1.64, Uy=0.58, p=33.72 |
| val_ood_cond | 2.063 | 0.279 | 0.186 | **22.83** | Ux=1.48, Uy=0.53, p=25.01 |
| val_ood_re | nan | 0.301 | 0.207 | **32.38** | Ux=1.38, Uy=0.54, p=55.58 |
| val_tandem_transfer | 3.504 | 0.665 | 0.353 | **43.97** | Ux=2.53, Uy=1.19, p=50.15 |
| **val/loss (mean)** | **2.4162** | | | | |

**vs baseline (val/loss 2.4067):**
| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 22.86 | 23.16 | **+1.3% ✗** |
| val_ood_cond | 22.93 | 22.83 | **-0.4% ≈** |
| val_ood_re | 32.68 | 32.38 | **-0.9% ≈** |
| val_tandem_transfer | 44.16 | 43.97 | **-0.4% ≈** |
| val/loss | 2.4067 | 2.4162 | **+0.4%** |

### What happened

Neutral result. val/loss is marginally worse (+0.4%) and the surface pressure changes are within noise — in_dist slightly worse (+1.3%), ood splits marginally better (-0.4% to -0.9%). This is consistent with the earlier k=5/α=0.5 experiment (#545) which was also neutral/mixed.

The more frequent slow-weight sync (every 5 steps vs 10) with the same strong interpolation (α=0.8) doesn't appear to materially change the optimization. Lookahead's benefit seems insensitive to k in the 5–10 range for this problem, at least with α=0.8.

### Suggested follow-ups
- Try k=5 with α=0.5 (the earlier experiment that showed some ood_cond improvement) on this updated baseline
- Test k=3 or k=2 for even more frequent syncing — there may be a threshold effect
- Disable Lookahead entirely and compare to understand its marginal contribution