### PR TITLE
Stronger Re auxiliary loss (0.02 instead of 0.01)

### DIFF
--- a/train.py
+++ b/train.py
@@ -666,7 +666,7 @@ for epoch in range(MAX_EPOCHS):
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
+        loss = loss + 0.02 * re_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Halving Re loss hurt (#871, +8.9%). But doubling it might help — forcing the preprocess features to encode Re information more strongly, improving generalization across different Reynolds numbers. With no weight decay, the model can use more capacity for this without penalty.

## Instructions
Change line 669: `loss = loss + 0.01 * re_loss` → `loss = loss + 0.02 * re_loss`

Run: `python train.py --agent askeladd --wandb_name "askeladd/re-0.02" --wandb_group re-loss-0.02`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `4gavzmdv`
**Epochs:** 67 (best at 66, EMA active) | **Peak memory:** 10.6 GB

### Loss comparison

| Split | Baseline | Re 0.02 | Delta |
|---|---|---|---|
| **val/loss** | **2.2068** | 2.2698 | +2.86% |
| val_in_dist/loss | — | 1.6003 | |
| val_tandem_transfer/loss | — | 3.2626 | |
| val_ood_cond/loss | — | 1.9465 | |

### Surface pressure MAE

| Split | Baseline | Re 0.02 | Delta |
|---|---|---|---|
| val_in_dist | **20.56** | 21.56 | +4.9% |
| val_ood_cond | — | 22.06 | |
| val_tandem_transfer | **40.78** | 41.49 | +1.7% |

### Full surface MAE (Re 0.02 run, best epoch)

| Split | surf Ux | surf Uy | surf p | vol p |
|---|---|---|---|---|
| val_in_dist | 0.297 | 0.175 | 21.56 | 25.85 |
| val_ood_cond | 0.286 | 0.194 | 22.06 | 21.26 |
| val_tandem_transfer | 0.626 | 0.336 | 41.49 | 44.33 |

### What happened

**Doubling Re loss weight to 0.02 is worse than baseline.** Val/loss increases by 2.86%, and surface pressure is worse across all splits (in_dist: 21.56 vs 20.56, ood_cond: 22.06 vs 19.71, tandem: 41.49 vs 40.78).

This is consistent with the previous result where halving Re loss also hurt (+8.9%). Both directions make things worse, suggesting the current 0.01 weight is already well-tuned. The Re prediction auxiliary task appears to be a balanced regularizer at 0.01: increasing it pushes more gradient signal into the preprocess/Re head at the cost of the main flow prediction.

The no-weight-decay configuration also doesn't seem to change the picture — the model appears to find 0.01 Re loss to be the right balance regardless.

### Suggested follow-ups

- **The 0.01 sweet spot seems confirmed**: Given both 0.005 (#871) and 0.02 hurt, the Re loss appears well-calibrated at 0.01. This axis is likely exhausted.
- **Try 0.0 (no Re loss)**: To verify the Re loss is actually helpful at all, a control run without it would confirm whether it's adding any value vs. the coarse loss already providing enough regularization.
- **Re loss in preprocessing features**: Instead of auxiliary prediction, injecting Re as a direct feature in the preprocessing might be more direct — let the model use Re information deterministically rather than via gradient signal.