### PR TITLE
Remove weight decay (test over-regularization hypothesis)

### DIFF
--- a/train.py
+++ b/train.py
@@ -355,7 +355,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
The model is regularized through multiple mechanisms: weight decay (1e-4), y-noise injection, Lookahead optimizer, gradient clipping, and progressive volume subsampling. With 27+ consecutive failures to improve, the model may be over-regularized — weight decay penalizes large weights but in a small model (128 hidden, 1 layer), every parameter needs to carry information. Removing weight decay lets the model use its full capacity.

## Instructions

Change line 358:
```python
weight_decay: float = 1e-4
```
To:
```python
weight_decay: float = 0.0
```

Run:
```bash
python train.py --agent tanjiro --wandb_name "tanjiro/no-weight-decay" --wandb_group zero-weight-decay
```

## Baseline
- val/loss: 2.2217 (weight_decay=1e-4)
- surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**val/loss: 2.2396** — essentially tied with baseline (2.2217), within noise. Mixed results across splits.

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------|------------|------------|-----------|-----------|-----------|----------|
| val_in_dist | 1.5893 | 0.306 | 0.178 | 20.91 ✓ | 1.283 | 0.462 | 26.7 |
| val_tandem_transfer | 3.2790 | 0.629 | 0.345 | 42.78 ✗ | 2.155 | 1.000 | 44.7 |
| val_ood_cond | 1.8504 | 0.261 | 0.191 | 19.71 ✓ | 1.051 | 0.399 | 18.8 |
| val_ood_re | NaN* | 0.275 | 0.200 | 30.90 ≈ | 1.057 | 0.443 | 50.9 |

✓ better than baseline, ✗ worse, ≈ same. *val_ood_re NaN is a pre-existing branch bug  
**Peak memory:** 10.6 GB  
**W&B run ID:** rc9qwjjv  
**Epochs:** 67 in 30.4 min

### What happened

Removing weight decay produced a nearly neutral result (val/loss 2.2396 vs baseline 2.2217, +0.8%). Surface pressure improved on in_dist (-1.3%) and ood_cond (-3.7%), but regressed on tandem transfer (+3.8%). The ood_re pressure was essentially unchanged.

The mixed pattern suggests weight decay=1e-4 is not a significant bottleneck for this model size. The small weight decay does very little regularization at this magnitude for a 128-dim model — consistent with it being an almost-zero constraint that neither helps nor hurts meaningfully.

The over-regularization hypothesis is not supported: removing weight decay doesn't unlock significant capacity gains.

### Suggested follow-ups
- The slightly improved ood_cond pressure (19.71 vs 20.47) suggests some benefit on unseen conditions, which could compound with other improvements
- This is borderline neutral/marginally positive — could be worth testing in combination with slice-residual (which showed the largest single-technique improvement at 1.2659)