### PR TITLE
Thinner block MLP (mlp_ratio=1 instead of 2)

### DIFF
--- a/train.py
+++ b/train.py
@@ -467,7 +467,7 @@ model_config = dict(
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
-    mlp_ratio=2,
+    mlp_ratio=1,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
The TransolverBlock MLP has hidden_dim = n_hidden * mlp_ratio = 128 * 2 = 256. With n_layers=1, this is the ONLY MLP processing features after attention. A thinner MLP (128*1=128, same as input) may:
1. Speed up epoch time, fitting more epochs in 30 min
2. Force more compact representations (similar to how no-weight-decay helped)
3. Reduce overfitting risk with fewer parameters

"Less is more" has been our winning strategy — let's try it on the block MLP.

## Instructions
Change line 470:
```python
mlp_ratio=2,
```
To:
```python
mlp_ratio=1,
```

Run: `python train.py --agent violet --wandb_name "violet/mlp-ratio-1" --wandb_group mlp-ratio-1`

## Baseline
- val/loss: 2.2396, surf_p: in_dist=20.91, ood_cond=19.71, ood_re=30.90, tandem=42.78
---
## Results

**W&B run ID**: `0cz4i0x9`
**Epochs completed**: 32 (best), 33 total
**Peak memory**: 10.1 GB

### Metrics vs Baseline

| Metric | Baseline | mlp_ratio=1 | Δ |
|---|---|---|---|
| val/loss | 2.2396 | **3.7945** | +69.4% 🔴 |
| in_dist surf_p | 20.91 Pa | **43.47 Pa** | +108% 🔴 |
| ood_cond surf_p | 19.71 Pa | **42.64 Pa** | +116% 🔴 |
| ood_re surf_p | 30.90 Pa | 46.12 Pa | +49% 🔴 |
| tandem surf_p | 42.78 Pa | **62.86 Pa** | +47% 🔴 |
| in_dist vol_Ux | — | 1.880 | — |
| in_dist vol_p | — | 46.12 Pa | — |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

The hypothesis is **false** — reducing mlp_ratio from 2 to 1 catastrophically degraded performance. With n_layers=1, the TransolverBlock MLP is the only feature transformation between attention and output. Removing its expansion capacity (128→256→128 → 128→128→128) eliminates the non-linear expressivity needed to translate slice-pooled representations into accurate flow predictions. The model essentially has no room to learn, producing errors 2× worse than baseline across all metrics.

The predicted speed benefit also didn't materialize meaningfully: 33 epochs vs presumably a similar count with ratio=2, since data loading and attention dominate wall-clock time, not the MLP.

### Suggested follow-ups

- **mlp_ratio=3 or 4**: The opposite direction — a wider MLP might improve accuracy at the cost of some speed. Given how severely ratio=1 hurt, the ratio=2 baseline may itself be underpowered.
- **Two MLP layers**: Alternatively, keep ratio=2 but add a second MLP layer (n_layers=2 in the block) to add depth without changing parameter count dramatically.