### PR TITLE
2x gradient scaling on pressure channel via constant loss weighting

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---
@@ -612,10 +612,11 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        channel_weights = torch.tensor([1.0, 1.0, 2.0], device=device)
+        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1) * channel_weights).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1) * channel_weights).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Constant 2x pressure weight on both vol AND surf loss from epoch 0. Previous [1,1,2] failed because it was surface-only and started late.

## Instructions
Before line 615: `channel_weights = torch.tensor([1.0, 1.0, 2.0], device=device)`
Line 615: `vol_loss = (abs_err * vol_mask_train.unsqueeze(-1) * channel_weights).sum() / vol_mask_train.sum().clamp(min=1)`
Line 618: `surf_per_sample = (abs_err * surf_mask.unsqueeze(-1) * channel_weights).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()`
Line 555: `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "senku/pressure-2x" --wandb_group pressure-grad-2x --agent senku`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82
---
## Results

**W&B run:** `75exzrjy` — 74 epochs completed (timeout), peak memory 8.8GB

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3537 | **2.5162** | +0.163 ↑worse |
| val_in_dist/mae_surf_p | 19.73 | **21.64** | +1.91 ↑worse |
| val_ood_cond/mae_surf_p | 22.97 | **23.20** | +0.23 ↑worse |
| val_ood_re/mae_surf_p | 31.99 | **32.19** | +0.20 ↑worse |
| val_tandem_transfer/mae_surf_p | 43.82 | **44.26** | +0.44 ↑worse |
| val_in_dist/mae_surf_Ux | — | 0.317 | — |
| val_in_dist/mae_surf_Uy | — | 0.189 | — |
| val_in_dist/mae_vol_p | — | 36.87 | — |

**What happened:** Negative result. All metrics worsened, including pressure MAE which the 2x weighting was intended to improve. The 2x pressure channel weighting inflated training losses (train vol ~0.33 vs ~0.25 in baseline), but — counterintuitively — did not produce better pressure predictions. The model appears to have had difficulty optimizing with the unbalanced channel gradients: pressures span a much larger dynamic range than Ux/Uy, so doubling pressure further amplifies existing gradient imbalance. The result is worse representations overall, including for pressure itself.

Additionally, the progress cap change (`min(1.0, epoch/75)`) means surf_weight reaches its maximum of 30.0 at epoch 75 (vs epoch 100 baseline). This may have contributed by over-emphasizing surface loss too early in training, before the volume representation has fully converged.

**Suggested follow-ups:**
- Separate the two changes: try the `progress = min(1.0, epoch/75)` surf weight ramp change on its own without the channel weights.
- If the intent is to help pressure prediction, consider a smaller pressure boost (1.5x instead of 2x) or apply it only to the surface loss where pressure MAE is most important.
- Investigate whether normalizing by per-channel standard deviation in the loss (rather than fixed weights) could better balance gradient contributions across channels.