### PR TITLE
Re prediction from preprocess features (not post-attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -334,8 +334,8 @@ class Transolver(nn.Module):
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)
 
-        # Auxiliary Re prediction from pre-output-head hidden representation
-        re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
+        # Auxiliary Re prediction from preprocess features
+        re_pred = self.re_head(fx_pre.mean(dim=1))  # [B, 1] — from preprocess features
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)


### PR DESCRIPTION
## Hypothesis
The Re auxiliary head currently predicts from post-attention features (line 338: `re_pred = self.re_head(fx.mean(dim=1))`). But with n_layers=1, the post-attention features are the same as pre-attention features for the non-last-block path. Moving Re prediction to preprocess features (fx_pre) ensures the preprocess MLP is forced to encode Re information, which could improve the quality of features entering the transformer.

## Instructions
Change line 338 in Transolver.forward:
```python
re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
```
To:
```python
re_pred = self.re_head(fx_pre.mean(dim=1))  # [B, 1] — from preprocess features
```

Run: `python train.py --agent gilbert --wandb_name "gilbert/re-from-preprocess" --wandb_group re-loss-in-preprocess`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** 4jxxb9ji
**Best epoch:** 67 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.6111 | — | — | 21.6 |
| val_tandem_transfer | 3.2417 | — | — | 41.5 |
| val_ood_cond | 1.9155 | — | — | 21.7 |
| val_ood_re | 18869.6 | — | — | 30.9 |
| **combined val/loss (3-split)** | **2.2561** | | | |

**Baseline val/loss: 2.2068 → This run: 2.2561 (+0.049, slightly worse)**

### What happened

Moving Re prediction to preprocess features is slightly worse than the baseline. The difference is small (+0.049) and within single-run noise, but the direction is negative.

The PR hypothesis was that forcing Re encoding into preprocess features would improve feature quality entering the transformer. However, the result suggests this doesn't help:

1. **With n_layers=1, the effect is minimal.** The observation that "post-attention features are the same as pre-attention features for the non-last-block path" is technically true but misses that `fx` goes through a full TransolverBlock (attention + MLP + SE gating) before the Re head was computed. This actually gives the Re head richer features than fx_pre (which is just the preprocess MLP output). Using fx_pre gives a simpler/shallower representation.

2. **The preprocess MLP already has an incentive to encode Re information** from the main reconstruction loss, since Re affects the flow field. The explicit supervision from the Re auxiliary head doesn't need to be at the preprocess level to influence those features.

3. **Backprop through fewer layers**: the Re loss gradient from fx_pre only reaches the preprocess MLP, whereas from fx it would backprop through the attention block too — providing a richer learning signal.

### Suggested follow-ups

- **No change needed**: the current position (from fx) appears slightly better. This negative result confirms the original design was reasonable.
- **Increase Re loss weight**: if Re encoding matters, try 0.05 instead of 0.01 — the loss signal may be too weak regardless of where it comes from.