### PR TITLE
EMA start epoch 60 with decay 0.995 (longer window)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -456,8 +456,8 @@ model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 65
-ema_decay = 0.998
+ema_start_epoch = 60
+ema_decay = 0.995
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
See PR description for details.

EMA of model weights starting at epoch 60 with decay 0.995 should produce smoother, better-generalizing weights by averaging over the last ~17 epochs of training (longer averaging window than starting later or using higher decay).

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** wn6i33uu
**Epochs completed:** ~77 (~23.2s/epoch, 30 min)

Implementation: `ema_start_epoch = 60`, `ema_decay = 0.995`. EMA weights used for all validation after epoch 60.

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3537 | **2.3838** | +1.3% ❌ |
| surf p in_dist | 19.73 | **20.81** | +5.5% ❌ |
| surf p ood_cond | 22.97 | **23.12** | +0.7% ❌ |
| surf p ood_re | 31.99 | **31.60** | -1.2% ✓ |
| surf p tandem | 43.82 | **44.30** | +1.1% ❌ |

Full surface MAE (Ux / Uy / p):
- val_in_dist: 0.277 / 0.174 / 20.81
- val_ood_cond: 0.280 / 0.194 / 23.12
- val_ood_re: 0.290 / 0.199 / 31.60
- val_tandem_transfer: 0.666 / 0.352 / 44.30

Volume MAE (Ux / Uy / p):
- val_in_dist: 1.641 / 0.583 / 32.72
- val_ood_cond: 1.415 / 0.518 / 25.61
- val_ood_re: 1.307 / 0.522 / 54.63
- val_tandem_transfer: 2.598 / 1.196 / 51.53

(val_ood_re/loss = NaN due to pre-existing vol_loss overflow; val/loss is average of the remaining 3 splits.)

**What happened:** EMA with decay 0.995 starting at epoch 60 gives marginally worse results overall (+1.3% val/loss). The only improvement is ood_re surface pressure (-1.2%). The in_dist regression (+5.5%) is the main concern.

The EMA approach has promise (val/loss 2.3838 is still competitive), but this particular configuration doesn't beat the raw model. A few possible reasons:

1. **Decay 0.995 may be too fast** (half-life ~138 optimizer steps ≈ 0.4 epochs), meaning the EMA is only averaging over ~1-2 epochs rather than providing a true long-horizon smoothing effect. Higher decay (e.g., 0.999) would average over more gradient steps.
2. **Lookahead already provides weight averaging.** The Lookahead optimizer (k=10, alpha=0.8) already performs a form of slow-update parameter averaging every 10 steps, which may overlap with EMA's benefits and reduce marginal gains.
3. **Starting at epoch 60 out of ~77** gives only ~17 epochs of EMA accumulation. If the learning rate schedule hasn't decayed enough by epoch 60, the EMA window captures some high-variance mid-training checkpoints.

**Suggested follow-ups:**
- Try decay 0.999 or 0.9995 (very long window, averaging over 10+ epochs) to see if a truly slow EMA helps.
- Try starting EMA later (epoch 70+) when LR is very low and weights are more stable — fewer noisy checkpoints in the average.
- Since Lookahead + EMA may interact poorly, try disabling Lookahead and using EMA alone as the weight averaging mechanism.