### PR TITLE
Higher surface weight floor (15 instead of 5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -573,7 +573,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    surf_weight = max(10.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
Multiple experiments report that the adaptive surface weight gets stuck at its minimum floor of 5 throughout training. This means the model allocates only 5/(1+5) ≈ 83% of its loss gradient budget to volume nodes and 17% to surface nodes. But surface nodes are <5% of all nodes and are the most important for our key metric. Raising the floor from 5 to 15 means surface gets 15/(1+15) ≈ 94% of the gradient budget — a much more aggressive focus on what matters.

This is the simplest possible change: one number. If the floor was always the binding constraint, changing it directly tests whether more surface emphasis helps.

## Instructions

1. **Find the adaptive surface weight computation** in `train.py`. Look for where `surf_weight` is computed or clamped. There should be a minimum/floor value — likely `surf_weight = max(5, ...)` or `surf_weight.clamp(min=5)` or similar.

2. **Change the floor from 5 to 15:**
```python
# CHANGE FROM:
surf_weight = max(5, computed_weight)  # or equivalent clamp

# CHANGE TO:
surf_weight = max(15, computed_weight)  # higher floor for more surface emphasis
```

3. **Also try a second run with floor=10** to bracket the optimal range:
```bash
python train.py --agent askeladd --wandb_name "askeladd/surf-weight-floor-15" --wandb_group higher-surf-weight-floor
python train.py --agent askeladd --wandb_name "askeladd/surf-weight-floor-10" --wandb_group higher-surf-weight-floor
```

4. **Watch for**: If val_in_dist volume MAE increases significantly while surface MAE decreases, it means we're trading volume for surface accuracy. That's acceptable if surface pressure improves — our key metric is surface, not volume.

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

### Run 1: floor=15
**W&B run:** `lp7bju8g` | `surf_weight = max(15.0, ...)`
**Epochs:** 64 (wall-clock limit, no EMA — EMA starts at ep65) | **Peak memory:** 10.6 GB

### Run 2: floor=10
**W&B run:** `d26ti2jv` | `surf_weight = max(10.0, ...)`
**Epochs:** 64 (wall-clock limit, no EMA) | **Peak memory:** 10.5 GB

### Metrics at best checkpoint

| Split | Baseline | floor=15 | floor=10 |
|---|---|---|---|
| **val/loss** | **2.2217** | 2.4515 | 2.4355 |
| val_in_dist/loss | — | 1.7758 | 1.7216 |
| val_ood_cond/loss | — | 2.0836 | 2.0949 |
| val_tandem_transfer/loss | — | 3.4951 | 3.4901 |

### Surface pressure MAE (most important metric)

| Split | Baseline | floor=15 | floor=10 |
|---|---|---|---|
| val_in_dist | **21.18** | 23.33 | 24.51 |
| val_ood_cond | **20.47** | 23.87 | 23.01 |
| val_ood_re | **30.95** | 33.66 | 32.98 |
| val_tandem_transfer | **41.23** | 44.09 | 44.52 |

### Full surface MAE

| Split | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|
| **floor=15** | | | | | | |
| val_in_dist | 0.322 | 0.197 | 23.33 | 1.57 | 0.60 | 33.85 |
| val_ood_cond | 0.277 | 0.200 | 23.87 | — | — | 25.94 |
| val_tandem_transfer | 0.680 | 0.358 | 44.09 | — | — | 50.33 |
| **floor=10** | | | | | | |
| val_in_dist | 0.300 | 0.200 | 24.51 | 1.51 | 0.58 | 32.72 |
| val_ood_cond | 0.287 | 0.204 | 23.01 | — | — | 24.12 |
| val_tandem_transfer | 0.659 | 0.357 | 44.52 | — | — | 49.03 |

*Note: Baseline includes EMA averaging (epoch 65+); these runs hit wall-clock limit at epoch 64, so no EMA. This somewhat disadvantages our runs, but the gap is large enough to be meaningful.*

### What happened

**Both higher floor values are clearly worse than the baseline.** Surface pressure MAE went UP (worse) in all splits for both floor=10 and floor=15, contrary to the hypothesis. Results:

1. **Higher surface floor increases training variance**: Looking at epoch-by-epoch val_in_dist with floor=15: 1.7758 → 1.9973 → 1.7758 → 1.9782 (swinging ~12% between adjacent epochs). With floor=5 (baseline), training was much smoother. The higher surf_weight destabilizes gradient updates because surface nodes represent a tiny fraction of points and the higher-weighted surface loss creates large gradient steps.

2. **Surface pressure is not improved by weighting more**: The adaptive mechanism reports surf_weight≈5 because the **vol_loss/surf_loss ratio is naturally ~5**. Forcing it higher doesn't make the model predict surface pressure better — it just throws off the balance. The model has limited capacity and forcing it to overfit surface nodes comes at the cost of learning the volume field correctly, which in turn hurts the representation that underlies surface prediction.

3. **No EMA in these runs**: Both runs hit the 30-min wall-clock limit at epoch 64, before EMA kicks in (epoch 65). The baseline's 2.2217 includes EMA smoothing. Even so, the val/loss gap is ~0.22–0.24, which is too large to attribute to missing EMA alone.

4. **The floor=5 adaptive mechanism is well-calibrated**: The fact that surf_weight stays at floor 5 throughout training suggests the natural vol/surf loss ratio is ~5:1 — this is the model's natural operating point. Forcing it higher disrupts a learned equilibrium.

### Suggested follow-ups

- **Don't raise the floor**: the adaptive mechanism is doing the right thing. The floor being binding throughout training is not a bug — it's informative that 5:1 is the natural balance.
- **If more surface emphasis is desired**: Consider a **per-channel loss weight** that upweights pressure (p) specifically within the surface loss, rather than raising the overall surface vs. volume balance. Surface Ux/Uy are already reasonable; pressure is the hard part.
- **Try explicit pressure weighting**: e.g., `surf_loss = w_Ux * mae_Ux + w_Uy * mae_Uy + w_p * mae_p` with `w_p > w_Ux, w_Uy`, rather than increasing the surface/volume floor.