### PR TITLE
Per-channel noise [0.008, 0.008, 0.003] (further reduction)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -572,7 +572,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+            noise_scale = torch.tensor([0.008, 0.008, 0.003], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)


### PR DESCRIPTION
## Hypothesis
Per-channel label noise further reduction from [0.01, 0.01, 0.005] to [0.008, 0.008, 0.003]. Less noise regularization may allow the model to fit the data more precisely.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `qn1xhq32` (thorfinn/noise-008-003, group: noise-008-003)
**Epochs:** 77 (30-min wall clock limit)

Changed: `noise_scale = torch.tensor([0.01, 0.01, 0.005])` → `[0.008, 0.008, 0.003]`

| Metric | Baseline | This run (best ep 77) | Δ |
|---|---|---|---|
| val/loss | 2.3537 | **2.4167** | +0.063 ↑ slightly worse |
| val_in_dist/loss | — | 1.6162 | — |
| val_ood_cond/loss | — | 2.0866 | — |
| val_tandem/loss | — | 3.5474 | — |
| in_dist surf_p (Pa) | 19.73 | 20.92 | +1.19 ↑ slightly worse |
| ood_cond surf_p (Pa) | 22.97 | 23.53 | +0.56 ↑ slightly worse |
| ood_re surf_p (Pa) | 31.99 | **31.75** | −0.24 ↓ slightly better |
| tandem surf_p (Pa) | 43.82 | 44.74 | +0.92 ↑ slightly worse |

Full surface MAE at best epoch:
- val_in_dist: Ux=0.294, Uy=0.177, p=20.92 Pa
- val_ood_cond: Ux=0.276, Uy=0.193, p=23.53 Pa
- val_ood_re: Ux=0.292, Uy=0.204, p=31.75 Pa
- val_tandem: Ux=0.679, Uy=0.357, p=44.74 Pa

**Peak memory:** ~8.8 GB (unchanged)

### What happened

**Slightly negative result.** Reducing per-channel noise from [0.01, 0.01, 0.005] to [0.008, 0.008, 0.003] slightly degraded overall performance. val/loss increased from 2.3537 to 2.4167 (+2.7%), and surface pressure MAE worsened by ~1 Pa on most splits. Only ood_re improved marginally (−0.24 Pa).

This is a small effect in either direction, suggesting the model is near the optimal noise level for this dataset. The current [0.01, 0.01, 0.005] noise appears well-tuned — further reduction doesn't help and may slightly underregularize (the model overfits the training noise level).

Notably the best epoch is 77 (the last epoch), suggesting the model was still converging — another 10-20 epochs might show a clearer picture, but within the 30-min budget the result is slightly worse.

### Suggested follow-ups
- Try even lower noise (e.g. [0.005, 0.005, 0.002]) to continue the sweep and find the minimum
- Try zero noise on velocity ([0.0, 0.0, 0.003]) — pressure is physically more variable at surfaces, but velocity might not need noise