### PR TITLE
Symmetric pressure normalization (center on stagnation pressure)

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,6 +24,7 @@ import os
 import time
 from collections.abc import Mapping
 from pathlib import Path
+from pathlib import Path
 
 import torch
 import torch.nn as nn
@@ -400,21 +401,40 @@ def _umag_q(y, mask):
     return Umag, q
 
 
-def _phys_norm(y, Umag, q):
-    """Normalize Ux→Ux/Umag, Uy→Uy/Umag, p→p/q (Cp)."""
+def _phys_norm(y, Umag, q, mask=None, is_surface=None):
+    """Normalize Ux→Ux/Umag, Uy→Uy/Umag, p→(p-p_stag)/q (delta-Cp).
+
+    Centers pressure on per-sample stagnation pressure (max surface p), making
+    the distribution zero-mean and symmetric: stagnation=0, suction=negative.
+    Returns (y_p, p_stag) so the caller can reverse the centering.
+    """
     y_p = y.clone()
     y_p[:, :, 0:1] = y[:, :, 0:1] / Umag
     y_p[:, :, 1:2] = y[:, :, 1:2] / Umag
-    y_p[:, :, 2:3] = y[:, :, 2:3] / q
-    return y_p
+    B = y.shape[0]
+    p_stag = torch.zeros(B, 1, 1, device=y.device)
+    for b in range(B):
+        if mask is not None and is_surface is not None:
+            valid_surf = mask[b] & is_surface[b]
+            if valid_surf.sum() > 0:
+                p_stag[b, 0, 0] = y[b, valid_surf, 2].max()
+            elif mask is not None and mask[b].sum() > 0:
+                p_stag[b, 0, 0] = y[b, mask[b], 2].max()
+        else:
+            p_stag[b, 0, 0] = y[b, :, 2].max()
+    y_p[:, :, 2:3] = (y[:, :, 2:3] - p_stag) / q
+    return y_p, p_stag
 
 
-def _phys_denorm(y_p, Umag, q):
-    """Reverse physics normalization: Ux/Umag→Ux, Uy/Umag→Uy, Cp→p."""
+def _phys_denorm(y_p, Umag, q, p_stag=None):
+    """Reverse physics normalization: Ux/Umag→Ux, Uy/Umag→Uy, delta-Cp→p."""
     y = y_p.clone()
     y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-50, 50) * Umag
     y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-50, 50) * Umag
-    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-100, 100) * q
+    if p_stag is not None:
+        y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-100, 100) * q + p_stag
+    else:
+        y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-100, 100) * q
     return y
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
@@ -448,8 +468,9 @@ _stats_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=False, *
 with torch.no_grad():
     for _x, _y, _is_surf, _mask in tqdm(_stats_loader, desc="Phys stats", leave=False):
         _y, _mask = _y.to(device), _mask.to(device)
+        _is_surf = _is_surf.to(device)
         _Um, _q = _umag_q(_y, _mask)
-        _yp = _phys_norm(_y, _Um, _q)
+        _yp, _ = _phys_norm(_y, _Um, _q, mask=_mask, is_surface=_is_surf)
         _m = _mask.float().unsqueeze(-1)  # [B, N, 1]
         _phys_sum += (_yp * _m).sum(dim=(0, 1))
         _phys_sq_sum += (_yp ** 2 * _m).sum(dim=(0, 1))
@@ -589,7 +610,7 @@ for epoch in range(MAX_EPOCHS):
 
         x = (x - stats["x_mean"]) / stats["x_std"]
         Umag, q = _umag_q(y, mask)
-        y_phys = _phys_norm(y, Umag, q)
+        y_phys, _ = _phys_norm(y, Umag, q, mask=mask, is_surface=is_surface)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
             noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
@@ -719,7 +740,7 @@ for epoch in range(MAX_EPOCHS):
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 Umag, q = _umag_q(y, mask)
-                y_phys = _phys_norm(y, Umag, q)
+                y_phys, p_stag = _phys_norm(y, Umag, q, mask=mask, is_surface=is_surface)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 # Per-sample std normalization: skip tandem samples
@@ -750,9 +771,9 @@ for epoch in range(MAX_EPOCHS):
                 val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
-                # Denormalize: phys_stats → Cp space → original scale
+                # Denormalize: phys_stats → delta-Cp space → original scale
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
-                pred_orig = _phys_denorm(pred_phys, Umag, q)
+                pred_orig = _phys_denorm(pred_phys, Umag, q, p_stag=p_stag)
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()
                 finite = err.isfinite()


### PR DESCRIPTION
## Hypothesis
The current physics normalization computes Cp = p/q, which produces an asymmetric distribution: ~+1 at stagnation and large negative values at suction peaks. This asymmetry means the model must learn an offset and handle very different magnitudes for positive vs negative regions. By centering on stagnation pressure — (p - p_stag)/q — the distribution becomes zero-mean and more symmetric: stagnation=0, suction=negative. This "delta Cp" representation is closer to what aerodynamicists actually analyze and is better suited to L1 loss (equal gradient for positive/negative errors).

