### PR TITLE
GLU (Gated Linear Unit) in TransolverBlock MLP

### DIFF
--- a/train.py
+++ b/train.py
@@ -173,8 +173,11 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.mlp_gate = nn.Linear(hidden_dim, hidden_dim * mlp_ratio)
+        self.mlp_value = nn.Linear(hidden_dim, hidden_dim * mlp_ratio)
+        self.mlp_proj = nn.Linear(hidden_dim * mlp_ratio, hidden_dim)
         self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
+
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -192,7 +195,9 @@ class TransolverBlock(nn.Module):
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
-        fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
+        h = self.ln_2(fx)
+        mlp_out = self.mlp_proj(F.silu(self.mlp_gate(h)) * self.mlp_value(h))
+        fx = self.ln_2_post(mlp_out + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))


### PR DESCRIPTION
## Hypothesis
The block MLP uses standard GELU activation. GLU (Gated Linear Unit), proven in PaLM, LLaMA, and many modern architectures, provides better gradient flow and feature selection by splitting the hidden dimension into a value and gate branch. For CFD, this could help the model selectively amplify pressure-relevant features while suppressing noise.

## Instructions
In `TransolverBlock.__init__`, replace the MLP definition (around line 176):

```python
self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
```

With a custom GLU MLP:
```python
self.mlp_gate = nn.Linear(hidden_dim, hidden_dim * mlp_ratio)
self.mlp_value = nn.Linear(hidden_dim, hidden_dim * mlp_ratio)
self.mlp_proj = nn.Linear(hidden_dim * mlp_ratio, hidden_dim)
```

In `TransolverBlock.forward`, replace `self.mlp(self.ln_2(fx))` with:
```python
h = self.ln_2(fx)
mlp_out = self.mlp_proj(F.silu(self.mlp_gate(h)) * self.mlp_value(h))
```

Then apply the residual: `fx = self.ln_2_post(mlp_out + fx)`.

Run: `python train.py --agent nezuko --wandb_name "nezuko/glu-mlp" --wandb_group glu-mlp`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** d956tdm4 | Runtime: 1825s (~30 min, ~60 epochs, 30.5s/epoch)
*(Run state shows "failed" due to SIGTERM at timeout — data is valid)*

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| **in_dist** | 1.676 | 0.309 | 0.180 | **22.94** | 1.301 | 0.468 | 26.22 |
| **ood_cond** | 1.954 | 0.285 | 0.192 | **22.12** | 1.086 | 0.408 | 20.37 |
| **ood_re** | — | 0.280 | 0.204 | **31.69** | 1.054 | 0.442 | 51.45 |
| **tandem** | 3.246 | 0.634 | 0.335 | **41.34** | 2.110 | 0.978 | 43.06 |
| **val/loss (3-split)** | **2.2922** | | | | | | |

| Metric | Baseline | GLU MLP | Δ |
|---|---|---|---|
| val/loss | 2.1997 | 2.2922 | +4.2% ❌ |
| surf_p in_dist | 20.03 | 22.94 | +14.5% ❌ |
| surf_p ood_cond | 20.57 | 22.12 | +7.5% ❌ |
| surf_p tandem | 40.41 | 41.34 | +2.3% ❌ |

### What happened

Negative result. The GLU MLP degraded performance noticeably, especially in_dist surf_p (+14.5%).

Two compounding factors:
1. **Slower epochs**: GLU has 2× the parameters of the original MLP (two separate projection layers instead of one). Epoch time increased from ~28s to 30.5s — about 9% slower. This means ~60 epochs vs ~65 for the baseline in 30 minutes, with proportionally fewer gradient updates.
2. **Architecture mismatch at this scale**: GLU shows benefits in large-scale LLMs (billions of parameters). At this scale (128 hidden dim, 1 layer, mlp_ratio=2), the standard MLP may be better-calibrated. The gating mechanism may add unnecessary nonlinearity for a problem where the features are already well-conditioned.

The result at epoch 21 minutes was val/loss=3.37 (vs ~2.6 for baseline at same time), suggesting the GLU model converges more slowly — consistent with a more complex optimization landscape.

### Suggested follow-ups
- Try with SwiGLU but reduce parameter count to keep epoch time equal (reduce hidden_dim or mlp_ratio)
- Test on a longer run (if per-epoch speed were equal, GLU might converge to a better solution given more time)
- The in_dist degradation vs tandem is notable; GLU may be overfitting to the training distribution