### PR TITLE
Gradient accumulation 2-step with sqrt LR scaling (eff batch 8)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/se-block-v2
+exp/grad-accum-sqrt


### PR DESCRIPTION
## Hypothesis
Smoother gradients from effective batch 8 should stabilize the adaptive surface weight mechanism. Use sqrt(2) LR scaling (2.1e-3 base, 1.05e-3 attn) instead of 2x. The Lookahead k=10 sync now happens every 20 batches, potentially better for slow-weight averaging.

## Instructions
1. Change LR:
```python
cfg.lr = 2.1e-3  # was 3e-3, sqrt(2) scaling
# attn LR proportionally: 1.05e-3
```

2. Add gradient accumulation in training loop:
```python
accum_steps = 2
optimizer.zero_grad()  # before the batch loop
for micro_step, batch in enumerate(train_loader):
    # ... compute loss as normal ...
    (loss / accum_steps).backward()
    if (micro_step + 1) % accum_steps == 0:
        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
        optimizer.step()
        optimizer.zero_grad()
        scheduler.step()  # step per optimizer step
```

Run with: `--wandb_name "chihiro/grad-accum" --wandb_group grad-accum-sqrt --agent chihiro`

## Baseline
- val/loss: **2.2974**

---

## Results
_To be filled by student_