### PR TITLE
Velocity noise annealing 0.015→0.005 (fixed pressure 0.005)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -567,7 +567,8 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+            vel_noise = 0.015 - 0.01 * min(epoch / 80, 1.0)  # 0.015 -> 0.005
+            noise_scale = torch.tensor([vel_noise, vel_noise, 0.005], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)


### PR DESCRIPTION
## Hypothesis
Noise annealing (round 20) achieved best-ever in_p=22.00 with higher early velocity noise (0.015). Combine with current pressure noise (0.005). Higher early vel noise gives stronger regularization, clean signal late.

## Instructions
In `structured_split/structured_train.py`:
1. Replace fixed noise_scale with epoch-dependent:
   ```python
   vel_noise = 0.015 - 0.01 * min(epoch / 80, 1.0)  # 0.015 -> 0.005
   noise_scale = torch.tensor([vel_noise, vel_noise, 0.005], device=device)
   ```
2. Keep pressure noise fixed at 0.005 as currently set.
3. Run with: `--wandb_name "haku/vel-anneal" --wandb_group vel-noise-anneal --agent haku`

## Baseline
val/loss: **2.4067**
val_in_dist/mae_surf_p: 22.86
val_ood_cond/mae_surf_p: 22.93
val_ood_re/mae_surf_p: 32.68
val_tandem_transfer/mae_surf_p: 44.16
---

## Results

**W&B run ID:** `734srpoa`  
**Best epoch:** 77 / 77 (30.1 min wall-clock timeout)  
**Peak GPU memory:** 8.8 GB (no change)

### Metrics at best checkpoint (epoch 77)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.8421 | 0.343 | 0.195 | 25.9 | 1.704 | 0.604 | 35.6 |
| val_tandem_transfer | 3.6306 | 0.668 | 0.364 | 48.0 | 2.583 | 1.243 | 54.6 |
| val_ood_cond | 2.1041 | 0.295 | 0.198 | 23.9 | 1.437 | 0.539 | 26.0 |
| val_ood_re | NaN* | 0.296 | 0.209 | 33.2 | 1.338 | 0.548 | 55.5 |
| **combined val/loss** | **2.5256** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.4067 → This run: 2.5256 — worse (+0.119, ~5%)**

Surface pressure MAE vs baseline:
- val_in_dist: 25.9 vs 22.86 (+3.0, worse)
- val_ood_cond: 23.9 vs 22.93 (+1.0, slightly worse)
- val_ood_re: 33.2 vs 32.68 (+0.5, slightly worse)
- val_tandem_transfer: 48.0 vs 44.16 (+3.8, worse)
- **All splits worse than baseline**

### What happened

The velocity noise annealing (0.015 → 0.005) performed worse than the fixed 0.01 noise baseline across all splits. The higher early noise (0.015 vs 0.01) appears to hurt more than it helps.

The likely mechanism: the current noise level (0.01) is already well-calibrated. Raising it to 0.015 in the critical early training epochs (1-40) when the model is learning basic flow patterns adds too much confusion. The progressive resolution and dynamic surface weighting already provide strong regularization in early epochs; the additional noise on top is detrimental rather than helpful.

The val_ood_cond and val_ood_re splits (OOD conditions) also degraded, suggesting the higher noise is not improving generalization either.

The referenced noise annealing round 20 that achieved val_in_dist/mae_surf_p=22.00 may have been running on a different baseline with different regularization stack — combining higher noise with the current noam baseline's per-sample std normalization, tandem boost, and progressive resolution may produce different interactions.

### Suggested follow-ups

- The current noise level (0.01) is near-optimal for this setup. Avoid increasing velocity noise.
- If noise annealing is worth exploring, try annealing DOWN from the current 0.01 to a lower value (e.g., 0.01 → 0.003) to see if cleaner late-training signal helps.
- Consider whether the noise annealing interacts with the per-sample std normalization: since y_norm is divided by sample_stds, the effective noise level is 0.01 / sample_std rather than absolute 0.01.
