### PR TITLE
EMA-smoothed val/loss for checkpoint selection (decay=0.9)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-experiment: Coordinate-conditioned slice assignment (spatial prior for physics tokens)
+exp/ema-ckpt-smooth


### PR DESCRIPTION
## Hypothesis
Single-epoch val/loss is noisy. EMA-smoothed selection picks consistently good epochs instead of lucky ones.

## Instructions
Track `val_ema = 0.9*val_ema + 0.1*mean_val_loss`. Use `val_ema` instead of `mean_val_loss` for checkpoint selection (`if val_ema < best_val`).
Run with: `--wandb_name "haku/ema-ckpt" --wandb_group ema-ckpt-smooth --agent haku`

## Baseline
- val/loss: **2.3272**
- val_in_dist/mae_surf_p: 21.23
- val_ood_cond/mae_surf_p: 21.59
- val_ood_re/mae_surf_p: 31.98
- val_tandem_transfer/mae_surf_p: 43.46

---

## Results

**W&B run:** `zwnm6ts1` (haku/ema-ckpt)

| Split | val/loss | surf_p MAE | surf_Ux MAE | surf_Uy MAE |
|---|---|---|---|---|
| val_in_dist | 1.5661 | **20.79** | 0.274 | 0.174 |
| val_ood_cond | 2.0684 | 23.32 | 0.290 | 0.192 |
| val_ood_re | NaN | 32.03 | 0.290 | 0.203 |
| val_tandem_transfer | 3.3879 | 43.81 | 0.643 | 0.348 |

**Best val/loss: 2.3408** (baseline: 2.3272 — slightly worse, +0.6%)

**Peak memory:** 9.0 GB (vs ~8.8 GB baseline — negligible increase)

**Epochs:** 75 (last checkpoint at epoch 75)

### What happened

The EMA-smoothed checkpoint selection had no meaningful impact. The combined val/loss is 2.3408 vs baseline 2.3272 (+0.6%), which is within noise. Individual split results are mixed:

- val_in_dist/mae_surf_p: **20.79** vs 21.23 — slight improvement (+0.44)
- val_ood_cond/mae_surf_p: 23.32 vs 21.59 — worse (−1.73)
- val_ood_re/mae_surf_p: 32.03 vs 31.98 — essentially unchanged
- val_tandem_transfer/mae_surf_p: 43.81 vs 43.46 — essentially unchanged

The EMA ended at 2.509 while raw val/loss was 2.341, meaning the EMA lagged behind the actual (still-improving) val/loss at the end of training. As a result, EMA checkpointing selected the final epoch (epoch 75) anyway — the same as the raw criterion would. With cosine LR + Lookahead creating a smooth and monotonically declining val/loss curve, there's no noisy oscillation for EMA to filter out.

### Suggested follow-ups

- **Training curve is already smooth**: The Lookahead optimizer inherently smooths optimization, so there's little noise for EMA to help with. This approach would be more useful for noisier training regimes.
- **Best-k averaging**: Instead of EMA for selection, average the weights of the last K checkpoints (model soups) for a more robust final model.
- **Patience-based checkpointing**: If the training curve IS noisy at some point (e.g., early epochs), a patience criterion might be more principled than EMA smoothing.