### PR TITLE
Top-k surface loss (hardest 50% surface nodes only)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---
@@ -597,6 +597,17 @@ for epoch in range(MAX_EPOCHS):
         abs_err = (pred - y_norm).abs()
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
+
+        # OHEM: keep only hardest 50% of surface nodes per sample
+        with torch.no_grad():
+            surf_err_per_node = abs_err.sum(dim=-1)
+            for b in range(B):
+                s_nodes = surf_mask[b].nonzero(as_tuple=True)[0]
+                if len(s_nodes) > 2:
+                    errs = surf_err_per_node[b, s_nodes]
+                    threshold = errs.median()
+                    easy = s_nodes[errs < threshold]
+                    surf_mask[b, easy] = False
 
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs


### PR DESCRIPTION
## Hypothesis
Focus gradient on the hardest 50% surface nodes (OHEM-style) to allocate capacity to challenging regions.

## Instructions
After line 598, add:
```python
with torch.no_grad():
    surf_err_per_node = abs_err.sum(dim=-1)
    for b in range(B):
        s_nodes = surf_mask[b].nonzero(as_tuple=True)[0]
        if len(s_nodes) > 2:
            errs = surf_err_per_node[b, s_nodes]
            threshold = errs.median()
            easy = s_nodes[errs < threshold]
            surf_mask[b, easy] = False
```
Also line 555: `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "gilbert/topk-surf" --wandb_group topk-surf-loss --agent gilbert`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82
---
## Results

**W&B run**: `zv3r47f8` (gilbert/topk-surf)
**Duration**: 30.1 min, **Best epoch**: 39/100

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.3537 | 3.4733 | +47.6% |
| in_p | 19.73 | 41.61 | +111% |
| ood_p | 22.97 | 34.88 | +51.9% |
| re_p | 31.99 | 40.83 | +27.6% |
| tan_p | 43.82 | 59.54 | +35.9% |

**Volume MAE (in_dist)**: Ux=2.226, Uy=0.878, p=56.23

### What happened

**Negative result** — significantly worse across all metrics and splits.

Two problems:

1. **Severe throughput penalty**: The per-sample Python for-loop in the OHEM block reduced training speed dramatically — only 39 epochs completed in 30 min vs. ~80 for baseline. The model never reaches the EMA stabilization phase (epoch 65+), which is a major handicap.

2. **Gradient starvation**: Dropping 50% of surface nodes per step may be too aggressive. The model can't reliably learn basic surface patterns when half the surface signal is withheld each batch. The OHEM threshold (median) means a random 50% in easy cases — not actually focusing on difficult geometry.

The Python-level loop is the critical bottleneck. Even at epoch 39, the val/loss is 3.47 vs ~2.8 expected for baseline at the same epoch, indicating the gradient focus itself hurts beyond just the speed.

### Suggested follow-ups

- If pursuing OHEM: vectorize the hard-node selection to eliminate the Python loop. Use `torch.topk` over a padded surface-node tensor to get hard indices without iterating over batch.
- Consider per-channel OHEM (focus on hard pressure nodes specifically) rather than sum-of-channels, since pressure is the hardest and most important component.
- A softer approach: weighted surface loss (harder nodes get higher weight rather than easy nodes zeroed out) might preserve more training signal while still emphasizing difficult regions.