### PR TITLE
Gentler warmup (start_factor=0.01 instead of 0.1) + ramp fix

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -497,7 +497,7 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.01, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
@@ -552,7 +552,7 @@ for epoch in range(MAX_EPOCHS):
 
     # Dynamic surface weight: linear ramp from 5 → 30 over training
     sw_start, sw_end = 5.0, 30.0
-    progress = epoch / MAX_EPOCHS
+    progress = min(1.0, epoch / 75)
     surf_weight = sw_start + (sw_end - sw_start) * progress
 
     # --- Train ---


### PR DESCRIPTION
## Hypothesis
Start LR at 0.01x (3e-5) instead of 0.1x (3e-4) to let orthogonal init settle before large gradients. Multiple experiments showed early training sensitivity. Also cap surface weight progress at epoch 75 to ensure full ramp completes within training budget.

## Instructions
1. Line 500: `start_factor=0.01` (was 0.1)
2. Line 555: `progress = min(1.0, epoch / 75)`

Run: `--wandb_name "haku/warmup-001" --wandb_group gentler-warmup --agent haku`

## Baseline
val/loss: **2.3537** | in_p: 19.73 | ood_p: 22.97 | re_p: 31.99 | tan_p: 43.82

---

## Results

**W&B run ID:** `cemun1l6`  
**Best epoch:** 77 / 77 (30.3 min wall-clock timeout)  
**Peak GPU memory:** 8.8 GB (no change)

### Metrics at best checkpoint (epoch 77)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6230 | 0.286 | 0.174 | 20.9 | 1.760 | 0.618 | 35.6 |
| val_tandem_transfer | 3.5615 | 0.685 | 0.361 | 44.5 | 2.702 | 1.253 | 53.3 |
| val_ood_cond | 2.1536 | 0.275 | 0.194 | 24.6 | 1.469 | 0.559 | 28.0 |
| val_ood_re | NaN* | 0.286 | 0.203 | 32.3 | 1.371 | 0.553 | 56.4 |
| **combined val/loss** | **2.4460** | | | | | | |

*val_ood_re NaN is a pre-existing issue across all runs.

**Baseline val/loss: 2.3537 → This run: 2.4460 — slightly worse (+0.092, ~4%)**

Surface pressure MAE vs baseline:
- val_in_dist: 20.9 vs 19.73 (+1.2, slightly worse)
- val_ood_cond: 24.6 vs 22.97 (+1.6, worse)
- val_ood_re: 32.3 vs 31.99 (+0.3, slightly worse)
- val_tandem_transfer: 44.5 vs 43.82 (+0.7, slightly worse)
- **All splits slightly worse than baseline**

### What happened

The gentler warmup (0.01x start factor) slightly underperformed the standard warmup (0.1x). The epoch 1 validation loss was much higher than usual (~20 vs ~10 for in_dist), indicating the extremely low initial LR (3e-5) left the model essentially untrained for the first few epochs. By epoch 2 it recovered quickly, but the delayed learning consumed some of the training budget.

The orthogonal weight initialization doesn't appear to need extra warmup time — the current 0.1x start factor is already conservative enough.

The surface weight ramp cap at epoch 75 (instead of epoch 100) is a separate change that marginally helps ensure the full surf_weight=30 is reached before timeout. However, since the model typically converges around epoch 76-77 anyway, this change has minimal impact on the results.

The combined effect of both changes is slightly negative, with the warmup change dominating.

### Suggested follow-ups

- The current 0.1x warmup appears well-calibrated for orthogonal init.
- The surf weight ramp cap at epoch 75 is a sensible safety improvement (surface weight should reach maximum before training ends), worth keeping in future experiments even if it had little effect here.
- If further warmup tuning is desired, try extending the warmup duration (total_iters=10 instead of 5) rather than reducing the start factor — this gives the network more time to adapt at moderate LR.
