### PR TITLE
Coarse loss weight 1.5 (slightly stronger multi-resolution signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -662,7 +662,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 1.5 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
The coarse pooling loss is essential (removing=catastrophic) and its structure can't be changed (spatial sorting=catastrophic, pool size 128=neutral, pool size 32=tbd). But the WEIGHT might be tunable. Increasing from 1.0 to 1.5 gives a 50% stronger coarse regularization signal. Since this loss is so important, a small increase could help.

## Instructions
Change line 665:
```python
loss = loss + 1.0 * coarse_loss
```
To:
```python
loss = loss + 1.5 * coarse_loss
```

Run: `python train.py --agent askeladd --wandb_name "askeladd/coarse-wt-1.5" --wandb_group coarse-weight-1.5`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `ner6w1ov`
**Epochs:** 67 (EMA active from epoch 65) | **Peak memory:** 10.6 GB

### Loss comparison

| Split | Baseline | Coarse wt 1.5 | Delta |
|---|---|---|---|
| **val/loss** | **2.2068** | 2.2249 | +0.82% |
| val_in_dist/loss | — | 1.5631 | |
| val_tandem_transfer/loss | — | 3.2063 | |
| val_ood_cond/loss | — | 1.9051 | |

### Surface pressure MAE

| Split | Baseline | Coarse wt 1.5 | Delta |
|---|---|---|---|
| val_in_dist | **20.56** | 20.60 | +0.04 |
| val_ood_cond | — | 20.97 | |
| val_tandem_transfer | **40.78** | 41.30 | +0.52 |

### Full surface MAE (coarse wt 1.5 run)

| Split | surf Ux | surf Uy | surf p | vol p |
|---|---|---|---|---|
| val_in_dist | 0.295 | 0.176 | 20.60 | 25.15 |
| val_ood_cond | 0.260 | 0.191 | 20.97 | 19.50 |
| val_tandem_transfer | 0.624 | 0.332 | 41.30 | 43.11 |

### What happened

**Coarse weight 1.5 does not improve over baseline.** Val/loss is 2.2249 vs 2.2068 (+0.82% worse). Surface pressure metrics are essentially unchanged (in_dist: 20.60 vs 20.56, tandem: 41.30 vs 40.78). The differences are small but consistently in the wrong direction.

The coarse loss appears to be well-tuned at weight=1.0. Increasing the weight to 1.5 likely over-regularizes: the model allocates more gradient signal to the coarse-group consistency constraint, slightly reducing attention to fine-grained surface accuracy. Given the coarse loss uses index-ordered (not spatially meaningful) groups, forcing this constraint harder seems to hurt rather than help.

### Suggested follow-ups

- **Try weight 0.5**: Since 1.5 is worse, the optimal may be below 1.0 rather than above. A lighter coarse regularization might let the fine-grained loss dominate more.
- **Try weight 2.0**: To understand the shape of the curve — is this a monotonic degradation, or is there a sweet spot above 1.0?
- **Spatial coarse + tuned weight**: Given x-sorted coarse grouping didn't hurt (just neutral vs no-EMA baseline), combining it with a lower weight like 0.75 might be worth testing once the optimal weight range is known.