### PR TITLE
Warmup 3 epochs (shorter warmup for faster training)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -497,10 +497,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=3)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[3]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Shorter warmup (3 epochs instead of 5) lets the model reach full learning rate faster, spending more time in the productive cosine decay phase.

## Instructions
Change warmup from 5 to 3 epochs:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=3)
...milestones=[3]
```

Run with: `--wandb_name "gilbert/warmup-3" --wandb_group warmup-3 --agent gilbert`

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `2qdp8y93` (gilbert/warmup-3)
**Epochs:** 80 (30.0 min wall-clock limit)
**Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.637 | 0.295 | 0.177 | **21.43** | 1.717 | 0.591 | 33.02 |
| val_ood_cond | 2.101 | 0.284 | 0.193 | **24.04** | 1.412 | 0.535 | 25.20 |
| val_ood_re | NaN | 0.290 | 0.203 | 32.30 | 1.318 | 0.532 | 54.89 |
| val_tandem_transfer | 3.485 | 0.649 | 0.350 | **44.94** | 2.579 | 1.197 | 51.35 |
| **val/loss (mean)** | **2.4077** | | | | | | |

**vs. baseline:**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.3537 | 2.4077 | +0.054 (+2.3%) ❌ |
| val_in_dist/mae_surf_p | 19.73 | 21.43 | +1.70 (+8.6%) ❌ |
| val_ood_cond/mae_surf_p | 22.97 | 24.04 | +1.07 (+4.7%) ❌ |
| val_ood_re/mae_surf_p | 31.99 | 32.30 | +0.31 (+1.0%) ❌ |
| val_tandem_transfer/mae_surf_p | 43.82 | 44.94 | +1.12 (+2.6%) ❌ |

**What happened:** Shorter warmup (3 epochs) hurt across all splits. All surface pressure MAEs regressed, with in-distribution being the worst (+8.6%). The hypothesis did not work.

The 5-epoch warmup appears necessary for the model to stabilize before the full learning rate is applied. With only 3 epochs of warmup, the model starts training with LR=0.003 (full rate) from epoch 4, which is too fast and leads to noisier early training. The cosine annealing then starts from a worse initial point.

Note: this is also not strictly a fair comparison as the baseline likely has a different configuration (it's the best-performing checkpoint from prior experiments), and the warmup change is a minor modification with small expected effect.

**Suggested follow-ups:**
- Try an even longer warmup (8 or 10 epochs) to see if more warmup helps
- The current 5-epoch warmup appears to be near optimal; leave it unchanged