### PR TITLE
Surf weight ramp 5 to 35 with fixed 75-epoch divisor

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -551,8 +551,8 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    sw_start, sw_end = 5.0, 35.0
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---


### PR DESCRIPTION
## Hypothesis
After fixing ramp, optimal endpoint may be above 30 since config was tuned when ramp was broken (effective ~23.75).

## Instructions
1. Line 554: `sw_end = 35.0`
2. Line 555: `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "nezuko/ramp-35" --wandb_group surf-ramp-35 --agent nezuko`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82

---

## Results

**W&B run ID:** ut3gvmym  
**Best checkpoint:** epoch 80 (wall-clock limited at 30 min)

### val/loss (combined)
| Split | Baseline | This run | Delta |
|---|---|---|---|
| val/loss (avg) | 2.3537 | 2.3685 | ↑0.015 (worse) |
| val_in_dist | 1.5663 | 1.6459 | ↑0.08 |
| val_ood_cond | 2.0645 | **1.9896** | **↓0.075** |
| val_ood_re | NaN | NaN | — |
| val_tandem | 3.4302 | 3.4699 | ↑0.04 |

### Surface MAE (mae_surf_p — most important)
| Split | Baseline | This run | Delta |
|---|---|---|---|
| val_in_dist | 19.73 | 21.10 | ↑1.37 (worse) |
| val_ood_cond | 22.97 | **20.88** | **↓2.09 (best!)** |
| val_ood_re | 31.99 | 32.03 | ↑0.04 (neutral) |
| val_tandem | 43.82 | **43.46** | **↓0.36** |

### Surface MAE (all channels, best checkpoint)
| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 0.290 | 0.171 | 21.10 |
| val_ood_cond | 0.267 | 0.189 | 20.88 |
| val_ood_re | 0.276 | 0.204 | 32.03 |
| val_tandem | 0.666 | 0.352 | 43.46 |

### Volume MAE (best checkpoint)
| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 1.81 | 0.64 | 36.53 |
| val_ood_cond | 1.48 | 0.55 | 26.07 |
| val_ood_re | 1.41 | 0.56 | 56.24 |
| val_tandem | 2.67 | 1.27 | 53.07 |

### Peak memory
No change. No new parameters.

## What happened

**Mixed result.** val/loss is marginally worse (2.3685 vs 2.3537, +0.015), but the split picture is interesting:

- **ood_cond** improved substantially: mae_surf_p 22.97 → 20.88 (-2.09). This is the best ood_cond performance seen so far.
- **in_dist** got worse: mae_surf_p 19.73 → 21.10 (+1.37). More aggressive surface weighting shifts the model's optimum toward generalization at the cost of in-distribution fitting.
- **tandem** slightly better (-0.36), **ood_re** neutral.

The ramp fix (dividing by 75 instead of MAX_EPOCHS=100) ensures surf_weight actually reaches the target endpoint within the training window. The trade-off: sw_end=35 pushes the model toward surface accuracy on harder OOD cases but sacrifices precision on in-dist. The val/loss metric (simple average of splits) is approximately neutral, but the cross-split balance shifts.

The hypothesis is partially confirmed: after fixing the ramp calculation, a higher endpoint (35) does help generalization splits. However, there's a regularization trade-off with in_dist that 30 handled better.

## Suggested follow-ups
1. **sw_end=32** with fixed ramp: A compromise between 30 (better in_dist) and 35 (better ood_cond). The ideal value may be between 30 and 35.
2. **Split-specific surface weights**: Apply different surf_weight to tandem vs single-foil during validation loss aggregation. Tandem may benefit from higher weight than in_dist.
3. **ood_cond improvement stacking**: The ood_cond improvement here (20.88) combined with in_dist improvement from late-EMA (#679, 19.73) could stack if both are applied together on the same branch.