### PR TITLE
Fixup-style learnable residual alpha (init=1.0, learn ratio)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -178,6 +178,8 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.attn_alpha = nn.Parameter(torch.tensor(1.0))
+        self.mlp_alpha = nn.Parameter(torch.tensor(1.0))
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -187,8 +189,8 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        fx = self.attn_alpha * self.attn(self.ln_1(fx)) + fx
+        fx = self.mlp_alpha * self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx


### PR DESCRIPTION
## Hypothesis
ReZero (init=0) killed signal. Layer Scale (init=0.1) too conservative. Init to 1.0 (=current behavior) but make learnable. Model can learn attn vs MLP contribution ratios.

## Instructions
In `TransolverBlock.__init__`, add:
```python
self.attn_alpha = nn.Parameter(torch.tensor(1.0))
self.mlp_alpha = nn.Parameter(torch.tensor(1.0))
```
In forward:
```python
fx = self.attn_alpha * self.attn(self.ln_1(fx)) + fx
fx = self.mlp_alpha * self.mlp(self.ln_2(fx)) + fx
```

Run with: `--wandb_name "tanjiro/fixup" --wandb_group fixup-alpha --agent tanjiro`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `7cbbt8cf` | **Best epoch:** 73 | **Peak memory:** 9.3 GB

| Split | val/loss | mae_surf_p | mae_surf_Ux | mae_surf_Uy | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.649 | **22.30** (+1.52 ✗) | 0.290 | 0.179 | 1.684 | 0.586 | 34.62 |
| ood_cond | 2.077 | **23.54** (+0.52 ✗) | 0.278 | 0.190 | 1.416 | 0.523 | 25.62 |
| ood_re | — | **32.12** (+0.36 ✗) | 0.290 | 0.205 | 1.352 | 0.536 | 55.56 |
| tandem_transfer | 3.597 | **46.43** (+1.23 ✗) | 0.682 | 0.358 | 2.620 | 1.218 | 52.16 |
| **combined** | **2.4410** | — | — | — | — | — | — |

**Baseline val/loss:** 2.3965 → **2.4410 (+0.045 ✗ worse than baseline)**

### What happened
Negative result — all splits regressed. The learnable alphas add per-block scalars (10 params total, 2 per block × 5 blocks), initialized to 1.0 so training starts identically to baseline.

The likely reason it fails: the existing residual connection already works well at scale=1.0. Adding learnable alphas introduces a new optimization degree of freedom, but the gradient signal to those scalars is noisy — the loss is far more sensitive to the weight matrices than to these scalars. During training, the optimizer perturbs the alphas away from 1.0 in a direction that destabilizes the residual stream, slightly degrading all splits. This is consistent with the literature showing that scalar residual scaling hurts unless the init is very small (ReZero/LayerScale style < 0.1), but we specifically wanted to avoid the signal-killing of small inits.

Minimal memory overhead (+0.5 GB vs baseline, negligible).

### Suggested follow-ups
- If the hypothesis is that fixed scale=1.0 is suboptimal, try per-layer-**depth** scaling: outer layers scaled lower (e.g., divide by sqrt(num_layers)) as in the Depth-scaled residual init strategy.
- Alternatively, try LayerScale with init=0.1 and see if fine-tuning from a pre-trained checkpoint recovers signal faster than training from scratch.