### PR TITLE
Output head dropout 0.1 (targeted regularization)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -183,6 +183,7 @@ class TransolverBlock(nn.Module):
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
+                nn.Dropout(0.1),
                 nn.Linear(hidden_dim, out_dim),
             )
 


### PR DESCRIPTION
## Hypothesis
Output head dropout 0.1 as targeted regularization — apply `nn.Dropout(0.1)` inside the final `mlp2` output head (`TransolverBlock` with `last_layer=True`), between GELU and the final projection.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run ID:** twpze7um  
**Best checkpoint:** epoch 77 (wall-clock limited at 30 min)

### val/loss (combined)
| Split | Baseline | This run | Delta |
|---|---|---|---|
| val/loss (avg) | 2.3537 | **2.4428** | **↑0.89 (worse)** |
| val_in_dist | 1.5663 | 1.6983 | ↑0.13 |
| val_ood_cond | 2.0645 | 2.1376 | ↑0.07 |
| val_ood_re | NaN | NaN | — |
| val_tandem | 3.4302 | 3.4923 | ↑0.06 |

### Surface MAE (mae_surf_p — most important)
| Split | Baseline | This run | Delta |
|---|---|---|---|
| val_in_dist | 19.73 | **22.57** | **↑2.84 (worse)** |
| val_ood_cond | 22.97 | **22.53** | ↓0.44 |
| val_ood_re | 31.99 | 32.08 | ↑0.09 |
| val_tandem | 43.82 | 44.01 | ↑0.19 |

### Surface MAE (all channels, best checkpoint)
| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 0.318 | 0.181 | 22.57 |
| val_ood_cond | 0.303 | 0.201 | 22.53 |
| val_ood_re | 0.305 | 0.207 | 32.08 |
| val_tandem | 0.664 | 0.353 | 44.01 |

### Volume MAE (best checkpoint)
| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 1.60 | 0.62 | 34.93 |
| val_ood_cond | 1.39 | 0.52 | 25.20 |
| val_ood_re | 1.30 | 0.53 | 55.00 |
| val_tandem | 2.52 | 1.21 | 51.11 |

### Peak memory
No OOM. Dropout adds no parameters.

## What happened

**Degraded.** val/loss went from 2.3537 → 2.4428 (+0.89). The most important metric, mae_surf_p on in_dist, worsened by +2.84 (19.73 → 22.57). Other splits were roughly neutral or slightly worse, except ood_cond which improved slightly (-0.44).

The model is very small: n_layers=1, n_hidden=128. At this scale, dropout immediately before the final output projection disrupts the model's ability to learn a precise mapping from latent features to outputs. The "targeted regularization" effect doesn't kick in because there's essentially no redundancy to leverage — the single output head layer needs all 128 hidden units to produce accurate predictions, and dropping 10% of them creates noise rather than regularization.

In larger models (n_layers=4+, n_hidden=256+), output dropout can help by forcing the network to distribute the predictive signal more broadly. Here, the model is too small for dropout to be beneficial.

## Suggested follow-ups
1. **Very low dropout (0.02–0.05)**: If dropout is desired, much lower values might not hurt. At n_layers=1, even 5% might be too high.
2. **Dropout on intermediate features**: If regularization is needed, applying it earlier (e.g., after the attention or MLP layers, not the output) might be less harmful — but this requires model scale-up to benefit.
3. **Larger model first**: The consistent pattern across experiments (SwiGLU #663, pos-in-slice #647, output-dropout here) is that small models (n_layers=1) don't benefit from architectural changes that require slack capacity. Increasing n_layers or n_hidden may be the more productive direction.