### PR TITLE
2x tandem sample weight in WeightedRandomSampler

### DIFF
--- a/train.py
+++ b/train.py
@@ -417,6 +417,17 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
+# Double tandem sample weights
+tandem_indices = []
+for i in range(len(train_ds)):
+    x_i = train_ds[i][0]
+    if x_i[:, -8:].abs().sum() > 0.01:  # tandem detection
+        tandem_indices.append(i)
+if tandem_indices:
+    for idx in tandem_indices:
+        sample_weights[idx] *= 2.0
+print(f"Tandem samples detected: {len(tandem_indices)}/{len(train_ds)} (weights doubled)")
+
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 


### PR DESCRIPTION
## Hypothesis
Instead of boosting tandem LOSS (which we've tested), boost tandem SAMPLING frequency. The WeightedRandomSampler (line 395) uses sample_weights from the data loader. Double the weights for tandem samples so the model sees tandem data twice as often.

## Instructions
After line 397 (`weights=sample_weights`), modify the weights. First need to detect tandem samples. After loading data (line 344), add:
```python
# Double tandem sample weights
tandem_indices = []
for i in range(len(train_ds)):
    x_i = train_ds[i][0]
    if x_i[:, -8:].abs().sum() > 0.01:  # tandem detection
        tandem_indices.append(i)
if tandem_indices:
    for idx in tandem_indices:
        sample_weights[idx] *= 2.0
```

Run: `python train.py --agent senku --wandb_name "senku/tandem-2x-sample" --wandb_group sample-weight-tandem2x`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** `83xanpui` (senku/tandem-2x-sample)  
**Best epoch:** 67  
**Peak GPU memory:** ~39% of 96GB  
**Note:** Run shows `State: failed` due to a pre-existing visualization bug in this branch (`visualize()` doesn't add the curvature proxy feature the model now expects). Training metrics are valid.

### Best checkpoint (epoch 67)

| Split | loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.5818 | 0.294 | 0.175 | 20.86 | 1.293 | 0.461 | 25.62 |
| val_tandem_transfer | 3.2498 | 0.637 | 0.335 | 41.59 | 2.132 | 0.983 | 43.08 |
| val_ood_cond | 1.8856 | 0.253 | 0.194 | 20.21 | 1.048 | 0.408 | 19.27 |
| val_ood_re | 18869.5 | 0.271 | 0.200 | 30.60 | 1.028 | 0.437 | 50.87 |

**val/loss (3-split): 2.2391** vs baseline **2.1997** → **neutral** (+1.8%)  
**surf_p in_dist: 20.86** vs baseline **20.03** → essentially the same  
**surf_p tandem: 41.59** vs baseline **40.41** → essentially the same

### What happened

**The tandem detection heuristic is wrong for this branch.** The detection condition `x_i[:, -8:].abs().sum() > 0.01` (checking if any of the last 8 raw features are nonzero) flagged **1318/1322 (99.7%) training samples as tandem** — essentially all samples. This means the weight doubling applied to almost all data, leaving only 4 samples at their original weight. The relative sampling distribution was barely changed.

The hypothesis was never actually tested: the 2x tandem upsampling didn't happen in practice.

**Why the heuristic fails:** In this branch (which has a curvature proxy and additional features), the last 8 raw features (indices 16–23) are not exclusively nonzero for tandem cases. The actual tandem indicator used in the training loop is `x[:, 0, 21]` (gap feature) with threshold `> 0.5` after normalization. On raw (un-normalized) data, feature 21 would be the gap in physical units and would be ~0 for single-airfoil cases.

**Visualization crash:** The post-training plotting crashes with `RuntimeError: mat1 and mat2 shapes cannot be multiplied (84905x24 and 25x256)` — the `visualize()` function passes raw val data without adding the curvature proxy that the model expects. This is a pre-existing bug in this branch and unrelated to this change.

### Suggested follow-ups
- Fix the tandem detection to use feature 21 (gap): `abs(x_i[0, 21]) > 0.01` (checking one representative node is sufficient)
- With correct detection, re-run to actually test whether 2x tandem upsampling helps tandem transfer
- Fix the visualization function to add the curvature proxy before forwarding through the model
