### PR TITLE
Exponential LR schedule (replace cosine, maintain higher LR longer)

### DIFF
--- a/train.py
+++ b/train.py
@@ -518,9 +518,9 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+exp_scheduler = torch.optim.lr_scheduler.ExponentialLR(base_opt, gamma=0.95)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_scheduler, exp_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The cosine schedule decays to eta_min=1e-4 over T_max=75 epochs. But the best checkpoint is often around epoch 64-67, suggesting the model is still improving when LR is very low. An exponential decay schedule (lr * 0.95^epoch) maintains higher LR longer in mid-training (epochs 20-50) where complex spatial patterns are learned, while still decaying enough for EMA to stabilize.

## Instructions
Replace the scheduler setup (lines ~520-524):

```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
exp_scheduler = torch.optim.lr_scheduler.ExponentialLR(base_opt, gamma=0.95)
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, exp_scheduler], milestones=[5]
)
```

This keeps the 5-epoch warmup, then switches to exponential decay. At epoch 30, LR will be ~0.95^25 * 3e-3 ≈ 0.83e-3 vs cosine's ~0.55e-3. The higher mid-training LR gives more useful gradients for feature learning.

Run: `python train.py --agent violet --wandb_name "violet/exp-lr-schedule" --wandb_group exp-lr-schedule`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run ID**: `qjm2f0u1`
**Epochs completed**: 66 (best), 30.0 min
**Peak memory**: 10.5 GB
**Note**: Visualization plots not generated — known visualization limitation with curvature proxy branch.

### Metrics vs Baseline (cosine schedule)

| Metric | Baseline (cosine) | Exponential (γ=0.95) | Δ |
|---|---|---|---|
| val/loss | 2.1997 | **2.2866** | +4.0% 🔴 |
| in_dist surf_p | 20.03 Pa | **21.32 Pa** | +6.4% 🔴 |
| ood_cond surf_p | 20.57 Pa | **20.61 Pa** | +0.2% |
| ood_re surf_p | — | **31.54 Pa** | — |
| tandem surf_p | 40.41 Pa | **41.85 Pa** | +3.6% 🔴 |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

Exponential decay is **worse** than cosine annealing. The PR hypothesis that exponential maintains higher LR in mid-training was incorrect based on actual LR values:

- At epoch 30 (25 steps after warmup):
  - Exponential: `3e-3 × 0.95^25 ≈ 8.3e-4`
  - Cosine: `(3e-3 - 1e-4) × 0.75 + 1e-4 ≈ 2.2e-3`

Cosine actually maintains 2.6× higher LR at epoch 30! The cosine schedule stays higher through mid-training before decaying steeply in late training. Exponential decays more uniformly throughout. The cosine schedule's shape (high early, steep late drop) is better suited for this problem — it provides strong gradients during early feature learning and gentle convergence near the end.

### Suggested follow-ups

- **T_max tuning**: The cosine schedule uses T_max=75, but runs complete in ~67 epochs. A tighter T_max (e.g., 70) that aligns with actual run length might provide slightly better convergence.
- **Cosine restarts (SGDR)**: CosineAnnealingWarmRestarts with T_0=30 could escape local optima in mid-training while preserving cosine-shaped LR decay.