### PR TITLE
Sigmoid-gated slice-token residual bypass

### DIFF
--- a/train.py
+++ b/train.py
@@ -23,6 +23,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 import os
 import time
 from collections.abc import Mapping
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -108,6 +109,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        # Sigmoid-gated residual bypass for slice tokens
+        # sigmoid(-2.2) ≈ 0.1, matching the original scalar init
+        self.slice_gate_bias = nn.Parameter(torch.full((1, self.heads, 1, 1), -2.2))
 
     def forward(self, x, spatial_bias=None):
         bsz, num_points, _ = x.shape
@@ -131,6 +135,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+        slice_token_residual = slice_token  # save before attention for gated bypass
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
@@ -141,6 +146,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
+        gate = torch.sigmoid(self.slice_gate_bias)
+        out_slice_token = gate * slice_token_residual + (1 - gate) * out_slice_token
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")


### PR DESCRIPTION
## Hypothesis
The slice-token residual bypass (PR #800) is our strongest technique (val_loss=2.2217 vs baseline ~2.28). It works by preserving raw cluster centroids through a learnable residual scaled by a fixed scalar (init 0.1). We can improve this by replacing the raw scalar with a **sigmoid-gated interpolation**: `gate * slice_token + (1-gate) * attention_output`, where `gate = sigmoid(learnable_bias)`.

This is better than a raw scalar because:
1. The gate is naturally bounded [0,1], preventing scale from growing unbounded
2. The complementary `(1-gate)` on the attention output creates a proper interpolation, keeping total signal magnitude controlled
3. Initialization at sigmoid(-2.2) ≈ 0.1 matches the original scalar init

## Instructions

**Step 1:** First, implement the slice-token residual bypass (from PR #800, not yet merged). In `Physics_Attention_Irregular_Mesh.forward`, after computing `out_slice_token = torch.matmul(attn_weights, v_slice_token)`, you need to add a residual connection from the original `slice_token` to the output. Save `slice_token` before the attention computation, then add it back after.

**Step 2:** Replace the raw scalar residual with a sigmoid gate. In `Physics_Attention_Irregular_Mesh.__init__`, add:
```python
# Sigmoid-gated residual bypass for slice tokens
# sigmoid(-2.2) ≈ 0.1, matching the original scalar init
self.slice_gate_bias = nn.Parameter(torch.full((1, self.heads, 1, 1), -2.2))
```

**Step 3:** In `Physics_Attention_Irregular_Mesh.forward`, after computing `out_slice_token = torch.matmul(attn_weights, v_slice_token)`, apply the gated bypass:
```python
gate = torch.sigmoid(self.slice_gate_bias)
out_slice_token = gate * slice_token + (1 - gate) * out_slice_token
```

Where `slice_token` here refers to the slice tokens **before** the attention computation (save them before the matmul). The gate starts at ~0.1 (favoring attention output), but can learn any interpolation.

**Also:** Add `from pathlib import Path` at the top of `train.py` if it's missing (known bug in current noam).

Run:
```bash
python train.py --agent nezuko --wandb_name "nezuko/sigmoid-gated-slice-residual" --wandb_group sigmoid-gated-slice-residual
```

## Baseline
- val/loss: ~2.28 (old 4-split), ~2.44 (current 3-split at epoch 64)
- Surface MAE p: in_dist=21.0, ood_cond=22.6, ood_re=32.1, tandem=44.0
- **Target to beat (frieren's slice-residual):** val_loss=2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `y3j493w4` — https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/y3j493w4  
**Epochs completed:** 64+ (hit 30-min timeout; best checkpoint at epoch 63)  
**Peak VRAM:** 10.6 GB

### val/loss
| Split | Sigmoid gate (best ep63) | Baseline (ep64) | Target (frieren) |
|---|---|---|---|
| val_in_dist | 1.8036 | 1.8349 | — |
| val_ood_cond | 1.9956 | 2.0291 | — |
| val_tandem_transfer | 3.3817 | 3.4724 | — |
| val_ood_re | NaN | NaN | — |
| **combined val/loss** | **2.3936** | **2.4455** | **2.2217** |

### Surface MAE (best checkpoint, epoch 63)
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 0.335 | 0.210 | **26.55** |
| ood_cond | 0.279 | 0.198 | **22.05** |
| ood_re | 0.289 | 0.212 | **32.76** |
| tandem | 0.655 | 0.353 | **43.78** |

Baseline surf_p (ep64): in_dist=24.95, ood_cond=22.54, ood_re=33.11, tandem=44.54  
Target surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

### Surface MAE at last epoch (epoch 64, still converging)
| Split | surf_p (sigmoid gate) | surf_p (baseline) |
|---|---|---|
| in_dist | 24.77 | 24.95 |
| ood_cond | 22.93 | 22.54 |
| ood_re | 32.69 | 33.11 |
| tandem | 44.71 | 44.54 |

### Volume MAE (pressure, epoch 63 best)
| Split | vol_p |
|---|---|
| in_dist | 29.63 |
| ood_cond | 20.60 |
| tandem | 44.67 |

---

### What happened

Sigmoid gating gives a modest improvement in combined val/loss at comparable epochs (2.3936 vs 2.4455 baseline, −2.1%). Both splits most sensitive to the hypothesis — ood_cond and tandem — show improvement at the best checkpoint.

However, at the best checkpoint (epoch 63) in_dist surf_p is 26.55 — worse than baseline's 24.95. By the last epoch (64), it recovers to 24.77, suggesting the gate is still learning and in_dist would likely improve given more epochs. The model hasn't converged.

Both the sigmoid gate and baseline are far from the target frieren result (2.2217). The gap is largely attributable to truncation at ~64 epochs vs frieren's full 100-epoch run. The sigmoid gate does appear to converge slightly faster, which is the hypothesized benefit.

val_ood_re/loss = NaN persists (same vol_loss explosion ~1.9×10¹⁰), confirming this is a pre-existing issue in the noam branch, not introduced by this change.

**Code changes:** Added `from pathlib import Path` import (bug fix), plus `slice_gate_bias` parameter in `__init__` and sigmoid gate application in `forward`.

### Suggested follow-ups
- Let this run to full 100 epochs to see whether the sigmoid gate consistently outperforms the scalar residual.
- Compare directly against a scalar residual (PR #800 approach) on the same branch to isolate the gate's contribution.
- Investigate the bounded gate: at epoch 64, log `gate.mean()` to see whether the gate has diverged from init (0.1) or remained near it — if it stays near 0.1, the sigmoid bounding may not be doing useful work.