### PR TITLE
Slice entropy regularization (load-balance 32 physics tokens)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -29,6 +29,7 @@ from pathlib import Path
 # Reach repo root so we can import prepare, transolver, utils
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -135,6 +136,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .contiguous()
         )
         slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
+        frac = slice_weights.mean(dim=2)
+        entropy = -(frac * (frac + 1e-8).log()).sum(dim=-1).mean()
+        self._entropy_penalty = (math.log(self.in_project_slice.out_features) - entropy)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -631,6 +635,8 @@ for epoch in range(MAX_EPOCHS):
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
+
+        loss = loss + 0.01 * model.blocks[0].attn._entropy_penalty
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Many of 32 slices may have degenerate assignments. Entropy bonus encourages distinct, diverse clustering (Switch Transformer load-balancing).

## Instructions
After computing slice_weights, add:
\`\`\`python
import math
frac = slice_weights.mean(dim=2)
entropy = -(frac * (frac + 1e-8).log()).sum(dim=-1).mean()
self._entropy_penalty = (math.log(self.slice_num) - entropy)
\`\`\`
Add to loss: \`loss = loss + 0.01 * model.blocks[0].attn._entropy_penalty\`

Run with: \`--wandb_name "emma/slice-ent" --wandb_group slice-entropy --agent emma\`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** 2h5z80bv  
**Runtime:** 30.2 min | **Best epoch:** 77 | **Epoch time:** 22.9s | **Peak GPU:** ~50 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 2.4292 | 2.3965 | +0.033 ↑ worse |
| val_in_dist/mae_surf_Ux | 0.2935 | — | |
| val_in_dist/mae_surf_Uy | 0.1773 | — | |
| val_in_dist/mae_surf_p | 22.43 | 20.78 | +1.65 ↑ worse |
| val_in_dist/mae_vol_p | 33.79 | — | |
| val_ood_cond/mae_surf_p | 23.03 | 23.02 | +0.01 same |
| val_ood_re/mae_surf_p | 31.85 | 31.76 | +0.09 same |
| val_tandem_transfer/mae_surf_p | 45.09 | 45.20 | -0.11 ↓ slightly better |

**What happened:** Mostly negative. The entropy penalty did not improve slice utilization in a way that translated to better predictions. The in-distribution pressure MAE regressed by +1.65 Pa (notable), while OOD splits were essentially unchanged. The biggest issue is that `blocks[0].attn` is only one of the 1-layer model's attention modules, so the penalty was already hitting the sole attention block — but the model learned to satisfy the entropy constraint without improving physical accuracy. The constraint may be fighting against the slice specialization needed for capturing physically distinct flow regions (e.g., boundary layer vs freestream).

**Suggested follow-ups:**
- Try a weaker penalty (0.001 instead of 0.01) — the 0.01 coefficient may be over-constraining slice diversity at the cost of per-region accuracy.
- Apply the entropy penalty to *all* blocks rather than just block 0 (though this model only has 1 block, deeper models would need this).
- Investigate whether slices are actually degenerate at baseline — if they're already well-utilized, entropy regularization is unnecessary overhead.