### PR TITLE
Boundary-type embedding (surface vs volume learnable tokens)

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,9 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        # Boundary-type embedding: 0=volume, 1=surface-foil1, 2=surface-foil2
+        self.boundary_embed = nn.Embedding(3, n_hidden)
+        nn.init.normal_(self.boundary_embed.weight, std=0.02)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -330,6 +333,27 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+
+        # Boundary type: 0=volume, 1=surface-foil1, 2=surface-foil2
+        # is_surface at feature index 12 is normalized; threshold to recover binary
+        is_surf_norm = x[:, :, 12]
+        is_surf_flag = (is_surf_norm > 0).long()  # 1=surface, 0=volume
+        btype = is_surf_flag.clone()
+
+        # For tandem samples, split surface into foil1/foil2 by x-coordinate
+        # gap feature at index 21; normalized but tandem samples have clearly nonzero values
+        gap_feat = x[:, 0, 21]
+        is_tandem = gap_feat.abs() > 0.5
+        for b in range(x.shape[0]):
+            if is_tandem[b]:
+                surf_nodes = (btype[b] == 1)
+                if surf_nodes.sum() > 10:
+                    surf_x = raw_xy[b, surf_nodes, 0]
+                    median_x = surf_x.median()
+                    foil2_mask = surf_nodes & (raw_xy[b, :, 0] > median_x)
+                    btype[b][foil2_mask] = 2
+
+        fx = fx + self.boundary_embed(btype)
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)


### PR DESCRIPTION
## Hypothesis
The Transolver treats all mesh nodes identically in its hidden representation — surface and volume nodes are only distinguished through the `is_surface` input feature (index 12). By adding a **learnable embedding** for node type (volume=0, surface-foil1=1, surface-foil2=2), the model gains an explicit inductive bias about different physics at each boundary type. This is analogous to token-type embeddings in BERT.

Key insight: for tandem samples, foil 1 and foil 2 surface nodes have fundamentally different flow physics (foil 2 is in the wake of foil 1). Distinct embeddings should help the model learn separate prediction strategies for each foil, directly targeting the tandem split (surf_p=41.23, the worst).

## Instructions

In `train.py`:

### 1. Add embedding table in `Transolver.__init__` (after line 271, after `self.re_head`)

```python
# Boundary-type embedding: 0=volume, 1=surface-foil1, 2=surface-foil2
self.boundary_embed = nn.Embedding(3, n_hidden)
nn.init.normal_(self.boundary_embed.weight, std=0.02)
```

### 2. Add embedding in `Transolver.forward` (after line 332)

After `fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]`, insert:

```python
# Boundary type: 0=volume, 1=surface-foil1, 2=surface-foil2
# is_surface at feature index 12 is normalized; threshold to recover binary
is_surf_norm = x[:, :, 12]
is_surf_flag = (is_surf_norm > 0).long()  # 1=surface, 0=volume
btype = is_surf_flag.clone()

# For tandem samples, split surface into foil1/foil2 by x-coordinate
# gap feature at index 21; normalized but tandem samples have clearly nonzero values
gap_feat = x[:, 0, 21]
is_tandem = gap_feat.abs() > 0.5
for b in range(x.shape[0]):
    if is_tandem[b]:
        surf_nodes = (btype[b] == 1)
        if surf_nodes.sum() > 10:
            surf_x = raw_xy[b, surf_nodes, 0]
            median_x = surf_x.median()
            foil2_mask = surf_nodes & (raw_xy[b, :, 0] > median_x)
            btype[b][foil2_mask] = 2

fx = fx + self.boundary_embed(btype)
```

**Note:** `raw_xy` is already computed at line 329 (`raw_xy = x[:, :, :2]`), so it's available.

### 3. No other changes needed

The embedding flows through all subsequent blocks.

Run:
```bash
python train.py --agent fern --wandb_name "fern/boundary-type-embed" --wandb_group boundary-embed
```

## Baseline
- val/loss: 2.2217
- surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `yeeddke2`

**Note:** Run crashed (killed by 30-min timeout) at epoch 60/100. At ~29s/epoch, a full 100-epoch run requires ~48 min — consistently exceeding the 30-min cap.

### Metrics at best/final epoch (epoch 60)

| Metric | This run (ep 60) | Baseline |
|--------|-----------------|----------|
| val/loss | 2.4936 | 2.2217 |
| val_in_dist/loss | 1.916 | — |
| Surface MAE Ux (in_dist) | 0.373 | — |
| Surface MAE Uy (in_dist) | 0.209 | — |
| Surface MAE p (in_dist) | 27.20 | 21.18 |
| Surface MAE p (tandem) | 43.78 | 41.23 |
| Surface MAE p (ood_cond) | 23.77 | 20.47 |
| Surface MAE p (ood_re) | 33.54 | 30.95 |
| Volume MAE Ux (in_dist) | 1.418 | — |
| Volume MAE Uy (in_dist) | 0.508 | — |
| Volume MAE p (in_dist) | 32.44 | — |
| val_ood_re/loss | NaN | — |
| val_ood_re/vol_loss | ~18.9B | — |

**Peak memory:** not tracked (added ~384B to model, negligible)

### What happened

**Hypothesis not supported.** All metrics at epoch 60 are worse than the baseline across every split. The val/loss was still descending (2.74 → 2.77 → 2.62 → 2.54 → 2.49) when the run was killed at epoch 60, so convergence was incomplete — but we're well behind the baseline's 2.2217.

The boundary embedding idea is sound in principle, but there are several issues:

1. **Foil-2 detection heuristic is fragile**: The threshold `gap_feat.abs() > 0.5` for tandem detection and the median-x split for foil-2 identification are heuristics that may misclassify nodes. If the normalization of the gap feature doesn't produce clean separation at 0.5, most tandem samples would never get type=2 embeddings.

2. **val_ood_re catastrophic divergence** persists (vol_loss ~18.9B, NaN) — this is a pre-existing issue on this branch, not caused by the boundary embedding. Both this run and the previous MLP-droppath run show the identical value (18867924528), suggesting a fixed numerical overflow in the OOD-Re split normalization.

3. **The Python for-loop** over batch samples may add per-step overhead, though this likely explains only small slowdowns.

The tandem surface pressure is still poor (43.78 vs baseline 41.23), suggesting the embedding isn't helping foil-2 either.

### Suggested follow-ups

- Fix the val_ood_re divergence first — it corrupts val/loss and may be hurting training (if any of those samples appear in training). There are branches specifically targeting this (`exp-noam/fix-ood-re-overflow`, `exp-noam/fix-ood-re-denorm`).
- If retrying boundary embed: use `boundary_ids` directly from the mesh data rather than heuristics; vectorize the foil-2 detection to avoid the Python for-loop
- A simpler approach: just a surface/volume binary embedding (2 types) without the fragile foil-1/foil-2 split