### PR TITLE
Weight decay 3e-5 (lighter regularization for small model)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -335,7 +335,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 3e-5
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "structured_split/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
Lighter weight decay (3e-5 vs default 1e-4) reduces regularization pressure on this small model, potentially allowing parameters to fit the data more freely.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `xretpmca`
**Epochs completed:** ~77 (hit 30-min timeout; val/loss still improving at cutoff)
**Runtime:** 1740s

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3537 | **2.4010** | +0.047 ↑ worse |
| val_in_dist/mae_surf_p | 19.73 | 21.09 | +1.36 ↑ |
| val_ood_cond/mae_surf_p | 22.97 | 24.24 | +1.27 ↑ |
| val_ood_re/mae_surf_p | 31.99 | 32.38 | +0.39 ↑ |
| val_tandem_transfer/mae_surf_p | 43.82 | 44.14 | +0.32 ↑ |

**Volume MAE (val_in_dist):** Ux=1.705, Uy=0.589, p=33.90

Note: `val_ood_re/surf_loss=NaN` is a pre-existing bug unrelated to this change.

### What happened

The hypothesis did not improve performance — all metrics are slightly worse than the baseline with standard weight decay (1e-4). The gap is moderate (~0.05 val/loss, ~1.3 on in-dist surf_p) but consistent across all splits.

Reducing weight decay from 1e-4 to 3e-5 (3.3x lighter) appears to mildly hurt the model. The baseline weight decay (1e-4) provides helpful regularization even for this small model. Both runs are cut off at the timeout so neither has fully converged, but the 30-minute budget is equal for both.

### Suggested follow-ups

- The other direction might be more interesting: try slightly *higher* weight decay (e.g., 3e-4) to see if there's underfitting at 1e-4.
- Alternatively, apply weight decay only to specific parameter groups (e.g., skip layer norms and biases) — standard practice that sometimes improves generalization.