### PR TITLE
Pressure-only coarse pooling loss (focus multi-resolution on key metric)

### DIFF
--- a/train.py
+++ b/train.py
@@ -660,7 +660,7 @@ for epoch in range(MAX_EPOCHS):
             y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
             mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
-            coarse_err = (pred_coarse - y_coarse).abs()
+            coarse_err = (pred_coarse[:, :, 2:3] - y_coarse[:, :, 2:3]).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
             loss = loss + 1.0 * coarse_loss
 


### PR DESCRIPTION
## Hypothesis
The coarse pooling loss currently pools all 3 channels equally. But pressure is the primary metric. Velocity channels may add noise. Applying coarse loss ONLY to pressure (channel 2) focuses the multi-resolution regularization specifically on pressure coherence.

## Instructions

Replace line 663:
```python
coarse_err = (pred_coarse - y_coarse).abs()
```
With:
```python
coarse_err = (pred_coarse[:, :, 2:3] - y_coarse[:, :, 2:3]).abs()
```

Everything else stays the same.

Run: `python train.py --agent kohaku --wandb_name "kohaku/pressure-coarse" --wandb_group pressure-only-coarse-loss`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** a3x2sl2b | **Epochs:** 64 (30-min timeout) | **Memory:** 10.5 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.6371 | 0.3043 | 0.1823 | 21.59 | 1.477 | 0.525 | 26.96 |
| tandem_transfer | 3.3837 | 0.6457 | 0.3478 | 43.44 | 2.342 | 1.093 | 45.94 |
| ood_cond | 1.9951 | 0.2736 | 0.1974 | 22.11 | 1.190 | 0.472 | 20.80 |
| ood_re | 18869.62 | 0.2809 | 0.2025 | 31.24 | 1.164 | 0.487 | 51.61 |
| **3-split mean** | **2.3386** | | | | | | |

**vs baseline (2.2068):** +5.9% worse

Surface pressure vs baseline:
- in_dist: 21.59 vs 20.56 (+5.0%)
- tandem: 43.44 vs 40.78 (+6.5%)
- ood_cond: 22.11 vs 19.71 (+12.2%)

**What happened:** Negative result. Restricting the coarse pooling loss to pressure only hurt both pressure and volume accuracy. The volume MAE degraded significantly (in_dist vol_Ux: 1.477 vs ~1.3 baseline, +14%), suggesting velocity channels provide useful spatial coherence signal that benefits the overall training, not just noise. The pressure surface MAE is slightly worse, not better. Notably, the run showed early training instability (val_in_dist ~50 in epochs 1–10 vs ~18 for baseline) — the reduced coarse loss scale (now 1/3 of the channels) weakened early regularization. The all-channel coarse loss appears well-calibrated: pressure benefits from the full regularization including velocity.

**Suggested follow-ups:**
- Try weighting pressure higher in the coarse loss (e.g. `coarse_err * torch.tensor([1,1,3])`) rather than dropping velocities entirely
- The early instability suggests the coarse loss weight might need to be 3x higher (3.0 instead of 1.0) to compensate when using single-channel