### PR TITLE
Surface-only loss for first 5 epochs (extreme early curriculum)

### DIFF
--- a/train.py
+++ b/train.py
@@ -644,7 +644,10 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        if epoch < 5:
+            loss = surf_weight * surf_loss  # surface-only for first 5 epochs
+        else:
+            loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
Surface accuracy is our primary metric. For the first 5 epochs (during warmup), compute loss ONLY on surface nodes (skip volume loss entirely). This gives the model's initial representations a strong surface-oriented bias before volume nodes are introduced. This is more extreme than progressive volume subsampling but only affects 5 epochs.

## Instructions
Change lines 642-647. Wrap vol_loss with epoch check:
```python
vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
# ... surf_loss computation stays the same ...
if epoch < 5:
    loss = surf_weight * surf_loss  # surface-only for first 5 epochs
else:
    loss = vol_loss + surf_weight * surf_loss
```

Run: `python train.py --agent fern --wandb_name "fern/surf-only-5" --wandb_group surf-only-first-5`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78

---

## Results

**W&B run:** `9cmzrobc`

**Note:** Run crashed (killed by 30-min timeout) at epoch 64/100.

### Metrics at best/final epoch (epoch 64)

| Metric | This run (ep 64) | New baseline (ep 64) | Δ |
|--------|-----------------|----------------------|---|
| val/loss | 2.2423 | 2.2068 | +1.6% |
| val_in_dist/loss | 1.645 | 1.547 | worse |
| Surface MAE p (in_dist) | 22.09 | 20.56 | +7.4% |
| Surface MAE p (tandem) | 41.27 | 40.78 | +1.2% |
| Surface MAE p (ood_cond) | **20.23** | 21.30 | **-5.0%** |
| Surface MAE p (ood_re) | **30.51** | 30.90 | **-1.3%** |
| Volume MAE Ux (in_dist) | 1.314 | 1.265 | worse |
| Volume MAE Uy (in_dist) | 0.465 | 0.457 | worse |
| Volume MAE p (in_dist) | 26.54 | 25.85 | worse |

**Peak memory:** not tracked

### What happened

**Hypothesis not supported in aggregate.** Val/loss 2.2423 vs new baseline 2.2068 (+1.6% worse). The curriculum had mixed effects: ood_cond improved nicely (-5.0% surf_p) and ood_re slightly improved (-1.3%), but in_dist and tandem were notably worse.

The tradeoff is understandable: pure surface-only loss in early epochs helps the model learn surface patterns for OOD conditions (which presumably share surface physics), but hurts the in-distribution split where volume context is important for accurate surface predictions. The model's initial representations become surface-biased at the cost of missing correlations between volume and surface that the in-dist split relies on.

The aggregate val/loss (3-split: in_dist + tandem + ood_cond) is dominated by in_dist and tandem performance, which both got worse. The ood_cond improvement alone isn't enough to offset this.

### Suggested follow-ups

- Try fewer warmup epochs (epoch < 2 or epoch < 1) — the effect might be too strong at 5 epochs
- Try partial surface emphasis (e.g., `loss = 0.1 * vol_loss + surf_weight * surf_loss` for first 5 epochs) rather than completely zeroing vol_loss
- The ood_cond improvement is interesting: surface-only curriculum seems to help generalization to extreme flow conditions. Could be worth investigating separately for ood-focused experiments