### PR TITLE
Higher learning rate (4e-3 instead of 3e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -354,7 +354,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 4e-3
+    lr: float = 2e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -590,6 +590,10 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        # z-score normalize curvature proxy over surface nodes
+        curv_mean = curv[curv > 0].mean() if (curv > 0).any() else curv.new_zeros(1)
+        curv_std = curv[curv > 0].std() if (curv > 0).any() else curv.new_ones(1)
+        curv = torch.where(is_surface.unsqueeze(-1), (curv - curv_mean) / (curv_std + 1e-8), curv)
         x = torch.cat([x, curv], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
@@ -723,6 +727,10 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                # z-score normalize curvature proxy over surface nodes
+                curv_mean = curv[curv > 0].mean() if (curv > 0).any() else curv.new_zeros(1)
+                curv_std = curv[curv > 0].std() if (curv > 0).any() else curv.new_ones(1)
+                curv = torch.where(is_surface.unsqueeze(-1), (curv - curv_mean) / (curv_std + 1e-8), curv)
                 x = torch.cat([x, curv], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
LR=3e-3 was set before the curvature proxy was added. The 25th feature changes the loss landscape. With weight_decay=0 and EMA at 40, a slightly higher LR might converge faster. The cosine schedule will still decay properly.

## Instructions
Change line 357: `lr: float = 3e-3` → `lr: float = 4e-3`

Run: `python train.py --agent askeladd --wandb_name "askeladd/lr-4e-3" --wandb_group lr-4e-3`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

### Run 1: LR=4e-3 only (W&B: 5qj9ifp0, 67 epochs)

| Metric | LR=4e-3 | Baseline (3e-3) | Δ |
|---|---|---|---|
| val/loss | 2.2509 | 2.1997 | +2.33% worse |
| in_dist / surf_p | 21.12 | 20.03 | +5.4% worse |
| tandem / surf_p | 42.72 | 40.41 | +5.7% worse |
| ood_cond / surf_p | 20.42 | — | — |

### Run 2: LR=2e-3 + z-score curvature normalization (W&B: linti0i0, 66 epochs)

Per advisor feedback, tried lower LR (2e-3) and z-score normalized the curvature proxy over surface nodes before concatenation.

| Metric | LR=2e-3+znorm | Baseline (3e-3) | Δ vs Run 1 |
|---|---|---|---|
| val/loss | 2.2862 | 2.1997 | +3.93% vs baseline; +1.6% vs run 1 |
| in_dist / surf_p | 21.45 | 20.03 | +7.1% vs baseline |
| tandem / surf_p | 42.45 | 40.41 | +5.0% vs baseline |
| ood_cond / surf_p | 21.76 | — | worse than run 1 |

### What happened

Both LR modifications hurt relative to the 3e-3 baseline. Surprisingly, LR=2e-3 with z-score normalization was even worse than LR=4e-3 without it. The z-score normalization of the curvature proxy may be actively harmful because:
- It discards magnitude information — all batches get similar-scale curvature features regardless of actual curvature variation
- Batch-level mean/std statistics are inconsistent between train and validation batches, introducing covariate shift
- 2e-3 LR may be too slow to converge within 67 epochs given the full model complexity

The original 3e-3 LR appears to be well-tuned for this architecture. Neither direction (higher or lower) improves on it, and the curvature proxy works better without explicit normalization (it's already in a reasonable scale relative to the normalized dsdf features it's derived from).

### Suggested follow-ups
- Accept that 3e-3 is optimal for LR with the curvature proxy
- Try normalizing the curvature proxy using a **fixed global statistic** (computed once from the training set) rather than per-batch statistics, to avoid covariate shift
- Investigate whether the curvature proxy benefits from a learned scale parameter (a small scalar multiplier initialized to 1.0)