### PR TITLE
Dead-zone L1 on surface (epsilon=0.02, ignore small errors)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -615,7 +615,8 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        deadzone_err = (abs_err - 0.02).clamp(min=0)  # dead-zone L1: ignore errors < 0.02
+        surf_per_sample = (deadzone_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Dead-zone L1 on surface: ignore small errors (< epsilon=0.02) to focus gradient on larger residuals. This encourages the model to focus on the hardest cases and not waste capacity on well-predicted nodes.

## Baseline
- val/loss: **2.3537**
- val_in_dist/mae_surf_p: 19.73
- val_ood_cond/mae_surf_p: 22.97
- val_ood_re/mae_surf_p: 31.99
- val_tandem_transfer/mae_surf_p: 43.82

---

## Results

**W&B run ID:** `0jnbn5sw`  
**Best epoch:** 76 / 76 (30.0 min wall-clock timeout)  
**Peak GPU memory:** 8.8 GB (no change)

### Metrics at best checkpoint (epoch 76)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6326 | 0.296 | 0.181 | 21.2 | 1.572 | 0.556 | 32.1 |
| val_tandem_transfer | 3.5154 | 0.659 | 0.360 | 44.9 | 2.522 | 1.184 | 50.5 |
| val_ood_cond | 2.1256 | 0.296 | 0.199 | 23.7 | 1.368 | 0.515 | 25.2 |
| val_ood_re | NaN* | 0.298 | 0.206 | 32.3 | 1.294 | 0.519 | 54.5 |
| **combined val/loss** | **2.4245** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.3537 → This run: 2.4245 — slightly worse (+0.071, ~3%)**

Surface pressure MAE vs baseline:
- val_in_dist: 21.2 vs 19.73 (+1.5, slightly worse)
- val_ood_cond: 23.7 vs 22.97 (+0.7, slightly worse)
- val_ood_re: 32.3 vs 31.99 (+0.3, slightly worse)
- val_tandem_transfer: 44.9 vs 43.82 (+1.1, slightly worse)
- **All splits slightly worse than baseline**

### What happened

Dead-zone L1 with epsilon=0.02 slightly underperformed the standard L1 baseline across all splits. The margins are small (1-3%), but consistently negative.

The likely explanation: epsilon=0.02 in normalized prediction space cuts off too much useful gradient. The surface error distribution is right-skewed — many nodes are well-predicted with small residuals, and the model benefits from refining these well-predicted nodes further. By zeroing gradient for errors < 0.02, we lose signal on most nodes (since many are close to correct) while trying to focus on fewer high-error nodes.

Additionally, the dead-zone loss is no longer a faithful proxy for MAE during validation. The training signal (dead-zone loss) and evaluation metric (regular MAE) diverge, potentially causing the optimizer to "settle" at a solution that minimizes dead-zone loss but not raw MAE.

The change is otherwise cost-free (same memory, same epoch count, same speed), so this is a clean negative result.

### Suggested follow-ups

- Try larger epsilon (0.05 or 0.10) to see if a more aggressive dead-zone helps, especially if many nodes are already well-predicted.
- Consider Huber loss (smooth L1) instead of dead-zone L1 — it attenuates gradient for small errors smoothly rather than cutting to zero, which may retain useful signal while reducing sensitivity to outliers.
- The training-evaluation mismatch (dead-zone training vs regular L1 evaluation) is fundamental to this approach. A loss that's monotone with MAE (like standard L1 or Huber) has a cleaner alignment with the evaluation metric.
