### PR TITLE
Residual prior: init output bias to mean target

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -456,6 +456,16 @@ model = Transolver(**model_config).to(device)
 
 n_params = sum(p.numel() for p in model.parameters())
 
+# Residual prior: init output head bias to mean normalized target so model starts
+# predicting mean flow and only needs to learn residuals.
+with torch.no_grad():
+    last_block = model.blocks[-1]
+    for module in reversed(list(last_block.mlp2.modules())):
+        if isinstance(module, nn.Linear):
+            if module.bias is not None:
+                module.bias.copy_(phys_stats['y_mean'] / phys_stats['y_std'])
+            break
+
 
 class Lookahead:
     def __init__(self, base_optimizer, k=5, alpha=0.5):


### PR DESCRIPTION
## Hypothesis
Init the output head bias to the mean normalized target. Model starts predicting mean flow and learns corrections (smaller residuals).

## Instructions
After model construction:
```python
with torch.no_grad():
    last_block = model.blocks[-1]
    for module in reversed(list(last_block.mlp2.modules())):
        if isinstance(module, nn.Linear):
            if module.bias is not None:
                module.bias.copy_(phys_stats['y_mean'] / phys_stats['y_std'])
            break
```

Run with: `--wandb_name "askeladd/residual-prior" --wandb_group residual-prior --agent askeladd`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `618yooiy`
**Epochs completed:** 77 (hit 30-min timeout; val/loss still improving at cutoff)
**Runtime:** 1755s

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3965 | **2.4827** | +0.086 ↑ worse |
| val_in_dist/mae_surf_p | 20.78 | 22.11 | +1.33 ↑ |
| val_ood_cond/mae_surf_p | 23.02 | 24.28 | +1.26 ↑ |
| val_ood_re/mae_surf_p | 31.76 | 32.71 | +0.95 ↑ |
| val_tandem_transfer/mae_surf_p | 45.20 | 45.57 | +0.37 ↑ |

**Volume MAE (val_in_dist):** Ux=1.746, Uy=0.610, p=36.63

Note: `val_ood_re/surf_loss=NaN` is a pre-existing bug unrelated to this change.

### What happened

The hypothesis failed — all metrics are worse than baseline. The initialization hurt convergence rather than helping it.

The root issue: the training normalizes targets as `y_norm = (y_phys - y_mean) / y_std`, which gives a distribution centered at 0. The optimal bias for mean flow prediction in normalized space is **0**, not `y_mean/y_std`. By initializing to `y_mean/y_std`, the model starts far from the optimum in normalized space, and early val/loss was extremely high (13.08 at epoch 1 vs a typical ~3–4 for a zero-initialized model). The model spends many epochs unlearning this bad initialization.

The val/loss curve confirms this: it started at 13.08 and declined steadily through all 77 epochs, while baseline converges from a much lower starting point.

### Suggested follow-ups

- If the goal is a residual prior, the correct initialization would be bias=0 (which is already the default). The hypothesis as stated is not aligned with how the normalization is done.
- Alternatively: if training without centering normalization (just scale by std), then `y_mean/y_std` would indeed be the mean prediction — but that would require changing the normalization scheme too.