### PR TITLE
Per-head attention dropout (1-of-4 head drop)

### DIFF
--- a/train.py
+++ b/train.py
@@ -23,6 +23,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 import os
 import time
 from collections.abc import Mapping
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -141,6 +142,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
+
+        # Per-head attention dropout: zero one random head per sample during training
+        if self.training:
+            drop_head = torch.randint(0, self.heads, (bsz,), device=out_slice_token.device)
+            head_mask = torch.ones(bsz, self.heads, 1, 1, device=out_slice_token.device)
+            head_mask.scatter_(1, drop_head.unsqueeze(1).unsqueeze(2).unsqueeze(3), 0.0)
+            out_slice_token = out_slice_token * head_mask * (self.heads / (self.heads - 1))
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")


### PR DESCRIPTION
## Hypothesis
MLP DropPath (-31%) proved regularization helps enormously. Attention head dropout forces head diversity and prevents co-adaptation between heads. Instead of dropping the whole attention branch, randomly zero out 1 of 4 heads per forward pass (p=0.25 per head, but attention as a whole is always active). This complements MLP DropPath.

## Instructions

In `train.py`, in `Physics_Attention_Irregular_Mesh.forward`, add head dropout after computing `out_slice_token` and before the einsum that maps back to nodes.

After this line:
```python
out_slice_token = torch.matmul(attn_weights, v_slice_token)
```

Add:
```python
# Per-head attention dropout: zero one random head per sample during training
if self.training:
    drop_head = torch.randint(0, self.heads, (bsz,), device=out_slice_token.device)
    head_mask = torch.ones(bsz, self.heads, 1, 1, device=out_slice_token.device)
    head_mask.scatter_(1, drop_head.unsqueeze(1).unsqueeze(2).unsqueeze(3), 0.0)
    out_slice_token = out_slice_token * head_mask * (self.heads / (self.heads - 1))
```

Run:
```bash
python train.py --agent senku --wandb_name "senku/per-head-attn-dropout" --wandb_group per-head-attn-dropout
```

## Baseline
- val/loss: ~2.28

---

## Results

**W&B run:** `uaiztp91`
**Epochs completed:** 67/100 (hit 30-min timeout)
**Peak memory:** not recorded (run timed out)

### Metrics at best checkpoint (epoch 67)

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.4134 | ~2.28 | +0.13 (+5.8%) ❌ |
| val_in_dist/surf Ux | 0.317 | — | |
| val_in_dist/surf Uy | 0.189 | — | |
| val_in_dist/surf p | 22.78 | — | |
| val_in_dist/vol Ux | 1.350 | — | |
| val_in_dist/vol Uy | 0.467 | — | |
| val_tandem/loss | 3.421 | — | |
| val_ood_cond/loss | 2.150 | — | |
| val_ood_re/vol_loss | **18.9 billion** | — | 💥 |

Note: val/loss = average of in_dist + tandem + ood_cond only (val_ood_re excluded due to NaN/explosion).

### What happened

**Negative result.** Per-head attention dropout hurt performance. val/loss at epoch 67 is 2.4134 vs baseline ~2.28 — ~6% worse.

Two problems:

1. **Worse overall generalization.** Even on the in-distribution and ood_cond splits, the model performs below baseline. Dropping one head per sample (25% head dropout) appears too aggressive — MLP DropPath works because it drops entire residual branches stochastically, forcing each branch to be self-sufficient. Dropping one attention head disrupts the token routing at the slice-attention level, which seems to degrade representation quality rather than improve diversity.

2. **Catastrophic explosion on val_ood_re.** Volume loss blew up to ~18.9B on the OOD-Reynolds split. The per-head mask with the `heads/(heads-1)` rescaling creates a 4/3 = 1.33x amplification on the surviving heads. For OOD inputs with different activation distributions, this amplification may push values out of the stable operating range of the normalization layers.

The hypothesis that head dropout complements MLP DropPath seems incorrect — they regularize different things, and attention head diversity does not appear to be the bottleneck here. The slice-attention mechanism in Transolver already has temperature-controlled routing that may provide enough implicit head diversity without explicit dropout.

### Suggested follow-ups

- **Softer head masking:** Instead of binary mask + rescaling, try multiplying one random head by a factor in [0, 1) (e.g. 0.5) — less disruptive, still encourages diversity.
- **Lower drop rate:** Try p=0.125 (drop 1-of-8 or weight 0.5 instead of 0.0) — 25% may be too high for this architecture.
- **Stabilize OOD-Re:** The explosion on val_ood_re suggests a general instability under distribution shift; gradient clipping may help across regularization experiments.