### PR TITLE
Soft stop-gradient on volume loss (50% gradient routing to surface)

### DIFF
--- a/train.py
+++ b/train.py
@@ -617,11 +617,18 @@ for epoch in range(MAX_EPOCHS):
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        abs_err = (pred - y_norm).abs()  # full gradient, used for surf_loss
+
+        # Soft stop-gradient: mix detached and live predictions for volume loss
+        # Halves the volume gradient through the backbone, prioritizing surface
+        pred_vol_mixed = 0.5 * pred.detach() + 0.5 * pred
+        abs_err_vol = (pred_vol_mixed - y_norm).abs()
+
         if epoch < 10:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
+            abs_err_vol = abs_err_vol * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -639,7 +646,7 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_loss = (abs_err_vol * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()


### PR DESCRIPTION
## Hypothesis
Even with adaptive surface weighting, the volume loss produces ~50-100x more gradient terms than surface loss because volume nodes vastly outnumber surface nodes. The backbone weights move primarily to satisfy volume predictions, with surface accuracy as a side effect.

By using a "soft" stop-gradient — mixing detached and live predictions for volume loss at 50/50 — we halve the volume gradient flowing through the backbone while keeping full surface gradients. This makes the backbone preferentially learn surface-relevant representations.

## Instructions

Replace line 642:
```python
vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
```

With:
```python
# Soft stop-gradient: mix detached and live predictions for volume loss
# This halves the volume gradient through the backbone, prioritizing surface
pred_mixed = 0.5 * pred.detach() + 0.5 * pred  # 50% gradient reduction for volume
mixed_abs_err = (pred_mixed - y_norm).abs()
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask_curr = (~is_tandem_curr).float()[:, None, None]
    mixed_abs_err = mixed_abs_err * sample_mask_curr
vol_loss = (mixed_abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
```

**Wait — this is tricky.** The `abs_err` on line 620 is used for BOTH vol_loss and surf_loss. We need to use the mixed version only for vol_loss and keep the original for surf_loss. Also the tandem masking (lines 621-624) applies to abs_err before both vol and surf loss.

**Cleaner approach — replace lines 620-646:**

After model prediction (line 615-616), compute separate abs_err for vol and surf:

```python
pred = pred.float()
re_pred = re_pred.float()
if model.training:
    pred = pred / sample_stds

abs_err = (pred - y_norm).abs()  # full gradient, used for surf_loss

# Volume: use 50% gradient reduction
pred_vol_mixed = 0.5 * pred.detach() + 0.5 * pred
abs_err_vol = (pred_vol_mixed - y_norm).abs()

if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
    abs_err_vol = abs_err_vol * sample_mask

# ... volume subsampling logic stays the same ...

vol_loss = (abs_err_vol * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
# surf_loss uses abs_err (full gradient) — unchanged
```

Run: `python train.py --agent nezuko --wandb_name "nezuko/vol-stopgrad-0.5" --wandb_group vol-stop-gradient`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** 95pysyve | Runtime: 1819s (~30 min, ~70 epochs)

*(Note: Two earlier runs — homsihxs, ypt9dwmz — ran concurrently due to a tooling issue and produced invalid results. 95pysyve is the clean single-process run.)*

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| **in_dist** | 1.621 | 0.300 | 0.175 | **21.65** | 1.389 | 0.495 | 28.24 |
| **ood_cond** | 1.893 | 0.255 | 0.186 | **21.08** | 1.101 | 0.422 | 21.09 |
| **ood_re** | — | 0.272 | 0.199 | **31.48** | 1.092 | 0.456 | 51.94 |
| **tandem** | 3.244 | 0.635 | 0.332 | **41.62** | 2.240 | 1.031 | 44.81 |
| **val/loss (3-split)** | **2.2528** | | | | | | |

| Metric | Baseline | soft-stopgrad | Δ |
|---|---|---|---|
| val/loss | 2.2068 | 2.2528 | +2.1% ❌ |
| surf_p in_dist | 20.56 | 21.65 | +5.3% ❌ |
| surf_p ood_cond | 21.30 | 21.08 | -1.0% ✅ |
| surf_p ood_re | 30.90 | 31.48 | +1.9% ❌ |
| surf_p tandem | 40.78 | 41.62 | +2.1% ❌ |

**Peak memory:** not tracked; soft stop-gradient adds one extra tensor (~same size as pred), negligible overhead.

### What happened

Negative result. The 50% reduction in volume gradient did not improve surface accuracy — in fact, it slightly degraded it across most splits (in_dist surf_p: 21.65 vs 20.56 baseline).

The hypothesis that volume gradients were crowding out surface learning doesn't appear to hold here. The model's backbone seems to learn surface-relevant representations without needing to deprioritize the volume signal. Possible explanations:
1. **surf_weight=5 is already doing the job**: The 5x surface weighting in the combined loss already biases the optimizer toward surface accuracy sufficiently. A further gradient reduction on volume doesn't add more signal, it just reduces information available to the backbone.
2. **Shared representations benefit from volume**: Volume and surface predictions share backbone features. The backbone learns flow physics from volume observations, and surface predictions piggyback on that. Halving the volume gradient degrades the backbone's physics understanding, which also hurts surface accuracy.
3. **The gradient magnitude imbalance isn't the bottleneck**: At convergence, the model's surface accuracy is limited by the representational capacity, not by gradient competition.

### Suggested follow-ups
- Try a harder stop-gradient (e.g., 10% volume gradient, 90% detached) — if the signal is there, it might be stronger with more extreme reduction
- Try routing volume gradients only to higher layers while blocking them from backbone shared layers — surgical version of this idea
- The per-split divergence (ood_cond improved slightly) suggests flow-condition generalization might respond to this; could explore condition-dependent gradient routing