### PR TITLE
Adaptive Gradient Clipping (AGC: clip by param-norm ratio)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -634,7 +634,16 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        def adaptive_gradient_clipping(model, clip_factor=0.01, eps=1e-3):
+            for p in model.parameters():
+                if p.grad is None: continue
+                p_norm = p.data.norm(2).clamp(min=eps)
+                g_norm = p.grad.data.norm(2).clamp(min=eps)
+                max_norm = p_norm * clip_factor
+                clip_coef = max_norm / g_norm
+                if clip_coef < 1.0:
+                    p.grad.data.mul_(clip_coef)
+        adaptive_gradient_clipping(model, clip_factor=0.01)
         optimizer.step()
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})


### PR DESCRIPTION
## Hypothesis
Fixed grad clip max_norm=1.0 treats all params equally. AGC clips by param-norm/grad-norm ratio, protecting small params while allowing big updates on large weights.

## Instructions
Replace clip_grad_norm_ with:
```python
def adaptive_gradient_clipping(model, clip_factor=0.01, eps=1e-3):
    for p in model.parameters():
        if p.grad is None: continue
        p_norm = p.data.norm(2).clamp(min=eps)
        g_norm = p.grad.data.norm(2).clamp(min=eps)
        max_norm = p_norm * clip_factor
        clip_coef = max_norm / g_norm
        if clip_coef < 1.0:
            p.grad.data.mul_(clip_coef)
adaptive_gradient_clipping(model, clip_factor=0.01)
```

Run with: `--wandb_name "gilbert/agc" --wandb_group agc --agent gilbert`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `xbv15zpu` (gilbert/agc)
**Epochs:** 77 (30.0 min wall-clock limit)
**Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.690 | 0.285 | 0.181 | **22.34** | 1.704 | 0.595 | 35.22 |
| val_ood_cond | 2.078 | 0.285 | 0.194 | **22.05** | 1.375 | 0.535 | 25.21 |
| val_ood_re | NaN | 0.295 | 0.204 | 31.77 | 1.307 | 0.532 | 54.91 |
| val_tandem_transfer | 3.524 | 0.658 | 0.361 | **44.41** | 2.586 | 1.208 | 51.63 |
| **val/loss (mean)** | **2.4303** | | | | | | |

**vs. baseline:**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.3965 | 2.4303 | +0.034 (+1.4%) ❌ |
| val_in_dist/mae_surf_p | 20.78 | 22.34 | +1.56 (+7.5%) ❌ |
| val_ood_cond/mae_surf_p | 23.02 | 22.05 | -0.97 (-4.2%) ✓ |
| val_ood_re/mae_surf_p | 31.76 | 31.77 | ~same |
| val_tandem_transfer/mae_surf_p | 45.20 | 44.41 | -0.79 (-1.7%) ✓ |

**What happened:** Mixed results. AGC with clip_factor=0.01 slightly improved OOD generalization (ood_cond -4.2%, tandem -1.7%) but significantly hurt in-distribution performance (in_dist +7.5%). Overall val/loss is 1.4% worse than baseline.

The per-parameter clipping at clip_factor=0.01 (max gradient norm = param_norm × 0.01) is likely too aggressive for some parameters. It may be over-clipping weight matrices with large norms, slowing down in-distribution learning. The slight improvement on OOD splits suggests AGC does add some regularization, but the overall effect is negative.

**Suggested follow-ups:**
- Try a larger clip_factor (e.g., 0.1) to be less aggressive
- Try AGC only on specific param groups (e.g., attention params) rather than all params
- Consider that the baseline's fixed clip of 1.0 may already be doing the right thing — the global norm is rarely exceeded