### PR TITLE
Kaiming fan-in init (replace orthogonal for GELU networks)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -255,6 +255,10 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
+        # Keep orthogonal init for in_project_slice (slice assignment weights)
+        for m in self.modules():
+            if hasattr(m, 'in_project_slice') and isinstance(m.in_project_slice, nn.Linear):
+                torch.nn.init.orthogonal_(m.in_project_slice.weight)
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
 
@@ -264,7 +268,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.kaiming_normal_(module.weight, mode='fan_in', nonlinearity='linear')
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:


### PR DESCRIPTION
## Hypothesis
Orthogonal init with gain=1.0 preserves norms in deep networks but is irrelevant for 1-layer. Kaiming fan-in is designed for GELU/ReLU (variance=2/fan_in), better matching activation statistics.

## Instructions
In `_init_weights`, replace `nn.init.orthogonal_(module.weight, gain=1.0)` with:
```python
nn.init.kaiming_normal_(module.weight, mode='fan_in', nonlinearity='linear')
```
Keep the explicit orthogonal init for `in_project_slice.weight`. Everything else gets Kaiming.

Run with: `--wandb_name "fern/kaiming" --wandb_group kaiming-init --agent fern`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**Run ID**: 1fc84qqh  
**Epochs**: 81 (wall-clock limit ~30 min)  
**Peak memory**: ~8.8 GB  

**Implementation note**: `initialize_weights()` (via `apply()`) overwrites all Linear weights after module construction. Added explicit re-application of orthogonal init to all `in_project_slice.weight` tensors after `initialize_weights()` to honor the "keep orthogonal for slice" instruction.

### Val/loss
| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.3965 | **2.4262** | +1.2% (slightly worse) |

### Surface MAE (primary metric)
| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|-------|---------------------|---------------------|-------|
| val_in_dist | 20.78 | 21.08 | +1.4% (slightly worse) |
| val_ood_cond | 23.02 | 23.33 | +1.3% (slightly worse) |
| val_ood_re | 31.76 | 32.81 | +3.3% (worse) |
| val_tandem_transfer | 45.20 | 45.20 | 0.0% (identical) |

All splits slightly worse or unchanged. Negative result overall.

### Full Surface MAE
| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|-------------|-------------|------------|
| val_in_dist | 0.270 | 0.179 | 21.08 |
| val_ood_cond | 0.279 | 0.197 | 23.33 |
| val_ood_re | 0.296 | 0.207 | 32.81 |
| val_tandem_transfer | 0.674 | 0.360 | 45.20 |

### Full Volume MAE
| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.700 | 0.589 | 35.36 |
| val_ood_cond | 1.428 | 0.538 | 26.72 |
| val_ood_re | 1.347 | 0.545 | 56.14 |
| val_tandem_transfer | 2.570 | 1.214 | 52.49 |

Note: val_ood_re/loss = nan (pre-existing issue).

### What happened

Slightly negative result. Kaiming fan-in init performs marginally worse than the orthogonal baseline across all surface pressure splits. The differences are small (1-3%), suggesting init choice matters less than other hyperparameters for this model.

The orthogonal init likely provides better gradient flow in the early training phases for this specific architecture — it preserves singular values which may help the Transolver's physics-attention mechanism converge faster. The 30-minute time budget means initialization quality at epoch 0 has a compounding effect.

### Suggested follow-ups

- The baseline orthogonal init appears well-suited for this architecture; further init experiments are likely not worth the research budget
- Worth verifying that the explicit orthogonal re-init for in_project_slice (line 112) is actually active and not overwritten — confirmed in this implementation