### PR TITLE
Checkpoint averaging: average top-3 best models (flat-minima finder)

### DIFF
--- a/train.py
+++ b/train.py
@@ -560,6 +560,7 @@ with open(model_dir / "config.yaml", "w") as f:
 best_val = float("inf")
 best_metrics = {}
 global_step = 0
+top_checkpoints = []  # list of (val_loss, state_dict) tuples, max 3
 train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
@@ -833,6 +834,13 @@ for epoch in range(MAX_EPOCHS):
         torch.save(save_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 
+    # Save to top-3 list
+    state_copy = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+    top_checkpoints.append((val_loss_3split, state_copy))
+    top_checkpoints.sort(key=lambda x: x[0])
+    if len(top_checkpoints) > 3:
+        top_checkpoints.pop()  # remove worst
+
     split_summary = "  ".join(
         f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
         for name in VAL_SPLIT_NAMES
@@ -843,6 +851,105 @@ for epoch in range(MAX_EPOCHS):
         f"val[{split_summary}]{tag}"
     )
 
+
+# --- Checkpoint averaging ---
+if len(top_checkpoints) >= 2:
+    print(f"\nAveraging {len(top_checkpoints)} best checkpoints...")
+    avg_state = {}
+    for key in top_checkpoints[0][1]:
+        avg_state[key] = sum(ckpt[1][key].float() for ckpt in top_checkpoints) / len(top_checkpoints)
+        avg_state[key] = avg_state[key].to(top_checkpoints[0][1][key].dtype)
+    model.load_state_dict({k: v.to(device) for k, v in avg_state.items()})
+    torch.save(avg_state, model_path)
+
+    # Re-evaluate with averaged model
+    model.eval()
+    avg_metrics_per_split: dict[str, dict] = {}
+    _avg_3split_names = ["val_in_dist", "val_tandem_transfer", "val_ood_cond"]
+    with torch.no_grad():
+        for split_name, vloader in val_loaders.items():
+            val_vol = 0.0
+            val_surf = 0.0
+            mae_surf = torch.zeros(3, device=device)
+            mae_vol = torch.zeros(3, device=device)
+            n_surf = torch.zeros(3, device=device)
+            n_vol = torch.zeros(3, device=device)
+            n_vbatches = 0
+            for x, y, is_surface, mask in vloader:
+                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                is_surface = is_surface.to(device, non_blocking=True)
+                mask = mask.to(device, non_blocking=True)
+                x = (x - stats["x_mean"]) / stats["x_std"]
+                Umag, q = _umag_q(y, mask)
+                y_phys = _phys_norm(y, Umag, q)
+                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                raw_gap = x[:, 0, 21]
+                is_tandem = raw_gap.abs() > 0.5
+                B = y_norm.shape[0]
+                sample_stds = torch.ones(B, 1, 3, device=device)
+                channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
+                for b in range(B):
+                    if not is_tandem[b]:
+                        valid = mask[b]
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                y_norm_scaled = y_norm / sample_stds
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred = model({"x": x})["preds"]
+                pred = pred.float()
+                pred_loss = pred / sample_stds
+                abs_err = (pred_loss - y_norm_scaled).abs().nan_to_num(0.0)
+                vol_mask = mask & ~is_surface
+                surf_mask = mask & is_surface
+                val_vol += min((abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(), 1e6)
+                val_surf += min((abs_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item(), 1e6)
+                n_vbatches += 1
+                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_orig = _phys_denorm(pred_phys, Umag, q)
+                y_clamped = y.clamp(-1e6, 1e6)
+                err = (pred_orig - y_clamped).abs()
+                finite = err.isfinite()
+                err = err.where(finite, torch.zeros_like(err))
+                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+                n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+            val_vol /= max(n_vbatches, 1)
+            val_surf /= max(n_vbatches, 1)
+            val_vol = float(torch.tensor(val_vol).nan_to_num(0.0).clamp(max=1e6))
+            val_surf = float(torch.tensor(val_surf).nan_to_num(0.0).clamp(max=1e6))
+            split_loss = val_vol + cfg.surf_weight * val_surf
+            mae_surf /= n_surf.clamp(min=1)
+            mae_vol /= n_vol.clamp(min=1)
+            avg_metrics_per_split[split_name] = {
+                f"{split_name}/vol_loss":    val_vol,
+                f"{split_name}/surf_loss":   val_surf,
+                f"{split_name}/loss":        split_loss,
+                f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
+                f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
+                f"{split_name}/mae_vol_p":   mae_vol[2].item(),
+                f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
+                f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
+                f"{split_name}/mae_surf_p":  mae_surf[2].item(),
+            }
+    _avg_3split_losses = [avg_metrics_per_split[n][f"{n}/loss"] for n in _avg_3split_names
+                          if not (torch.tensor(avg_metrics_per_split[n][f"{n}/loss"]).isnan() or
+                                  torch.tensor(avg_metrics_per_split[n][f"{n}/loss"]).isinf())]
+    avg_val_loss_3split = sum(_avg_3split_losses) / max(len(_avg_3split_losses), 1)
+
+    avg_wandb = {"checkpoint_avg/val_loss": avg_val_loss_3split}
+    for split_metrics in avg_metrics_per_split.values():
+        for k, v in split_metrics.items():
+            avg_wandb[f"checkpoint_avg/{k}"] = v
+    wandb.log(avg_wandb)
+
+    print(f"Averaged checkpoint val/loss: {avg_val_loss_3split:.4f}  (best single: {best_val:.4f})")
+    if avg_val_loss_3split < best_val:
+        print("  -> Averaged checkpoint is better — updating best_metrics")
+        best_val = avg_val_loss_3split
+        best_metrics = {"epoch": "avg", "val_loss": avg_val_loss_3split}
+        for split_metrics in avg_metrics_per_split.values():
+            for k, v in split_metrics.items():
+                best_metrics[f"best_{k}"] = v
 
 # --- Final summary ---
 total_time = (time.time() - train_start) / 60.0


### PR DESCRIPTION
## Hypothesis
Instead of saving only the single best checkpoint, save top-3 and average their weights at the end. This is different from EMA (which weights by recency) — it selects the BEST performers and uniformly averages them, finding flatter minima.

## Instructions

After line 461 (`best_val = float("inf")`), add:
```python
top_checkpoints = []  # list of (val_loss, state_dict) tuples, max 3
```

In the checkpoint saving section (around line 826 where `if val_loss_3split < best_val:`), add checkpoint to the top-3 list:
```python
# Save to top-3 list
state_copy = {k: v.cpu().clone() for k, v in model.state_dict().items()}
top_checkpoints.append((val_loss_3split, state_copy))
top_checkpoints.sort(key=lambda x: x[0])
if len(top_checkpoints) > 3:
    top_checkpoints.pop()  # remove worst
```

After the training loop ends (before the final summary), average the top checkpoints:
```python
if len(top_checkpoints) >= 2:
    print(f"Averaging {len(top_checkpoints)} best checkpoints...")
    avg_state = {}
    for key in top_checkpoints[0][1]:
        avg_state[key] = sum(ckpt[1][key].float() for _, ckpt in top_checkpoints) / len(top_checkpoints)
        avg_state[key] = avg_state[key].to(top_checkpoints[0][1][key].dtype)
    model.load_state_dict(avg_state)
    torch.save(avg_state, model_path)
    # Re-evaluate with averaged model
    # ... (run validation again and update best_metrics)
```

Run: `python train.py --agent senku --wandb_name "senku/ckpt-avg-top3" --wandb_group checkpoint-avg-top3`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** `svbcojov` (senku/ckpt-avg-top3, second run — first run `a7lkp8mi` crashed due to a bug, see below)  
**Best epoch:** 67  
**Peak GPU memory:** ~28% of 96GB

### Best single checkpoint (epoch 67)

| Split | loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.5800 | 0.297 | 0.177 | 20.82 | 1.294 | 0.446 | 26.27 |
| val_tandem_transfer | 3.2351 | 0.618 | 0.338 | 41.65 | 2.155 | 0.984 | 43.59 |
| val_ood_cond | 1.9294 | 0.273 | 0.189 | 20.94 | 1.043 | 0.404 | 19.99 |
| val_ood_re | 18869.6 | 0.278 | 0.200 | 30.99 | 1.048 | 0.440 | 51.10 |

**val/loss (3-split, single): 2.2482** vs baseline **2.2068** → **neutral** (+1.9%)  
**surf_p in_dist: 20.82** vs baseline **20.56** → essentially the same

### Averaged top-3 checkpoint

| Split | loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6442 | 0.304 | 0.183 | 22.77 | 1.307 | 0.458 | 27.51 |
| val_tandem_transfer | 3.3061 | 0.630 | 0.347 | 43.32 | 2.168 | 0.995 | 44.94 |
| val_ood_cond | 1.9668 | 0.279 | 0.192 | 21.35 | 1.048 | 0.408 | 20.29 |
| val_ood_re | 18869.6 | 0.283 | 0.203 | 31.08 | 1.060 | 0.447 | 51.22 |

**val/loss (3-split, averaged): 2.3057** — **worse** than single checkpoint (2.2482) and baseline (2.2068)

### Bug in instructions

The first run crashed with `KeyError: 1`. The instructions had:
```python
avg_state[key] = sum(ckpt[1][key].float() for _, ckpt in top_checkpoints) / len(top_checkpoints)
```
When unpacking `for _, ckpt in top_checkpoints`, `ckpt` becomes the state_dict directly. Then `ckpt[1][key]` tries to use integer `1` as a dict key. Fix: use `for ckpt in top_checkpoints` (no unpacking), so `ckpt = (val_loss, state_dict)` and `ckpt[1][key]` works as intended.

### What happened

Checkpoint averaging **hurt** performance (2.3057 vs 2.2482 for the best single). The hypothesis doesn't hold here, and the reason is timing: with the 30-min wall-clock limit, **the model was still converging at epoch 67** (the last epoch was also the best epoch). This means the top-3 includes earlier checkpoints from epochs 65–67, when the model was not yet at a flat minimum. Averaging a model at its best with slightly less-trained versions pulls the weights away from the optimal rather than toward a flat minimum.

The checkpoint-averaging technique works when the loss landscape has a flat minimum and the top-3 checkpoints are all near the same basin. When training is cut off before convergence, the top-3 are spread along a still-descending trajectory, and averaging them is counterproductive.

### Suggested follow-ups
- This technique may work if the run is long enough to converge (best epoch is NOT the last epoch). Try on a fully-converged model, or increase the timeout.
- Alternatively, only average checkpoints from the LAST N epochs (e.g., last 5), which more likely share a basin if the model is near-converged.
- SWA (Stochastic Weight Averaging) over a cyclic LR tail might be more effective than top-k averaging for regularization purposes.
