### PR TITLE
Reduce Re auxiliary loss weight (0.005 instead of 0.01)

### DIFF
--- a/train.py
+++ b/train.py
@@ -666,7 +666,7 @@ for epoch in range(MAX_EPOCHS):
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
+        loss = loss + 0.005 * re_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The auxiliary Re prediction loss (0.01 * re_loss on line 669) was added to improve feature quality. But we now know the model is slightly over-regularized (no-weight-decay helped). The Re aux loss forces the hidden features to encode Reynolds number information — useful for generalization, but it diverts gradient from the primary prediction task. Halving the weight to 0.005 maintains the benefit while giving more gradient to the main loss.

## Instructions
Change line 669:
```python
loss = loss + 0.01 * re_loss
```
To:
```python
loss = loss + 0.005 * re_loss
```

Run: `python train.py --agent kohaku --wandb_name "kohaku/half-re-loss" --wandb_group nowd-half-re-loss`

If improved, try 0.001.

## Baseline
- val/loss: 2.2396, surf_p: in_dist=20.91, ood_cond=19.71, ood_re=30.90, tandem=42.78
---
## Results

**W&B run:** l9yax2s8 | **Epochs:** 64 (30-min timeout) | **Memory:** 10.6 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.8918 | 0.3705 | 0.2256 | 25.78 | 1.321 | 0.478 | 27.94 |
| tandem_transfer | 3.4092 | 0.6487 | 0.3519 | 43.04 | 2.140 | 1.003 | 45.03 |
| ood_cond | 2.0154 | 0.2803 | 0.2014 | 22.28 | 1.053 | 0.420 | 20.93 |
| ood_re | 18869.73 | 0.2908 | 0.2158 | 33.27 | 1.050 | 0.450 | 52.58 |
| **3-split mean** | **2.4388** | | | | | | |

**vs baseline (2.2396):** +8.9% worse

Surface pressure degraded across all splits:
- in_dist: 25.78 vs 20.91 (+23%)
- ood_cond: 22.28 vs 19.71 (+13%)
- tandem: 43.04 vs 42.78 (flat)
- ood_re: 33.27 vs 30.90 (+8%)

**What happened:** Negative result. Halving the Re aux loss weight from 0.01 to 0.005 made training worse, not better. The hypothesis that the aux loss was diverting too much gradient from the primary task does not hold — removing half of it hurt both volume and surface accuracy. The 0.01 weight was already well-calibrated. Since the 0.005 result is worse than baseline, I did not try 0.001 as the PR instructions specify (only try lower if improved).

**Suggested follow-ups:**
- Try the opposite direction: increase re_loss weight to 0.02 or 0.05 to see if more Re encoding helps generalization (especially ood_re)
- Investigate why val_ood_re remains catastrophically broken (18869 loss) — this appears to be a structural issue unrelated to the Re aux weight