### PR TITLE
Depthwise conv on slice tokens (local token mixing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -109,6 +109,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
         )
+        # Depthwise conv across slice dimension for token mixing
+        self.slice_conv = nn.Conv1d(dim_head, dim_head, kernel_size=3, padding=1, groups=dim_head)
+        nn.init.zeros_(self.slice_conv.weight)
+        nn.init.zeros_(self.slice_conv.bias)
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
     def forward(self, x, spatial_bias=None):
@@ -143,6 +147,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
+        # Token mixing: depthwise conv across slices
+        B_s, H_s, S_s, D_s = out_slice_token.shape
+        conv_in = out_slice_token.reshape(B_s * H_s, S_s, D_s).permute(0, 2, 1)  # [B*H, D, S]
+        conv_out = self.slice_conv(conv_in).permute(0, 2, 1).reshape(B_s, H_s, S_s, D_s)
+        out_slice_token = out_slice_token + conv_out
         out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)


### PR DESCRIPTION
## Hypothesis
After Q,K,V attention, adjacent slice tokens do not share information except through global attention. A lightweight depthwise 1D convolution across the slice dimension (treating 32 slice tokens as a 1D sequence) lets neighboring slices exchange local information. This is the "ConvNeXt trick" applied to slice tokens — zero-initialized so it starts as identity and can only help.

## Instructions
In `Physics_Attention_Irregular_Mesh.__init__`, add after the `to_out` definition:
```python
# Depthwise conv across slice dimension for token mixing
self.slice_conv = nn.Conv1d(dim_head, dim_head, kernel_size=3, padding=1, groups=dim_head)
nn.init.zeros_(self.slice_conv.weight)
nn.init.zeros_(self.slice_conv.bias)
```

In `forward`, after `out_slice_token = torch.matmul(attn_weights, v_slice_token)` (around line 145), before the slice residual:
```python
# Token mixing: depthwise conv across slices
B_s, H_s, S_s, D_s = out_slice_token.shape
conv_in = out_slice_token.reshape(B_s * H_s, S_s, D_s).permute(0, 2, 1)  # [B*H, D, S]
conv_out = self.slice_conv(conv_in).permute(0, 2, 1).reshape(B_s, H_s, S_s, D_s)
out_slice_token = out_slice_token + conv_out
```

Only 96 new parameters (32 * 3), negligible compute overhead.

Run: `python train.py --agent gilbert --wandb_name "gilbert/slice-token-conv" --wandb_group slice-token-conv`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** ijonfjhv
**Best epoch:** 66 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.5426 | — | — | 21.1 |
| val_tandem_transfer | 3.2924 | — | — | 43.1 |
| val_ood_cond | 1.9437 | — | — | 21.6 |
| val_ood_re | 18869.6 | — | — | 31.2 |
| **combined val/loss (3-split)** | **2.2596** | | | |

**Baseline val/loss: 2.1997 → This run: 2.2596 (+0.060, slightly worse)**

Note: Visualization crashed post-training (pre-existing issue: curvature proxy not applied in `visualize()` function).

Comparison vs baseline (surf_p):
- in_dist: 21.1 vs 20.03 — worse (+1.1)
- tandem: 43.1 vs 40.41 — worse (+2.7)
- ood_cond: 21.6 vs 20.57 — worse (+1.0)
- ood_re: 31.2 — normal

### What happened

The depthwise conv across slice tokens shows no improvement — results are across-the-board slightly worse than baseline. The +0.060 combined val/loss is at the noise boundary but the consistent mae_surf_p regression across all splits suggests the conv is not learning useful cross-slice communication.

Two likely explanations:

1. **Slice ordering is arbitrary.** The 32 slice tokens are not ordered by spatial position — their assignment is soft-assignment by the learned `in_project_slice` weights. A 1D convolution assumes local structure (i.e., slice `i` is "adjacent" to slice `i+1`), but this spatial relationship may not exist in the slice index dimension. The conv can only help if nearby slice indices represent nearby spatial regions, which is not guaranteed.

2. **Zero initialization is too strong a prior.** Starting the conv weights at zero means the gradient signal must be strong enough to break symmetry and learn non-zero weights. In 30 minutes, the 96 parameters may not have gotten meaningful gradients if the slice ordering truly carries no spatial structure.

### Suggested follow-ups

- **Cross-attention between slice tokens**: instead of conv, use a small self-attention block on the 32 slice tokens — this is permutation-equivariant and does not assume spatial ordering.
- **Sort slice tokens by spatial centroid**: if slices are sorted by their spatial centroid before the conv, the locality assumption becomes valid.