### PR TITLE
Surface-only loss in final 10 epochs (late-stage surface focus)

### DIFF
--- a/train.py
+++ b/train.py
@@ -644,7 +644,10 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        if epoch >= MAX_EPOCHS - 10:  # last ~10 epochs: surface-only
+            loss = surf_weight * surf_loss
+        else:
+            loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
The model learns volume structure in early epochs, then fine-tunes. In the final 10 epochs (when EMA is active and LR is low), switch to surface-only loss — dropping volume loss entirely. This gives the backbone a pure surface signal during the critical fine-tuning phase, when the volume representation is already well-established.

This is different from the "surface-only first 5" experiment (#884) which removed volume EARLY and hurt. Here we remove volume LATE, when the backbone has already learned good representations from volume supervision.

## Instructions

Replace line 647:
```python
loss = vol_loss + surf_weight * surf_loss
```
With:
```python
if epoch >= MAX_EPOCHS - 10:  # last ~10 epochs: surface-only
    loss = surf_weight * surf_loss
else:
    loss = vol_loss + surf_weight * surf_loss
```

The coarse loss and Re loss still apply (lines 649-669).

Run: `python train.py --agent nezuko --wandb_name "nezuko/surf-only-late" --wandb_group surface-loss-only-late`

## Baseline
- val/loss: 2.2068, surf_p: in_dist=20.56, tandem=40.78
---
## Results

**W&B run:** mpigfdwa | Runtime: 1811s (~30 min, ~63 epochs, 28.2s/epoch)

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| **in_dist** | 1.680 | 0.320 | 0.180 | **21.37** | 1.330 | 0.463 | 26.79 |
| **ood_cond** | 1.961 | 0.278 | 0.194 | **22.45** | 1.095 | 0.410 | 20.12 |
| **ood_re** | — | 0.275 | 0.203 | **30.96** | 1.052 | 0.443 | 51.03 |
| **tandem** | 3.302 | 0.636 | 0.340 | **41.80** | 2.149 | 0.994 | 44.41 |
| **val/loss (3-split)** | **2.3144** | | | | | | |

| Metric | Baseline | surf-only-late | Δ |
|---|---|---|---|
| val/loss | 2.2068 | 2.3144 | +4.9% ❌ |
| surf_p in_dist | 20.56 | 21.37 | +3.9% ❌ |
| surf_p ood_cond | 21.30 | 22.45 | +5.4% ❌ |
| surf_p ood_re | 30.90 | 30.96 | +0.2% ≈ |
| surf_p tandem | 40.78 | 41.80 | +2.5% ❌ |

### What happened

**Design mismatch with 30-minute cap — the surface-only phase never triggered.**

The threshold `epoch >= MAX_EPOCHS - 10` = `epoch >= 90` was never reached. With epoch_time=28.2s and the 30-minute cap, training completed ~63 epochs (steps 0–62). The code path for surface-only loss was dead code for this entire run.

The worse-than-baseline results (val/loss +4.9%) are attributable to run-to-run variance and slightly fewer epochs converged (63 vs ~69 for the baseline run), not to the code change.

**Conclusion:** This experiment effectively tested the unmodified baseline, and the results are within expected variance.

### Suggested follow-ups
- To actually test this hypothesis, set the threshold to `epoch >= 50` (or whatever epoch is reached at ~25 min), or restructure as "last N epochs relative to how many actually run"
- Alternatively, use a fraction: `epoch >= int(0.9 * actual_epochs_so_far)` — but this requires tracking elapsed time
- A cleaner implementation: use the wall-clock elapsed time check that the training loop already has for the 30-min timeout, and set surface-only when remaining time < X minutes