### PR TITLE
AdamW beta2 warmup (0.99 → 0.999 over 20 epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -572,6 +572,11 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
+    # Beta2 warmup: 0.99 -> 0.999 over first 20 epochs
+    target_beta2 = 0.99 + 0.009 * min(1.0, epoch / 20)
+    for pg in base_opt.param_groups:
+        pg['betas'] = (pg['betas'][0], target_beta2)
+
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 


### PR DESCRIPTION
## Hypothesis
AdamW's default beta2=0.999 means the second moment estimate adapts slowly. In early training when the loss landscape changes rapidly, this stale variance estimate causes suboptimal step sizes. Starting with beta2=0.99 (faster adaptation) and ramping to 0.999 (more stable final steps) can improve both early convergence speed and final accuracy. This "beta2 warmup" technique was shown effective in LLM training (Gilmer et al.).

## Instructions
In the training loop, at the start of each epoch (after `t0 = time.time()`), add a beta2 schedule:

\`\`\`python
# Beta2 warmup: 0.99 -> 0.999 over first 20 epochs
target_beta2 = 0.99 + 0.009 * min(1.0, epoch / 20)
for pg in base_opt.param_groups:
    pg['betas'] = (pg['betas'][0], target_beta2)
\`\`\`

This is a zero-cost change — no extra compute or parameters. It improves optimizer dynamics by allowing more aggressive early updates when the loss landscape is changing rapidly.

Run: `python train.py --agent thorfinn --wandb_name "thorfinn/beta2-warmup" --wandb_group beta2-warmup`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** \`u2t4hg57\` (thorfinn/beta2-warmup)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.1997 | 2.2523 | +2.4% ❌ |
| val_in_dist / mae_surf_p | 20.03 | 21.06 | +5.1% ❌ |
| val_tandem / mae_surf_p | 40.41 | 41.73 | +3.3% ❌ |
| val_ood_cond / mae_surf_p | 20.57 | 21.04 | +2.3% ❌ |
| val_in_dist / mae_vol_Ux | — | 1.299 | — |
| val_tandem / mae_vol_Ux | — | 2.151 | — |
| Peak memory | — | 10.6 GB | — |

Best checkpoint: epoch 67 of 100 (30 min timeout).

**What happened:** Negative result. Beta2 warmup (0.99 → 0.999 over 20 epochs) degraded performance on all splits. val/loss rose 2.1997 → 2.2523 (+2.4%), and surface pressure increased across all three tracked splits.

The hypothesis was that lower beta2 early on allows faster second-moment adaptation. However, the Lookahead wrapper (k=10, alpha=0.8) already introduces its own "slow adaptation" mechanism by periodically snapping the slow weights back. Combining Lookahead with low beta2 may be counterproductive — Lookahead works best when the fast weights take confident steps, but low beta2 makes the per-step size more volatile (high variance in second moment estimate), which conflicts with Lookahead's stable slow weight assumption.

Additionally, this model trains for ~67 epochs in 30 minutes, which is much fewer epochs than LLM training where beta2 warmup was demonstrated. The benefit may require more epochs to manifest.

**Suggested follow-ups:**
- Try a slower ramp (0.99 → 0.999 over 40 epochs) to be less aggressive.
- Try beta2 warmup without Lookahead, to isolate the interaction.
- Try a lower final beta2 (0.99 → 0.99, i.e., fixed low beta2) to verify whether early or late beta2 is the problem.