### PR TITLE
Remove y-noise injection (test if over-regularized)

### DIFF
--- a/train.py
+++ b/train.py
@@ -591,10 +591,6 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
-
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5


### PR DESCRIPTION
## Hypothesis
The current y-noise injection (line 595-596) adds Gaussian noise to targets with scale [0.01, 0.01, 0.005] every step. With all the structural changes since (skip connections, residual bypass, aux Re head), the model may now be over-regularized. Removing this noise may give cleaner gradients and better convergence.

## Instructions

Remove y-noise injection (lines 594-596):
```python
if model.training:
    noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
    y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
```

If removing all noise helps, try halving noise ([0.005, 0.005, 0.0025]).

## Baseline
- val/loss: 2.2217
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** 83cwy6no | **Best epoch:** 67/100 (30-min timeout, 27.3s/epoch)

| Split | val/loss | surf p MAE |
|---|---|---|
| val_in_dist | 1.6502 | 22.11 |
| val_ood_cond | 1.8665 | 21.55 |
| val_tandem_transfer | 3.1802 | 40.43 |
| val_ood_re | nan | 31.07 |
| **combined** | **2.2323** | |

vs baseline (val/loss=2.2217): **+0.5% (essentially neutral)**

Did not run half-noise variant — results did not improve.

### What happened

**Null result.** Removing y-noise produces results essentially identical to baseline (2.2323 vs 2.2217, within noise). No meaningful difference in any metric — val/loss change is within expected run-to-run variance.

Mixed picture on surf_p: val_tandem_transfer improved slightly (40.43 vs 41.23, -2%), but val_in_dist and val_ood_cond were slightly worse. No consistent direction.

The y-noise is effectively neutral at its current scale ([0.01, 0.01, 0.005]). These perturbations are small relative to the signal (typical y values have std ~1 after normalization), so they act as mild label smoothing that neither helps nor hurts. The model is not over-regularized by this noise.

### Suggested follow-ups

- **Larger noise ablation**: Test significantly larger noise (e.g. [0.1, 0.1, 0.05]) to find the threshold where noise starts hurting, which would bound the useful range.
- **Noise on inputs instead of targets**: Input feature dropout or noise on x (coordinates, geometry) might be more effective regularization for mesh-based models than target noise.
- **Remove entirely and accept**: Since it's neutral, removing the noise simplifies the code with no measurable cost. Could be merged as a cleanup.