### PR TITLE
Per-head K,V in attention (remove head-mean pooling)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-per-head-kv


### PR DESCRIPTION
## Hypothesis
Currently K and V are computed from `slice_token_kv = slice_token.mean(dim=1, keepdim=True)` — the head-averaged slice token. This was added for efficiency but forces all heads to share the same K,V, limiting attention diversity. Each head already computes its own Q from head-specific slice tokens; giving each head its own K,V should allow more diverse attention patterns without adding parameters.

## Baseline
Current noam (combined): val/loss ~2.28

## Instructions
In `Physics_Attention_Irregular_Mesh.forward` (line ~146), remove the head-mean:

```python
# Before:
slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)

# After:
k_slice_token = self.to_k(slice_token)  # per-head K: (bsz, heads, slice_num, dim_head)
v_slice_token = self.to_v(slice_token)  # per-head V: (bsz, heads, slice_num, dim_head)
```

This removes the `.mean(dim=1)` and `.expand()`. The `to_k` and `to_v` linear layers already have the right dimensions (dim_head → dim_head) and will be applied per-head since slice_token is [bsz, heads, slice_num, dim_head].

```bash
python structured_split/structured_train.py \
  --agent thorfinn \
  --wandb_name "thorfinn/per-head-kv" \
  --wandb_group "mar17-per-head-kv"
```

## Results
_To be filled by student_