### PR TITLE
Fourier feature spatial bias (multi-frequency positional encoding)

### DIFF
--- a/train.py
+++ b/train.py
@@ -174,7 +174,7 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
-        self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0, 16.0]) * 2 * 3.14159, requires_grad=False)
+        self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0, 16.0]) * 2 * 3.14159)
         # Input: 2 coords * 5 freqs * 2 (sin+cos) = 20 dims
         self.spatial_bias = nn.Sequential(nn.Linear(20, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)


### PR DESCRIPTION
## Hypothesis
The spatial bias MLP takes raw (x,y) through a tiny 2->32->slice_num network. Fourier features (Tancik et al., 2020) dramatically improve coordinate-based networks' ability to represent high-frequency spatial patterns like boundary layers and wakes. Replacing the raw coordinates with multi-frequency sin/cos features should sharpen slice assignment.

## Instructions

In `train.py`, modify `TransolverBlock.__init__` — replace the spatial_bias definition:

```python
# REPLACE:
self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))

# WITH:
self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0, 16.0]) * 2 * 3.14159, requires_grad=False)
# Input: 2 coords * 5 freqs * 2 (sin+cos) = 20 dims
self.spatial_bias = nn.Sequential(nn.Linear(20, 32), nn.GELU(), nn.Linear(32, slice_num))
```

In `TransolverBlock.forward`, replace:
```python
sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
```
with:
```python
if raw_xy is not None:
    # Fourier features: [sin(f*x), cos(f*x), sin(f*y), cos(f*y)] for each freq
    xy_scaled = raw_xy.unsqueeze(-1) * self.fourier_freqs  # [B, N, 2, 5]
    ff = torch.cat([xy_scaled.sin(), xy_scaled.cos()], dim=-1)  # [B, N, 2, 10]
    ff = ff.reshape(raw_xy.shape[0], raw_xy.shape[1], -1)  # [B, N, 20]
    sb = self.spatial_bias(ff)
else:
    sb = None
```

Run:
```bash
python train.py --agent alphonse --wandb_name "alphonse/fourier-spatial-bias" --wandb_group fourier-spatial-bias
```

## Baseline
- val/loss: ~2.28 (original); **2.2217** (updated after slice-residual merge)

---

## Results

Two runs were executed: one with fixed frequencies and one with learnable frequencies (per advisor feedback).

### Run 1 — Fixed frequencies (requires_grad=False)

**W&B run ID:** `9lrz3yjk`  
**Epochs completed:** 64/100 (30-min timeout)  
**Peak memory:** 10.7 GB  
**val/loss (best):** 2.3964

### Run 2 — Learnable frequencies (requires_grad=True)

**W&B run ID:** `ccqa3w5q`  
**Epochs completed:** 64/100 (30-min timeout)  
**Peak memory:** 10.7 GB  
**val/loss (best):** 2.3784

### Comparison vs baseline

| Metric | Baseline (post slice-residual) | Run 1 (fixed freqs) | Run 2 (learnable freqs) |
|--------|-------------------------------|---------------------|-------------------------|
| val/loss | 2.2217 | 2.3964 | 2.3784 |
| val_in_dist/loss | — | 1.7726 | 1.7189 |
| val_tandem_transfer/loss | — | 3.3862 | 3.4370 |
| val_ood_cond/loss | — | 2.0303 | 1.9792 |

### Surface MAE — val_in_dist (Run 2, best checkpoint epoch 63)

| Field | MAE |
|-------|-----|
| Ux | 0.3306 |
| Uy | 0.1888 |
| p | 24.72 |

### Volume MAE — val_in_dist (Run 2, best checkpoint)

| Field | MAE |
|-------|-----|
| Ux | 1.326 |
| Uy | 0.476 |
| p | 26.98 |

### What happened

Both fixed and learnable Fourier frequencies failed to match the updated baseline (2.2217) within the 30-minute training budget. Learnable frequencies were marginally better (2.3784 vs. 2.3964), but both lagged ~0.16 behind baseline at epoch 64.

Both runs were still converging at the timeout — each of the final several epochs set new bests. The gap to baseline likely comes from slower early-epoch convergence: the 10× wider input to the spatial bias MLP (2 → 20 dims) means the network has more parameters to tune before the Fourier features become useful.

Neither variant offers a clear advantage over simple raw (x,y) input within the 30-minute budget. The Fourier feature idea is not disproven — it's a convergence-speed problem — but in practice it costs training time without measurable benefit.

**Note:** Also fixed a pre-existing `NameError: name 'Path' is not defined` crash that affected any fresh run on this branch before this PR.

### Suggested follow-ups

- The Fourier bias consistently lags baseline at 64 epochs but is still descending — it may converge if given more epochs. Not recommended unless training time is extended.
- A simpler intermediate option: use a 4-dim input (raw xy + normalized xy) instead of 20-dim Fourier features — lower parameter overhead, still richer than raw xy.
- The slice-residual improvement (now in baseline) combined with other architectural ideas seems more promising than encoding improvements to the spatial bias sub-network.