### PR TITLE
Cosine similarity auxiliary loss on surface pressure profile

### DIFF
--- a/train.py
+++ b/train.py
@@ -646,6 +646,24 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 
+        # Cosine similarity loss on surface pressure profile
+        # Measures shape agreement, not just pointwise error
+        cos_loss = torch.tensor(0.0, device=device)
+        n_cos = 0
+        pred_for_cos = pred  # already in normalized space (divided by sample_stds if training)
+        for b in range(pred_for_cos.shape[0]):
+            s = surf_mask[b]
+            if s.sum() > 10:  # need enough surface nodes for meaningful cosine sim
+                p_pred = pred_for_cos[b, s, 2]   # predicted pressure, surface only
+                p_true = y_norm[b, s, 2]          # target pressure, surface only
+                # Cosine similarity: 1.0 = perfect agreement, -1.0 = opposite
+                cos_sim = F.cosine_similarity(p_pred.unsqueeze(0), p_true.unsqueeze(0))
+                cos_loss = cos_loss + (1.0 - cos_sim)  # minimize 1 - cos_sim
+                n_cos += 1
+        if n_cos > 0:
+            cos_loss = cos_loss / n_cos
+            loss = loss + 0.3 * cos_loss
+
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
         B, N, C = pred.shape
@@ -680,7 +698,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/cos_loss": cos_loss.item() if isinstance(cos_loss, torch.Tensor) else 0.0, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
L1 loss measures pointwise error magnitude. But for surface pressure, the *shape* of the Cp distribution matters as much as absolute values — a prediction that captures the correct pressure distribution topology but is shifted by a constant is more useful than one with lower MAE but wrong shape. A cosine similarity loss between predicted and true surface pressure vectors (per sample) directly optimizes for profile shape agreement.

## Instructions

(See PR for implementation details — weight=0.3 first, then 0.1/1.0 if improved)

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** 1d4mod5m | **Best epoch:** 65/100 (30-min timeout, 27.5s/epoch) | **Peak VRAM:** ~10.5GB

Cosine similarity loss weight: **0.3**

| Split | val/loss | surf p MAE |
|---|---|---|
| val_in_dist | 1.6882 | 23.14 |
| val_ood_cond | 1.9543 | 20.97 |
| val_tandem_transfer | 3.3742 | 42.84 |
| val_ood_re | nan | 32.28 |
| **combined** | **2.3389** | |

vs baseline (val/loss=2.2217): **+5.3% worse**

Did not run 0.1/1.0 variants — the 0.3 result did not improve.

### What happened

**Negative result.** Cosine similarity loss at weight 0.3 hurts performance: val/loss=2.3389 vs 2.2217 baseline (+5.3% worse). All surf_p values are slightly worse across splits.

**Key diagnostic**: The final  is essentially zero — meaning the model already achieves near-perfect cosine similarity between predicted and true surface pressure profiles. The cosine loss provides no useful gradient signal because the *shape* problem is already solved; the remaining error is in absolute magnitude and local offsets.

This means the hypothesis was incorrect: the model does not struggle to learn the pressure distribution *shape*. Its remaining pressure errors are magnitude/offset errors, not topological ones. Adding a loss that's already near-zero just corrupts gradients by upweighting an already-saturated objective.

### Suggested follow-ups

- **Pressure offset correction**: Since the model captures shape but has absolute magnitude error, try predicting a per-sample pressure offset (mean subtraction + scaling) as a correction applied post-network.
- **Pressure residual relative to freestream**: Normalize pressure predictions relative to the freestream q (dynamic pressure) derived from the Re and AoA inputs — this might reduce absolute magnitude variance.
- **Different shape loss**: Instead of global cosine similarity, use a local gradient/curvature loss on the Cp distribution (differences between adjacent surface nodes) to penalize local shape errors rather than global direction.