### PR TITLE
Batch size 8 with sqrt-scaled LR (leverage 96GB VRAM)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -336,7 +336,7 @@ MAX_EPOCHS = 100
 class Config:
     lr: float = 3e-3
     weight_decay: float = 1e-4
-    batch_size: int = 4
+    batch_size: int = 8
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"
     stats_file: str = "structured_split/split_stats.json"
@@ -488,8 +488,8 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
+    {'params': attn_params, 'lr': 4.2e-3 * 0.5},
+    {'params': other_params, 'lr': 4.2e-3}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)


### PR DESCRIPTION
## Hypothesis
Model uses ~9GB of 96GB. Batch 8 doubles gradient quality. Apply sqrt-scaling: lr=4.2e-3. Helps rare tandem samples.

## Instructions
Change batch_size default to 8. Adjust LR:
```python
base_opt = torch.optim.AdamW([
    {'params': attn_params, 'lr': 4.2e-3 * 0.5},
    {'params': other_params, 'lr': 4.2e-3}
], weight_decay=cfg.weight_decay)
```

Run with: `--wandb_name "thorfinn/bs8" --wandb_group bs8-scaled --agent thorfinn`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `5a66gn6f` (thorfinn/bs8, group: bs8-scaled)
**Epochs:** 74 (30-min wall clock limit)
**Peak memory:** 17.5 GB (vs ~8.8 GB baseline — doubled as expected)

| Metric | Baseline | This run (best ep 74) | Δ |
|---|---|---|---|
| val/loss | 2.3965 | **2.5577** | +0.161 ↑ worse |
| val_in_dist/loss | — | 1.8629 | — |
| val_ood_cond/loss | — | 2.2177 | — |
| val_tandem/loss | — | 3.5923 | — |
| in_dist surf_p (Pa) | 20.78 | 26.28 | +5.50 ↑ worse |
| ood_cond surf_p (Pa) | 23.02 | 24.88 | +1.86 ↑ worse |
| ood_re surf_p (Pa) | 31.76 | 33.34 | +1.58 ↑ worse |
| tandem surf_p (Pa) | 45.20 | 45.68 | +0.48 ↑ slightly worse |

Full surface MAE at best epoch:
- val_in_dist: Ux=0.340, Uy=0.188, p=26.28 Pa
- val_ood_cond: Ux=0.288, Uy=0.193, p=24.88 Pa
- val_ood_re: Ux=0.297, Uy=0.207, p=33.34 Pa
- val_tandem: Ux=0.676, Uy=0.364, p=45.68 Pa

### What happened

**Negative result.** Doubling batch size with sqrt-scaled LR degraded performance across all splits. val/loss worsened from 2.3965 to 2.5577 (+6.7%), and in_dist surface pressure MAE increased by +5.50 Pa (+26%).

The larger batch size doubled memory usage as expected (8.8 → 17.5 GB), confirming the change took effect. The training ran 74 epochs, slightly fewer than the baseline, suggesting larger batches need more compute per step and hit the wall clock limit sooner.

The sqrt-scaled LR (3e-3 → 4.2e-3 at 2x batch) may be too aggressive for this architecture. The physics attention with learnable temperature and attention scale parameters may be sensitive to LR — the differential LR already reduces attn_params to 0.5x. With 4.2e-3 base, the effective attn LR is 2.1e-3 (vs 1.5e-3 baseline), a 40% increase that may destabilize the attention mechanism.

Tandem transfer was least affected (+0.48 Pa), which goes against the hypothesis that larger batches would help rare tandem samples most.

### Suggested follow-ups
- Try batch_size=8 with the same LR (3e-3) — test if the gradient quality benefit without LR change helps
- If larger batches are wanted, try batch_size=6 as a middle ground (less LR scaling needed)