### PR TITLE
Learned curvature weights (4 learnable dsdf channel weights)

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,7 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.curv_weights = nn.Parameter(torch.ones(4) * 0.25)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -327,6 +328,10 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         raw_xy = x[:, :, :2]
+        w = F.softmax(self.curv_weights, dim=0)
+        is_surf_proxy = (x[:, :, 12:13] > 0).float()  # is_surface from feature 12
+        curv_weighted = (x[:, :, 2:6] * w[None, None, :]).norm(dim=-1, keepdim=True) * is_surf_proxy
+        x = torch.cat([x, curv_weighted], dim=-1)
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
@@ -588,9 +593,6 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -721,9 +723,6 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
The curvature proxy equally weights dsdf channels 0-3. Let the model learn which channels matter most via a learnable 4-element softmax weight.

## Instructions
In Transolver.__init__ (around line 268), add:
```python
self.curv_weights = nn.Parameter(torch.ones(4) * 0.25)
```

Move curvature computation INTO the model's forward method. Before `fx = self.preprocess(x)` (line 304):
```python
w = F.softmax(self.curv_weights, dim=0)
is_surf_proxy = (x[:, :, 12:13] > 0).float()  # is_surface from feature 12
curv_weighted = (x[:, :, 2:6] * w[None, None, :]).norm(dim=-1, keepdim=True) * is_surf_proxy
x = torch.cat([x, curv_weighted], dim=-1)
```

REMOVE the curvature proxy lines from train loop (lines 592-593) and val loop (lines 725-726) since it's now inside the model.

Run: `python train.py --agent nezuko --wandb_name "nezuko/learned-curv" --wandb_group learned-curvature-weights`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** 7yhzv8i5 | Runtime: 1825s (~30 min, ~65 epochs, 28.3s/epoch)

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| **in_dist** | 1.581 | 0.295 | 0.180 | **20.97** | 1.279 | 0.462 | 26.01 |
| **ood_cond** | 1.929 | 0.283 | 0.191 | **20.81** | 1.042 | 0.406 | 19.72 |
| **ood_re** | — | 0.291 | 0.201 | **31.05** | 1.050 | 0.440 | 51.25 |
| **tandem** | 3.258 | 0.630 | 0.334 | **41.83** | 2.101 | 0.978 | 44.00 |
| **val/loss (3-split)** | **2.2557** | | | | | | |

| Metric | Baseline (fixed curv) | Learned weights | Δ |
|---|---|---|---|
| val/loss | 2.1997 | 2.2557 | +2.5% ❌ |
| surf_p in_dist | 20.03 | 20.97 | +4.7% ❌ |
| surf_p tandem | 40.41 | 41.83 | +3.5% ❌ |

### What happened

Negative result. Learning the 4 curvature channel weights via softmax did not improve upon the fixed equal-weight (1/4, 1/4, 1/4, 1/4) baseline.

The fixed equal-weight curvature proxy was good enough — or possibly even slightly better at initialization. Several possible reasons:
1. **Equal weights are near-optimal**: dsdf channels 0-3 may encode curvature signal roughly equally, making the optimal weighting close to uniform.
2. **Training dynamics**: the 4 learnable weights compete with thousands of other parameters during the 65-epoch run. They may not converge to a better solution within the 30-min budget.
3. **Noise from the feature proxy**: using  as the surface proxy (after normalization) works but is less precise than the original binary  tensor from the data loader, which was used in the fixed-weight version.

The 2.5% degradation could partially be run-to-run variance (we've seen ±3% variance across reruns), so this result is not strongly negative.

### Suggested follow-ups
- Log  to W&B to see what the model actually learned (helpful for diagnostics)
- Try a simpler form: single learnable scale on the curvature feature instead of 4 channel weights
- Consider whether the is_surf_proxy from normalized x[:, :, 12:13] is correct — if not, restore explicit is_surface masking as a non-learned parameter inside the model