### PR TITLE
Truncated backprop through slice attention + aux loss

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# Experiment: adaptive-sw
+experiment: Truncated backprop through slice attention (auxiliary slice loss)


### PR DESCRIPTION
## Hypothesis
Detach slice_weights so output loss doesn't backprop through assignment. Train slices with auxiliary loss maximizing inter-slice variance.

## Instructions
In `structured_split/structured_train.py`:

1. Detach slice_weights: `slice_weights_detached = slice_weights.detach()` — use for attention
2. Add aux loss: `aux_loss = -0.01 * slice_tokens.var(dim=1).mean()` (maximize variance)
3. Add aux_loss to total loss.

Run with: `--wandb_name "chihiro/detach-slice" --wandb_group detached-slicing --agent chihiro`

## Baseline
- val/loss: **2.3396**
- val_in_dist/mae_surf_p: 21.49
- val_ood_cond/mae_surf_p: 22.68
- val_ood_re/mae_surf_p: 31.60
- val_tandem_transfer/mae_surf_p: 44.28

---

## Results

**W&B run**: `utplzvmm` (chihiro/detach-slice)
**Best epoch**: 12
**Wall-clock**: 30.2 min (timeout)
**Peak VRAM**: 8.8 GB

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.3396 | 5.8800 | +3.54 worse |
| val_in_dist/mae_surf_p | 21.49 | 81.92 | +60.4 worse |
| val_ood_cond/mae_surf_p | 22.68 | 72.18 | +49.5 worse |
| val_ood_re/mae_surf_p | 31.60 | 71.4 | +39.8 worse |
| val_tandem_transfer/mae_surf_p | 44.28 | 96.38 | +52.1 worse |

Additional best-epoch metrics (val_in_dist): mae_surf_Ux=0.913, mae_surf_Uy=0.420, mae_vol_Ux=2.878, mae_vol_Uy=1.136, mae_vol_p=74.28.

### What happened

**Catastrophic failure — training diverged after epoch 12.** The detached slice weights broke gradient flow through the assignment step, and the aux loss could not compensate.

1. **Detaching slice_weights severs the critical gradient path.** The scatter step uses `slice_weights_detached` in the reconstruction einsum. By detaching here, gradients cannot flow back through assignments during reconstruction. The model can no longer learn assignments that minimize reconstruction error — only through the aux loss.

2. **The aux loss pushes assignments away from what the task needs.** Maximizing inter-slice variance (`-var(dim=1).mean()`) is an unsupervised objective that may be orthogonal or antagonistic to the downstream task. Highly variable slices need not correspond to physically meaningful node groups.

3. **Best epoch 12 is suspiciously early.** The model was fine for the first ~12 epochs (good random init), but as training progressed the aux loss actively degraded assignment quality. Epoch 81 val losses were 40+ (vs ~2.4 baseline) — full divergence.

4. **Implementation note**: A detach-after-use pattern was required for EMA deepcopy compatibility. The first run crashed on `deepcopy(model)` due to stored non-leaf tensors; after fixing, training completed but diverged badly.

### Suggested follow-ups

- **Aux loss only, no detach**: Drop `slice_weights.detach()`, keep only variance-maximizing aux at a very small weight (e.g., -0.001). Tests diversity pressure without severing gradient flow.
- **Entropy regularization instead**: Negative entropy on `slice_weights` to prevent collapse — more standard for soft-assignment models and doesn't break backprop.
- **Detach on gather side only**: Try detaching in the gather step (`einsum(..., slice_weights.detach())` for `slice_token` computation) rather than scatter. Lets reconstruction gradients flow while blocking them from influencing gather assignment.
