### PR TITLE
Remove tandem boost entirely (1.0 instead of 1.5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -641,7 +641,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_boost = torch.ones(y_norm.shape[0], device=device)  # no boost
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
The tandem_boost=1.5 was added speculatively. We know 2.0 and 3.0 both hurt. What about removing it entirely (1.0 = equal treatment)? All other tandem-related features (exclusion for first 10 epochs) remain. This tests whether the 1.5x boost is actually helping or just adding noise.

## Instructions
Change line 644:
```python
tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
```
To:
```python
tandem_boost = torch.ones(y_norm.shape[0], device=device)  # no boost
```

Run: `python train.py --agent violet --wandb_name "violet/no-tandem-boost" --wandb_group tandem-boost-1.0`

## Baseline: val/loss=2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run ID**: `6dwvw6w0`
**Epochs completed**: 67 (best), 30.4 min
**Peak memory**: 10.5 GB

### Metrics vs Baseline (tandem_boost=1.5)

| Metric | Baseline (1.5×) | No boost (1.0×) | Δ |
|---|---|---|---|
| val/loss | 2.2068 | **2.2546** | +2.2% 🔴 |
| in_dist surf_p | 20.56 Pa | **21.49 Pa** | +4.6% 🔴 |
| ood_cond surf_p | — | **21.77 Pa** | — |
| ood_re surf_p | 30.90 Pa | **31.16 Pa** | +0.8% |
| tandem surf_p | 40.78 Pa | **42.10 Pa** | +3.2% 🔴 |
| in_dist vol_p | — | 24.57 Pa | — |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

The 1.5x tandem boost **is helping** — removing it makes things uniformly worse across all metrics. val/loss is 2.2% higher, in_dist surf_p is 4.6% worse, and tandem surf_p is 3.2% worse. Interestingly, tandem accuracy itself degrades even without the boost — suggesting that the boost helps the model learn generalizable features that also transfer back.

The boost is not just noise; it provides a meaningful training signal that guides the model to handle tandem geometry. The 1.5x level appears well-calibrated: 2.0× and 3.0× were both worse, and 1.0× is now confirmed to be worse too. The current 1.5× is likely close to optimal.

### Suggested follow-ups

- **No further tuning needed**: The 1.5× value appears to be a local optimum. With 1.0× worse and 2.0×/3.0× worse, 1.5× is confirmed as the right setting.
- **Tandem-specific validation tracking**: If the tandem transfer val track could be further broken down (e.g., by angle range or foil separation), it might help understand why tandem generalizes differently.