### PR TITLE
Deeper preprocess MLP (n_layers=2 with residual)

### DIFF
--- a/train.py
+++ b/train.py
@@ -243,7 +243,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
The preprocess MLP (24→256→128, n_layers=1, res=True) is the only feature extractor. Adding depth (n_layers=2) allows learning more complex feature interactions without increasing width.

## Instructions
In the model class init, change the preprocess MLP (around line 246):
`self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)`
To:
`self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)`

Run: `python train.py --agent alphonse --wandb_name "alphonse/preprocess-n2" --wandb_group preprocess-n2`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** le7cu2k8
**Epochs completed:** ~60/100 (30-min timeout)

### Metrics at best checkpoint (epoch ~60)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.629 | 0.305 | 0.181 | 21.37 | 1.250 | 0.454 | 26.20 |
| tandem_transfer | 3.295 | 0.629 | 0.336 | 42.87 | 2.094 | 0.979 | 44.28 |
| ood_cond | 1.908 | 0.262 | 0.191 | 20.85 | 0.971 | 0.389 | 18.94 |
| **3split avg** | **2.2775** | — | — | — | — | — | — |

**Baseline comparison:**
- val/loss: 2.2775 vs 2.1997 — **regression (+0.0778)**
- mae_surf_p in_dist: 21.37 vs 20.03 — **regression (+1.34)**
- mae_surf_p tandem: 42.87 vs 40.41 — **regression (+2.46)**

**Peak memory:** Not logged (no OOM).

### What happened

Deepening the preprocess MLP to n_layers=2 did not improve performance within the 30-minute budget. The model was still converging at epoch ~60 (val/loss went from ~2.42 at ep50 to 2.28 at ep60), but is behind the baseline of 2.1997.

The key issue is **epoch throughput**: the deeper MLP adds compute per forward pass, reducing from ~64 epochs (n_layers=1) to ~60 epochs (n_layers=2) in 30 minutes. At epoch 60, the n_layers=2 model is at 2.2775, while the baseline (n_layers=1) was at a similar epoch count when it eventually converged to 2.1997. Looking at the convergence rate, n_layers=2 doesn't seem faster at each epoch — so it costs compute without speeding up convergence.

The hypothesis that deeper preprocessing helps learn more complex feature interactions appears to be incorrect for this model at this scale. The preprocess MLP takes inputs directly from raw mesh features, and at n_hidden=128 width, a single hidden layer (256→128) may already be sufficient to extract relevant patterns.

### Suggested follow-ups

- **Width instead of depth**: Try n_hidden=160 or n_hidden=192 in the full model — wider representations may help more than deeper preprocessing.
- **Preprocess n_layers=2 with more epochs**: If not budget-constrained, the n_layers=2 model might converge to a better optimum given >100 epochs.
- **Preprocess width only**: Try  intermediate dimension in the preprocess MLP while keeping n_layers=1 — more expressive per layer without the epoch cost of extra layers.