### PR TITLE
Z-order coarse + surface checkpoint selection (compound novel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -651,10 +651,27 @@ for epoch in range(MAX_EPOCHS):
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred[:, :n_groups * coarse_pool_size]
-            y_trunc = y_norm[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask[:, :n_groups * coarse_pool_size]
+            # Z-order (Morton) sort for spatially coherent groups
+            # Use raw_xy (features 0-1) before normalization for spatial coordinates
+            with torch.no_grad():
+                raw_pos = x[:, :, :2]  # x is already normalized, but relative ordering preserved
+                # Quantize to 10-bit integers for Morton code
+                x_q = ((raw_pos[:, :, 0] - raw_pos[:, :, 0].min(dim=1, keepdim=True).values) * 1023).long().clamp(0, 1023)
+                y_q = ((raw_pos[:, :, 1] - raw_pos[:, :, 1].min(dim=1, keepdim=True).values) * 1023).long().clamp(0, 1023)
+                # Interleave bits for Z-order curve (simplified: just x*1024+y)
+                morton = x_q * 1024 + y_q  # crude Z-order, but preserves 2D locality
+                # Set padded nodes to max so they sort to the end
+                morton = morton.masked_fill(~mask, morton.max() + 1)
+                sort_idx = morton.argsort(dim=1)
+
+            # Apply sort to predictions and targets for coarse loss only
+            pred_sorted = pred.gather(1, sort_idx.unsqueeze(-1).expand_as(pred))
+            y_sorted = y_norm.gather(1, sort_idx.unsqueeze(-1).expand_as(y_norm))
+            mask_sorted = mask.gather(1, sort_idx)
+
+            pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
+            y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
+            mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
             pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
             y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
@@ -815,6 +832,15 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+
+    # Select checkpoint by average surface pressure MAE (our actual metric)
+    _3split_names = ["val_in_dist", "val_tandem_transfer", "val_ood_cond"]
+    _surf_p_metric = sum(
+        val_metrics_per_split[n].get(f"{n}/mae_surf_p", float('inf'))
+        for n in _3split_names
+    ) / len(_3split_names)
+    metrics["val/surf_p_3split"] = _surf_p_metric
+
     wandb.log(metrics)
 
     if torch.cuda.is_available():
@@ -823,9 +849,9 @@ for epoch in range(MAX_EPOCHS):
         peak_mem_gb = 0.0
 
     tag = ""
-    if val_loss_3split < best_val:
-        best_val = val_loss_3split
-        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split}
+    if _surf_p_metric < best_val:
+        best_val = _surf_p_metric
+        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split, "surf_p_metric": _surf_p_metric}
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v


### PR DESCRIPTION
## Hypothesis
Compound of the two most orthogonal novel ideas: Z-order sorting for coarse loss (#894) + surface-aware checkpoint selection (#893). If both help individually, together they attack the problem from two levels: better training signal (spatially coherent coarse loss) + better model selection (surface-focused criterion).

## Instructions
Apply BOTH changes from #894 (z-order sorting in coarse loss) and #893 (surface checkpoint selection). See those PRs for detailed code.

Run: `python train.py --agent fern --wandb_name "fern/zorder-surfckpt" --wandb_group zorder-plus-surf-checkpoint`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78

---

## Results

**W&B run:** `tk1yvdff`

**Note:** Run crashed (killed by 30-min timeout) at epoch 64/100.

### Metrics at best/final epoch (epoch 64)

| Metric | This run (ep 64) | New baseline (ep 64) | Δ |
|--------|-----------------|----------------------|---|
| val/loss | 2.2695 | 2.2068 | +2.8% |
| val/surf_p_3split | 28.40 | — | — |
| val_in_dist/loss | 1.652 | 1.547 | worse |
| Surface MAE p (in_dist) | 22.57 | 20.56 | +9.7% |
| Surface MAE p (tandem) | 41.74 | 40.78 | +2.4% |
| Surface MAE p (ood_cond) | **20.90** | 21.30 | **-1.9%** |
| Surface MAE p (ood_re) | 31.41 | 30.90 | +1.7% |
| Volume MAE Ux (in_dist) | 1.314 | 1.265 | worse |
| Volume MAE Uy (in_dist) | 0.469 | 0.457 | worse |

**Peak memory:** not tracked

### What happened

**Hypothesis not supported.** Val/loss 2.2695 is 2.8% worse than the new baseline. All key metrics deteriorated except ood_cond surf_p (-1.9%).

The compound hurt more than either change could help:

**Z-order sorting**: The Morton code `x_q * 1024 + y_q` is a simplified approximation that preserves 2D locality but isn't a true Z-order curve (true Morton interleaves bits). More importantly, the coarse loss already forces the model to generalize across node groups — the original random grouping acts as a form of data augmentation, while spatial grouping enforces structure that may not be beneficial when the model's physics-attention already handles spatial structure through its attention mechanism. The gradient-stopping overhead adds per-step compute without clear benefit.

**Surface checkpoint selection**: Switching from val_loss_3split to avg surf_p for checkpoint selection means saving the model at epochs that are best for surface pressure specifically, but this can misalign with overall model quality. A model that minimizes surf_p at epoch 35 might overfit to surface geometry while having poor volume predictions.

The interaction compounds both issues: the modified training signal (z-order coarse) + modified checkpoint criterion (surf_p) creates a different optimization trajectory from both the original baseline and each individual change.

### Suggested follow-ups

- Test #894 and #893 individually rather than together — it's hard to diagnose which change is hurting
- For #893 (surf checkpoint): consider tracking both criteria — save two checkpoints (one by val_loss, one by surf_p) to test which generalizes better at eval time
- The Z-order coarse loss may work better with actual bit-interleaving Morton codes or with larger pool sizes