### PR TITLE
Combined: 2 heads + grad clip 2.0 (compound top improvements)

### DIFF
--- a/train.py
+++ b/train.py
@@ -465,7 +465,7 @@ model_config = dict(
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
-    n_head=4,
+    n_head=2,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
@@ -670,7 +670,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=2.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:


### PR DESCRIPTION
## Hypothesis
Two of our best single-change results: n_head=2 (in_dist=19.99, -4.4%) and max_norm=2.0 (in_dist=19.89, -6.1%). These changes are orthogonal (attention heads vs gradient clipping). Testing their compound effect on the new baseline could push in_dist below 19.0.

## Instructions
1. Change line 468: `n_head=4` → `n_head=2`
2. Change line 673: `max_norm=1.0` → `max_norm=2.0`

Run: `python train.py --agent senku --wandb_name "senku/2head-gc2" --wandb_group 2head-grad-clip-2`

## Baseline (new, after #858 merge)
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `jgy8yn14` (senku/2head-gc2)  
**Best epoch:** 33 of ~36 logged (run timed out at 30 min)  
**Peak GPU memory:** ~94% of 96GB

### Best checkpoint (epoch 33)

| Split | loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 3.0939 | 0.565 | 0.319 | 51.48 | 1.889 | 0.752 | 54.84 |
| val_tandem_transfer | 4.4885 | 0.842 | 0.475 | 54.61 | 2.626 | 1.263 | 59.68 |
| val_ood_cond | 3.3307 | 0.467 | 0.306 | 36.53 | 1.617 | 0.628 | 34.02 |
| val_ood_re | 18870.8 | 0.439 | 0.295 | 43.93 | 1.579 | 0.636 | 62.51 |

**val/loss (3-split): 3.6377** vs baseline **2.2068** → **+65% worse**  
**surf_p in_dist: 51.48** vs baseline **20.56** → **+150% worse**

### What happened

The combination of n_head=2 and max_norm=2.0 is a large regression on the new (#858) baseline — not just a failure to compound, but a major step backward.

A few likely factors:
1. **Individual improvements may not transfer to the new baseline.** The n_head=2 and max_norm=2.0 results (in_dist=19.99, 19.89) were measured on the old baseline. After #858, the model architecture/dynamics may have changed in ways that alter how each hyperparameter interacts.
2. **Reduced capacity + looser gradient clipping destabilize training.** With only 2 heads the model has limited attention diversity. Allowing larger gradients (clip 2.0 vs 1.0) may amplify instability rather than helping early convergence.
3. **The model was still converging at epoch 33** (best_val_loss trending downward), but even allowing much longer training seems unlikely to recover to baseline levels given how far off it is.

The compound hypothesis does not hold on this baseline.

### Suggested follow-ups
- Before assuming the combination can work, validate whether **n_head=2 alone** and **max_norm=2.0 alone** each still improve over the new #858 baseline — those individual benchmarks were on the old baseline and may no longer hold.
- If either individual change still helps on the new baseline, they could be combined again with that confirmed starting point.
- Consider whether #858 already incorporated some of the capacity/stability improvements that made n_head=2 beneficial, making it redundant or harmful now.
