### PR TITLE
Two Transolver layers at n_hidden=128 (add depth)

### DIFF
--- a/train.py
+++ b/train.py
@@ -464,7 +464,7 @@ model_config = dict(
     fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_layers=2,
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
The current model has only 1 Transolver layer — a single round of slice attention + MLP, no compositional reasoning. With all merged improvements (SE-block, sandwich norm, slice residual, spatial bias, skip connections), the single layer is well-optimized. Adding a second layer allows the first to learn local spatial patterns while the second refines cross-region interactions — critical for tandem foils where wake-foil2 interactions span the entire domain.

Expected: ~45-50 epochs in 30 min (vs ~67 with 1 layer), ~15 GB VRAM (well within 96 GB budget). The richer per-epoch processing may compensate for fewer epochs.

## Instructions

**The change is minimal.** In `train.py`, change the model config:

```python
n_layers=2,  # was 1
```

Everything else (SE blocks, sandwich norm, slice residual, skip connections, re_head) automatically works for both layers because they're defined per-block. The `re_head` will now operate on the output of block[0] (richer features after 1 attention layer).

**Also:** Add `from pathlib import Path` if missing.

Run:
```bash
python train.py --agent tanjiro --wandb_name "tanjiro/depth-2layers-128h" --wandb_group depth-2layers
```

## Baseline (post-merge PR #800, slice-residual)
- val/loss: 2.2217
- surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**val/loss: 3.2725** — substantially worse than baseline (2.2217).

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------|------------|------------|-----------|-----------|-----------|----------|
| val_in_dist | 2.9424 | 0.531 | 0.320 | 49.09 | 1.651 | 0.662 | 47.4 |
| val_tandem_transfer | 4.1449 | 0.741 | 0.433 | 54.05 | 2.282 | 1.122 | 54.5 |
| val_ood_cond | 2.7302 | 0.354 | 0.258 | 32.09 | 1.092 | 0.511 | 27.4 |
| val_ood_re | NaN* | 0.351 | 0.255 | 38.62 | 1.091 | 0.514 | 57.2 |

*val_ood_re/vol_loss = 18.9B (pre-existing branch bug, NaN throughout all epochs)

**Peak memory:** 16.7 GB  
**W&B run ID:** wa0ysx33  
**Epochs completed:** 40 (stopped at 30.6 min)

### What happened

The 2-layer model was still rapidly converging at the time limit — val_in_dist went from 18.86 (epoch 1) to 2.94 (epoch 40). The model clearly needs far more than 40 epochs to match the 1-layer baseline. The hypothesis failed because:

1. **Per-epoch time was ~45s** (not the predicted ~29s for 1-layer, which actually ran at ~28s/epoch). The 2-layer model ran 40 epochs vs 65 for 1-layer — substantially fewer epochs than expected.
2. **Slower convergence:** With twice as many parameters to optimize, each epoch makes smaller proportional progress toward the optimum. The learning dynamics with 2 layers appear to require a longer warm-up phase (epochs 1-10 showed near-zero train surf/vol losses — training was in warm-up mode longer).
3. **The quality/quantity tradeoff didn't hold:** The 1-layer model converges to a well-optimized solution within the 30-minute window. Adding depth hurts within this constraint.

Note: the val_ood_re NaN is a pre-existing branch bug present across all epochs, unrelated to the depth change.

### Suggested follow-ups
- If we want to test depth, try a longer wall-clock budget (60 min) — at epoch 40 the 2-layer model was clearly still on the downslope
- Alternatively, try n_layers=2 with reduced n_hidden (e.g., 96 instead of 128) to keep per-epoch time comparable to 1-layer
- Consider n_layers=2 with a warmup LR schedule that helps the deeper model ramp up faster