### PR TITLE
Decoupled weight decay (exclude norms, scales, biases from WD)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -485,12 +485,20 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
+no_decay_names = ['bias', 'ln_', 'LayerNorm', 'placeholder_scale', 'placeholder_shift', 'temperature', 'attn_scale']
+attn_keywords = ['Wqkv', 'temperature', 'slice_weight', 'attn_scale']
+
+attn_decay = [p for n, p in model.named_parameters() if any(k in n for k in attn_keywords) and not any(nd in n for nd in no_decay_names)]
+attn_no_decay = [p for n, p in model.named_parameters() if any(k in n for k in attn_keywords) and any(nd in n for nd in no_decay_names)]
+other_decay = [p for n, p in model.named_parameters() if not any(k in n for k in attn_keywords) and not any(nd in n for nd in no_decay_names)]
+other_no_decay = [p for n, p in model.named_parameters() if not any(k in n for k in attn_keywords) and any(nd in n for nd in no_decay_names)]
+
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
+    {'params': attn_decay, 'lr': cfg.lr * 0.5, 'weight_decay': 1e-4},
+    {'params': attn_no_decay, 'lr': cfg.lr * 0.5, 'weight_decay': 0.0},
+    {'params': other_decay, 'lr': cfg.lr, 'weight_decay': 1e-4},
+    {'params': other_no_decay, 'lr': cfg.lr, 'weight_decay': 0.0},
+], weight_decay=1e-4)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)


### PR DESCRIPTION
## Hypothesis
Weight decay=1e-4 applies to all params including LayerNorm, placeholder_scale/shift, temperature, and attn_scale. Regularizing normalization params and learned scales hurts generalization. Excluding them from WD is standard practice in modern transformer training.

## Instructions
In the optimizer parameter group setup, split params into 4 groups based on whether they need weight decay and which LR group they belong to:
```python
no_decay_names = ['bias', 'ln_', 'LayerNorm', 'placeholder_scale', 'placeholder_shift', 'temperature', 'attn_scale']
attn_keywords = ['Wqkv', 'temperature', 'slice_weight', 'attn_scale']

attn_decay = [p for n, p in model.named_parameters() if any(k in n for k in attn_keywords) and not any(nd in n for nd in no_decay_names)]
attn_no_decay = [p for n, p in model.named_parameters() if any(k in n for k in attn_keywords) and any(nd in n for nd in no_decay_names)]
other_decay = [p for n, p in model.named_parameters() if not any(k in n for k in attn_keywords) and not any(nd in n for nd in no_decay_names)]
other_no_decay = [p for n, p in model.named_parameters() if not any(k in n for k in attn_keywords) and any(nd in n for nd in no_decay_names)]

base_opt = torch.optim.AdamW([
    {'params': attn_decay, 'lr': cfg.lr * 0.5, 'weight_decay': 1e-4},
    {'params': attn_no_decay, 'lr': cfg.lr * 0.5, 'weight_decay': 0.0},
    {'params': other_decay, 'lr': cfg.lr, 'weight_decay': 1e-4},
    {'params': other_no_decay, 'lr': cfg.lr, 'weight_decay': 0.0},
], weight_decay=1e-4)
```

Run with: `--wandb_name "frieren/decoupled-wd" --wandb_group decoupled-wd --agent frieren`

## Baseline
- val/loss: **2.3965**
- val_in_dist/mae_surf_p: 20.78
- val_ood_cond/mae_surf_p: 23.02
- val_ood_re/mae_surf_p: 31.76
- val_tandem_transfer/mae_surf_p: 45.20

---

## Results

**W&B run:** `hx25bity` (~78 epochs, 29.2 min, timed out)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3965 | **2.4198** | +0.97% |
| val_in_dist/mae_surf_p | 20.78 | **22.27** | +7.2% |
| val_ood_cond/mae_surf_p | 23.02 | **23.59** | +2.5% |
| val_ood_re/mae_surf_p | 31.76 | **32.28** | +1.6% |
| val_tandem_transfer/mae_surf_p | 45.20 | **45.51** | +0.7% |

Surface MAE (Ux, Uy, p) by split (last epoch):
- val_in_dist: (0.282, 0.173, 22.27), mean = 7.58
- val_ood_cond: (0.281, 0.197, 23.59), mean = 8.02
- val_tandem_transfer: (0.650, 0.355, 45.51), mean = 15.50

Volume MAE by split:
- val_in_dist: (1.658, 0.587, 34.25), mean = 12.17
- val_ood_cond: (1.410, 0.527, 26.47), mean = 9.47
- val_tandem_transfer: (2.564, 1.212, 51.56), mean = 18.45

### What happened
Decoupled weight decay (zero WD on biases, LayerNorm, temperature, attn_scale) slightly hurt performance across all splits. The most notable regression is in-distribution surface pressure (+7.2%), while tandem transfer was barely affected (+0.7%).

The result is mildly negative. This model is small (242K params) and is already lightly regularized; removing WD from a subset of params mostly small-magnitude learned scalars appears to make little difference or marginally hurts. With WD on the full model, the temperature and attn_scale are gently pulled toward zero, which may have a mild stabilizing effect. Removing it allows them to drift further, which at this scale could be slightly destabilizing.

### Suggested follow-ups
- Try WD=0 on everything (no weight decay at all) to test whether WD is helpful in any form.
- Try a smaller WD (1e-5 vs 1e-4) across all params as an alternative to decoupling.