### PR TITLE
Smaller coarse pool (32 instead of 64)

### DIFF
--- a/train.py
+++ b/train.py
@@ -647,7 +647,7 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
+        coarse_pool_size = 32
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:


### PR DESCRIPTION
## Hypothesis
The coarse pooling loss is essential (removing it = catastrophic). Currently it pools over groups of 64 nodes. With pool_size=32, we get twice as many groups — a finer multi-resolution view. If the model benefits from coarse regularization, finer coarse groups may help by providing more spatially localized regularization.

## Instructions
Change line 650:
```python
coarse_pool_size = 64
```
To:
```python
coarse_pool_size = 32
```

Run: `python train.py --agent alphonse --wandb_name "alphonse/coarse-32" --wandb_group coarse-pool-32`

## Baseline
- val/loss: 2.2396, surf_p: in_dist=20.91, ood_cond=19.71, ood_re=30.90, tandem=42.78

---

## Results

**W&B run ID:** `n3le4rp8`
**Epochs completed:** 64/100 (30-min timeout)
**Peak memory:** 10.6 GB

### Metrics vs Baseline

| Metric | Baseline | coarse=32 (ep 63 best) | Delta |
|--------|----------|------------------------|-------|
| val/loss | 2.2396 | 2.4258 | +0.19 (worse) |
| val_in_dist/loss | — | 1.8192 | — |
| val_tandem_transfer/loss | — | 3.4277 | — |
| val_ood_cond/loss | — | 2.0303 | — |

### Surface pressure MAE vs Baseline

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 24.95 | 20.91 | +4.04 (worse) |
| val_ood_cond | 22.35 | 19.71 | +2.64 (worse) |
| val_ood_re | 32.39 | 30.90 | +1.49 (worse) |
| val_tandem_transfer | 46.59 | 42.78 | +3.81 (worse) |

### What happened

Reducing the pool size from 64 to 32 made all splits noticeably worse. Surface pressure MAE increased by 1.5–4.0 across splits, with tandem transfer particularly hard-hit (+3.81).

The 64-node pool provides a coarser, more globally-representative view of the domain. At 32 nodes, the groups are too small — the averaged prediction captures local neighborhoods rather than large-scale flow structures. The coarse loss with 64 nodes apparently provides beneficial long-range regularization that 32-node pooling cannot replicate.

This confirms the hypothesis direction: the coarse loss is useful for large-scale flow coherence, and the pool size of 64 is appropriate (or possibly could be even larger for more benefit).

### Suggested follow-ups

- Try pool_size=128 (less groups, more global) — if the benefit comes from long-range regularization, a coarser pool might be even better.
- The tandem split is particularly sensitive to this change, which may indicate that tandem patterns have large-scale spatial structure (wake interactions, interference fields) that the 64-node global average captures better.