### PR TITLE
Temperature annealing 1.0→0.25 over 60 epochs (schedule)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -104,7 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.register_buffer('temperature', torch.ones(1) * 1.0)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
@@ -485,8 +485,8 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'slice_weight', 'attn_scale'])]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'slice_weight', 'attn_scale'])]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
@@ -544,6 +544,11 @@ for epoch in range(MAX_EPOCHS):
         break
 
     t0 = time.time()
+
+    # Temperature annealing: 1.0 → 0.25 over first 60 epochs
+    temp_val = 1.0 - 0.75 * min(epoch / 60.0, 1.0)
+    for block in model.blocks:
+        block.attn.temperature.fill_(temp_val)
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0


### PR DESCRIPTION
## Hypothesis
Learned temp may oscillate. Fixed annealing 1.0→0.25 gives monotonic sharpening: early soft exploration, late sharp specialization.

## Instructions
Change temperature from nn.Parameter to buffer: `self.register_buffer('temperature', torch.ones(1)*init_temp)`
Remove from optimizer. In training loop:
```python
temp_val = 1.0 - 0.75 * min(epoch / 60.0, 1.0)
for block in model.blocks:
    block.attn.temperature.fill_(temp_val)
```

Run with: `--wandb_name "senku/temp-anneal" --wandb_group temp-anneal-sched --agent senku`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `tl1ooiz5` — 77 epochs completed (timeout), peak memory 8.6GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3965 | **2.4631** | +0.067 ↑worse |
| val_in_dist/mae_surf_p | 20.78 | **22.33** | +1.55 ↑worse |
| val_ood_cond/mae_surf_p | 23.02 | **22.97** | -0.05 ≈same |
| val_ood_re/mae_surf_p | 31.76 | **32.37** | +0.61 ↑worse |
| val_tandem_transfer/mae_surf_p | 45.20 | **46.11** | +0.91 ↑worse |
| val_in_dist/mae_surf_Ux | — | 0.303 | — |
| val_in_dist/mae_surf_Uy | — | 0.178 | — |
| val_in_dist/mae_vol_p | — | 33.40 | — |

**What happened:** Negative result. Replacing the learned temperature parameter with a fixed 1.0→0.25 annealing schedule hurt most metrics. The baseline learned temperature (init 0.5) appears to find a better fixed or stable value on its own — starting too soft at 1.0 likely diffuses the slice attention weights too much in early epochs, hampering the model's ability to learn meaningful physics-aware slice assignments during the critical early training phase. The ood_cond split is essentially unchanged (~0.05 improvement, within noise), suggesting that for easier generalization the schedule is near-neutral, but the harder splits (in_dist, ood_re, tandem) pay a real cost.

**Suggested follow-ups:**
- If the learned temperature really does oscillate, consider inspecting its trajectory in W&B to confirm before designing a schedule. It may settle quickly (e.g., within 10 epochs) to a stable value around 0.4–0.6, in which case a schedule isn't beneficial.
- Try annealing from 0.5→0.25 (matching the learned temperature's init) so early epochs are not penalized by the overly soft 1.0 start.
- Consider clamping the learned temperature to a minimum (e.g., clamp(min=0.2)) to prevent it from going too large while still allowing optimization.