### PR TITLE
Cosine T_max=65 (match actual epoch count)

### DIFF
--- a/train.py
+++ b/train.py
@@ -518,7 +518,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=65, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
The CosineAnnealingLR has T_max=75, but training only reaches ~67 epochs in 30 min. This means the LR hasn't fully decayed to eta_min=1e-4 when training stops — at epoch 67, the cosine schedule is at ~18% of its cycle. Setting T_max=65 ensures the LR reaches its minimum BEFORE the EMA starts capturing snapshots, giving the final 25+ epochs (40→65) clean, low-LR fine-tuning that the EMA averages over.

## Instructions
Change line 521:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
```
To:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=65, eta_min=1e-4)
```

Run: `python train.py --agent frieren --wandb_name "frieren/tmax-65" --wandb_group cosine-tmax-65`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `gcwfe5gm` (frieren/tmax-65)
**Epochs:** 66 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.589 | 0.307 | 0.178 | **21.47** | 1.309 | 0.465 | 26.67 |
| val_ood_cond | 1.855 | 0.259 | 0.183 | **19.64** | 1.080 | 0.394 | 18.79 |
| val_ood_re | overflow | 0.271 | 0.199 | **30.79** | 1.064 | 0.445 | 50.99 |
| val_tandem_transfer | 3.254 | 0.630 | 0.339 | **41.70** | 2.194 | 0.995 | 44.99 |
| **combined val/loss** | **2.2327** | | | | | | |

**vs baseline (2.2068):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2068 | 2.2327 | **+0.026 (+1.2%)** |
| surf_p in_dist | 20.56 | 21.47 | **+0.91 (+4.4%)** |
| surf_p tandem | 40.78 | 41.70 | **+0.92 (+2.3%)** |

**Peak GPU memory:** ~10.6 GB

### What happened

Null-to-slight-negative result. Setting T_max=65 (to match actual epoch count) marginally worsened all metrics by 1-4%. The combined val/loss is 2.2327 vs baseline 2.2068 (+1.2%).

**Why the hypothesis may be wrong**: The original T_max=75 acts as an implicit learning rate that decays slowly even beyond the training window. At epoch 66, with T_max=75, the LR is still gradually declining (~1.2×10⁻⁴ vs eta_min 1×10⁻⁴ at the end) — which is near-minimal anyway. With T_max=65, the LR hits eta_min at epoch 65 and stays flat for the last epoch, but this flat region may actually be less beneficial than a very gently declining LR. The difference is marginal either way.

**On EMA quality**: EMA start epoch=40, so EMA captures epochs 40→66. With T_max=75, epochs 40→66 see a cosine LR ranging from ~5×10⁻⁴ down to ~1.2×10⁻⁴ (still declining). With T_max=65, epochs 40→65 see LR declining to minimum, then epoch 66 at flat 1×10⁻⁴. The slightly steeper LR decay in the T_max=65 case doesn't help EMA capture better fine-tuning — if anything, the earlier arrival at eta_min may have caused the model to get stuck in a local minimum with fewer escape opportunities.

**Run-to-run variance caveat**: The ~1% degradation is within typical run-to-run variance. This is likely a null result, not a genuine regression.

### Suggested follow-ups

- **T_max=55**: If the hypothesis is that aligning T_max to actual training helps, try an even more aggressive schedule (T_max=55) to see if there's a sweet spot where early LR minimization clearly helps.
- **eta_min tuning**: The current eta_min=1e-4 may be too low (under-fitting) or too high (not converging). Try eta_min=5e-5 or eta_min=2e-4 to see if the floor matters more than T_max.
- **Log the LR trajectory**: Confirm where the LR actually lands at epoch 66 for both T_max values to validate the hypothesis numerically before further T_max experiments.