### PR TITLE
Slice-token residual bypass — resubmit on current noam (from #778)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-exp/post-norm-v2
+exp/mar17-slice-residual-v2


### PR DESCRIPTION
## Hypothesis
Same as PR #778 — slice tokens carry concentrated cluster information. Adding a learnable-scale residual bypass around Q/K/V attention preserves raw cluster centroids. PR #778 achieved val/loss **1.2659** (-44.9%) but was based on older noam (missing sandwich norm, aux Re, preprocess skip). This resubmit applies the change on current noam.

## Instructions

In `structured_split/structured_train.py`, make these two changes:

### 1. In `Physics_Attention_Irregular_Mesh.__init__`, add after `self.to_v`:
```python
self.to_v = nn.Linear(dim_head, dim_head, bias=False)
self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))  # <-- ADD THIS LINE
self.to_out = nn.Sequential(
```

### 2. In `Physics_Attention_Irregular_Mesh.forward`, add after `out_slice_token = torch.matmul(attn_weights, v_slice_token)`:
```python
out_slice_token = torch.matmul(attn_weights, v_slice_token)
out_slice_token = out_slice_token + self.slice_residual_scale * slice_token  # <-- ADD THIS LINE
```

This adds a single learnable scalar (init 0.1) that lets raw pre-attention cluster summaries bypass the Q/K/V transformation. Negligible memory cost.

Run with: `--wandb_name "edward/slice-residual-v2" --wandb_group slice-residual-v2 --agent edward`

## Baseline (current noam)
- val/loss: **2.2887** (sandwich norm + aux Re + preprocess skip + SE-block + curriculum)

## Prior result (on older noam, PR #778)
- val/loss: **1.2659** (-44.9% vs 2.2974 old baseline)