### PR TITLE
Curvature × Reynolds interaction feature

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 2,  # X_DIM=24 + 2 (curvature proxy + curv×log_Re); fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -590,7 +590,8 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        curv_re = curv * x[:, :, 13:14]  # curvature × log_Re
+        x = torch.cat([x, curv, curv_re], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -723,7 +724,8 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                curv_re = curv * x[:, :, 13:14]  # curvature × log_Re
+                x = torch.cat([x, curv, curv_re], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Different Re produces different boundary layer behavior at the same curvature. A curv×Re interaction lets the model directly attend to Re-dependent curvature effects. Feature 13 is log_Re.

## Instructions
After curv computation (line 593), before x = torch.cat, add:
```python
curv_re = curv * x[:, :, 13:14]  # curvature × log_Re
x = torch.cat([x, curv, curv_re], dim=-1)
```
(Remove the existing `x = torch.cat([x, curv], dim=-1)` line and replace with the above.)

Change model_config (line 464): `fun_dim=X_DIM - 2 + 2` (2 extra features now).
Do the same in the validation loop (line 725-726).

Run: `python train.py --agent frieren --wandb_name "frieren/curv-re" --wandb_group curvature-re-interaction`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** `43ve07f6` (frieren/curv-re)
**Epochs:** 66 (30-min wall-clock limit; run state=failed due to timeout kill)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.630 | 0.311 | 0.175 | **21.91** | 1.294 | 0.454 | 26.18 |
| val_ood_cond | 1.920 | 0.263 | 0.183 | **21.78** | 1.037 | 0.402 | 19.99 |
| val_ood_re | overflow | 0.272 | 0.198 | **31.15** | 1.039 | 0.438 | 51.10 |
| val_tandem_transfer | 3.253 | 0.620 | 0.336 | **41.97** | 2.094 | 0.989 | 43.57 |
| **combined val/loss** | **2.2678** | | | | | | |

**vs baseline (2.1997):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.1997 | 2.2678 | **+0.068 (+3.1%)** |
| surf_p in_dist | 20.03 | 21.91 | **+1.88 (+9.4%)** |
| surf_p tandem | 40.41 | 41.97 | **+1.56 (+3.9%)** |

**Peak GPU memory:** ~10.6 GB
**Note:** W&B run state=failed due to 30-min timeout kill, but metrics are valid (logged through epoch 66).

### What happened

Negative result. The curv×Re interaction feature degraded all metrics by 3-9%. Val/loss went from 2.1997 (baseline) to 2.2678 (+3.1%), with surf_p in_dist worsening by 9.4%.

**Why the interaction feature didn't help**:

1. **Redundant signal**: After normalization, feature 13 (log_Re) is already present in the input. The Transolver's attention mechanism can already learn arbitrary interactions between log_Re and curv implicitly through multi-head attention — the interaction doesn't need to be baked in as an explicit feature.

2. **Noisy at non-surface nodes**: `curv` is zeroed out for volume nodes (only nonzero on surface), making `curv_re` also zero on volume. This means the added feature provides no additional signal for volume nodes, only for surface nodes, and even there it's just a multiplicative combination the model could learn itself.

3. **Slight capacity dilution**: Adding one extra input feature increases model capacity slightly (the embedding layer is larger), which with only 1,322 training samples could lead to mild overfitting rather than the intended benefit.

4. **Epoch parity**: 66 epochs vs baseline — similar training time, so the degradation isn't due to fewer epochs.

### Suggested follow-ups

- **Curvature alone, more carefully**: The curvature proxy (norm of dsdf gradient) might be inaccurate or noisy. Verifying that the curvature feature actually correlates with physical curvature (e.g., by visualizing it on sample geometries) could determine whether the feature itself is the issue.
- **Re-conditioned curvature only on surface**: Apply curv_re only on surface nodes explicitly (where curv ≠ 0), rather than computing it everywhere. This avoids wasting model capacity on zero-valued interaction features.
- **Explicit Re-dependent attention bias**: Instead of a feature product, add Re as a bias to the attention scores selectively, which would let the model attend differently across Re in a learned rather than hand-crafted way.