### PR TITLE
Slower EMA decay (0.999 instead of 0.998)

### DIFF
--- a/train.py
+++ b/train.py
@@ -477,7 +477,7 @@ model = Transolver(**model_config).to(device)
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.999
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
EMA start at epoch 40 (merged in #858) was a big win. The current decay of 0.998 means ~500 steps half-life. With the earlier start, the EMA now averages over 28+ epochs (vs 5 before). A slower decay (0.999, ~1000 steps half-life) would create a smoother average that's more stable for checkpoint selection. This is especially relevant with no weight decay — the optimizer weights may drift more, making a stronger EMA more valuable.

## Instructions
Change line 480:
```python
ema_decay = 0.998
```
To:
```python
ema_decay = 0.999
```

Run: `python train.py --agent nezuko --wandb_name "nezuko/ema-999" --wandb_group ema-decay-999`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, ood_cond=21.30, ood_re=30.90, tandem=40.78

---
## Results

**W&B run:** `xhtuh9l7` — https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/xhtuh9l7
**Epochs completed:** 63 (29s/epoch)
**Peak VRAM:** 10.6 GB

| Metric | ema=0.999 | Baseline (0.998) | Delta |
|---|---|---|---|
| val/loss | 2.2554 | 2.2068 | +2.2% |
| in_dist surf_p | 21.73 | 20.56 | +5.7% |
| ood_cond surf_p | **21.08** | 21.30 | **-1.0%** ✓ |
| ood_re surf_p | 31.07 | 30.90 | +0.6% |
| tandem surf_p | 40.78 | 40.78 | 0.0% |

### Surface MAE detail
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 0.310 | 0.183 | 21.73 |
| ood_cond | 0.261 | 0.188 | 21.08 |
| ood_re | 0.277 | 0.200 | 31.07 |
| tandem | 0.626 | 0.336 | 40.78 |

### Volume MAE (pressure)
| Split | vol_p |
|---|---|
| in_dist | 26.56 |
| ood_cond | 19.71 |
| ood_re | 51.26 |
| tandem | 43.38 |

Note: val_ood_re/vol_loss = 18868 (pre-existing overflow bug, excluded from val/loss avg).

---

### What happened

**ema_decay=0.999 is slightly worse than 0.998 overall** — val/loss +2.2%, in_dist surf_p +5.7%. The only improvement is ood_cond surf_p (-1.0%), which is a small gain.

The hypothesis that slower decay would help with longer EMA windows doesn't pan out. Here's why: with EMA starting at epoch 40 and training ending at epoch 63 (~7,590 steps), the 0.999 EMA has an effective window of ~1000 steps (≈3 epochs) vs 0.998's ~500 steps (≈1.5 epochs). In the final training phase where the model is still improving, the slower 0.999 EMA is more stale — it underweights the most recent (better) parameter updates relative to earlier epochs. The 0.998 decay is a better fit for this training regime.

### Suggested follow-ups
- The 0.998 decay appears well-calibrated for the 30-min/~63-epoch window. If training epochs increase (e.g., 100+), a slower decay might become beneficial.
- Try ema_start_epoch=50 (vs 40) to see if the EMA benefits from starting even closer to convergence, when the model is more stable.