### PR TITLE
Surface node feature boost (1.5x magnitude before attention)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -317,6 +317,11 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
+        is_surface_flag = data.get("is_surface", None) if isinstance(data, dict) else None
+        if is_surface_flag is not None:
+            surf_boost = 1.0 + 0.5 * is_surface_flag.unsqueeze(-1).float()
+            fx = fx * surf_boost
+
         for block in self.blocks:
             fx = block(fx)
         self._validate_output_dims(fx)
@@ -584,7 +589,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
+            pred = model({"x": x, "is_surface": is_surface})["preds"]
         pred = pred.float()
         if model.training:
             pred = pred / sample_stds
@@ -688,7 +693,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = model({"x": x})["preds"]
+                    pred = model({"x": x, "is_surface": is_surface})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
Surface nodes (~5%) are underrepresented in attention. Scaling features 1.5x before attention increases their influence in slice clustering.

## Instructions
Before the TransolverBlock:
```python
surf_boost = 1.0 + 0.5 * is_surface_flag.unsqueeze(-1).float()
fx = fx * surf_boost
```

Run with: `--wandb_name "chihiro/surf-boost" --wandb_group surf-boost-attn --agent chihiro`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---
## Results

**W&B run:** `ak4ulgbn`
**Best epoch:** 76 (wall-clock limit: 30.1 min)
**VRAM:** ~8.8 GB

Implementation: passed `is_surface` flag through the model input dict (`model({"x": x, "is_surface": is_surface})`) and applied `surf_boost = 1.0 + 0.5 * is_surface_flag.unsqueeze(-1).float()` to `fx` after `self.preprocess` in `Transolver.forward`.

### val/loss

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.4531** | 2.3965 | +0.057 (slightly worse) |

Note: val_ood_re loss = NaN (pre-existing issue).

### Surface MAE (mae_surf_p, Pa)

| Split | This run | Baseline | Δ |
|-------|----------|----------|---|
| val_in_dist | 21.16 | 20.78 | +0.38 (slightly worse) |
| val_ood_cond | 26.19 | 23.02 | **+3.17 (much worse)** |
| val_ood_re | 32.38 | 31.76 | +0.62 (slightly worse) |
| val_tandem_transfer | 44.93 | 45.20 | **-0.27 (slightly better)** |

### Volume MAE (val_in_dist)

| Channel | MAE |
|---------|-----|
| Ux | 1.68 |
| Uy | 0.59 |
| p | 33.00 |

### What happened

Mixed but mostly negative. The most notable effect is a large ood_cond regression (+3.17 Pa), while in_dist, ood_re, and tandem are near-baseline. The tandem result improves very slightly (-0.27 Pa), but the ood_cond loss is a clear problem.

Why ood_cond regressed: The 1.5x feature scaling for surface nodes happens before the physics attention (slice pooling). Surface nodes get more attention to their hidden representations, which should theoretically help them cluster together in slices. But this boost uses the same scale factor for all geometric configurations. For ood_cond (different flow conditions, same geometry), the surface positions are the same but the flow field magnitude differs significantly. The boost amplifies whatever the surface nodes contribute — if the surface representations carry features that are flow-condition-specific (e.g., they encode normalized boundary conditions), scaling them up biases the slice assignments toward in-dist flow patterns and hurts ood_cond generalization.

The approach is directionally interesting (surface nodes are underrepresented) but the 1.5x uniform boost is too blunt.

### Suggested follow-ups
- A softer boost (e.g., 1.2x or 1.1x) might reduce the ood_cond regression while retaining the tandem benefit
- Alternatively, instead of scaling features, add learned bias tokens for surface nodes (a learned scalar offset per hidden channel)
- The ood_cond regression pattern suggests that the model is overfitting to in-dist surface dynamics — a related investigation would check whether ood_cond baseline quality is sensitive to surface weight ramp schedule