### PR TITLE
Split tandem/single-foil normalization (separate phys_stats)

### DIFF
--- a/train.py
+++ b/train.py
@@ -438,26 +438,37 @@ val_loaders = {
     for name, subset in val_splits.items()
 }
 
-# --- Physics normalization stats (computed over training set) ---
-# Compute mean/std of Cp-normalized targets so the model sees O(1) values.
-print("Computing physics normalization stats...")
-_phys_sum = torch.zeros(3, device=device)
-_phys_sq_sum = torch.zeros(3, device=device)
-_phys_n = 0.0
+# --- Physics normalization stats (computed over training set, split by domain) ---
+# Tandem and single-foil have different pressure distributions; separate stats give
+# each domain tighter normalization and better-scaled gradients.
+print("Computing physics normalization stats (split single/tandem)...")
+_ps = {k: [torch.zeros(3, device=device), torch.zeros(3, device=device), 0.0]
+       for k in ("single", "tandem")}
 _stats_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
 with torch.no_grad():
     for _x, _y, _is_surf, _mask in tqdm(_stats_loader, desc="Phys stats", leave=False):
-        _y, _mask = _y.to(device), _mask.to(device)
+        _x, _y, _mask = _x.to(device), _y.to(device), _mask.to(device)
+        _x_norm = (_x - stats["x_mean"]) / stats["x_std"]
+        _is_tan = _x_norm[:, 0, 21].abs() > 0.5  # [B]
         _Um, _q = _umag_q(_y, _mask)
         _yp = _phys_norm(_y, _Um, _q)
         _m = _mask.float().unsqueeze(-1)  # [B, N, 1]
