### PR TITLE
Remove multi-scale coarse pooling loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -646,24 +646,6 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 
-        # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
-        B, N, C = pred.shape
-        n_groups = N // coarse_pool_size
-        if n_groups > 1:
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask[:, :n_groups * coarse_pool_size]
-
-            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
-
-            coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
-
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss


### PR DESCRIPTION
## Hypothesis
The multi-scale coarse pooling loss (lines 649-665) was never independently validated. It pools predictions/targets over groups of 64 **index-ordered** nodes (not spatially local) and adds L1 loss with weight 1.0. Problems:
1. Index-order pooling mixes random spatial positions — not a meaningful coarse representation
2. Mixes surface and volume nodes in each group
3. Uses un-normalized \`pred\` and \`y_norm\` (not per-sample-std-scaled), creating a normalization mismatch with the main loss
4. Weight of 1.0 is the same as vol_loss — this is a substantial gradient contribution from a noisy signal

Removing it simplifies the loss landscape and lets the optimizer focus on the meaningful vol/surf losses.

## Instructions

Remove lines 649-665 entirely:
```python
# Multi-scale loss: coarse spatial pooling
coarse_pool_size = 64
B, N, C = pred.shape
n_groups = N // coarse_pool_size
if n_groups > 1:
    pred_trunc = pred[:, :n_groups * coarse_pool_size]
    y_trunc = y_norm[:, :n_groups * coarse_pool_size]
    mask_trunc = mask[:, :n_groups * coarse_pool_size]
    pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
    y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
    mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
    coarse_err = (pred_coarse - y_coarse).abs()
    coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
    loss = loss + 1.0 * coarse_loss
```

Run:
```bash
python train.py --agent askeladd --wandb_name "askeladd/no-coarse-loss" --wandb_group remove-coarse-loss
```

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `052om3bt`
**Epochs:** 64 (wall-clock limit, no EMA) | **Peak memory:** 10.5 GB

### Metrics at best checkpoint (epoch 63)

| Split | Baseline | No coarse loss |
|---|---|---|
| **val/loss** | **2.2217** | 4.3949 |
| val_in_dist/loss | — | 2.6834 |
| val_ood_cond/loss | — | 4.4815 |
| val_tandem_transfer/loss | — | 6.0198 |

### Surface pressure MAE

| Split | Baseline | No coarse loss |
|---|---|---|
| val_in_dist | **21.18** | 38.04 |
| val_ood_cond | **20.47** | 54.45 |
| val_ood_re | **30.95** | 44.64 |
| val_tandem_transfer | **41.23** | 75.92 |

*All metrics dramatically worse. Note: baseline includes EMA (epoch 65+); our run hit wall-clock limit at epoch 64 with no EMA. However, the gap (val/loss 4.39 vs 2.22, surface p 38+ vs 21) is far too large to attribute to missing EMA alone.*

### What happened

**Removing the coarse loss is catastrophically bad.** Every metric is dramatically worse:
- val/loss: 4.39 vs 2.22 baseline (+97%)
- val_in_dist/surf_p: 38 vs 21 (+80%)
- val_tandem_transfer/surf_p: 76 vs 41 (+85%)

Looking at the full training curve (epochs 1–64):
- Without coarse loss, val_in_dist is still at 2.65 at epoch 64 — about where other runs were at epoch 30–35
- val_tandem_transfer stays above 6.0 throughout — it never converges to the 3.4–3.5 level seen in other runs
- Training vol_loss (0.37) and surf_loss (0.24) are higher than comparable runs at epoch 64, confirming slower learning

**The coarse loss is load-bearing, not noise.** Despite all its theoretical flaws (random index pooling, mixed surface/volume, normalization mismatch), it provides a strong auxiliary gradient signal that significantly accelerates training convergence. At weight 1.0, it roughly doubles the effective gradient magnitude in the early-to-mid training phase. Removing it leaves the optimizer to learn entirely from sparse vol/surf L1 losses, which converges ~2× slower.

The coarse loss is functioning like a "consistency regularizer": even if individual node predictions are wrong, the average over groups of 64 nodes should match the target average. This broad signal speeds up initial learning. Whether it's spatially meaningful doesn't matter for convergence speed.

### Suggested follow-ups

- **Don't remove the coarse loss** — it's crucial for convergence speed
- **Replace with spatially-aware pooling**: rather than removing, replace the index-order pooling with actual spatial nearest-neighbor groups or graph-based local aggregation. This would preserve the regularization benefit while being physically meaningful
- **Reduce the coarse loss weight**: if the concern is gradient noise, try weight=0.1 instead of 1.0 to reduce its dominance while keeping the convergence benefit
- **Investigate why tandem_transfer degrades most**: the coarse loss seems especially critical for the tandem transfer split — possibly because global/coarse consistency is more important for generalizing to unseen geometries