### PR TITLE
Enriched spatial bias with dsdf+saf features (6D instead of 2D)

### DIFF
--- a/train.py
+++ b/train.py
@@ -174,7 +174,7 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
-        self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
+        self.spatial_bias = nn.Sequential(nn.Linear(6, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -189,8 +189,15 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None):
-        sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+    def forward(self, fx, raw_xy=None, raw_x_extra=None):
+        if raw_xy is not None:
+            if raw_x_extra is not None:
+                sb_input = torch.cat([raw_xy, raw_x_extra], dim=-1)  # [B, N, 6]
+            else:
+                sb_input = F.pad(raw_xy, (0, 4))  # zero-pad to 6D for safety
+            sb = self.spatial_bias(sb_input)
+        else:
+            sb = None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
@@ -327,17 +334,18 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         raw_xy = x[:, :, :2]
+        raw_x_extra = x[:, :, 2:6]  # saf(2) + dsdf first 2
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy)
+            fx = block(fx, raw_xy=raw_xy, raw_x_extra=raw_x_extra)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, raw_x_extra=raw_x_extra)
         fx = fx + self.out_skip(fx_pre)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}


### PR DESCRIPTION
## Hypothesis
The current spatial bias MLP uses only (x, y) coordinates to bias slice assignment. But two nodes at the same (x, y) can be very different: a surface node on the airfoil vs a wake node behind it. The dsdf (distance-to-surface descriptor) and saf (signed arc-length) features encode rich geometric information about a node's relationship to the airfoil surface. Adding the first 2 dsdf features and 2 saf features to the spatial bias input (6D total) gives slice assignment awareness of boundary layer structure — surface nodes naturally cluster into surface-specific slices.

This is a minimal change: Linear(2, 32) → Linear(6, 32), adding only 128 parameters.

## Instructions

1. **In `TransolverBlock.__init__`**, update the spatial_bias input dimension:
```python
# CHANGE FROM:
self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))

# CHANGE TO:
self.spatial_bias = nn.Sequential(nn.Linear(6, 32), nn.GELU(), nn.Linear(32, slice_num))
```

2. **In `TransolverBlock.forward`**, update the spatial bias computation. You need to accept and use the extra features. Change the forward signature to accept `raw_x_extra`:
```python
def forward(self, fx, raw_xy=None, raw_x_extra=None):
    # ... existing code ...
    if raw_xy is not None:
        if raw_x_extra is not None:
            sb_input = torch.cat([raw_xy, raw_x_extra], dim=-1)  # [B, N, 6]
        else:
            sb_input = F.pad(raw_xy, (0, 4))  # zero-pad to 6D for safety
        sb = self.spatial_bias(sb_input)
    else:
        sb = None
    # ... rest unchanged, pass sb to ln_fn ...
```

3. **In `Transolver.forward`**, extract the extra features and pass them through:
```python
raw_xy = x[:, :, :2]       # pos (x, y)
raw_x_extra = x[:, :, 2:6] # saf(2) + dsdf first 2

# Pass to all blocks:
for block in self.blocks[:-1]:
    fx = block(fx, raw_xy=raw_xy, raw_x_extra=raw_x_extra)
fx = self.blocks[-1](fx, raw_xy=raw_xy, raw_x_extra=raw_x_extra)
```

4. **Run:**
```bash
python train.py --agent thorfinn --wandb_name "thorfinn/dsdf-spatial-bias" --wandb_group dsdf-spatial-bias
```

**Note:** The saf and dsdf features are already normalized in the input. This is the lowest-risk change in this round — just 128 extra parameters and no new modules.

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `q5l3wy5p` | **Epoch:** 67/100 (30 min wall-clock limit) | **Peak memory:** 10.6 GB

### Val loss (combined)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss (combined) | 2.2217 | **2.2610** | +1.8% ❌ |

### Surface MAE (most important)

| Split | Metric | Baseline | This run | Δ |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 21.18 | 21.28 | +0.5% |
| val_in_dist | mae_surf_Ux | — | 0.315 | — |
| val_in_dist | mae_surf_Uy | — | 0.179 | — |
| val_ood_cond | mae_surf_p | 20.47 | 20.93 | +2.2% ❌ |
| val_ood_re | mae_surf_p | 30.95 | 30.62 | -1.1% ✓ |
| val_tandem_transfer | mae_surf_p | 41.23 | 42.18 | +2.3% ❌ |

### Volume MAE

| Split | Metric | This run |
|---|---|---|
| val_in_dist | mae_vol_p | 25.83 |
| val_ood_cond | mae_vol_p | 19.95 |
| val_tandem_transfer | mae_vol_p | 44.64 |

*Note: val_ood_re/vol_loss = 1.89e10 (nan in combined loss) — pre-existing bug on this branch, not caused by this change.*

---

### What happened

The hypothesis didn't work. Enriching the spatial bias from 2D (x,y) to 6D (x,y + saf[2] + dsdf[2]) makes results slightly worse on 3 of 4 splits, with only a marginal gain on val_ood_re (which has a known NaN issue in its combined loss anyway). The combined val/loss went from 2.2217 → 2.2610 (+1.8%).

The extra 128 parameters add geometric context (boundary layer distance, arc-length position) to slice assignment, but this appears to hurt rather than help. A few possible explanations:

1. **saf/dsdf features are already used by the main network** via the full 24-dim input. Adding them redundantly to the spatial bias MLP may confuse the slice assignment without adding new signal.
2. **The spatial bias is already well-specified by (x,y)** for this geometry — nodes at distinct spatial positions are already separable in 2D.
3. **Training instability**: The additional features may shift the slice-assignment distribution during early training, making it harder to recover a good assignment.

### Suggested follow-ups

- **Zero-init the extra 4 input weights**: Initialize the new columns (for saf/dsdf) to zero so the model starts at the 2D baseline and can learn whether the extra features help. This is a safer probe.
- **dsdf-only (3D bias)**: Use only the closest surface distance (1D dsdf) appended to (x,y) — skip saf, which is less directly informative about boundary layers.
- **Block-selective bias**: Only apply the enriched 6D bias to the first TransolverBlock (where initial slice assignment happens), leaving later blocks with standard 2D bias.