### PR TITLE
No weight decay + include tandem from epoch 0

### DIFF
--- a/train.py
+++ b/train.py
@@ -355,7 +355,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
@@ -618,10 +618,6 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 


### PR DESCRIPTION
## Hypothesis
Combine no-weight-decay (sp_id=20.91, sp_ood=19.71 — both below baseline) with including tandem from epoch 0. The no-weight-decay may allow the model to learn tandem geometry better when it has more training epochs with tandem data.

## Instructions
1. Set `weight_decay: float = 0.0` (line 358)
2. Remove tandem exclusion (lines 621-624):
   ```python
   # REMOVE:
   if epoch < 10:
       is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
       sample_mask = (~is_tandem_curr).float()[:, None, None]
       abs_err = abs_err * sample_mask
   ```

Run: `python train.py --agent nezuko --wandb_name "nezuko/nowd-tandem0" --wandb_group nowd-tandem0`

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23

---
## Results

**W&B run:** `g3l0rjq6` — https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/g3l0rjq6
**Epochs completed:** 63 (28s/epoch)
**Peak VRAM:** 10.5 GB

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 2.4100 | 2.2217 | +8.5% |
| in_dist surf_p | 25.65 | 21.18 | +21.1% |
| ood_cond surf_p | 22.75 | 20.47 | +11.1% |
| ood_re surf_p | 32.25 | 30.95 | +4.2% |
| tandem surf_p | 43.48 | 41.23 | +5.5% |

### Surface MAE detail
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 0.331 | 0.192 | 25.65 |
| ood_cond | 0.273 | 0.197 | 22.75 |
| ood_re | 0.291 | 0.212 | 32.25 |
| tandem | 0.673 | 0.347 | 43.48 |

### Volume MAE (pressure)
| Split | vol_p |
|---|---|
| in_dist | 29.27 |
| ood_cond | 20.56 |
| ood_re | 52.28 |
| tandem | 46.50 |

Note: val_ood_re/vol_loss = 18868 (pre-existing overflow bug in noam branch, not introduced here).

---

### What happened

**This combination is decisively worse than baseline** — val/loss +8.5%, with in_dist surf_p degrading by +21% (21.18 → 25.65). The combination of no weight decay + tandem from epoch 0 hurts across every metric.

The no-weight-decay ablation in isolation showed improvements (sp_id=20.91, sp_ood=19.71 — better than baseline). But adding tandem geometry from epoch 0 appears to undermine this. Two likely mechanisms:

1. **Too much task diversity too early**: Tandem data has qualitatively different wake structure. Without the warmup exclusion, the model tries to learn single-foil and tandem physics simultaneously from epoch 1, preventing stable convergence on either.

2. **No weight decay + hard examples = overfitting early**: Without the regularizing effect of weight decay, training on the harder tandem samples early may cause the model to develop large activations or overfit to tandem-specific patterns, hurting generalization on in_dist.

The baseline's strategy (exclude tandem for 10 epochs, then introduce) acts as a curriculum — the model first stabilizes on simpler cases before tackling tandem. Removing this curriculum while also removing the implicit regularization from weight decay is a double-edged change.

### Suggested follow-ups
- **No weight decay alone** (the PR body says it improved sp_id=20.91, sp_ood=19.71). The problem here is the tandem-from-0 combination, not zero weight decay itself.
- Try a longer tandem warmup (epoch 20–30 instead of 10) — since no-weight-decay training may need more epochs to stabilize before handling tandem data.
- Try a smaller but non-zero weight decay (1e-5) combined with no tandem exclusion to see if light regularization is sufficient for stable early training.