### PR TITLE
Laplacian proxy (second-order geometry from dsdf max-mean)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 2,  # X_DIM=24 + 1 curvature proxy + 1 laplacian proxy; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -590,7 +590,11 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        dsdf_feat = x[:, :, 2:10]
+        dsdf_mean = dsdf_feat.mean(dim=-1, keepdim=True)
+        dsdf_max = dsdf_feat.max(dim=-1, keepdim=True).values
+        laplacian_proxy = (dsdf_max - dsdf_mean) * is_surface.float().unsqueeze(-1)
+        x = torch.cat([x, curv, laplacian_proxy], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -723,7 +727,11 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                dsdf_feat = x[:, :, 2:10]
+                dsdf_mean = dsdf_feat.mean(dim=-1, keepdim=True)
+                dsdf_max = dsdf_feat.max(dim=-1, keepdim=True).values
+                laplacian_proxy = (dsdf_max - dsdf_mean) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv, laplacian_proxy], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Curvature captures first-order geometry. Laplacian (second-order) captures how fast curvature changes — highlights leading edges and flap junctions.

## Instructions
After curv (line 592-593), add:
```python
dsdf_feat = x[:, :, 2:10]
dsdf_mean = dsdf_feat.mean(dim=-1, keepdim=True)
dsdf_max = dsdf_feat.max(dim=-1, keepdim=True).values
laplacian_proxy = (dsdf_max - dsdf_mean) * is_surface.float().unsqueeze(-1)
x = torch.cat([x, curv, laplacian_proxy], dim=-1)
```
Change fun_dim to `X_DIM - 2 + 2`. Do same in val loop.

Run: `python train.py --agent violet --wandb_name "violet/laplacian" --wandb_group laplacian-proxy`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run ID**: `uzvewumh`
**Epochs completed**: 66 (best), 30.1 min
**Peak memory**: 10.5 GB
**Note**: Visualization plots not generated — `data/utils.py:visualize()` passes raw 24-dim x to the model without the extra proxy features; the call crashed at end-of-run but all training metrics were logged before this.

### Metrics vs Baseline (curvature proxy only)

| Metric | Baseline (curv only) | curv + laplacian | Δ |
|---|---|---|---|
| val/loss | 2.1997 | **2.2364** | +1.7% 🔴 |
| in_dist surf_p | 20.03 Pa | **21.28 Pa** | +6.2% 🔴 |
| ood_cond surf_p | — | **21.12 Pa** | — |
| ood_re surf_p | — | **30.93 Pa** | — |
| tandem surf_p | 40.41 Pa | **40.95 Pa** | +1.3% |
| in_dist vol_p | — | 26.19 Pa | — |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

The laplacian proxy **does not help** — adding it makes things slightly worse. val/loss is 1.7% higher, in_dist surf_p is 6.2% worse.

The laplacian proxy `(dsdf_max - dsdf_mean)` approximates second-order geometry by measuring the spread of dsdf values across the first 8 channels. However:
1. The curvature proxy (first-order) already captures the most informative local geometry signal
2. The laplacian proxy (max - mean) is a crude approximation that may conflate boundary curvature with noise in the dsdf representation
3. Adding an extra feature increases the model's input dimension without adding proportionate signal, potentially causing the model to devote attention to a low-quality feature

The result confirms that the curvature proxy already captures the relevant geometric information, and the second-order extension adds noise.

### Side note on visualization crash

`data/utils.py:visualize()` normalizes x with stats but doesn't add the curvature/laplacian features before passing to the model. This causes a dimension error at the visualization call. Since visualization is called post-training, all W&B metrics were already logged and are valid. This is a known limitation when augmenting features in the training loop with a read-only visualization utility.

### Suggested follow-ups

- **Continuous curvature**: Instead of a single curvature proxy, try several dsdf channels at different distances to create a multi-scale curvature profile.
- **Stop at curvature**: The single curvature proxy (from the base branch) appears to be the right balance. No further geometry feature augmentation is likely to help.