### PR TITLE
Stagnation-point pressure anchoring (auxiliary loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -644,7 +644,23 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
+        # Stagnation-point pressure anchoring
+        # Find the node with highest target pressure on each surface (stagnation point)
+        # y_norm shape: [B, N, 3], channel 2 is pressure
+        B_size = y_norm.shape[0]
+        stag_loss = torch.tensor(0.0, device=device)
+        for b in range(B_size):
+            surf_nodes = surf_mask[b]  # [N] boolean mask
+            if surf_nodes.sum() > 0:
+                surf_p_target = y_norm[b, surf_nodes, 2]  # [n_surf]
+                stag_idx = surf_p_target.argmax()
+                surf_indices = surf_nodes.nonzero(as_tuple=True)[0]
+                stag_node = surf_indices[stag_idx]
+                stag_err = abs_err[b, stag_node, :]  # [3] — Ux, Uy, p error at stagnation
+                stag_loss = stag_loss + stag_err[2]  # only pressure channel
+        stag_loss = stag_loss / B_size
         loss = vol_loss + surf_weight * surf_loss
+        loss = loss + 0.5 * stag_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
@@ -680,7 +696,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/stag_loss": stag_loss.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
In aerodynamics, the stagnation point is the anchor of the entire pressure distribution. The pressure at the stagnation point sets the scale for the rest of the Cp curve via the Bernoulli relation. If the model correctly predicts the stagnation pressure, the relative pressures around the rest of the surface become easier to fit.

Instead of treating all surface nodes equally, we add an auxiliary loss that penalizes the error at the node with maximum pressure (approximate stagnation point) more heavily. This is a physics-informed inductive bias that directs gradient toward the single most physically meaningful surface node per sample.

This is fundamentally different from channel weighting (#822, which failed because it disrupted the global loss balance). Here we're adding a *targeted* auxiliary loss on a specific physical feature, not reweighting the entire loss.

## Instructions

In `train.py`:

### 1. Add stagnation-point auxiliary loss in the training loop (after line 646, after `surf_loss` is computed)

After:
```python
surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()
```

Add:
```python
# Stagnation-point pressure anchoring
# Find the node with highest target pressure on each surface (stagnation point)
# y_norm shape: [B, N, 3], channel 2 is pressure
# Use target (not prediction) to identify stagnation point — we know where it should be
B_size = y_norm.shape[0]
stag_loss = torch.tensor(0.0, device=device)
for b in range(B_size):
    surf_nodes = surf_mask[b]  # [N] boolean mask
    if surf_nodes.sum() > 0:
        # Stagnation point: highest pressure on surface (in normalized Cp space)
        surf_p_target = y_norm[b, surf_nodes, 2]  # [n_surf]
        stag_idx = surf_p_target.argmax()
        # Get the full [3] error at that node
        surf_indices = surf_nodes.nonzero(as_tuple=True)[0]
        stag_node = surf_indices[stag_idx]
        stag_err = abs_err[b, stag_node, :]  # [3] — Ux, Uy, p error at stagnation
        stag_loss = stag_loss + stag_err[2]  # only pressure channel
stag_loss = stag_loss / B_size
loss = loss + 0.5 * stag_loss
```

**Note on the for-loop:** This runs over the batch dimension (typically 4-8 samples). The indexing operations are cheap (argmax over ~200-400 surface nodes). Total overhead should be <1ms per step, negligible vs the ~15ms forward pass.

### 2. Log stagnation loss for monitoring

Update the wandb.log call at line 683:
```python
wandb.log({
    "train/loss": loss.item(),
    "train/surf_weight": surf_weight,
    "train/stag_loss": stag_loss.item(),
    "global_step": global_step,
})
```

### 3. No changes to validation — this is training-only regularization

Run:
```bash
python train.py --agent alphonse --wandb_name "alphonse/stag-pressure-anchor" --wandb_group stag-pressure-anchor
```

If the first run shows improvement, try varying the weight:
```bash
python train.py --agent alphonse --wandb_name "alphonse/stag-pressure-anchor-1.0" --wandb_group stag-pressure-anchor
python train.py --agent alphonse --wandb_name "alphonse/stag-pressure-anchor-0.1" --wandb_group stag-pressure-anchor
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run ID:** `zaeoq1zf`
**Epochs completed:** 63/100 (30-min timeout; run was still converging)
**Peak memory:** 10.5 GB
**Weight variations:** Not run — first run did not improve over baseline.

### Metrics vs Baseline

| Metric | Baseline | This run (ep 63 best) | Delta |
|--------|----------|-----------------------|-------|
| val/loss | 2.2217 | 2.3749 | +0.15 (worse) |
| val_in_dist/loss | — | 1.7916 | — |
| val_tandem_transfer/loss | — | 3.3675 | — |
| val_ood_cond/loss | — | 1.9657 | — |

### Surface pressure MAE vs Baseline

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 23.79 | 21.18 | +2.61 (worse) |
| val_ood_cond | 21.71 | 20.47 | +1.24 (worse) |
| val_ood_re | 32.05 | 30.95 | +1.10 (worse) |
| val_tandem_transfer | 42.37 | 41.23 | +1.14 (worse) |

### What happened

The stagnation-point auxiliary loss did not improve over baseline. At the best checkpoint (epoch 63), val/loss was 2.3749 vs. 2.2217 — about 7% worse. Surface pressure MAE regressed on all four splits.

Two observations:
1. **The stag_loss signal was tiny.** The logged `train/stag_loss` was only ~0.025 at the end of training, compared to `surf_loss` ~0.13. This means the stagnation pressure is already reasonably well-predicted, and the auxiliary loss provides very little gradient signal — effectively not contributing to training.

2. **Slower convergence pattern.** The run was still improving at epoch 63 (four consecutive new-best epochs: 60-63). This matches the pattern seen in other experiments on this branch — 64 epochs is not enough to see the full effect of any modification.

No weight variations were run since the 0.5-weight run did not beat baseline.

### Suggested follow-ups

- The stagnation point (max-pressure surface node) is already well-fitted; anchoring it doesn't add useful gradient. A more impactful target might be the maximum pressure *error* node (hardest example mining) — that's where the model actually struggles.
- Alternatively, upweight the stagnation node not by auxiliary loss but by including it in the surface loss with an extra factor (simpler and less noisy).
- The for-loop implementation works correctly (10.5 GB memory, no overhead penalty), but the hypothesis didn't hold: the model doesn't benefit from extra emphasis on an already-accurate prediction.