### PR TITLE
Asymmetric loss: Huber for volume, L1 for surface

### DIFF
--- a/train.py
+++ b/train.py
@@ -23,6 +23,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 import os
 import time
 from collections.abc import Mapping
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -636,7 +637,12 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        if vol_mask_train.sum() > 0:
+            vol_pred = pred[vol_mask_train]
+            vol_target = y_norm[vol_mask_train]
+            vol_loss = F.huber_loss(vol_pred, vol_target, reduction='mean', delta=2.0)
+        else:
+            vol_loss = torch.tensor(0.0, device=device)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()


### PR DESCRIPTION
## Hypothesis
PR #720 showed Huber loss hurts surface but improves volume predictions. Since vol and surf use separate loss terms, use Huber (delta=2.0) only for vol_loss while keeping L1 for surf_loss. This gives smoother volume optimization without hurting surface accuracy.

## Instructions

In `train.py`, in the training loop, replace the vol_loss computation:

```python
# REPLACE:
vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)

# WITH:
if vol_mask_train.sum() > 0:
    vol_pred = pred[vol_mask_train]
    vol_target = y_norm[vol_mask_train]
    vol_loss = F.huber_loss(vol_pred, vol_target, reduction='mean', delta=2.0)
else:
    vol_loss = torch.tensor(0.0, device=device)
```

Keep surf_loss as-is (L1/MAE). No changes to validation.

Run:
```bash
python train.py --agent kohaku --wandb_name "kohaku/asymmetric-huber-vol" --wandb_group asymmetric-huber-vol
```

## Baseline
- val/loss: ~2.28

---

## Results

**W&B run:** `eiao0f9f`
**Epochs completed:** 64/100 (timed out at 30 min)

### Metrics at best epoch (epoch 64)
| Split | val/loss |
|---|---|
| val_in_dist | 1.8962 |
| val_tandem_transfer | 3.5184 |
| val_ood_cond | 2.1836 |
| val_ood_re | NaN (pre-existing, see below) |
| **Overall val/loss** | **2.5327** |

**Baseline val/loss:** ~2.28

### Surface MAE (val_in_dist, last epoch)
| | Ux | Uy | p |
|---|---|---|---|
| Surface MAE | 0.362 | 0.197 | 25.79 |

### Volume MAE (val_in_dist, last epoch)
| | Ux | Uy | p |
|---|---|---|---|
| Volume MAE | 1.644 | 0.597 | 36.43 |

**Peak memory:** 10.6 GB

### What happened

**Negative result.** val/loss 2.533 at epoch 64/100 is notably worse than baseline ~2.28. The curve was still slowly improving at timeout, but is unlikely to recover to baseline levels.

Two mechanisms explain the failure:

1. **Huber barely differs from L1 here.** Training vol_loss values are tiny (0.009–0.018), well below delta=2.0. At these scales Huber and L1 are identical, so there's no smoothing benefit.

2. **Adaptive surf_weight collapsed.** The surf_weight is computed as `vol_loss / surf_loss`. Because Huber compresses large-error gradients, the effective vol_loss signal was weaker early in training, causing the ratio to fall to the minimum clamp of 5 and stay there. The baseline typically runs at a higher surf_weight during early epochs, meaning more surface emphasis. With weight stuck at 5, the model gets less surface supervision, worsening surface accuracy.

**val_ood_re = NaN throughout:** This appeared from epoch 1 and is unrelated to our change — it's a pre-existing issue with that split.

### Suggested follow-ups

- **Try smaller delta (e.g. 0.1 or 0.5):** The vol errors are ~0.01–0.02, so delta needs to be closer to that range to have any effect. If Huber-vol is worth trying, match delta to the actual error scale.
- **Investigate val_ood_re NaN:** The NaN on ood_re appears independent of this change and might be worth fixing to get a full 4-split val/loss picture.