### PR TITLE
Huber loss for surface nodes (delta=1.0, smooth L1/L2 transition)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---
@@ -615,7 +615,9 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        huber_delta = 1.0
+        surf_huber = torch.where(abs_err < huber_delta, 0.5 * sq_err, huber_delta * (abs_err - 0.5 * huber_delta))
+        surf_per_sample = (surf_huber * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Huber acts like L2 for small errors (smoother convergence) and L1 for large errors (robust). Better than dead-zone or pure L1.

## Instructions
Around line 618, replace surface loss with Huber:
\`\`\`python
huber_delta = 1.0
surf_sq = (pred - y_norm) ** 2
surf_huber = torch.where(abs_err < huber_delta, 0.5 * surf_sq, huber_delta * (abs_err - 0.5 * huber_delta))
surf_per_sample = (surf_huber * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
\`\`\`
Line 555: \`progress = min(1.0, epoch / 75)\`

Run: \`--wandb_name "emma/huber-surf" --wandb_group huber-surf-loss --agent emma\`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82
---
## Results

**W&B run:** 88domzs8  
**Runtime:** 30.4 min | **Best epoch:** 80 | **Epoch time:** 22.7s | **Peak GPU:** ~50 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 2.5915 | 2.3537 | +0.238 ↑ worse |
| val_in_dist/mae_surf_Ux | 0.3405 | — | |
| val_in_dist/mae_surf_Uy | 0.2035 | — | |
| val_in_dist/mae_surf_p | 25.54 | 19.73 | +5.81 ↑ much worse |
| val_in_dist/mae_vol_Ux | 1.2558 | — | |
| val_in_dist/mae_vol_Uy | 0.4387 | — | |
| val_in_dist/mae_vol_p | 25.71 | — | |
| val_ood_cond/mae_surf_p | 25.66 | 22.97 | +2.69 ↑ worse |
| val_ood_re/mae_surf_p | 34.22 | 31.99 | +2.23 ↑ worse |
| val_tandem_transfer/mae_surf_p | 46.74 | 43.82 | +2.92 ↑ worse |

**What happened:** Strongly negative. Replacing the surface MAE loss with Huber (delta=1.0) caused a significant regression across all metrics — in_dist pressure MAE jumped +5.81 Pa (~30% worse). The L1 tail of Huber reduces gradient magnitude for large errors, which are exactly the hard samples (extreme pressures, high AoA, tandem leading edge) the model most needs to learn from. By capping gradient sensitivity at delta=1.0, Huber effectively gives up on these difficult cases in favour of smoother convergence on easier ones. The progress-ramp change (epoch/75 instead of epoch/MAX_EPOCHS) also reaches max surface weight earlier (epoch 75 vs 100), which may have destabilized training. Note that vol_loss metrics (vol_Ux, vol_Uy, vol_p) are better — Huber may work better for the smoother volume fields but is harmful for the sharp surface pressure gradients.

**Suggested follow-ups:**
- Revert to MAE (L1) — it's the right loss for CFD pressure fields where large errors are informative, not outliers.
- If Huber is worth trying again, use a larger delta (e.g. delta=5.0 or 10.0) so the L1 regime only kicks in for genuinely extreme outliers in normalized space.
- The ramp change (epoch/75) should be tested independently — it may have a different effect on its own.