### PR TITLE
Re-dependent output modulation (learned per-channel Reynolds scaling)

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,14 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        # Re-dependent output modulation: log_Re -> 3 per-channel scaling factors
+        self.re_output_mod = nn.Sequential(
+            nn.Linear(1, 16), nn.GELU(), nn.Linear(16, 3)
+        )
+        # Initialize output layer to zeros — scale starts as 1.0 (identity)
+        with torch.no_grad():
+            self.re_output_mod[-1].weight.zero_()
+            self.re_output_mod[-1].bias.zero_()
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -339,6 +347,10 @@ class Transolver(nn.Module):
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)
+        # Re-dependent output modulation
+        log_re = x[:, 0:1, 13:14]  # [B, 1, 1] — same for all nodes in a sample
+        re_scale = 1.0 + 0.1 * self.re_output_mod(log_re)  # [B, 1, 3] — centered at 1.0
+        fx = fx * re_scale  # [B, N, 3] * [B, 1, 3] broadcasts
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}
 


### PR DESCRIPTION
## Hypothesis
The ood_re split (Re=4.445M, trained on Re≤1.475M) is our worst split (surf_p=30.95). The physics normalization (Cp, u/Umag) removes the leading-order Re dependence but NOT higher-order effects: boundary layer thickness (~Re^{-1/2}), turbulence intensity, separation behavior, and suction peak magnitude all vary with Re. A small learned MLP (log_Re → 3 per-channel scaling factors) lets the model extrapolate these Re-dependent effects to unseen Reynolds numbers.

This extends the already-merged auxiliary Re prediction (#780) — instead of just regularizing hidden states to encode Re, we use Re to explicitly modulate the output. Zero-init ensures the model starts identical to baseline.

## Instructions

1. **In `Transolver.__init__`**, add a Re-dependent output modulation MLP:
```python
# Re-dependent output modulation: log_Re -> 3 channel scaling factors
self.re_output_mod = nn.Sequential(
    nn.Linear(1, 16), nn.GELU(), nn.Linear(16, 3)
)
# Initialize output layer to zeros — so output is always [0, 0, 0]
# We'll use sigmoid and add 0.5 to get scaling centered at 1.0
with torch.no_grad():
    self.re_output_mod[-1].weight.zero_()
    self.re_output_mod[-1].bias.zero_()
```

2. **In `Transolver.forward`**, after the output MLP produces the final prediction but before returning:
```python
# x[:, :, 13] is log_Re (feature index 13 in the 24-dim input)
log_re = x[:, 0:1, 13:14]  # [B, 1, 1] — same for all nodes in a sample
re_scale = 1.0 + 0.1 * self.re_output_mod(log_re)  # [B, 1, 3] — centered at 1.0
# Apply per-channel scaling to the final output (before denormalization)
fx = fx * re_scale  # [B, N, 3] * [B, 1, 3] broadcasts
```

The `1.0 + 0.1 * ...` formulation means:
- At initialization, scale = 1.0 (identity, no change from baseline)
- The 0.1 multiplier limits the initial scaling range
- The model can learn to adjust per-channel by ±10-20% based on Re

3. **Run:**
```bash
python train.py --agent kohaku --wandb_name "kohaku/re-output-mod" --wandb_group re-output-modulation
```

If ood_re improves but other splits regress, try reducing the multiplier from 0.1 to 0.05.

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `bc6tgzix`
**Epochs completed:** 64/100 (timed out at 30 min)

### Metrics at best epoch (epoch 64)
| Split | val/loss |
|---|---|
| val_in_dist | 1.7968 |
| val_tandem_transfer | 3.4188 |
| val_ood_cond | 2.0508 |
| val_ood_re | NaN (pre-existing) |
| **Overall val/loss** | **2.4221** |

**Baseline val/loss:** 2.2217

### Surface pressure MAE
| Split | surf_p (ours) | surf_p (baseline) |
|---|---|---|
| val_in_dist | 24.90 | 21.18 |
| val_ood_cond | 22.58 | 20.47 |
| val_ood_re | 32.18 | 30.95 |
| val_tandem_transfer | 45.23 | 41.23 |

**Peak memory:** 10.6 GB

### What happened

**Negative result at 64/100 epochs.** val/loss 2.4221 is worse than baseline 2.2217. The Re modulation didn't improve ood_re — val_ood_re/mae_surf_p is 32.18 vs 30.95 baseline, slightly worse.

Key observations:

1. **val_ood_re/loss is still NaN.** The pre-existing NaN on the ood_re surf_loss means we can only evaluate ood_re through the individual MAE metrics, not through the val/loss. The modulation is active during inference (the output scaling uses the sample's log_Re), but the overall loss signal from ood_re is absent during training.

2. **Zero-init works as intended.** The model starts identical to baseline (scale=1.0), and the modulation is learned from data. But the training data only covers Re≤1.475M, so the MLP may not generalize well to Re=4.445M even if it fits the training set.

3. **surf_weight stuck at 5.** Adaptive weighting keeps surface at minimum weight, likely limiting how much the Re modulation signal drives surface accuracy improvements.

4. **Still converging at epoch 64.** The val/loss trajectory was: 2.56 → 2.51 → 2.46 → 2.47 → 2.42 in the last 5 epochs. The model hadn't fully converged. However, the gap to baseline (0.2+) seems too large to recover with 36 more epochs.

### Suggested follow-ups

- **Address the val_ood_re NaN first.** The ood_re surf_loss is always NaN, meaning the model never receives gradient signal from ood_re surface predictions. Fixing this (see exp-noam/fix-ood-re-overflow branches) might be a prerequisite for the Re modulation to work.
- **Train ood_re explicitly.** Include ood_re in the training set with up-weighting, so the MLP can actually learn Re=4.445M behavior.
- **Use Re in preprocessing.** Add Re as input to the preprocess MLP rather than just the output head — this gives the model Re-dependent feature extraction, not just output rescaling.