### PR TITLE
Stochastic surface weight (Uniform(10,40) per batch)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# Experiment: adaptive-sw
+experiment: Stochastic surface weight (Uniform(10,40) per batch)

--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -617,6 +617,11 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
+        # Stochastic surface weight: sample Uniform(10, 40) per batch during training
+        if model.training:
+            surf_weight = torch.empty(1, device=device).uniform_(10.0, 40.0).item()
+        else:
+            surf_weight = 25.0
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
Instead of a fixed adaptive surf_weight per epoch, randomly sample surf_weight from Uniform(10,40) each training batch. This turns the model into an implicit ensemble over different vol/surf tradeoffs, finding Pareto-optimal parameters. At evaluation, use the mean value (25). The randomization acts as a regularizer similar to dropout.

## Instructions
In `structured_split/structured_train.py`, in the training loop where `surf_weight` is computed:

1. Replace the adaptive surf_weight computation with stochastic sampling during training:
```python
if model.training:
    surf_weight = torch.empty(1, device=device).uniform_(10.0, 40.0).item()
else:
    surf_weight = 25.0
```

2. Keep the adaptive surf_weight code but override it. The existing `sw_ema` tracking can remain for logging.

3. For the tandem boost, still apply `surf_weight *= 1.5` for tandem samples after the random sampling.

Run with: `--wandb_name "frieren/stoch-sw" --wandb_group stochastic-surf-weight --agent frieren`

## Baseline
- val/loss: **2.3396**
- val_in_dist/mae_surf_p: 21.49
- val_ood_cond/mae_surf_p: 22.68
- val_ood_re/mae_surf_p: 31.60
- val_tandem_transfer/mae_surf_p: 44.28

---

## Results

**W&B run:** `vyt93fzc` (~78 epochs, 29.1 min, timed out)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 2.3396 | **2.4847** | +6.2% |
| val_in_dist/mae_surf_p | 21.49 | **21.25** | **-1.1%** |
| val_ood_cond/mae_surf_p | 22.68 | **23.99** | +5.8% |
| val_ood_re/mae_surf_p | 31.60 | **32.55** | +3.0% |
| val_tandem_transfer/mae_surf_p | 44.28 | **45.82** | +3.5% |

Surface MAE (Ux, Uy, p):
- val_in_dist: (0.290, 0.176, 21.25), mean = 7.24
- val_ood_cond: (0.294, 0.194, 23.99), mean = 8.16
- val_tandem_transfer: (0.691, 0.360, 45.82), mean = 15.62

Volume MAE:
- val_in_dist: (1.889, 0.671, 37.36), mean = 13.31
- val_ood_cond: (1.550, 0.570, 28.86), mean = 10.33
- val_tandem_transfer: (2.776, 1.309, 55.70), mean = 19.93

### What happened
Clearly negative result — val/loss is +6.2% worse. Volume MAE worsened significantly across all splits (in_dist vol: 12.45→13.31; ood_cond vol: 9.30→10.33), and surface pressure regressed in most OOD splits. Only in-dist surf_p showed a tiny improvement (-1.1%).

**Why it hurt:** Stochastic surf_weight introduces severe gradient variance — when surf_weight=10 the vol loss dominates, when surf_weight=40 the surface loss dominates. Rather than finding a Pareto-optimal solution, the model gets conflicting gradient signals every batch, making it harder to converge. The implicit ensemble effect is real in theory but doesn't outweigh the optimization instability at this training horizon (~78 epochs).

The adaptive loss-ratio baseline (2.3396) is already a principled approach to setting surf_weight — it auto-adjusts to keep vol and surf losses balanced. Random sampling doesn't improve on this.

### Suggested follow-ups
- Try a narrower stochastic range (e.g., Uniform(15, 30)) to reduce variance while keeping the ensemble effect.
- Try stochastic surf_weight only in early training, switching to fixed adaptive weight in later epochs.