### PR TITLE
Exponential surface weight ramp (5→30, convex curve)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -550,10 +550,10 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Dynamic surface weight: linear ramp from 5 → 30 over training
+    # Dynamic surface weight: exponential ramp from 5 → 30 over training (convex curve)
     sw_start, sw_end = 5.0, 30.0
     progress = epoch / MAX_EPOCHS
-    surf_weight = sw_start + (sw_end - sw_start) * progress
+    surf_weight = sw_start * (sw_end / sw_start) ** progress
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
See PR description for details.

The current baseline already uses a linear ramp from 5→30. This experiment replaces that with an exponential (convex) curve over the same range: `surf_weight = 5 * (30/5) ** progress`. The convex shape spends more time at lower weights early and ramps aggressively near the end.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run ID**: `g3wll2eo`  
**Epochs completed**: 80 (30-minute wall-clock limit)  
**Peak memory**: 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| val/loss (combined) | **2.3755** | — | — | — | — | — | — |
| in_dist | 1.6319 | 0.285 | 0.175 | **21.45** | 1.594 | 0.558 | 30.48 |
| ood_cond | 2.1023 | 0.287 | 0.195 | **23.26** | 1.354 | 0.510 | 24.12 |
| ood_re | nan | 0.294 | 0.204 | **32.14** | — | — | — |
| tandem_transfer | 3.3924 | 0.628 | 0.342 | **44.48** | 2.465 | 1.149 | 48.53 |

### Comparison vs baseline

| Split | Baseline mae_surf_p | This run | Δ |
|-------|---------------------|----------|---|
| in_dist | 19.73 | 21.45 | **+8.7%** ↑ |
| ood_cond | 22.97 | 23.26 | **+1.3%** ↑ |
| ood_re | 31.99 | 32.14 | **+0.5%** ↑ |
| tandem | 43.82 | 44.48 | **+1.5%** ↑ |

### What happened

The convex ramp is slightly worse than the linear ramp across all splits. The exponential curve spends the first ~half of training at surf_weights far below the linear midpoint (e.g., at epoch 40/80, linear gives ~17.5 while exponential gives ~12.2), meaning the model receives weaker surface pressure signal during the critical mid-training phase when most generalization is established. Then near the end, the weight spikes aggressively (hitting 25–30 in the last ~20% of epochs), which can destabilize refinement.

The in_dist regression (+8.7%) is notable. The linear ramp appears better calibrated for this task — giving sufficient surface emphasis throughout training rather than deferring it.

Note: val_ood_re/loss = nan is a pre-existing issue (vol_loss ~18.8B due to extreme Re extrapolation).

### Suggested follow-ups

- **Concave ramp** (fast start, slow finish): the opposite of this experiment — ramp quickly to high surf_weight early so the model focuses on surface accuracy from the beginning. Could try `sw_start + (sw_end - sw_start) * progress^0.5`.
- **Earlier peak**: fixed high surf_weight from epoch ~20 onward (e.g., warm to 20 in 10 epochs, then hold at 20 or continue gently to 30). The linear ramp may be suboptimal because it's still at low values in early epochs.
- **Constant surf_weight at 15 or 20**: test whether ramping at all helps vs. a well-tuned constant.