### PR TITLE
Cyclic slice number (alternate 16/32 per epoch)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# Experiment: adaptive-sw
+experiment: Cyclic slice number (alternate 16/32 slices per epoch)


### PR DESCRIPTION
## Hypothesis
Even epochs use all 32 slices, odd epochs use 16 (zero out last 16). Forces first 16 to learn coarse structure. Eval uses all 32.

## Instructions
In `structured_split/structured_train.py`:

1. In TransolverBlock forward, after computing slice_weights:
```python
if self.training and epoch % 2 == 1:
    slice_weights = slice_weights.clone()
    slice_weights[:, :, 16:] = 0
    slice_weights = slice_weights / slice_weights.sum(dim=-1, keepdim=True).clamp(min=1e-8)
```
2. Pass epoch via `model.current_epoch = epoch`.

Run with: `--wandb_name "kohaku/cyclic-slices" --wandb_group cyclic-slices --agent kohaku`

## Baseline
- val/loss: **2.3396**
- val_in_dist/mae_surf_p: 21.49
- val_ood_cond/mae_surf_p: 22.68
- val_ood_re/mae_surf_p: 31.60
- val_tandem_transfer/mae_surf_p: 44.28

---

## Results
_To be filled by student_
