### PR TITLE
Adaptive EMA decay (gradient-based, 0.99→0.9995 sigmoid ramp)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -457,7 +457,9 @@ model = Transolver(**model_config).to(device)
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 65
-ema_decay = 0.998
+ema_min_decay = 0.99
+ema_max_decay = 0.9995
+ema_grad_norm = 1.0  # smoothed gradient norm for adaptive decay
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -639,15 +641,19 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(model)
             else:
+                # Adaptive EMA decay: sigmoid ramp from 0.99 (large gradients) to 0.9995 (small gradients)
+                ema_grad_norm = 0.99 * ema_grad_norm + 0.01 * grad_norm.item()
+                t = torch.sigmoid(torch.tensor(-5.0 * (ema_grad_norm - 0.4))).item()
+                ema_decay_step = ema_min_decay + (ema_max_decay - ema_min_decay) * t
                 with torch.no_grad():
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+                        ep.data.mul_(ema_decay_step).add_(mp.data, alpha=1 - ema_decay_step)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 


### PR DESCRIPTION
## Hypothesis
Adaptive EMA decay based on gradient norms: when learning is active (large gradients), use lower EMA decay (0.99, more responsive); as learning converges (small gradients), ramp up to 0.9995 (more stable). Uses a sigmoid mapping to smoothly transition the decay.

**Note:** The PR body was missing implementation details. I inferred from the title ("gradient-based, 0.99→0.9995 sigmoid ramp") and implemented accordingly. My design choices are documented in Results.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `8o8cuqty` (~78 epochs, 29.3 min, timed out)

**Implementation:** Smoothed EMA of grad norm (`ema_grad_norm = 0.99*prev + 0.01*step_grad`), then `t = sigmoid(-5*(ema_grad_norm - 0.4))`, `decay = 0.99 + 0.0095 * t`.

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3537 | **2.4068** | +2.26% |
| val_in_dist/mae_surf_p | 19.73 | **19.99** | +1.3% |
| val_ood_cond/mae_surf_p | 22.97 | **24.08** | +4.8% |
| val_ood_re/mae_surf_p | 31.99 | **31.90** | -0.3% |
| val_tandem_transfer/mae_surf_p | 43.82 | **45.30** | +3.4% |

Surface MAE (Ux, Uy, p) by split:
- val_in_dist: (0.272, 0.171, 19.99), mean = 6.81
- val_ood_cond: (0.297, 0.197, 24.08), mean = 8.19
- val_tandem_transfer: (0.656, 0.357, 45.30), mean = 15.44

Volume MAE by split:
- val_in_dist: (1.671, 0.589, 33.39), mean = 11.88
- val_ood_cond: (1.412, 0.536, 26.18), mean = 9.38
- val_tandem_transfer: (2.600, 1.227, 52.47), mean = 18.77

### What happened
Slightly worse than baseline across most splits (+2.26% val/loss). The in-dist surf_p regressed modestly (+1.3%), ood_cond more noticeably (+4.8%), and tandem also slightly worse (+3.4%). ood_re surf_p showed a minor improvement (-0.3%) which is likely noise.

**Implementation note:** At late training (epoch 65+, LR near eta_min=1e-4), gradient norms are small (~0.1-0.2). With the sigmoid center at 0.4:
- `ema_grad_norm ≈ 0.1-0.2` → `t ≈ 0.73-0.82` → `decay ≈ 0.997-0.998`

This is close to but slightly below the baseline 0.998, meaning slightly more responsive EMA than baseline. The small difference didn't help.

Since the PR body was missing, my implementation choices (sigmoid center=0.4, sharpness=5) may differ from the advisor's intent. The core idea — gradient-adaptive decay — is sound but the calibration matters.

### Suggested follow-ups
- If the intended implementation was different (e.g., epoch-based sigmoid ramp rather than per-step grad-norm), try that instead.
- A simpler approach: epoch-based linear ramp of EMA decay over the EMA phase (e.g., from 0.99 at epoch 65 to 0.9995 at epoch 100).
- Try starting EMA earlier (epoch 50) with lower initial decay to capture more of the mid-training dynamics.