### PR TITLE
Attn LR 0.4x with fixed surf_weight ramp

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -493,7 +493,7 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
+    {'params': attn_params, 'lr': cfg.lr * 0.4},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---


### PR DESCRIPTION
## Hypothesis
Attn LR 0.4x was closest miss (2.3725). Ramp fix delivers stronger late surface emphasis to compensate.

## Instructions
1. Line 496: `cfg.lr * 0.4` (was 0.5)
2. Line 555: `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "thorfinn/attn-04x" --wandb_group attn-04x-ramp-fix --agent thorfinn`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82
---
## Results

**W&B run:** `airdpqqf` (thorfinn/attn-04x, group: attn-04x-ramp-fix)
**Epochs:** 77 (30-min wall clock limit, best at epoch 72)

| Metric | Baseline | This run (best ep 72) | Δ |
|---|---|---|---|
| val/loss | 2.3537 | **2.4248** | +0.071 ↑ slightly worse |
| val_in_dist/loss | — | 1.6119 | — |
| val_ood_cond/loss | — | 2.1268 | — |
| val_tandem/loss | — | 3.5358 | — |
| in_dist surf_p (Pa) | 19.73 | 20.71 | +0.98 ↑ slightly worse |
| ood_cond surf_p (Pa) | 22.97 | 23.41 | +0.44 ↑ slightly worse |
| ood_re surf_p (Pa) | 31.99 | **31.84** | −0.15 ↓ slightly better |
| tandem surf_p (Pa) | 43.82 | 44.77 | +0.95 ↑ slightly worse |

Full surface MAE at best epoch:
- val_in_dist: Ux=0.274, Uy=0.170, p=20.71 Pa
- val_ood_cond: Ux=0.280, Uy=0.191, p=23.41 Pa
- val_ood_re: Ux=0.293, Uy=0.201, p=31.84 Pa
- val_tandem: Ux=0.675, Uy=0.355, p=44.77 Pa

**Peak memory:** ~8.8 GB

### What happened

**Slightly negative result.** Both changes together (attn LR 0.4x + ramp fix) produced slightly worse results than baseline. val/loss increased 2.7% and surface pressure MAE worsened by ~1 Pa across most splits.

The attn LR reduction from 0.5x to 0.4x further constrains the attention parameters' learning rate. While slower attention learning can stabilize training, it appears too conservative here — the attention mechanism already had 0.5x LR which may already be at the right balance. Reducing further to 0.4x likely slows the physics attention convergence without corresponding benefit.

The ramp fix (clamping progress to max 1.0 at epoch 75) adds a slight surf_weight plateau in the last ~25 epochs. The effect is small since MAX_EPOCHS=100 means without the fix, progress reaches 1.0 at epoch 99 anyway — the two schedules differ mainly in epochs 75-99 where the fix holds surf_weight at 30 (max) rather than continuing to ramp.

### Suggested follow-ups
- The attn LR of 0.5x may be near-optimal; minor tweaks (0.3x, 0.6x) might not meaningfully differ
- If the ramp fix is valuable, apply it to the baseline without the LR change to isolate its effect