### PR TITLE
Gradient accumulation over 2 steps (effective batch=8, same step count)

### DIFF
--- a/train.py
+++ b/train.py
@@ -580,6 +580,7 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
+    optimizer.zero_grad()
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
@@ -668,10 +669,14 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
+        accum_steps = 2
+        loss_scaled = loss / accum_steps
+        loss_scaled.backward()
+
+        if (n_batches + 1) % accum_steps == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(model)


### PR DESCRIPTION
## Hypothesis
Batch_size=8 failed (#867) because it halved gradient steps. Gradient accumulation gives noise-reduction of larger batches while keeping the same number of optimizer updates. Accumulate over 2 forward passes, step every 2nd iteration.

## Instructions

Replace lines 498-501 (optimizer step block):
```python
optimizer.zero_grad()
loss.backward()
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
optimizer.step()
```
With:
```python
accum_steps = 2
loss_scaled = loss / accum_steps
loss_scaled.backward()

if (n_batches + 1) % accum_steps == 0:
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    optimizer.step()
    optimizer.zero_grad()
```

Add `optimizer.zero_grad()` before the training loop starts (after line 578).

Run: `python train.py --agent edward --wandb_name "edward/grad-accum-2" --wandb_group grad-accum-2step`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78

---
## Results

**W&B run:** `jhmlmj1s`
**Best epoch:** 64/100 (~28.3s/epoch)

### val/loss
| Metric | Baseline | grad-accum-2 | Delta |
|--------|----------|-------------|-------|
| val/loss (3-split) | 2.2068 | 2.3676 | +0.1608 (+7.3%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (accum) | p delta |
|-------|-----|-----|--------------|-----------|---------|
| in_dist | 0.325 | 0.192 | 20.56 | 23.04 | +2.48 (+12.1%) |
| ood_cond | 0.280 | 0.196 | — | 22.16 | — |
| ood_re | 0.294 | 0.208 | — | 32.18 | — |
| tandem | 0.668 | 0.347 | 40.78 | 41.46 | +0.68 (+1.7%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.458 | 0.516 | 28.88 |
| ood_cond | 1.136 | 0.426 | 20.85 |
| ood_re | 1.128 | 0.463 | 52.49 |
| tandem | 2.335 | 1.059 | 44.50 |

**Peak memory:** No change.

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868 — same persistent numerical instability.

### What happened
Gradient accumulation hurts: val/loss is 7.3% worse than baseline, in_dist surf_p degrades 12.1%. This is a clear negative result.

The root cause is optimizer step starvation. With accum_steps=2, each epoch delivers only ~165 gradient updates instead of 331. Over 64 epochs (the 30-min budget), that is ~10,560 total optimizer steps vs ~23,800 for the baseline. The gradient accumulation premise ("same number of optimizer updates") only holds if training is not wall-time-limited. In this capped 30-min setting, accumulation actually halves the total optimizer updates — the same failure mode as batch_size=8 that motivated this experiment.

The larger effective batch may provide marginally cleaner gradients per step, but it cannot offset the 2x reduction in steps within the time budget.

### Suggested follow-ups
- If gradient accumulation is still worth testing, try it with a longer timeout (60+ min) so total steps are not cut in half
- Consider higher learning rates to approximate larger-batch noise reduction without reducing step count