### PR TITLE
Fix surf_weight ramp to reach 30 by actual epoch count

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---


### PR DESCRIPTION
## Hypothesis
surf_weight ramp uses epoch/100 but training reaches ~75 epochs. Fix: epoch/75 so surf_weight actually reaches 30.

## Instructions
Line 555: change `progress = epoch / MAX_EPOCHS` to `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "frieren/fix-ramp" --wandb_group fix-surf-ramp-75 --agent frieren`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82
---
## Results

**W&B run:** `0ypos88h` (~78 epochs, 29.3 min, timed out)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3537 | **2.3956** | +1.78% |
| val_in_dist/mae_surf_p | 19.73 | **20.41** | +3.4% |
| val_ood_cond/mae_surf_p | 22.97 | **22.53** | **-1.9%** |
| val_ood_re/mae_surf_p | 31.99 | **31.45** | **-1.7%** |
| val_tandem_transfer/mae_surf_p | 43.82 | **44.28** | +1.1% |

Surface MAE (Ux, Uy, p) by split:
- val_in_dist: (0.287, 0.175, 20.41), mean = 6.96
- val_ood_cond: (0.275, 0.192, 22.53), mean = 7.67
- val_tandem_transfer: (0.665, 0.352, 44.28), mean = 15.10

Volume MAE by split:
- val_in_dist: (1.780, 0.620, 35.46), mean = 12.62
- val_ood_cond: (1.468, 0.561, 27.54), mean = 9.86
- val_tandem_transfer: (2.734, 1.255, 53.18), mean = 19.06

### What happened
Mixed result. OOD splits (ood_cond, ood_re) improved slightly on surf_p (-1.9%, -1.7%), but in-dist worsened (+3.4%) and tandem was nearly flat (+1.1%). Overall val/loss regressed by +1.78%.

**Why it might have hurt:** The fix makes the ramp steeper — surf_weight is always higher at any given epoch (e.g., at epoch 50: 22.3 vs 17.5). The higher surface weight earlier in training applies stronger gradient signal to surface nodes before the model has converged, which may over-emphasize surface accuracy at the expense of volume consistency. The original slow ramp inadvertently acted as a form of curriculum learning (easy objectives first).

**The OOD improvement** is interesting — the stronger surface emphasis may generalize better to unseen conditions. But it hurts in-distribution and overall loss.

### Suggested follow-ups
- Try a gentler corrected ramp: e.g., epoch/90 instead of epoch/75, to split the difference.
- Try keeping the max lower (e.g., 25 instead of 30) with the corrected ramp.
- The baseline slow ramp may have been accidentally good — if intentional, keep it; if unintentional bug, the fix makes the design explicit.