### PR TITLE
Relative position encoding in slice attention (spatial Q/K bias)

### DIFF
--- a/train.py
+++ b/train.py
@@ -110,8 +110,15 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        # Relative position bias for inter-slice attention
+        self.rel_pos_proj = nn.Sequential(
+            nn.Linear(2, 16), nn.GELU(), nn.Linear(16, 1)
+        )
+        # Zero-init so it starts as no-op
+        nn.init.zeros_(self.rel_pos_proj[-1].weight)
+        nn.init.zeros_(self.rel_pos_proj[-1].bias)
 
-    def forward(self, x, spatial_bias=None):
+    def forward(self, x, raw_xy=None, spatial_bias=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -140,7 +147,21 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
         q_norm = F.normalize(q_slice_token, dim=-1)
         k_norm = F.normalize(k_slice_token, dim=-1)
-        attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
+        # Compute relative position bias between slice pairs
+        if raw_xy is not None:
+            # Mean position of each slice: weighted avg of node positions
+            # slice_weights: [B, H, N, S], raw_xy: [B, N, 2]
+            sw_avg = slice_weights.mean(dim=1)  # [B, N, S] — avg across heads
+            slice_pos = torch.einsum("bns,bnd->bsd", sw_avg, raw_xy.float())  # [B, S, 2]
+            slice_count = sw_avg.sum(dim=1).clamp(min=1e-5)  # [B, S]
+            slice_pos = slice_pos / slice_count.unsqueeze(-1)  # normalize by count
+            # Pairwise position differences: [B, S, S, 2]
+            rel_pos = slice_pos.unsqueeze(2) - slice_pos.unsqueeze(1)
+            pos_bias = self.rel_pos_proj(rel_pos).squeeze(-1)  # [B, S, S]
+            # Add to attention logits (broadcast across heads)
+            attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale + pos_bias.unsqueeze(1)
+        else:
+            attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
         out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
@@ -191,7 +212,7 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
+        fx = self.ln_1_post(self.attn(self.ln_1(fx), raw_xy=raw_xy, spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))


### PR DESCRIPTION
## Hypothesis
The current inter-slice attention (Q/K/V after aggregation into slice tokens) is purely content-based — slices attend to each other based on feature similarity, with no awareness of spatial proximity. In CFD, spatial proximity is critical: a wake slice downstream of an airfoil should attend more strongly to the boundary layer slice than to a far-field slice. Adding a learned spatial bias from pairwise slice position differences injects this physics into the attention.

## Instructions

1. **In `Physics_Attention_Irregular_Mesh.__init__`**, add a relative position projection:
```python
# Relative position bias for inter-slice attention
self.rel_pos_proj = nn.Sequential(
    nn.Linear(2, 16), nn.GELU(), nn.Linear(16, 1)
)
# Zero-init so it starts as no-op
nn.init.zeros_(self.rel_pos_proj[-1].weight)
nn.init.zeros_(self.rel_pos_proj[-1].bias)
```

2. **In `Physics_Attention_Irregular_Mesh.forward`**, accept `raw_xy` as parameter. After computing `q_norm` and `k_norm`, compute spatial bias before the attention logits:
```python
def forward(self, x, raw_xy=None, spatial_bias=None):
    # ... existing code up to q_norm, k_norm computation ...
    
    # Compute relative position bias between slice pairs
    if raw_xy is not None:
        # Mean position of each slice: weighted avg of node positions
        # slice_weights: [B, H, N, S], raw_xy: [B, N, 2]
        sw_avg = slice_weights.mean(dim=1)  # [B, N, S] — avg across heads
        slice_pos = torch.einsum("bns,bnd->bsd", sw_avg, raw_xy.float())  # [B, S, 2]
        slice_count = sw_avg.sum(dim=1).clamp(min=1e-5)  # [B, S]
        slice_pos = slice_pos / slice_count.unsqueeze(-1)  # normalize by count
        
        # Pairwise position differences: [B, S, S, 2]
        rel_pos = slice_pos.unsqueeze(2) - slice_pos.unsqueeze(1)
        pos_bias = self.rel_pos_proj(rel_pos).squeeze(-1)  # [B, S, S]
        
        # Add to attention logits (broadcast across heads)
        A = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale + pos_bias.unsqueeze(1)
    else:
        A = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
    
    A = F.softmax(A, dim=-1)
    # ... rest of forward unchanged ...
```

3. **In `TransolverBlock.forward`**, pass `raw_xy` to the attention module:
```python
# Where self.ln_fn is called:
out = self.ln_fn(fx, raw_xy=raw_xy, spatial_bias=sb)
# Make sure raw_xy is threaded through from the block's forward signature
```

4. **Run:**
```bash
python train.py --agent alphonse --wandb_name "alphonse/rel-pos-slice-attn" --wandb_group rel-pos-slice-attn
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run ID:** `zq7z7ouy`
**Epochs completed:** 61/100 (30-min timeout; run was still improving)
**Peak memory:** 10.6 GB

### Metrics vs Baseline

| Metric | Baseline | This run (ep 60 best) | Delta |
|--------|----------|-----------------------|-------|
| val/loss | 2.2217 | 2.4658 | +0.24 (worse) |
| val_in_dist/loss | — | 1.7832 | — |
| val_tandem_transfer/loss | — | 3.5411 | — |
| val_ood_cond/loss | — | 2.0731 | — |

### Surface MAE (val_in_dist, best checkpoint ep 60)

| Field | MAE | Baseline |
|-------|-----|----------|
| Ux | 0.313 | — |
| Uy | 0.207 | — |
| p | 25.70 | 21.18 |

### Volume MAE (val_in_dist, best checkpoint)

| Field | MAE |
|-------|-----|
| Ux | 1.318 |
| Uy | 0.491 |
| p | 28.58 |

### OOD surface pressure MAE (best checkpoint)

| Split | p MAE | Baseline |
|-------|-------|----------|
| val_ood_cond | 22.09 | 20.47 |
| val_ood_re | 32.44 | 30.95 |
| val_tandem_transfer | 46.08 | 41.23 |

### What happened

The relative position bias in slice attention did not improve over baseline. At epoch 60 (best checkpoint) val/loss was 2.4658 — about 11% worse than the 2.2217 baseline. Surface pressure MAE also regressed across all splits.

The likely issue is that the mean-position representation of slices is too coarse. A slice token is the weighted average of all nodes assigned to it, so its "center of mass" may span a large region of the domain — the relative position difference between two such aggregate tokens is not a precise spatial quantity. The bias signal may be noisy or misleading, and with zero initialization, the model may struggle to learn a useful signal within 60 epochs.

Additionally, the approach adds a non-trivial compute step (einsum for slice positions, pairwise differences, MLP) every attention call. With 27s per epoch, this matches baseline throughput, so overhead was not the bottleneck.

### Suggested follow-ups

- The mean-position approx is lossy — try using the spatial_bias (existing node→slice assignment) to bias slice attention indirectly rather than computing slice centroid positions explicitly.
- If spatial proximity matters, it may be more effective to bias the node-to-slice assignment (already done via spatial_bias) rather than the slice-to-slice attention (which operates on aggregate tokens).
- Try a simpler version: rather than pairwise relative positions, just concatenate each slice token's mean position (2D) directly to the key/query before attention.