### PR TITLE
Surface weight ramp: low→high over training (inverse curriculum)

### DIFF
--- a/train.py
+++ b/train.py
@@ -572,8 +572,10 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Progressive surface weight: start low, ramp to high
+    base_surf = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    surf_ramp = 0.5 + 1.5 * min(epoch / 50, 1.0)  # ramps 0.5→2.0 over 50 epochs
+    surf_weight = base_surf * surf_ramp
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
The adaptive surf_weight clamped at [5,50] settles at floor=5 throughout training. But surface accuracy matters most for our metric. An inverse curriculum starts with low surface weight (2x) to learn volume structure, then ramps to high weight (10x) in late training to fine-tune surface predictions. This gives late-training gradients a strong surface bias, which the EMA (starting at epoch 40) will average over.

## Instructions
Replace line 576:
```python
surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
```
With:
```python
# Progressive surface weight: start low, ramp to high
base_surf = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
surf_ramp = 0.5 + 1.5 * min(epoch / 50, 1.0)  # ramps 0.5→2.0 over 50 epochs
surf_weight = base_surf * surf_ramp
```

Run: `python train.py --agent violet --wandb_name "violet/surf-weight-ramp" --wandb_group surf-weight-schedule`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run ID**: `siomhvjr`
**Epochs completed**: 67 (best), 30.3 min
**Peak memory**: 10.5 GB

### Metrics vs Baseline

| Metric | Baseline | surf-weight-ramp | Δ |
|---|---|---|---|
| val/loss | 2.2068 | **2.2775** | +3.2% 🔴 |
| in_dist surf_p | 20.56 Pa | **20.92 Pa** | +1.7% |
| ood_cond surf_p | — | **20.76 Pa** | — |
| ood_re surf_p | 30.90 Pa | **30.60 Pa** | -1.0% |
| tandem surf_p | 40.78 Pa | **43.08 Pa** | +5.6% 🔴 |
| in_dist vol_p | — | 28.87 Pa | — |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

The hypothesis is **false** — the surface weight ramp hurts performance. val/loss is 3.2% worse, tandem surf_p is 5.6% worse. The ramp degrades by:

1. **Early under-weighting** (epochs 0–50): `surf_ramp=0.5` at epoch 0 means the effective surface weight is `5.0 × 0.5 = 2.5` — well below the fixed 5.0. Early training learns a worse surface fit, and those early iterations shape the model's internal representations.

2. **Late over-weighting** (epochs 50+): `surf_ramp=2.0` means surface weight reaches up to `5.0 × 2.0 = 10.0`. While this might seem like it helps fine-tune the surface, it disrupts a model that has already converged its internal structure, pushing it toward surface-specific gradients at the cost of generalization (particularly visible in tandem degradation).

The existing adaptive mechanism already handles surf_weight appropriately. Multiplying it by a ramp adds noise rather than signal.

### Suggested follow-ups

- **Fixed high surf_weight**: Instead of a ramp, try a fixed higher floor (e.g., clamp [8, 50] or [10, 50]). This would uniformly emphasize surface throughout training without the destabilizing curriculum.
- **Ramp starting from a higher base**: If curriculum learning is desired, start from the baseline weight (not 0.5×) and ramp up: `surf_ramp = 1.0 + min(epoch / 50, 1.0)` (1.0→2.0). This avoids the under-weighting in early training.