### PR TITLE
SWA in final 15 epochs (flat LR + uniform averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 
 import os
 import time
+from pathlib import Path
 from collections.abc import Mapping
 
 import torch
@@ -472,9 +473,9 @@ model_config = dict(
 model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
-ema_model = None
-ema_start_epoch = 65
-ema_decay = 0.998
+swa_model = None
+swa_start_epoch = 60
+swa_n = 0
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -568,6 +569,10 @@ for epoch in range(MAX_EPOCHS):
         break
 
     t0 = time.time()
+
+    if epoch >= swa_start_epoch:
+        for pg in base_opt.param_groups:
+            pg['lr'] = 5e-4  # flat LR for SWA phase
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
@@ -669,13 +674,15 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(model)
+        if epoch >= swa_start_epoch:
+            if swa_model is None:
+                swa_model = deepcopy(model)
+                swa_n = 1
             else:
+                swa_n += 1
                 with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+                    for sp, mp in zip(swa_model.parameters(), model.parameters()):
+                        sp.data.add_((mp.data - sp.data) / swa_n)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -691,7 +698,7 @@ for epoch in range(MAX_EPOCHS):
     prev_surf_loss = epoch_surf
 
     # --- Validate across all splits ---
-    eval_model = ema_model if ema_model is not None else model
+    eval_model = swa_model if swa_model is not None else model
     eval_model.eval()
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}
@@ -812,7 +819,7 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        save_model = ema_model if ema_model is not None else model
+        save_model = swa_model if swa_model is not None else model
         torch.save(save_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 


### PR DESCRIPTION
## Hypothesis
Current EMA (decay 0.998 from epoch 65) averages exponentially, heavily weighting recent parameters. Stochastic Weight Averaging (SWA) uses a flat LR phase with uniform averaging, which is theoretically superior for finding flat minima (Izmailov et al., 2018). With the potential new loss landscape from slice-residual, SWA may find a better generalization basin.

## Instructions

In `train.py`, replace the EMA mechanism with SWA:

### 1. Replace EMA variables:
```python
# REPLACE:
ema_model = None
ema_start_epoch = 65
ema_decay = 0.998

# WITH:
swa_model = None
swa_start_epoch = 60
swa_n = 0
```

### 2. Replace the EMA update block in the training loop:
```python
# REPLACE the EMA block:
if epoch >= ema_start_epoch:
    if ema_model is None:
        ema_model = deepcopy(model)
    else:
        with torch.no_grad():
            for ep, mp in zip(ema_model.parameters(), model.parameters()):
                ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)

# WITH:
if epoch >= swa_start_epoch:
    if swa_model is None:
        swa_model = deepcopy(model)
        swa_n = 1
    else:
        swa_n += 1
        with torch.no_grad():
            for sp, mp in zip(swa_model.parameters(), model.parameters()):
                sp.data.add_((mp.data - sp.data) / swa_n)
```

### 3. Replace eval_model references:
```python
# REPLACE:
eval_model = ema_model if ema_model is not None else model
# WITH:
eval_model = swa_model if swa_model is not None else model
```

### 4. Override cosine schedule after epoch 60 — add at start of epoch loop:
```python
if epoch >= swa_start_epoch:
    for pg in base_opt.param_groups:
        pg['lr'] = 5e-4  # flat LR for SWA phase
```

Run:
```bash
python train.py --agent askeladd --wandb_name "askeladd/swa-final-epochs" --wandb_group swa-final-epochs
```

## Baseline
- val/loss: ~2.28

---

## Results

### Run 1 (initial)
**W&B run:** `lcebuxes` | `swa_start_epoch=60`, `flat_lr=5e-4`
**Epochs:** 64 (wall-clock limit) | **SWA epochs:** 5 (60–64) | **Peak memory:** 10.6 GB

### Run 2 (advisor revision: earlier start, lower LR)
**W&B run:** `m8k3e7yr` | `swa_start_epoch=45`, `flat_lr=2e-4`
**Epochs:** 64 (wall-clock limit) | **SWA epochs:** 20 (45–64) | **Peak memory:** 10.6 GB

### Metrics (epoch 64 = best checkpoint in both runs)

| Split | Baseline | Run 1 (ep60, lr=5e-4) | Run 2 (ep45, lr=2e-4) |
|---|---|---|---|
| val/loss (aggregate) | ~2.28 | **2.3124** | 2.4322 |
| val_in_dist/loss | — | **1.6440** | 1.7487 |
| val_ood_cond/loss | — | **1.9809** | 2.1655 |
| val_tandem_transfer/loss | — | **3.3124** | 3.3823 |

**Surface MAE — Run 1 (epoch 60, lr=5e-4):**

| Split | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.305 | 0.184 | **22.12** | 1.37 | 0.48 | 26.23 |
| val_ood_cond | 0.276 | 0.191 | **21.37** | 1.13 | 0.42 | 19.95 |
| val_tandem_transfer | 0.635 | 0.341 | 42.23 | 2.19 | 1.00 | 43.28 |
| val_ood_re | 0.281 | 0.202 | 31.40 | 1.07 | 0.44 | 51.45 |

**Surface MAE — Run 2 (epoch 45, lr=2e-4):**

| Split | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.332 | 0.190 | 24.01 | 1.41 | 0.49 | 29.07 |
| val_ood_cond | 0.296 | 0.202 | 24.96 | 1.15 | 0.44 | 23.13 |
| val_tandem_transfer | 0.658 | 0.345 | 43.14 | 2.31 | 1.05 | 45.51 |
| val_ood_re | 0.305 | 0.210 | 33.02 | 1.13 | 0.47 | 52.98 |

*val_ood_re/loss is NaN throughout both runs (vol_loss overflow ~1.9e10) — pre-existing issue.*

### What happened

**Neither SWA run beat the ~2.28 baseline.** Run 1 (2.3124) was closer, but run 2 (2.4322) was worse in every metric. The advisor's suggested earlier start / lower LR revision made things worse, not better. Here's why:

1. **Starting SWA too early hurts**: At epoch 45, the pre-SWA in-dist validation loss was ~3.04 — the model was still in a phase of rapid improvement. Starting SWA here means averaging over suboptimal weights, dragging the running mean down. The cosine LR schedule (which normally drives rapid improvement in epochs 40–65) is replaced by a flat 2e-4 LR at epoch 45, cutting off that improvement phase 20 epochs early. By contrast, run 1 started SWA at epoch 60 when the model was already near its optimum (~2.01 in-dist), so SWA immediately helped.

2. **Lower LR (2e-4) slows convergence in SWA phase**: Despite having 20 SWA epochs, run 2 only reached in-dist=1.75 vs run 1's 1.64 in just 5 SWA epochs. The flat 5e-4 allowed larger parameter updates at each step, making the SWA average move more quickly toward a good basin.

3. **Both runs are wall-clock limited to 64 epochs**: With 27s/epoch × 64 epochs ≈ 29 min. There's no room for longer SWA phases within the timeout.

**Bottom line**: SWA does not improve over EMA in the 30-minute training budget. The issue is structural — EMA (decay 0.998) naturally runs throughout training with negligible overhead, while SWA's flat-LR phase necessarily trades off convergence time. With only 64 epochs available, starting the flat LR phase cuts off the steepest part of the loss curve.

### Suggested follow-ups

- **EMA is likely better for this budget**: With 30 min and ~64 epochs, EMA is simply more efficient. SWA's theoretical advantage (finding flatter minima) requires many more flat-LR epochs than the budget allows.
- **If SWA is tried again**: Only start flat LR in the final 5 epochs (epoch 59+), which is what run 1 effectively did. Or consider a cosine schedule within the SWA phase rather than a fixed flat LR.
- **Investigate val_ood_re NaN**: The ood_re vol_loss overflow is persistent across all experiments and corrupts the aggregate val/loss metric. Worth a focused fix.