### PR TITLE
2 Transolver layers with n_hidden=96 (depth vs width tradeoff)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-depth-2layer


### PR DESCRIPTION
## Hypothesis
Current architecture uses 1 Transolver layer with n_hidden=128. Adding a second layer gives the model compositional depth — the first layer can learn local spatial patterns while the second refines cross-region interactions. Reducing n_hidden to 96 compensates for the extra layer to maintain epoch budget within 30 min. n_hidden=96 with 4 heads gives 24-dim per head (vs current 32), which is still reasonable.

## Baseline
Current noam (combined): val/loss ~2.28

## Instructions
Change the model config in `structured_split/structured_train.py` (lines ~473-474):

```python
# Before:
n_hidden=128,
n_layers=1,

# After:
n_hidden=96,
n_layers=2,
```

**Important**: The `re_head` and `out_skip` use `n_hidden`, so they'll automatically adjust to 96. The preprocess MLP will also adjust (n_hidden*2 = 192 intermediate). The aux Re prediction and skip connection still operate on the pre-final-block representation, which now comes after 1 block instead of 0 (since blocks[:-1] with 2 layers = [block_0]).

Also note that `out_dim=3` is passed to `TransolverBlock`, and the last block's `mlp2` decoder will have hidden_dim=96 instead of 128. This is fine.

```bash
python structured_split/structured_train.py \
  --agent nezuko \
  --wandb_name "nezuko/depth-2layer-96h" \
  --wandb_group "mar17-depth-2layer"
```

## Results
_To be filled by student_