### PR TITLE
Combined: ramp fix + earlier EMA (epoch 60, decay 0.999)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -456,8 +456,8 @@ model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 65
-ema_decay = 0.998
+ema_start_epoch = 60
+ema_decay = 0.999
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---
@@ -782,7 +782,8 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        torch.save(model.state_dict(), model_path)
+        save_model = ema_model if ema_model is not None else model
+        torch.save(save_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(


### PR DESCRIPTION
## Hypothesis
Ramp fix changes loss landscape in EMA window. Longer EMA (epoch 60, slower decay 0.999) averages over better-converged weights.

## Instructions
1. Line 555: `progress = min(1.0, epoch / 75)`
2. Line 459: `ema_start_epoch = 60`
3. Line 460: `ema_decay = 0.999`
4. Line 785: save EMA weights

Run: `--wandb_name "edward/ema60-999" --wandb_group fix-ramp-ema60-999 --agent edward`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82

---
## Results

**W&B run:** pef78oi7
**Best epoch:** 81 / 81 completed
**Peak memory:** 8.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ surf_p vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 1.612 | 0.273 | 0.173 | 21.22 | +7.5% ✗ |
| val_ood_cond | 2.141 | 0.287 | 0.201 | 23.55 | +2.5% ✗ |
| val_ood_re | NaN | 0.286 | 0.203 | 32.03 | +0.1% ≈ |
| val_tandem_transfer | 3.506 | 0.651 | 0.351 | 45.39 | +3.6% ✗ |

**Composite val/loss: 2.4199** vs baseline 2.3537 (+2.8%, worse across all splits)

### What happened
Negative across the board. The combination of three changes makes it hard to isolate the cause, but the ramp fix is the most likely culprit. Changing `progress = epoch / MAX_EPOCHS` to `progress = min(1.0, epoch / 75)` means the surface weight hits its maximum (30.0) at epoch 75 instead of 100, so the last 25 epochs train under full surface weight. This likely over-pressures the model on surface accuracy in the final phase, hurting volume predictions and ultimately degrading all splits.

Saving EMA weights for the checkpoint (instead of regular model) may have hurt in early epochs where EMA hasn't had enough time to stabilize.

The earlier EMA start (epoch 60 vs 65) and slower decay (0.999 vs 0.998) are reasonable ideas but can't be evaluated independently here because of the ramp interaction.

### Suggested follow-ups
- Test ramp fix in isolation: just change to `min(1.0, epoch / 75)` without EMA changes, to see if it helps or hurts alone.
- Test EMA changes in isolation: `ema_start_epoch=60, decay=0.999` without the ramp fix.
- Revert the EMA checkpoint saving — it complicates things when EMA hasn't converged yet.