### PR TITLE
Output head 2x width (256 intermediate → 3)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -181,9 +181,9 @@ class TransolverBlock(nn.Module):
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
+                nn.Linear(hidden_dim, hidden_dim * 2),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
+                nn.Linear(hidden_dim * 2, out_dim),
             )
 
     def forward(self, fx):


### PR DESCRIPTION
## Hypothesis
Widen the output head from \`Linear(128 → 128 → 3)\` to \`Linear(128 → 256 → 3)\` in the last Block's mlp2 — doubling the intermediate dimension to give the model more capacity when projecting from the hidden representation to predictions.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** \`0hpapzc8\` (\`violet/wider-output\`)
**Epochs:** ~79 (30-min timeout)
**Peak GPU memory:** 9.3 GB

### Key metrics vs. baseline

| Split | Metric | Baseline | This run | Δ |
|---|---|---|---|---|
| — | val/loss | 2.3537 | **2.4174** | +2.7% ↑ worse |
| val_in_dist | mae_surf_p | 19.73 | **20.73** | +5.1% ↑ worse |
| val_ood_cond | mae_surf_p | 22.97 | **24.19** | +5.3% ↑ worse |
| val_ood_re | mae_surf_p | 31.99 | **31.50** | −1.5% ↓ slightly better |
| val_tandem_transfer | mae_surf_p | 43.82 | **44.80** | +2.2% ↑ worse |

### Full surface MAE breakdown (best checkpoint, epoch 78)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.285 | 0.171 | 20.73 | 1.724 | 0.577 | 32.83 |
| val_ood_cond | 0.275 | 0.191 | 24.19 | 1.415 | 0.519 | 26.00 |
| val_ood_re | 0.274 | 0.201 | 31.50 | 1.325 | 0.524 | 54.71 |
| val_tandem_transfer | 0.663 | 0.350 | 44.80 | 2.592 | 1.189 | 50.90 |

### What happened

The wider output head made things slightly worse across most splits (especially surface pressure on val_in_dist and val_ood_cond, +5%). The output head doubling adds ~17K extra parameters but does not improve expressiveness where it matters — the bottleneck is in the attention/feature extraction layers, not in the final linear projection. The extra capacity in the output head likely just adds noise during early training and does not help the model generalize better.

val_ood_re is the only split showing marginal improvement (−1.5%), which is within noise.

Memory is unchanged (9.3 GB), so no VRAM cost concern, but the capacity is wasted.

### Suggested follow-ups

- If more output head capacity is wanted, try \`n_layers=2\` (adding a full attention block) rather than widening the final MLP — that would increase model capacity in the representation, not just the projection.
- Alternatively, try widening \`n_hidden\` (e.g. 192 or 256) which affects all layers, not just the output head.