### PR TITLE
Gradient-weighted surface loss (pressure importance sampling)

### DIFF
--- a/train.py
+++ b/train.py
@@ -642,7 +642,19 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Gradient-weighted surface loss: weight nodes by target pressure magnitude
+        # Nodes with larger |p| are at stagnation/suction peaks — harder and more important
+        p_target_mag = y_norm[:, :, 2].abs()  # [B, N] — magnitude of normalized pressure
+        # Normalize weights per sample so they average to 1.0 (preserves overall scale)
+        surf_p_weights = torch.ones_like(p_target_mag)
+        for b in range(y_norm.shape[0]):
+            s = surf_mask[b]
+            if s.sum() > 0:
+                w = 1.0 + 2.0 * p_target_mag[b, s]  # alpha=2.0: 3x weight at |p|=1 vs |p|=0
+                surf_p_weights[b, s] = w / w.mean()  # normalize to mean=1
+
+        weighted_abs_err = abs_err * surf_p_weights.unsqueeze(-1)
+        surf_per_sample = (weighted_abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
The current surface loss treats all surface nodes equally. But pressure error concentrates at leading edges, stagnation points, and separation bubbles where the pressure varies most. By weighting each surface node's contribution proportional to its target pressure magnitude, we allocate more gradient to the physically hardest locations without changing the loss function itself. This is importance sampling for surface nodes — still L1 loss, but smarter spatial allocation.

This is fundamentally different from channel weighting (#822, which failed by reweighting all pressure equally) and stagnation anchoring (#836, which uses a separate loss on just one node). Here we create a continuous spatial weighting across ALL surface nodes based on their physical importance.

## Instructions

In `train.py`:

### 1. Add gradient-weighted surface loss (replace lines 645-646)

Replace:
```python
surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()
```

With:
```python
# Gradient-weighted surface loss: weight nodes by target pressure magnitude
# Nodes with larger |p| are at stagnation/suction peaks — harder and more important
p_target_mag = y_norm[:, :, 2].abs()  # [B, N] — magnitude of normalized pressure
# Normalize weights per sample so they average to 1.0 (preserves overall scale)
surf_p_weights = torch.ones_like(p_target_mag)
for b in range(y_norm.shape[0]):
    s = surf_mask[b]
    if s.sum() > 0:
        w = 1.0 + 2.0 * p_target_mag[b, s]  # alpha=2.0: 3x weight at |p|=1 vs |p|=0
        surf_p_weights[b, s] = w / w.mean()  # normalize to mean=1

weighted_abs_err = abs_err * surf_p_weights.unsqueeze(-1)
surf_per_sample = (weighted_abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()
```

### 2. That's it — no other changes needed

Run:
```bash
python train.py --agent thorfinn --wandb_name "thorfinn/grad-weighted-surf" --wandb_group grad-weighted-surf-loss
```

If improved, try alpha=1.0 and alpha=4.0:
```bash
python train.py --agent thorfinn --wandb_name "thorfinn/grad-weighted-surf-a1" --wandb_group grad-weighted-surf-loss
python train.py --agent thorfinn --wandb_name "thorfinn/grad-weighted-surf-a4" --wandb_group grad-weighted-surf-loss
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `3xx81rhb` (alpha=2.0) | **Epoch:** 66/100 (30.2 min wall-clock) | **Peak memory:** 10.6 GB

**Note:** The result with alpha=2.0 is a significant regression, so alpha=1.0 and alpha=4.0 were not run (per instructions: "If improved, try...").

### Val loss (combined)

| Split | Baseline | This run (α=2.0) | Δ |
|---|---|---|---|
| val/loss (combined) | 2.2217 | **2.4200** | +8.9% ❌ |

### Surface MAE (most important)

| Split | Metric | Baseline | This run | Δ |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 21.18 | 24.18 | +14.2% ❌ |
| val_in_dist | mae_surf_Ux | — | 0.321 | — |
| val_in_dist | mae_surf_Uy | — | 0.195 | — |
| val_ood_cond | mae_surf_p | 20.47 | 22.54 | +10.1% ❌ |
| val_ood_re | mae_surf_p | 30.95 | 32.41 | +4.7% ❌ |
| val_tandem_transfer | mae_surf_p | 41.23 | 44.56 | +8.1% ❌ |

### Volume MAE

| Split | Metric | This run |
|---|---|---|
| val_in_dist | mae_vol_p | 29.85 |
| val_ood_cond | mae_vol_p | 21.24 |
| val_tandem_transfer | mae_vol_p | 47.20 |

*Note: val_ood_re/vol_loss = 1.89e10 (nan in combined loss) — pre-existing bug on this branch.*

---

### What happened

Clear negative result. The gradient-weighted surface loss with alpha=2.0 significantly worsens all metrics — val/loss goes from 2.2217 to 2.4200 (+8.9%), and mae_surf_p on val_in_dist jumps from 21.18 to 24.18 (+14.2%). This is not a borderline result; the weighting is actively hurting performance.

A few reasons this likely failed:

1. **Mismatch with the adaptive surf_weight calibration.** The existing code (lines 565-576) dynamically scales `surf_weight` based on `prev_vol_loss / prev_surf_loss`. With the importance weighting, `surf_loss` now reflects a spatially biased average — high-pressure nodes dominate. The adaptive weight ratio was calibrated for an unweighted mean, so the new scale disrupts the vol/surf balance during training.

2. **The weighting increases loss variance.** By up-weighting stagnation/suction nodes 3x while de-weighting low-pressure nodes, the per-batch gradient signal becomes noisier. The optimizer receives inconsistent signals from different batch compositions.

3. **Stagnation nodes may already be well-predicted.** The hypothesis assumes high-|p| nodes are "harder," but they may actually be easier to predict (large, systematic pressure gradient at leading edge). Weighting them more just forces the model to allocate capacity there at the expense of subtler errors elsewhere.

4. **The for loop per batch item is non-vectorized** — slightly slower, but this is a minor issue, not the cause of the regression.

### Suggested follow-ups

- **Smaller alpha (0.5)**: The alpha=2.0 weight swing (1x to 3x) may be too large. A softer weighting like alpha=0.5 (1x to 1.5x) might help without disrupting the surf_weight calibration.
- **Clip the surf_loss normalization**: Rather than per-node weighting that distorts the loss magnitude, use a separate auxiliary loss term for high-pressure nodes (added alongside the standard surf_loss) so the adaptive weight calibration isn't disturbed.
- **Error-based importance sampling**: Rather than weighting by |p_target|, weight by the running error on each node (curriculum learning) — but this requires tracking per-node error across epochs.