### PR TITLE
No weight decay + remove coarse pooling loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -355,7 +355,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 1e-4
+    weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
@@ -645,24 +645,6 @@ for epoch in range(MAX_EPOCHS):
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
-
-        # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
-        B, N, C = pred.shape
-        n_groups = N // coarse_pool_size
-        if n_groups > 1:
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask[:, :n_groups * coarse_pool_size]
-
-            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
-
-            coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
Combine no-weight-decay (sp_id=20.91, sp_ood=19.71 — both below baseline) with removing the coarse pooling loss. The coarse loss pools over index-ordered groups (not spatial), which may be adding noise. Removing both weight decay and coarse loss simplifies training.

## Instructions
1. Set `weight_decay: float = 0.0` (line 358)
2. Remove coarse pooling loss (lines 649-665):
   ```python
   # REMOVE entire block:
   coarse_pool_size = 64
   ...
   loss = loss + 1.0 * coarse_loss
   ```

Run: `python train.py --agent kohaku --wandb_name "kohaku/nowd-nocoarse" --wandb_group nowd-nocoarse`

## Baseline
- val/loss: 2.2217, surf_p: in_dist=21.18, ood_cond=20.47, ood_re=30.95, tandem=41.23
---
## Results

**W&B run:** `lsrjaafa`
**Epochs completed:** 65/100 (timed out at 30 min)

### Metrics at best epoch (epoch 62)
| Split | val/loss |
|---|---|
| val_in_dist | 2.7342 |
| val_tandem_transfer | 6.0601 |
| val_ood_cond | 4.7235 |
| val_ood_re | 18870.75 |
| **3-split val/loss** | **4.5059** |

**Baseline val/loss:** 2.2217

### Surface pressure MAE (last epoch)
| Split | surf_p (ours) | surf_p (baseline) |
|---|---|---|
| val_in_dist | 38.93 | 21.18 |
| val_ood_cond | 54.77 | 20.47 |
| val_ood_re | 44.45 | 30.95 |
| val_tandem_transfer | 75.82 | 41.23 |

**Peak memory:** 10.5 GB

### What happened

**Strongly negative result.** 3-split val/loss 4.51 is more than double the baseline 2.22. Surface pressure is catastrophically worse on all splits (in_dist: 38.9 vs 21.2; tandem: 75.8 vs 41.2).

Key findings:

1. **Removing the coarse pooling loss is strongly harmful.** The coarse pooling loss provides a multi-scale regularization signal that prevents the model from overfitting to local noise. Without it, the model loses training signal quality.

2. **No weight decay appears to also hurt here.** The combination is particularly damaging. Even though no-weight-decay alone showed promising results in other experiments (surf_p in_dist=20.91 < baseline 21.18), combining it with removing the coarse loss leads to severe degradation.

3. **val_ood_re is now finite (18870).** The noam branch was updated to fix the ood_re NaN issue — it now shows finite but huge values, indicating the model fails badly at high Re extrapolation under these conditions.

4. **Convergence appears stalled** — val/loss plateaued at 4.50-4.58 from epoch 61 onwards without significant improvement.

### Suggested follow-ups

- **Don't remove the coarse pooling loss.** It's clearly load-bearing for training quality.
- **Test no-weight-decay alone** (without removing coarse loss) to isolate which change causes the damage. The experiment that inspired this (sp_id=20.91, sp_ood=19.71) presumably kept coarse loss intact.