### PR TITLE
Stochastic attention depth (skip attention with p=0.1)

### DIFF
--- a/train.py
+++ b/train.py
@@ -191,7 +191,10 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
+        if self.training and torch.rand(1).item() < 0.1:
+            pass  # skip attention, keep fx unchanged (implicit residual)
+        else:
+            fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))


### PR DESCRIPTION
## Hypothesis
With only 1 Transolver layer, the attention block is always active. But the slice residual (#800) showed that bypassing attention partially helps. Stochastic depth (randomly skipping the entire attention block with p=0.1 during training, always using it during eval) acts as a regularizer by forcing the model to produce good features from the preprocess MLP alone. This creates an implicit ensemble of "with attention" and "without attention" models that EMA averaging can exploit.

## Instructions
In `TransolverBlock.forward`, replace the attention call (around line 194):

```python
fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
```

With:
```python
if self.training and torch.rand(1).item() < 0.1:
    pass  # skip attention, keep fx unchanged (implicit residual)
else:
    fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
```

Zero new parameters, negligible compute impact. The 0.1 probability means attention is skipped ~10% of training iterations.

Run: `python train.py --agent senku --wandb_name "senku/stochastic-attn-depth" --wandb_group stochastic-attn-depth`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** `0zkzk5v0` (senku/stochastic-attn-depth)  
**Best epoch:** 69  
**Peak GPU memory:** ~48% of 96GB  
**Note:** Run shows `State: failed` due to a pre-existing visualization bug (curvature proxy not added in `visualize()`). Training metrics are fully valid.

### Best checkpoint (epoch 69)

| Split | loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.5590 | 0.282 | 0.185 | 21.54 | 1.250 | 0.463 | 25.83 |
| val_tandem_transfer | 3.2871 | 0.634 | 0.342 | 41.97 | 2.159 | 1.001 | 44.69 |
| val_ood_cond | 1.9038 | 0.266 | 0.190 | 20.51 | 1.063 | 0.405 | 19.23 |
| val_ood_re | 18869.6 | 0.276 | 0.200 | 31.12 | 1.048 | 0.443 | 51.22 |

**val/loss (3-split): 2.2500** vs baseline **2.1997** → **neutral** (+2.3%)  
**surf_p in_dist: 21.54** vs baseline **20.03** → slightly worse  
**surf_p tandem: 41.97** vs baseline **40.41** → slightly worse

### What happened

Stochastic attention depth (p=0.1 skip) is essentially neutral — no meaningful improvement over the baseline. The regularization effect doesn't seem to help in the 30-minute training window.

A few possible reasons:

1. **Stochastic depth is most valuable in deep networks.** With a single Transolver layer, skipping the only attention block 10% of the time means the model spends ~10% of gradient steps training without any attention mechanism. In a deep network, stochastic depth allows gradients to flow more easily through shallower paths, but with 1 layer there's no depth regularization benefit — it's more like 10% attention dropout.

2. **EMA doesn't directly exploit the ensemble.** The hypothesis relies on EMA averaging benefiting from the implicit ensemble of "attention on/off" modes. But EMA is a time-weighted average along the training trajectory, not a spatial average across configurations. The ensemble benefit would require the model to learn a good "attention-free" representation, which is a strong requirement.

3. **The MLP-only subnetwork is insufficiently expressive.** When attention is skipped, only the MLP and SE block update `fx`. If the MLP alone can't produce useful representations for the CFD problem, the 10% skip iterations add noise rather than useful regularization signal.

### Suggested follow-ups
- Try a higher skip probability (p=0.2 or p=0.3) — p=0.1 may be too conservative to provide meaningful regularization
- Try DropPath-style scaling instead of simple skip: multiply the attention output by `1/(1-0.1)` during training to maintain expected values
- The hypothesis about MLP-only representations may be worth testing directly — explicitly train a baseline with no attention at all to see if the MLP provides meaningful signal
