### PR TITLE
MLP-only DropPath p=0.1 (resubmit on current noam)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 
 import os
 import time
+from pathlib import Path
 from collections.abc import Mapping
 
 import torch
@@ -189,7 +190,11 @@ class TransolverBlock(nn.Module):
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
-        fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
+        mlp_out = self.mlp(self.ln_2(fx))
+        if self.training:
+            drop_mask = (torch.rand(fx.shape[0], 1, 1, device=fx.device) > 0.1).float()
+            mlp_out = mlp_out * drop_mask / 0.9
+        fx = self.ln_2_post(mlp_out + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))


### PR DESCRIPTION
## Hypothesis
Dropping only the MLP branch with p=0.1 forces attention to learn independently useful representations. Proven in PR #784: val/loss 1.5733 (-31%). Some instability at final epoch noted.

## Instructions

In `train.py`, in `TransolverBlock.forward`, replace:
```python
fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
```
with:
```python
mlp_out = self.mlp(self.ln_2(fx))
if self.training:
    drop_mask = (torch.rand(fx.shape[0], 1, 1, device=fx.device) > 0.1).float()
    mlp_out = mlp_out * drop_mask / 0.9
fx = self.ln_2_post(mlp_out + fx)
```

Run:
```bash
python train.py --agent fern --wandb_name "fern/mlp-droppath-resubmit" --wandb_group mlp-droppath-resubmit
```

## Baseline
- val/loss: ~2.28
- Prior proven result: val/loss **1.5733** (-31%)

---

## Results

**W&B run:** `a4rmz75c`

**Note:** Run crashed (killed by 30-min timeout) at epoch 63/100. At ~28s/epoch, a full 100-epoch run would take ~47 min — this experiment cannot complete within the timeout constraint.

Also fixed a pre-existing bug: `Path` from `pathlib` was not imported in `train.py`, causing the first attempt to crash immediately at model save.

### Metrics at best epoch (epoch 61/63)

| Metric | This run (ep 61) | Baseline |
|--------|-----------------|----------|
| val/loss | 2.5394 | ~2.28 |
| val_in_dist/loss | 1.982 | — |
| Surface MAE Ux | 0.376 | — |
| Surface MAE Uy | 0.203 | — |
| Surface MAE p | 30.51 | — |
| Volume MAE Ux | 1.415 | — |
| Volume MAE Uy | 0.533 | — |
| Volume MAE p | 33.24 | — |

**Peak memory:** not tracked (same model architecture as baseline, no change expected)

### What happened

The prior result of 1.5733 from PR #784 was not reproduced. On the current noam branch, val/loss reached a best of **2.5394** at epoch 61 — still worse than baseline 2.28. The run was still descending when killed (last 5 val/losses: 2.62, 2.65, 2.58, 2.54, 2.64), so convergence was incomplete.

More concerning: **val_ood_re shows catastrophic divergence** — val_ood_re/vol_loss reached ~18.9 billion and val_ood_re/loss went NaN. The drop mask is applied per-sample (batch dim), so with batch size 4, individual samples where the MLP is dropped entirely may produce extremely large outputs during early training. On OOD Reynolds data this instability was severe and persistent.

The "some instability at final epoch" noted in PR #784 appears much worse on the current branch, likely due to interactions with Sandwich LayerNorm and other accumulated architectural changes.

**Hypothesis not supported on current noam branch.** The 30-min timeout also prevents full 100-epoch evaluation.

### Suggested follow-ups

- Reduce drop probability to p=0.05 and add gradient clipping to contain OOD instability
- Try stochastic depth at the block level rather than MLP-only — more conservative regularization
- Investigate why PR #784's 1.5733 doesn't transfer: the accumulated architectural changes (Sandwich LN, aux Reynolds, skip connections) may change the regularization dynamics significantly