### PR TITLE
Progressive tandem boost (1.0→2.0 ramp over training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -641,7 +641,8 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        boost_val = 1.0 + 1.0 * min(epoch / 50, 1.0)  # ramps 1.0→2.0 over 50 epochs
+        tandem_boost = torch.where(is_tandem, boost_val, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Tandem boost=1.5 is well-calibrated, boost=2.0 showed promising tandem improvement but in_dist regression (#863). A progressive ramp (1.0 at start → 2.0 by end) gives the model gentle tandem emphasis early, increasing as the model stabilizes. This avoids the early-training destabilization from a fixed high boost.

## Instructions
Replace line 644:
```python
tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
```
With:
```python
boost_val = 1.0 + 1.0 * min(epoch / 50, 1.0)  # ramps 1.0→2.0 over 50 epochs
tandem_boost = torch.where(is_tandem, boost_val, 1.0).to(device)
```

Run: `python train.py --agent thorfinn --wandb_name "thorfinn/progressive-tandem" --wandb_group progressive-tandem-boost`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `sfsau9um` | **Epoch:** 67/100 (30.4 min) | **Peak memory:** 10.5 GB

### Val loss (combined)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss (3-split) | 2.2068 | **2.2615** | +2.5% ❌ |

### Surface MAE

| Split | Metric | Baseline | This run | Δ |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 20.56 | 21.34 | +3.8% ❌ |
| val_ood_cond | mae_surf_p | — | 21.48 | — |
| val_ood_re | mae_surf_p | — | 31.11 | — |
| val_tandem_transfer | mae_surf_p | 40.78 | 42.08 | +3.2% ❌ |

*Note: val_ood_re/loss = 18869 (overflow bug) — pre-existing.*

---

### What happened

Clear negative result. The progressive ramp (1.0→2.0 over 50 epochs) is worse than the fixed 1.5 boost on all key metrics. Both tandem and in_dist surface pressure got worse.

The ramp starts at boost=1.0 (no tandem emphasis at all), which means the model learns with no tandem signal for the first 25 epochs. By the time the boost reaches 1.5 at epoch 37 and 2.0 at epoch 50, the model has already learned patterns without tandem guidance — the late boost can't easily override those early patterns.

In contrast, the fixed 1.5 boost provides consistent tandem weighting from epoch 1, which appears more useful than a ramp. The hypothesis that "gentle early emphasis avoids destabilization" doesn't hold here — the fixed 1.5 was already well-calibrated and not causing destabilization.

Additionally, the max val_surf_loss shown in the output (~0.19 surf) is slightly higher than the typical baseline, suggesting the model is having a harder time optimizing the surface loss when the tandem gradient signal is weak early on.

### Suggested follow-ups

- **Later start + faster ramp**: Instead of starting at 1.0, start at 1.5 (the current baseline) and ramp to 2.0 after epoch 30 — this way the model always has meaningful tandem signal, and the boost only increases.
- **Ramp from 1.5→2.0**: `boost_val = 1.5 + 0.5 * min((epoch - 20) / 30, 1.0)` — try ramping from epoch 20 to 50 from 1.5 to 2.0.
- **Fixed 2.0 revisit with max_norm=2.0**: The previous fixed boost=2.0 run (#863) that showed tandem improvement but in_dist regression was done before max_norm=2.0. The better gradient dynamics might allow boost=2.0 to work cleanly.