### PR TITLE
Larger coarse pool size (128 instead of 64)

### DIFF
--- a/train.py
+++ b/train.py
@@ -647,7 +647,7 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
+        coarse_pool_size = 128
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:


### PR DESCRIPTION
## Hypothesis
The coarse pooling loss is essential (removing it = catastrophic). The current pool_size=64 creates many small groups. Increasing to 128 creates fewer, larger groups — a coarser multi-resolution view that might provide better long-range regularization.

## Instructions
Change line 650:
```python
coarse_pool_size = 64
```
To:
```python
coarse_pool_size = 128
```

Run: `python train.py --agent emma --wandb_name "emma/coarse-128" --wandb_group coarse-pool-128`

If improved, try pool_size=256.

## Baseline
- val/loss: 2.2396, surf_p: in_dist=20.91, ood_cond=19.71, tandem=42.78

---

## Results

**W&B run:** mp4zcyug
**Runtime:** 30.5 min
**Peak GPU memory:** ~46.8 GB

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 1.6287 | 0.3209 | 0.1799 | 21.35 | 1.3300 | 0.4756 | 26.03 |
| ood_cond | 1.8534 | 0.2571 | 0.1850 | 20.28 | 1.0364 | 0.4023 | 19.20 |
| ood_re | 18869.6 | 0.2741 | 0.2019 | 30.92 | 1.0236 | 0.4410 | 51.06 |
| tandem | 3.2900 | 0.6388 | 0.3388 | 42.05 | 2.2046 | 1.0011 | 44.64 |
| **combined** | **2.2573** | — | — | — | — | — | — |

**Baseline val/loss: 2.2396 → Result: 2.2573 (+0.8%, slightly worse)**

Did not run pool_size=256 since 128 did not improve on baseline.

### What happened

Mixed results. The combined val/loss is marginally worse (+0.8%), but the results are within noise for this level of difference. Most per-split metrics are within ~2-3% of baseline in either direction:
- in_dist surf p: 21.35 vs 20.91 (+2.1%)
- ood_cond surf p: 20.28 vs 19.71 (+2.8%)
- tandem surf p: 42.05 vs 42.78 (-1.7%, slightly better)The larger pool creates fewer groups (N/128 instead of N/64), so the coarse regularization operates at a coarser spatial scale. This doesn't seem to make a meaningful difference, suggesting the coarse pool size of 64 is already tuned well for this mesh size. The slight regression is within noise.

### Suggested follow-ups
- Try pool_size=32 (finer grouping) to see if the current 64 is already too coarse
- The val_ood_re loss is very large (18869) due to the known overflow issue — this may be masking the true ood_re performance