### PR TITLE
Cosine T_max=70 (LR reaches min before EMA starts)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -498,7 +498,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=70, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
See PR description for details.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `ez6ac4zb` | **Best epoch:** 77 | **Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_p | mae_surf_Ux | mae_surf_Uy | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.616 | **21.47** (+1.74 ✗) | 0.280 | 0.176 | 1.706 | 0.599 | 32.79 |
| ood_cond | 2.075 | **22.75** (−0.22 ✓) | 0.276 | 0.192 | 1.414 | 0.530 | 25.65 |
| ood_re | — | **32.38** (+0.39 ✗) | 0.290 | 0.203 | 1.343 | 0.539 | 55.43 |
| tandem_transfer | 3.528 | **44.73** (+0.91 ✗) | 0.668 | 0.356 | 2.592 | 1.212 | 50.88 |
| **combined** | **2.4065** | — | — | — | — | — | — |

**Baseline val/loss:** 2.3537 → **2.4065 (+0.053 ✗ worse than baseline)**

### What happened
Negative result — T_max=70 is worse than the current baseline (which uses T_max=75). With T_max=70, the cosine cycle completes at epoch 75 (5 warmup + 70), leaving ~2-3 more training epochs with LR flat at eta_min=1e-4. The problem is that once the LR reaches its minimum that early, the final training epochs become effectively frozen: the optimizer can barely move weights, and the model doesn't converge further. With T_max=75, the LR is still decreasing up to the actual end of training (~epoch 80), which appears to be the right balance.

OOD condition is the only split that marginally benefits (−0.22 Pa), but this is within noise.

T_max=75 appears to be the sweet spot for this setup: the cycle completes right at the practical end of training without prematurely hitting eta_min.

### Suggested follow-ups
- Stick with T_max=75 as the calibrated value.
- If EMA is planned to start at a specific epoch (e.g., epoch 75), then T_max=70 makes sense as a companion change — but without EMA, completing the cosine too early hurts.