### PR TITLE
EMA-smoothed adaptive surf_weight (reduce epoch-to-epoch noise)

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,6 +563,8 @@ global_step = 0
 train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
+ema_vol_loss = 1.0
+ema_surf_loss = 0.2
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -573,7 +575,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    surf_weight = max(5.0, min(50.0, ema_vol_loss / max(ema_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()
@@ -692,6 +694,8 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
+    ema_vol_loss = 0.8 * ema_vol_loss + 0.2 * epoch_vol
+    ema_surf_loss = 0.8 * ema_surf_loss + 0.2 * epoch_surf
 
     # --- Validate across all splits ---
     eval_model = ema_model if ema_model is not None else model


### PR DESCRIPTION
## Hypothesis
The adaptive surf_weight uses prev_vol/prev_surf from a single epoch — this is noisy and can swing dramatically. Smoothing with EMA removes oscillations. This fixes the MECHANISM, not the schedule or bounds.

## Instructions

Before the training loop (near line 564-565), change:
```python
prev_vol_loss = 1.0
prev_surf_loss = 0.2
```
To:
```python
prev_vol_loss = 1.0
prev_surf_loss = 0.2
ema_vol_loss = 1.0
ema_surf_loss = 0.2
```

Replace lines 693-694:
```python
prev_vol_loss = epoch_vol
prev_surf_loss = epoch_surf
```
With:
```python
prev_vol_loss = epoch_vol
prev_surf_loss = epoch_surf
ema_vol_loss = 0.8 * ema_vol_loss + 0.2 * epoch_vol
ema_surf_loss = 0.8 * ema_surf_loss + 0.2 * epoch_surf
```

Replace line 576:
```python
surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
```
With:
```python
surf_weight = max(5.0, min(50.0, ema_vol_loss / max(ema_surf_loss, 1e-8)))
```

Run: `python train.py --agent gilbert --wandb_name "gilbert/ema-surf-weight" --wandb_group ema-smoothed-surf-weight`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** jkiofdoj
**Best epoch:** 67 / 100 (30-min timeout)
**Peak memory:** ~10.5 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.5439 | 0.281 | 0.178 | 20.3 |
| val_tandem_transfer | 3.2968 | — | — | 42.8 |
| val_ood_cond | 1.8514 | — | — | 19.7 |
| val_ood_re | 18869.5 | — | — | 30.5 |
| **combined val/loss (3-split)** | **2.2307** | | | |

**Baseline val/loss: 2.2068 → This run: 2.2307 (+0.024, within noise)**

### What happened

EMA smoothing of the surf_weight ratio shows no meaningful difference from the baseline. The +0.024 change is well within single-run noise (σ ≈ 0.05, established by PR #898).

Split-level comparison vs baseline (surf_p):
- in_dist: 20.3 vs 20.56 — slight improvement (+0.26)
- tandem: 42.8 vs 40.78 — regression (-2.0)
- ood_cond: 19.7 — competitive
- ood_re: 30.5 vs ~31 — slight improvement

The mixed picture on individual splits with no change in combined loss suggests the epoch-to-epoch noise in surf_weight was not actually harming training. The adaptive weight ratio (vol/surf) tracks a smoothly changing quantity as the model converges — it does not oscillate dramatically in practice, so EMA smoothing provides no benefit.

### Suggested follow-ups

- **The adaptive surf_weight mechanism is solid** — noise in the single-epoch signal is not a problem worth fixing.
- **Change the schedule or bounds instead**: if surf_weight matters, explore a fixed cosine schedule from 5→50 (removes ratio dependence entirely) or expand the upper bound from 50 to 100 to give more room during late training.