### PR TITLE
Cosine-annealed surface weight floor (5→20 over training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -573,7 +574,8 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    floor = 5.0 + 15.0 * (1.0 - math.cos(math.pi * epoch / MAX_EPOCHS)) / 2.0
+    surf_weight = max(floor, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
The adaptive surf_weight is clamped at [5, 50], settling at floor=5 throughout. Previous ramp experiment (#890) UNDER-weighted surface early (0.5x multiplier). This is different: we only RAISE the floor using a smooth cosine schedule from 5→20. The adaptive ratio still operates freely above the floor. Late training always prioritizes surface without the jerky transitions that hurt #890.

## Instructions

Replace line 576:
```python
surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
```
With:
```python
import math
floor = 5.0 + 15.0 * (1.0 - math.cos(math.pi * epoch / MAX_EPOCHS)) / 2.0
surf_weight = max(floor, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
```

(Add `import math` at the top if not already imported.)

Run:
```bash
python train.py --agent tanjiro --wandb_name "tanjiro/cosine-surf-floor" --wandb_group cosine-surf-weight-floor
```

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78

---

## Results

**val/loss: 2.2784** — slightly worse than baseline (2.2068, +3.2%).

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------|------------|------------|-----------|-----------|-----------|----------|
| val_in_dist | 1.5983 | 0.293 | 0.177 | 21.18 | 1.442 | 0.526 | 30.5 |
| val_tandem_transfer | 3.3069 | 0.636 | 0.343 | 42.14 | 2.338 | 1.074 | 46.7 |
| val_ood_cond | 1.9300 | 0.248 | 0.185 | 21.74 | 1.175 | 0.460 | 23.1 |
| val_ood_re | 18869.6* | 0.269 | 0.200 | 31.19 | 1.145 | 0.475 | 53.5 |

*val_ood_re loss is the vol_loss overflow issue in this branch  
**Peak memory:** 10.5 GB  
**W&B run ID:** 6aduk54a  
**Epochs:** 67 in 30.3 min

### What happened

The cosine surf floor raised pressure emphasis gradually (5→20 by epoch 67), but all metrics slightly regressed vs baseline. Surface pressure on in_dist was 21.18 vs baseline 20.56 (+3%), tandem 42.14 vs 40.78 (+3.3%).

Most likely the adaptive weight ratio was already operating above the floor=5 for most of training (since the model naturally needs more weight on surface losses), making the cosine floor schedule largely irrelevant. When the floor does become binding in later epochs (approaching 20), it forces the model toward surface at the expense of volume loss, but without commensurate gains in surface accuracy.

The vol_loss on in_dist increased (0.202 vs implied lower baseline from the 2.2068 run), suggesting the cosine floor forced too much attention on surface at the cost of volume accuracy without improving surface accuracy.

### Suggested follow-ups
- Monitor what the adaptive surf_weight actually is during training to understand if floor=5 is ever binding — if the ratio is always >5 naturally, floor scheduling has no effect
- Try raising the ceiling instead of the floor: allow surf_weight up to 100 instead of 50 to see if the model benefits from stronger surface emphasis when the ratio calls for it