### PR TITLE
Tandem boost 2.0 (mild increase, keep curriculum)

### DIFF
--- a/train.py
+++ b/train.py
@@ -641,7 +641,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_boost = torch.where(is_tandem, 2.0, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Tandem surf_p (42.78) is our worst metric. The boost=3.0 experiment (#846) failed because it combined a high boost with removing tandem exclusion. Here we try a MILDER boost (2.0 instead of 1.5) while KEEPING the tandem exclusion for the first 10 epochs. This preserves the curriculum learning while giving tandem slightly more emphasis.

## Instructions
Change line 644:
```python
tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
```
To:
```python
tandem_boost = torch.where(is_tandem, 2.0, 1.0).to(device)
```

Run: `python train.py --agent norman --wandb_name "norman/tandem-boost-2" --wandb_group nowd-tandem-boost-2`

## Baseline
- val/loss: 2.2396, surf_p: in_dist=20.91, ood_cond=19.71, ood_re=30.90, tandem=42.78
---

## Results

**W&B run:** 8zdg2f3d  
**Epochs:** 67 (30-min wall-clock limit)  
**Peak memory:** 10.5 GB  

### Metrics vs baseline

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6324 | 0.3120 | 0.1780 | 21.85 | 1.3519 | 0.4847 | 26.96 |
| val_ood_cond | 1.9249 | 0.2710 | 0.1896 | 20.02 | 1.0701 | 0.4122 | 19.31 |
| val_tandem_transfer | 3.2132 | 0.6251 | 0.3280 | **40.66** | 2.1603 | 1.0000 | 44.37 |
| val_ood_re | 18870 | 0.2755 | 0.1979 | **30.45** | 1.0607 | 0.4435 | 51.61 |
| **combined val/loss** | **2.2568** | | | | | | |

Baseline val/loss 2.2396 → **2.2568: slightly worse by +0.017 (+0.8%)**

Surface pressure vs baseline:
- in_dist: 21.85 vs 20.91 → **+0.94 worse**
- ood_cond: 20.02 vs 19.71 → +0.31 worse
- ood_re: **30.45 vs 30.90 → -0.45 better**
- tandem: **40.66 vs 42.78 → -2.12 better** (significant improvement!)

### What happened

Clear trade-off: tandem surface pressure improved significantly (-2.1 points) but in_dist regressed (+0.94). The combined val/loss is slightly worse (+0.8%).

Increasing tandem_boost from 1.5 to 2.0 redirects gradient emphasis from in_dist samples (which are more numerous) to tandem samples. The model converges on a different minimum that's better for tandem geometry but marginally worse for single-foil in-distribution cases.

The tandem improvement (40.66 vs 42.78) is the most significant absolute gain we've seen for tandem pressure in these experiments. The val_ood_re surface pressure also improved (30.45 vs 30.90), though the loss is still large due to the OOD re vol overflow.

The key question is whether the tandem gain (+2.12) is worth the in_dist loss (+0.94). Given that tandem is our worst metric, this trade-off is reasonable, but the combined val/loss slightly increases.

### Suggested follow-ups

- **Try boost=1.75**: The sweet spot between 1.5 (baseline) and 2.0 might give tandem improvement without as much in_dist regression.
- **Boost only in later epochs** (e.g., epoch > 30): Let the model first learn in_dist well, then shift emphasis to tandem. This avoids the curriculum disruption that comes with high boost from epoch 0.
- **Per-split surf_weight**: Use a higher surf_weight for tandem samples specifically, rather than the same weight for all.