### PR TITLE
Input feature dropout (regularization against co-adaptation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -588,6 +588,16 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        # Input feature dropout: randomly zero non-spatial features during training
+        # Preserves positions (features 0-1) and is_surface (feature 12)
+        if model.training:
+            feat_drop_mask = torch.ones(1, 1, x.shape[2], device=device)
+            # Only drop features 2-11 (saf, dsdf) and 13-23 (Re, AoA, NACA, gap, stagger)
+            drop_indices = list(range(2, 12)) + list(range(13, x.shape[2]))
+            for idx in drop_indices:
+                if torch.rand(1).item() < 0.1:  # 10% drop probability per feature
+                    feat_drop_mask[0, 0, idx] = 0.0
+            x = x * feat_drop_mask
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
The model has 24 input features, but many are constant across all nodes in a sample (log_Re, AoA, NACA, gap, stagger — features 13-23). With only 1,322 training samples, the preprocess MLP (24→256→128) may overfit to specific feature correlations. Randomly masking a subset of non-spatial input features during training forces redundant representations and prevents co-adaptation.

This is a classical regularization technique from pre-deep-learning ML. No input regularization of any kind has been tried in our 21 experiments. The existing dropout in the attention layer is set to 0.0. Y-noise injection (line 596) adds noise to targets, not inputs.

## Instructions

In `train.py`:

### 1. Add input feature dropout after x normalization (after line 590)

After:
```python
x = (x - stats["x_mean"]) / stats["x_std"]
```

Add:
```python
# Input feature dropout: randomly zero non-spatial features during training
# Preserves positions (features 0-1) and is_surface (feature 12)
if model.training:
    feat_drop_mask = torch.ones(1, 1, x.shape[2], device=device)
    # Only drop features 2-11 (saf, dsdf) and 13-23 (Re, AoA, NACA, gap, stagger)
    drop_indices = list(range(2, 12)) + list(range(13, x.shape[2]))
    for idx in drop_indices:
        if torch.rand(1).item() < 0.1:  # 10% drop probability per feature
            feat_drop_mask[0, 0, idx] = 0.0
    x = x * feat_drop_mask
```

### 2. That's it — no other changes needed

The feature dropout is applied before the preprocess MLP, so it affects all downstream computation. The probability is conservative (10% per feature, ~2 features dropped per step on average out of 22 droppable).

Run:
```bash
python train.py --agent tanjiro --wandb_name "tanjiro/input-feat-dropout" --wandb_group input-feature-dropout
```

If improved, try 15% and 5% drop rates:
```bash
python train.py --agent tanjiro --wandb_name "tanjiro/input-feat-dropout-15pct" --wandb_group input-feature-dropout
python train.py --agent tanjiro --wandb_name "tanjiro/input-feat-dropout-5pct" --wandb_group input-feature-dropout
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**val/loss: 2.5468** (10% drop rate) — worse than baseline (2.2217). Not testing 15% and 5% variants since the 10% result showed no improvement.

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------|------------|------------|-----------|-----------|-----------|----------|
| val_in_dist | 2.0338 | 0.373 | 0.223 | 28.97 | 1.549 | 0.602 | 32.8 |
| val_tandem_transfer | 3.4625 | 0.657 | 0.358 | 43.56 | 2.235 | 1.073 | 44.6 |
| val_ood_cond | 2.1442 | 0.297 | 0.205 | 24.39 | 1.148 | 0.456 | 21.6 |
| val_ood_re | NaN* | 0.313 | 0.223 | 35.68 | 1.142 | 0.513 | 53.8 |

*val_ood_re NaN is a pre-existing branch bug  
**Peak memory:** 10.6 GB  
**W&B run ID:** 52sb8kqu  
**Epochs:** 67 in 30.4 min

### What happened

Input feature dropout hurt performance across all metrics. Surface pressure degraded substantially (in_dist: 28.97 vs 21.18, ood_cond: 24.39 vs 20.47, ood_re: 35.68 vs 30.95).

The regularization direction was correct (the model likely does have some feature co-adaptation), but feature masking is too destructive for this architecture:

1. **Spatial features are intertwined:** Features 2-11 (saf, dsdf) encode spatial relationships critical for every node's pressure/velocity prediction. Randomly zeroing even 10% of these per-step significantly degrades the quality of information entering the attention mechanism.
2. **Per-sample features (13-23) provide critical global context:** AoA, Re, NACA geometry, and tandem gap/stagger are essential for calibrating the prediction scale. Dropping these features (even 10% of the time) confuses the model about which flow regime it's in.
3. **The model already has y-noise regularization** (lines 595-596) that provides soft target-domain regularization. Adding input masking on top may be over-regularizing.

Per-epoch time was ~27s (comparable to baseline ~28s), memory 10.6GB.

### Suggested follow-ups
- Try feature noise (add Gaussian noise to features 13-23, not masking) — softer regularization that preserves global conditioning while adding variety
- Try masking only the geometric conditioning features (13-20: AoA, NACA, gap, stagger) and never the per-node spatial features (2-11)