### PR TITLE
Surface curvature proxy from dsdf features (25th input feature)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -588,6 +588,9 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        x = torch.cat([x, curv], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -718,6 +721,9 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
+                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Surface curvature correlates strongly with Cp peaks (leading/trailing edges). Create a derived feature: dsdf gradient magnitude for surface nodes only, concatenated as a 25th feature. This gives the model explicit geometric info without learned parameters.

## Instructions

In the training loop, after loading and normalizing x (line 590), add:
```python
# Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
x = torch.cat([x, curv], dim=-1)
```

Do the same in the validation loop (after line 535).

Change `model_config` (line 410): `fun_dim=X_DIM - 2 + 1` (add 1 for the new feature).

Run: `python train.py --agent askeladd --wandb_name "askeladd/curvature-feat" --wandb_group curvature-proxy-feature`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `i8cd9kzk`
**Epochs:** 67 (best at 67, EMA active) | **Peak memory:** 10.6 GB
*(Note: run state shows "failed" due to 30-min wall-clock limit — all 67 epochs completed normally)*

### Loss comparison

| Split | Baseline | Curvature proxy | Delta |
|---|---|---|---|
| **val/loss** | 2.2068 | **2.1997** | **-0.32%** |
| val_in_dist/loss | — | 1.5442 | |
| val_tandem_transfer/loss | — | 3.1931 | |
| val_ood_cond/loss | — | 1.8619 | |

### Surface pressure MAE

| Split | Baseline | Curvature proxy | Delta |
|---|---|---|---|
| val_in_dist | 20.56 | **20.03** | **-2.6%** |
| val_ood_cond | **19.71** | 20.57 | +4.4% |
| val_tandem_transfer | 40.78 | **40.41** | -0.9% |

### Full surface MAE (curvature proxy run, best epoch)

| Split | surf Ux | surf Uy | surf p | vol p |
|---|---|---|---|---|
| val_in_dist | 0.285 | 0.174 | 20.03 | 25.83 |
| val_ood_cond | 0.264 | 0.182 | 20.57 | 18.74 |
| val_tandem_transfer | 0.605 | 0.334 | 40.41 | 43.31 |

### What happened

**The curvature proxy feature provides a modest improvement.** Val/loss improved by 0.32% (2.2068 → 2.1997) and in_dist surface pressure improved by 2.6% (20.56 → 20.03). Tandem transfer also improved slightly (-0.9%). However, ood_cond surface pressure is slightly worse (+4.4%).

The curvature proxy (norm of the first 4 normalized dsdf gradient channels, zeroed for volume nodes) gives the model explicit information about local surface geometry. This is a zero-parameter derived feature that effectively highlights surface curvature hotspots, which are exactly the locations where pressure peaks occur. The improvement in in_dist and tandem metrics suggests the model is using this signal productively for the standard foil cases.

The ood_cond degradation (+4.4%) is notable — out-of-distribution conditions may have different curvature-pressure relationships, and the model might be overfitting to the curvature-Cp correlation that holds in training conditions.

Overall this is a small but consistent positive result on the primary metrics (val/loss + in_dist + tandem), making it one of the few experiments that actually improved over baseline.

### Suggested follow-ups

- **Normalize the curvature feature**: The current implementation is unnormalized. Adding a separate normalization (e.g., divide by dataset-level std) might improve learning stability and potentially get more benefit.
- **Include curvature for volume nodes too**: Currently zeroed for volume nodes. Including the gradient magnitude everywhere (not masked by is_surface) might help the model understand field structure near the surface.
- **Try multiple curvature features**: Instead of just the norm of channels 2-6, adding individual gradient components (x, y derivatives of dsdf) might provide richer directional information.