### PR TITLE
Remove Lookahead optimizer (use plain AdamW)

### DIFF
--- a/train.py
+++ b/train.py
@@ -516,7 +516,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = base_opt
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Lookahead with k=10 and alpha=0.8 was added speculatively and never A/B tested against plain AdamW. With k=10, slow-weight sync happens every ~10 steps. Alpha=0.8 is aggressive (typical is 0.5), pulling fast weights back toward stale values. This may hurt late-training fine-tuning — exactly the phase where we need precision for the final 2-3% improvement.

Lookahead was designed for SGD-style optimizers. AdamW already maintains its own momentum and variance states, making Lookahead potentially redundant or counterproductive.

## Instructions

Replace line 519:
```python
optimizer = Lookahead(base_opt, k=10, alpha=0.8)
```

With:
```python
optimizer = base_opt
```

That's it. The scheduler already references \`base_opt\` directly. The \`optimizer.zero_grad()\` and \`optimizer.step()\` calls work identically on the base AdamW.

Run:
```bash
python train.py --agent gilbert --wandb_name "gilbert/no-lookahead" --wandb_group remove-lookahead
```

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** zhauoxw1
**Best epoch:** 67 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.6200 | 0.299 | 0.182 | 22.1 |
| val_tandem_transfer | 3.2673 | 0.634 | 0.342 | 42.4 |
| val_ood_cond | 1.8527 | 0.253 | 0.189 | 20.8 |
| val_ood_re | NaN | 0.277 | 0.202 | 30.7 |
| **combined val/loss** | **2.2467** | | | |

**Baseline val/loss: 2.2217 → This run: 2.2467 (+0.025, slightly worse)**

Comparison vs baseline mae_surf_p: in_dist 22.1 vs 21.18 (+0.9), ood_cond 20.8 vs 20.47 (+0.3), ood_re 30.7 vs 30.95 (-0.25), tandem 42.4 vs 41.23 (+1.2).

### What happened

Removing Lookahead (plain AdamW) is slightly worse than the baseline with Lookahead. The hypothesis that Lookahead is "redundant or counterproductive" with AdamW is not supported — it provides a small consistent benefit (+0.025 val/loss when removed).

The gap is small (~1% relative), consistent across most splits (worse on in_dist, tandem, ood_cond; tiny improvement on ood_re). Single-run noise could explain the difference, but at minimum Lookahead is not hurting.

Possible reasons Lookahead helps:
- Periodic slow-weight sync acts as regularization, preventing fast weights from drifting too far.
- Composite momentum from AdamW + Lookahead may help navigate the loss landscape more effectively.

The argument that "alpha=0.8 is aggressive" may be valid, but the practical effect is net positive here.

### Suggested follow-ups

- **Tune Lookahead params**: try alpha=0.5, k=5 (original paper defaults) vs. current k=10, alpha=0.8 — there may be a better configuration.
- **Lower alpha**: try alpha=0.5 while keeping k=10 to reduce the aggressive pull-back effect while retaining the sync interval.