### PR TITLE
SAF magnitude derived feature (surface arc-length)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 2,  # X_DIM=24 + 1 curvature proxy + 1 saf_mag; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -590,7 +590,8 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        saf_mag = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        x = torch.cat([x, curv, saf_mag], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -723,7 +724,8 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                saf_mag = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv, saf_mag], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
SAF (features 2-3) encodes signed arc-length. Its norm for surface nodes is complementary to curvature — it encodes position-along-surface. Add as a second derived feature.

## Instructions
After curv computation (line 593), add before torch.cat:
```python
saf_mag = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
x = torch.cat([x, curv, saf_mag], dim=-1)
```
(Replace existing `x = torch.cat([x, curv], dim=-1)`.)
Change fun_dim to `X_DIM - 2 + 2`. Do same in val loop.

Run: `python train.py --agent edward --wandb_name "edward/saf-mag" --wandb_group saf-magnitude`

## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41

---
## Results

**W&B run:** `ngfvfgiz`
**Best epoch:** 63/100 (~28.1s/epoch)

### val/loss
| Metric | Baseline | saf-mag | Delta |
|--------|----------|---------|-------|
| val/loss (3-split) | 2.1997 | 2.2553 | +0.0556 (+2.5%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (saf-mag) | p delta |
|-------|-----|-----|--------------|-------------|---------|
| in_dist | 0.280 | 0.182 | 20.03 | 21.41 | +1.38 (+6.9%) |
| ood_cond | 0.269 | 0.184 | — | 21.04 | — |
| ood_re | 0.275 | 0.199 | — | 31.22 | — |
| tandem | 0.627 | 0.338 | 40.41 | 42.29 | +1.88 (+4.7%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.289 | 0.470 | 26.09 |
| ood_cond | 1.075 | 0.402 | 19.95 |
| ood_re | 1.059 | 0.444 | 51.19 |
| tandem | 2.183 | 0.999 | 44.25 |

**Peak memory:** Minimal increase — one extra scalar feature per node.

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868 — same persistent instability.

**Note on run state:** W&B reports state "failed" despite exit_code=0 and complete metrics (63 epochs, plots saved). Likely a wandb timeout-handling quirk; the metrics are valid.

### What happened
SAF magnitude hurts: val/loss is 2.5% worse than baseline, in_dist surf_p degrades 6.9%, tandem degrades 4.7%. Clear negative result.

Adding saf_mag also slightly increased epoch time from ~25s to ~28s, reducing training from ~72 epochs to 63 — fewer optimizer steps may contribute to the regression, though the degradation is substantial enough that the feature itself likely causes harm.

The issue is probably redundancy: saf_mag (norm of SAF features 2:4) is geometrically related to curv (norm of dsdf features 2:6, which includes the same 2:4 channels). Adding a near-redundant feature may confuse the model's input representation and dilute the curvature signal by co-varying with it. Volume nodes have saf_mag=0 (masked by is_surface), creating a sharp discontinuity that the model must separately handle.

### Suggested follow-ups
- Try SAF angle (atan2(x[:,:,3], x[:,:,2])) instead of magnitude — encodes direction-along-surface, orthogonal to curvature magnitude
- Check whether the curvature proxy itself uses the same SAF channels and whether using different dsdf channels for curv (e.g., 4:8) would be better