### PR TITLE
Volume-node subsampling curriculum (2x throughput in early epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -625,11 +625,16 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
-        # Volume-node subsampling curriculum: randomly drop 50% of volume nodes in loss
-        # for epochs 0-29, giving ~2x throughput in early training; full mesh from epoch 30
-        if epoch < 30:
-            vol_drop = torch.rand_like(vol_mask.float()) < 0.5
-            vol_mask_train = vol_mask & ~vol_drop
+        # Progressive resolution: faster ramp 5%→100% over 25 epochs, full mesh from epoch 25
+        if epoch < 25:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / 25)
+            vol_indices = vol_mask.nonzero(as_tuple=False)
+            n_vol = vol_indices.shape[0]
+            n_keep = max(int(n_vol * vol_keep_ratio), 1)
+            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
+            vol_mask_train = torch.zeros_like(vol_mask)
+            if n_keep > 0:
+                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
         else:
             vol_mask_train = vol_mask
 


### PR DESCRIPTION
## Hypothesis
Our 30-minute training cap is the binding constraint — most experiments get only ~65 epochs. In early epochs, the model is learning global flow structure and doesn't need full-resolution meshes (85K-200K nodes). By randomly subsampling 50% of **volume nodes** (keeping ALL surface nodes) during epochs 1-30, we nearly double effective throughput: each epoch processes roughly half the data, so we fit ~130 effective epochs instead of 65. Switch to full mesh at epoch 31 for fine-grained convergence.

This is a form of curriculum learning on resolution — common in image super-resolution (train on patches, finetune on full images) but not yet tried here.

## Instructions

1. **In the training loop**, before the forward pass, subsample volume nodes during early epochs:
```python
# At the start of each batch, after unpacking (x, y, is_surf, mask)
if epoch < 30:
    # Keep all surface nodes, randomly subsample 50% of volume nodes
    B, N, _ = x.shape
    for b in range(B):
        valid = mask[b]  # [N] bool
        vol_mask = valid & ~is_surf[b]  # volume nodes
        vol_idx = vol_mask.nonzero(as_tuple=True)[0]
        n_keep = vol_idx.shape[0] // 2
        perm = torch.randperm(vol_idx.shape[0], device=x.device)[:n_keep]
        drop_idx = vol_idx[perm[n_keep:]] if n_keep < vol_idx.shape[0] else torch.tensor([], dtype=torch.long, device=x.device)
        
        # Zero out dropped nodes in mask (they won't contribute to loss)
        # Actually simpler: just set mask to False for dropped volume nodes
        drop_mask = torch.zeros(N, dtype=torch.bool, device=x.device)
        keep_perm = perm[:n_keep]
        # Keep surface + randomly selected 50% of volume
        new_vol_idx = vol_idx[keep_perm]
        vol_mask_new = torch.zeros(N, dtype=torch.bool, device=x.device)
        vol_mask_new[new_vol_idx] = True
        mask[b] = is_surf[b] | vol_mask_new  # surface + 50% volume
```

2. **Alternative simpler approach** (if the above is too fiddly): Just use a smaller batch size for the first 30 epochs — set `batch_size=4` for epochs 1-30 (instead of the default) to process more batches per epoch:
```python
# Before creating loaders, decide on curriculum:
early_bs = min(batch_size * 2, 8)  # larger batch = fewer steps but not what we want
# Actually: just reduce n_nodes by random masking in the loss computation
# After computing abs_err, before reduction:
if epoch < 30:
    # Random volume-node dropout in loss
    vol_mask_loss = (~is_surf_expanded) & (torch.rand_like(mask.float()) > 0.5).bool()
    effective_mask = mask & (~vol_mask_loss)  # keeps surface, drops 50% vol in loss
    abs_err = abs_err * effective_mask.unsqueeze(-1)
```

3. The cleanest approach: **apply the subsampling in the loss only** (not the forward pass). The model still sees all nodes in attention, but loss gradients only come from surface + 50% of volume nodes. This is fastest to implement:
```python
# In the training loss computation, after abs_err = (pred - y_norm).abs():
if epoch < 30:
    vol_drop = (~is_surf_batch) & (torch.rand(B, N, device=device) < 0.5)
    loss_mask = mask_batch & ~vol_drop  # surface always kept
else:
    loss_mask = mask_batch
# Use loss_mask instead of mask_batch for vol_loss computation
```

4. **Run:**
```bash
python train.py --agent norman --wandb_name "norman/volume-subsample-curriculum" --wandb_group volume-subsample-curriculum
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

### Run 1 (flat 50% dropout, epochs 0-29)

**W&B run:** g5sqlkj2  
**Epochs:** 67 | **Peak memory:** 10.5 GB  

| Split | val/loss | mae_surf_p |
|---|---|---|
| val_in_dist | 1.6266 | 21.99 |
| val_ood_cond | 1.8334 | **19.83** |
| val_tandem_transfer | 3.2956 | 42.08 |
| val_ood_re | nan | 30.96 |
| **combined** | **2.2519** | |

val/loss 2.2217 → 2.2519 (+1.4%)

### Run 2 (aggressive ramp 5%→100% over 25 epochs, full mesh from epoch 25)

After advisor review, revised to use the original-style progressive ramp but compressed to 25 epochs:
```python
if epoch < 25:
    vol_keep_ratio = 0.05 + 0.95 * (epoch / 25)  # faster ramp
```

**W&B run:** vnwxqtib  
**Epochs:** 67 | **Peak memory:** 10.5 GB  

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6252 | 0.3011 | 0.1785 | 21.90 | 1.2935 | 0.4698 | 27.05 |
| val_ood_cond | 1.8657 | 0.2737 | 0.1935 | 20.58 | 1.0325 | 0.4022 | 19.82 |
| val_tandem_transfer | 3.2291 | 0.6277 | 0.3386 | 41.25 | 2.1209 | 0.9826 | 43.55 |
| val_ood_re | nan | 0.2725 | 0.2000 | 30.85 | 1.0360 | 0.4374 | 51.04 |
| **combined val/loss** | **2.2400** | | | | | | |

Baseline val/loss 2.2217 → **2.2400: slightly worse by +0.018 (+0.8%)**

Surface pressure vs baseline:
- in_dist: 21.90 vs 21.18 → +0.72 worse
- ood_cond: 20.58 vs 20.47 → +0.11 worse
- ood_re: **30.85 vs 30.95 → -0.10 better** (tiny)
- tandem: 41.25 vs 41.23 → ~same

### What happened

Run 2 is much better than Run 1 (2.2400 vs 2.2519) — the aggressive early sparsity with the progressive ramp clearly helps vs flat 50% dropout. But it's still 0.8% above baseline.

The compressed ramp (25 vs 40 epochs) gives 42 full-mesh epochs instead of ~27, and the network converges better in those later epochs. However, it's trading some early training quality (the original 40-epoch ramp was better calibrated) for more late-stage full-mesh epochs. The net effect is essentially neutral to slightly negative.

The core finding: the 10%→100% progressive ramp baseline is well-tuned. Compressing it slightly (40→25 epochs) gives slightly fewer early training benefits and the additional full-mesh epochs don't quite compensate.

### Suggested follow-ups

- **Try epoch=20 ramp boundary**: If 25 is still slightly worse and 40 is the baseline, try 20 to find the sweet spot where we balance early sparsity vs full-mesh epochs.
- **Combine with surface-only early epochs**: For the first 10 epochs, skip volume entirely (ratio=0) to maximize surface learning before introducing volume complexity.