### PR TITLE
Asymmetric loss: L1 for pressure, MSE for velocity

### DIFF
--- a/train.py
+++ b/train.py
@@ -622,6 +622,10 @@ for epoch in range(MAX_EPOCHS):
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
+        # Asymmetric loss: MSE for velocity (channels 0,1), L1 for pressure (channel 2)
+        err_mixed = torch.cat([sq_err[:, :, 0:2], abs_err[:, :, 2:3]], dim=-1)
+        if epoch < 10:
+            err_mixed = err_mixed * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -639,10 +643,10 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_loss = (err_mixed * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_per_sample = (err_mixed * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
The current code uses L1 (`abs_err`) uniformly for all 3 output channels. But pressure and velocity have fundamentally different error distributions. Pressure errors on surfaces tend to be large and sparse (leading/trailing edge spikes) — L1 is appropriate. Velocity fields are smoother and more Gaussian — MSE (which penalizes outliers quadratically) helps focus on the smooth bulk. **No previous experiment has tried different loss functions per physical channel.**

## Instructions

In `train.py`, replace the volume and surface loss computation (lines 642-646):

**Currently:**
```python
vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
...
surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
```

**Change to:**
```python
# Asymmetric loss: MSE for velocity (channels 0,1), L1 for pressure (channel 2)
err_mixed = torch.cat([sq_err[:, :, 0:2], abs_err[:, :, 2:3]], dim=-1)

# Apply tandem masking to err_mixed same as abs_err (already done above for abs_err)
if epoch < 10:
    err_mixed = err_mixed * sample_mask  # sample_mask from tandem exclusion

vol_loss = (err_mixed * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
...
surf_per_sample = (err_mixed * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
```

**Important**: `sq_err` is already computed on line 619. Just use it for channels 0:2 and `abs_err` for channel 2:3.

Note: the tandem masking block (lines 621-624) modifies `abs_err` but NOT `sq_err`. You need to apply the same tandem mask to `sq_err` as well, or better yet, create `err_mixed` AFTER the tandem masking block.

Run:
```bash
python train.py --agent fern --wandb_name "fern/asymmetric-loss" --wandb_group asymmetric-loss-l1p-mse-v
```

## Baseline
- val/loss: 2.2068
- surf_p: in_dist=20.56, ood_cond=21.30, ood_re=30.90, tandem=40.78

---

## Results

**W&B run ID:** ea3tb2ql  
**Best epoch:** 67 (~27s/epoch, killed at timeout)  
**Peak memory:** ~65 GB (no OOM, consistent with prior runs)

### val/loss: 2.5946 vs baseline 2.2068

⚠️ **Important caveat:** val/loss is NOT directly comparable to baseline. The asymmetric loss uses MSE for velocity channels, which changes the loss scale — velocity MAE is ~0.4–2.2, so MSE values (~0.16–4.8) are systematically larger than L1 for the same errors. Validation also runs through `err_mixed`, inflating the reported val/loss.

### Surface MAE (comparable metric)

| Split | surf_Ux | surf_Uy | surf_p | surf_p baseline | Δ |
|-------|---------|---------|--------|-----------------|---|
| val_in_dist | 0.403 | 0.241 | **20.37** | 20.56 | **+0.19** |
| val_ood_cond | 0.419 | 0.284 | **20.98** | 21.30 | **+0.32** |
| val_ood_re | 0.349 | 0.253 | **30.59** | 30.90 | **+0.31** |
| val_tandem_transfer | 0.751 | 0.417 | **41.92** | 40.78 | **-1.14** |

### Volume MAE

| Split | vol_Ux | vol_Uy | vol_p |
|-------|--------|--------|-------|
| val_in_dist | 1.362 | 0.512 | 25.41 |
| val_ood_cond | 1.117 | 0.450 | 19.44 |
| val_ood_re | 1.054 | 0.457 | 50.52 |
| val_tandem_transfer | 2.185 | 1.032 | 43.84 |

### What happened

The asymmetric loss provides a modest, mixed signal. Pressure surface MAE improved on 3/4 splits (by 0.2–0.3 units), but the tandem split regressed by 1.1 units. The improvements are likely real since pressure still uses L1 (the well-tuned baseline), while velocity now uses MSE.

The fundamental problem: velocity MAE is large (~1–2.2), so MSE >> L1 for those errors. This forces the optimizer to over-weight velocity bulk smoothness. The adaptive surf_weight adjusted down to compensate (train/surf_weight: 5 at epoch 67), which partially explains why surface pressure accuracy degraded on tandem — less emphasis on surface under MSE dynamics.

The val/loss being "worse" (2.5946 vs 2.2068) is mostly a scale artifact from MSE inflating the velocity contribution, not a genuine signal of worse predictions.

**Verdict:** The hypothesis doesn't clearly work. Pressure surface MAE has marginal improvements on most splits but regresses on tandem. The asymmetric loss also pollutes the val/loss metric (making it non-comparable to future runs), which is a significant practical downside.

### Suggested follow-ups
1. **Normalize MSE channels**: divide MSE terms by the typical error variance before combining — this would make val/loss comparable again and prevent over-weighting velocity.
2. **L1+L2 blend for velocity**: use Huber loss (`F.smooth_l1_loss`) instead of pure MSE — less sensitive to scale issues.
3. **Separate validation metrics**: track pure MAE for val/loss regardless of training loss to keep comparisons consistent across experiments.