### PR TITLE
Noise curriculum: clean 0-10, noisy 10-50, clean 50+

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -567,8 +567,9 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+            if 10 <= epoch <= 50:
+                noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+                y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
Noise helps regularization mid-training but corrupts early learning and prevents exact late convergence. Clean bookends: no noise first 10 and last 25 epochs.

## Instructions
Change the noise injection to:
```python
if model.training:
    if 10 <= epoch <= 50:
        noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
        y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
```

Run with: `--wandb_name "alphonse/noise-curr" --wandb_group noise-curriculum --agent alphonse`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** xtmx0yb7
**Epochs completed:** 77 (~23.5s/epoch, ~30 min)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3965 | **2.4362** | +1.6% ❌ |
| surf p in_dist | 20.78 | **22.35** | +7.6% ❌ |
| surf p ood_cond | 23.02 | **22.57** | -2.0% ✓ |
| surf p ood_re | 31.76 | **32.03** | +0.8% ❌ |
| surf p tandem | 45.20 | **45.36** | +0.4% ❌ |

Full surface MAE (Ux / Uy / p):
- val_in_dist: 0.292 / 0.176 / 22.35
- val_ood_cond: 0.281 / 0.189 / 22.57
- val_ood_re: 0.292 / 0.204 / 32.03
- val_tandem_transfer: 0.668 / 0.357 / 45.36

Volume MAE (Ux / Uy / p):
- val_in_dist: 1.739 / 0.592 / 35.49
- val_ood_cond: 1.481 / 0.526 / 26.45
- val_ood_re: 1.372 / 0.533 / 55.80
- val_tandem_transfer: 2.656 / 1.232 / 52.94

(val_ood_re/loss = NaN due to pre-existing vol_loss overflow; val/loss is average of the remaining 3 splits.)

**What happened:** The noise curriculum didn't help — val/loss is +1.6% worse than baseline, and in_dist surface pressure is notably worse (+7.6%). The only bright spot is a minor ood_cond improvement (-2.0%). The hypothesis that clean bookends improve learning doesn't hold here:

1. **The baseline is already well-calibrated.** Always-on noise (as in the baseline) appears to provide enough regularization without disrupting convergence — likely because per-sample std normalization and differential LR already act as stabilizers.
2. **Short training window limits the benefit.** With only 77 epochs in 30 minutes, the clean convergence window is epochs 51–77 (27 epochs). It may not be long enough to fully exploit noise-free fine-tuning.
3. **Abrupt transitions may be mildly disruptive.** Turning noise off at epoch 51 causes a sudden shift in the training distribution that could temporarily unsettle the optimizer.

**Suggested follow-ups:**
- Try a softer curriculum: linearly ramp noise amplitude from 0 → max over epochs 5–15, then back to 0 over epochs 60–75 (avoids abrupt switches).
- Try always-on but lower noise (0.5× current scale) to test whether the baseline noise is already near optimal.
- Post-hoc noise-free fine-tuning: keep baseline noise schedule but set noise to 0 for the last 10 epochs with a lower LR, specifically to improve in_dist convergence.