### PR TITLE
Gentler volume stop-gradient (25% instead of 50%)

### DIFF
--- a/train.py
+++ b/train.py
@@ -639,7 +639,9 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        pred_vol_mixed = 0.25 * pred.detach() + 0.75 * pred  # 25% gradient reduction
+        vol_abs_err = (pred_vol_mixed - y_norm).abs()
+        vol_loss = (vol_abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()


### PR DESCRIPTION
## Hypothesis
The 50% stop-gradient (#895) may be too aggressive (val_loss=5.62 at 1006s). Try 25% — reduce volume backbone gradient by only 25% instead of 50%, keeping most of the volume supervision.

## Instructions
Same as #895 but with alpha=0.25:
```python
pred_vol_mixed = 0.25 * pred.detach() + 0.75 * pred  # 25% gradient reduction
```

Run: `python train.py --agent frieren --wandb_name "frieren/stopgrad-25" --wandb_group vol-stopgrad-25pct`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `5og8sw86` (frieren/stopgrad-25)
**Epochs:** 67 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.601 | 0.300 | 0.177 | **21.18** | 1.319 | 0.475 | 25.95 |
| val_ood_cond | 1.913 | 0.276 | 0.185 | **20.81** | 1.066 | 0.404 | 19.86 |
| val_ood_re | overflow | 0.289 | 0.200 | **30.61** | 1.071 | 0.443 | 51.38 |
| val_tandem_transfer | 3.306 | 0.635 | 0.338 | **41.97** | 2.181 | 1.006 | 44.55 |
| **combined val/loss** | **2.2730** | | | | | | |

**vs baseline (2.2068):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2068 | 2.2730 | **+0.066 (+3.0%)** |
| surf_p in_dist | 20.56 | 21.18 | **+0.62 (+3.0%)** |
| surf_p tandem | 40.78 | 41.97 | **+1.19 (+2.9%)** |

**Peak GPU memory:** ~10.6 GB

### What happened

Negative result. The 25% stop-gradient also hurts performance (+3.0% val/loss vs baseline), though it's much less catastrophic than the 50% version that collapsed training entirely. The surf_p metrics are slightly worse across all splits (in_dist +3%, tandem +2.9%).

**Why stop-gradient hurts even at 25%**: The Transolver model has shared representations — the backbone features that predict volume fields also encode geometric structure needed for surface prediction. Partially blocking volume gradients doesn't just divert gradient budget to the surface; it also reduces the quality of the backbone feature extractor that surface prediction depends on. The volume loss is actually a useful regularizer for learning good spatial representations, not just a competing objective.

**Comparison with 50% version**: The 50% version collapsed training (val/loss=5.62 at 1006s = incomplete run) while 25% gives a coherent but degraded result (2.2730). This suggests there's a monotonic relationship: less stop-gradient is less harmful, but even small amounts hurt because the backbone benefit outweighs any gradient competition reduction.

**The hypothesis is likely wrong**: For Transolver, volume and surface don't compete for gradient budget in a way that stop-gradient can fix. Both benefit from a strong shared backbone; the adaptive surf_weight mechanism already handles the balance at the loss level more effectively.

### Suggested follow-ups

- **Stop-gradient only in early epochs**: If gradient competition is only an issue during warm-up (when the model is still learning basic volume structure), apply stop-gradient only for epochs 0-20 and remove it thereafter. This might help early training without hurting the final fine-tuning.
- **Separate heads with shared backbone**: Instead of stop-gradient, try explicit architecture separation with a shared backbone that forks into separate volume and surface decoder heads, each with their own parameters. This gives true gradient isolation without corrupting shared features.
- **Accept the null**: The volume loss as-is seems to be a useful signal. The adaptive surf_weight already handles priority dynamically. Stop-gradient adds complexity without benefit.