### PR TITLE
Gradient-stopped surface feature injection

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,16 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        # Surface feature injection: lightweight MLP that modulates features for surface nodes
+        # Gradient-stopped on the surface mask to prevent destabilizing main pathway
+        self.surf_inject = nn.Sequential(
+            nn.Linear(n_hidden, 32),
+            nn.GELU(),
+            nn.Linear(32, n_hidden),
+        )
+        # Zero-init output layer so it starts as no-op
+        nn.init.zeros_(self.surf_inject[2].weight)
+        nn.init.zeros_(self.surf_inject[2].bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -330,6 +340,12 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+
+        # Surface feature injection with gradient-stopped mask
+        # is_surface is at feature index 12 (normalized); threshold to recover binary flag
+        is_surf = (x[:, :, 12] > 0).float().detach()  # [B, N] — detach stops gradient through mask
+        surf_modulation = self.surf_inject(fx)  # [B, N, n_hidden]
+        fx = fx + surf_modulation * is_surf.unsqueeze(-1)  # only surface nodes get the modulation
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)


### PR DESCRIPTION
## Hypothesis
The model treats surface and volume nodes identically through the transformer — surface awareness comes only from the loss weighting. By injecting a surface-specific feature modulation *before* the Physics-Attention, the single transformer layer can allocate its representational capacity differently for surface vs volume nodes.

The key insight: previous attempts at surface-aware features failed because they disrupted gradient flow (sigmoid gating in #814 added +7.7%). By **stopping gradients** on the surface mask path, we give the transformer a surface \"hint\" without backpropagating through a fragile detection pathway. This is analogous to conditional batch normalization in image generation — inject context without letting it dominate the gradient.

## Instructions

In `train.py`:

### 1. Add surface injection module in `Transolver.__init__` (after line 271, after `self.re_head`)

```python
# Surface feature injection: lightweight MLP that modulates features for surface nodes
# Gradient-stopped on the surface mask to prevent destabilizing main pathway
self.surf_inject = nn.Sequential(
    nn.Linear(n_hidden, 32),
    nn.GELU(),
    nn.Linear(32, n_hidden),
)
# Zero-init output layer so it starts as no-op
nn.init.zeros_(self.surf_inject[2].weight)
nn.init.zeros_(self.surf_inject[2].bias)
```

### 2. Apply injection in `Transolver.forward` (after line 332, after the placeholder scale/shift)

After `fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]`, add:

```python
# Surface feature injection with gradient-stopped mask
# is_surface is at feature index 12 (normalized); threshold to recover binary flag
is_surf = (x[:, :, 12] > 0).float().detach()  # [B, N] — detach stops gradient through mask
surf_modulation = self.surf_inject(fx)  # [B, N, n_hidden]
fx = fx + surf_modulation * is_surf.unsqueeze(-1)  # only surface nodes get the modulation
```

**Important:** The `.detach()` on `is_surf` is critical — it ensures gradients only flow through the modulation MLP weights, not through the surface detection heuristic.

### 3. No other changes needed

The injection happens before the transformer block, so it flows through all subsequent computation naturally.

Run:
```bash
python train.py --agent fern --wandb_name "fern/grad-stopped-surf-inject" --wandb_group grad-stopped-surf-inject
```

If the first run shows promising results (within 5% of baseline or better), try a second run with a wider injection MLP (64 instead of 32 hidden dim):
```bash
python train.py --agent fern --wandb_name "fern/grad-stopped-surf-inject-wide" --wandb_group grad-stopped-surf-inject
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `r7de1fxa`

**Note:** Run crashed (killed by 30-min timeout) at epoch ~60/100. At ~29s/epoch, full 100-epoch run requires ~48 min. This is the third consecutive experiment with this issue on the current noam branch. First run not within 5% of baseline, so no second wider run was attempted.

### Metrics at best epoch (epoch 56)

| Metric | This run (ep 56) | Baseline |
|--------|-----------------|----------|
| val/loss | 2.5918 | 2.2217 |
| val_in_dist/loss | 1.920 | — |
| Surface MAE Ux (in_dist) | 0.319 | — |
| Surface MAE Uy (in_dist) | 0.241 | — |
| Surface MAE p (in_dist) | 25.69 | 21.18 |
| Surface MAE p (tandem) | 44.82 | 41.23 |
| Surface MAE p (ood_cond) | 27.93 | 20.47 |
| Surface MAE p (ood_re) | 35.85 | 30.95 |
| Volume MAE Ux (in_dist) | 1.376 | — |
| Volume MAE Uy (in_dist) | 0.505 | — |
| Volume MAE p (in_dist) | 29.83 | — |
| val_ood_re/loss | NaN | — |
| val_ood_re/vol_loss | ~18.9B | — |

**Peak memory:** not tracked (added ~12k parameters — <5% of model size, negligible)

### What happened

**Hypothesis not supported.** All metrics are substantially worse than baseline across all splits. The best val/loss of 2.5918 at epoch 56 is 16.7% worse than baseline 2.2217, well outside the 5% threshold needed to justify the wider run. The val/loss was noisy but trending down (2.59, 2.74, 2.63, 2.60, 2.67), consistent with incomplete convergence.

The gradient-stopped surface injection failed to help for the same structural reason as the boundary embedding (PR #821) and likely the sigmoid gating (PR #814): **adding structure to what the model already learns from the `is_surface` feature at index 12 provides diminishing returns.** The Transolver's physics-attention slices already implicitly separate surface from volume nodes through the attention mechanism, so explicit surface modulation adds parameters without adding information.

The pre-existing val_ood_re NaN/overflow (~18.9B vol_loss) persists — identical value across all three runs on this branch, strongly suggesting a normalization bug in the OOD-Re split rather than a training instability.

**Pattern across 3 experiments**: All three recent runs (MLP-droppath, boundary-embed, grad-stopped-inject) show the same issues: val/loss ~2.5-2.6 at epoch 60 (vs baseline 2.22), val_ood_re NaN, and 30-min timeout killing the run before convergence. The noam branch may need the OOD-Re overflow fixed before meaningful comparisons are possible.

### Suggested follow-ups

- Fix the val_ood_re overflow bug first — it corrupts val/loss aggregate and may be poisoning training if any OOD-Re samples appear in the training set. See `exp-noam/fix-ood-re-overflow` and `exp-noam/fix-ood-re-denorm` branches.
- The surface modulation idea itself isn't promising — the model already has `is_surface` as an input feature; adding it again through a different pathway doesn't add information
- If surface accuracy is the target, focus on loss weighting (higher `surf_weight`) or architecture changes that affect how surface nodes attend to each other