### PR TITLE
Batch size 8 (more stable gradients per step)

### DIFF
--- a/train.py
+++ b/train.py
@@ -356,7 +356,7 @@ MAX_EPOCHS = 100
 class Config:
     lr: float = 3e-3
     weight_decay: float = 0.0
-    batch_size: int = 4
+    batch_size: int = 8
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
     stats_file: str = "data/split_stats.json"


### PR DESCRIPTION
## Hypothesis
With batch_size=4 and ~330 training batches per epoch, gradient estimates are noisy. Doubling to batch_size=8 halves the number of steps per epoch but gives more stable gradient estimates per step. With 96GB VRAM, memory is not a constraint. Fewer steps per epoch may also speed up epoch time (less Python overhead), fitting more epochs in 30 minutes.

## Instructions
Change line 359:
```python
batch_size: int = 4
```
To:
```python
batch_size: int = 8
```

Run: `python train.py --agent senku --wandb_name "senku/bs8" --wandb_group batch-size-8`

## Baseline (new, after #849 merge)
- val/loss: 2.2396, surf_p: in_dist=20.91, ood_cond=19.71, ood_re=30.90, tandem=42.78
---
## Results

**W&B run:** `epwgy4jz`
**Epochs completed:** ~63/100 (hit 30-min timeout at 1800s)
**Epoch time:** 28.2s/epoch (vs ~26.8s for bs=4)
**Peak memory:** not logged (final summary code cut by timeout)

### Metrics at final checkpoint (epoch ~63)

| Metric | This run (bs=8) | Baseline (bs=4) | Delta |
|---|---|---|---|
| val/loss (3-split) | **2.7228** | 2.2396 | +21.6% ❌ |
| val_in_dist/loss | 2.293 | ~1.65 | worse |
| val_in_dist/surf_p | 32.07 | 20.91 | worse |
| val_ood_cond/surf_p | 27.91 | 19.71 | worse |
| val_tandem/loss | 3.582 | — | |
| val_tandem/surf_p | 45.37 | 42.78 | worse |
| val_ood_re/surf_loss | 0.091 | 0.077 | finite ✓ |
| val_ood_re/vol_loss | 37037 | 18868 | higher |
| Gradient steps taken | **10,458** | **22,177** | 47% fewer |

### What happened

**Negative result within the 30-minute budget.** val/loss = 2.7228 vs baseline 2.2396 — 21.6% worse.

**Root cause: fewer gradient steps.** With batch_size=8, there are only 166 batches per epoch (vs 331 for bs=4). At epoch 63, bs=8 has taken 10,458 gradient updates vs 22,177 for bs=4 — only 47% as many. The model is still rapidly converging (val/loss dropped from 2.87 to 2.72 in the last few epochs), so it simply hasn't had enough updates to reach baseline quality.

**Epoch timing didn't improve.** bs=8 takes 28.2s/epoch vs bs=4's ~26.8s/epoch. Each larger batch takes ~2× longer to process (0.17s vs 0.08s per batch), so the per-epoch time is roughly equal. This means bs=8 runs only ~63 epochs in 30 min vs ~67 for bs=4, making the step-count disadvantage even worse.

The val/loss curve was still declining rapidly when the timeout hit. Extrapolating the trajectory, it would likely need another ~100 more epochs (~47 minutes more at 28s/epoch) to reach the baseline. This experiment effectively doubled the required wall-clock time for convergence.

Within the 30-minute research iteration budget, batch_size=8 is clearly inferior to batch_size=4.

### Suggested follow-ups

- **Learning rate scaling:** If batch_size=8 is revisited with a longer budget, scale LR by 2× (linear scaling rule) to compensate for fewer, larger steps. This might speed up convergence.
- **Gradient accumulation instead:** PR #819 (grad-accum-2step) applies gradient accumulation to effectively get bs=8 from bs=4 without reducing steps per epoch. That should give the stability benefits without the convergence slowdown.