### PR TITLE
Add noise to input features (regularization on x, not y)

### DIFF
--- a/train.py
+++ b/train.py
@@ -588,6 +588,10 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        if model.training:
+            x_noise = torch.zeros_like(x)
+            x_noise[:, :, 2:] = 0.02 * torch.randn_like(x[:, :, 2:])  # noise on non-spatial features
+            x = x + x_noise
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Y-noise (on targets) is neutral. But INPUT noise could help differently — by forcing the model to make predictions robust to small perturbations in the geometry/condition features. Add Gaussian noise to the non-spatial input features (features 2+) after normalization. This is data augmentation without changing the data — each sample is seen slightly differently each epoch.

## Instructions
After line 590 (`x = (x - stats["x_mean"]) / stats["x_std"]`), add:
```python
if model.training:
    x_noise = torch.zeros_like(x)
    x_noise[:, :, 2:] = 0.02 * torch.randn_like(x[:, :, 2:])  # noise on non-spatial features
    x = x + x_noise
```

Run: `python train.py --agent edward --wandb_name "edward/x-noise" --wandb_group noise-on-x-features`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78

---
## Results

**W&B run:** `fpacokib`  
**Best epoch:** 63/100 (~28.6s/epoch)

### val/loss
| Metric | Baseline | x-noise | Delta |
|--------|----------|---------|-------|
| val/loss (3-split) | 2.2068 | 2.3105 | +0.1037 (+4.7%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (x-noise) | p delta |
|-------|-----|-----|--------------|-------------|---------|
| in_dist | 0.326 | 0.182 | 20.56 | 21.60 | +1.04 (+5.1%) |
| ood_cond | 0.264 | 0.191 | — | 21.31 | — |
| ood_re | 0.276 | 0.200 | — | 30.96 | — |
| tandem | 0.646 | 0.344 | 40.78 | 43.54 | +2.76 (+6.8%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.356 | 0.471 | 27.22 |
| ood_cond | 1.059 | 0.407 | 19.83 |
| ood_re | 1.055 | 0.444 | 50.98 |
| tandem | 2.194 | 1.005 | 45.03 |

**Peak memory:** No change (noise tensor same size as input).

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868 again — persistent numerical instability in this split, unrelated to this change.

### What happened
x-noise hurts: val/loss is 4.7% worse than baseline, and surface pressure degrades across all splits. This is a clear negative result.

Two likely explanations:

1. **Noise scale too large.** At std=0.02, perturbation of normalized features corrupts the signal rather than regularizing it. The non-spatial features (Reynolds, AoA, foil geometry params) are already normalized — 0.02 std is not obviously small in that space.

2. **Fewer epochs due to overhead.** The noise operations (zeros_like + randn_like per batch) increased epoch time from ~25s to ~28.6s, reducing training from ~72 epochs to ~63 epochs. This gives the model less time to converge. Some of the degradation may be from this reduction, not purely from the noise.

3. **Attention disruption.** Transolver assigns mesh nodes to slice-tokens based on input features. Perturbing the non-spatial features may destabilize these soft assignments, hurting the learned geometry encoding.

### Suggested follow-ups
- Try a much smaller noise scale (0.002 instead of 0.02) — the current scale may simply be too large to be useful
- Try noise only on condition features (Re, AoA, indices 22–23), not geometry features — the geometry should stay precise
- Try dropout instead of Gaussian noise on the non-spatial features