### PR TITLE
Cosine similarity slice assignment (replace softmax temperature)

### DIFF
--- a/train.py
+++ b/train.py
@@ -95,12 +95,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.slice_prototypes = nn.Parameter(torch.randn(1, heads, slice_num, dim_head) * 0.02)
+        self.slice_scale = nn.Parameter(torch.tensor(10.0))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
-        self.in_project_slice = nn.Linear(dim_head, slice_num)
-        torch.nn.init.orthogonal_(self.in_project_slice.weight)
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
@@ -126,7 +125,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_logits = self.in_project_slice(x_mid) / self.temperature
+        x_norm = F.normalize(x_mid, dim=-1)  # [B, H, N, D]
+        proto_norm = F.normalize(self.slice_prototypes, dim=-1)  # [1, H, S, D]
+        slice_logits = torch.einsum("bhnd,bhsd->bhns", x_norm, proto_norm) * self.slice_scale.clamp(1, 20)
         if spatial_bias is not None:
             slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
         slice_weights = self.softmax(slice_logits)


### PR DESCRIPTION
## Hypothesis
Slice assignment uses `softmax(linear(x_mid) / temperature)` with a learned temperature per head. But softmax+temperature can collapse to one-hot (too cold) or uniform (too hot). Cosine similarity with learnable slice prototypes is more stable and gives richer representation of what each slice should capture. Inspired by prototypical networks and slot attention.

## Instructions
In `Physics_Attention_Irregular_Mesh.__init__`, add learnable slice prototypes:
```python
self.slice_prototypes = nn.Parameter(torch.randn(1, heads, slice_num, dim_head) * 0.02)
self.slice_scale = nn.Parameter(torch.tensor(10.0))
```

In `forward`, replace the slice assignment (lines ~129-132):
```python
# Old: slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
# New:
x_norm = F.normalize(x_mid, dim=-1)  # [B, H, N, D]
proto_norm = F.normalize(self.slice_prototypes, dim=-1)  # [1, H, S, D]
slice_logits = torch.einsum("bhnd,bhsd->bhns", x_norm, proto_norm) * self.slice_scale.clamp(1, 20)
if spatial_bias is not None:
    slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
slice_weights = self.softmax(slice_logits)
```

Remove `self.in_project_slice` and `self.temperature` from `__init__`.

Run: `python train.py --agent alphonse --wandb_name "alphonse/cosine-slice-assign" --wandb_group cosine-slice-assign`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** f4r0d56a
**Epochs completed:** ~57/100 (30-min timeout)

### Metrics at best checkpoint (epoch ~57)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.743 | 0.338 | 0.192 | 23.94 | 1.360 | 0.483 | 28.52 |
| tandem_transfer | 3.308 | 0.643 | 0.342 | 41.80 | 2.170 | 0.993 | 44.36 |
| ood_cond | 2.030 | 0.273 | 0.196 | 23.33 | 1.118 | 0.425 | 21.28 |
| **3split avg** | **2.3605** | — | — | — | — | — | — |

**Baseline comparison:**
- val/loss: 2.3605 vs 2.1997 — **regression (+0.1608)**
- mae_surf_p in_dist: 23.94 vs 20.03 — **regression (+3.91)**
- mae_surf_p tandem: 41.80 vs 40.41 — **regression (+1.39)**
- mae_surf_p ood_cond: 23.33 vs 20.57 — **regression (+2.76)**

**Peak memory:** Not logged (no OOM).

### What happened

Cosine similarity slice assignment significantly regresses vs the learned-projection baseline. At epoch 57, val/loss is 2.3605 — 7.3% worse than baseline. The model was still converging (2.38 → 2.37 → 2.36 over last 3 epochs), but the trajectory doesn't suggest it would catch baseline given the rate of improvement.

The key problem appears to be **slower convergence**, not a different optimum. The original  (a linear projection from dim_head → slice_num) provides a data-dependent assignment that learns quickly from gradient signal. The cosine prototype approach compares features against fixed prototypes — the prototypes can only be updated globally (not per-sample), making it harder to specialize early in training.

Additionally, the cosine similarity mechanism removes the per-head temperature, which was a useful learnable parameter to control slice sharpness. The  substitute is less flexible — it's scalar rather than per-head, and the clamp prevents it from going below 1 or above 20.

### Suggested follow-ups

- **Per-head scale**: Replace scalar `slice_scale` with per-head parameter `torch.ones(1, heads, 1, 1) * 10.0` to restore the original temperature's expressiveness.
- **Initialize prototypes from data**: Rather than random prototypes, warm-start from k-means clusters of early training features — could accelerate convergence.
- **Hybrid approach**: Keep the learned projection but add cosine regularization (prototype diversity loss) as a soft constraint — may improve slice specialization without sacrificing convergence speed.