### PR TITLE
Cyclic snapshot averaging (explore multiple minima)

### DIFF
--- a/train.py
+++ b/train.py
@@ -475,9 +475,10 @@ model_config = dict(
 model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
-ema_model = None
-ema_start_epoch = 65
-ema_decay = 0.998
+# Snapshot averaging: collect model state at end of each cosine cycle
+snapshots = []
+snapshot_epochs = [24, 44, 64]  # end of each 20-epoch cycle (0-indexed)
+avg_model = None
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -518,9 +519,11 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+cosine_restart_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+    base_opt, T_0=20, T_mult=1, eta_min=1e-4
+)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_scheduler, cosine_restart_scheduler], milestones=[5]
 )
 
 # --- wandb ---
@@ -672,13 +675,6 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -693,8 +689,20 @@ for epoch in range(MAX_EPOCHS):
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
 
+    # Collect snapshot at end of each cosine cycle
+    if epoch in snapshot_epochs:
+        snapshots.append(deepcopy(model.state_dict()))
+        print(f"  Snapshot collected at epoch {epoch+1} ({len(snapshots)} total)")
+
+        # Build averaged model from all snapshots so far
+        avg_model = deepcopy(model)
+        avg_state = avg_model.state_dict()
+        for key in avg_state:
+            avg_state[key] = sum(s[key] for s in snapshots) / len(snapshots)
+        avg_model.load_state_dict(avg_state)
+
     # --- Validate across all splits ---
-    eval_model = ema_model if ema_model is not None else model
+    eval_model = avg_model if avg_model is not None else model
     eval_model.eval()
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}
@@ -815,7 +823,7 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        save_model = ema_model if ema_model is not None else model
+        save_model = avg_model if avg_model is not None else model
         torch.save(save_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 


### PR DESCRIPTION
## Hypothesis
The current cosine annealing decays LR monotonically, converging to a single minimum. The EMA starts at epoch 65 with only ~5 epochs of averaging before timeout — barely enough to smooth noise. Cyclic snapshot averaging (Huang et al., 2017) uses shorter cosine cycles with warm restarts, collecting snapshots at the end of each cycle (the LR minimum, where the model is most converged). Averaging these diverse snapshots produces better generalization than any single minimum or late-start EMA.

With ~67 epochs available, we can fit 3 complete cycles of 20 epochs each, collecting 3 diverse snapshots that explore different regions of the loss landscape.

This is fundamentally different from SWA (which crashed 3x), EMA (which starts too late), and OneCycleLR (which uses a single cycle). The key difference: we deliberately restart learning rate to escape local minima, then average across the diverse converged points.

## Instructions

In `train.py`:

### 1. Replace LR scheduler setup (lines 520-524)

Replace:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
)
```

With:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
cosine_restart_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
    base_opt, T_0=20, T_mult=1, eta_min=1e-4
)
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_restart_scheduler], milestones=[5]
)
```

This gives: 5-epoch warmup, then 20-epoch cosine cycles restarting at epochs 25, 45, 65.

### 2. Collect snapshots at cycle boundaries

After the EMA/scheduler logic, add snapshot collection. Replace the EMA block (lines 475-481 and 675-681):

Replace:
```python
ema_model = None
ema_start_epoch = 65
ema_decay = 0.998
```

With:
```python
# Snapshot averaging: collect model state at end of each cosine cycle
snapshots = []
snapshot_epochs = [24, 44, 64]  # end of each 20-epoch cycle (0-indexed)
avg_model = None
```

Replace the EMA update block (lines 675-681):
```python
if epoch >= ema_start_epoch:
    if ema_model is None:
        ema_model = deepcopy(model)
    else:
        with torch.no_grad():
            for ep, mp in zip(ema_model.parameters(), model.parameters()):
                ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
```

With:
```python
# Collect snapshot at end of each cosine cycle
if epoch in snapshot_epochs:
    snapshots.append(deepcopy(model.state_dict()))
    print(f"  Snapshot collected at epoch {epoch+1} ({len(snapshots)} total)")
    
    # Build averaged model from all snapshots so far
    avg_model = deepcopy(model)
    avg_state = avg_model.state_dict()
    for key in avg_state:
        avg_state[key] = sum(s[key] for s in snapshots) / len(snapshots)
    avg_model.load_state_dict(avg_state)
```

### 3. Use averaged model for evaluation (line 697)

Replace:
```python
eval_model = ema_model if ema_model is not None else model
```

With:
```python
eval_model = avg_model if avg_model is not None else model
```

### 4. No other changes needed

Run:
```bash
python train.py --agent gilbert --wandb_name "gilbert/snapshot-avg" --wandb_group snapshot-averaging
```

If the cyclic schedule hurts early convergence, try longer first cycle:
```bash
# T_0=30, T_mult=1, snapshot_epochs=[34, 64]
python train.py --agent gilbert --wandb_name "gilbert/snapshot-avg-30" --wandb_group snapshot-averaging
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** kaps2lpq
**Best epoch:** 45 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 2.3489 | 0.559 | 0.225 | 30.6 |
| val_tandem_transfer | 3.8233 | 0.805 | 0.392 | 45.8 |
| val_ood_cond | 2.6431 | 0.434 | 0.235 | 28.1 |
| val_ood_re | NaN | 0.454 | 0.240 | 36.6 |
| **combined val/loss** | **2.9384** | | | |

**Baseline val/loss: 2.2217 → This run: 2.9384 (+0.72, much worse)**

### What happened

Cyclic snapshot averaging significantly hurt performance. Two main issues:

1. **Cycle duration too short for convergence.** With 20-epoch cycles and the existing progressive resolution curriculum (epochs 0-40 sub-sample volume nodes) + warmup effects, the model doesn't fully converge within each 20-epoch cycle. Epoch 24's snapshot had val_in_dist=2.286 (close to baseline), but immediately after the warm restart at epoch 25, training loss jumped from vol=0.18 → 0.38. The model needs more than 20 epochs to recover per cycle.

2. **Averaging underfitted snapshots degrades performance.** Snapshots 2 (epoch 44) and 3 (epoch 64) were taken from partially-recovered restarts. At epoch 45 (2-snapshot average), val/loss was 2.35; at epoch 65 (3-snapshot average), it was 2.47 — each additional snapshot made things worse. The best snapshot (epoch 24, val_in_dist≈2.29) was degraded by the later ones.

3. **The baseline's late-stage EMA (epoch 65+) is more effective** because it only averages well-trained models near the end of a single long convergence curve. Snapshot averaging here forces averaging across very different convergence stages.

The method is valid in principle (original paper uses many epochs with shorter per-epoch time), but requires longer cycles than 30-min training allows.

### Suggested follow-ups

- **Longer cycles**: try T_0=40, snapshot_epochs=[44, 84] — 2 snapshots from longer cycles. Or T_0=60 with a single restart.
- **Average only late snapshots**: keep the original cosine schedule but collect snapshots at epochs 50, 60, 65 (all late-stage) — averages only well-converged models.
- **Single-snapshot baseline**: restore the original EMA (epoch 65+, decay 0.998) and check whether a snapshot at epoch 60 adds value on top — isolates the averaging benefit from the restart disruption.