### PR TITLE
Kitchen sink: curvature + saf_mag + wall_dist (3 derived features)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 3,  # X_DIM=24 + 3 derived features (curv, saf_mag, wall_dist); fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -588,9 +588,11 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+        # Derived features: curvature proxy, SAF magnitude, wall distance
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        saf_mag = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        wall_dist = x[:, :, 2:10].norm(dim=-1, keepdim=True) * (1.0 - is_surface.float().unsqueeze(-1))
+        x = torch.cat([x, curv, saf_mag, wall_dist], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -721,9 +723,11 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+                # Derived features: curvature proxy, SAF magnitude, wall distance
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                saf_mag = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                wall_dist = x[:, :, 2:10].norm(dim=-1, keepdim=True) * (1.0 - is_surface.float().unsqueeze(-1))
+                x = torch.cat([x, curv, saf_mag, wall_dist], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Combine three physically motivated derived features: (a) surface curvature, (b) SAF magnitude (position along surface), (c) wall-distance for volume nodes. These are orthogonal signals.

## Instructions
Replace curv computation (lines 592-593) with:
```python
curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
saf_mag = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
wall_dist = x[:, :, 2:10].norm(dim=-1, keepdim=True) * (1.0 - is_surface.float().unsqueeze(-1))
x = torch.cat([x, curv, saf_mag, wall_dist], dim=-1)
```
Change fun_dim to `X_DIM - 2 + 3`. Do same in val loop.

Run: `python train.py --agent gilbert --wandb_name "gilbert/kitchen-sink" --wandb_group kitchen-sink-3feat`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** s1uf4qpt
**Best epoch:** 66 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.5698 | — | — | 20.1 |
| val_tandem_transfer | 3.2830 | — | — | 41.9 |
| val_ood_cond | 1.9299 | — | — | 21.5 |
| val_ood_re | 18869.6 | — | — | 30.7 |
| **combined val/loss (3-split)** | **2.2609** | | | |

**Baseline val/loss: 2.1997 → This run: 2.2609 (+0.061, slightly worse)**

Note: W&B summary unavailable — visualization crashed after training completed (the `visualize()` function does not apply the 3 derived features, causing a shape mismatch on checkpoint reload). Training metrics are from the TRAINING COMPLETE block.

Comparison vs baseline (surf_p):
- in_dist: 20.1 vs 20.03 — essentially same
- tandem: 41.9 vs 40.41 — slightly worse
- ood_cond: 21.5 — worse than typical ~20
- ood_re: 30.7 — normal range

### What happened

Adding saf_mag and wall_dist on top of the curvature proxy does not improve over the single-feature baseline. The combined val/loss (2.2609) is worse than baseline (2.1997) by +0.061, which is at the boundary of noise but consistently shows no improvement across splits.

Two factors explain the null result:

1. **saf_mag is redundant with curv.** Both are derived from `x[:, :, 2:6]` — `saf_mag = x[:, :, 2:4].norm()` (first 2 dsdf channels) and `curv = x[:, :, 2:6].norm()` (first 4 dsdf channels). They are correlated, so saf_mag adds little orthogonal information.

2. **wall_dist for volume nodes** uses `x[:, :, 2:10].norm()` — 8 channels. While physically meaningful, the raw dsdf norm is a crude proxy for wall distance and may be noisy. The model may not be able to extract useful signal from this without more training.

3. **More parameters without benefit.** Three input features means the model has a slightly wider input to process, slightly increasing the first layer. This doesn't help if the signals are redundant or noisy.

The single curvature proxy (PR baseline at 2.1997) already captures the most useful spatial information for surface nodes.

### Suggested follow-ups

- **Drop saf_mag, keep only curv + wall_dist**: test if wall distance alone (without the redundant saf_mag) adds value.
- **Try a cleaner wall-distance proxy**: use only `x[:, :, 2].abs()` (single signed-distance channel) rather than the full 8-channel norm.