### PR TITLE
Small noise on spatial coordinates (0.01 std on x,y)

### DIFF
--- a/train.py
+++ b/train.py
@@ -588,6 +588,8 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        if model.training:
+            x[:, :, :2] = x[:, :, :2] + 0.01 * torch.randn_like(x[:, :, :2])  # jitter spatial coords
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
X-noise on non-spatial features (#891) is running. But noise on SPATIAL coordinates (x,y positions) is a form of jittering that makes the model robust to mesh variation — similar to how PointNet++ benefits from point jittering. This is a physics-inspired augmentation: slightly perturbing node positions simulates mesh refinement variation.

## Instructions
After line 590 (`x = (x - stats["x_mean"]) / stats["x_std"]`), add:
```python
if model.training:
    x[:, :, :2] = x[:, :, :2] + 0.01 * torch.randn_like(x[:, :, :2])  # jitter spatial coords
```

Run: `python train.py --agent askeladd --wandb_name "askeladd/xy-jitter" --wandb_group noise-xy-0.01`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `s2anfhmq`
**Epochs:** 67 (best at 66, EMA active) | **Peak memory:** 10.5 GB

### Loss comparison

| Split | Baseline | XY jitter 0.01 | Delta |
|---|---|---|---|
| **val/loss** | **2.2068** | 2.2117 | +0.22% |
| val_in_dist/loss | — | 1.5441 | |
| val_tandem_transfer/loss | — | 3.2054 | |
| val_ood_cond/loss | — | 1.8856 | |

### Surface pressure MAE

| Split | Baseline | XY jitter 0.01 | Delta |
|---|---|---|---|
| val_in_dist | **20.56** | 21.61 | +5.1% |
| val_ood_cond | **19.71** | 21.04 | +6.8% |
| val_tandem_transfer | **40.78** | 40.96 | +0.4% |

### Full surface MAE (XY jitter run, best epoch)

| Split | surf Ux | surf Uy | surf p | vol p |
|---|---|---|---|---|
| val_in_dist | 0.276 | 0.179 | 21.61 | 25.49 |
| val_ood_cond | 0.256 | 0.186 | 21.04 | 19.22 |
| val_tandem_transfer | 0.613 | 0.329 | 40.96 | 43.34 |

### What happened

**XY jitter (0.01 std) does not improve over baseline.** The overall val/loss is nearly identical (+0.22%), but surface pressure is consistently worse across all splits: in_dist +5.1%, ood_cond +6.8%, with only tandem staying neutral (+0.4%).

The most likely explanation: perturbing the spatial coordinates after normalization disrupts the model's ability to accurately locate surface nodes. The Transolver model uses spatial positions to assign physics slices — even small coordinate perturbations during training may degrade the model's learned spatial representations, hurting surface prediction where precise position matters most. The augmentation adds training noise that doesn't translate to better generalization.

Interestingly, the vol/loss and tandem metrics are less affected, suggesting the spatial-position sensitivity is particularly important for in_dist/ood_cond surface accuracy.

### Suggested follow-ups

- **Try smaller jitter (0.001 std)**: If 0.01 is too large and disrupts the spatial representation, a 10x smaller perturbation might provide useful regularization without breaking the spatial coding.
- **Jitter only non-surface nodes**: Surface nodes' positions are particularly important for prediction, so perturbing only interior/volume nodes could give augmentation benefits without harming surface accuracy.
- **Velocity-field noise instead of position noise**: Adding noise to input velocity features rather than positions might be a more physically meaningful augmentation.