### PR TITLE
Float64 precision for surface loss computation (higher gradient accuracy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -642,8 +642,8 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-        surf_loss = (surf_per_sample * tandem_boost).mean()
+        surf_per_sample = (abs_err.double() * surf_mask.unsqueeze(-1).double()).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).double()
+        surf_loss = (surf_per_sample * tandem_boost.double()).mean().float()
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling


### PR DESCRIPTION
## Hypothesis
The forward pass uses bfloat16, then loss in float32. But surface nodes are few (~5% of total) and most important. Computing surface loss in float64 (double) precision adds negligible overhead but gives higher gradient accuracy for the most critical nodes.

## Instructions

Replace the surface loss computation (lines 645-646):
```python
surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()
```
With:
```python
surf_per_sample = (abs_err.double() * surf_mask.unsqueeze(-1).double()).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).double()
surf_loss = (surf_per_sample * tandem_boost.double()).mean().float()
```

Run: `python train.py --agent emma --wandb_name "emma/f64-surf-loss" --wandb_group float64-surf-loss`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** 5xrxaqjo  
**Peak memory:** 10.6 GB  
**Epochs completed:** 66 (30-min wall-clock limit)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.296 | 0.178 | 21.11 | 1.247 | 0.453 | 25.79 |
| val_tandem | 0.615 | 0.331 | 41.00 | 2.112 | 0.988 | 43.01 |
| val_ood_cond | 0.252 | 0.188 | 20.81 | 1.027 | 0.403 | 19.72 |
| val_ood_re | 0.272 | 0.200 | 30.83 | 1.035 | 0.439 | 51.08 |

**val/loss (3-split): 2.2188** vs baseline 2.2068 (+0.5%, within noise)

### What happened

Float64 surface loss gave essentially no improvement. Val/loss of 2.2188 vs 2.2068 is a 0.5% difference that falls within run-to-run noise. Surface pressure on in_dist (21.11 vs 20.56) and tandem (41.00 vs 40.78) are marginally worse to essentially the same.

This was expected in hindsight: the model forward pass uses bfloat16 activations, so the actual values going into the loss already have limited precision (~3 decimal digits). Aggregating those low-precision values in float64 doesn't recover accuracy that was lost in the forward pass. The precision bottleneck is the model itself, not the loss summation. Float64 loss with bfloat16 activations is like trying to measure a rough-cut board with a micrometer.

### Suggested follow-ups

- This change is essentially neutral — no reason to add this complexity
- If precision is a concern, the right fix is to run the final layers in float32 (not the whole forward pass), which is what AMP already does with loss scaling
- The ~21 Pa surface pressure floor appears to be a model capacity/data issue, not a numerical precision issue