### PR TITLE
Auxiliary surface reconstruction from preprocess features

### DIFF
--- a/train.py
+++ b/train.py
@@ -330,11 +330,13 @@ class Transolver(nn.Module):
         raw_xy = x[:, :, :2]
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
-        aux_surf_pred = self.aux_surf_head(fx_pre)  # [B, N, 3]
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)
+
+        # Aux surface prediction from pre-output-block hidden features (attention-enriched)
+        aux_surf_pred = self.aux_surf_head(fx)  # [B, N, 3]
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
@@ -674,7 +676,8 @@ for epoch in range(MAX_EPOCHS):
             aux_surf_pred = aux_surf_pred / sample_stds
         aux_surf_err = (aux_surf_pred - y_norm).abs()
         aux_surf_loss = (aux_surf_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-        loss = loss + 0.05 * aux_surf_loss
+        aux_weight = 0.01 * max(0.0, 1.0 - epoch / 50)
+        loss = loss + aux_weight * aux_surf_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Deep supervision forces intermediate representations to carry useful information. The aux Re head (merged, -0.86%) works by forcing hidden features to encode conditioning variables. An auxiliary surface prediction from the preprocess output (before Transolver blocks) provides direct gradient signal for surface-relevant features early in the network. Zero-init so it starts as no-op.

## Instructions

In `train.py`:

### 1. In `Transolver.__init__`, add after `self.re_head`:
```python
self.aux_surf_head = nn.Linear(n_hidden, 3)
nn.init.zeros_(self.aux_surf_head.weight)
nn.init.zeros_(self.aux_surf_head.bias)
```

### 2. In `Transolver.forward`, compute aux prediction from preprocess:
After `fx_pre = fx`:
```python
aux_surf_pred = self.aux_surf_head(fx_pre)  # [B, N, 3]
```
Return it: `return {"preds": fx, "re_pred": re_pred, "aux_surf_pred": aux_surf_pred}`

### 3. In the training loop, add aux surface loss:
After the `re_loss` line, add:
```python
aux_surf_pred = out["aux_surf_pred"].float()
if model.training:
    aux_surf_pred = aux_surf_pred / sample_stds
aux_surf_err = (aux_surf_pred - y_norm).abs()
aux_surf_loss = (aux_surf_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
loss = loss + 0.05 * aux_surf_loss
```

### 4. In validation, ignore the aux prediction (it's training-only regularization).

Run:
```bash
python train.py --agent emma --wandb_name "emma/aux-surface-recon" --wandb_group aux-surface-recon
```

## Baseline
- val/loss: ~2.22

---

## Results

### Run 1 (original: preprocess features, weight=0.05)
**W&B run:** j55deq9q  
**val/loss: 2.3759** (+6.9% vs baseline 2.2217)

### Run 2 (revised: pre-output-block features, weight=0.01, annealed over 50 epochs)
**W&B run:** 5iyqx40y  
**Runtime:** 30.5 min  
**Peak GPU memory:** ~46.8 GB (per GPU)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 1.8045 | 0.3441 | 0.2058 | 25.17 | 1.3726 | 0.4947 | 28.55 |
| ood_cond | 2.0467 | 0.2897 | 0.1960 | 23.08 | 1.0790 | 0.4058 | 21.31 |
| ood_re | NaN | 0.3041 | 0.2098 | 32.56 | 1.0631 | 0.4494 | 52.26 |
| tandem | 3.2996 | 0.6404 | 0.3423 | 42.50 | 2.1428 | 0.9890 | 44.40 |
| **combined** | **2.3836** | — | — | — | — | — | — |

**Baseline val/loss: 2.2217 → Result: 2.3836 (+7.3%, worse)**

### What happened

Both revisions failed to improve on baseline. The core issue: **with `n_layers=1`, there are no intermediate attention blocks between preprocess and the output block**. `blocks[:-1]` is an empty list, so the aux head in run 2 still computed from the preprocess output (same as run 1 — just with a lower weight and annealing). The architectural structure doesn't expose attention-enriched intermediate features without modifying the block forward pass.

The weight reduction to 0.01 and annealing didn't help either — the fundamental problem is where the representation comes from, not how much weight it has.

Note: the val_ood_re vol_loss shows a large constant value (18867924528) in both runs — this appears to be a pre-existing issue specific to that split, not introduced by these changes.

### Suggested follow-ups

- With n_layers=1, this idea needs a deeper architecture to be testable. Might be worth trying with n_layers=2+ on a short ablation run
- Alternatively, expose pre-mlp2 hidden features from inside the block (requires modifying block forward to have a `return_hidden=True` mode) to get truly attention-enriched features even with n_layers=1
- The idea itself (deep supervision on surface nodes) may still be valid — it just needs a model that has intermediate representations to supervise