### PR TITLE
Compressed volume subsample ramp (25 epochs instead of 40)

### DIFF
--- a/train.py
+++ b/train.py
@@ -627,8 +627,8 @@ for epoch in range(MAX_EPOCHS):
 
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+        if epoch < 25:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / 25)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
The progressive vol subsample ramp (5%→100% over 40 epochs) means full-mesh training only starts at epoch 40. Norman's earlier experiment (#830) with a 25-epoch ramp got val_loss=2.2400 (essentially baseline on old code). On the NEW baseline code (with weight_decay=0 + ema_start=40), the compressed ramp could compound — more full-mesh epochs at the new EMA start means more epochs of high-quality averaging.

## Instructions
Change lines 630-631:
```python
if epoch < 40:
    vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
```
To:
```python
if epoch < 25:
    vol_keep_ratio = 0.05 + 0.95 * (epoch / 25)
```

Run: `python train.py --agent emma --wandb_name "emma/ramp-25" --wandb_group vol-subsample-25-ramp`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** bi795kt1  
**Peak memory:** 10.5 GB  
**Epochs completed:** 67 (30-min wall-clock limit)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.294 | 0.176 | 21.79 | 1.303 | 0.461 | 26.46 |
| val_tandem | 0.619 | 0.337 | 41.67 | 2.114 | 0.982 | 43.54 |
| val_ood_cond | 0.261 | 0.186 | 21.04 | 1.022 | 0.389 | 19.29 |
| val_ood_re | 0.273 | 0.201 | 30.76 | 1.030 | 0.435 | 50.62 |

**val/loss (3-split): 2.2385** vs baseline 2.2068 (+1.4%, slightly worse)

### What happened

The compressed ramp did not improve on the baseline. Val/loss of 2.2385 is marginally worse than the baseline 2.2068, and surface pressure is slightly worse across both in-dist (21.79 vs 20.56) and ood_cond (21.04 vs baseline ~19.71). Tandem is essentially the same (41.67 vs 40.78).

The hypothesis was that 15 additional epochs of full-mesh training before EMA starts (epochs 25–40) would allow better EMA averaging. In practice this didn't help. Two plausible explanations: (1) The original 40-epoch ramp is deliberately synchronized with the EMA start at epoch 40 — the model transitions to full mesh just as EMA begins, which may be intentional. (2) 15 extra full-mesh epochs before EMA could allow the model to drift into a suboptimal pre-EMA state. In both cases, the ramp-40 design may be better tuned than it looks.

Norman's earlier result with ramp-25 (val_loss=2.2400) on old code is consistent with ours (2.2385), suggesting this is a stable but slightly inferior configuration regardless of the other hyperparameter changes.

### Suggested follow-ups

- Try ramp-50 or ramp-60: if the current ramp-40 aligns intentionally with ema_start=40, extending past it might help (model gets more gradual training before hitting full mesh at the same time EMA starts)
- Try reducing EMA start to 25 alongside ramp-25, so the EMA-ramp alignment is preserved but compressed
- Try a non-linear ramp (e.g., cosine) to give more time at intermediate mesh fractions