### PR TITLE
FP32 preprocess and output MLP (bf16 only for attention)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -187,7 +187,9 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            attn_out = self.attn(self.ln_1(fx))
+        fx = attn_out.to(fx.dtype) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
@@ -583,9 +585,7 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
-        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
-        pred = pred.float()
+        pred = model({"x": x})["preds"]
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -687,9 +687,7 @@ for epoch in range(MAX_EPOCHS):
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
 
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
-                pred = pred.float()
+                pred = model({"x": x})["preds"]
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis
bf16's 3-digit mantissa may lose precision for small features (binary is_surface, small AoA). Running preprocess and output in fp32, keeping only attention in bf16, should improve numerical precision at minimal speed cost.

## Instructions
In `structured_split/structured_train.py`:
1. Move the `torch.amp.autocast` context to wrap ONLY the TransolverBlock forward call, not preprocess or output.
2. Or explicitly: run preprocess MLP in fp32, cast to bf16 before attention, cast back to fp32 for output MLP.
3. Run with: `--wandb_name "chihiro/fp32-io" --wandb_group fp32-preprocess --agent chihiro`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---
## Results

**W&B run:** `63jw35qe`
**Best epoch:** 63 (wall-clock limit: 30.3 min)
**Epoch time:** 28.1 s/epoch vs ~22 s/epoch baseline (+28% slower)
**VRAM:** ~8.8 GB

### val/loss

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.7261** | 2.4067 | +0.319 (much worse) |

### Surface MAE (mae_surf_p, Pa)

| Split | This run | Baseline | Δ |
|-------|----------|----------|---|
| val_in_dist | 29.80 | 22.86 | +6.94 (much worse) |
| val_ood_cond | 30.04 | 22.93 | +7.11 (much worse) |
| val_ood_re | 36.50 | 32.68 | +3.82 (worse) |
| val_tandem_transfer | 47.41 | 44.16 | +3.25 (worse) |

### Volume MAE (val_in_dist)

| Channel | MAE |
|---------|-----|
| Ux | 1.80 |
| Uy | 0.67 |
| p | 37.48 |

### What happened

Strong negative result. All splits significantly worse, with in_dist and ood_cond surface pressure errors jumping by ~7 Pa each. Two issues compounded:

1. **Slower training**: fp32 for preprocess + intermediate MLPs + output head is 28% slower per epoch (28.1 s vs ~22 s). This leaves only 63 epochs in the 30-min budget instead of 80, so the model is significantly undertrained.

2. **Possible degraded optimization**: Full bf16 training may provide beneficial implicit gradient noise/regularization that fp32 removes, or the bf16-fp32 boundary casts within each block add numerical overhead.

The precision hypothesis did not hold. The bf16 mantissa is sufficient for this task — input features like `is_surface` (binary) and small AoA differences are encoded through learned embeddings in the preprocess MLP, and by that point the representation is in hidden_dim=128 space where bf16 has ample precision. The 28% speed cost of fp32 dominates over any precision benefit.

### Suggested follow-ups
- Precision issues, if any, are more likely to occur in the final output (small differences in predicted p that map to large physical errors) rather than the input processing. A targeted study could test fp32 only for mlp2 (the output head), keeping everything else in bf16 — this would add nearly zero overhead.
- The val_ood_re NaN vol_loss = 18.9B persists — this is a different issue from precision.