### PR TITLE
Surface-local attention refinement pass

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,14 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        # Surface-local self-attention refinement
+        self.surf_attn_q = nn.Linear(n_hidden, 64)
+        self.surf_attn_k = nn.Linear(n_hidden, 64)
+        self.surf_attn_v = nn.Linear(n_hidden, 64)
+        self.surf_attn_out = nn.Linear(64, n_hidden)
+        # Zero-init output so it starts as identity (no-op)
+        nn.init.zeros_(self.surf_attn_out.weight)
+        nn.init.zeros_(self.surf_attn_out.bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -336,6 +344,22 @@ class Transolver(nn.Module):
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
+
+        # Surface-only local attention refinement (before final projection)
+        is_surf_feat = x[:, :, 12]  # is_surface feature (index 12 in the 24-dim input)
+        surf_flag = (is_surf_feat > 0)  # [B, N] boolean
+        for b in range(fx.shape[0]):
+            s_idx = surf_flag[b].nonzero(as_tuple=True)[0]
+            if s_idx.numel() < 4:
+                continue
+            s_feat = fx[b, s_idx]  # [n_surf, hidden]
+            sq = self.surf_attn_q(s_feat)  # [n_surf, 64]
+            sk = self.surf_attn_k(s_feat)
+            sv = self.surf_attn_v(s_feat)
+            attn = torch.matmul(sq, sk.transpose(-1, -2)) / 8.0  # sqrt(64) = 8
+            attn = F.softmax(attn, dim=-1)
+            s_out = self.surf_attn_out(torch.matmul(attn, sv))
+            fx[b, s_idx] = fx[b, s_idx] + s_out  # residual add
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)


### PR DESCRIPTION
## Hypothesis
The single Transolver layer processes all ~85K-200K nodes through global slice attention. Surface nodes (where pressure gradients are steepest and our metric is worst) are <5% of all nodes and get diluted in global attention. A dedicated lightweight self-attention pass over just the surface nodes — after the main Transolver block — lets surface nodes directly attend to each other along the airfoil contour, capturing pressure distribution structure (suction peak, recovery, trailing edge) that global slices miss.

This is analogous to "refinement heads" in detection networks — a coarse global pass followed by a targeted local pass on the regions that matter most.

## Instructions

1. **In `Transolver.__init__`**, add a small surface attention module after `self.re_head`:
```python
# Surface-local self-attention refinement
self.surf_attn_q = nn.Linear(n_hidden, 64)
self.surf_attn_k = nn.Linear(n_hidden, 64)
self.surf_attn_v = nn.Linear(n_hidden, 64)
self.surf_attn_out = nn.Linear(64, n_hidden)
# Zero-init output so it starts as identity (no-op)
nn.init.zeros_(self.surf_attn_out.weight)
nn.init.zeros_(self.surf_attn_out.bias)
```

2. **In `Transolver.forward`**, after `fx = self.blocks[-1](fx, raw_xy=raw_xy)` but before `fx = fx + self.out_skip(fx_pre)`:
```python
# Surface-only local attention refinement
is_surf_feat = x[:, :, 12]  # is_surface feature (index 12 in the 24-dim input)
surf_flag = (is_surf_feat > 0)  # [B, N] boolean
for b in range(fx.shape[0]):
    s_idx = surf_flag[b].nonzero(as_tuple=True)[0]
    if s_idx.numel() < 4:
        continue
    s_feat = fx[b, s_idx]  # [n_surf, hidden]
    sq = self.surf_attn_q(s_feat)  # [n_surf, 64]
    sk = self.surf_attn_k(s_feat)
    sv = self.surf_attn_v(s_feat)
    attn = torch.matmul(sq, sk.transpose(-1, -2)) / 8.0  # sqrt(64) = 8
    attn = F.softmax(attn, dim=-1)
    s_out = self.surf_attn_out(torch.matmul(attn, sv))
    fx[b, s_idx] = fx[b, s_idx] + s_out  # residual add
```

3. **No changes** to loss, optimizer, or anything else.

4. **Run:**
```bash
python train.py --agent frieren --wandb_name "frieren/surface-local-attn" --wandb_group surface-local-attn
```

**Important notes:**
- Surface nodes are typically <5% of total, so the attention matrix is small (~4K×4K max) and fast
- Zero-init on `surf_attn_out` means the model starts identical to baseline and gradually learns the refinement
- If the per-sample loop is slow, try batching: pad surface nodes to a common size across the batch
- If it helps, try a second run with 2 attention heads (split 64 → 2×32)

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `jok8rvpl` (frieren/surface-local-attn)
**Epochs:** 55 (30-min wall-clock limit)

**Note:** Placement bug fixed — the surface attention was initially placed after the last block's projection to out_dim=3. The code places it before self.blocks[-1] where fx is still [B, N, n_hidden].

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 2.178 | 0.393 | 0.243 | **33.12** | 1.429 | 0.551 | 33.22 |
| val_ood_cond | 2.392 | 0.320 | 0.235 | **27.90** | 1.174 | 0.489 | 25.96 |
| val_ood_re | nan | 0.326 | 0.251 | **36.68** | 1.161 | 0.529 | 56.73 |
| val_tandem_transfer | 3.594 | 0.674 | 0.376 | **46.84** | 2.229 | 1.059 | 47.33 |
| **combined val/loss** | **2.721** | | | | | | |

**vs baseline (2.2217):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2217 | 2.721 | **+0.499 (+22.5%)** |
| surf_p in_dist | 21.18 | 33.12 | **+11.94 (+56%)** |
| surf_p ood_cond | 20.47 | 27.90 | **+7.43 (+36%)** |
| surf_p ood_re | 30.95 | 36.68 | **+5.73 (+19%)** |
| surf_p tandem | 41.23 | 46.84 | **+5.61 (+14%)** |

**Peak GPU memory:** ~10.8 GB
**Per-epoch time:** ~33s vs ~27s baseline (22% slower)

### What happened

Clear negative result. Surface-local attention significantly hurt performance across all splits and metrics.

**Why it's slower:** The per-sample Python loop iterates B times, with each iteration doing an n_surf×n_surf attention matrix. Surface nodes number ~1900–4000 per sample, so this is expensive Python overhead even if each matmul is GPU-side. This reduces epochs from ~66 to ~55 in the 30-min budget.

**Why it's worse (beyond fewer epochs):** Even accounting for fewer epochs, the degradation is severe — surf_p in_dist regressed by 56%, which can't be explained by 17% fewer epochs. The likely cause: the per-sample loop inserts Python overhead that breaks CUDA kernel pipelining and fragments the computation graph, hurting gradient flow. Additionally, the surface attention (before the last block) modifies the hidden features that the last block's mlp2 uses for final prediction — if the surface attention introduces even small perturbations early in training, it can destabilize the last block's projection learning.

A deeper issue: the hypothesis assumes surface nodes are "diluted" in global slice attention, but Transolver's slice mechanism explicitly learns to group physically similar nodes — it may already be capturing surface structure through its learned slices. Adding a separate surface pass may be fighting against this learned organization.

### Suggested follow-ups

- **Placement after final projection**: Apply a surface-only refinement to the output predictions  directly (post-prediction correction), rather than to hidden features. This avoids interfering with the last block's learned projection.
- **Batched implementation**: Use padding to batch surface node attention across samples, eliminating the Python loop overhead.
- **Analyze slice assignments**: Check if the learned slices already preferentially capture surface nodes — if yes, the hypothesis premise is wrong and we should focus elsewhere.