### PR TITLE
Mixup data augmentation in normalized feature space

### DIFF
--- a/train.py
+++ b/train.py
@@ -608,6 +608,19 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        # Mixup augmentation (after all normalization)
+        if model.training and torch.rand(1).item() < 0.5:
+            B_curr = x.shape[0]
+            if B_curr > 1:
+                lam = torch.distributions.Beta(0.4, 0.4).sample().item()
+                lam = max(lam, 1 - lam)
+                idx = torch.randperm(B_curr, device=device)
+                x = lam * x + (1 - lam) * x[idx]
+                y_norm = lam * y_norm + (1 - lam) * y_norm[idx]
+                mask = mask & mask[idx]
+                is_surface = is_surface & is_surface[idx]
+                sample_stds = lam * sample_stds + (1 - lam) * sample_stds[idx]
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
             pred = out["preds"]


### PR DESCRIPTION
## Hypothesis
With only 1,322 training samples and a 30-minute cap, data efficiency is paramount. No data augmentation has been tried — every failed experiment modified the model, loss, or optimizer. Mixup (Zhang et al., 2017) creates virtual training examples by linearly interpolating between pairs of samples in input and target space. For PDE solutions in normalized Cp space, linear interpolation between solutions at nearby conditions is physically reasonable.

This effectively multiplies the dataset diversity without adding compute per epoch — a completely orthogonal axis to all 21 previous experiments.

## Instructions

In `train.py`:

### 1. Add mixup after normalization

Placement: after `y_norm = y_norm / sample_stds`, right before the autocast block.

```python
# Mixup augmentation (after all normalization)
if model.training and torch.rand(1).item() < 0.5:
    B_curr = x.shape[0]
    if B_curr > 1:
        lam = torch.distributions.Beta(0.4, 0.4).sample().item()
        lam = max(lam, 1 - lam)
        idx = torch.randperm(B_curr, device=device)
        x = lam * x + (1 - lam) * x[idx]
        y_norm = lam * y_norm + (1 - lam) * y_norm[idx]
        mask = mask & mask[idx]
        is_surface = is_surface & is_surface[idx]
        sample_stds = lam * sample_stds + (1 - lam) * sample_stds[idx]
```

### 2. No other changes needed

Run:
```bash
python train.py --agent frieren --wandb_name "frieren/mixup-aug" --wandb_group feature-space-mixup
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `65fgdpy9` (frieren/mixup-aug)
**Epochs:** 34 (30-min wall-clock limit; ~2x slower than baseline per-epoch)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 4.088 | 0.834 | 0.438 | **64.21** | 2.250 | 0.951 | 65.80 |
| val_ood_cond | 4.209 | 0.581 | 0.385 | **47.75** | 1.841 | 0.767 | 46.03 |
| val_ood_re | nan | 0.539 | 0.371 | **52.03** | 1.701 | 0.730 | 73.01 |
| val_tandem_transfer | 5.915 | 1.245 | 0.639 | **73.46** | 3.096 | 1.521 | 71.14 |
| **combined val/loss** | **4.737** | | | | | | |

**vs baseline (2.2217):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2217 | 4.737 | **+2.515 (+113%)** |
| surf_p in_dist | 21.18 | 64.21 | **+43.03 (+203%)** |
| surf_p ood_cond | 20.47 | 47.75 | **+27.28 (+133%)** |
| surf_p ood_re | 30.95 | 52.03 | **+21.08 (+68%)** |
| surf_p tandem | 41.23 | 73.46 | **+32.23 (+78%)** |

**Peak GPU memory:** ~10.6 GB
**Per-epoch time:** ~52s vs ~27s baseline (2x slower)

### What happened

Catastrophically bad result. Mixup completely broke training, achieving less than half the baseline's epochs (34 vs 66) and metrics 2-3x worse across the board.

**Root cause 1 — Conservative mask intersection + progressive volume subsampling**: Training uses progressive volume resolution (epochs 1-40: 5%→100% random volume node subset). When two samples are mixed with conservative masking (`mask = mask & mask[idx]`), the volume mask becomes the intersection of two independent random subsets. At epoch 10 (~25% volume ratio), each sample has ~25% of nodes; the intersection has only ~6.25%. This reduces volume gradient signal by 16x during warm-up, severely slowing convergence.

**Root cause 2 — 2x slowdown per epoch**: `torch.distributions.Beta(0.4, 0.4).sample()` creates a new distribution object ~165 times per epoch (50% of 331 batches). This Python-level overhead cuts available epochs from ~66 to ~34.

**Root cause 3 — PDE solutions are not linear**: CFD solutions at different Reynolds numbers, AoA, and geometries don't interpolate linearly even in normalized space. A mixed sample doesn't correspond to any physically realizable flow.

### Suggested follow-ups

- **Fix conservative masking**: Skip mixup during the progressive warm-up phase (only apply after epoch 40), or use per-sample masks instead of intersection.
- **Fix Beta overhead**: Pre-sample lam for all batches at epoch start, or use `torch.rand(1).item() * 0.5 + 0.5` instead (uniform in [0.5, 1.0]).
- **Alternative augmentation**: Random geometric perturbations or condition scaling that preserves PDE structure would be more appropriate than interpolation-based mixup.