### PR TITLE
Light attention dropout (0.05)

### DIFF
--- a/train.py
+++ b/train.py
@@ -468,6 +468,7 @@ model_config = dict(
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,
+    dropout=0.05,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
Attention dropout is currently 0.0. A light dropout (0.05) in the Physics Attention module adds regularization that prevents the attention from overfitting to specific node-to-slice assignments. With no weight decay (now merged), a small amount of attention dropout could compensate as complementary regularization.

## Instructions
Change line 469 (in model_config):
```python
# Add dropout=0.05 to model config
```
Actually, the dropout parameter is passed through model_config but not currently set. Find where Transolver is instantiated and add:
```python
model_config = dict(
    space_dim=2,
    fun_dim=X_DIM - 2,
    out_dim=3,
    n_hidden=128,
    n_layers=1,
    n_head=4,
    slice_num=32,
    mlp_ratio=2,
    dropout=0.05,  # ADD THIS LINE
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)
```

Run: `python train.py --agent norman --wandb_name "norman/attn-dropout-0.05" --wandb_group attn-dropout-0.05`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** 4ssyfrct

| Metric | Baseline | Dropout-0.05 | Δ |
|--------|----------|--------------|---|
| val/loss | 2.2068 | 2.2826 | +0.0758 (+3.4%) |
| in_dist surf_p | 20.56 | 21.67 | +1.11 |
| tandem surf_p | 40.78 | 43.47 | +2.69 |
| ood_cond surf_p | — | 21.31 | — |
| ood_re surf_p | — | 31.21 | — |

**Full surface MAE:**
- in_dist: Ux=0.292, Uy=0.179, p=21.67
- tandem: Ux=0.639, Uy=0.341, p=43.47
- ood_cond: Ux=0.265, Uy=0.182, p=21.31
- ood_re: Ux=0.278, Uy=0.198, p=31.21

**Full volume MAE:**
- in_dist: Ux=1.260, Uy=0.455, p=26.61
- tandem: Ux=2.185, Uy=1.007, p=46.40
- ood_cond: Ux=1.033, Uy=0.398, p=20.09
- ood_re: Ux=1.042, Uy=0.441, p=51.29

**Peak memory:** not logged

### What happened
Light attention dropout (0.05) hurts consistently across all splits — val/loss is 3.4% worse, in_dist surf_p +1.11, tandem surf_p +2.69. The hypothesis that dropout could substitute for weight decay doesn't hold here. With a very small model (1 layer, n_hidden=128, ~180K params), the model is likely already capacity-limited rather than over-regularized. Adding dropout during training only limits what it can learn. The physics attention's node-to-slice assignment may also need to memorize specific geometric patterns that dropout disrupts.

### Suggested follow-ups
- If exploring regularization, try a tiny dropout on the MLP sublayer only (not attention), which might be less disruptive
- The model might benefit from the opposite — slightly more capacity (n_hidden=160 or mlp_ratio=3) rather than more regularization