### PR TITLE
Bernoulli physics consistency loss (pressure-velocity coupling)

### DIFF
--- a/train.py
+++ b/train.py
@@ -668,6 +668,18 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
 
+        # Bernoulli consistency: total pressure should be nearly constant on surface
+        pred_phys = pred * phys_stats['y_std'] + phys_stats['y_mean']
+        p_total = pred_phys[:, :, 2:3] + 0.5 * (pred_phys[:, :, 0:1]**2 + pred_phys[:, :, 1:2]**2)
+        # Only for surface nodes, non-tandem samples
+        p_total_surf = p_total.squeeze(-1) * surf_mask.float()
+        # Per-sample variance of total pressure on surface
+        n_surf_per_sample = surf_mask.float().sum(dim=1).clamp(min=1)
+        p_total_mean = (p_total_surf.sum(dim=1) / n_surf_per_sample).unsqueeze(1)
+        p_total_var = ((p_total_surf - p_total_mean * surf_mask.float())**2 * surf_mask.float()).sum(dim=1) / n_surf_per_sample
+        physics_loss = p_total_var.mean()
+        loss = loss + 0.001 * physics_loss
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
No previous experiment used physics-informed constraints. Bernoulli: p + 0.5*(Ux² + Uy²) ≈ const along streamlines. Add soft constraint: variance of total pressure at surface nodes should be small. This couples pressure and velocity channels during training.

## Instructions

After the Re loss block (line 669), add:
```python
# Bernoulli consistency: total pressure should be nearly constant on surface
pred_phys = pred * phys_stats['y_std'] + phys_stats['y_mean']
p_total = pred_phys[:, :, 2:3] + 0.5 * (pred_phys[:, :, 0:1]**2 + pred_phys[:, :, 1:2]**2)
# Only for surface nodes, non-tandem samples
p_total_surf = p_total.squeeze(-1) * surf_mask.float()
# Per-sample variance of total pressure on surface
n_surf_per_sample = surf_mask.float().sum(dim=1).clamp(min=1)
p_total_mean = (p_total_surf.sum(dim=1) / n_surf_per_sample).unsqueeze(1)
p_total_var = ((p_total_surf - p_total_mean * surf_mask.float())**2 * surf_mask.float()).sum(dim=1) / n_surf_per_sample
physics_loss = p_total_var.mean()
loss = loss + 0.001 * physics_loss
```

Note: `phys_stats` is available from the data loading section. Start with weight 0.001 (very light).

Run: `python train.py --agent alphonse --wandb_name "alphonse/bernoulli" --wandb_group bernoulli-physics-loss`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** rwbzg0f7
**Epochs completed:** ~64/100 (30-min timeout)

### Metrics at best checkpoint (epoch ~64)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.647 | 0.308 | 0.183 | 22.41 | 1.304 | 0.463 | 26.40 |
| tandem_transfer | 3.227 | 0.623 | 0.336 | 41.19 | 2.139 | 0.985 | 44.45 |
| ood_cond | 1.935 | 0.273 | 0.191 | 21.42 | 1.061 | 0.404 | 20.29 |
| **3split avg** | **2.2697** | — | — | — | — | — | — |

**Baseline comparison:**
- val/loss: 2.2697 vs 2.2068 — **regression (+0.0629)**
- mae_surf_p in_dist: 22.41 vs 20.56 — **regression (+1.85)**
- mae_surf_p tandem: 41.19 vs 40.78 — **slight regression (+0.41)**

**Peak memory:** Not logged (no OOM).

### What happened

The Bernoulli physics loss did not help — val/loss regressed by 2.85% relative to baseline, and surface pressure MAE worsened on all splits.

The loss trajectory was still decreasing at epoch 64 (from ~3.9 at ep35 down to 2.27 at ep64), but the model appears to be training slower than the baseline and shows no sign of catching up within the 30-minute window.

The physics constraint is likely counterproductive for this problem. Bernoulli's principle (p + ½v² = const) is only valid for inviscid, incompressible, steady flow along a streamline. Airfoil CFD data has:
1. Viscous boundary layers where total pressure is NOT conserved.
2. Stagnation points where total pressure is intentionally high (stagnation pressure).
3. Wakes with significant total pressure loss.

So penalizing variance of total pressure on surface nodes directly conflicts with the physics we want to learn — the model is being pushed to make total pressure uniform when in reality it varies significantly across the surface. The net effect is corrupted gradients for pressure prediction.

### Suggested follow-ups

- **Smarter physics constraint**: Instead of total pressure variance, try enforcing continuity (∇·v ≈ 0) using finite differences across mesh neighbors — this holds everywhere in incompressible flow.
- **Streamline Bernoulli only**: Rather than all surface nodes, apply the constraint only between pairs of adjacent nodes where flow direction can be inferred — much harder to implement but physically correct.
- **Disable for tandem samples**: The tandem case has two interacting airfoils where Bernoulli is even less applicable; excluding them might reduce noise.
- **Weight search**: If the constraint is worth keeping at all, 0.0001 might avoid corrupting gradients while still providing weak guidance.