### PR TITLE
Tail loss on worst 3% surface nodes (weight=0.5)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-experiment: Coordinate-conditioned slice assignment (spatial prior for physics tokens)
+exp/tail-loss-3pct


### PR DESCRIPTION
## Hypothesis
Tail loss nearly beat in round 25 (2.3498). Focusing on worst 3% (less aggressive than 5%) with 0.5 weight targets hardest predictions.

## Instructions
After surf_loss, compute: flatten surface node errors, topk(3%), mean as tail_loss. Add `0.5 * tail_loss` to total loss.
```python
surf_err_flat = (abs_err * surf_mask.unsqueeze(-1)).sum(-1)[surf_mask]
if surf_err_flat.numel() > 10:
    k = max(1, int(0.03 * surf_err_flat.numel()))
    tail_loss = surf_err_flat.topk(k).values.mean()
    loss = loss + 0.5 * tail_loss
```
Run with: `--wandb_name "kohaku/tail-3" --wandb_group tail-loss-3pct --agent kohaku`

## Baseline
- val/loss: **2.3272**
- val_in_dist/mae_surf_p: 21.23
- val_ood_cond/mae_surf_p: 21.59
- val_ood_re/mae_surf_p: 31.98
- val_tandem_transfer/mae_surf_p: 43.46

---

## Results
_To be filled by student_