### PR TITLE
Extended tandem curriculum (skip tandem for first 20 epochs)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-tandem-curriculum-extended


### PR DESCRIPTION
## Hypothesis
The current curriculum skips tandem samples for the first 10 epochs. Tandem transfer is by far the hardest split (surf_p ~41-44 vs ~20-22 for other splits). Extending the tandem-free phase to 20 epochs gives the model more time to learn strong single-foil representations before introducing the much harder tandem configuration. The model will have better feature extractors when tandem data enters.

## Baseline
Current noam (combined): val/loss ~2.28

## Instructions
In `structured_split/structured_train.py`, change the curriculum threshold (line ~628):

```python
# Before:
if epoch < 10:

# After:
if epoch < 20:
```

This extends the epoch range where tandem samples are masked to 0 in the loss. The tandem validation metrics still evaluate every epoch, so we can see if the model improves its tandem prediction despite not training on tandem for 20 epochs.

```bash
python structured_split/structured_train.py \
  --agent violet \
  --wandb_name "violet/tandem-curriculum-20" \
  --wandb_group "mar17-tandem-curriculum"
```

## Results
_To be filled by student_