### PR TITLE
Dual-scale coarse loss (pool 64 at 0.5 + pool 256 at 0.5)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---
@@ -635,7 +635,23 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 0.5 * coarse_loss
+
+        # Multi-scale loss: coarse spatial pooling (pool 256)
+        coarse_pool_size_256 = 256
+        n_groups_256 = N // coarse_pool_size_256
+        if n_groups_256 > 1:
+            pred_trunc_256 = pred[:, :n_groups_256 * coarse_pool_size_256]
+            y_trunc_256 = y_norm[:, :n_groups_256 * coarse_pool_size_256]
+            mask_trunc_256 = mask[:, :n_groups_256 * coarse_pool_size_256]
+
+            pred_coarse_256 = pred_trunc_256.reshape(B, n_groups_256, coarse_pool_size_256, C).mean(dim=2)
+            y_coarse_256 = y_trunc_256.reshape(B, n_groups_256, coarse_pool_size_256, C).mean(dim=2)
+            mask_coarse_256 = mask_trunc_256.reshape(B, n_groups_256, coarse_pool_size_256).any(dim=2)
+
+            coarse_err_256 = (pred_coarse_256 - y_coarse_256).abs()
+            coarse_loss_256 = (coarse_err_256 * mask_coarse_256.unsqueeze(-1)).sum() / mask_coarse_256.sum().clamp(min=1)
+            loss = loss + 0.5 * coarse_loss_256
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Pool 256 captures large-scale flow structure. Keep total coarse weight at 1.0 (0.5 + 0.5).

## Instructions
1. Line 638: change weight to 0.5: \`loss = loss + 0.5 * coarse_loss\`
2. After line 638, add pool-256 coarse loss (same pattern, pool_size=256, weight=0.5)
3. Line 555: \`progress = min(1.0, epoch / 75)\`

Run: \`--wandb_name "norman/dual-coarse" --wandb_group dual-coarse-64-256 --agent norman\`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82
---
## Results

**W&B run:** \`3zp2fsuv\` | **Best epoch:** 80 (killed during epoch 81 validation at ~30 min) | **Peak memory:** 8.8 GB

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | **2.4326** | 2.3537 | +3.3% ✗ |
| val_in_dist/mae_surf_p | 20.52 | 19.73 | +4.0% ✗ |
| val_ood_cond/mae_surf_p | 23.75 | 22.97 | +3.4% ✗ |
| val_ood_re/mae_surf_p | 32.54 | 31.99 | +1.7% ✗ |
| val_tandem_transfer/mae_surf_p | 44.51 | 43.82 | +1.6% ✗ |

**What happened:** Dual-scale coarse loss (pool-64 at 0.5 + pool-256 at 0.5) performed worse than the single pool-64 at 1.0 baseline across all metrics. The hypothesis that pool-256 captures useful large-scale structure did not hold — adding a very coarse (256-node) auxiliary loss appears to hurt training. Likely the pool-256 groups are too large to provide meaningful spatial supervision; each group covers ~10% of the domain, so the pooled targets become so averaged that they give little gradient signal beyond what the main loss already provides. Splitting the weight to 0.5+0.5 also halved the effective pool-64 signal.

The \`progress = min(1.0, epoch / 75)\` change caps surf_weight at 30.0 from epoch 75 onward — this may have interacted with the dual coarse loss change. Without the cap, at epoch 80, progress=0.8 gives surf_weight=25.0; with the cap, surf_weight=30.0 from epoch 75 onwards. So the capped version trains with a higher surf_weight in late epochs, which is a confound.

**Suggested follow-ups:**
- Try pool-128 as a single coarse loss at weight 1.0 to check if an intermediate pooling scale helps
- Test \`progress = min(1.0, epoch / 75)\` in isolation to understand its isolated effect on results
- If dual-scale is worth revisiting, try 0.8 + 0.2 to preserve the dominant pool-64 signal