### PR TITLE
Output residual learning (predict deviation from physics baseline)

### DIFF
--- a/train.py
+++ b/train.py
@@ -591,6 +591,11 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+        # Bernoulli pressure baseline: Cp ≈ 1 - (Ux/Umag)^2 - (Uy/Umag)^2
+        with torch.no_grad():
+            p_baseline_phys = 1.0 - (y_phys[:, :, 0] ** 2 + y_phys[:, :, 1] ** 2)
+            y_baseline_norm = torch.zeros_like(y_norm)
+            y_baseline_norm[:, :, 2] = (p_baseline_phys - phys_stats["y_mean"][2]) / phys_stats["y_std"][2]
         if model.training:
             noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
@@ -607,6 +612,7 @@ for epoch in range(MAX_EPOCHS):
                     valid = mask[b]
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
+            y_baseline_scaled = y_baseline_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
@@ -616,8 +622,9 @@ for epoch in range(MAX_EPOCHS):
         re_pred = re_pred.float()
         if model.training:
             pred = pred / sample_stds
-        sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        y_residual = y_norm - y_baseline_scaled
+        sq_err = (pred - y_residual) ** 2
+        abs_err = (pred - y_residual).abs()
         if epoch < 10:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
@@ -653,7 +660,7 @@ for epoch in range(MAX_EPOCHS):
         if n_groups > 1:
             # Pool predictions and targets over groups of 64 nodes
             pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
+            y_trunc = y_residual[:, :n_groups * coarse_pool_size]
             mask_trunc = mask[:, :n_groups * coarse_pool_size]
 
             pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
@@ -721,6 +728,10 @@ for epoch in range(MAX_EPOCHS):
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                with torch.no_grad():
+                    p_baseline_phys = 1.0 - (y_phys[:, :, 0] ** 2 + y_phys[:, :, 1] ** 2)
+                    y_baseline_norm = torch.zeros_like(y_norm)
+                    y_baseline_norm[:, :, 2] = (p_baseline_phys - phys_stats["y_mean"][2]) / phys_stats["y_std"][2]
 
                 # Per-sample std normalization: skip tandem samples
                 raw_gap = x[:, 0, 21]
@@ -733,13 +744,15 @@ for epoch in range(MAX_EPOCHS):
                         valid = mask[b]
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
+                y_baseline_scaled = y_baseline_norm / sample_stds
+                y_residual_scaled = y_norm_scaled - y_baseline_scaled
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
-                sq_err = (pred_loss - y_norm_scaled) ** 2
-                abs_err = (pred_loss - y_norm_scaled).abs()
+                sq_err = (pred_loss - y_residual_scaled) ** 2
+                abs_err = (pred_loss - y_residual_scaled).abs()
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
@@ -750,8 +763,11 @@ for epoch in range(MAX_EPOCHS):
                 val_surf += (abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                 n_vbatches += 1
 
-                # Denormalize: phys_stats → Cp space → original scale
+                # Denormalize: add Bernoulli baseline, then phys_stats → Cp space → original scale
+                # Model predicts (y_phys - p_baseline) / phys_std for pressure channel
+                # so to recover y_phys: pred * phys_std + p_baseline (no phys_mean for pressure)
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_phys[:, :, 2] = pred_phys[:, :, 2] - phys_stats["y_mean"][2] + p_baseline_phys
                 pred_orig = _phys_denorm(pred_phys, Umag, q)
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()


### PR DESCRIPTION
## Hypothesis
Instead of predicting the full normalized field directly, the model predicts the *residual* from a simple analytical baseline. For pressure, this baseline is the Bernoulli approximation (Cp ≈ 1 - Ux²/Umag² - Uy²/Umag²). For velocity, the baseline is zero.

## Instructions
[see original PR body for detailed instructions]

Run:
```bash
python train.py --agent emma --wandb_name "emma/residual-learning" --wandb_group residual-target-learning
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** nkh3jzxq (final; first run zunpslyc had a denormalization bug)
**Runtime:** 30.5 min
**Peak GPU memory:** ~46.8 GB

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 1.7031 | 0.2917 | 0.1826 | 23.46 | 1.2169 | 0.4669 | 38.19 |
| ood_cond | 2.0217 | 0.2635 | 0.1970 | 23.87 | 1.0124 | 0.4319 | 27.73 |
| ood_re | NaN | 0.2715 | 0.2043 | 31.42 | 0.9866 | 0.4435 | 53.85 |
| tandem | 3.4559 | 0.6197 | 0.3344 | 45.82 | 2.0694 | 0.9769 | 54.18 |
| **combined** | **2.3936** | — | — | — | — | — | — |

**Baseline val/loss: 2.2217 → Result: 2.3936 (+7.8%, worse)**

Note: val/loss here measures residual error (pred vs y-baseline), not full-field error — so it is not directly comparable to baseline val/loss on the same scale. The physical MAE metrics are comparable.

### Denormalization bug (first run, zunpslyc)
The first run had a bug: when adding the Bernoulli baseline back at validation MAE time,  was incorrectly included, producing surf_p MAE of 222. Fixed by using  (no phys_mean) for the pressure channel.

### What happened

Residual learning did not help. The pressure MAE is slightly worse (23.46 vs 21.18, +10.8%) and velocity MAEs are slightly better (Ux: 0.29 vs ~0.3). The Bernoulli approximation gives Cp = 1 - u² - v² which is the inviscid potential flow prediction. The network's job was to learn the viscous correction on top of that. 

However, the Bernoulli baseline at each node uses the TRUE y_phys values (ground truth velocity), not the model's velocity prediction. This means:
1. The training residual target is physics-informed (clean deviation from Bernoulli)
2. But at validation, the baseline still uses ground truth velocities — so the model is still predicting the same quantity, just with a shifted target

The key insight missed: the Bernoulli baseline is not a useful simplification here because (a) the Bernoulli residuals (viscous wake, separation) are actually the hard part that needs learning, and (b) using ground truth velocity to compute the baseline means no information is saved at inference time.

The tandem pressure MAE got worse (45.82 vs 41.23) — tandem flows have strong aerodynamic interaction effects that deviate significantly from Bernoulli.

### Suggested follow-ups

- A simpler pressure baseline (e.g., the mean pressure from the dataset statistics) might be more useful than Bernoulli, since it avoids the circular dependency
- The velocity MAEs improved slightly — this is a weak signal that the residual formulation slightly helps for velocity (even though baseline is zero for velocity, the loss being in residual space may have affected training dynamics)
- This idea has merit for scenarios with a better closed-form baseline (e.g., if freestream pressure is known a priori), but Bernoulli is too good an approximation in the easy regions and too poor in the hard regions