### PR TITLE
Split vel/pressure output (shared first layer, specialized heads)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -180,17 +180,16 @@ class TransolverBlock(nn.Module):
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.shared_out = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU())
+            self.vel_head = nn.Linear(hidden_dim, 2)
+            self.p_head = nn.Linear(hidden_dim, 1)
 
     def forward(self, fx):
         fx = self.attn(self.ln_1(fx)) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.shared_out(self.ln_3(fx))
+            return torch.cat([self.vel_head(h), self.p_head(h)], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Velocity is smooth, pressure has sharp gradients. Share first output layer, split second: vel branch (2ch) and pressure branch (1ch). Few extra params.

## Instructions
In TransolverBlock.__init__ when last_layer=True:
```python
self.ln_3 = nn.LayerNorm(hidden_dim)
self.shared_out = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU())
self.vel_head = nn.Linear(hidden_dim, 2)
self.p_head = nn.Linear(hidden_dim, 1)
```
In forward: `h = self.shared_out(self.ln_3(fx)); return torch.cat([self.vel_head(h), self.p_head(h)], dim=-1)`

Run with: `--wandb_name "edward/split-out" --wandb_group split-head-v2 --agent edward`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** nudmdmut
**Best epoch:** 78 / 79 completed
**Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ surf_p vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 1.611 | 0.284 | 0.175 | 21.15 | +1.8% |
| val_ood_cond | 2.084 | 0.280 | 0.192 | 22.94 | -0.3% |
| val_ood_re | NaN | 0.295 | 0.203 | 31.79 | +0.1% |
| val_tandem_transfer | 3.548 | 0.670 | 0.351 | 44.97 | -0.5% |

**Composite val/loss: 2.4142** vs baseline 2.3965 (+0.7%, slightly worse)

### What happened
Neutral to slightly negative. The split vel/pressure output head added negligible benefit — all splits are within noise of baseline. The hypothesis that pressure deserves a dedicated branch isn't validated here: at the output level, the shared representation already handles both. The extra parameters (one Linear(hidden_dim, 2) + one Linear(hidden_dim, 1) vs one Linear(hidden_dim, 3)) are minimal, so this isn't a capacity issue — the architecture just doesn't exploit the structure in a useful way.

Memory and epoch count are identical to baseline (8.8 GB, 79 epochs), so there's no efficiency cost either — it just doesn't help.

### Suggested follow-ups
- Try splitting earlier: give each modality its own MLP block (not just the final linear), so the specialization has more depth to work with.
- Try a pressure-specific loss weight instead — directly upweight the pressure channel in MAE rather than architectural separation.
- Could combine with tandem boost: apply tandem_boost to pressure channel only, since that's where tandem transfer fails most.