### PR TITLE
Symmetric AoA flip augmentation (double single-foil data)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -563,6 +563,14 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        # Symmetric AoA flip augmentation for non-tandem samples
+        if model.training:
+            is_tandem_pre = x[:, 0, 21].abs() > 0.5
+            flip_mask = torch.rand(x.shape[0], device=device) > 0.5
+            for b in range(x.shape[0]):
+                if flip_mask[b] and not is_tandem_pre[b]:
+                    y[b, :, 1] = -y[b, :, 1]  # Flip Uy
+                    x[b, :, 1] = -x[b, :, 1]  # Flip y-coord
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Flow at +AoA mirrors -AoA (Uy flip). Training-time aug doubles effective data for single-foil. Apply before normalization.

## Instructions
In training loop after loading batch, before normalization:
```python
if model.training:
    flip_mask = torch.rand(B, device=device) > 0.5
    for b in range(B):
        if flip_mask[b] and not is_tandem[b]:
            y[b, :, 1] = -y[b, :, 1]  # Flip Uy
            x[b, :, 1] = -x[b, :, 1]  # Flip y
```
Only non-tandem samples.

Run with: `--wandb_name "norman/sym-flip" --wandb_group sym-flip --agent norman`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `licfdkop` | 80 epochs (30.0 min, wall-clock limit) | Peak memory: 8.8 GB

| Split | val/loss | mae_surf_p | Note |
|---|---|---|---|
| val_in_dist | 1.584 | **21.30** | |
| val_ood_cond | 2.236 | **24.19** | |
| val_ood_re | nan | **33.29** | |
| val_tandem_transfer | 3.707 | **46.53** | |
| **val/loss (mean)** | **2.5091** | | |

**vs baseline (val/loss 2.3965):**
| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 20.78 | 21.30 | **+2.5% ✗** |
| val_ood_cond | 23.02 | 24.19 | **+5.1% ✗** |
| val_ood_re | 31.76 | 33.29 | **+4.8% ✗** |
| val_tandem_transfer | 45.20 | 46.53 | **+2.9% ✗** |
| val/loss | 2.3965 | 2.5091 | **+4.7%** |

### What happened

Negative result. All 4 splits got worse, and val/loss regressed by 4.7%. The flip augmentation appears to hurt generalization rather than help it.

Several possible causes:
1. **Aggressive augmentation rate (50%)**: Flipping half the non-tandem samples per batch may over-regularize the model or introduce conflicting signals when combined with label noise.
2. **Incomplete symmetry**: The flip only negates `y[b,:,1]` (Uy) and `x[b,:,1]` (y-coordinate), but pressure fields at +AoA vs -AoA are related by reflection — the pressure on the suction side becomes the pressure on the pressure side. This is geometrically correct when y-coord is flipped. However, the physics normalization (`_umag_q`) is applied after the flip, and Umag = sqrt(Ux²+Uy²) is unchanged — so this step is consistent. The issue may be that the model needs to learn Uy sign correctly from the physical flow and the augmentation introduces ambiguity.
3. **Training throughput**: The per-sample Python loop adds overhead, slightly reducing effective epochs/time.

The val_in_dist loss (1.584) is actually the best seen in any run, suggesting the augmentation helps on that split at the cost of tandem_transfer and ood generalization.

### Suggested follow-ups
- Reduce flip probability (e.g., 25% instead of 50%) to be less aggressive
- Only flip during the first half of training (before epoch 40), when the model is still learning coarse representations
- Apply a vectorized flip (avoid the Python loop) and test whether the result improves with better throughput