### PR TITLE
Split dsdf into two 4-channel norms (dual geometry signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 2,  # X_DIM=24 + 2 curvature proxies; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -588,9 +588,10 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        # Curvature proxy: norms of two 4-channel dsdf groups for surface nodes
+        curv1 = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        curv2 = x[:, :, 6:10].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        x = torch.cat([x, curv1, curv2], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -721,9 +722,10 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                # Curvature proxy: norms of two 4-channel dsdf groups for surface nodes
+                curv1 = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                curv2 = x[:, :, 6:10].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv1, curv2], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Instead of one norm over dsdf[2:6], compute two: dsdf[2:6].norm and dsdf[6:10].norm, each surface-masked. Gives the model two orthogonal geometric signals.

## Instructions
Replace curv computation (line 592-593) and add second:
```python
curv1 = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
curv2 = x[:, :, 6:10].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
x = torch.cat([x, curv1, curv2], dim=-1)
```
Change fun_dim to `X_DIM - 2 + 2`. Do same in val loop.

Run: `python train.py --agent alphonse --wandb_name "alphonse/split-dsdf" --wandb_group split-dsdf-norms`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** ubgracsn
**Epochs completed:** ~64/100 (30-min timeout)

### Metrics at best checkpoint (epoch ~64)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.609 | 0.293 | 0.176 | 21.45 | 1.308 | 0.453 | 26.08 |
| tandem_transfer | 3.284 | 0.632 | 0.338 | 41.77 | 2.136 | 0.987 | 44.11 |
| ood_cond | 1.971 | 0.262 | 0.193 | 22.69 | 1.088 | 0.421 | 20.87 |
| **3split avg** | **2.2881** | — | — | — | — | — | — |

**Baseline comparison:**
- val/loss: 2.2881 vs 2.1997 — **regression (+0.0884)**
- mae_surf_p in_dist: 21.45 vs 20.03 — **regression (+1.42)**
- mae_surf_p tandem: 41.77 vs 40.41 — **regression (+1.36)**

**Peak memory:** Not logged (no OOM).

### What happened

Splitting dsdf into two 4-channel groups did not help — val/loss at epoch 64 is 2.2881, worse than baseline (2.1997). The model was still converging at cutoff (from ~2.42 at ep60 to 2.29 at ep64), but the trajectory doesn't suggest it would catch up to baseline given more time.

The second geometry signal (dsdf[6:10]) appears not to add useful information. One explanation: dsdf[6:10] encodes the second foil's geometry, which is only relevant for tandem samples (~16% of training data). For single-foil samples, curv2 is all zeros, making it a sparse and mostly uninformative feature. The model may still learn to use it for tandem, but the signal-to-noise ratio is low.

Comparing with the single-curv baseline (which achieved 2.1997), adding curv2 seems to slow convergence without improving accuracy. The extra input dimension may be distributing model capacity across a less useful feature.

### Suggested follow-ups

- **Tandem-only curv2**: Zero out curv2 for non-tandem samples (currently done via is_surface mask, but the tandem foil nodes are not surface nodes in the single-foil sense). Might need separate logic.
- **Learned combination**: Instead of two separate norms, use a small MLP to combine dsdf[2:10] into a single learned geometric feature — gives the model more flexibility to find what's useful.
- **dsdf[6:10] for volume**: The second foil's dsdf might be more useful at volume nodes (indicating proximity to the second foil) than at surface nodes.