### PR TITLE
Spectral reparametrization of output head

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# Experiment: adaptive-sw
+experiment: Spectral reparametrization of output head (SVD-constrained)

--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -454,6 +454,21 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+# Spectral reparametrization: decompose final Linear(n_hidden, out_dim) via SVD
+# Freeze U and Vh; learn only sigma (singular values)
+with torch.no_grad():
+    W = model.blocks[-1].mlp2[-1].weight.data
+    U, S, Vh = torch.linalg.svd(W, full_matrices=False)
+    model.register_buffer('out_U', U)
+    model.register_buffer('out_Vh', Vh)
+    model.out_sigma = nn.Parameter(S)
+    model.blocks[-1].mlp2[-1].weight.requires_grad = False
+_out_bias = model.blocks[-1].mlp2[-1].bias
+def _spectral_forward(x):
+    W_eff = model.out_U @ torch.diag(model.out_sigma) @ model.out_Vh
+    return F.linear(x, W_eff, _out_bias)
+model.blocks[-1].mlp2[-1].forward = _spectral_forward
+
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 65


### PR DESCRIPTION
## Hypothesis
Decompose output Linear(128,3) via SVD: W = U @ diag(sigma) @ V^T. Freeze U,V, learn sigma only. Constrains output to well-conditioned subspace.

## Instructions
In `structured_split/structured_train.py`:

1. After model creation, decompose the final linear layer:
```python
with torch.no_grad():
    W = model.mlp2[-1].weight.data
    U, S, Vh = torch.linalg.svd(W, full_matrices=False)
    model.register_buffer('out_U', U)
    model.register_buffer('out_Vh', Vh)
    model.out_sigma = nn.Parameter(S)
```
2. After each optimizer step, reconstruct: `model.mlp2[-1].weight.data = model.out_U @ torch.diag(model.out_sigma) @ model.out_Vh`

Run with: `--wandb_name "gilbert/spectral-out" --wandb_group spectral-output --agent gilbert`

## Baseline
- val/loss: **2.3396**
- val_in_dist/mae_surf_p: 21.49
- val_ood_cond/mae_surf_p: 22.68
- val_ood_re/mae_surf_p: 31.60
- val_tandem_transfer/mae_surf_p: 44.28

---

## Results

**W&B run**: `rulxke9h` (gilbert/spectral-out)
**Duration**: 30.1 min, **Best epoch**: 76/100

**Implementation note**: The PR instructions reference `model.mlp2[-1]` but the layer is at `model.blocks[-1].mlp2[-1]`. Also, for sigma to receive proper gradients (and not be ignored by autograd), I implemented it by monkey-patching the final linear layer's forward to reconstruct `W_eff = out_U @ diag(out_sigma) @ out_Vh` inside the computation graph, rather than using a post-step `.data` assignment:
```python
def _spectral_forward(x):
    W_eff = model.out_U @ torch.diag(model.out_sigma) @ model.out_Vh
    return F.linear(x, W_eff, _out_bias)
model.blocks[-1].mlp2[-1].forward = _spectral_forward
```

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.3396 | 2.3744 | +1.5% |
| in_p | 21.49 | 21.97 | +2.2% |
| ood_p | 22.68 | 21.75 | **-4.1%** |
| re_p | 31.60 | 31.65 | ~0% |
| tan_p | 44.28 | 44.78 | +1.1% |

**Volume MAE (in_dist)**: Ux=1.416, Uy=0.489, p=26.94

### What happened

**Neutral/slightly negative result**. val/loss is marginally worse (+1.5%), with mixed pressure MAEs: ood_p improved (-4.1%) but in_p and tan_p slightly worse. Overall performance is essentially on par with baseline.

The SVD reparametrization reduces the effective degrees of freedom in the output head from `n_hidden * out_dim` (256×3=768) to just `min(n_hidden, out_dim) = 3` singular values. This is very aggressive regularization on an already small output layer. The benefit is that the output head is constrained to stay well-conditioned, but the constraint may be too tight — with only 3 learnable scalars, the output head has very limited capacity to adapt from its initial (random init) singular value structure.

Training ran to epoch 76 (EMA active from 65+), same throughput as baseline.

### Suggested follow-ups

- Try keeping U trainable (only freeze Vh, learn U and sigma): this gives more flexibility while still preserving the spectral structure.
- Apply spectral reparametrization to the first Linear in mlp2 (128→128) which has more parameters to constrain.
- Consider spectral normalization (normalize by largest singular value) rather than full SVD reparametrization, as a lighter-weight alternative.