### PR TITLE
Extended tandem exclusion (15 epochs instead of 10)

### DIFF
--- a/train.py
+++ b/train.py
@@ -618,7 +618,7 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
+        if epoch < 15:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask


### PR DESCRIPTION
## Hypothesis
The tandem exclusion for first 10 epochs was confirmed essential (#856, #846). Alphonse's student noted that a longer warmup might help. Testing 15 epochs of exclusion gives the model more time with simpler single-foil geometry before tandem. With EMA starting at epoch 40, this still leaves 52 epochs of tandem training + EMA averaging.

## Instructions
Change line 621:
```python
if epoch < 10:
```
To:
```python
if epoch < 15:
```

Run: `python train.py --agent kohaku --wandb_name "kohaku/tandem-excl-15" --wandb_group tandem-exclusion-15`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** nsktlkoq | **Epochs:** 64 (30-min timeout) | **Memory:** 10.5 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.6275 | 0.3008 | 0.1805 | 21.45 | 1.300 | 0.477 | 26.35 |
| tandem_transfer | 3.3606 | 0.6393 | 0.3451 | 43.68 | 2.168 | 1.006 | 45.73 |
| ood_cond | 1.9283 | 0.2703 | 0.1901 | 22.15 | 1.055 | 0.406 | 20.43 |
| ood_re | 18869.60 | 0.2794 | 0.2031 | 31.01 | 1.028 | 0.438 | 51.20 |
| **3-split mean** | **2.3055** | | | | | | |

**vs baseline (2.2068):** +4.5% worse

Surface pressure vs baseline:
- in_dist: 21.45 vs 20.56 (+4.3%)
- tandem: 43.68 vs 40.78 (+7.1%)
- ood_cond: 22.15 vs 19.71 (+12.4%)

**What happened:** Negative result. Extending the tandem exclusion warmup from 10 to 15 epochs delays convergence without helping final accuracy. The curve was still steadily improving at epoch 64 (setting new bests every epoch from epoch 41 onward), but the 5 extra warmup epochs mean the model spends less of its 30-minute budget on tandem training — it only starts seeing tandem at epoch 16 vs epoch 11. By the end, tandem transfer loss (3.36) and surface pressure (43.68) are both worse than baseline (40.78), suggesting the extra single-foil warmup doesn't improve tandem generalization; it just shifts the convergence curve later. 10-epoch exclusion appears to be the right balance for this 30-minute budget.

**Suggested follow-ups:**
- Test 5-epoch exclusion (shorter warmup) to see if the model can handle tandem earlier without degradation
- The steady per-epoch improvement at the end of training suggests a longer run (or faster iterations) could close the gap — explore LR schedule tuned for early-stop at 65 epochs rather than 100