### PR TITLE
Earlier EMA start (epoch 30 instead of 40)

### DIFF
--- a/train.py
+++ b/train.py
@@ -476,7 +476,7 @@ model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 30
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
EMA at epoch 40 was a clear win over epoch 65 (#858 merged). Does starting even earlier (epoch 30) give more averaging benefit? With 67 epochs, EMA from epoch 30 gives 37 epochs of averaging vs 27 from epoch 40. The risk is that early-training weights are too noisy to include in the average.

## Instructions
Change line 479:
```python
ema_start_epoch = 40
```
To:
```python
ema_start_epoch = 30
```

Run: `python train.py --agent gilbert --wandb_name "gilbert/ema-30" --wandb_group ema-start-30`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** 1hv7c73f
**Best epoch:** 67 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.6182 | 0.300 | 0.180 | 21.7 |
| val_tandem_transfer | 3.2346 | 0.629 | 0.340 | 41.1 |
| val_ood_cond | 1.9121 | 0.264 | 0.189 | 21.3 |
| val_ood_re | 18869.6 | 0.273 | 0.199 | 31.2 |
| **combined val/loss (3-split)** | **2.2549** | | | |

**Baseline val/loss: 2.2068 (ema_start=40) → This run: 2.2549 (+0.048, slightly worse)**

### What happened

Starting EMA at epoch 30 is slightly worse than epoch 40. The hypothesis that "more averaging = better" didn't hold — the improvement from epoch 40 doesn't extend further back to epoch 30.

This is consistent with the PR's stated risk: "early-training weights are too noisy to include." With EMA starting at epoch 30, the model averages in 10 extra epochs of noisier, less-converged weights. By epoch 30, the model is still in the middle of the progressive resolution curriculum (epochs 0-40 subsample volume nodes) and hasn't fully converged. These early weights add noise rather than diversity.

The sweet spot appears to be around epoch 40, where the model has completed the progressive resolution phase and is starting to converge stably. The earlier averages (epochs 30-40) include states that are systematically biased by the sub-sampled volume training.

### Suggested follow-ups

- **Try ema_start=35**: the boundary between "too noisy" (30) and "optimal" (40) might be at 35.
- **Investigate what changes around epoch 40**: since the progressive volume sub-sampling completes at epoch 40, the EMA sweet spot may be tied to that transition. Starting EMA right after this phase completes may be optimal.