### PR TITLE
dsdf anisotropy ratio (max/min channel as shape descriptor)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 2,  # X_DIM=24 + 1 curvature proxy + 1 aniso; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -590,7 +590,11 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        dsdf_abs = x[:, :, 2:10].abs()
+        dsdf_max = dsdf_abs.max(dim=-1, keepdim=True).values
+        dsdf_min = dsdf_abs.min(dim=-1, keepdim=True).values.clamp(min=0.01)
+        aniso = (dsdf_max / dsdf_min) * is_surface.float().unsqueeze(-1)
+        x = torch.cat([x, curv, aniso], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -723,7 +727,11 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                dsdf_abs = x[:, :, 2:10].abs()
+                dsdf_max = dsdf_abs.max(dim=-1, keepdim=True).values
+                dsdf_min = dsdf_abs.min(dim=-1, keepdim=True).values.clamp(min=0.01)
+                aniso = (dsdf_max / dsdf_min) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv, aniso], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Anisotropy (max/min of dsdf channels) captures how sharp the local geometry is. High ratio = leading/trailing edge. Fundamentally different signal from norm.

## Instructions
After curv (line 592-593), add:
```python
dsdf_abs = x[:, :, 2:10].abs()
dsdf_max = dsdf_abs.max(dim=-1, keepdim=True).values
dsdf_min = dsdf_abs.min(dim=-1, keepdim=True).values.clamp(min=0.01)
aniso = (dsdf_max / dsdf_min) * is_surface.float().unsqueeze(-1)
x = torch.cat([x, curv, aniso], dim=-1)
```
Change fun_dim to `X_DIM - 2 + 2`. Do same in val loop.

Run: `python train.py --agent norman --wandb_name "norman/anisotropy" --wandb_group anisotropy-ratio`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** ca8q1ez1 (state: failed — hit timeout)

| Metric | Baseline | Anisotropy | Δ |
|--------|----------|------------|---|
| val/loss | 2.1997 | 2.4427 | +0.243 (+11.1%) |
| in_dist surf_p | 20.03 | 23.36 | +3.33 |
| tandem surf_p | 40.41 | 44.43 | +4.02 |
| ood_cond surf_p | — | 25.27 | — |
| ood_re surf_p | — | 33.36 | — |

**Full surface MAE:**
- in_dist: Ux=0.319, Uy=0.198, p=23.36
- tandem: Ux=0.671, Uy=0.366, p=44.43
- ood_cond: Ux=0.275, Uy=0.199, p=25.27
- ood_re: Ux=0.282, Uy=0.210, p=33.36

**Full volume MAE:**
- in_dist: Ux=1.383, Uy=0.487, p=28.83
- tandem: Ux=2.328, Uy=1.057, p=47.63
- ood_cond: Ux=1.122, Uy=0.441, p=22.39
- ood_re: Ux=1.096, Uy=0.459, p=52.36

**Peak memory:** not logged

### What happened
The anisotropy feature significantly hurts performance across all splits — val/loss +11.1%, in_dist surf_p +3.33, tandem surf_p +4.02. The run also hit a failure condition (likely the 30-min timeout with fewer epochs completed than baseline).

The core issue is value range: the anisotropy ratio max(dsdf_abs) / min(dsdf_abs).clamp(0.01) can be extremely large (potentially 100–1000+) even with the min clamp. Unlike the curvature norm which is bounded by the magnitude of the dsdf channels, the ratio is unbounded and can dominate the model's input distribution. The model's preprocess linear layer cannot easily handle both normal-range features and extreme ratio values simultaneously.

The run was marked 'failed' in W&B but still logged final checkpoint metrics — results represent the best model seen before failure.

### Suggested follow-ups
- If anisotropy is worth exploring, normalize it more aggressively (e.g., log(aniso) or sigmoid(log(aniso))) to prevent extreme values
- Alternatively, use a rank-based anisotropy: argsort the dsdf channels and use the rank of the max as a bounded categorical signal