### PR TITLE
Lower learning rate (1.5e-3 instead of 3e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -354,7 +354,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 1.5e-3
     weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The base learning rate (3e-3) was tuned before the recent architectural additions (slice-token residual bypass, preprocess-to-output skip, aux Re head). These skip connections and residual pathways increase the effective learning rate through the network by providing shortcut gradient paths. The optimizer may be overshooting due to the combined effect of high LR + multiple gradient pathways.

Previous LR experiments (#817 OneCycleLR, #807 SWA) changed the schedule *structure*, not the base rate. Simply halving the LR to 1.5e-3 (with same schedule) is the simplest possible hyperparameter change and tests whether the current LR is too high for the modified architecture.

## Instructions

In `train.py`:

### 1. Change the learning rate in the config dataclass (line 357)

Replace:
```python
lr: float = 3e-3
```

With:
```python
lr: float = 1.5e-3
```

### 2. That's it — one number change

Everything else stays the same: AdamW + Lookahead, CosineAnnealing, warmup, etc.

Run:
```bash
python train.py --agent kohaku --wandb_name "kohaku/lr-1.5e-3" --wandb_group lower-learning-rate
```

If improved, try 1e-3:
```bash
python train.py --agent kohaku --wandb_name "kohaku/lr-1e-3" --wandb_group lower-learning-rate
```

## Baseline
- val/loss: 2.2217 (lr=3e-3)
- val_in_dist/mae_surf_p: 21.18
- val_ood_cond/mae_surf_p: 20.47
- val_ood_re/mae_surf_p: 30.95
- val_tandem_transfer/mae_surf_p: 41.23

---

## Results

**W&B run:** `4ekzunl2`
**Epochs completed:** 64/100 (timed out at 30 min)

### Metrics at best epoch (epoch 63)
| Split | val/loss |
|---|---|
| val_in_dist | 1.8386 |
| val_tandem_transfer | 3.4580 |
| val_ood_cond | 2.0889 |
| val_ood_re | NaN (pre-existing) |
| **Overall val/loss** | **2.4618** |

**Baseline val/loss:** 2.2217

### Surface pressure MAE (last epoch, epoch 64)
| Split | surf_p (ours) | surf_p (baseline) |
|---|---|---|
| val_in_dist | 27.84 | 21.18 |
| val_ood_cond | 25.35 | 20.47 |
| val_ood_re | 35.55 | 30.95 |
| val_tandem_transfer | 43.72 | 41.23 |

**Peak memory:** 10.5 GB

### What happened

**Negative result.** val/loss 2.4618 at epoch 63 is significantly worse than baseline 2.2217. Surface pressure is worse on all splits. The lower LR does not improve convergence at the 64-epoch mark.

For comparison, other experiments at similar epoch counts:
- Output channel scale (3e-3 LR): 2.3372 at epoch 62
- Re output modulation (3e-3 LR): 2.4221 at epoch 64
- **This (1.5e-3 LR): 2.4618 at epoch 63**

The hypothesis was that high LR causes overshooting due to skip connections. However, the evidence shows the opposite: lower LR actually slows convergence without improving the final value at this epoch count.

**val/loss at epoch 64 (2.536) was worse than epoch 63 (2.462)**, suggesting the model is oscillating rather than cleanly descending. This is consistent with a LR that's too low for the cosine schedule — when the LR decays too small (CosineAnnealingLR decaying 1.5e-3 → near zero), updates may become ineffective.

The skip connections likely *help* the gradient flow, not hurt it. The original 3e-3 LR remains appropriate. Did not run 1e-3 since 1.5e-3 already showed degradation.

### Suggested follow-ups

- **The 3e-3 LR appears correct for this architecture.** The skip connections may actually benefit from higher LR since they provide regularized gradient paths.
- **OneCycleLR with a lower peak LR** (e.g. 2e-3) might be a better schedule experiment than simply halving the base rate — OneCycleLR's warmup and annealing shape could help more than a flat reduction.