### PR TITLE
Log-cosh loss for surface nodes

### DIFF
--- a/train.py
+++ b/train.py
@@ -557,6 +557,11 @@ model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
+def _log_cosh(diff):
+    """log(cosh(x)) — smooth L1. L2-like near 0, L1-like for large errors."""
+    return diff.abs() + F.softplus(-2.0 * diff.abs()) - 0.6931
+
+
 best_val = float("inf")
 best_metrics = {}
 global_step = 0
@@ -642,7 +647,8 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        lc_err = _log_cosh(pred - y_norm)
+        surf_per_sample = (lc_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
L1 loss has constant gradient magnitude — small and large errors get equal signal. Log-cosh loss is smooth at zero (L2-like for fine-tuning near convergence) and asymptotically L1 for large errors (robust to outliers). This focuses more gradient on "almost right" predictions where small improvements compound. Unlike the failed Huber experiment (#811), which collapsed the adaptive surf_weight, log-cosh only changes behavior near zero and preserves the large-error regime.

## Instructions

**Step 1:** Define a log-cosh helper before the training loop:
```python
def _log_cosh(diff):
    """log(cosh(x)) — smooth L1. L2-like near 0, L1-like for large errors."""
    return diff.abs() + F.softplus(-2.0 * diff.abs()) - 0.6931
```

**Step 2:** Replace the surface loss computation in the training loop. Find:
```python
surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / ...
```
Replace `abs_err` with `_log_cosh(pred - y_norm)` for the surface term only:
```python
lc_err = _log_cosh(pred - y_norm)
surf_per_sample = (lc_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()
```

**Step 3:** Keep volume loss as L1 (`abs_err`). Only change the surface loss.

**Also:** Add `from pathlib import Path` if missing.

Run:
```bash
python train.py --agent frieren --wandb_name "frieren/log-cosh-surface" --wandb_group log-cosh-surface
```

## Baseline (post-merge PR #800, slice-residual)
- val/loss: 2.2217
- surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `3q638s9n` (frieren/log-cosh-surface)
**Epochs:** 66 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.944 | 0.384 | 0.234 | **27.11** | 1.192 | 0.421 | 25.88 |
| val_ood_cond | 2.411 | 0.361 | 0.258 | **26.01** | 0.986 | 0.375 | 18.93 |
| val_ood_re | nan | 0.333 | 0.246 | **34.25** | 0.998 | 0.420 | 50.11 |
| val_tandem_transfer | 3.558 | 0.711 | 0.389 | **44.30** | 2.034 | 0.931 | 42.76 |
| **combined val/loss** | **2.638** | | | | | | |

**vs baseline (2.2217):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2217 | 2.638 | **+0.416 (+18.7%)** |
| surf_p in_dist | 21.18 | 27.11 | **+5.93 (+28%)** |
| surf_p ood_cond | 20.47 | 26.01 | **+5.54 (+27%)** |
| surf_p ood_re | 30.95 | 34.25 | **+3.30 (+11%)** |
| surf_p tandem | 41.23 | 44.30 | **+3.07 (+7.5%)** |

**Peak GPU memory:** ~10.6 GB

### What happened

This is a clear negative result — log-cosh surface loss significantly degraded performance on all metrics compared to the L1 baseline.

The likely mechanism: log-cosh has a quadratic regime near zero (`~x²/2` for small `x`), which means gradient magnitude → 0 as errors → 0. With L1, every nonzero error gets a unit gradient. For surface pressure prediction — where we're often making small but consequential errors — this near-zero smoothing actually *removes* the gradient signal that matters most for the model to learn fine-grained pressure distinctions. The "fine-tuning" property is counterproductive here.

Additionally, the smooth near-zero behavior changes the absolute scale of `surf_loss` values compared to L1 (smaller losses for the same errors), which disrupts the adaptive `surf_weight` scheduler that expects L1-scale magnitudes.

The hypothesis that log-cosh would help near-convergence fine-tuning appears to be incorrect for this task — surface pressure errors are not in the "large outlier" regime where L1 vs L2 tradeoffs matter most; they're distributed errors where the L1 unit gradient is actually a strength.

### Suggested follow-ups

- **Root cause confirmation**: The adaptive surf_weight is calibrated for L1 magnitudes. A variant worth testing: keep L1 loss but re-tune the surf_weight schedule. Or: apply log-cosh but rescale the output to match L1 magnitude (divide by a factor to renormalize).
- **Surface-only loss weighting by field**: Pressure errors dominate surface MAE. A per-channel weight (e.g. Ux/Uy get lower weight, p gets higher) might be more targeted than changing the loss shape.
- **Vol loss shape change instead**: The volume loss is less noise-sensitive. If any loss shape change helps, it may be on the volume side.