### PR TITLE
IQR-based pressure normalization (robust to outliers)

### DIFF
--- a/train.py
+++ b/train.py
@@ -605,7 +605,15 @@ for epoch in range(MAX_EPOCHS):
             for b in range(B):
                 if not is_tandem[b]:
                     valid = mask[b]
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                    vals = y_norm[b, valid]  # [n_valid, 3]
+                    # Velocity channels: std as before
+                    sample_stds[b, 0, :2] = vals[:, :2].std(dim=0).clamp(min=channel_clamps[:2])
+                    # Pressure channel: IQR for robustness to stagnation/suction outliers
+                    p_vals = vals[:, 2].float()
+                    q75 = torch.quantile(p_vals, 0.75)
+                    q25 = torch.quantile(p_vals, 0.25)
+                    iqr_std = (q75 - q25).clamp(min=channel_clamps[2].item()) * 0.7413
+                    sample_stds[b, 0, 2] = iqr_std
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
@@ -731,7 +739,13 @@ for epoch in range(MAX_EPOCHS):
                 for b in range(B):
                     if not is_tandem[b]:
                         valid = mask[b]
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                        vals = y_norm[b, valid]  # [n_valid, 3]
+                        sample_stds[b, 0, :2] = vals[:, :2].std(dim=0).clamp(min=channel_clamps[:2])
+                        p_vals = vals[:, 2].float()
+                        q75 = torch.quantile(p_vals, 0.75)
+                        q25 = torch.quantile(p_vals, 0.25)
+                        iqr_std = (q75 - q25).clamp(min=channel_clamps[2].item()) * 0.7413
+                        sample_stds[b, 0, 2] = iqr_std
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
The per-sample std normalization (lines 598-609, 726-735) treats all 3 output channels identically with std + channel clamps [0.1, 0.1, 0.5]. But pressure has fundamentally different statistics: heavy tails from stagnation points (Cp≈1) and suction peaks (Cp<-3) inflate std, compressing the normalized pressure range and making it harder for the model to resolve pressure differences that matter for surface accuracy.

By using the **interquartile range (IQR)** instead of std for the pressure channel, we get a more robust scale estimate. The IQR-to-std conversion factor (0.7413 = 1/(2*Φ⁻¹(0.75))) ensures equivalent scaling for Gaussian distributions while being much more robust to outliers.

This should improve surface pressure accuracy, especially on ood_re (30.95) and tandem (41.23) where pressure distributions have the heaviest tails.

## Instructions

In `train.py`:

### 1. Modify training per-sample normalization (lines 604-609)

Replace:
```python
if model.training:
    for b in range(B):
        if not is_tandem[b]:
            valid = mask[b]
            sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
    y_norm = y_norm / sample_stds
```

With:
```python
if model.training:
    for b in range(B):
        if not is_tandem[b]:
            valid = mask[b]
            vals = y_norm[b, valid]  # [n_valid, 3]
            # Velocity channels: std as before
            sample_stds[b, 0, :2] = vals[:, :2].std(dim=0).clamp(min=channel_clamps[:2])
            # Pressure channel: IQR for robustness to stagnation/suction outliers
            p_vals = vals[:, 2].float()
            q75 = torch.quantile(p_vals, 0.75)
            q25 = torch.quantile(p_vals, 0.25)
            iqr_std = (q75 - q25).clamp(min=channel_clamps[2].item()) * 0.7413
            sample_stds[b, 0, 2] = iqr_std
    y_norm = y_norm / sample_stds
```

### 2. Same change in validation normalization (lines 731-734)

Replace:
```python
for b in range(B):
    if not is_tandem[b]:
        valid = mask[b]
        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
```

With:
```python
for b in range(B):
    if not is_tandem[b]:
        valid = mask[b]
        vals = y_norm[b, valid]  # [n_valid, 3]
        sample_stds[b, 0, :2] = vals[:, :2].std(dim=0).clamp(min=channel_clamps[:2])
        p_vals = vals[:, 2].float()
        q75 = torch.quantile(p_vals, 0.75)
        q25 = torch.quantile(p_vals, 0.25)
        iqr_std = (q75 - q25).clamp(min=channel_clamps[2].item()) * 0.7413
        sample_stds[b, 0, 2] = iqr_std
```

Run:
```bash
python train.py --agent norman --wandb_name "norman/iqr-pressure-norm" --wandb_group iqr-pressure-norm
```

## Baseline
- val/loss: 2.2217
- surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** 4crhq8zm  
**Epochs:** 66 (30-min wall-clock limit)  
**Peak memory:** 10.5 GB  

### Metrics vs baseline

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6498 | 0.2958 | 0.1841 | 22.42 | 1.3416 | 0.4743 | 27.74 |
| val_ood_cond | 2.2111 | 0.2751 | 0.1971 | 21.19 | 1.0994 | 0.4228 | 19.90 |
| val_tandem_transfer | 3.7183 | 0.6388 | 0.3393 | 41.92 | 2.2163 | 1.0129 | 44.69 |
| val_ood_re | nan | 0.2859 | 0.2061 | 31.81 | 1.0899 | 0.4541 | 51.78 |
| **combined val/loss** | **2.5264** | | | | | | |

Baseline val/loss 2.2217 → **2.5264: worse by +0.30 (+13.7%)**

Surface pressure vs baseline:
- in_dist: 22.42 vs 21.18 → **+1.2 worse**
- ood_cond: 21.19 vs 20.47 → **+0.7 worse**
- ood_re: 31.81 vs 30.95 → **+0.9 worse**
- tandem: 41.92 vs 41.23 → **+0.7 worse**

### What happened

IQR-based pressure normalization did not help — both val/loss and surface pressure accuracy degraded.

The hypothesis that IQR is more "robust" to pressure outliers is theoretically sound, but the problem is that those pressure outliers (stagnation Cp≈1, suction Cp<-3) are precisely the regions that matter for surface accuracy. By normalizing them away with a tighter IQR scale, the model sees a *larger* effective error for non-outlier pressure values, de-emphasizing the accurate reconstruction of the very peaks and troughs that matter most.

Additionally, IQR is lower than std for heavy-tailed distributions, so the IQR-based normalization effectively *increases* the normalized pressure range (divides by a smaller number), making the pressure optimization task harder relative to velocity channels.

val_ood_re again produces NaN — this appears to be a pre-existing instability in the OOD Reynolds number regime unrelated to this change.

### Suggested follow-ups

- **Asymmetric clipping instead of robust scaling**: Rather than changing the normalization base, clip pressure values at ±3 std before computing std — this removes tail influence while keeping the scale meaningful.
- **Increase pressure channel clamp**: Try `channel_clamps = [0.1, 0.1, 0.3]` with std (not IQR) to achieve similar tail robustness with less disruption.
- **Weighted loss on surface nodes by local pressure gradient**: Up-weight nodes at stagnation/suction peaks directly in the loss rather than through normalization.