### PR TITLE
Start vol subsample at 10% instead of 5% (less aggressive early sparsity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -628,7 +628,7 @@ for epoch in range(MAX_EPOCHS):
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
         if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+            vol_keep_ratio = 0.10 + 0.90 * (epoch / 40)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
The vol subsample ramp starts at 5% and ramps to 100% over 40 epochs. With 5%, the early epochs see very few volume nodes — potentially too few for stable gradient estimates. Starting at 10% doubles the early-epoch volume information while still providing the progressive curriculum benefit.

## Instructions
Change line 631:
```python
vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
```
To:
```python
vol_keep_ratio = 0.10 + 0.90 * (epoch / 40)
```

Run: `python train.py --agent emma --wandb_name "emma/subsample-10pct" --wandb_group vol-subsample-start-10pct`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** psxj7gds  
**Peak memory:** 10.6 GB  
**Epochs completed:** 67 (30-min wall-clock limit)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.296 | 0.176 | 21.32 | 1.280 | 0.451 | 25.69 |
| val_tandem | 0.624 | 0.337 | 41.38 | 2.125 | 0.969 | 43.59 |
| val_ood_cond | 0.260 | 0.190 | 20.93 | 1.014 | 0.399 | 19.67 |
| val_ood_re | 0.271 | 0.201 | 30.92 | 1.017 | 0.437 | 51.11 |

**val/loss (3-split): 2.2366** vs baseline 2.2068 (+1.3%, slightly worse)

### What happened

Starting at 10% instead of 5% did not improve performance. Val/loss of 2.2366 is slightly worse than baseline 2.2068, and surface pressure is worse on in_dist (21.32 vs 20.56) and comparable on tandem (41.38 vs 40.78).

The hypothesis — that 5% is too sparse for stable early gradients — doesn't appear to hold. The 5% start doesn't seem to hurt the model; the original curriculum may actually benefit from very sparse early volume sampling, which forces the model to rely more on surface nodes initially (since those aren't subsampled), building a stronger surface representation before volume is reintroduced.

Interestingly, vol_Ux and vol_Uy are marginally better with 10% start, but the surface improvements that would matter to the advisor don't materialize.

### Suggested follow-ups

- Try an even more aggressive start (1-2%) to further emphasize surface learning in early epochs
- Try freezing volume loss entirely for the first 10-15 epochs rather than using any fraction — pure surface-first curriculum
- The original 5% ramp may be essentially optimal for this balance; the ramp shape (linear vs cosine) might be worth exploring instead