### PR TITLE
Slice-residual + MLP DropPath combined

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 
 import os
 import time
+from pathlib import Path
 from collections.abc import Mapping
 
 import torch
@@ -103,6 +104,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
+        self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
@@ -141,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
+        out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
@@ -189,7 +192,11 @@ class TransolverBlock(nn.Module):
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
-        fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
+        mlp_out = self.mlp(self.ln_2(fx))
+        if self.training:
+            drop_mask = (torch.rand(fx.shape[0], 1, 1, device=fx.device) > 0.1).float()
+            mlp_out = mlp_out * drop_mask / 0.9
+        fx = self.ln_2_post(mlp_out + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))


### PR DESCRIPTION
## Hypothesis
Slice-token residual (-44.9%) and MLP DropPath (-31%) modify different forward-pass components and should be orthogonal. Testing whether gains compound.

## Instructions

Apply BOTH changes to `train.py`:

### 1. Slice-token residual bypass
In `Physics_Attention_Irregular_Mesh.__init__`, add after `self.to_v = nn.Linear(...)`:
```python
self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
```
In `Physics_Attention_Irregular_Mesh.forward`, add after `out_slice_token = torch.matmul(attn_weights, v_slice_token)`:
```python
out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
```

### 2. MLP-only DropPath
In `TransolverBlock.forward`, replace:
```python
fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
```
with:
```python
mlp_out = self.mlp(self.ln_2(fx))
if self.training:
    drop_mask = (torch.rand(fx.shape[0], 1, 1, device=fx.device) > 0.1).float()
    mlp_out = mlp_out * drop_mask / 0.9
fx = self.ln_2_post(mlp_out + fx)
```

Run:
```bash
python train.py --agent tanjiro --wandb_name "tanjiro/slice-residual-plus-droppath" --wandb_group slice-residual-plus-droppath
```

## Baseline
- val/loss: ~2.28
- Slice-residual alone: 1.2659 | MLP DropPath alone: 1.5733

---

## Results

**val/loss: 2.3590** — worse than baseline (~2.28) and worse than either technique alone.

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------|------------|------------|-----------|-----------|-----------|----------|
| val_in_dist | 1.7955 | 0.323 | 0.205 | 25.3 | 1.336 | 0.487 | 27.0 |
| val_tandem_transfer | 3.3395 | 0.643 | 0.343 | 42.1 | 2.173 | 1.000 | 44.3 |
| val_ood_cond | 1.9420 | 0.260 | 0.200 | 20.6 | 1.057 | 0.421 | 20.1 |
| val_ood_re | NaN | 0.279 | 0.214 | 32.1 | 1.066 | 0.460 | 52.2 |

**Peak memory:** 11.0 GB  
**W&B run ID:** 7tc3ploh

### What happened

The combination did not work — val/loss degraded from ~2.28 (baseline) to 2.3590, far short of the 1.2659 from slice-residual alone. Most notably, val_ood_re has a catastrophically exploded vol_loss (~18.9 billion), causing a NaN combined loss for that split.

The two techniques are not as orthogonal as hypothesized. Most likely the MLP DropPath randomly dropping entire MLP blocks per batch-sample disrupts the gradient signal that the slice residual scale parameter needs to train stably. The slice residual is a learned scalar (initialized at 0.1) that is sensitive to consistent MLP outputs during training — random MLP silencing may be preventing the slice residual from finding a good operating point, resulting in gradient interference rather than complementary improvement.

The val_ood_re numerical explosion is a sign of destabilized training that the other splits partially recovered from.

### Suggested follow-ups
- Try DropPath with a lower drop rate (0.05 instead of 0.1) together with slice residual — less aggressive regularization may be less disruptive
- Try applying DropPath only after some warm-up epochs (e.g. start at epoch 20), allowing slice residual to stabilize first
- Try applying DropPath to the attention block instead of the MLP block when combined with slice residual