### PR TITLE
Huber loss for volume nodes, L1 for surface (heterogeneous loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -639,7 +639,17 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        # Huber loss for volume nodes: quadratic near zero, linear for large errors
+        # delta=0.5 means quadratic for |error| < 0.5, linear beyond
+        vol_diff = (pred - y_norm) * vol_mask_train.unsqueeze(-1)
+        vol_abs = vol_diff.abs()
+        huber_delta = 0.5
+        vol_huber = torch.where(
+            vol_abs < huber_delta,
+            0.5 * vol_diff ** 2 / huber_delta,  # quadratic regime (normalized to match L1 scale at delta)
+            vol_abs - 0.5 * huber_delta           # linear regime
+        )
+        vol_loss = vol_huber.sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()


### PR DESCRIPTION
## Hypothesis
Volume nodes include many near-zero-error \"easy\" interior nodes where L1's constant gradient wastes optimization capacity. Huber loss (smooth L1) has a quadratic regime near zero that gives smaller gradients for easy nodes, letting the optimizer focus gradient magnitude on the harder near-wall/wake volume nodes. Surface nodes keep L1 where every error counts equally.

Previous loss changes (log-cosh, channel weighting, IQR) all changed the loss *for the entire field*. This is the first experiment to use **different loss functions for volume vs surface** — the model sees Huber gradients from volume and L1 gradients from surface simultaneously.

## Instructions

In `train.py`:

### 1. Replace volume loss computation (line 642)

Replace:
```python
vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
```

With:
```python
# Huber loss for volume nodes: quadratic near zero, linear for large errors
# delta=0.5 means quadratic for |error| < 0.5, linear beyond
vol_pred = pred * vol_mask_train.unsqueeze(-1)
vol_target = y_norm * vol_mask_train.unsqueeze(-1)
# Compute Huber manually to support masking
vol_diff = (vol_pred - vol_target) * vol_mask_train.unsqueeze(-1)
vol_abs = vol_diff.abs()
huber_delta = 0.5
vol_huber = torch.where(
    vol_abs < huber_delta,
    0.5 * vol_diff ** 2 / huber_delta,  # quadratic regime (normalized to match L1 scale at delta)
    vol_abs - 0.5 * huber_delta           # linear regime
)
vol_loss = vol_huber.sum() / vol_mask_train.sum().clamp(min=1)
```

**Note on the formula:** The quadratic term is `0.5 * x^2 / delta` (not `0.5 * x^2`). This normalization ensures the Huber loss matches L1 in magnitude at `|x| = delta`, preventing a scale mismatch between volume and surface losses. At the transition point: L1 = delta, Huber = 0.5 * delta^2 / delta = 0.5 * delta, so there's actually a factor-of-2 difference. To match exactly: `0.5 * x^2 / delta` for `|x| < delta`, `|x| - 0.5 * delta` for `|x| >= delta`. Both equal `0.5 * delta` at the transition.

### 2. Surface loss stays unchanged (L1, line 645-646)

No changes to `surf_per_sample` or `surf_loss`.

### 3. That's it — one block of code changed

Run:
```bash
python train.py --agent fern --wandb_name "fern/huber-volume" --wandb_group huber-volume-loss
```

If improved, try delta=0.3 and delta=1.0 to calibrate the threshold:
```bash
python train.py --agent fern --wandb_name "fern/huber-volume-d0.3" --wandb_group huber-volume-loss
python train.py --agent fern --wandb_name "fern/huber-volume-d1.0" --wandb_group huber-volume-loss
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `68d52s68`

**Note:** Run crashed (killed by 30-min timeout) at epoch 64/100. At ~29s/epoch, 100 epochs requires ~48 min. No follow-up delta runs attempted — first run did not reach within 5% of baseline at partial convergence.

### Metrics at best/final epoch (epoch 64)

| Metric | This run (ep 64) | Baseline |
|--------|-----------------|----------|
| val/loss | 2.3973 | 2.2217 |
| val_in_dist/loss | 1.763 | — |
| Surface MAE Ux (in_dist) | 0.329 | — |
| Surface MAE Uy (in_dist) | 0.192 | — |
| Surface MAE p (in_dist) | 24.94 | 21.18 |
| Surface MAE p (tandem) | 43.55 | 41.23 |
| Surface MAE p (ood_cond) | 22.07 | 20.47 |
| Surface MAE p (ood_re) | 32.61 | 30.95 |
| Volume MAE Ux (in_dist) | 1.433 | — |
| Volume MAE Uy (in_dist) | 0.539 | — |
| Volume MAE p (in_dist) | 32.72 | — |
| val_tandem_transfer/loss | 3.387 | — |
| val_ood_cond/loss | 2.042 | — |
| val_ood_re/loss | NaN | — |

**Peak memory:** not tracked (no architectural change)

### What happened

**Inconclusive — run timed out before convergence.** The val/loss at ep 64 (2.3973) is 7.9% above baseline (2.2217). However, this is the most promising trajectory of the 4 experiments on this branch: the loss was still clearly declining (2.86 → 2.80 → 2.70 → 2.61 → 2.56 → 2.47 → 2.46 → 2.46 → 2.42 → 2.40) and not showing signs of plateauing.

Compared to other recent runs at similar epochs: MLP-droppath was ~2.47 at ep 60, boundary-embed was ~2.49 at ep 60, grad-stopped-inject was ~2.66 at ep 60. Huber volume reached ~2.47 at ep 60 and kept improving to 2.40 by ep 64 — suggesting it's converging more smoothly.

**Structural note on the implementation**: The PR description has a slight inconsistency: it defines `vol_pred = pred * vol_mask_train.unsqueeze(-1)` and `vol_target = y_norm * vol_mask_train.unsqueeze(-1)`, but then computes `vol_diff = (pred - y_norm) * vol_mask_train.unsqueeze(-1)` directly (simpler and equivalent). The `vol_pred` and `vol_target` lines are technically unused. This was left as-is since the result is correct.

The val_ood_re NaN/overflow persists — same pre-existing issue (identical 18.9B value) across all runs on this branch.

**Would need full 100-epoch run to know if it beats baseline.** Given the convergence rate, it could potentially reach ~2.2-2.3 by epoch 100.

### Suggested follow-ups

- This is the most promising change tested so far — worth running a full 100-epoch evaluation if the timeout can be extended, or using early stopping
- If retrying: try delta=0.3 (more quadratic) and delta=1.0 (more linear) as requested
- Fix the val_ood_re overflow before further experiments — it corrupts the composite val/loss metric