### PR TITLE
Frequency-decomposed output head (low+high frequency branches)

### DIFF
--- a/train.py
+++ b/train.py
@@ -183,11 +183,10 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            # Low-frequency branch: bottleneck forces smooth output
+            self.out_low = nn.Sequential(nn.Linear(hidden_dim, 16), nn.GELU(), nn.Linear(16, out_dim))
+            # High-frequency branch: full capacity for local detail
+            self.out_high = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -198,7 +197,8 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            return self.out_low(h) + self.out_high(h)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Pressure fields have distinct low-frequency (freestream Cp distribution) and high-frequency (leading edge suction peak, separation bubble) components. A single linear output head conflates these scales. Decomposing into a smooth branch (low-rank bottleneck) and a detail branch (full-rank) lets the model separately optimize for global pressure pattern and local peaks. Inspired by Fourier Neural Operators' multi-scale design.

## Instructions
In `TransolverBlock.__init__`, replace the output head (lines ~186-190):

```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    # Low-frequency branch: bottleneck forces smooth output
    self.out_low = nn.Sequential(nn.Linear(hidden_dim, 16), nn.GELU(), nn.Linear(16, out_dim))
    # High-frequency branch: full capacity for local detail
    self.out_high = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
```

In `forward`, replace `self.mlp2(self.ln_3(fx))` with:
```python
h = self.ln_3(fx)
return self.out_low(h) + self.out_high(h)
```

Run: `python train.py --agent edward --wandb_name "edward/freq-decomposed-head" --wandb_group freq-decomposed-head`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---
## Results

**W&B run:** `j3zbvtcj`
**Best epoch:** 61/100 (~29.3s/epoch)

### val/loss
| Metric | Baseline | freq-decomposed | Delta |
|--------|----------|----------------|-------|
| val/loss (3-split) | 2.1997 | 2.3319 | +0.1322 (+6.0%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (freq-head) | p delta |
|-------|-----|-----|--------------|---------------|---------|
| in_dist | 0.305 | 0.180 | 20.03 | 22.58 | +2.55 (+12.7%) |
| ood_cond | 0.288 | 0.199 | 20.57 | 22.09 | +1.52 (+7.4%) |
| ood_re | 0.286 | 0.203 | — | 31.28 | — |
| tandem | 0.647 | 0.343 | 40.41 | 42.80 | +2.39 (+5.9%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.327 | 0.466 | 27.20 |
| ood_cond | 1.080 | 0.408 | 20.28 |
| ood_re | 1.054 | 0.442 | 51.20 |
| tandem | 2.138 | 0.996 | 44.57 |

**Peak memory:** Slightly increased — two parallel output branches vs one.

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868 — same persistent instability.

**Note on run state:** W&B reports state "failed" despite exit_code=0 and complete metrics (61 epochs).

### What happened
The frequency-decomposed output head hurts across all splits: val/loss +6%, in_dist surf_p +12.7%, tandem surf_p +5.9%. Clear negative result.

The dual-branch head has higher parameter count (out_low: 128*16 + 16*3 = 2096 params; out_high: 128*128 + 128*3 = 16768 params — total 18864 vs original 128*128 + 128*3 = 16768). The out_high branch alone is identical to the original mlp2, so the only difference is adding out_low. This doubles the output head slightly and adds 4.6s/epoch overhead, reducing to 61 epochs.

The output decomposition premise doesn't hold here: the Transolver's slice-token attention already operates across all spatial scales simultaneously. Adding a separate "low-frequency" bottleneck branch (rank-16 in 3D output space) doesn't improve things because the bottleneck is so narrow (16 dims) that it can only encode trivial global offsets — not the freestream Cp pattern the hypothesis describes.

### Suggested follow-ups
- A larger low-frequency branch (e.g., hidden_dim=32) might be more useful
- The multi-scale hypothesis might be better addressed at the attention level (multi-scale slice assignments) rather than the output head
- Residual output: instead of out_low + out_high, try a prediction + correction structure where out_low predicts the global field and out_high predicts the residual