### PR TITLE
Adaptive tandem curriculum (introduce when val_in_dist < 2.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,6 +563,8 @@ global_step = 0
 train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
+introduce_tandem = False
+prev_val_in_dist_loss = float('inf')
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -618,7 +620,7 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
+        if not introduce_tandem:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
@@ -842,6 +844,11 @@ for epoch in range(MAX_EPOCHS):
         f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
         f"val[{split_summary}]{tag}"
     )
+    if not introduce_tandem and epoch >= 5:
+        in_dist_loss = val_metrics_per_split.get('val_in_dist', {}).get('val_in_dist/loss', float('inf'))
+        if in_dist_loss < 2.0:
+            introduce_tandem = True
+            print(f"  [CURRICULUM] Introducing tandem at epoch {epoch+1} (val_in_dist/loss={in_dist_loss:.3f})")
 
 
 # --- Final summary ---


### PR DESCRIPTION
## Hypothesis
Fixed tandem exclusion at 10 epochs was confirmed optimal. But different seeds converge at different rates (seed variance ±4%). An adaptive approach introduces tandem when in-dist val loss drops below 2.0, making the curriculum respond to model readiness.

## Instructions

Before the training loop (after line 565 `prev_surf_loss = 0.2`), add:
```python
introduce_tandem = False
prev_val_in_dist_loss = float('inf')
```

Replace lines 621-624:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
```
With:
```python
if not introduce_tandem:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
```

At the end of each epoch (after validation), update:
```python
if not introduce_tandem and epoch >= 5:
    in_dist_loss = val_metrics_per_split.get('val_in_dist', {}).get('val_in_dist/loss', float('inf'))
    if in_dist_loss < 2.0:
        introduce_tandem = True
        print(f"  [CURRICULUM] Introducing tandem at epoch {epoch+1} (val_in_dist/loss={in_dist_loss:.3f})")
```

Run: `python train.py --agent violet --wandb_name "violet/adaptive-tandem" --wandb_group adaptive-tandem-curriculum`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run ID**: `ps4wmg8o`
**Epochs completed**: 67 (best), 30.4 min
**Peak memory**: 10.6 GB

### Metrics vs Baseline

| Metric | Baseline | Adaptive curriculum | Δ |
|---|---|---|---|
| val/loss | 2.2068 | **4.0768** | +85% 🔴 |
| in_dist surf_p | 20.56 Pa | **46.26 Pa** | +125% 🔴 |
| ood_cond surf_p | — | **36.97 Pa** | — |
| ood_re surf_p | 30.90 Pa | **43.53 Pa** | +41% 🔴 |
| tandem surf_p | 40.78 Pa | **60.62 Pa** | +49% 🔴 |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

**The threshold was never crossed** — `val_in_dist/loss` never dropped below 2.0 throughout the entire 67 epochs (final value: 3.20). So tandem was excluded for all 67 epochs, and the model catastrophically degraded.

This reveals a chicken-and-egg problem: the threshold of 2.0 was calibrated to where normal runs (which include tandem after epoch 10) reach. But when tandem is excluded indefinitely:

1. The model trains on a reduced, less diverse dataset
2. Without the additional training signal from tandem samples, convergence is slower and worse
3. val_in_dist stays above 2.0, so tandem is never introduced
4. The model is stuck without tandem forever

In normal runs, val_in_dist reliably drops below 2.0 around epochs 10–15 **because** tandem is introduced at epoch 10, adding data diversity. The adaptive approach breaks this dependency. The threshold of 2.0 is too aggressive relative to what the model can achieve on non-tandem data alone.

### Suggested follow-ups

- **Higher threshold** (e.g., 3.5): If the threshold were set at a value reachable with non-tandem-only training, this approach might work. Testing `val_in_dist < 3.5` (approximately where this run was stuck) could work.
- **Hybrid approach**: Use the epoch-10 fallback: introduce tandem at epoch 10 OR when val_in_dist < 2.0, whichever comes first. This prevents the feedback loop.
- **Abandon adaptive approach**: The fixed 10-epoch curriculum was validated and works well. This experiment confirms the fixed schedule is robust.