### PR TITLE
Include tandem samples from epoch 0 (remove early exclusion)

### DIFF
--- a/train.py
+++ b/train.py
@@ -618,10 +618,6 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 


### PR DESCRIPTION
## Hypothesis
Tandem samples are excluded from training for the first 10 epochs (lines 621-624). This was a curriculum learning decision — learn single-foil first, then tandem. But with the current architecture (skip connections, aux Re head), the model may be robust enough to handle tandem from the start. Including tandem from epoch 0 gives 10 more epochs of tandem training, which could improve the worst-performing split (tandem surf_p=41.23).

This is different from #846 (which combined tandem inclusion with 3.0x boost and made things worse). Here we ONLY remove the exclusion, keeping the default 1.5x tandem boost. This isolates the effect of the curriculum.

## Instructions

Remove lines 621-624:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
```

Run:
```bash
python train.py --agent alphonse --wandb_name "alphonse/tandem-from-start" --wandb_group include-tandem-from-start
```

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run ID:** `ahtyjefa`
**Epochs completed:** 64/100 (30-min timeout; run was still converging)
**Peak memory:** 10.6 GB

### Metrics vs Baseline

| Metric | Baseline | This run (ep 64 best) | Delta |
|--------|----------|-----------------------|-------|
| val/loss | 2.2217 | 2.4405 | +0.22 (worse) |
| val_in_dist/loss | — | 1.8009 | — |
| val_tandem_transfer/loss | — | 3.4170 | — |
| val_ood_cond/loss | — | 2.1036 | — |

### Surface pressure MAE vs Baseline

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 23.75 | 21.18 | +2.57 (worse) |
| val_ood_cond | 22.05 | 20.47 | +1.58 (worse) |
| val_ood_re | 32.54 | 30.95 | +1.59 (worse) |
| val_tandem_transfer | 44.20 | 41.23 | +2.97 (worse) |

### What happened

Removing the early tandem exclusion made all splits worse — including tandem itself (+2.97 on surf_p). This confirms that the curriculum (no tandem for 10 epochs) is actually helpful, not a limitation.

The early exclusion gives the model stable single-foil representations before it encounters the harder tandem cases. Without this warmup, the tandem samples in epochs 1-10 add noise to the gradient before the model has a good foundation, ultimately leading to worse convergence for all splits. This is a classic curriculum learning effect.

The result is clear and consistent: removing the curriculum hurts. The experiment in #846 that combined this removal with 3.0x boost saw a similar degradation, confirming this component (not the boost level) was the main driver of that result.

### Suggested follow-ups

- The early tandem exclusion is justified and should be kept.
- If tandem accuracy needs improvement, architecture changes (explicitly encoding foil-2 geometry) are more likely to help than loss weighting.
- A more targeted curriculum might extend the exclusion period (e.g., 15 or 20 epochs) and test whether longer warmup helps further.