### PR TITLE
Surf weight ramp 5 to 25 with fixed 75-epoch divisor

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -551,8 +551,8 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
-    sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    sw_start, sw_end = 5.0, 25.0
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---


### PR DESCRIPTION
## Hypothesis
Broken ramp maxes at ~23.75. Maybe that IS near optimal. Testing 25 with fixed ramp isolates the fix from endpoint increase.

## Instructions
1. Line 554: `sw_end = 25.0`
2. Line 555: `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "alphonse/ramp-25" --wandb_group surf-ramp-25 --agent alphonse`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82

---
## Results

**W&B run:** u5rk9hg2
**Epochs:** 77 (~23.6s/epoch, 1819s)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3537 | **2.3744** | +0.9% ❌ |
| surf p in_dist | 19.73 | **21.50** | +9.0% ❌ |
| surf p ood_cond | 22.97 | **21.75** | -5.3% ✓ |
| surf p ood_re | 31.99 | **32.48** | +1.5% ❌ |
| surf p tandem | 43.82 | **45.47** | +3.8% ❌ |

Full surface MAE (Ux / Uy / p):
- val_in_dist: 0.270 / 0.176 / 21.50
- val_ood_cond: 0.271 / 0.191 / 21.75
- val_ood_re: 0.281 / 0.205 / 32.48
- val_tandem_transfer: 0.640 / 0.347 / 45.47

Volume MAE (Ux / Uy / p):
- val_in_dist: 1.706 / 0.583 / 35.16 (best_epoch not logged for vol splits)
- val_ood_cond: 1.444 / 0.535 / 25.87
- val_ood_re: 1.314 / 0.536 / 56.03
- val_tandem_transfer: 2.551 / 1.211 / 53.57

(val_ood_re/loss = NaN, pre-existing issue. val/loss averages 3 valid splits.)

**What happened:** Fixing the ramp to actually reach 25 by epoch 75 (instead of the broken ~23.75 at epoch 77) gives mixed results. ood_cond surface pressure improved by 5.3%, but in_dist regressed by 9% and val/loss is 0.9% worse overall.

The hypothesis that ~23.75 is near-optimal doesn't fully hold — ood splits respond differently. The large in_dist regression is notable and consistent across EMA and ramp experiments. 

A key insight: the ramp schedule affects training dynamics more than endpoint value. With the fixed divisor (epoch/75), the ramp reaches its plateau earlier, meaning the model trains with high surf_weight for the last ~2 epochs. This could suppress volume features that matter for in_dist.

**Suggested follow-ups:**
- Try sw_end=25 but keep the original divisor (epoch/MAX_EPOCHS) — this tests whether the endpoint matters more than the timing.
- Try a lower endpoint (sw_end=20) to see if the baseline was already over-weighting surface.
- The consistent in_dist regression across multiple experiments suggests in_dist is sensitive to over-regularization via high surf_weight late in training.