### PR TITLE
Auxiliary Reynolds number prediction (regularize Re-awareness)

### DIFF
--- a/structured_split/structured_train.py
+++ b/structured_split/structured_train.py
@@ -270,6 +270,7 @@ class Transolver(nn.Module):
         self.initialize_weights()
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
+        self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -331,10 +332,15 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
-        for block in self.blocks:
+        for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)
+
+        # Auxiliary Re prediction from pre-output-head hidden representation
+        re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
+
+        fx = self.blocks[-1](fx, raw_xy=raw_xy)
         self._validate_output_dims(fx)
-        return {"preds": fx}
+        return {"preds": fx, "re_pred": re_pred}
 
 
 # ---------------------------------------------------------------------------
@@ -603,8 +609,11 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            pred = model({"x": x})["preds"]
+            out = model({"x": x})
+            pred = out["preds"]
+            re_pred = out["re_pred"]
         pred = pred.float()
+        re_pred = re_pred.float()
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -654,6 +663,10 @@ for epoch in range(MAX_EPOCHS):
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
+
+        log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
+        re_loss = F.mse_loss(re_pred, log_re_target)
+        loss = loss + 0.01 * re_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Force the model to encode Re information by predicting log(Re) from internal representations. This should improve ood_re generalization. Re is available in input (feature index 13) but predicting it from transformed representation forces Re-awareness through attention.

## Instructions
1. Add auxiliary head after TransolverBlock in `Transolver.__init__`:
```python
self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
```

2. In `Transolver.forward`, after block output but before output head, add:
```python
re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
```

3. In training loop, compute auxiliary loss:
```python
log_re_target = x[:, 0, 13:14]  # log(Re) from input features
re_loss = F.mse_loss(re_pred, log_re_target)
loss = loss + 0.01 * re_loss
```

Run with: `--wandb_name "askeladd/aux-re-pred" --wandb_group aux-re-pred --agent askeladd`

## Baseline
- val/loss: **2.2974**

---

## Results

**W&B run:** `obgrkvxe` | ~70 epochs | ~29 min

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | **2.2777** | 2.2974 | **-0.0197** ✓ |
| val_in_dist/loss | 1.5493 | — | |
| val_tandem/loss | 3.3148 | — | |
| val_ood_cond/loss | 1.9690 | — | |
| val_ood_re/loss | NaN (pre-existing) | — | |

**Surface MAE:**

| Split | Ux | Uy | p |
|-------|-----|-----|---|
| val_in_dist | 0.2643 | 0.1750 | 21.36 |
| val_tandem | 0.6483 | 0.3410 | 42.94 |
| val_ood_cond | 0.2778 | 0.1883 | 23.07 |
| val_ood_re | 0.2834 | 0.1998 | 31.55 |

**Volume MAE:**

| Split | Ux | Uy | p |
|-------|-----|-----|---|
| val_in_dist | 1.2781 | 0.4566 | 26.14 |
| val_tandem | 2.2215 | 1.0073 | 44.81 |
| val_ood_cond | 1.0708 | 0.4069 | 19.74 |
| val_ood_re | 1.0536 | 0.4419 | 50.98 |

**Peak memory:** N/A (no OOM; epoch time 24.3s, similar to baseline)

### What happened

The auxiliary Re prediction worked — val/loss improved by **-0.0197** (0.86%) vs baseline. The hypothesis holds: forcing the hidden representation to encode log(Re) explicitly via a mean-pooled auxiliary head appears to provide a mild regularization benefit.

Implementation note: since the last TransolverBlock transforms hidden state → predictions (via its `mlp2`), the `re_head` is applied to the pre-final-block hidden representation (i.e., after `self.blocks[:-1]` and before `self.blocks[-1]`). This ensures the head operates on the full n_hidden-dimensional representation, not the 3-dim prediction output.

The ood_re split still has the pre-existing NaN bug so we cannot directly confirm improved Re generalization through val/loss, but the ood_re Surface MAE values (Ux=0.2834, Uy=0.1998, p=31.55) are available for qualitative comparison.

The re_head is tiny (~5K params for n_hidden=128) and adds negligible compute overhead.

### Suggested follow-ups

- Try a stronger auxiliary weight (0.05 or 0.1) to see if more Re-pressure helps further
- Add auxiliary prediction of AoA (index 14) with a similar head — the model may benefit from encoding multiple conditioning variables explicitly
- Once the ood_re NaN bug is fixed, verify whether Re generalization actually improved using the val/loss metric directly