### PR TITLE
OneCycleLR schedule (higher peak LR, aggressive annealing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -517,10 +517,17 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+# Get the LR for each param group from base_opt
+param_group_lrs = [pg['lr'] for pg in base_opt.param_groups]
+scheduler = torch.optim.lr_scheduler.OneCycleLR(
+    base_opt,
+    max_lr=[lr * 2.0 for lr in param_group_lrs],  # 2x peak
+    epochs=75,
+    steps_per_epoch=len(train_loader),
+    pct_start=0.1,       # 10% warmup (~7 epochs)
+    anneal_strategy='cos',
+    div_factor=10,        # start at max_lr/10
+    final_div_factor=100, # end at max_lr/1000
 )
 
 # --- wandb ---
@@ -672,6 +679,7 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        scheduler.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(model)
@@ -687,7 +695,6 @@ for epoch in range(MAX_EPOCHS):
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
-    scheduler.step()
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
The current schedule is warmup(5 epochs) + cosine(T_max=75, eta_min=1e-4) at lr=3e-3. OneCycleLR (Smith & Topin, 2018) uses a single cycle that ramps to a higher peak LR then decays to near-zero, exploring a wider loss landscape early and settling into a sharper minimum late. It's specifically designed to maximize performance from limited training epochs — exactly our situation with the 30-min cap.

Previous LR experiments changed the constant level, not the schedule shape. OneCycleLR is fundamentally different — it explores high LR transiently, then converges aggressively.

## Instructions

**Step 1:** Replace the scheduler setup in `train.py`. Remove:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
)
```
Replace with:
```python
# Get the LR for each param group from base_opt
param_group_lrs = [pg['lr'] for pg in base_opt.param_groups]
scheduler = torch.optim.lr_scheduler.OneCycleLR(
    base_opt,
    max_lr=[lr * 2.0 for lr in param_group_lrs],  # 2x peak
    epochs=75,
    steps_per_epoch=len(train_loader),
    pct_start=0.1,       # 10% warmup (~7 epochs)
    anneal_strategy='cos',
    div_factor=10,        # start at max_lr/10
    final_div_factor=100, # end at max_lr/1000
)
```

**Step 2:** Move `scheduler.step()` from per-epoch to per-batch. Inside the training loop, after `optimizer.step()`, add `scheduler.step()`. Remove the epoch-level `scheduler.step()` call.

**Also:** Add `from pathlib import Path` if missing.

Run:
```bash
python train.py --agent thorfinn --wandb_name "thorfinn/onecycle-lr" --wandb_group onecycle-lr
```

## Baseline (post-merge PR #800, slice-residual)
- val/loss: 2.2217
- surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `iy4e3b2y`
**Epochs completed:** 67 (30-min wall-clock limit)
**Peak memory:** 10.6 GB

### Metrics vs Baseline

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6083 | 0.298 | 0.176 | 21.6 | 1.280 | 0.459 | 27.2 |
| val_tandem_transfer | 3.4204 | 0.657 | 0.353 | 44.1 | 2.181 | 1.023 | 46.0 |
| val_ood_cond | 2.0710 | 0.292 | 0.204 | 24.0 | 1.055 | 0.434 | 22.4 |
| val_ood_re | nan | 0.279 | 0.203 | 30.8 | 1.012 | 0.447 | 51.4 |
| **combined val/loss** | **2.3666** | | | | | | |

**Baseline:** val/loss 2.2217 → **this run: 2.3666 (+0.14, worse)**

| surf_p | Baseline | This Run | Δ |
|---|---|---|---|
| in_dist | 21.18 | 21.6 | +0.4 |
| ood_cond | 20.47 | 24.0 | +3.5 |
| ood_re | 30.95 | 30.8 | -0.15 |
| tandem | 41.23 | 44.1 | +2.9 |

### What happened

OneCycleLR did not improve over baseline. Combined val/loss increased from 2.2217 to 2.3666 (+6.5%). Surface pressure accuracy is notably worse on ood_cond (+3.5) and tandem (+2.9); only ood_re shows a marginal improvement (-0.15).

The `val_ood_re/vol_loss` explodes to ~1.9e10 (producing a NaN loss), which appears to be a pre-existing evaluation issue (seen in other experiments on this branch too) — not caused by the schedule change itself.

The likely cause: OneCycleLR drives LR up to 6e-3 (2× peak) during the first ~7 epochs, which is aggressive for the highly imbalanced dataset. The Lookahead wrapper with k=10 may also interact poorly with OneCycleLR — Lookahead slow weights are updated every 10 steps, but OneCycleLR is designed assuming the base optimizer takes every step. This mismatch could prevent OneCycleLR from behaving as intended.

Additionally, OneCycleLR fixes `epochs=75` but training hit the wall-clock at epoch 67, so the final annealing phase was cut short. The schedule was not able to complete its intended convergence phase.

### Suggested follow-ups
- Try OneCycleLR with a lower peak (1.5×) — 2× may be too aggressive with Lookahead.
- Alternatively, separate OneCycleLR from Lookahead by applying it only to the base optimizer (which is what was done here, but the Lookahead interaction deserves investigation).
- The val_ood_re vol_loss explosion warrants a dedicated bug investigation — it may be masking true improvements in combined val/loss.