### PR TITLE
Three-tier LR: 2x for preprocess MLP (accelerate feature learning)

### DIFF
--- a/train.py
+++ b/train.py
@@ -510,10 +510,13 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+attn_keys = ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias']
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in attn_keys)]
+preprocess_params = [p for n, p in model.named_parameters() if 'preprocess' in n]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in attn_keys) and 'preprocess' not in n]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
+    {'params': preprocess_params, 'lr': cfg.lr * 2.0},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)


### PR DESCRIPTION
## Hypothesis
The preprocess MLP is the ONLY feature extractor with n_layers=1. Currently it uses the same LR as the output MLP. Giving it 2x LR (6e-3 vs 3e-3) accelerates feature learning — the bottleneck for this architecture.

## Instructions

Modify the parameter group setup (around line 513-518). Currently:
\`\`\`python
attn_params = [...]
other_params = [...]
base_opt = torch.optim.AdamW([
    {'params': attn_params, 'lr': cfg.lr * 0.5},
    {'params': other_params, 'lr': cfg.lr}
], weight_decay=cfg.weight_decay)
\`\`\`

Change to 3 groups:
\`\`\`python
attn_keys = ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias']
attn_params = [p for n, p in model.named_parameters() if any(k in n for k in attn_keys)]
preprocess_params = [p for n, p in model.named_parameters() if 'preprocess' in n]
other_params = [p for n, p in model.named_parameters() if not any(k in n for k in attn_keys) and 'preprocess' not in n]
base_opt = torch.optim.AdamW([
    {'params': attn_params, 'lr': cfg.lr * 0.5},
    {'params': preprocess_params, 'lr': cfg.lr * 2.0},
    {'params': other_params, 'lr': cfg.lr}
], weight_decay=cfg.weight_decay)
\`\`\`

Run: \`python train.py --agent thorfinn --wandb_name "thorfinn/3tier-lr" --wandb_group 3tier-lr-preprocess\`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** \`ndefntl1\` (thorfinn/3tier-lr)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.2068 | 2.3200 | +5.1% ❌ |
| val_in_dist / mae_surf_p | 20.56 | 21.49 | +4.5% ❌ |
| val_tandem / mae_surf_p | 40.78 | 43.12 | +5.7% ❌ |
| val_ood_cond / mae_surf_p | — | 21.25 | — |
| val_in_dist / mae_vol_Ux | — | 1.256 | — |
| val_tandem / mae_vol_Ux | — | 2.175 | — |
| Peak memory | — | 10.5 GB | — |

Best checkpoint: epoch 67 of 100 (30 min timeout).

**What happened:** Negative result. Giving the preprocess MLP 2× LR (6e-3) hurt performance across all splits. val/loss rose from 2.2068 → 2.3200 (+5.1%), and surface pressure degraded on both in_dist (+4.5%) and tandem (+5.7%).

The hypothesis that the preprocess MLP is the training bottleneck does not appear to hold. Most likely explanation: the preprocess MLP is a shallow single-layer network that is already easy to optimize at base LR. A 2× boost likely over-shoots its optima early in training, causing it to converge to a worse representation before the attention layers are mature enough to use it. The interaction with Lookahead (which smooths updates) may amplify this mistuning.

**Suggested follow-ups:**
- Try a lower multiplier (1.5×) — the aggressive 2× may be the problem, not the idea itself.
- Try boosting preprocess LR only during warmup, then returning to base LR.
- Try reducing attn LR instead (lr*0.25 vs lr*0.5) — maybe attn is the real bottleneck.