### PR TITLE
Per-head residual scale (vector instead of scalar)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,8 +22,8 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 
 import os
 import time
-from collections.abc import Mapping
 from pathlib import Path
+from collections.abc import Mapping
 
 import torch
 import torch.nn as nn
@@ -105,6 +105,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
         self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
+        self.slice_head_mod = nn.Parameter(torch.ones(self.heads, 1, 1))
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
@@ -143,7 +144,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
-        out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
+        out_slice_token = out_slice_token + self.slice_residual_scale * self.slice_head_mod * slice_token
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")


### PR DESCRIPTION
## Hypothesis
The slice-token residual bypass uses a single scalar for all heads. Different heads learn different spatial patterns (boundary layer, wake, freestream). A per-head scale lets each head independently tune centroid retention. This builds on the slice-residual (-44.9%) with minimal additional complexity.

## Instructions

In `train.py`, make these changes:

### 1. In `Physics_Attention_Irregular_Mesh.__init__`, add after `self.to_v`:
```python
self.slice_residual_scale = nn.Parameter(torch.ones(self.heads, 1, 1) * 0.1)
```
(Note: `self.heads` not `torch.tensor(0.1)` — per-head vector, shape [4, 1, 1])

### 2. In `Physics_Attention_Irregular_Mesh.forward`, add after `out_slice_token = torch.matmul(attn_weights, v_slice_token)`:
```python
out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
```
(Broadcasting works: scale [4,1,1] * slice_token [B,4,S,D])

Run:
```bash
python train.py --agent edward --wandb_name "edward/per-head-residual-scale" --wandb_group per-head-residual-scale
```

## Baseline
- val/loss: ~2.28
- Scalar slice-residual alone: 1.2659

---

## Results

### Revision 1: Standalone per-head (replacing scalar)

**W&B run:** tl6pipwh | **Best epoch:** 67/100 (timeout) | **Peak VRAM:** 10.5 GB

| Split | val/loss | surf p MAE |
|---|---|---|
| val_in_dist | 1.5698 | 20.80 |
| val_ood_cond | 1.8523 | 20.08 |
| val_tandem_transfer | 3.3224 | 43.05 |
| val_ood_re | nan | 31.00 |
| **combined** | **2.2482** | |

**Negative.** Per-head alone barely beats the ~2.28 baseline (-1.8%) and is far worse than scalar alone (1.2659). Dropped because the scalar (#800) was merged with val_loss=2.2217.

---

### Revision 2: Per-head modulator stacked on scalar (warmstart)

After rebase onto noam (which now has the scalar residual from #800):

```python
# __init__:
self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))   # scalar (from noam)
self.slice_head_mod = nn.Parameter(torch.ones(self.heads, 1, 1))  # per-head, init=1.0

# forward:
out_slice_token = out_slice_token + self.slice_residual_scale * self.slice_head_mod * slice_token
```

**W&B run:** ofjjlkos | **Best epoch:** 67/100 (timeout) | **Peak VRAM:** 10.5 GB

| Split | val/loss | surf p MAE |
|---|---|---|
| val_in_dist | 1.5494 | 20.61 |
| val_ood_cond | 1.8670 | 20.55 |
| val_tandem_transfer | 3.2992 | 42.43 |
| val_ood_re | nan | 31.02 |
| **combined** | **2.2385** | |

vs new baseline (#800 merged, val_loss=2.2217): **+0.0168 worse (-0.76%)**

### What happened

**Negative result (revision 2).** Adding a per-head modulator on top of the scalar residual doesn't help — val/loss=2.2385 is slightly worse than the scalar-only baseline (2.2217), and surf_p values are nearly identical across all splits.

The init at 1.0 preserves the scalar's skip signal, but during training the 4 head-mod parameters learn small deviations that don't improve the combined loss. The extra complexity (4 parameters) produces noise rather than signal. The scalar residual appears to have already found the optimal regime for this architecture; per-head tuning on top does not add useful capacity.

Both runs timed out at 67/100 epochs (30 min). The convergence trajectory at epoch 67 doesn't suggest further improvement would overcome the baseline gap.

### Suggested follow-ups

- **Per-head softmax gating**: Instead of a multiplicative scale, use a learned per-head gate that selects which slice tokens to bypass (sparse residual). This is more structured than a free scale.
- **Different residual targets**: Rather than bypassing the Q/K/V attention, try a residual on the projection output (`to_out`) or on `slice_token` normalization.
- **Accept the scalar**: The scalar residual (-44.9%) is likely the best simple change available here; the per-head variants add complexity without gain.