### PR TITLE
Error-conditioned training (hard example mining via loss-based reweighting)

### DIFF
--- a/train.py
+++ b/train.py
@@ -420,18 +420,44 @@ def _phys_denorm(y_p, Umag, q):
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
+
+class IndexedDataset(torch.utils.data.Dataset):
+    def __init__(self, dataset):
+        self.dataset = dataset
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        x, y, is_surf = self.dataset[idx]
+        return x, y, is_surf, idx
+
+
+def pad_collate_with_idx(batch):
+    xs = [b[0] for b in batch]
+    ys = [b[1] for b in batch]
+    surfs = [b[2] for b in batch]
+    idxs = torch.tensor([b[3] for b in batch])
+    x_pad, y_pad, surf_pad, mask = pad_collate(list(zip(xs, ys, surfs)))
+    return x_pad, y_pad, surf_pad, mask, idxs
+
+
+train_ds_indexed = IndexedDataset(train_ds)
+indexed_loader_kwargs = dict(collate_fn=pad_collate_with_idx, num_workers=4, pin_memory=True,
+                             persistent_workers=True, prefetch_factor=2)
+
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
-                              shuffle=True, **loader_kwargs)
+    train_loader = DataLoader(train_ds_indexed, batch_size=cfg.batch_size,
+                              shuffle=True, **indexed_loader_kwargs)
 else:
     sampler = WeightedRandomSampler(
         weights=sample_weights,
         num_samples=len(train_ds),
         replacement=True,
     )
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
-                              sampler=sampler, **loader_kwargs)
+    train_loader = DataLoader(train_ds_indexed, batch_size=cfg.batch_size,
+                              sampler=sampler, **indexed_loader_kwargs)
 
 val_loaders = {
     name: DataLoader(subset, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
@@ -564,6 +590,11 @@ train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 
+# Hard example mining: per-sample loss EMA tracker
+n_train = len(train_ds)
+sample_loss_ema = torch.zeros(n_train)
+loss_ema_decay = 0.9
+
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
     if elapsed_min >= MAX_TIMEOUT:
@@ -582,7 +613,7 @@ for epoch in range(MAX_EPOCHS):
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    for x, y, is_surface, mask, batch_idxs in pbar:
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -668,6 +699,13 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
 
+        # Update per-sample loss EMA for hard example mining
+        with torch.no_grad():
+            per_sample_loss = abs_err.mean(dim=(1, 2))  # [B]
+            for i, idx in enumerate(batch_idxs):
+                old = sample_loss_ema[idx]
+                sample_loss_ema[idx] = loss_ema_decay * old + (1 - loss_ema_decay) * per_sample_loss[i].cpu()
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
@@ -692,6 +730,14 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
+
+    # Update sampler weights based on per-sample loss EMA (hard example mining)
+    if epoch >= 5 and not cfg.debug:
+        loss_weights = sample_loss_ema.clone()
+        loss_weights = loss_weights / (loss_weights.mean() + 1e-8)  # normalize to mean=1
+        loss_weights = loss_weights.clamp(0.5, 3.0)  # cap at 3x upweight
+        new_weights = torch.tensor(sample_weights) * loss_weights.double()
+        sampler.weights = new_weights
 
     # --- Validate across all splits ---
     eval_model = ema_model if ema_model is not None else model


### PR DESCRIPTION
## Hypothesis
The current WeightedRandomSampler balances domains but treats all samples within a domain equally. Some samples are much harder (extreme AoA, complex wake interactions, high Re) and consistently get higher loss. By tracking per-sample running average loss and upweighting persistently hard samples (2x), the model focuses gradient budget on the cases that most need improvement. This is online hard example mining (OHEM) — proven in detection where easy/hard imbalance is similar.

## Instructions

1. **Before the training loop**, initialize a per-sample loss tracker:
```python
n_train = len(train_ds)
sample_loss_ema = torch.zeros(n_train)
loss_ema_decay = 0.9
```

2. **We need sample indices from the DataLoader.** Since `pad_collate` is read-only, wrap it. Before loader creation:
```python
class IndexedDataset(torch.utils.data.Dataset):
    def __init__(self, dataset):
        self.dataset = dataset
    def __len__(self):
        return len(self.dataset)
    def __getitem__(self, idx):
        x, y, is_surf = self.dataset[idx]
        return x, y, is_surf, idx

def pad_collate_with_idx(batch):
    xs = [b[0] for b in batch]
    ys = [b[1] for b in batch]
    surfs = [b[2] for b in batch]
    idxs = torch.tensor([b[3] for b in batch])
    x_pad, y_pad, surf_pad, mask = pad_collate(list(zip(xs, ys, surfs)))
    return x_pad, y_pad, surf_pad, mask, idxs

# Wrap train_ds and use the new collate
train_ds_indexed = IndexedDataset(train_ds)
train_loader = DataLoader(train_ds_indexed, batch_size=..., sampler=sampler,
                          collate_fn=pad_collate_with_idx, ...)
```

3. **In the training loop**, after computing per-sample loss (before reduction), update the EMA:
```python
# After computing loss for the batch, also compute per-sample loss for tracking
with torch.no_grad():
    per_sample_loss = abs_err.mean(dim=(1, 2))  # [B] — mean across nodes and channels
    for i, idx in enumerate(batch_idxs):
        old = sample_loss_ema[idx]
        sample_loss_ema[idx] = loss_ema_decay * old + (1 - loss_ema_decay) * per_sample_loss[i].cpu()
```

4. **After each epoch (starting from epoch 5)**, update sampler weights:
```python
if epoch >= 5:
    # Upweight hard samples: multiply base weights by (1 + normalized_loss)
    loss_weights = sample_loss_ema.clone()
    loss_weights = loss_weights / (loss_weights.mean() + 1e-8)  # normalize to mean=1
    loss_weights = loss_weights.clamp(0.5, 3.0)  # cap at 3x upweight
    new_weights = torch.tensor(sample_weights) * loss_weights.double()
    sampler.weights = new_weights
```

5. **Run:**
```bash
python train.py --agent gilbert --wandb_name "gilbert/hard-example-mining" --wandb_group hard-example-mining
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** beohqfml
**Best epoch:** 68 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6559 | 0.311 | 0.186 | 22.4 | 1.364 | 0.486 | 28.2 |
| val_tandem_transfer | 3.2951 | 0.638 | 0.346 | 43.1 | 2.141 | 1.002 | 45.5 |
| val_ood_cond | 2.0497 | 0.283 | 0.205 | 23.4 | 1.116 | 0.444 | 22.0 |
| val_ood_re | NaN | 0.285 | 0.205 | 32.0 | 1.089 | 0.463 | 52.1 |
| **combined val/loss** | **2.3336** | | | | | | |

**Baseline val/loss: 2.2217 → This run: 2.3336 (+0.112, worse)**

Comparison vs baseline mae_surf_p: in_dist 22.4 vs 21.18 (+1.2), ood_cond 23.4 vs 20.47 (+2.9), tandem 43.1 vs 41.23 (+1.9), ood_re 32.0 vs 30.95 (+1.1). Regression across all splits.

### What happened

Hard example mining hurt performance, regressing from the baseline across all splits. The largest regression is on val_ood_cond (+0.15 loss, +2.9 surface p).

Two likely causes:

1. **Distribution shift disrupts existing curriculum.** The baseline already has a carefully tuned `WeightedRandomSampler` with domain-level weights. Dynamically upweighting per-sample hard examples (up to 3×) fights against this — hard samples are often OOD cases (extreme AoA, high Re) that the model needs to generalize on, not overfit to.

2. **IndexedDataset adds overhead and changes epoch behavior.** The EMA starts at zero for all samples, so early epochs (1-5) assign equal weights before any signal builds up. After epoch 5 the weights update, but with 0.9 decay the EMA is slow — at epoch 5, effective weight comes from only ~40% of samples seen. The clamp range (0.5–3.0) is wide enough to strongly perturb the distribution.

3. **abs_err is computed in the normalized space**, which may not properly reflect which samples are "hard" in physical terms. Samples with high normalization (large Umag) will systematically appear easy in normalized space even if they're physically challenging.

The OHEM idea is sound in detection (where easy/hard imbalance is extreme) but in this regression task the existing sampler already handles domain imbalance, and further per-sample reweighting adds noise rather than signal.

### Suggested follow-ups

- **Gentler upweighting**: cap at 1.5× instead of 3×, and require more EMA warmup (start at epoch 20) before activating.
- **Surface-only OHEM**: use `surf_per_sample` loss (already computed) instead of full `abs_err.mean()` — this focuses mining on what matters (surface accuracy) rather than being dominated by volume nodes.
- **Separate surface/volume mining**: upweight based on surface loss to improve surface p, since volume nodes vastly outnumber surface nodes and may dilute the signal.