### PR TITLE
Surface checkpoint + 50% vol stop-gradient (compound novel ideas)

### DIFF
--- a/train.py
+++ b/train.py
@@ -617,11 +617,17 @@ for epoch in range(MAX_EPOCHS):
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        abs_err = (pred - y_norm).abs()  # full gradient, used for surf_loss
+
+        # Volume: use 50% gradient reduction (soft stop-gradient)
+        pred_vol_mixed = 0.5 * pred.detach() + 0.5 * pred
+        abs_err_vol = (pred_vol_mixed - y_norm).abs()
+
         if epoch < 10:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
+            abs_err_vol = abs_err_vol * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -639,7 +645,7 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_loss = (abs_err_vol * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
@@ -802,6 +808,13 @@ for epoch in range(MAX_EPOCHS):
 
     dt = time.time() - t0
 
+    # Select checkpoint by average surface pressure MAE across 3 splits
+    _3split_names = ["val_in_dist", "val_tandem_transfer", "val_ood_cond"]
+    _surf_p_metric = sum(
+        val_metrics_per_split[n].get(f"{n}/mae_surf_p", float('inf'))
+        for n in _3split_names
+    ) / len(_3split_names)
+
     # --- Log to wandb ---
     metrics = {
         "train/vol_loss": epoch_vol,
@@ -809,6 +822,7 @@ for epoch in range(MAX_EPOCHS):
         "val/loss": val_loss_3split,
         "val/loss_3split": val_loss_3split,
         "val/loss_4split": val_loss_4split,
+        "val/surf_p_3split": _surf_p_metric,
         "lr": scheduler.get_last_lr()[0],
         "epoch_time_s": dt,
     }
@@ -823,9 +837,9 @@ for epoch in range(MAX_EPOCHS):
         peak_mem_gb = 0.0
 
     tag = ""
-    if val_loss_3split < best_val:
-        best_val = val_loss_3split
-        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split}
+    if _surf_p_metric < best_val:
+        best_val = _surf_p_metric
+        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split, "surf_p_metric": _surf_p_metric}
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v


### PR DESCRIPTION
## Hypothesis
If both surface-aware checkpoint selection (#893) and vol stop-gradient (#895) individually help, their compound could be our best result yet. Both target the same fundamental issue: surface accuracy is undertargeted relative to volume.

## Instructions
Apply BOTH changes from #893 (surface checkpoint selection) and #895 (50% vol stop-gradient). See those PRs for detailed instructions.

Run: `python train.py --agent thorfinn --wandb_name "thorfinn/surf-ckpt-stopgrad" --wandb_group surf-checkpoint-plus-stopgrad`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `rqe2il3c` | **Epoch:** 67/100 (30.4 min) | **Peak memory:** 10.6 GB

**Changes applied:** vol stop-gradient (50% detached) + surface pressure MAE checkpoint selection

### Val loss (combined)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss (3-split) | 2.2068 | **2.2445** | +1.7% ❌ |

### Surface MAE

| Split | Metric | Baseline | This run | Δ |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 20.56 | 20.94 | +1.8% ❌ |
| val_tandem_transfer | mae_surf_p | 40.78 | 41.07 | +0.7% ❌ |
| val_ood_cond | mae_surf_p | — | 21.10 | — |
| val_ood_re | mae_surf_p | — | 31.00 | — |

### Volume MAE

| Split | Metric | This run |
|---|---|---|
| val_in_dist | mae_vol_p | 27.81 |
| val_ood_cond | mae_vol_p | 21.02 |
| val_tandem_transfer | mae_vol_p | 44.65 |

*Note: val_ood_re/loss = 18869 (overflow bug).*

---

### What happened

The compound is slightly worse than baseline on all key metrics. Neither the vol stop-gradient nor the surface checkpoint selection (nor their combination) provides a net benefit here.

**On vol stop-gradient:** The vol_in_dist/mae_vol_p (27.81) is higher than in typical baseline runs (~24-25), indicating the stop-gradient does reduce volume accuracy. But the surface metrics didn't improve either — the 50% gradient reduction weakens the backbone's overall representational capacity without producing a compensating gain in surface specificity. This suggests the backbone representations learned from volume nodes are shared with and helpful for surface accuracy, not competing with it.

**On surface checkpoint selection:** Using surf_p_metric instead of val_loss_3split for checkpoint selection doesn't appear to help meaningfully in this case. The checkpoint selected at epoch 67 by surf_p criterion (average surf_p = 27.7) was the same as what val_loss_3split would have selected, since both metrics tend to improve together.

The compound doesn't recover from the vol stop-gradient's baseline harm.

### Suggested follow-ups

- **Surface checkpoint selection alone:** Test #893's change without the stop-gradient — it's a zero-cost change that might marginally improve checkpoint quality on later-epoch models.
- **Weaker stop-gradient (0.1 instead of 0.5):** Use `0.9 * pred.detach() + 0.1 * pred` for volume to apply a very gentle gradient reduction that still lets the backbone learn from volume.
- **Surface-only training loss:** Instead of stop-gradient on volume, try temporarily weighting vol_loss to zero for the last 10 epochs to force the model to optimize surface in the final fine-tuning phase.