### PR TITLE
Windowed attention: 4 spatial quadrants with local slices

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -119,7 +119,42 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
-    def forward(self, x):
+    def _run_slice_attn(self, fx_mid, x_mid, node_mask=None):
+        """Run slice-based attention on (optionally masked) nodes.
+
+        node_mask: [bsz, N] float mask; if provided, non-masked nodes are
+        excluded from slice aggregation via large-negative logit masking.
+        """
+        if node_mask is not None:
+            # Mask out non-quadrant nodes: set their slice logits to -inf before softmax
+            qm = node_mask.unsqueeze(1).unsqueeze(-1)  # [bsz, 1, N, 1]
+            sw_logits = self.in_project_slice(x_mid) / self.temperature  # [bsz, h, N, S]
+            sw_logits = sw_logits + (node_mask - 1).unsqueeze(1).unsqueeze(-1) * 1e9
+            slice_weights = self.softmax(sw_logits)
+        else:
+            slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
+            qm = 1.0
+
+        slice_norm = slice_weights.sum(2)
+        slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid * qm, slice_weights)
+        slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        q_st = self.to_q(slice_token)
+        st_kv = slice_token.mean(dim=1, keepdim=True)
+        k_st = self.to_k(st_kv).expand(-1, self.heads, -1, -1)
+        v_st = self.to_v(st_kv).expand(-1, self.heads, -1, -1)
+        q_norm = F.normalize(q_st, dim=-1)
+        k_norm = F.normalize(k_st, dim=-1)
+        attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
+        attn_weights = F.softmax(attn_logits, dim=-1)
+        out_slice_token = torch.matmul(attn_weights, v_st)
+
+        out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
+        if node_mask is not None:
+            out_x = out_x * qm
+        return out_x
+
+    def forward(self, x, x_raw=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -134,22 +169,20 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
-        slice_norm = slice_weights.sum(2)
-        slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
-        slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
 
-        q_slice_token = self.to_q(slice_token)
-        slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
-        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
-        v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
-        q_norm = F.normalize(q_slice_token, dim=-1)
-        k_norm = F.normalize(k_slice_token, dim=-1)
-        attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
-        attn_weights = F.softmax(attn_logits, dim=-1)
-        out_slice_token = torch.matmul(attn_weights, v_slice_token)
+        if x_raw is not None:
+            # Windowed attention: 4 spatial quadrants from median x,y split
+            pos = x_raw[:, :, :2]
+            med_x = pos[:, :, 0].median(dim=1, keepdim=True).values  # [bsz, 1]
+            med_y = pos[:, :, 1].median(dim=1, keepdim=True).values  # [bsz, 1]
+            q_assign = (pos[:, :, 0] > med_x).long() * 2 + (pos[:, :, 1] > med_y).long()  # [bsz, N]
+            out_x = torch.zeros(bsz, self.heads, num_points, self.dim_head, device=x.device, dtype=x.dtype)
+            for q_id in range(4):
+                quad_mask = (q_assign == q_id).float()
+                out_x += self._run_slice_attn(fx_mid, x_mid, node_mask=quad_mask)
+        else:
+            out_x = self._run_slice_attn(fx_mid, x_mid)
 
-        out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
         return self.to_out(out_x)
 
@@ -186,8 +219,8 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
+    def forward(self, fx, x_raw=None):
+        fx = self.attn(self.ln_1(fx), x_raw=x_raw) + fx
         fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
@@ -318,7 +351,7 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks:
-            fx = block(fx)
+            fx = block(fx, x_raw=x)
         self._validate_output_dims(fx)
         return {"preds": fx}
 


### PR DESCRIPTION
## Hypothesis
32 slices cover entire mesh globally. Swin-style spatial partitioning into 4 quadrants gives 32 slices per window = 128 effective local slices.

## Instructions
In Physics_Attention_Irregular_Mesh.forward, partition by median x,y:
```python
pos = x_raw[:, :, :2]
med_x = pos[:,:,0].median(dim=1,keepdim=True).values
med_y = pos[:,:,1].median(dim=1,keepdim=True).values
q = (pos[:,:,0] > med_x).long() * 2 + (pos[:,:,1] > med_y).long()
```
Process each quadrant separately, concatenate outputs.

Run with: `--wandb_name "haku/windowed" --wandb_group windowed-attn --agent haku`

## Baseline
- val/loss: **2.3965**
- Surface MAE: in=20.78, ood=23.02, re=31.76, tan=45.20

---

## Results

**W&B run ID:** `5orap5k8`  
**Best epoch:** 36 / 36 (30.4 min wall-clock timeout)  
**Peak GPU memory:** 13.2 GB (was 8.8 GB — +50%)

### Metrics at best checkpoint (epoch 36)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 3.2835 | 0.626 | 0.323 | 51.2 | 2.350 | 0.932 | 55.6 |
| val_tandem_transfer | 5.4020 | 1.075 | 0.526 | 68.2 | 3.289 | 1.623 | 75.0 |
| val_ood_cond | 3.7247 | 0.482 | 0.289 | 43.4 | 1.882 | 0.745 | 42.3 |
| val_ood_re | NaN* | 0.441 | 0.275 | 46.0 | 1.671 | 0.686 | 66.9 |
| **combined val/loss** | **4.1367** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.3965 → This run: 4.1367 — dramatically worse (+1.74, ~73%)**

Surface pressure MAE vs baseline:
- val_in_dist: 51.2 vs 20.78 (+30.4, much worse)
- val_ood_cond: 43.4 vs 23.02 (+20.4, much worse)
- val_ood_re: 46.0 vs 31.76 (+14.2, much worse)
- val_tandem_transfer: 68.2 vs 45.20 (+23.0, much worse)

### What happened

The windowed attention degraded performance severely. The core problem is the same as PR #659 (cross-attention): the computational overhead per epoch exceeded the 30-minute budget.

**Compute overhead**: Each epoch took ~57 seconds (vs ~22 seconds baseline — 2.6x slower), leaving only 36 epochs vs the baseline's 77. The 4-quadrant loop runs the slice aggregation, attention, and scatter 4 times per batch, roughly tripling the attention-related compute even though the dominant costs (in_project_x, in_project_fx projections) are only computed once. The quadrant assignment also adds per-batch overhead.

**Memory overhead**: 13.2 GB peak (vs 8.8 GB — +50%), from storing 4× slice_weights and intermediate tensors in the quadrant loop.

**Epoch deficit**: At epoch 36, the model is still far from converged — the val_in_dist loss is at 3.28 while the baseline reaches 1.84. More epochs are clearly needed, and with only ~47% of baseline epochs, performance is expected to be poor regardless of the architectural change's merits.

**Implementation note**: `x_raw` was passed through Transolver → TransolverBlock → Physics_Attention as an `x_raw` keyword argument. The spatial coordinates (first 2 dims of normalized input) were used for quadrant assignment. Non-quadrant nodes were masked from slice aggregation via large-negative logit addition before softmax.

### Suggested follow-ups

- Windowed attention at the slice level requires much faster per-quadrant processing to fit in the 30-minute budget. A cheaper implementation would reduce slice_num inside each window (e.g., 8 slices × 4 windows = 32 total), matching the baseline's total information capacity with no added compute.
- Alternatively, compute all 4 quadrants in parallel using tensor masking rather than sequential Python loops — replace the for loop with a batch dimension over quadrants.
- The concept (local attention for CFD mesh) is physically motivated, but the current 1-layer architecture with 30-minute budget can't afford any significant compute increase without epoch reduction.
