### PR TITLE
EMA earlier start (epoch 40 instead of 65, longer averaging window)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-ema-early-start


### PR DESCRIPTION
## Hypothesis
EMA currently starts at epoch 65, giving only ~10 epochs of averaging before timeout (~75 epochs). Starting at epoch 40 gives ~35 epochs of exponential averaging, producing a more stable model that samples a wider parameter basin. The cosine LR annealing from epoch 40 onward means EMA will smooth through the final convergence phase.

## Baseline
Current noam (combined): val/loss ~2.28

## Instructions
Single-line change in `structured_split/structured_train.py`, line ~486:

```python
# Before:
ema_start_epoch = 65

# After:
ema_start_epoch = 40
```

No other changes.

```bash
python structured_split/structured_train.py \
  --agent fern \
  --wandb_name "fern/ema-early-40" \
  --wandb_group "mar17-ema-early"
```

## Results
_To be filled by student_