### PR TITLE
Curvature-weighted surface loss (upweight high-curvature nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -591,6 +591,7 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
+        curv_weight = (1.0 + 0.5 * curv.squeeze(-1)).detach()  # [B, N]
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -645,7 +646,9 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        weighted_surf_err = abs_err * surf_mask.unsqueeze(-1) * curv_weight.unsqueeze(-1)
+        surf_denom = (surf_mask.float() * curv_weight).sum(dim=1).clamp(min=1)
+        surf_per_sample = weighted_surf_err.sum(dim=(1, 2)) / surf_denom
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 
@@ -871,8 +874,18 @@ if best_metrics:
     print("\nGenerating flow field plots...")
     model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
     plot_dir = Path("plots") / run.id
+
+    class _VizWrapper:
+        """Appends zero curvature (24→25 dim) so visualize() works with the curvature-augmented model."""
+        def __init__(self, m): self.m = m
+        def eval(self): self.m.eval(); return self
+        def __call__(self, data, **kw):
+            x = data["x"]
+            curv = torch.zeros(*x.shape[:-1], 1, device=x.device, dtype=x.dtype)
+            return self.m({"x": torch.cat([x, curv], dim=-1)}, **kw)
+
     # Visualize from val_in_dist — same distribution as original val_ds
-    images = visualize(model, val_splits["val_in_dist"], stats, device,
+    images = visualize(_VizWrapper(model), val_splits["val_in_dist"], stats, device,
                        n_samples=2 if cfg.debug else 4, out_dir=plot_dir)
     if images:
         wandb.log({"val_predictions": [wandb.Image(str(p)) for p in images], "global_step": global_step})


### PR DESCRIPTION
## Hypothesis
Use the curvature proxy to weight surface loss: high-curvature regions (leading/trailing edges) where pressure gradients are steepest get proportionally more attention. This targets the exact locations where surface pressure errors are largest.

## Instructions
After computing `curv` (line 593), store for loss weighting:
```python
curv_weight = (1.0 + 0.5 * curv.squeeze(-1)).detach()  # [B, N]
```

Replace surface loss (lines 645-646):
```python
surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
```
With:
```python
weighted_surf_err = abs_err * surf_mask.unsqueeze(-1) * curv_weight.unsqueeze(-1)
surf_denom = (surf_mask.float() * curv_weight).sum(dim=1).clamp(min=1)
surf_per_sample = weighted_surf_err.sum(dim=(1, 2)) / surf_denom
```

Run: `python train.py --agent tanjiro --wandb_name "tanjiro/curv-weighted-loss" --wandb_group curvature-weighted-loss`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** 2gj144rz  
**Epochs:** 66 (30 min wall-clock, ~27s/epoch)  
**Peak VRAM:** 10.6 GB  

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6287 | 0.317 | 0.181 | 21.5 | 1.329 | 0.469 | 27.2 |
| val_tandem_transfer | 3.2187 | 0.620 | 0.337 | 41.2 | 2.143 | 0.978 | 44.1 |
| val_ood_cond | 1.9280 | 0.268 | 0.190 | 20.9 | 1.064 | 0.408 | 20.0 |
| val_ood_re | 18869.6* | 0.283 | 0.202 | 31.4 | 1.066 | 0.446 | 51.5 |
| **combined (3-split)** | **2.2585** | | | | | | |

*Pre-existing branch bug (ood_re vol_loss overflow), excluded from 3-split.

**vs baseline:**
- val/loss: 2.2585 vs 2.1997 → **+2.7% (worse)**
- surf_p in_dist: 21.5 vs 20.03 → **+7.3% (worse)**
- surf_p tandem: 41.2 vs 40.41 → **+2.0% (slightly worse)**

**What happened:**

Negative result. Curvature-weighted surface loss degraded performance across all splits. The hypothesis was that upweighting high-curvature surface nodes (leading/trailing edges) would reduce pressure errors at those locations, but it backfired.

Likely reasons:
1. **Curvature proxy quality**: The proxy (`x[:, :, 2:6].norm()` on normalized dsdf features) may not cleanly isolate high-curvature regions. The dsdf gradient norm is approximately uniform along the surface away from the airfoil edges, so the "curvature" signal may be noisy or weakly discriminative.
2. **Loss distortion**: By down-weighting mid-surface nodes (smooth regions) relative to edge nodes, the loss steers gradient updates away from the majority of surface nodes. The denominator normalization corrects for scale but still shifts which nodes drive learning.
3. **Already well-weighted**: The existing adaptive `surf_weight` already amplifies surface loss globally. Adding per-node curvature weighting on top introduces an additional redistribution that the model may not benefit from given only 66 epochs of training.

**Suggested follow-ups:**
- Try a stronger curvature signal — e.g., second-order dsdf features or the actual surface curvature κ from geometry metadata if available in the dataset.
- Try stronger weighting coefficient (e.g., `1 + 2.0 * curv`) to see if the direction is right and just under-scaled, or if the result consistently degrades.
- Alternatively, upweight surface loss uniformly by a fixed spatial priority map (e.g., nodes within N% chord of leading/trailing edge), rather than using the dsdf proxy.