### PR TITLE
Asymmetric EMA decay (early start, channel-specific blending)

### DIFF
--- a/train.py
+++ b/train.py
@@ -475,12 +475,9 @@ model_config = dict(
 model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
-ema_fast = None  # starts epoch 40, decay 0.995 — for velocity channels
-ema_slow = None  # starts epoch 55, decay 0.999 — for pressure channel
-ema_fast_start = 40
-ema_slow_start = 55
-ema_fast_decay = 0.995
-ema_slow_decay = 0.999
+ema_model = None
+ema_start_epoch = 40  # was 65 — earlier start gives more averaging epochs
+ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -675,22 +672,13 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
-        # Fast EMA (velocity channels)
-        if epoch >= ema_fast_start:
-            if ema_fast is None:
-                ema_fast = deepcopy(model)
+        if epoch >= ema_start_epoch:
+            if ema_model is None:
+                ema_model = deepcopy(model)
             else:
                 with torch.no_grad():
-                    for ep, mp in zip(ema_fast.parameters(), model.parameters()):
-                        ep.data.mul_(ema_fast_decay).add_(mp.data, alpha=1 - ema_fast_decay)
-        # Slow EMA (pressure channel)
-        if epoch >= ema_slow_start:
-            if ema_slow is None:
-                ema_slow = deepcopy(model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_slow.parameters(), model.parameters()):
-                        ep.data.mul_(ema_slow_decay).add_(mp.data, alpha=1 - ema_slow_decay)
+                    for ep, mp in zip(ema_model.parameters(), model.parameters()):
+                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -706,11 +694,8 @@ for epoch in range(MAX_EPOCHS):
     prev_surf_loss = epoch_surf
 
     # --- Validate across all splits ---
-    eval_model_fast = ema_fast if ema_fast is not None else model
-    eval_model_slow = ema_slow if ema_slow is not None else (ema_fast if ema_fast is not None else model)
-    eval_model = eval_model_fast  # primary for the eval loop structure
-    eval_model_fast.eval()
-    eval_model_slow.eval()
+    eval_model = ema_model if ema_model is not None else model
+    eval_model.eval()
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
@@ -750,15 +735,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    out_fast = eval_model_fast({"x": x})
-                    pred_fast = out_fast["preds"]
-                    if ema_slow is not None and ema_slow is not eval_model_fast:
-                        out_slow = eval_model_slow({"x": x})
-                        pred_slow = out_slow["preds"]
-                        pred = pred_fast.clone()
-                        pred[:, :, 2:3] = pred_slow[:, :, 2:3]  # pressure from slow EMA
-                    else:
-                        pred = pred_fast
+                    pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
@@ -838,7 +815,7 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        save_model = ema_fast if ema_fast is not None else model
+        save_model = ema_model if ema_model is not None else model
         torch.save(save_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 


### PR DESCRIPTION
## Hypothesis
The current EMA starts at epoch 65 with decay 0.998, giving only ~5 epochs of averaging before the 30-min timeout (~70 epochs). This is barely enough to smooth out training noise. By starting EMA much earlier (epoch 40) and using channel-specific blending at inference, we can exploit the different convergence dynamics of velocity vs pressure channels.

Key insight: pressure is the hardest channel with highest variance across training. A higher-decay (slower) EMA should smooth pressure prediction noise more effectively. Velocity channels converge more reliably and benefit from a faster (more responsive) EMA. This is analogous to channel-specific learning rates but implemented as a post-hoc ensemble.

This approach has **zero additional cost during training** — we just start EMA earlier and compose outputs from two EMA trackers at eval time.

## Instructions

[see original instructions above — revised to simpler single-EMA variant per advisor request]

Single EMA, earlier start:
```python
ema_model = None
ema_start_epoch = 40  # was 65
ema_decay = 0.998     # same
```

Run with `--wandb_group asymmetric-ema`.

## Baseline
- val/loss: 2.2217 (run vbcsks47, EMA epoch 65, 100 epochs)
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

### Run 1: Dual EMA + channel blending (original submission)

**W&B run:** `xwdgo1r9` — https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/xwdgo1r9  
**Epochs completed:** 63 (30s/epoch — dual forward pass overhead)

| Metric | Dual EMA | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.2703 | 2.2217 | +2.2% |
| in_dist surf_p | 21.65 | 21.18 | +2.2% |
| ood_cond surf_p | 20.52 | 20.47 | +0.2% |
| ood_re surf_p | 30.91 | 30.95 | −0.1% ✓ |
| tandem surf_p | 41.60 | 41.23 | +0.9% |

### Run 2: Single EMA, early start (epoch 40, decay 0.998) — revised per advisor

**W&B run:** `hdyzlerr` — https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/hdyzlerr  
**Epochs completed:** 68 (27s/epoch — no dual pass)  
**Peak VRAM:** 10.6 GB

| Metric | Single EMA early | Dual EMA | Baseline | Delta vs baseline |
|---|---|---|---|---|
| val/loss | **2.2654** | 2.2703 | 2.2217 | +2.0% |
| in_dist surf_p | 21.86 | 21.65 | 21.18 | +3.2% |
| ood_cond surf_p | 21.28 | 20.52 | 20.47 | +3.9% |
| ood_re surf_p | **30.78** | 30.91 | 30.95 | −0.5% ✓ |
| tandem surf_p | 42.12 | 41.60 | 41.23 | +2.2% |

### Surface MAE detail (Run 2, epoch 64 best)
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 0.299 | 0.178 | 21.86 |
| ood_cond | 0.271 | 0.187 | 21.28 |
| ood_re | 0.276 | 0.204 | 30.78 |
| tandem | 0.630 | 0.335 | 42.12 |

### Volume MAE (pressure, Run 2)
| Split | vol_p |
|---|---|
| in_dist | 26.33 |
| ood_cond | 20.16 |
| ood_re | 51.00 |
| tandem | 44.67 |

---

### What happened

**Single EMA (epoch 40 start) is marginally better than dual EMA** — val/loss 2.2654 vs 2.2703, and gets 5 more epochs within the 30-min budget (68 vs 63) due to removed validation overhead.

Both runs remain ~2% above the actual baseline (2.2217). The baseline achieves its lower loss by running to full 100 epochs with EMA starting at epoch 65, giving 35 epochs of averaging vs our 24-28 epochs. Within the 30-min cap, starting EMA at epoch 40 provides modest benefit over the effective zero-benefit of starting at epoch 65 (only ~3 epochs of averaging within 68 epochs).

Interestingly, the dual-EMA channel blend did produce better ood_cond surf_p (20.52 vs 21.28) — the channel-specific approach may genuinely help for OOD pressure, but it's not cost-effective within the 30-min window.

val_ood_re/loss = NaN persists — pre-existing.

### Suggested follow-ups
- The real win for EMA would be allowing longer runs (100+ epochs). EMA is most effective in the final epochs of convergence.
- Try ema_start_epoch=30 and ema_decay=0.999 to see if more aggressive early averaging helps at 68 epochs.
- The ood_cond surf_p advantage from channel blending (20.52 vs 21.28) suggests the slow EMA does help specifically for pressure OOD. If the double-pass overhead can be reduced (e.g., only blend on val not train), it may be worth exploring.