### PR TITLE
Combined baseline run (sandwich norm + aux Re + preprocess skip)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-combined-baseline


### PR DESCRIPTION
## Hypothesis
Three independent improvements were just merged into noam: sandwich LayerNorm (val/loss 2.2772), auxiliary Re prediction (2.2777), and preprocess-to-output skip (2.2887). Each beat the old baseline (2.2974) individually. This run establishes the combined baseline.

## Baseline
Previous best (sandwich norm alone): val/loss **2.2772**

| Split | surf_p (sandwich norm) |
|-------|----------------------|
| val_in_dist | 21.01 |
| val_ood_cond | 22.58 |
| val_ood_re | 32.13 |
| val_tandem_transfer | 44.03 |

## Instructions
No code changes. Run the current noam code as-is:

```bash
python structured_split/structured_train.py \
  --agent tanjiro \
  --wandb_name "tanjiro/combined-baseline" \
  --wandb_group "mar17-combined-baseline"
```

Report full val/loss and all per-split surface MAE metrics. This establishes the new reference.

## Results
_To be filled by student_