### PR TITLE
Prediction-scaled label smoothing (larger noise where model is uncertain)

### DIFF
--- a/train.py
+++ b/train.py
@@ -563,6 +563,7 @@ global_step = 0
 train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
+y_noise_scale_factor = 1.0  # will be updated each epoch
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -595,7 +596,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device) * y_noise_scale_factor
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
@@ -695,6 +696,9 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
+    # Scale y-noise based on surface loss relative to initial
+    if epoch_surf > 0:
+        y_noise_scale_factor = min(2.0, max(0.1, epoch_surf / 0.2))  # 0.2 is initial surf_loss
 
     # --- Validate across all splits ---
     eval_model = ema_model if ema_model is not None else model


### PR DESCRIPTION
## Hypothesis
Current y-noise is constant [0.01, 0.01, 0.005]. But high-error regions (where the model is uncertain) should get MORE noise (aggressive smoothing) while well-predicted regions get LESS. Use the running average of per-epoch surface loss to scale the noise.

## Instructions
Before the training loop (around line 565), add:
```python
y_noise_scale_factor = 1.0  # will be updated each epoch
```

After each epoch (after line 694), add:
```python
# Scale y-noise based on surface loss relative to initial
if epoch_surf > 0:
    y_noise_scale_factor = min(2.0, max(0.1, epoch_surf / 0.2))  # 0.2 is initial surf_loss
```

Change line 595:
```python
noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device) * y_noise_scale_factor
```

Run: `python train.py --agent nezuko --wandb_name "nezuko/adaptive-noise" --wandb_group label-smoothing-y-scaled`
## Baseline: val/loss=2.1997, surf_p: in_dist=20.03, tandem=40.41
---
## Results

**W&B run:** ecdudlan | Runtime: 1813s (~30 min, ~64 epochs, 28.3s/epoch)
*(Run state shows "failed" in W&B due to SIGTERM at timeout — data is valid, task exited with code 0)*

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| **in_dist** | 1.588 | 0.299 | 0.175 | **21.21** | 1.287 | 0.459 | 26.15 |
| **ood_cond** | 1.902 | 0.260 | 0.187 | **21.31** | 1.039 | 0.403 | 19.51 |
| **ood_re** | — | 0.272 | 0.201 | **31.18** | 1.044 | 0.442 | 50.91 |
| **tandem** | 3.258 | 0.633 | 0.339 | **42.00** | 2.136 | 0.986 | 44.06 |
| **val/loss (3-split)** | **2.2494** | | | | | | |

| Metric | Baseline | Adaptive noise | Δ |
|---|---|---|---|
| val/loss | 2.1997 | 2.2494 | +2.3% ❌ |
| surf_p in_dist | 20.03 | 21.21 | +5.9% ❌ |
| surf_p tandem | 40.41 | 42.00 | +3.9% ❌ |

### What happened

Negative result. Adaptive noise scaling did not improve upon constant noise.

The scaling works as follows: when epoch_surf > 0.2 (early training, model uncertain), scale_factor > 1.0 (more noise). When epoch_surf < 0.2 (later training, model converged), scale_factor < 1.0 (less noise). 

The problem: this applies MORE noise in early epochs when the model is actively learning the basic flow structure, and LESS noise when the model is fine-tuning. More noise early likely disrupts feature learning — the opposite of what a curriculum would prescribe. The model needs clean signal early to learn physics, not extra noise.

Additionally, this scales noise uniformly across ALL samples and ALL nodes, not specifically in high-error regions. The hypothesis of "noise where uncertain" isn't actually implemented at the node level — it's just epoch-level scaling.

The baseline constant noise [0.01, 0.01, 0.005] works better because it provides a consistent, mild regularization signal throughout training without disrupting early convergence.

### Suggested follow-ups
- Flip the schedule: START with less noise and INCREASE over time (noise as fine-tuning regularizer)
- Node-level uncertainty noise: apply more noise at surface nodes where the gradient is high
- Try reducing baseline noise (e.g., 0.005, 0.005, 0.0025) — the current noise might already be too high