### PR TITLE
Scaled y-noise: larger noise on pressure channel (0.01→0.02)

### DIFF
--- a/train.py
+++ b/train.py
@@ -595,7 +595,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+            noise_scale = torch.tensor([0.01, 0.01, 0.02], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)


### PR DESCRIPTION
## Hypothesis
Y-noise [0.01, 0.01, 0.005] is currently uniform across velocity channels. Increasing PRESSURE noise to 0.02 provides more label smoothing for the hardest channel without affecting velocity accuracy.

## Instructions
Change line 595: `noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)`
To: `noise_scale = torch.tensor([0.01, 0.01, 0.02], device=device)`

Run: `python train.py --agent gilbert --wandb_name "gilbert/y-noise-scaled" --wandb_group y-noise-scaled`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** pv47tgdp
**Best epoch:** 66 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.5698 | — | — | 21.7 |
| val_tandem_transfer | 3.2488 | — | — | 41.8 |
| val_ood_cond | 1.8703 | — | — | 21.1 |
| val_ood_re | 18869.6 | — | — | 31.5 |
| **combined val/loss (3-split)** | **2.2297** | | | |

**Baseline val/loss: 2.1997 → This run: 2.2297 (+0.030, within noise)**

Note: Visualization crashed post-training (pre-existing issue: curvature proxy not applied in `visualize()` function).

Comparison vs baseline (surf_p):
- in_dist: 21.7 vs 20.03 — worse (+1.7)
- tandem: 41.8 vs 40.41 — slightly worse (+1.4)
- ood_cond: 21.1 — slightly worse

### What happened

Increasing pressure noise from 0.005→0.02 shows no improvement and appears to slightly degrade pressure accuracy. The +0.030 combined val/loss change is within noise, but the consistent worsening of mae_surf_p across all splits (in_dist: +1.7, tandem: +1.4) suggests the higher noise is counterproductive.

The hypothesis that more pressure noise provides "label smoothing for the hardest channel" may be backwards: pressure is difficult precisely because it requires high precision, and adding 4× more noise degrades the training signal without providing useful regularization. The current [0.01, 0.01, 0.005] appears well-tuned — pressure noise is already lower than velocity noise for this reason.

### Suggested follow-ups

- **Try intermediate pressure noise 0.01** (matching velocity channels): removes the asymmetry without over-noising.
- **Keep current [0.01, 0.01, 0.005]** — the current scale appears optimal: pressure gets less noise because it needs more precise supervision.