### PR TITLE
Two-scale coarse pooling (pool_size=32 AND pool_size=128)

### DIFF
--- a/train.py
+++ b/train.py
@@ -664,6 +664,20 @@ for epoch in range(MAX_EPOCHS):
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 
+        # Second-scale coarse pooling (pool_size=128)
+        coarse_pool_size_2 = 128
+        n_groups_2 = N // coarse_pool_size_2
+        if n_groups_2 > 1:
+            pred_trunc_2 = pred[:, :n_groups_2 * coarse_pool_size_2]
+            y_trunc_2 = y_norm[:, :n_groups_2 * coarse_pool_size_2]
+            mask_trunc_2 = mask[:, :n_groups_2 * coarse_pool_size_2]
+            pred_coarse_2 = pred_trunc_2.reshape(B, n_groups_2, coarse_pool_size_2, C).mean(dim=2)
+            y_coarse_2 = y_trunc_2.reshape(B, n_groups_2, coarse_pool_size_2, C).mean(dim=2)
+            mask_coarse_2 = mask_trunc_2.reshape(B, n_groups_2, coarse_pool_size_2).any(dim=2)
+            coarse_err_2 = (pred_coarse_2 - y_coarse_2).abs()
+            coarse_loss_2 = (coarse_err_2 * mask_coarse_2.unsqueeze(-1)).sum() / mask_coarse_2.sum().clamp(min=1)
+            loss = loss + 0.5 * coarse_loss_2  # lower weight for coarser scale
+
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss


### PR DESCRIPTION
## Hypothesis
The single coarse pool (size=64) is essential. Adding a SECOND coarse pool at a different scale (128) gives two-scale multi-resolution regularization. This is inspired by multi-grid methods in numerical analysis — regularizing at multiple spatial scales simultaneously.

## Instructions
After the existing coarse pooling block (line 665), add a second one with pool_size=128:
```python
# Second-scale coarse pooling (pool_size=128)
coarse_pool_size_2 = 128
n_groups_2 = N // coarse_pool_size_2
if n_groups_2 > 1:
    pred_trunc_2 = pred[:, :n_groups_2 * coarse_pool_size_2]
    y_trunc_2 = y_norm[:, :n_groups_2 * coarse_pool_size_2]
    mask_trunc_2 = mask[:, :n_groups_2 * coarse_pool_size_2]
    pred_coarse_2 = pred_trunc_2.reshape(B, n_groups_2, coarse_pool_size_2, C).mean(dim=2)
    y_coarse_2 = y_trunc_2.reshape(B, n_groups_2, coarse_pool_size_2, C).mean(dim=2)
    mask_coarse_2 = mask_trunc_2.reshape(B, n_groups_2, coarse_pool_size_2).any(dim=2)
    coarse_err_2 = (pred_coarse_2 - y_coarse_2).abs()
    coarse_loss_2 = (coarse_err_2 * mask_coarse_2.unsqueeze(-1)).sum() / mask_coarse_2.sum().clamp(min=1)
    loss = loss + 0.5 * coarse_loss_2  # lower weight for coarser scale
```

Run: `python train.py --agent kohaku --wandb_name "kohaku/double-coarse" --wandb_group double-coarse-pool`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** 0ycra7ik | **Epochs:** 64 (30-min timeout) | **Memory:** 10.6 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.6339 | 0.3114 | 0.1800 | 21.54 | 1.306 | 0.459 | 26.46 |
| tandem_transfer | 3.2896 | 0.6321 | 0.3392 | 42.55 | 2.203 | 1.013 | 45.05 |
| ood_cond | 1.9223 | 0.2715 | 0.1920 | 20.95 | 1.039 | 0.402 | 19.67 |
| ood_re | 18869.59 | 0.2775 | 0.2010 | 31.25 | 1.048 | 0.440 | 51.09 |
| **3-split mean** | **2.2819** | | | | | | |

**vs baseline (2.2068):** +3.4% worse (at epoch 64 vs baseline at ~100 epochs)

Surface pressure vs baseline:
- in_dist: 21.54 vs 20.56 (+4.8%)
- tandem: 42.55 vs 40.78 (+4.3%)
- ood_cond: 20.95 vs 19.71 (+6.3%)

**What happened:** Mildly negative result (3.4% worse), but this is the closest to baseline of any of the recent experiments. The two-scale regularization does not hurt convergence — the model steadily improved every epoch from epoch 41 onward, showing healthy training dynamics. The tandem transfer surface pressure (42.55) is the best seen in this series of experiments, suggesting the coarser-scale regularization may help capture larger-scale spatial patterns relevant to tandem geometry.

The 3.4% gap vs baseline could be partially explained by epoch count (64 vs ~100), since the curve was still converging at timeout. This is worth following up with a longer or faster-iterating version.

**Suggested follow-ups:**
- Try weight 0.25 instead of 0.5 for the coarse-128 term (may be over-regularizing slightly)
- Combine with other improvements (e.g. the nowd baseline) for a cumulative test