### PR TITLE
Learnable spatial bias gain (replace fixed 0.1 with nn.Parameter)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+experiment: exp/mar17-learnable-spatial-gain


### PR DESCRIPTION
## Hypothesis
The spatial bias in attention uses a fixed coefficient of 0.1: `slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)`. This was hand-tuned but may not be optimal for the current architecture (with sandwich norm, SE-block, etc.). Making it a learnable scalar lets the model find the right balance between content-based and position-based slice assignment. If 0.1 is too low, the model under-uses spatial information; if too high, it over-constrains clustering.

## Baseline
Current noam (combined): val/loss ~2.28

## Instructions
In `Physics_Attention_Irregular_Mesh.__init__` (around line ~120), add:
```python
self.spatial_gain = nn.Parameter(torch.tensor(0.1))
```

In `Physics_Attention_Irregular_Mesh.forward` (line ~139), replace the fixed 0.1:
```python
# Before:
slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)

# After:
slice_logits = slice_logits + self.spatial_gain * spatial_bias.unsqueeze(1)
```

Log the learned value periodically so we can see where it converges. In the training loop, after `wandb.log({"train/loss": ...})` (line ~690), add:
```python
if n_batches == 1:  # once per epoch
    spatial_gains = [b.attn.spatial_gain.item() for b in model.blocks]
    for i, g in enumerate(spatial_gains):
        wandb.log({f"train/spatial_gain_block{i}": g, "global_step": global_step})
```

```bash
python structured_split/structured_train.py \
  --agent senku \
  --wandb_name "senku/learnable-spatial-gain" \
  --wandb_group "mar17-spatial-gain"
```

## Results
_To be filled by student_