### PR TITLE
Multi-scale slice granularity (16 coarse + 32 fine parallel branches)

### DIFF
--- a/train.py
+++ b/train.py
@@ -105,6 +105,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
         self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
+        self.coarse_slice_num = slice_num // 2
+        self.in_project_slice_coarse = nn.Linear(dim_head, self.coarse_slice_num)
+        torch.nn.init.orthogonal_(self.in_project_slice_coarse.weight)
+        self.coarse_to_q = nn.Linear(dim_head, dim_head, bias=False)
+        self.coarse_to_k = nn.Linear(dim_head, dim_head, bias=False)
+        self.coarse_to_v = nn.Linear(dim_head, dim_head, bias=False)
+        self.scale_mix = nn.Parameter(torch.tensor(0.0))  # sigmoid(0) = 0.5 → equal mix
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
@@ -147,6 +154,28 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
+
+        # --- Coarse branch (coarse_slice_num slices) ---
+        coarse_logits = self.in_project_slice_coarse(x_mid) / self.temperature
+        if spatial_bias is not None:
+            sb_coarse = spatial_bias[:, :, :, ::2] if spatial_bias.dim() == 4 else spatial_bias[:, :, ::2]
+            coarse_logits = coarse_logits + 0.1 * sb_coarse.unsqueeze(1)
+        coarse_weights = self.softmax(coarse_logits)
+        coarse_norm = coarse_weights.sum(2)
+        coarse_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, coarse_weights)
+        coarse_token = coarse_token / ((coarse_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+        cq = F.normalize(self.coarse_to_q(coarse_token), dim=-1)
+        ck = F.normalize(self.coarse_to_k(coarse_token), dim=-1)
+        cv = self.coarse_to_v(coarse_token)
+        c_attn = F.softmax(torch.matmul(cq, ck.transpose(-2, -1)) * self.attn_scale, dim=-1)
+        out_coarse = torch.matmul(c_attn, cv)
+        out_coarse = out_coarse + self.slice_residual_scale * coarse_token
+        out_x_coarse = torch.einsum("bhgc,bhng->bhnc", out_coarse, coarse_weights)
+        out_x_coarse = rearrange(out_x_coarse, "b h n d -> b n (h d)")
+
+        # Learnable mix of fine and coarse
+        mix = torch.sigmoid(self.scale_mix)
+        out_x = mix * out_x + (1 - mix) * out_x_coarse
         return self.to_out(out_x)
 
 


### PR DESCRIPTION
## Hypothesis
The current 32 slices try to simultaneously capture large-scale flow patterns (freestream, wake) and local detail (boundary layer, stagnation). This is a fundamental tension. Two parallel resolution branches — 16 coarse slices for global structure and 32 fine slices for local detail — let the model decompose the problem, like multi-scale feature pyramids in vision (FPN). A learnable sigmoid-gated mix combines them.

## Instructions

1. **In `Physics_Attention_Irregular_Mesh.__init__`**, add a coarse slice branch:
```python
# Coarse slice branch (16 slices for global structure)
self.coarse_slice_num = slice_num // 2  # 16
self.in_project_slice_coarse = nn.Linear(dim_head, self.coarse_slice_num)
torch.nn.init.orthogonal_(self.in_project_slice_coarse.weight)
self.coarse_to_q = nn.Linear(dim_head, dim_head, bias=False)
self.coarse_to_k = nn.Linear(dim_head, dim_head, bias=False)
self.coarse_to_v = nn.Linear(dim_head, dim_head, bias=False)
self.scale_mix = nn.Parameter(torch.tensor(0.0))  # sigmoid(0) = 0.5 → equal mix
```

2. **In `Physics_Attention_Irregular_Mesh.forward`**, after computing the existing fine-grained `out_x`, add the coarse branch and mix.

4. **Run:**
```bash
python train.py --agent edward --wandb_name "edward/multiscale-slices" --wandb_group multiscale-slices
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** ujc3nwc3
**Best epoch:** 57/100 (30-minute timeout, 31.8s/epoch)
**Peak VRAM:** ~10.5GB (no OOM)

| Split | val/loss | surf p MAE |
|---|---|---|
| val_in_dist | 2.1523 | 30.33 |
| val_ood_cond | 2.3154 | 26.60 |
| val_tandem_transfer | 3.5589 | 44.63 |
| val_ood_re | nan | 36.31 |
| **combined** | **2.6755** | |

vs baseline (val/loss=2.2217): **+20.4% worse**
surf_p (in_dist): 30.33 vs 21.18 → +43% worse

### What happened

**Negative result.** Multi-scale branches significantly hurt performance across all splits. Val/loss is 2.6755 vs 2.2217 baseline — a 20% regression. Surf_p values are substantially worse than baseline everywhere.

Root causes:

1. **Bad initialization of the mix**: `scale_mix=0.0` means sigmoid=0.5, giving equal weight to both branches from epoch 1. The coarse branch starts from random initialization, so it outputs noise for the first ~10-20 epochs. This noise degrades fine-branch predictions immediately, making early training much harder.

2. **Fewer epochs**: Epoch time rose from 27s to 31.8s (17% increase) due to the second attention pass, reducing training from 67 to 57 epochs in the 30-minute budget. Less convergence time.

3. **Competing optimization landscapes**: The coarse (16-slice) and fine (32-slice) branches operate at different resolutions and need to co-learn. When one is behind, it actively corrupts the other through the equal mix. The fine-only baseline has no such issue.

4. **Shared `attn_scale`**: The coarse branch reuses `self.attn_scale` (initialized for the fine branch's geometry). With 16 slices instead of 32, the attention distribution may be miscalibrated.

### Suggested follow-ups

- **Fine-dominant init**: Initialize `scale_mix=+6.0` (sigmoid≈0.997) so training starts nearly identical to the single-branch baseline. Let the coarse contribution grow only after the fine branch has converged.
- **Sequential fine-then-coarse**: Run fine branch for first N epochs, then add coarse. This avoids the cold-start noise problem.
- **Separate attn_scale**: Give the coarse branch its own `coarse_attn_scale` so it can calibrate independently.