### PR TITLE
Split pressure/velocity output heads (separate decoders)

### DIFF
--- a/train.py
+++ b/train.py
@@ -181,9 +181,20 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2_shared = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU())
-            self.mlp2_vel = nn.Linear(hidden_dim, 2)   # Ux, Uy
-            self.mlp2_prs = nn.Linear(hidden_dim, 1)   # p
+            # Velocity decoder (2 layers)
+            self.dec_vel = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, 2),  # Ux, Uy
+            )
+            # Pressure decoder (3 layers — more capacity for steep gradients)
+            self.dec_prs = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, 1),  # p
+            )
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -194,8 +205,8 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            h = self.mlp2_shared(self.ln_3(fx))
-            return torch.cat([self.mlp2_vel(h), self.mlp2_prs(h)], dim=-1)
+            h = self.ln_3(fx)
+            return torch.cat([self.dec_vel(h), self.dec_prs(h)], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The output decoder maps hidden_dim -> 3 with shared weights. Pressure has very different characteristics from velocity (steep surface gradients, different physical units). Splitting into separate heads for velocity (Ux, Uy) and pressure (p) allows specialization. Keep a shared first layer but split the final projection.

## Instructions

In `train.py`, in `TransolverBlock.__init__`, replace the last_layer output head:

```python
# REPLACE:
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.mlp2 = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim),
        nn.GELU(),
        nn.Linear(hidden_dim, out_dim),
    )

# WITH:
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    self.mlp2_shared = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU())
    self.mlp2_vel = nn.Linear(hidden_dim, 2)   # Ux, Uy
    self.mlp2_prs = nn.Linear(hidden_dim, 1)   # p
```

In `TransolverBlock.forward`, replace:
```python
if self.last_layer:
    return self.mlp2(self.ln_3(fx))

# WITH:
if self.last_layer:
    h = self.mlp2_shared(self.ln_3(fx))
    return torch.cat([self.mlp2_vel(h), self.mlp2_prs(h)], dim=-1)
```

Run:
```bash
python train.py --agent violet --wandb_name "violet/split-pressure-head" --wandb_group split-pressure-head
```

## Baseline
- val/loss: ~2.28

---

## Results

### Revision 2: Deep pressure decoder (W&B run ID: l8utn1lo)

**Training:** Ran 60/100 epochs before 30-minute timeout. Epoch time ~29s (vs 27s for rev 1) due to deeper pressure decoder.

| Metric | Rev 2 deep decoder (ep 60) | Rev 1 shared (ep 62) | Baseline (ep 64) |
|--------|---------------------------|----------------------|-----------------|
| val/loss | 2.503 | 2.459 | 2.4455 |
| val_in_dist/loss | 1.868 | 1.908 | — |
| surf MAE Ux | 0.355 | 0.346 | — |
| surf MAE Uy | 0.202 | 0.212 | — |
| surf MAE p | 26.92 Pa | 26.17 Pa | 24.95 Pa |
| vol MAE Ux | 1.425 | 1.430 | — |
| vol MAE Uy | 0.523 | 0.521 | — |
| vol MAE p | 29.75 Pa | 29.31 Pa | — |
| Peak memory | 11.5 GB | 10.6 GB | ~10.6 GB |

**What happened:** The deeper pressure decoder (3-layer dec_prs vs 2-layer dec_vel) did not improve over the shallow split-head revision. Both revisions fall short of the baseline. At comparable epoch counts:
- Rev 2 val/loss (2.503) is **worse** than Rev 1 (2.459)
- surf MAE p (26.92 Pa) is **worse** than Rev 1 (26.17 Pa) and both are worse than baseline (24.95 Pa)
- Memory increased by ~0.9 GB due to the extra linear layer

The extra depth in the pressure decoder is not helping. One possible explanation: the bottleneck is in the shared transformer representation before the decoder, not in the decoder itself. A deeper decoder can't compensate for shared features that aren't specialized for pressure. The added complexity isn't justified.

**Suggested follow-ups:**
- The decoder specialization approach seems insufficient — the real specialization may need to happen earlier (in the attention mechanism itself, e.g., separate pressure-specific slices).
- Alternatively, accept that a simple shared decoder is fine and focus improvements elsewhere (e.g., loss weighting, training schedule).

### Revision 1: Shared first layer (W&B run ID: snna04w5)

Ran 64/100 epochs. Best val/loss: 2.459. Details in original results above.