### PR TITLE
Unified position encoding (ref=8 grid, 512 positional features)

### DIFF
--- a/train.py
+++ b/train.py
@@ -235,7 +235,7 @@ class Transolver(nn.Module):
 
         if self.unified_pos:
             self.preprocess = MLP(
-                fun_dim + self.ref * self.ref * self.ref,
+                fun_dim + space_dim + self.ref * self.ref * self.ref,
                 n_hidden * 2,
                 n_hidden,
                 n_layers=0,
@@ -468,6 +468,8 @@ model_config = dict(
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,
+    unified_pos=True,
+    ref=8,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )
@@ -612,7 +614,8 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            pos3d = torch.cat([x[:, :, :2], torch.zeros_like(x[:, :, :1])], dim=-1)
+            out = model({"x": x, "pos": pos3d})
             pred = out["preds"]
             re_pred = out["re_pred"]
         pred = pred.float()
@@ -741,7 +744,8 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    pos3d = torch.cat([x[:, :, :2], torch.zeros_like(x[:, :, :1])], dim=-1)
+                    pred = eval_model({"x": x, "pos": pos3d})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
The Transolver supports `unified_pos` mode (ref=8 grid of 8x8x8=512 distance features). This wasn't tested because it was complex, but it could give the model richer positional information than raw (x,y) coordinates. It encodes distance to 512 reference points in 3D space.

## Instructions
Change model_config (line 462-473):
Add: `unified_pos=True, ref=8,`
Also pass `pos` in the forward call — the model expects `pos` input when unified_pos=True. In the training loop (line 489), change:
`pred = model({"x": x})["preds"]`
To:
`pred = model({"x": x, "pos": x[:, :, :2]})["preds"]`
Do the same in the validation loop.

Note: This changes fun_dim since unified_pos uses `fun_dim + ref^3 = fun_dim + 512` for the preprocess MLP. The model handles this automatically when unified_pos=True.

Run: `python train.py --agent norman --wandb_name "norman/unified-pos" --wandb_group ref-8-unified`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** hsxpnwyb (state: failed — hit timeout)

| Metric | Baseline | Unified-pos | Δ |
|--------|----------|-------------|---|
| val/loss | 2.1997 | 4.4708 | +2.27 (+103%) |
| in_dist surf_p | 20.03 | 58.69 | +38.66 |
| tandem surf_p | 40.41 | 64.49 | +24.08 |

**Peak memory:** not logged

### What happened
Unified position encoding is dramatically worse — val/loss doubles (+103%) and surf_p errors are 2–3x larger. The run also hit the 30-min timeout with fewer epochs than baseline.

Two bugs had to be fixed before the run would start at all:

1. **2D vs 3D pos mismatch**: The  function builds a 3D reference grid (8×8×8) and computes distances using 3D positions, but our data has 2D (x,y) coordinates. The PR instruction  would fail with a shape error. Fixed by padding z=0: .

2. **MLP input dimension bug**: When , the model's  builds , but the  concatenates the full x (including space_dim) with the ref positions, making the actual input . Fixed by changing  in .

Even after fixing both bugs, the results are terrible. The root cause: the 3D reference grid (spanning z=-4 to +4) was designed for volumetric CFD domains. For our 2D airfoil problem (z=0), all 512 reference points are at varying z-offsets and the resulting distance features provide poor spatial discrimination in the x-y plane. The 512 extra features overwhelm the model while providing low-quality signal.

### Suggested follow-ups
- A 2D grid (ref² = 64 features, not 512) would be more appropriate — much smaller overhead and geometrically meaningful for 2D data
- If the advisor wants to pursue reference point positional encoding, build a custom 2D version with a proper grid aligned to the airfoil domain (x∈[-1.5,1.5], y∈[-0.5,0.5])