### PR TITLE
No weight decay + no y-noise (compound simplification)

### DIFF
--- a/train.py
+++ b/train.py
@@ -355,7 +355,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
@@ -591,10 +591,6 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
-
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5


### PR DESCRIPTION
## Hypothesis
Tanjiro's no-weight-decay showed improved surf_p. Edward's no-y-noise was neutral. Combining both tests whether they compound.

## Instructions
1. Set `weight_decay: float = 0.0`
2. Remove y-noise injection

Run: `python train.py --agent edward --wandb_name "edward/nowd-nonoise" --wandb_group nowd-nonoise`

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** yc7kutl4 | **Best epoch:** 67/100 (30-min timeout, 26.6s/epoch)

| Split | val/loss | surf p MAE |
|---|---|---|
| val_in_dist | 1.5818 | 21.58 |
| val_ood_cond | 1.9237 | 21.57 |
| val_tandem_transfer | 3.3350 | 42.65 |
| val_ood_re | nan | 30.86 |
| **combined** | **2.2801** | |

vs baseline (val/loss=2.2217): **+2.6% worse**

### What happened

**Negative result.** The compound simplification (no weight decay + no y-noise) performs worse than baseline across most metrics. Surf_p is slightly worse on in_dist (+0.4) and ood_cond (+1.1) splits. Val_ood_re surf_p is marginally better (30.86 vs 30.95), but within noise.

Note that Tanjiro's no-weight-decay experiment used a different code state (before recent changes like vol_subsample curriculum, EMA, etc.). The benefit may not transfer to the current noam baseline, which has changed significantly. The two simplifications do not compound positively here.

### Suggested follow-ups

- **Weight decay ablation on current noam**: Run weight_decay=0.0 alone (without removing noise) to isolate whether the weight_decay benefit still exists at the current code state.
- **Accept current regularization**: The existing weight_decay=1e-4 and y-noise appear to work fine as-is for the current model state.