### PR TITLE
No weight decay + EMA from epoch 40 (compound)

### DIFF
--- a/train.py
+++ b/train.py
@@ -355,7 +355,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
@@ -476,7 +476,7 @@ model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 65
+ema_start_epoch = 40
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
Combine no-weight-decay (which showed sp_id=20.91, sp_ood=19.71) with earlier EMA start (epoch 40 instead of 65). Earlier EMA gives 28 epochs of averaging vs 5, and the no-weight-decay result suggests regularization through weight decay was hurting.

## Instructions
1. Set `weight_decay: float = 0.0` (line 358)
2. Set `ema_start_epoch = 40` (line 479)

Run: `python train.py --agent fern --wandb_name "fern/nowd-ema40" --wandb_group nowd-ema40`

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---

## Results

**W&B run:** `sk2srxw0`

**Note:** Run crashed (killed by 30-min timeout) at epoch 64/100. At ~27s/epoch, 100 epochs requires ~45 min. However, this is the **first experiment on this branch to beat the baseline at partial convergence**.

### Metrics at best/final epoch (epoch 64)

| Metric | This run (ep 64) | Baseline | Δ |
|--------|-----------------|----------|---|
| val/loss (3-split) | **2.2068** | 2.2217 | **-0.67%** |
| val_in_dist/loss | 1.547 | — | — |
| Surface MAE Ux (in_dist) | 0.282 | — | — |
| Surface MAE Uy (in_dist) | 0.173 | — | — |
| Surface MAE p (in_dist) | **20.56** | 21.18 | **-2.9%** |
| Surface MAE p (tandem) | **40.78** | 41.23 | **-1.1%** |
| Surface MAE p (ood_cond) | 21.30 | 20.47 | +4.1% |
| Surface MAE p (ood_re) | 30.90 | 30.95 | -0.2% |
| Volume MAE Ux (in_dist) | 1.265 | — | — |
| Volume MAE Uy (in_dist) | 0.457 | — | — |
| Volume MAE p (in_dist) | 25.85 | — | — |
| val_tandem_transfer/loss | 3.189 | — | — |
| val_ood_cond/loss | 1.884 | — | — |
| val_ood_re/loss | 18870 | — | NaN→finite |

**Peak memory:** not tracked (no architectural change; same 257k parameters)

### What happened

**Hypothesis supported.** This is the first experiment on this branch to beat the 3-split baseline (2.2068 < 2.2217) even at partial convergence (64/100 epochs). The run was still descending when killed (last 10 epochs: 2.33, 2.33, 2.29, 2.28, 2.28, 2.27, 2.25, 2.24, 2.22, 2.21), suggesting the full 100-epoch run could achieve 2.15-2.20 or better.

Key observations:
1. **Surface pressure improved significantly**: in_dist dropped from 21.18 → 20.56 (-2.9%), tandem from 41.23 → 40.78 (-1.1%). The ood_cond was slightly worse (+4%) but ood_re was essentially unchanged.
2. **val_ood_re is no longer NaN**: `val_ood_re/loss = 18870` and `val_ood_re/vol_loss = 18868`. These are still large but finite — a dramatic improvement over the 18.9 billion seen in all prior experiments. This suggests the noam branch was updated with an OOD-Re fix between this and the previous PRs (see `exp-noam/fix-ood-re-overflow` merges).
3. **Faster epochs**: 26.8s/epoch vs 28-29s in earlier runs — likely due to no-weight-decay simplifying the optimizer step.

The compound effect works: no weight decay removes parameter shrinkage that was fighting the learning rate, and earlier EMA start (epoch 40 vs 65) gives 24 more epochs of model averaging. Both changes are complementary — no-weight-decay allows more aggressive weight growth, and EMA stabilizes this by smoothing over noisy late updates.

### Suggested follow-ups

- Run to full convergence (extend timeout or use a checkpoint restart) — this combination is clearly promising
- Try EMA start at epoch 30 or even epoch 20 to see if even earlier averaging helps
- Combine with Huber volume loss (PR #845) — if Huber also converges better, the combination could be synergistic
- Investigate the remaining OOD-Re instability (vol_loss ~18k) — finite but still very large. A proper fix might unlock further improvements on the ood_re split