### PR TITLE
Wider preprocess MLP hidden layer (512 instead of 256)

### DIFF
--- a/train.py
+++ b/train.py
@@ -243,7 +243,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 4, n_hidden, n_layers=1, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
The preprocess MLP is the **only** feature extraction stage before the single transformer layer. With 24 input dimensions encoding complex nonlinear relationships (dsdf 8 channels, saf 2 channels, Re, AoA, etc.), the current 256-wide hidden layer may bottleneck feature extraction quality. The transformer can only work with the features it receives.

Doubling only the *hidden* dimension of the preprocess MLP from 256 to 512 gives the initial feature extraction more expressive capacity at minimal speed cost (it's a single dense layer). The output dimension stays at 128 (n_hidden), so nothing downstream changes. The preprocess-to-output skip connection (`out_skip`) also benefits from richer initial features.

This is the simplest possible architectural change — one number — and hasn't been tried before.

## Instructions

In `train.py`:

### 1. Change preprocess MLP hidden dimension (line 246)

Replace:
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
```

With:
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 4, n_hidden, n_layers=1, res=True, act=act)
```

This changes:
- `MLP(24, 256, 128, ...)` → `MLP(24, 512, 128, ...)`
- The MLP has: Linear(24→512) + GELU + Linear(512→512) + GELU (with residual) + Linear(512→128)
- Adds ~236K parameters (small relative to total model)
- Should have minimal impact on epoch time since it's just wider dense layers

### 2. That's it — one line change

Everything downstream (transformer block, output heads, skip connections) stays the same since the output dimension is still 128.

Run:
```bash
python train.py --agent emma --wandb_name "emma/preprocess-width-512" --wandb_group preprocess-width-512
```

If this improves, try `n_hidden * 6` (768 hidden) to see if there's more headroom:
```bash
python train.py --agent emma --wandb_name "emma/preprocess-width-768" --wandb_group preprocess-width-512
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** w1f3pjt6
**Runtime:** 30.5 min
**Peak GPU memory:** ~46.8 GB (per GPU)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 2.0184 | 0.3527 | 0.2211 | 30.55 | 1.3797 | 0.5199 | 34.04 |
| ood_cond | 2.1206 | 0.2834 | 0.2196 | 23.52 | 1.0652 | 0.4359 | 22.77 |
| ood_re | NaN | 0.2886 | 0.2259 | 32.66 | 1.0423 | 0.4694 | 53.07 |
| tandem | 3.4382 | 0.6526 | 0.3609 | 44.12 | 2.1471 | 1.0150 | 45.65 |
| **combined** | **2.5258** | — | — | — | — | — | — |

**Baseline val/loss: 2.2217 → Result: 2.5258 (+13.7%, worse)**

Did not run the n_hidden * 6 (768) variant since the 512 result was already worse than baseline.

### What happened

The wider preprocess MLP made things worse. The in-dist surface pressure MAE jumped from 21.18 to 30.55 (+44%), and the combined val/loss went from 2.22 to 2.53 (+14%). The hypothesis was that the 256-wide hidden layer was a bottleneck, but the result suggests the opposite: the narrower preprocess forces a more compact, generalizable representation.

A wider preprocess MLP has more parameters to overfit with, and fewer epochs to converge — the 30-min cap means fewer passes through training data per parameter. The result is likely underfitting of the larger network rather than better representations.

Also notable: the in_dist pressure surface MAE is the most affected metric, which is the one the advisor cares most about. This is a clear negative.

### Suggested follow-ups

- Try a narrower preprocess (n_hidden * 1 = 128, same as output) to see if even the current 256-wide is too large
- The preprocess is not the bottleneck; focus on the attention mechanism or the output head instead
- A deeper preprocess (n_layers=2) might help more than a wider one since it can learn hierarchical features