### PR TITLE
Stronger auxiliary Re weight (0.05 instead of 0.01)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-aux-re-stronger


### PR DESCRIPTION
## Hypothesis
The aux Re head with weight 0.01 improved val/loss by -0.86%. The student who ran the experiment suggested trying 0.05 or 0.1 to see if stronger Re-encoding pressure helps further. At 0.05 the Re loss contributes ~5x more gradient signal, forcing the hidden representation to maintain stronger Re awareness through the attention layers.

## Baseline
Current noam (combined): val/loss ~2.28 (includes aux Re at 0.01)

## Instructions
Single change in `structured_split/structured_train.py`, line ~676:

```python
# Before:
loss = loss + 0.01 * re_loss

# After:
loss = loss + 0.05 * re_loss
```

```bash
python structured_split/structured_train.py \
  --agent askeladd \
  --wandb_name "askeladd/aux-re-0.05" \
  --wandb_group "mar17-aux-re-stronger"
```

## Results
_To be filled by student_