### PR TITLE
Differential LR 0.4x for attention (1.2e-3 vs 3e-3 base)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -493,7 +493,7 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
+    {'params': attn_params, 'lr': cfg.lr * 0.4},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)


### PR DESCRIPTION
## Hypothesis
Reducing attention LR multiplier from 0.5× to 0.4× (1.2e-3 vs 3e-3 base) provides more conservative updates for attention parameters while keeping base LR for other layers.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `9e62fug3` | 79 epochs (killed during epoch 81 validation at ~30 min) | Peak memory: 8.8 GB

| Split | val/loss (ep79) | mae_surf_p | Note |
|---|---|---|---|
| val_in_dist | 1.638 | **21.53** | last W&B state |
| val_ood_cond | 2.014 | **22.12** | last W&B state |
| val_ood_re | nan | **31.94** | last W&B state |
| val_tandem_transfer | 3.465 | **44.31** | last W&B state |
| **val/loss (mean, ep79)** | **2.3721** | | |

_Note: Run killed during epoch 81 validation. val/loss from epoch 79 output log (last best checkpoint); MAE from W&B summary (last logged state, may include epoch 81 partial values for in_dist/tandem/ood_cond)._

**vs baseline (val/loss 2.3537):**
| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 19.73 | 21.53 | **+9.1% ✗** |
| val_ood_cond | 22.97 | 22.12 | **-3.7% ✓** |
| val_ood_re | 31.99 | 31.94 | **-0.2% ≈** |
| val_tandem_transfer | 43.82 | 44.31 | **+1.1% ✗** |
| val/loss | 2.3537 | 2.3721 | **+0.8%** |

### What happened

Marginal negative result. val/loss is 0.8% worse than baseline, and in_dist surface pressure regressed significantly (+9.1%), while ood_cond improved (-3.7%) and ood_re was flat. 

The larger regression in in_dist vs the ood_cond improvement suggests the lower attention LR (0.4× vs 0.5×) may be trading in-distribution accuracy for marginal out-of-distribution robustness. The attention parameters (temperature, attn_scale, slice weights) may need more gradient signal to converge properly on the training distribution within the 30-min budget.

Note: the baseline in this PR (val/loss 2.3537, in_dist=19.73) appears to be a stronger baseline than previous PRs in this session, suggesting continued improvements to the noam branch.

### Suggested follow-ups
- Try 0.3× multiplier (9e-4) — smaller steps might help further or reveal diminishing returns  
- Compare to no differential LR (all params at 3e-3) — establishes whether differential LR helps at all
- Look at how temperature and attn_scale values evolve — if they're converging slowly, lower LR may be appropriate; if they're overshooting, lower LR would help