### PR TITLE
Cosine temperature annealing for slice assignment

### DIFF
--- a/train.py
+++ b/train.py
@@ -575,8 +575,8 @@ for epoch in range(MAX_EPOCHS):
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
-    # Temperature annealing: warm (soft) -> cold (sharp) over 60 epochs
-    temp_mult = 2.0 - 1.5 * min(1.0, epoch / 60)
+    # Temperature warmup: gentle exploration phase (1.3 → 1.0) over first 20 epochs
+    temp_mult = 1.3 - 0.3 * min(1.0, epoch / 20)
 
     # --- Train ---
     model.train()
@@ -738,7 +738,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x}, temp_mult=temp_mult)["preds"]
+                    pred = eval_model({"x": x}, temp_mult=1.0)["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
The learned temperature in slice attention controls clustering sharpness. Scheduling it from warm (soft, exploratory) to cold (sharp, specialized) implements a natural curriculum: early training explores broad slice assignments, later training commits to sharp specialization. Analogous to simulated annealing.

## Instructions

In `train.py`:

### 1. Pass epoch info to the model. In `Transolver.forward`, accept and pass `temp_mult`:
Add a `temp_mult` parameter to `Transolver.forward`:
```python
def forward(self, data, pos=None, condition=None, temp_mult=1.0):
```
Pass it through to blocks — in the block loop:
```python
for block in self.blocks[:-1]:
    fx = block(fx, raw_xy=raw_xy, temp_mult=temp_mult)
fx = self.blocks[-1](fx, raw_xy=raw_xy, temp_mult=temp_mult)
```

### 2. In `TransolverBlock.forward`, accept and pass `temp_mult`:
```python
def forward(self, fx, raw_xy=None, temp_mult=1.0):
    sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
    fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, temp_mult=temp_mult) + fx)
```

### 3. In `Physics_Attention_Irregular_Mesh.forward`, apply the multiplier:
```python
def forward(self, x, spatial_bias=None, temp_mult=1.0):
    ...
    slice_logits = self.in_project_slice(x_mid) / (self.temperature * temp_mult)
```

### 4. In the training loop, compute temp_mult from epoch:
```python
temp_mult = 2.0 - 1.5 * min(1.0, epoch / 60)  # 2.0 -> 0.5 over 60 epochs
```
Pass to model: `out = model({"x": x}, temp_mult=temp_mult)`
And in validation: `pred = eval_model({"x": x}, temp_mult=temp_mult)["preds"]`

Run:
```bash
python train.py --agent gilbert --wandb_name "gilbert/cosine-temp-anneal" --wandb_group cosine-temp-anneal
```

## Baseline
- val/loss: ~2.28 (original); ~2.2217 (updated, after slice-residual merge)

---

## Results

### Attempt 1: Aggressive schedule (2.0→0.5 over 60 epochs, temp_mult at validation too)

**W&B run:** lghomcyj | **Best epoch:** 67 | **Peak memory:** ~10.6 GB

| Split | val/loss | mae_surf_p |
|---|---|---|
| val_in_dist | 1.6653 | 22.4 |
| val_tandem_transfer | 3.3608 | 43.6 |
| val_ood_cond | 1.9341 | 21.9 |
| val_ood_re | NaN | 31.2 |
| **combined** | **2.3201** | |

Result: worse than baseline (2.3201 vs ~2.28). val_ood_re NaN due to extreme cold temp destabilizing vol_loss.

---

### Attempt 2 (revision): Mild warmup-only schedule (1.3→1.0 over 20 epochs, temp_mult=1.0 at validation)

**W&B run:** pv0ggzvm | **Best epoch:** 67 | **Peak memory:** ~10.6 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6108 | 0.309 | 0.176 | 20.8 | 1.314 | 0.462 | 25.8 |
| val_tandem_transfer | 3.2425 | 0.624 | 0.335 | 40.7 | 2.115 | 0.986 | 42.5 |
| val_ood_cond | 1.8971 | 0.261 | 0.195 | 21.2 | 1.039 | 0.405 | 20.0 |
| val_ood_re | NaN | 0.268 | 0.201 | 31.3 | 1.023 | 0.439 | 51.1 |
| **combined** | **2.2501** | | | | | | |

**Updated baseline: 2.2217 → This run: 2.2501 (+0.028, still slightly worse)**

### What happened

The mild warmup-only schedule significantly improved over attempt 1 (2.2501 vs 2.3201). Improvements are visible across all splits — surface p dropped from 22.4→20.8 (in-dist) and 43.6→40.7 (tandem), which is meaningful.

However, it still didn't beat the updated baseline (2.2217). Two observations:

1. **The val_ood_re NaN is pre-existing, not caused by temperature.** The vol_loss value is identical (18867924528.45) in both attempts, and appears to come from the base noam branch — not affected by temp_mult since validation uses temp_mult=1.0 in attempt 2.

2. **The gentle warmup helps slightly but doesn't improve over the baseline's own learned temperature.** The model's temperature parameter is already optimized by the optimizer; the mild external nudge (1.3→1.0) adds some exploratory pressure early on but the effect is marginal and slightly negative overall. The per-split improvements (surface p, tandem) are real but the combined val/loss is dragged by the val_ood_re NaN contributing to the mean.

### Suggested follow-ups

- **Fix the val_ood_re NaN first.** The vol_loss exploding to ~1.9e10 for OOD Re is a pre-existing issue (unchanged whether temp_mult=1.0 or not at validation). It inflates the combined val/loss and makes it harder to evaluate improvements. Investigating the stats normalization for the OOD Re split could unlock cleaner signal.
- **Warmup applied to training only with smaller range**: try 1.1→1.0 over 10 epochs — even milder, just a tiny early-training nudge.
- **Cosine schedule on temperature parameter itself**: instead of multiplying externally, add a cosine warmup to the learning rate of the temperature parameter specifically, letting it explore more in early epochs.