### PR TITLE
Gentle warm restart at epoch 60 (5e-4 peak, 15-epoch cycle)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -493,10 +493,9 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
-)
+cosine1 = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=5e-4)
+cosine2 = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=15, eta_min=1e-4)
+scheduler = torch.optim.lr_scheduler.SequentialLR(base_opt, schedulers=[warmup_scheduler, cosine1, cosine2], milestones=[5, 60])
 
 # --- wandb ---
 run = wandb.init(


### PR DESCRIPTION
## Hypothesis
Full restart failed (too disruptive). A gentle restart at ep 60 with peak=5e-4 (not 3e-3) and 15-epoch mini-cycle could escape late local minima.

## Instructions
Replace cosine scheduler:
```python
cosine1 = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=5e-4)
cosine2 = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=15, eta_min=1e-4)
scheduler = torch.optim.lr_scheduler.SequentialLR(base_opt, schedulers=[warmup_scheduler, cosine1, cosine2], milestones=[5, 60])
```

Run with: `--wandb_name "violet/gentle-restart" --wandb_group gentle-restart --agent violet`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `jh8zlyt8` | **Best epoch:** 78 (of 81 completed before 30-min timeout)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3965 | **2.4939** | +0.097 ↑ worse |
| mae_surf_p (in_dist) | 20.78 | **23.2** | +2.42 ↑ worse |
| mae_surf_p (ood_cond) | 23.02 | **23.6** | +0.58 ↑ worse |
| mae_surf_p (ood_re) | 31.76 | **33.5** | +1.74 ↑ worse |
| mae_surf_p (tandem) | 45.20 | **45.4** | +0.20 ↑ worse |

**Peak memory:** 8.8 GB

### What happened

The gentle restart did not improve over baseline — all metrics are worse. The 30-minute training timeout became a bottleneck here: the second cosine cycle peaked at epoch 61 and only completed 20 more epochs after that (training cut off at ep 81). This likely wasn't enough time for the model to fully reconverge after the LR bump at epoch 60.

Additionally, the second cosine cycle (T_max=15) ends at epoch 75 and then the LR is stuck at eta_min=1e-4 for the remaining epochs with no further learning signal. The restart may have disrupted the model's converged state without sufficient time to recover within the 30-minute budget.

The val_ood_re split also remained NaN (no out-of-distribution Re samples available in the val set), which is consistent with prior runs.

### Suggested follow-ups
- Earlier restart (e.g. ep 45 instead of 60) with a longer mini-cycle might have more training budget remaining to benefit
- Alternatively, a simpler multi-cycle approach from the start (e.g. two equal-length cosine phases) rather than a late restart
- Stochastic Weight Averaging (SWA) in the late phase could smooth out the local minima issue without disrupting convergence