### PR TITLE
Lookahead alpha=0.9 (stronger slow-weight pull) + ramp fix

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -496,7 +496,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=10, alpha=0.9)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---


### PR DESCRIPTION
## Hypothesis
Alpha=0.9 pulls slow weights more aggressively, behaving closer to pure AdamW while retaining smoothing.

## Instructions
1. Line 499: \`alpha=0.9\` (was 0.8)
2. Line 555: \`progress = min(1.0, epoch / 75)\`

Run: \`--wandb_name "violet/alpha-09" --wandb_group lookahead-alpha09 --agent violet\`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82

---

## Results

**W&B run:** \`rdjsi3nz\` (\`violet/alpha-09\`)
**Epochs:** 80 (30-min timeout)
**Peak GPU memory:** 8.8 GB

### Key metrics vs. baseline

| Split | Metric | Baseline | This run | Δ |
|---|---|---|---|---|
| — | val/loss | 2.3537 | **2.4650** | +4.7% ↑ worse |
| val_in_dist | mae_surf_p | 19.73 | **20.91** | +6.0% ↑ worse |
| val_ood_cond | mae_surf_p | 22.97 | **24.85** | +8.2% ↑ worse |
| val_ood_re | mae_surf_p | 31.99 | **32.03** | ~0% no change |
| val_tandem_transfer | mae_surf_p | 43.82 | **45.53** | +3.9% ↑ worse |

### Full surface MAE breakdown (best checkpoint, epoch 80)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.282 | 0.172 | 20.91 | 1.744 | 0.611 | 35.24 |
| val_ood_cond | 0.294 | 0.195 | 24.85 | 1.478 | 0.553 | 27.89 |
| val_ood_re | 0.292 | 0.200 | 32.03 | 1.341 | 0.541 | 56.03 |
| val_tandem_transfer | 0.689 | 0.357 | 45.53 | 2.667 | 1.257 | 53.34 |

### What happened

Negative result: alpha=0.9 made things noticeably worse across all splits (−4.7% to −8.2% on surface pressure). The higher alpha means the slow weights are pulled 90% of the way toward the fast weights every k=10 steps, making Lookahead behave more like vanilla AdamW and losing the smoothing/regularization benefit. The original alpha=0.8 leaves more of the slow-weight averaging intact.

The ramp fix (\`min(1.0, epoch / 75)\`) is a sensible fix on its own (surf_weight hits 30 at epoch 75 instead of 100), but it cannot be isolated from the alpha change here. The combination made things worse.

Memory dropped slightly to 8.8 GB from 9.3 GB baseline — probably run-to-run variance, not a meaningful difference.

### Suggested follow-ups

- Try the ramp fix alone (alpha=0.8, just apply \`min(1.0, epoch/75)\`) to see if the ramp fix itself helps.
- If Lookahead tuning is worth pursuing, alpha values below 0.8 (e.g. 0.5, 0.6) might be worth exploring as they would increase the smoothing effect.