### PR TITLE
EMA start epoch 55 (test late-side of optimal range)

### DIFF
--- a/train.py
+++ b/train.py
@@ -476,7 +476,7 @@ model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 55
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
EMA at epoch 30 was too early, 40 optimal, 50 not tested between baseline and 40. Let's try 55 — more weight on late, clean training. 12 epochs of averaging.

## Instructions
Change line 479: `ema_start_epoch = 40` → `ema_start_epoch = 55`

Run: `python train.py --agent norman --wandb_name "norman/ema-55" --wandb_group ema-55-test`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** 5ce1p39s

| Metric | Baseline (ema=40) | EMA-55 | Δ |
|--------|-------------------|--------|---|
| val/loss | 2.2068 | 2.2716 | +0.0648 (+2.9%) |
| in_dist surf_p | 20.56 | 21.18 | +0.62 |
| tandem surf_p | 40.78 | 42.42 | +1.64 |
| ood_cond surf_p | — | 21.04 | — |
| ood_re surf_p | — | 30.58 | — |

**Full surface MAE:**
- in_dist: Ux=0.310, Uy=0.182, p=21.18
- tandem: Ux=0.636, Uy=0.338, p=42.42
- ood_cond: Ux=0.264, Uy=0.193, p=21.04
- ood_re: Ux=0.276, Uy=0.198, p=30.58

**Full volume MAE:**
- in_dist: Ux=1.304, Uy=0.460, p=26.28
- tandem: Ux=2.174, Uy=0.995, p=43.92
- ood_cond: Ux=1.061, Uy=0.410, p=19.64
- ood_re: Ux=1.046, Uy=0.442, p=50.87

**Peak memory:** not logged

### What happened
EMA start at epoch 55 is consistently worse than epoch 40 across all splits — val/loss +2.9%, in_dist surf_p +0.62, tandem surf_p +1.64. With ~67 total epochs, starting EMA at 55 leaves only ~12 epochs of averaging vs ~27 epochs when starting at 40. Fewer averaging epochs means the EMA model is noisier and benefits less from smoothing out late-training fluctuations. The optimal start at 40 appears to be well-tuned — early enough to accumulate sufficient smoothing, late enough to avoid early high-variance weights.

### Suggested follow-ups
- The sweet spot appears to be around epoch 40. EMA at 30 was too early, 55 is too late. Could try 45 to see if there's a slight improvement, but the marginal value seems low.
- Consider whether EMA decay=0.998 is also tuned well, or if a slower decay (0.999) could help at epoch 40