### PR TITLE
Remove progressive volume subsampling + 0.5x vol loss weight

### DIFF
--- a/train.py
+++ b/train.py
@@ -625,26 +625,14 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
-        # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
-            vol_indices = vol_mask.nonzero(as_tuple=False)
-            n_vol = vol_indices.shape[0]
-            n_keep = max(int(n_vol * vol_keep_ratio), 1)
-            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
-            vol_mask_train = torch.zeros_like(vol_mask)
-            if n_keep > 0:
-                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
-        else:
-            vol_mask_train = vol_mask
+        vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        loss = 0.5 * vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
Progressive volume subsampling (lines 628-640) uses 5%→100% of volume nodes over 40 epochs. This means 60% of training has corrupted volume gradients, and there's a discontinuity at epoch 40 when full volume nodes kick in. The PR #830 experiment confirmed that compressed ramps (25 epochs) gave val_loss=2.2400 (essentially baseline), suggesting the subsampling provides no benefit.

Additionally, surface accuracy is the primary metric. Reducing volume loss weight to 0.5x shifts gradient budget toward surface learning, which the adaptive surf_weight can't fully capture because it adjusts epoch-by-epoch rather than step-by-step.

## Instructions

### 1. Remove progressive volume subsampling (lines 628-640)

Replace the entire block:
```python
if epoch < 40:
    vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
    ...
else:
    vol_mask_train = vol_mask
```

With just:
```python
vol_mask_train = vol_mask
```

### 2. Reduce vol_loss weight (line 647)

Replace:
```python
loss = vol_loss + surf_weight * surf_loss
```

With:
```python
loss = 0.5 * vol_loss + surf_weight * surf_loss
```

Run:
```bash
python train.py --agent frieren --wandb_name "frieren/no-subsample-halfvol" --wandb_group remove-vol-subsample
```

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `k6n0ulaj` (frieren/no-subsample-halfvol)
**Epochs:** 67 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.588 | 0.298 | 0.176 | **21.16** | 1.370 | 0.491 | 28.13 |
| val_ood_cond | 1.909 | 0.264 | 0.192 | **20.65** | 1.099 | 0.430 | 20.44 |
| val_ood_re | nan | 0.275 | 0.200 | **31.16** | 1.086 | 0.460 | 51.96 |
| val_tandem_transfer | 3.294 | 0.632 | 0.342 | **42.33** | 2.264 | 1.044 | 45.55 |
| **combined val/loss** | **2.264** | | | | | | |

**vs baseline (2.2217):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2217 | 2.264 | **+0.042 (+1.9%)** |
| surf_p in_dist | 21.18 | 21.16 | **-0.02 (~0%)** |
| surf_p ood_cond | 20.47 | 20.65 | **+0.18 (+0.9%)** |
| surf_p ood_re | 30.95 | 31.16 | **+0.21 (+0.7%)** |
| surf_p tandem | 41.23 | 42.33 | **+1.10 (+2.7%)** |

**Peak GPU memory:** ~10.6 GB

### What happened

Essentially a null result. Surface pressure metrics are unchanged from baseline (within 1-3%), and the combined val/loss is marginally worse (+1.9%). The individual split-level losses for in_dist (1.588) and ood_cond (1.909) are notably better than the combined baseline, but tandem transfer (3.294) pulled the combined up.

**On removing progressive volume subsampling**: The training now sees full volume at every epoch. The expected benefit (no discontinuity at epoch 40, cleaner gradients) doesn't materialize as a measurable improvement. The progressive schedule may actually help early convergence by keeping the loss landscape simpler during warm-up, even if the final benefit is zero.

**On 0.5x vol_loss weight**: Halving the volume weight didn't shift meaningful gradient budget to surface learning. The adaptive surf_weight mechanism already balances surface vs volume dynamically — the additional static scaling is redundant. The tandem transfer got slightly worse, suggesting the volume representation quality matters for generalization to new geometries.

**Combined effect**: Neither change helped, and the slight degradation in tandem suggests the volume signal is more important than the hypothesis assumed.

### Suggested follow-ups

- **Isolate the effects**: Run each change independently (remove subsampling alone, then 0.5x vol alone) to understand which if either is beneficial.
- **Higher vol_loss weight instead**: If volume accuracy is critical for generalization (as suggested by tandem degradation), try 2x vol weight to see if it helps tandem transfer.
- **Target the adaptive surf_weight floor**: The floor at 5.0 caps the gradient shift toward surface. Raising the floor to 10-15 might be more effective than static vol weight reduction.