### PR TITLE
Slightly wider model: n_hidden=160 (25% more capacity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -463,7 +463,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=128,
+    n_hidden=160,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs


### PR DESCRIPTION
## Hypothesis
192 may be too aggressive (slower epochs). 160 is a safer step: 25% more capacity, dim_head=40 (160/4), moderate speed impact.

## Instructions
Change line 466: `n_hidden=128` → `n_hidden=160`. Keep n_head=4.

Run: `python train.py --agent edward --wandb_name "edward/nhidden-160" --wandb_group nhidden-160`

## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41

---
## Results

**W&B run:** `3cbita3y`
**Best epoch:** 54/100 (~33.7s/epoch)

### val/loss
| Metric | Baseline (n_hidden=128) | n_hidden=160 | Delta |
|--------|------------------------|--------------|-------|
| val/loss (3-split) | 2.1997 | 2.2799 | +0.0802 (+3.6%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (160) | p delta |
|-------|-----|-----|--------------|---------|---------|
| in_dist | 0.315 | 0.183 | 20.03 | 22.65 | +2.62 (+13.1%) |
| ood_cond | 0.267 | 0.192 | — | 21.91 | — |
| ood_re | 0.275 | 0.202 | — | 31.31 | — |
| tandem | 0.619 | 0.333 | 40.41 | **40.24** | -0.17 (-0.4%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.302 | 0.468 | 26.01 |
| ood_cond | 1.032 | 0.414 | 20.13 |
| ood_re | 1.029 | 0.442 | 51.54 |
| tandem | 2.117 | 0.979 | 42.74 |

**Peak memory:** Moderate increase from wider layers (160 vs 128 hidden dim).

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868 — same persistent instability.

**Note on run state:** W&B reports state "failed" despite exit_code=0 and complete metrics (54 epochs, plots saved). Same timeout-handling quirk as previous runs; metrics are valid.

### What happened
n_hidden=160 is worse overall (val/loss +3.6%), though tandem surf_p improved marginally (-0.4%). This is primarily a step-starvation problem: the wider model runs at 33.7s/epoch, only completing 54 epochs in 30 minutes vs ~72 for the baseline. That is 54 × 331 = 17,874 optimizer steps vs 72 × 331 = 23,832 — a 25% reduction in total training steps.

The capacity increase (25%) is exactly offset by the training-time reduction (25%). The wider model cannot compensate for fewer updates in this regime. Tandem's tiny improvement may just be noise.

### Suggested follow-ups
- n_hidden=160 might help with a longer timeout (60 min would give ~107 epochs, ~50% more steps than baseline)
- Alternatively, try n_hidden=144 (12.5% wider) which might only add 2-3s/epoch and stay closer to 70 epochs
- The pattern across all width experiments: more capacity is step-starved by the 30-min cap. The sweet spot is the widest model that can still complete ~70 epochs