### PR TITLE
Stochastic depth: skip attention block 10% during training

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -187,8 +187,11 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx):
-        fx = self.attn(self.ln_1(fx)) + fx
-        fx = self.mlp(self.ln_2(fx)) + fx
+        if self.training and torch.rand(1).item() < 0.1:
+            fx = self.mlp(self.ln_2(fx)) + fx
+        else:
+            fx = self.attn(self.ln_1(fx)) + fx
+            fx = self.mlp(self.ln_2(fx)) + fx
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))
         return fx
@@ -552,7 +555,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---


### PR DESCRIPTION
## Hypothesis
Randomly skipping attention 10% forces preprocess MLP to be more independently predictive. Proven in vision transformers.

## Instructions
In TransolverBlock.forward (line 189-194):
```python
def forward(self, fx):
    if self.training and torch.rand(1).item() < 0.1:
        fx = self.mlp(self.ln_2(fx)) + fx
    else:
        fx = self.attn(self.ln_1(fx)) + fx
        fx = self.mlp(self.ln_2(fx)) + fx
    if self.last_layer:
        return self.mlp2(self.ln_3(fx))
    return fx
```
Line 555: `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "chihiro/stoch-depth" --wandb_group stochastic-depth-attn --agent chihiro`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82
---
## Results

**W&B run:** `pte0cbst`
**Best epoch:** 83 (wall-clock limit: 30.2 min)
**VRAM:** ~8.8 GB

### val/loss

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.4660** | 2.3537 | +0.112 (worse) |

Note: val_ood_re loss = NaN (pre-existing issue).

### Surface MAE (mae_surf_p, Pa)

| Split | This run | Baseline | Δ |
|-------|----------|----------|---|
| val_in_dist | 20.33 | 19.73 | +0.60 (slightly worse) |
| val_ood_cond | 26.05 | 22.97 | **+3.08 (much worse)** |
| val_ood_re | 32.52 | 31.99 | +0.53 (slightly worse) |
| val_tandem_transfer | 46.17 | 43.82 | +2.35 (worse) |

### Volume MAE (val_in_dist)

| Channel | MAE |
|---------|-----|
| Ux | 1.76 |
| Uy | 0.62 |
| p | 35.67 |

### What happened

Negative result overall. ood_cond regressed significantly (+3.08 Pa) and tandem also worsened (+2.35 Pa), while in_dist and ood_re are near-baseline. val/loss is +0.112 worse.

The ood_cond regression is a recurring pattern in several experiments (surf-boost, asym-coarse, here), suggesting this split is sensitive to regularization that biases the model toward in-distribution surface patterns.

Stochastic depth should help generalization by making the network more robust, but the 10% skip probability and the combination with the updated surface weight schedule (saturating at epoch 75 via `min(1.0, epoch/75)`) may interact poorly. When attention is skipped, the model falls back to the MLP-only path, which is less expressive for flow field interpolation. The Transolver's slice attention mechanism is central to the physics, and skipping it even 10% of the time may hurt the quality of the learned slice assignments.

Additionally, the surface weight changes: `progress = min(1.0, epoch/75)` instead of `epoch/MAX_EPOCHS` means surf_weight reaches 30.0 at epoch 75 and stays there for epochs 75+. This is a more aggressive ramp (30.0 by epoch 75 vs ~24 at epoch 75 in the baseline), which might explain some of the tandem regression.

### Suggested follow-ups
- Try stochastic depth without the surface weight ramp change — isolate which part drives the regression
- If stochastic depth is revisited, try a very low drop rate (0.05 or less) that's less likely to affect the core physics representation