### PR TITLE
Manifold mixup on preprocess features (Beta(0.2,0.2), skip tandem)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/se-block-v2
+exp/manifold-mixup


### PR DESCRIPTION
## Hypothesis
Standard input mixup failed because mesh data mixing is physically meaningless. Manifold mixup interpolates in latent space after the preprocess MLP, where features are in an abstract representation space. Only apply to non-tandem samples.

## Instructions
In the training loop, after `pred = model(x, mask)`, but this needs modification inside the model. Instead, apply manifold mixup in the training loop:

1. In `Transolver.forward`, add a `return_features` mode that returns the preprocess features.
2. In the training loop:
```python
# After forward pass, get features and pred:
# Simpler approach: add mixup directly in forward
# In Transolver.forward, after fx = self.preprocess(x):
if self.training and hasattr(self, '_mixup_lambda'):
    lam = self._mixup_lambda
    idx = torch.randperm(fx.shape[0], device=fx.device)
    fx = lam * fx + (1 - lam) * fx[idx]
    # Store idx for target mixing in training loop
    self._mixup_idx = idx
```

3. In training loop:
```python
lam = np.random.beta(0.2, 0.2) if epoch > 10 else 1.0  # skip during curriculum
model._mixup_lambda = lam
pred = model(x, mask)
if hasattr(model, '_mixup_idx') and lam < 1.0:
    y_norm = lam * y_norm + (1 - lam) * y_norm[model._mixup_idx]
    mask = mask & mask[model._mixup_idx]  # intersection of valid masks
```

Run with: `--wandb_name "emma/manifold-mixup" --wandb_group manifold-mixup --agent emma`

## Baseline
- val/loss: **2.2974**

---

## Results
_To be filled by student_