### PR TITLE
Progressive resolution end at epoch 50 (extended ramp)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -599,9 +599,9 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
 
         # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+        # Ramps from 10% → 100% of volume nodes over first 50 epochs
+        if epoch < 50:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / 50)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
See PR description for details.

*Chihiro's interpretation*: Extend the progressive resolution ramp (volume node subsampling) from ending at epoch 40 to ending at epoch 50 (change `epoch < 40` to `epoch < 50` and `epoch / 40` to `epoch / 50`). Hypothesis: a longer warm-up on subsampled volume nodes helps the surface-weight ramp stabilize before full resolution kicks in.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run:** `o599jjbm`
**Best epoch:** 80 (wall-clock limit: 30.3 min)
**VRAM:** ~8.8 GB

### val/loss

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.3985** | 2.3537 | +0.045 (slightly worse) |

Note: val_ood_re loss = NaN (pre-existing issue).

### Surface MAE (mae_surf_p, Pa)

| Split | This run | Baseline | Δ |
|-------|----------|----------|---|
| val_in_dist | 21.11 | 19.73 | +1.38 (worse) |
| val_ood_cond | 23.94 | 22.97 | +0.97 (worse) |
| val_ood_re | 32.28 | 31.99 | +0.29 (worse) |
| val_tandem_transfer | 45.81 | 43.82 | +1.99 (worse) |

### Volume MAE (val_in_dist)

| Channel | MAE |
|---------|-----|
| Ux | 1.66 |
| Uy | 0.59 |
| p | 33.53 |

### What happened

Slightly worse across all splits. The extended progressive resolution ramp (40→50 epochs) doesn't improve convergence — all surface MAEs regress, with in_dist (+1.38 Pa) and tandem (+1.99 Pa) being the most affected.

The likely reason: extending the subsampling window means the model spends epochs 40-50 still training on partial volume nodes, which delays convergence toward the full-resolution objective. The original 40-epoch ramp may already be optimal (or slightly too long). By epoch 50, the model should have learned coarse flow patterns and be ready to refine on the full volume. Delaying this full-resolution training past 50% of the 80-epoch budget makes the convergence more surface-focused but at the cost of volume accuracy, which degrades the final joint objective.

Note: the baseline in this branch (2.3537) is notably better than previous baselines (2.5700, 2.4067), suggesting the advisor's main branch has been improving. The absolute performance is still better than many earlier experiments but this change doesn't help.

### Suggested follow-ups
- Try shortening the ramp instead (epoch 30 instead of 40) — the model may benefit from seeing full resolution earlier
- Or try a non-linear (convex) ramp rather than linear, so the model sees more volume nodes throughout and ramps up faster in the final epochs