### PR TITLE
Lookahead alpha=0.7 (lighter interpolation)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -496,7 +496,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=10, alpha=0.7)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
See PR description for details.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** 38z760j8
**Best epoch:** 81 / 81 completed
**Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ surf_p vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 1.638 | 0.287 | 0.178 | 20.73 | +5.1% ✗ |
| val_ood_cond | 2.031 | 0.273 | 0.190 | 22.42 | -2.4% ✓ |
| val_ood_re | NaN | 0.284 | 0.201 | 31.90 | -0.3% ≈ |
| val_tandem_transfer | 3.496 | 0.663 | 0.349 | 43.87 | +0.1% ≈ |

**Composite val/loss: 2.3881** vs baseline 2.3537 (+1.5%, slightly worse)

### What happened
Mixed result. Reducing Lookahead alpha from 0.8 to 0.7 (lighter slow-weight update) produced a tradeoff: ood_cond improved noticeably (-2.4%), but in_dist regressed significantly (+5.1%), leaving the composite val/loss worse overall (+1.5%).

The asymmetry suggests alpha=0.7 may regularize the optimizer too aggressively for in-distribution samples. With slower slow-weight updates, the effective parameter trajectory is more conservative, which can help on harder OOD splits but slightly underfits the main distribution. The original alpha=0.8 appears to be a better overall balance.

### Suggested follow-ups
- Try alpha=0.5 (even lighter) — if the ood_cond trend continues while in_dist worsens further, this confirms a tradeoff. Then a split-alpha approach won't help.
- Check if alpha interacts with the EMA: with late EMA starting at epoch 65, the slow-weight trajectory of Lookahead may compound with EMA smoothing in unexpected ways.
- Try removing Lookahead entirely (just AdamW) to understand its marginal contribution at the current baseline.