### PR TITLE
Higher tandem boost factor (3.0 instead of 1.5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -618,10 +618,6 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -641,7 +637,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_boost = torch.where(is_tandem, 3.0, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
The tandem split (surf_p=41.23) is our worst-performing split by far — nearly 2x worse than in_dist (21.18). Currently tandem samples get only a 1.5x surface loss boost (line 644). The model sees tandem geometry as a harder problem but doesn't allocate enough gradient to learn it well.

By doubling the tandem boost to 3.0, we give tandem samples 3x the surface gradient signal. This is different from channel weighting (#822, which failed by reweighting all channels across all splits equally). Here we specifically target the worst-performing split while leaving in_dist/ood_cond/ood_re gradients unchanged.

Combined with including tandem samples from epoch 0 (currently excluded for first 10 epochs, lines 621-624), this should substantially improve tandem accuracy.

## Instructions

In `train.py`:

### 1. Increase tandem boost (line 644)

Replace:
```python
tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
```

With:
```python
tandem_boost = torch.where(is_tandem, 3.0, 1.0).to(device)
```

### 2. Include tandem samples from epoch 0 (lines 621-624)

Remove or comment out the tandem exclusion block:
```python
# REMOVED: tandem exclusion in early epochs
# if epoch < 10:
#     is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
#     sample_mask = (~is_tandem_curr).float()[:, None, None]
#     abs_err = abs_err * sample_mask
```

### 3. That's it — two simple changes

Run:
```bash
python train.py --agent alphonse --wandb_name "alphonse/tandem-boost-3" --wandb_group higher-tandem-boost
```

If tandem improves but other splits regress, try boost=2.0 (keeping tandem from epoch 0):
```bash
python train.py --agent alphonse --wandb_name "alphonse/tandem-boost-2" --wandb_group higher-tandem-boost
```

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run ID:** `llcpsihs`
**Epochs completed:** 64/100 (30-min timeout; run was still improving)
**Peak memory:** 10.6 GB
**Boost=2.0 variation:** Not run — boost=3.0 did not improve tandem or any other split.

### Metrics vs Baseline

| Metric | Baseline | This run (ep 64 best) | Delta |
|--------|----------|-----------------------|-------|
| val/loss | 2.2217 | 2.4134 | +0.19 (worse) |
| val_in_dist/loss | — | 1.7977 | — |
| val_tandem_transfer/loss | — | 3.4290 | — |
| val_ood_cond/loss | — | 2.0134 | — |

### Surface pressure MAE vs Baseline

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 24.72 | 21.18 | +3.54 (worse) |
| val_ood_cond | 22.52 | 20.47 | +2.05 (worse) |
| val_ood_re | 32.79 | 30.95 | +1.84 (worse) |
| val_tandem_transfer | 43.15 | 41.23 | +1.92 (worse) |

### What happened

The higher tandem boost (3.0 vs 1.5) did not improve tandem accuracy — in fact, all four splits got worse. Surface pressure MAE increased by 1.8–3.5 on every split, including tandem itself.

Two reasons explain this:

1. **Gradient imbalance.** With boost=3.0, tandem surface loss dominates training ( vs.  in baseline). This pulls the model toward tandem geometry at the expense of generalization to other splits. The model hasn't converged yet at epoch 64, so the boosted tandem gradient is distorting the optimization trajectory.

2. **Including tandem from epoch 0 may have hurt.** The original exclusion of tandem in the first 10 epochs is likely a curriculum learning decision — letting the model first learn the simpler single-airfoil regime before introducing tandem geometry. Removing this gives the model harder examples before it has stable representations, which may have slowed down in-distribution learning.

Since boost=3.0 didn't improve tandem (or any split), the boost=2.0 variation was not run — there's no indication it would produce a different qualitative outcome.

### Suggested follow-ups

- The tandem gap likely comes from the fact that tandem geometry is genuinely harder (secondary foil wakes, interference patterns) — loss weighting alone may not be sufficient.
- Rather than boosting tandem gradient globally, consider targeted architectural changes: adding the secondary foil's NACA code and AoA as explicit input features (currently it's only implicit via dsdf/saf features).
- Re-enabling the early-epoch tandem exclusion while boosting from epoch 10 onward might strike a better balance than removing it entirely.