### PR TITLE
Gradient-penalty surface loss (finite-difference smoothness)

### DIFF
--- a/train.py
+++ b/train.py
@@ -644,7 +644,27 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+
+        # Gradient-penalty: finite-difference smoothness on surface predictions
+        grad_loss = torch.tensor(0.0, device=device)
+        for b in range(B):
+            s_mask = surf_mask[b]
+            if s_mask.sum() < 2:
+                continue
+            s_idx = s_mask.nonzero(as_tuple=True)[0]
+            # Sort surface nodes by x-coordinate for meaningful finite differences
+            x_coords = x[b, s_idx, 0]  # x-position (feature index 0, already normalized)
+            sort_order = x_coords.argsort()
+            s_idx_sorted = s_idx[sort_order]
+            # Finite differences on all 3 channels in normalized space
+            p_pred = pred[b, s_idx_sorted]    # [n_surf, 3]
+            p_targ = y_norm[b, s_idx_sorted]  # [n_surf, 3]
+            dp_pred = p_pred[1:] - p_pred[:-1]
+            dp_targ = p_targ[1:] - p_targ[:-1]
+            grad_loss = grad_loss + (dp_pred - dp_targ).abs().mean()
+        grad_loss = grad_loss / max(B, 1)
+
+        loss = vol_loss + surf_weight * surf_loss + 0.1 * grad_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
@@ -680,7 +700,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/grad_loss": grad_loss.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Surface pressure predictions on airfoils should be spatially smooth — no unphysical oscillations between neighboring surface nodes. Currently the L1 loss treats each surface node independently with no spatial structure. Adding a finite-difference smoothness penalty on neighboring surface nodes' predictions regularizes the output to respect the physical constraint that Cp varies smoothly along the airfoil chord.

This is analogous to total-variation regularization in image processing, applied to the 1D surface pressure distribution. It should particularly help on tandem (41.23) and ood_re (30.95) where the model has less data and may produce noisy predictions.

## Instructions

In `train.py`:

### Add gradient-penalty loss after line 646

After `surf_loss = (surf_per_sample * tandem_boost).mean()`, and **before** the line `loss = vol_loss + surf_weight * surf_loss` (line 647), insert:

```python
# Gradient-penalty: finite-difference smoothness on surface predictions
grad_loss = torch.tensor(0.0, device=device)
for b in range(B):
    s_mask = surf_mask[b]
    if s_mask.sum() < 2:
        continue
    s_idx = s_mask.nonzero(as_tuple=True)[0]
    # Sort surface nodes by x-coordinate for meaningful finite differences
    x_coords = x[b, s_idx, 0]  # x-position (feature index 0, already normalized)
    sort_order = x_coords.argsort()
    s_idx_sorted = s_idx[sort_order]
    # Finite differences on all 3 channels in normalized space
    p_pred = pred[b, s_idx_sorted]    # [n_surf, 3]
    p_targ = y_norm[b, s_idx_sorted]  # [n_surf, 3]
    dp_pred = p_pred[1:] - p_pred[:-1]
    dp_targ = p_targ[1:] - p_targ[:-1]
    grad_loss = grad_loss + (dp_pred - dp_targ).abs().mean()
grad_loss = grad_loss / max(B, 1)
```

Then modify line 647:
```python
loss = vol_loss + surf_weight * surf_loss + 0.1 * grad_loss
```

Also update the wandb.log call at line 683 to include `"train/grad_loss": grad_loss.item()`.

Run:
```bash
python train.py --agent kohaku --wandb_name "kohaku/grad-penalty-surf" --wandb_group grad-penalty-surf
```

## Baseline
- val/loss: 2.2217
- surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `yfwemmml`
**Epochs completed:** 63/100 (timed out at 30 min)

### Metrics at best epoch (epoch 63)
| Split | val/loss |
|---|---|
| val_in_dist | 1.7856 |
| val_tandem_transfer | 3.5610 |
| val_ood_cond | 2.0293 |
| val_ood_re | NaN (pre-existing) |
| **Overall val/loss** | **2.4586** |

**Baseline val/loss:** 2.2217

### Surface pressure MAE
| Split | surf_p (ours) | surf_p (baseline) |
|---|---|---|
| val_in_dist | 24.76 | 21.18 |
| val_ood_cond | 22.26 | 20.47 |
| val_ood_re | 32.86 | 30.95 |
| val_tandem_transfer | 46.35 | 41.23 |

### Other Surface MAE (val_in_dist)
| | Ux | Uy | p |
|---|---|---|---|
| Surface MAE | 0.329 | 0.195 | 24.76 |

**train/grad_loss at timeout:** 0.037
**Peak memory:** 10.6 GB

### What happened

**Negative result.** val/loss 2.459 at epoch 63/100 is notably worse than baseline 2.2217, and surface pressure is worse on all splits. The gradient penalty is small (0.037) but nonzero, showing it's being optimized. However, it's not helping.

Likely reasons for failure:

1. **x-coordinate sort doesn't give contiguous airfoil surface order.** Airfoil nodes form a closed loop; sorting by x-coordinate places both the upper and lower surface nodes interleaved at the same x values. The finite differences are then taken between mismatched upper/lower surface points, penalizing physically meaningful pressure differences (upper vs lower surface) rather than spatial oscillations.

2. **surf_weight stuck at 5 (minimum).** Same issue as other experiments: the adaptive weighting is dominated by vol_loss/surf_loss ratio. Surface receives minimal weight throughout.

3. **Added regularization may slow learning.** The per-sample Python loop adds extra gradient signal that could conflict with the L1 surface loss during early epochs when predictions are noisy.

### Suggested follow-ups

- **Separate upper/lower surface.** Split surface nodes into upper (y > chord midpoint) and lower sets before taking finite differences. This would correctly penalize oscillations within each surface, not between them.
- **Apply penalty only to pressure channel.** The hypothesis was about Cp smoothness; Ux/Uy smoothness is less physically motivated and may hurt.
- **Use arc-length parameterization.** Sort by distance along the surface (cumulative chord length from leading edge) rather than x-coordinate for a physically correct ordering.