### PR TITLE
Pressure-aware preprocess branch (dedicated pressure feature pathway)

### DIFF
--- a/train.py
+++ b/train.py
@@ -245,6 +245,17 @@ class Transolver(nn.Module):
         else:
             self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
 
+        # Pressure-aware branch: pos(2) + saf(2) + dsdf(8) + is_surface(1) + log_Re(1) = 14 features
+        self.pressure_preprocess = nn.Sequential(
+            nn.Linear(14, 64), nn.GELU(), nn.Linear(64, 32)
+        )
+        # Project combined 128+32=160 back to n_hidden; init to identity on main branch
+        self.combine_proj = nn.Linear(160, n_hidden)
+        with torch.no_grad():
+            self.combine_proj.weight.zero_()
+            self.combine_proj.weight[:n_hidden, :n_hidden].copy_(torch.eye(n_hidden))
+            self.combine_proj.bias.zero_()
+
         self.n_hidden = n_hidden
         self.space_dim = space_dim
         self.blocks = nn.ModuleList(
@@ -328,6 +339,8 @@ class Transolver(nn.Module):
 
         raw_xy = x[:, :, :2]
         fx = self.preprocess(x)
+        fp = self.pressure_preprocess(x[:, :, :14])
+        fx = self.combine_proj(torch.cat([fx, fp], dim=-1))
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 


### PR DESCRIPTION
## Hypothesis
The current preprocess MLP maps all 24 input features to a single 128-dim hidden state. But pressure prediction has fundamentally different input feature importance than velocity: pressure depends heavily on position relative to stagnation (saf), distance to surface (dsdf), and Reynolds number (log_Re), while velocity depends more on global position and angle of attack. A dedicated small pressure-feature pathway (14→64→32) concatenated with the main branch, then projected back to 128, ensures high-frequency spatial features critical for surface pressure don't get averaged away.

This is different from the failed "dual preprocess" (PR #776) which split the *same* features into two identical branches. Here we use *different* feature subsets for each branch.

## Instructions

1. **In `Transolver.__init__`**, add a pressure-specific preprocess and combiner:
```python
# Pressure pathway: pos(2) + saf(2) + dsdf(8) + is_surface(1) + log_Re(1) = 14 features
self.pressure_preprocess = nn.Sequential(
    nn.Linear(14, 64), nn.GELU(), nn.Linear(64, 32)
)
# Project combined 128+32=160 back to 128
self.combine_proj = nn.Linear(160, n_hidden)
# Initialize to pass through the main branch unchanged at start
with torch.no_grad():
    self.combine_proj.weight.zero_()
    self.combine_proj.weight[:128, :128].copy_(torch.eye(128))
    self.combine_proj.bias.zero_()
```

2. **In `Transolver.forward`**, after `fx = self.preprocess(x)` and before the Transolver blocks:
```python
# x[:,:,0:14] = [pos(2), saf(2), dsdf(8), is_surface(1), log_Re(1)]
fp = self.pressure_preprocess(x[:, :, :14])  # [B, N, 32]
fx = self.combine_proj(torch.cat([fx, fp], dim=-1))  # [B, N, 128]
# Continue with fx_pre = fx, etc.
```

3. No changes to loss, optimizer, or blocks.

4. **Run:**
```bash
python train.py --agent tanjiro --wandb_name "tanjiro/pressure-preprocess" --wandb_group pressure-preprocess-branch
```

**Note:** The identity init for combine_proj means training starts exactly at baseline and gradually learns to use the pressure branch. The tiny MLP (14→64→32 = ~3K params) adds negligible compute.

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**val/loss: 2.4472** — worse than baseline (2.2217) by ~10%.

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------|------------|------------|-----------|-----------|-----------|----------|
| val_in_dist | 1.7544 | 0.327 | 0.198 | 24.85 | 1.359 | 0.484 | 28.9 |
| val_tandem_transfer | 3.4411 | 0.670 | 0.358 | 43.69 | 2.169 | 1.012 | 45.4 |
| val_ood_cond | 2.1461 | 0.318 | 0.204 | 24.87 | 1.124 | 0.434 | 23.1 |
| val_ood_re | NaN* | 0.301 | 0.211 | 33.16 | 1.077 | 0.459 | 52.7 |

*val_ood_re NaN is a pre-existing branch bug  
**Peak memory:** 11.2 GB  
**W&B run ID:** p4gng3pg  
**Epochs:** 64 in 30.0 min (~28s/epoch — negligible compute overhead as predicted)

### What happened

The pressure-aware pathway hurt rather than helped, with surface pressure degrading across all splits (in_dist: 24.85 vs 21.18, ood_cond: 24.87 vs 20.47, tandem: 43.69 vs 41.23).

Most likely reasons:
1. **Redundant information:** The main 24-dim preprocess already sees all 14 pressure-relevant features. The secondary pathway doesn't add new information — it creates a duplicate signal that competes rather than complements.
2. **Cold-start problem from identity init:** The combine_proj starts projecting purely from the main branch (identity) with zero gradient signal for the pressure pathway in early epochs. As training progresses, the pressure branch gets a very weak gradient push that may interfere rather than synergize.
3. **Feature ordering assumption:** The implementation assumes x[:, :, :14] contains [pos(2), saf(2), dsdf(8), is_surface(1), log_Re(1)]. If this isn't the exact ordering in the data, the pathway is processing the wrong features entirely.

The compute overhead was negligible (~28s/epoch vs ~28s/epoch baseline, 11.2GB vs ~11GB memory), so the architectural complexity itself is the issue.

### Suggested follow-ups
- Try applying a dedicated pathway only to surface nodes (masking the pathway by is_surface flag) to force pressure specialization specifically where it matters
- Try a gated combination instead of concat+linear: learn a scalar gate per node that blends the main and pressure pathways