-        _phys_sum += (_yp * _m).sum(dim=(0, 1))
-        _phys_sq_sum += (_yp ** 2 * _m).sum(dim=(0, 1))
-        _phys_n += _mask.float().sum().item()
-_pmean = (_phys_sum / _phys_n).float()
-_pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
-phys_stats = {"y_mean": _pmean, "y_std": _pstd}
-print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
+        for _key, _flag in (("tandem", _is_tan), ("single", ~_is_tan)):
+            _wt = _flag.float()[:, None, None]  # [B, 1, 1]
+            _ps[_key][0] += (_yp * _m * _wt).sum(dim=(0, 1))
+            _ps[_key][1] += (_yp ** 2 * _m * _wt).sum(dim=(0, 1))
+            _ps[_key][2] += (_m * _wt).sum().item()
+
+def _make_phys_stats(acc):
+    n = max(acc[2], 1.0)
+    mean = (acc[0] / n).float()
+    std = ((acc[1] / n - mean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
+    return {"y_mean": mean, "y_std": std}
+
+phys_stats_single = _make_phys_stats(_ps["single"])
+phys_stats_tandem = _make_phys_stats(_ps["tandem"])
+print(f"  Single Cp — mean: {phys_stats_single['y_mean'].tolist()}, std: {phys_stats_single['y_std'].tolist()}")
+print(f"  Tandem Cp — mean: {phys_stats_tandem['y_mean'].tolist()}, std: {phys_stats_tandem['y_std'].tolist()}")
 
 model_config = dict(
     space_dim=2,
@@ -588,12 +599,17 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        _is_tan_b = x[:, 0, 21].abs() > 0.5  # [B] — tandem detection for phys stats
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
-        y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+        # Per-domain phys normalization: tandem and single-foil have different distributions
+        _t = _is_tan_b.float().unsqueeze(-1)  # [B, 1]
+        y_mean_ps = _t * phys_stats_tandem["y_mean"] + (1 - _t) * phys_stats_single["y_mean"]  # [B, 3]
+        y_std_ps = _t * phys_stats_tandem["y_std"] + (1 - _t) * phys_stats_single["y_std"]    # [B, 3]
+        y_norm = (y_phys - y_mean_ps.unsqueeze(1)) / y_std_ps.unsqueeze(1)
         if model.training:
             noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
@@ -726,7 +742,12 @@ for epoch in range(MAX_EPOCHS):
                 x = torch.cat([x, curv], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
-                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                # Per-domain phys normalization
+                _is_tan_v = x[:, 0, 21].abs() > 0.5  # [B]
+                _tv = _is_tan_v.float().unsqueeze(-1)  # [B, 1]
+                y_mean_ps_v = _tv * phys_stats_tandem["y_mean"] + (1 - _tv) * phys_stats_single["y_mean"]
+                y_std_ps_v = _tv * phys_stats_tandem["y_std"] + (1 - _tv) * phys_stats_single["y_std"]
+                y_norm = (y_phys - y_mean_ps_v.unsqueeze(1)) / y_std_ps_v.unsqueeze(1)
 
                 # Per-sample std normalization: skip tandem samples
                 raw_gap = x[:, 0, 21]
@@ -760,8 +781,8 @@ for epoch in range(MAX_EPOCHS):
                 )
                 n_vbatches += 1
 
-                # Denormalize: phys_stats → Cp space → original scale
-                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                # Denormalize: per-domain phys_stats → Cp space → original scale
+                pred_phys = pred * y_std_ps_v.unsqueeze(1) + y_mean_ps_v.unsqueeze(1)
                 pred_orig = _phys_denorm(pred_phys, Umag, q)
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()


### PR DESCRIPTION
## Hypothesis
Currently, `phys_stats` (y_mean, y_std) are computed over ALL training samples. But tandem and single-foil samples have very different pressure distributions (tandem pressures span much wider). A single mean/std means tandem pressure outliers inflate the std, making single-foil predictions underweighted. Separate normalization per sample type should give each domain tighter normalization and better-scaled gradients.

## Instructions
During the phys-stats computation loop (lines ~443-460), separate the accumulation by tandem status. You need to check the source name for each sample — tandem samples come from the "tandem" source.

After computing stats, store two sets:
```python
phys_stats_single = {"y_mean": y_mean_single, "y_std": y_std_single}
phys_stats_tandem = {"y_mean": y_mean_tandem, "y_std": y_std_tandem}
```

In the training loop, after loading each batch and detecting tandem samples via the source mask, apply the appropriate stats per sample:
```python
for b in range(B):
    if is_tandem[b]:
        y_norm[b] = (y_phys[b] - phys_stats_tandem["y_mean"]) / phys_stats_tandem["y_std"]
    else:
        y_norm[b] = (y_phys[b] - phys_stats_single["y_mean"]) / phys_stats_single["y_std"]
```

Same split for denormalization in the validation loop. Be careful to apply the correct stats for each val split (tandem_transfer uses tandem stats, others use single stats).

Run: `python train.py --agent tanjiro --wandb_name "tanjiro/split-phys-norm" --wandb_group split-phys-norm`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** zgxn7uvi  
**Epochs:** 66 (30 min wall-clock, ~27s/epoch)  
**Peak VRAM:** 10.6 GB  

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.8592 | 0.283 | 0.179 | 20.4 | 1.305 | 0.457 | 24.9 |
| val_tandem_transfer | 3.2844 | 0.639 | 0.340 | 41.0 | 2.216 | 1.004 | 43.8 |
| val_ood_cond | 2.0117 | 0.268 | 0.192 | 22.0 | 1.088 | 0.422 | 20.9 |
| val_ood_re | 18869.7* | 0.277 | 0.201 | 31.1 | 1.086 | 0.453 | 51.8 |
| **combined (3-split)** | **2.3851** | | | | | | |

*Pre-existing branch bug (ood_re vol_loss overflow), excluded from 3-split.

**vs baseline:**
- val/loss: 2.3851 vs 2.1997 → **+8.4% (worse)**
- surf_p in_dist: 20.4 vs 20.03 → **+1.8% (minor)**
- surf_p tandem: 41.0 vs 40.41 → **+1.5% (minor)**
- surf_p ood_cond: 22.0 vs 20.57 → **+7.0% (worse)**

**What happened:**

Negative result. Split phys_stats degraded val/loss by 8.4%, though the physical surface MAE numbers are close to baseline.

The val/loss metric is computed in normalized space. With domain-split stats, tandem and single-foil samples have different normalization scales. The model must learn to produce outputs at different absolute magnitudes depending on whether it is processing a tandem sample — but the model has no explicit tandem/single pathway; it must implicitly infer this from input features (primarily the gap feature). This makes the optimization harder without a structural advantage.

The improved surface MAE (near baseline) suggests the model is learning the right physical outputs, but the val/loss metric (normalized errors) is worse because the denominator (phys_std) is smaller for each domain after splitting, making errors look larger relative to the tighter normalization.

Additionally, this approach introduces inconsistency: at test time (visualize/inference), the phys_stats applied depend on correctly identifying tandem vs single. If the gap feature is ambiguous near the threshold, the wrong stats could be applied.

**Suggested follow-ups:**
- Instead of splitting normalization, try a learned per-domain offset: add a small learnable bias to the output head conditioned on whether the sample is tandem/single. This would let the model learn the domain offset explicitly without changing the normalization scale.
- The tandem split has noticeably higher losses (3.28 vs 2.01 for single) — the real issue may be that tandem requires more model capacity, not normalization differences.