### PR TITLE
Surface weight start at 8 (higher initial emphasis)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -551,7 +551,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
+    sw_start, sw_end = 8.0, 30.0
     progress = epoch / MAX_EPOCHS
     surf_weight = sw_start + (sw_end - sw_start) * progress
 


### PR DESCRIPTION
## Hypothesis
Higher initial surface weight emphasis (8 vs 5) helps the model learn surface features better from the start of training, since surface accuracy is what matters most.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `t2gjp5k3` — 74 epochs completed (timeout), peak memory 8.8GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3537 | **2.4258** | +0.072 ↑worse |
| val_in_dist/mae_surf_p | 19.73 | **21.74** | +2.01 ↑worse |
| val_ood_cond/mae_surf_p | 22.97 | **23.60** | +0.63 ↑worse |
| val_ood_re/mae_surf_p | 31.99 | **32.34** | +0.35 ↑worse |
| val_tandem_transfer/mae_surf_p | 43.82 | **45.34** | +1.52 ↑worse |
| val_in_dist/mae_surf_Ux | — | 0.268 | — |
| val_in_dist/mae_surf_Uy | — | 0.181 | — |
| val_in_dist/mae_vol_p | — | 35.09 | — |

**What happened:** Negative result. All metrics worsened. Starting with a higher surface weight (8 vs 5) hurt rather than helped. The progressive resolution schedule starts with only 5% of volume nodes in epoch 1, combined with a high surface weight, appears to destabilize early training — the model is pushed to over-fit surface nodes before it has learned a coherent volume representation. The baseline's sw_start=5.0 seems to be a better balance: enough surface emphasis to guide the model, but not so much that it starves volume learning during the critical early epochs.

**Suggested follow-ups:**
- The evidence suggests sw_start=5.0 is near-optimal or that higher starts consistently hurt. It may be worth trying sw_start=3.0 or even 1.0 to see if lower initial emphasis helps.
- Alternatively, decouple the surface weight start from progressive resolution: start higher surface weight only after the volume ramp completes (epoch 40+).
- Try a different ramp shape for the surface weight — e.g., convex ramp (slow start, fast end) to delay heavy surface emphasis until the volume representation is more stable.