### PR TITLE
Richer spatial bias: 4D input (pos + saf) instead of 2D

### DIFF
--- a/train.py
+++ b/train.py
@@ -174,7 +174,7 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
-        self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
+        self.spatial_bias = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -326,7 +326,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
-        raw_xy = x[:, :, :2]
+        raw_xy = x[:, :, :4]  # 4D: (x, y, saf_0, saf_1) for richer spatial bias
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]


### PR DESCRIPTION
## Hypothesis
The spatial bias MLP (line 177) only uses 2D position (x,y). Including saf features (2 channels) gives the slice assignment richer geometric context: 4D = (x, y, saf_0, saf_1). The saf features encode surface-aligned coordinates.

## Instructions
Change the spatial_bias MLP input dim (line 177):
\`self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))\`
To:
\`self.spatial_bias = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, slice_num))\`

In TransolverBlock.forward (line 180), change:
\`def forward(self, fx, raw_xy=None):\`
The spatial bias is computed from raw_xy. Need to pass the extra saf features. In Transolver.forward (line 309), currently \`raw_xy = x[:, :, :2]\`. Change to \`raw_xy = x[:, :, :4]\` to include saf.

Run: \`python train.py --agent thorfinn --wandb_name "thorfinn/spatial-4d" --wandb_group spatial-bias-4d\`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** \`altyti7c\` (thorfinn/spatial-4d)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.1997 | 2.2630 | +2.9% ❌ |
| val_in_dist / mae_surf_p | 20.03 | 21.34 | +6.5% ❌ |
| val_tandem / mae_surf_p | 40.41 | 40.84 | +1.1% ❌ |
| val_ood_cond / mae_surf_p | — | 23.27 | — |
| val_in_dist / mae_vol_Ux | — | 1.315 | — |
| val_tandem / mae_vol_Ux | — | 2.113 | — |
| Peak memory | — | 10.6 GB | — |

Best checkpoint: epoch 66 of 100 (30 min timeout).

**Note:** Visualization at training end threw a dimension error because data/utils.py doesn't apply the raw_xy extension. Training metrics are unaffected.

**What happened:** Negative result. Expanding the spatial bias from 2D to 4D (pos + saf channels) hurt performance across all splits. val/loss rose 2.1997 → 2.2630 (+2.9%), surface pressure degraded on in_dist (+6.5%) with tandem roughly flat (+1.1%).

Most likely explanation: the saf channels (surface-aligned frame features at indices 2–3) encode relative position in the surface frame, which is already implicitly available to the model via the full 24D input. Passing them to the spatial bias MLP as well creates redundancy and potentially confuses the slice assignment with coordinate information that isn't meaningful in the same geometric way as raw (x, y) position. The 2-layer spatial bias is small (2→32→slice_num), so the extra 2D input adds parameters but the model may be underfitting the new signal in the 30-min window.

**Suggested follow-ups:**
- Try using raw (pre-normalization) saf features, since normalized coordinates have different statistical properties.
- Try a larger spatial bias MLP (2→64→slice_num) to better use the 4D input.
- Try using signed distance (first SDF channel only) as an additional spatial dimension — a 3D spatial bias (x, y, sdf_1) that has clearer physical meaning.