Different from IQR normalization (#820) which addresses outliers — this addresses the fundamental asymmetry of the pressure distribution.

## Instructions

1. **Find the `_phys_norm` function** in `train.py`. Modify it to center pressure on the per-sample stagnation (max surface) pressure:
```python
def _phys_norm(y, Umag, q, mask=None, is_surface=None):
    y_p = y.clone()
    y_p[:, :, 0:1] = y[:, :, 0:1] / Umag  # Ux/Umag
    y_p[:, :, 1:2] = y[:, :, 1:2] / Umag  # Uy/Umag
    
    # Center pressure on stagnation (max surface pressure)
    B = y.shape[0]
    p_stag = torch.zeros(B, 1, 1, device=y.device)
    for b in range(B):
        if mask is not None and is_surface is not None:
            valid_surf = mask[b] & is_surface[b]
            if valid_surf.sum() > 0:
                p_stag[b, 0, 0] = y[b, valid_surf, 2].max()
            elif mask is not None and mask[b].sum() > 0:
                p_stag[b, 0, 0] = y[b, mask[b], 2].max()
        else:
            p_stag[b, 0, 0] = y[b, :, 2].max()
    
    y_p[:, :, 2:3] = (y[:, :, 2:3] - p_stag) / q
    return y_p, p_stag  # return p_stag for denorm
```

2. **Update `_phys_denorm`** to reverse the centering:
```python
def _phys_denorm(y_p, Umag, q, p_stag=None):
    y = y_p.clone()
    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-50, 50) * Umag
    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-50, 50) * Umag
    if p_stag is not None:
        y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-100, 100) * q + p_stag
    else:
        y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-100, 100) * q
    return y
```

3. **Update all call sites** of `_phys_norm` and `_phys_denorm` to pass `mask`, `is_surface`, and thread `p_stag` through. In the training loop:
```python
y_norm, p_stag = _phys_norm(y, Umag, q, mask=mask, is_surface=is_surf)
# ... after prediction ...
pred_denorm = _phys_denorm(pred, Umag, q, p_stag=p_stag)
```

4. **Recompute `phys_stats`** (y_mean, y_std) at the start — these will change because the centered pressure distribution has different statistics. The existing stats computation should handle this automatically if `_phys_norm` is called during the stats pass.

5. **Run:**
```bash
python train.py --agent nezuko --wandb_name "nezuko/symmetric-pressure-norm" --wandb_group symmetric-pressure-norm
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `tl2265oq` — https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/tl2265oq  
**Epochs completed:** 68 (hit 30-min timeout; best checkpoint at epoch 63)  
**Peak VRAM:** 10.6 GB

### val/loss
| Split | Sym-norm (best ep63) | Baseline (ep64) | Target |
|---|---|---|---|
| val_in_dist | 2.0603 | 1.8349 | — |
| val_ood_cond | 2.1801 | 2.0291 | — |
| val_tandem_transfer | 3.5932 | 3.4724 | — |
| val_ood_re | NaN | NaN | — |
| **combined val/loss** | **2.6112** | **2.4455** | **2.2217** |

### Surface MAE (last epoch, ~ep64)
| Split | surf_p (sym-norm) | surf_p (baseline) | surf_p (target) |
|---|---|---|---|
| in_dist | **37.15** | 24.95 | 21.18 |
| ood_cond | **25.26** | 22.54 | 20.47 |
| ood_re | **30.07** | 33.11 | 30.95 |
| tandem | **48.73** | 44.54 | 41.23 |

### Volume MAE (pressure)
| Split | vol_p |
|---|---|
| in_dist | 39.12 |
| ood_cond | 22.78 |
| ood_re | 49.28 |
| tandem | 49.52 |

---

### What happened

**Negative result.** Symmetric pressure normalization makes things significantly worse overall at epoch 64:
- Combined val/loss: 2.6112 vs 2.4455 baseline (+7%)
- in_dist surf_p: 37.15 vs 24.95 baseline (+49%) — badly regressed
- ood_cond surf_p: 25.26 vs 22.54 (+12%) — worse
- tandem surf_p: 48.73 vs 44.54 (+9%) — worse

The one bright spot: ood_re surf_p improved (30.07 vs 33.11, -9%), consistent with the intuition that a more symmetric distribution helps OOD generalization on pressure magnitude.

**Why it likely failed:** The per-sample p_stag introduces per-sample non-stationarity into the normalized target. Unlike Ux/Umag and Uy/Umag where Umag tracks the input conditions, p_stag is a function of the output distribution itself. This creates a target that varies in a way the model's input features cannot directly encode, making it harder to learn. The phys_stats mean for pressure shifted from -0.289 to -1.700 (Cp), and std changed from 1.101 to 1.133 — substantially different distribution that the model hasn't adapted to within 64 epochs.

Also: both runs are still far from the target (2.2217) and not converged. The in_dist regression is large enough to be concerning even accounting for training noise.

### Suggested follow-ups
- Try a simpler centering: subtract a fixed global stagnation reference (computed once from training stats) rather than per-sample p_stag. This would avoid the non-stationarity issue.
- If per-sample centering is desired, consider encoding p_stag as a model input feature so the model can condition on it explicitly.
- The ood_re surf_p improvement (30.07 vs 33.11) is interesting — might be worth revisiting this normalization specifically for the high-Re regime.