### PR TITLE
Per-channel output heads (separate decoders for Ux, Uy, p)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-per-channel-output


### PR DESCRIPTION
## Hypothesis
The current output decoder (mlp2) maps hidden_dim → 3 with a shared linear layer, forcing Ux, Uy, and p to share the same decoder weights. But pressure (p) has very different characteristics than velocity (Ux, Uy) — p is a scalar field with steep gradients near surfaces while velocity is a vector field with boundary layers. Separate lightweight decoders for each channel should allow specialization.

## Baseline
Current noam (combined): val/loss ~2.28

## Instructions
Replace the single `mlp2` in the last TransolverBlock with per-channel heads.

In `TransolverBlock.__init__`, replace the `if self.last_layer` block (lines ~191-197):

```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    # Separate heads for each output channel
    self.head_Ux = nn.Sequential(nn.Linear(hidden_dim, hidden_dim // 2), nn.GELU(), nn.Linear(hidden_dim // 2, 1))
    self.head_Uy = nn.Sequential(nn.Linear(hidden_dim, hidden_dim // 2), nn.GELU(), nn.Linear(hidden_dim // 2, 1))
    self.head_p = nn.Sequential(nn.Linear(hidden_dim, hidden_dim // 2), nn.GELU(), nn.Linear(hidden_dim // 2, 1))
```

In `TransolverBlock.forward`, replace the `if self.last_layer` return (line ~208):

```python
if self.last_layer:
    h = self.ln_3(fx)
    return torch.cat([self.head_Ux(h), self.head_Uy(h), self.head_p(h)], dim=-1)
```

The rest of the pipeline (loss computation, skip connection) sees the same shape [B, N, 3] so nothing else changes.

```bash
python structured_split/structured_train.py \
  --agent alphonse \
  --wandb_name "alphonse/per-channel-heads" \
  --wandb_group "mar17-per-channel"
```

## Results
_To be filled by student_