### PR TITLE
Z-order node sorting for spatially coherent coarse pooling

### DIFF
--- a/train.py
+++ b/train.py
@@ -651,10 +651,27 @@ for epoch in range(MAX_EPOCHS):
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask[:, :n_groups * coarse_pool_size]
+            # Z-order (Morton) sort for spatially coherent groups
+            # Use raw_xy (features 0-1) before normalization for spatial coordinates
+            with torch.no_grad():
+                raw_pos = x[:, :, :2]  # x is already normalized, but relative ordering preserved
+                # Quantize to 10-bit integers for Morton code
+                x_q = ((raw_pos[:, :, 0] - raw_pos[:, :, 0].min(dim=1, keepdim=True).values) * 1023).long().clamp(0, 1023)
+                y_q = ((raw_pos[:, :, 1] - raw_pos[:, :, 1].min(dim=1, keepdim=True).values) * 1023).long().clamp(0, 1023)
+                # Interleave bits for Z-order curve (simplified: just x*1024+y)
+                morton = x_q * 1024 + y_q  # crude Z-order, but preserves 2D locality
+                # Set padded nodes to max so they sort to the end
+                morton = morton.masked_fill(~mask, morton.max() + 1)
+                sort_idx = morton.argsort(dim=1)
+
+            # Apply sort to predictions and targets for coarse loss only
+            pred_sorted = pred.gather(1, sort_idx.unsqueeze(-1).expand_as(pred))
+            y_sorted = y_norm.gather(1, sort_idx.unsqueeze(-1).expand_as(y_norm))
+            mask_sorted = mask.gather(1, sort_idx)
+
+            pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
+            y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
+            mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
             pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
             y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)


### PR DESCRIPTION
## Hypothesis
The coarse pooling loss (essential, pool_size=64) groups consecutive nodes, but the node ordering from the mesh is arbitrary — consecutive indices may be spatially scattered. This means the coarse loss is averaging predictions over random spatial locations, providing noise rather than genuine multi-scale supervision.

By sorting nodes using a Z-order (Morton) space-filling curve before computing the coarse loss, each group of 64 consecutive nodes will be spatially nearby. The coarse loss then becomes a true multi-resolution loss: each group represents a local spatial average, providing structured low-frequency supervision.

**Important:** Only sort for the coarse loss computation — don't sort the main loss or model input.

## Instructions

In the coarse pooling loss block (lines 649-665), sort predictions/targets by Z-order before grouping:

Replace:
```python
coarse_pool_size = 64
B, N, C = pred.shape
n_groups = N // coarse_pool_size
if n_groups > 1:
    pred_trunc = pred[:, :n_groups * coarse_pool_size]
    y_trunc = y_norm[:, :n_groups * coarse_pool_size]
    mask_trunc = mask[:, :n_groups * coarse_pool_size]
```

With:
```python
coarse_pool_size = 64
B, N, C = pred.shape
n_groups = N // coarse_pool_size
if n_groups > 1:
    # Z-order (Morton) sort for spatially coherent groups
    # Use raw_xy (features 0-1) before normalization for spatial coordinates
    with torch.no_grad():
        raw_pos = x[:, :, :2]  # x is already normalized, but relative ordering preserved
        # Quantize to 10-bit integers for Morton code
        x_q = ((raw_pos[:, :, 0] - raw_pos[:, :, 0].min(dim=1, keepdim=True).values) * 1023).long().clamp(0, 1023)
        y_q = ((raw_pos[:, :, 1] - raw_pos[:, :, 1].min(dim=1, keepdim=True).values) * 1023).long().clamp(0, 1023)
        # Interleave bits for Z-order curve (simplified: just x*1024+y)
        morton = x_q * 1024 + y_q  # crude Z-order, but preserves 2D locality
        # Set padded nodes to max so they sort to the end
        morton = morton.masked_fill(~mask, morton.max() + 1)
        sort_idx = morton.argsort(dim=1)
    
    # Apply sort to predictions and targets for coarse loss only
    pred_sorted = pred.gather(1, sort_idx.unsqueeze(-1).expand_as(pred))
    y_sorted = y_norm.gather(1, sort_idx.unsqueeze(-1).expand_as(y_norm))
    mask_sorted = mask.gather(1, sort_idx)
    
    pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
    y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
    mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
```

**Key difference from #864 (which was catastrophic at val_loss=88):** #864 sorted nodes for ALL computations (main loss, model input, everything), which completely broke the training. This only sorts for the coarse loss computation — main loss and model forward pass are unchanged.

Run: `python train.py --agent senku --wandb_name "senku/zorder-coarse" --wandb_group zorder-node-sort`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `a06cop8t` (senku/zorder-coarse)  
**Best epoch:** 66  
**Peak GPU memory:** ~48% of 96GB

### Best checkpoint (epoch 66)

| Split | loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.5843 | 0.291 | 0.182 | 22.00 | 1.307 | 0.478 | 26.00 |
| val_tandem_transfer | 3.2870 | 0.635 | 0.341 | 41.77 | 2.170 | 0.985 | 44.11 |
| val_ood_cond | 1.8456 | 0.264 | 0.184 | 20.22 | 1.044 | 0.392 | 19.66 |
| val_ood_re | 18869.6 | 0.270 | 0.199 | 30.79 | 1.041 | 0.435 | 51.05 |

**val/loss (3-split): 2.2389** vs baseline **2.2068** → **+1.4% worse** (neutral)  
**surf_p in_dist: 22.00** vs baseline **20.56** → slightly worse  
**surf_p tandem: 41.77** vs baseline **40.78** → slightly worse

### What happened

Z-order sorting for the coarse loss is essentially neutral — no clear improvement or regression. Training was healthy (best epoch 66, no NaN issues, good convergence).

Possible reasons it didn't help:
1. **CFD mesh nodes may already have partial spatial ordering.** The mesh generator tends to number nearby nodes consecutively, so the random-grouping baseline may already have some spatial coherence in practice.
2. **The crude Z-order approximation** (`x*1024+y` instead of true Morton interleaving) doesn't achieve as tight spatial locality as a true space-filling curve — groups may not be as compact as hoped.
3. **Noise from random grouping may have regularization value.** Averaging random spatial locations forces the model to produce globally consistent predictions, which could be an implicit regularizer that the spatially coherent version loses.

The coarse pooling loss appears to provide useful signal regardless of node ordering — the hypothesis about spatial coherence being important doesn't seem to hold.

### Suggested follow-ups
- Try true Morton bit-interleaving (not the `x*1024+y` approximation) to test if better spatial locality helps.
- Try larger `coarse_pool_size` (e.g., 128 or 256) — bigger groups might benefit more from spatial coherence.
- If the coarse loss is already helping via a different mechanism (global averaging regularization rather than spatial structure), it may be worth investigating whether that's the key driver and building on it.
