### PR TITLE
EMA start epoch 50 (between current 40 and old 65)

### DIFF
--- a/train.py
+++ b/train.py
@@ -476,7 +476,7 @@ model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 50
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
EMA 30 was too early (noisy), EMA 40 was the sweet spot. But maybe 40 was on the early side of the sweet spot. Testing 50 to see if less averaging (17 epochs) with cleaner weights beats more averaging (27 epochs) with noisier early weights.

## Instructions
Change line 479: `ema_start_epoch = 40` → `ema_start_epoch = 50`

Run: `python train.py --agent frieren --wandb_name "frieren/ema-50" --wandb_group ema-start-50`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `si809v8e` (frieren/ema-50)
**Epochs:** 67 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.626 | 0.301 | 0.179 | **22.01** | 1.312 | 0.468 | 27.26 |
| val_ood_cond | 1.848 | 0.251 | 0.188 | **20.48** | 1.020 | 0.393 | 18.93 |
| val_ood_re | overflow | 0.270 | 0.200 | **30.58** | 1.029 | 0.433 | 50.76 |
| val_tandem_transfer | 3.304 | 0.632 | 0.342 | **42.09** | 2.146 | 1.000 | 43.99 |
| **combined val/loss** | **2.2593** | | | | | | |

**vs baseline (2.2068):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2068 | 2.2593 | **+0.053 (+2.4%)** |
| surf_p in_dist | 20.56 | 22.01 | **+1.45 (+7.1%)** |
| surf_p tandem | 40.78 | 42.09 | **+1.31 (+3.2%)** |

**Peak GPU memory:** ~10.6 GB

### What happened

Negative result. EMA start at epoch 50 is clearly worse than epoch 40 (val/loss +2.4%, surf_p in_dist +7.1%). Starting EMA later means the average is computed over only 17 epochs (50→67) instead of 27 (40→67). The quantity of averaging matters more than the quality of the earlier (slightly noisier) weights.

**Why epoch 40 beats epoch 50**: EMA is a low-pass filter over model snapshots. With more averaging (27 epochs vs 17), the EMA model averages over a larger portion of the late-training landscape, smoothing out per-epoch oscillations and finding a flatter minimum. The weights at epoch 40 aren't significantly noisier than at epoch 50 — by epoch 40 the LR has already decayed substantially via the cosine schedule (from peak ~3×10⁻³ at epoch 5 down to ~1.5×10⁻³ at epoch 40). There's no real "noisy" regime for the EMA to avoid.

**The original hypothesis is likely wrong**: The issue with EMA 30 vs 40 wasn't that epoch 30 weights were too noisy — it was just fewer snapshots. EMA benefits come from quantity of averaging over the settled training region, not from delaying the start to get "cleaner" weights.

### Suggested follow-ups

- **EMA start epoch 35**: Given 40 beats 50 (more averaging wins), try 35 to get even more averaging coverage without starting too early in training.
- **EMA decay tuning**: The current ema_decay=0.998 means half-life of ~350 steps. Increasing to 0.9995 would weight recent epochs more heavily — worth testing alongside earlier EMA start.
- **Log EMA vs raw model per epoch**: Tracking the EMA model's val/loss separately would show exactly when EMA diverges from (or beats) the raw model, clarifying the optimal start epoch empirically.