### PR TITLE
Full 8-channel dsdf norm (all dsdf channels, not just first 4)

### DIFF
--- a/train.py
+++ b/train.py
@@ -588,8 +588,8 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        # Curvature proxy: norm of all 8 dsdf channels (gradient magnitude) for surface nodes
+        curv = x[:, :, 2:10].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
@@ -721,8 +721,8 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                # Curvature proxy: norm of all 8 dsdf channels (gradient magnitude) for surface nodes
+                curv = x[:, :, 2:10].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
Current curvature uses dsdf[2:6] (first 4 of 8 dsdf channels). The remaining 4 may encode complementary shape info. Test full 8-channel norm.

## Instructions
In both train (line 592) and val (line 725), change `x[:, :, 2:6]` to `x[:, :, 2:10]`.

Run: `python train.py --agent askeladd --wandb_name "askeladd/full-dsdf" --wandb_group full-dsdf-norm`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** `pl6w8ckv`
**Epochs:** 66 (best at 66, EMA active) | **Peak memory:** 10.6 GB
*(Note: run state shows "failed" due to 30-min wall-clock limit)*

### Loss comparison

| Split | Curvature 2:6 baseline | Full dsdf 2:10 | Delta |
|---|---|---|---|
| **val/loss** | 2.1997 | 2.2598 | +2.74% |
| val_tandem_transfer/loss | — | 3.2806 | |

### Surface pressure MAE

| Split | Curvature 2:6 baseline | Full dsdf 2:10 | Delta |
|---|---|---|---|
| val_in_dist | **20.03** | 21.10 | +5.3% |
| val_ood_cond | **20.57** | 21.40 | +4.0% |
| val_tandem_transfer | **40.41** | 42.13 | +4.3% |

### What happened

**Using all 8 dsdf channels (2:10) is clearly worse than the original 4-channel version (2:6).** Val/loss degrades by 2.74% relative to the curvature-proxy baseline, and all surface pressure metrics are worse across every split.

The first 4 dsdf channels (2:6) appear to capture the most geometrically meaningful information (likely the nearest surface point direction and distance in the first foil frame), while channels 5-8 add noisy or redundant signals that confuse the curvature proxy. Including all 8 creates a norm that mixes these signals, which appears to hurt rather than help.

This confirms that `2:6` (the first 4 channels) is the better curvature proxy subset.

### Suggested follow-ups

- **Try channels 6:10 alone**: If channels 5-8 encode different geometry (second foil frame?), they might be useful independently — just not combined with the first 4.
- **Try channels 2:4 (just the first 2)**: Maybe an even smaller subset of dsdf channels gives a cleaner signal.
- **Confirm which dsdf channels encode what**: Looking at the data/prepare_multi.py dsdf feature definitions would clarify which channels correspond to which geometric quantities.