### PR TITLE
Shorter tandem exclusion (5 epochs instead of 10)

### DIFF
--- a/train.py
+++ b/train.py
@@ -621,7 +621,7 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
+        if epoch < 5:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask


### PR DESCRIPTION
## Hypothesis
With curvature proxy giving better surface features, the model may not need 10 full epochs of single-foil warmup. Testing 5 epochs to give tandem 5 more epochs of training.

## Instructions
Change line 621: `if epoch < 10:` → `if epoch < 5:`

Run: `python train.py --agent violet --wandb_name "violet/tandem-excl-5" --wandb_group tandem-exclusion-5`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run ID**: `i0rq82gp`
**Epochs completed**: 66 (best), 30.1 min
**Peak memory**: 10.5 GB
**Note**: Visualization plots not generated — `data/utils.py:visualize()` doesn't augment features; this is a known limitation of the curvature proxy branch.

### Metrics vs Baseline (10-epoch exclusion)

| Metric | Baseline (10 epochs) | 5-epoch exclusion | Δ |
|---|---|---|---|
| val/loss | 2.1997 | **2.2101** | +0.47% |
| in_dist surf_p | 20.03 Pa | **20.87 Pa** | +4.2% 🔴 |
| ood_cond surf_p | — | **20.21 Pa** | — |
| ood_re surf_p | — | **31.50 Pa** | — |
| tandem surf_p | 40.41 Pa | **40.71 Pa** | +0.7% |
| in_dist vol_p | — | 26.29 Pa | — |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

5-epoch exclusion is **slightly worse** than 10-epoch exclusion. val/loss is 0.47% higher, in_dist surf_p is 4.2% worse. The tandem surf_p degradation is small (+0.7%), but the in_dist penalty is meaningful.

The result suggests that the 10-epoch warmup is doing useful work even with the curvature proxy. The model benefits from establishing stable in-distribution representations before being exposed to the more complex tandem geometry. Cutting warmup in half provides slightly less clean initial representations, which propagates through training.

However, the differences are small — within the noise range for some metrics. The 10-epoch exclusion remains the current optimum, but the advantage is modest.

### Suggested follow-ups

- **Epoch 15**: The opposite direction — might more warmup (15 epochs) help further? If the model benefits from even more single-foil training, this could be worth testing.
- **No exclusion (0 epochs)**: Testing immediate tandem inclusion would confirm whether any warmup is needed, completing the ablation.