### PR TITLE
Learned output skip from preprocess (zero-init)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-experiment: Coordinate-conditioned slice assignment (spatial prior for physics tokens)
+exp/output-residual


### PR DESCRIPTION
## Hypothesis
Skip connection from preprocessed features to output gives access to raw geometric features that may be lost through attention. Zero-init starts as baseline.

## Instructions
Add `self.output_skip = nn.Linear(n_hidden, 3, bias=False)` with `nn.init.zeros_(self.output_skip.weight)`. Save `fx_pre = fx` after preprocess. After final output: `out = out + self.output_skip(fx_pre)`.
Run with: `--wandb_name "chihiro/out-skip" --wandb_group output-residual --agent chihiro`

## Baseline
- val/loss: **2.3272**
- val_in_dist/mae_surf_p: 21.23
- val_ood_cond/mae_surf_p: 21.59
- val_ood_re/mae_surf_p: 31.98
- val_tandem_transfer/mae_surf_p: 43.46

---

## Results

**W&B run**: `oplslhvy` (chihiro/out-skip)
**Best epoch**: 76
**Wall-clock**: 30.2 min (timeout)
**Peak VRAM**: 9.2 GB

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.3272 | 2.3094 | -0.018 better |
| val_in_dist/mae_surf_p | 21.23 | 20.6 | -0.63 better |
| val_ood_cond/mae_surf_p | 21.59 | 21.4 | -0.19 better |
| val_ood_re/mae_surf_p | 31.98 | 30.9 | -1.08 better |
| val_tandem_transfer/mae_surf_p | 43.46 | 43.0 | -0.46 better |

Additional best-epoch metrics (val_in_dist): mae_surf_Ux=0.283, mae_surf_Uy=0.176, mae_vol_Ux=1.329, mae_vol_Uy=0.468, mae_vol_p=26.15.

### What happened

**Modest but consistent improvement across all splits.** The skip connection helps, though the gain is small.

The zero-init design means training started identically to baseline and the skip weight was learned from scratch. By epoch 76, the model found a small correction to add based on preprocess features. The improvement is:
- Consistent across all 4 splits (none regressed)
- Largest in ood_re (-1.08 Pa), which is the most OOD regime — geometric information that would otherwise be "forgotten" through attention layers may be most valuable when generalizing to unseen Reynolds numbers
- Small in ood_cond (-0.19 Pa), which is OOD on flow conditions rather than geometry

The complexity cost is one Linear layer (256×3 ≈ 768 parameters, ~6KB) and one tensor save — minimal. The 9.2 GB VRAM is a small increase from ~8.8 GB in previous runs.

One note on the W&B val/loss of 2.3094: this is the best-epoch combined loss across 3 non-NaN splits. The training curve shows steady improvement with no sign of premature convergence.

### Suggested follow-ups

- **Train longer**: The skip weight is still learning at epoch 76 (last epoch before timeout). A longer run might widen the gap.
- **Mid-network skip**: Save `fx` at an intermediate block (e.g., after block 2 of 5) rather than after preprocess. Mid-network features have more processed geometry but haven't been fully averaged by attention.
- **LayerScale on skip**: Add a learnable scalar initialized to 0.01 (LayerScale style) so the skip starts with very small contribution and grows more gently.
