### PR TITLE
Wall-distance proxy for volume nodes (complement surface curvature)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 2,  # X_DIM=24 + 1 curvature proxy + 1 wall-dist proxy; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -590,7 +590,9 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        # Wall-distance proxy: norm of dsdf channels 0-7 (all 8 sdf directions), masked to volume nodes
+        wall_dist = x[:, :, 2:10].norm(dim=-1, keepdim=True) * (1.0 - is_surface.float().unsqueeze(-1))
+        x = torch.cat([x, curv, wall_dist], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -723,7 +725,9 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                # Wall-distance proxy: norm of dsdf channels 0-7 (all 8 sdf directions), masked to volume nodes
+                wall_dist = x[:, :, 2:10].norm(dim=-1, keepdim=True) * (1.0 - is_surface.float().unsqueeze(-1))
+                x = torch.cat([x, curv, wall_dist], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Curvature helps surface nodes. For volume nodes, distance-to-wall is the most important geometric signal (controls boundary layer, y+ scaling). Add dsdf norm masked to volume nodes only.

## Instructions
After curv (line 592-593), add:
\`\`\`python
wall_dist = x[:, :, 2:10].norm(dim=-1, keepdim=True) * (1.0 - is_surface.float().unsqueeze(-1))
x = torch.cat([x, curv, wall_dist], dim=-1)
\`\`\`
Change fun_dim to \`X_DIM - 2 + 2\`. Do same in val loop.

Run: \`python train.py --agent thorfinn --wandb_name "thorfinn/wall-dist" --wandb_group wall-distance-volume\`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** \`oyymfp45\` (thorfinn/wall-dist)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.1997 | 2.2388 | +1.8% ❌ |
| val_in_dist / mae_surf_p | 20.03 | 21.04 | +5.0% ❌ |
| val_tandem / mae_surf_p | 40.41 | 41.13 | +1.8% ❌ |
| val_ood_cond / mae_surf_p | — | 20.99 | — |
| val_in_dist / mae_vol_Ux | — | 1.285 | — |
| val_tandem / mae_vol_Ux | — | 2.114 | — |
| Peak memory | — | 10.6 GB | — |

Best checkpoint: epoch 66 of 100 (30 min timeout).

**Note:** Visualization at training end threw a dimension error (data/utils.py calls the model without applying the wall_dist transform). Training metrics are unaffected — this is a post-hoc plotting issue only.

**What happened:** Negative result. Adding a wall-distance proxy for volume nodes slightly degraded all splits. val/loss rose 2.1997 → 2.2388 (+1.8%), surface pressure got worse on both in_dist (+5.0%) and tandem (+1.8%).

The wall-distance proxy (norm of 8 dsdf channels, masked to volume) isn't providing additional useful signal. Most likely explanation: the dsdf channels 2–9 contain the individual directional SDF values, whose norm is already implicitly encoded in the existing x features (the model sees all 24 dims). Adding the norm doesn't give the model new information, just a linear combination of features it already has. The slight degradation could be from the extra parameter group interfering with optimization.

An alternative is that `x[:, :, 2:10]` is already normalized (after x = (x - mean)/std), so its norm is not a meaningful distance proxy in normalized space — it's noisier than the raw value.

**Suggested follow-ups:**
- Use raw (pre-normalization) dsdf to compute wall_dist before the stats normalization step.
- Try only the first SDF (x[:, :, 2:3], the primary foil SDF) as a scalar wall-distance rather than the full 8-channel norm.
- Consider whether the volume node boundary-layer signal can be captured through a spatial bias on the attention (distance from surface in 2D coordinates).