### PR TITLE
Lookahead k=5 (more frequent slow-weight sync)

### DIFF
--- a/train.py
+++ b/train.py
@@ -516,7 +516,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=5, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Removing Lookahead entirely was neutral-to-slightly-negative (#853, val_loss=2.2895). But the current k=10 means slow-weight sync every 10 steps — with the new earlier EMA and no weight decay, more frequent syncing (k=5) could help stabilize updates while keeping Lookahead's benefits.

## Instructions
Change line 519:
```python
optimizer = Lookahead(base_opt, k=10, alpha=0.8)
```
To:
```python
optimizer = Lookahead(base_opt, k=5, alpha=0.8)
```

Run: `python train.py --agent violet --wandb_name "violet/lookahead-k5" --wandb_group lookahead-k5`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run ID**: `j5ueuw1p`
**Epochs completed**: 67 (best), 30.3 min
**Peak memory**: 10.5 GB

### Metrics vs Baseline (k=10)

| Metric | Baseline (k=10) | k=5 | Δ |
|---|---|---|---|
| val/loss | 2.2068 | **2.2158** | +0.41% ⬤ |
| in_dist surf_p | 20.56 Pa | **20.79 Pa** | +1.1% |
| ood_cond surf_p | — | 20.44 Pa | — |
| ood_re surf_p | 30.90 Pa | **30.58 Pa** | -1.0% |
| tandem surf_p | 40.78 Pa | **41.67 Pa** | +2.2% |
| in_dist vol_Ux | — | 1.257 | — |
| in_dist vol_p | — | 25.27 Pa | — |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

k=5 is **essentially neutral** — all changes are within noise range (±2%). Slightly worse on in_dist and tandem, negligibly better on ood_re surf_p. The hypothesis that more frequent slow-weight syncing stabilizes training is not confirmed.

The Lookahead slow-weight update frequency doesn't appear to be a meaningful tuning axis here. With 67 epochs in 30 min, we take ~3,000+ steps per epoch × 67 epochs = ~200K total steps. At k=5 vs k=10, we double the number of slow-weight syncs from ~20K to ~40K, but the model converges to nearly identical quality. The slow-weight mechanism likely already saturates its benefit at k=10 or lower.

### Suggested follow-ups

- **Lower alpha**: The interpolation coefficient α=0.8 means slow weights = 0.2×current + 0.8×slow. A lower α (e.g., 0.5) would give slow weights more influence. Combined with k=5, this could be worth testing.
- **No Lookahead at all** (revisit): #853 showed neutral-to-negative removal of Lookahead. Given the current better baseline, it's worth confirming if Lookahead still contributes on this updated noam branch.