### PR TITLE
Grad clip 2.0 on new baseline (fresh run, no rebase needed)

### DIFF
--- a/train.py
+++ b/train.py
@@ -670,7 +670,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=2.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:


### PR DESCRIPTION
## Hypothesis
Thorfinn's grad-clip-2.0 experiment (#850) showed incredible results: val_loss=2.2090, in_dist surf_p=19.89 (-6.1%). But that was on old code. This is a fresh run on the NEW baseline code (weight_decay=0, ema_start=40) with just the max_norm change. If the improvement compounds, we could see in_dist surf_p below 19.0.

## Instructions
Change line 673:
```python
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
```
To:
```python
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=2.0)
```

Run: `python train.py --agent fern --wandb_name "fern/grad-clip-2-new" --wandb_group grad-clip-2-fresh`

## Baseline (new, after #858 merge)
- val/loss: 2.2068, surf_p: in_dist=20.56, ood_cond=21.30, ood_re=30.90, tandem=40.78

---

## Results

**W&B run:** `005zq8n4`

**Note:** Run crashed (killed by 30-min timeout) at epoch 64/100.

### Metrics at best/final epoch (epoch 64)

| Metric | This run (ep 64) | New baseline (ep 64) |
|--------|-----------------|----------------------|
| val/loss | 2.2687 | 2.2068 |
| val_in_dist/loss | 1.671 | 1.547 |
| Surface MAE Ux (in_dist) | 0.308 | 0.282 |
| Surface MAE Uy (in_dist) | 0.182 | 0.173 |
| Surface MAE p (in_dist) | 22.28 | 20.56 |
| Surface MAE p (tandem) | 40.91 | 40.78 |
| Surface MAE p (ood_cond) | 21.39 | 21.30 |
| Surface MAE p (ood_re) | 31.00 | 30.90 |
| Volume MAE Ux (in_dist) | 1.338 | 1.265 |
| Volume MAE Uy (in_dist) | 0.474 | 0.457 |
| Volume MAE p (in_dist) | 27.26 | 25.85 |

**Peak memory:** not tracked

### What happened

**Hypothesis not supported.** Grad clip 2.0 performs *worse* than the new baseline (2.2687 vs 2.2068) on all metrics. The run was still converging (2.40 → 2.38 → 2.36 → 2.35 → 2.33 → 2.31 → 2.30 → 2.29 → 2.28 → 2.27) but tracking consistently above the new baseline's trajectory.

The interaction between grad clip and no-weight-decay is different from the interaction with weight_decay=1e-4. With weight decay, the model parameters are constantly shrunk, creating a regime where larger gradients can help "fight back" against regularization. Without weight decay, parameters are free to grow, so allowing larger gradients (clip 2.0 vs 1.0) may introduce more noise into updates without a counterbalancing shrinkage force. The result: slightly worse convergence on every metric.

This is consistent with PR #850's result being on older code where weight_decay was active. The benefit of higher grad clip was likely compensating for overly aggressive weight decay, not a fundamental improvement.

### Suggested follow-ups

- Try lower grad clip (0.5 or 0.3) on the new baseline — if higher clip hurts, lower might help by reducing gradient noise
- The new baseline (nowd+ema40) is already strong; incremental changes to grad clip seem unlikely to compound well
- Focus on architectural changes or loss function changes that are orthogonal to the optimizer settings