### PR TITLE
SWA in last 15 epochs (uniform snapshot averaging vs EMA)

### DIFF
--- a/train.py
+++ b/train.py
@@ -478,6 +478,10 @@ from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
 ema_decay = 0.998
+swa_model = None
+swa_count = 0
+swa_start_epoch = 52
+swa_interval = 3
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -688,13 +692,22 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    if epoch >= swa_start_epoch and (epoch - swa_start_epoch) % swa_interval == 0:
+        if swa_model is None:
+            swa_model = deepcopy(model)
+            swa_count = 1
+        else:
+            swa_count += 1
+            with torch.no_grad():
+                for sp, mp in zip(swa_model.parameters(), model.parameters()):
+                    sp.data.mul_((swa_count - 1) / swa_count).add_(mp.data, alpha=1.0 / swa_count)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
 
     # --- Validate across all splits ---
-    eval_model = ema_model if ema_model is not None else model
+    eval_model = swa_model if swa_model is not None else (ema_model if ema_model is not None else model)
     eval_model.eval()
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}


### PR DESCRIPTION
## Hypothesis
EMA with decay=0.998 from epoch 40 strongly favors recent weights. SWA takes a simple arithmetic average of snapshots at regular intervals, provably finding wider minima. Starting SWA at epoch 52, save a snapshot every 3 epochs and average uniformly. This gives 5 equally-weighted snapshots rather than exponentially-decayed averaging.

## Instructions

After line 480 (`ema_decay = 0.998`), add:
```python
swa_model = None
swa_count = 0
swa_start_epoch = 52
swa_interval = 3
```

In the training loop after the EMA block (after line 681), add:
```python
if epoch >= swa_start_epoch and (epoch - swa_start_epoch) % swa_interval == 0:
    if swa_model is None:
        swa_model = deepcopy(model)
        swa_count = 1
    else:
        swa_count += 1
        with torch.no_grad():
            for sp, mp in zip(swa_model.parameters(), model.parameters()):
                sp.data.mul_((swa_count - 1) / swa_count).add_(mp.data, alpha=1.0 / swa_count)
```

Change line 697 to use SWA model when available:
```python
eval_model = swa_model if swa_model is not None else (ema_model if ema_model is not None else model)
```

Run: `python train.py --agent frieren --wandb_name "frieren/swa-last-15" --wandb_group swa-last-15`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `dgdqqbwd` (frieren/swa-last-15)
**Epochs:** 67 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.746 | 0.330 | 0.193 | **23.82** | 1.330 | 0.492 | 27.38 |
| val_ood_cond | 2.030 | 0.302 | 0.197 | **23.77** | 1.081 | 0.425 | 21.10 |
| val_ood_re | overflow | 0.290 | 0.205 | **31.96** | 1.052 | 0.449 | 51.93 |
| val_tandem_transfer | 3.315 | 0.640 | 0.345 | **41.51** | 2.168 | 0.994 | 43.73 |
| **combined val/loss** | **2.3634** | | | | | | |

**vs baseline (2.2068):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.2068 | 2.3634 | **+0.157 (+7.1%)** |
| surf_p in_dist | 20.56 | 23.82 | **+3.26 (+15.9%)** |
| surf_p tandem | 40.78 | 41.51 | **+0.73 (+1.8%)** |

**Peak GPU memory:** ~10.6 GB

### What happened

Negative result. SWA significantly underperforms EMA baseline (+7.1% val/loss, +15.9% surf_p in_dist). This is a clear regression, not noise.

**Why SWA underperforms EMA here**:

1. **Far fewer effective samples**: SWA averages 5 snapshots at epochs 52, 55, 58, 61, 64. EMA from epoch 40 accumulates ~27 epochs of smoothed weight trajectory. Despite being "uniform" rather than exponentially-weighted, 5 samples is a coarser representation of the late-training landscape than EMA's continuous integration.

2. **Snapshot spacing too coarse**: 3-epoch intervals at a 27s/epoch pace mean snapshots are ~81 seconds apart. Within that window, the model may have moved significantly in weight space (at LR ~1.5×10⁻⁴ with cosine decay). EMA updates every batch (~165 updates/epoch), capturing much finer trajectory detail.

3. **SWA eliminates EMA contribution**: By replacing EMA with SWA in eval_model, we lose the EMA's 27 epochs of smooth averaging. The SWA's 5 coarse snapshots cannot match the quality of EMA's continuous averaging, even if SWA weights are theoretically "wider minima."

4. **Dataset sensitivity**: The "wider minima = better generalization" property of SWA was established on image classification tasks. For PDE surrogate learning with 1,322 samples, the loss landscape geometry may be different — wider may not mean better for this specific regression task.

**Note**: The SWA update was placed after scheduler.step() (epoch-level), not inside the batch loop, ensuring exactly one update per qualifying epoch.

### Suggested follow-ups

- **EMA as auxiliary evaluation**: Keep EMA as the primary model but also track SWA as a separate eval metric, without replacing EMA. This would show whether SWA + EMA ensemble beats either alone.
- **SWA with more snapshots**: Start at epoch 40 with interval=2 to get ~13 snapshots — more comparable to EMA's averaging window. The current 5 snapshots may simply be too few.
- **Post-hoc SWA on saved checkpoints**: Save model checkpoints at every 5 epochs, then do SWA as a post-training step (no training cost). This would isolate whether the snapshot averaging is useful at all without the warm-up cost.