### PR TITLE
Local surface neighborhood smoothing (post-hoc k=3 averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -619,6 +619,25 @@ for epoch in range(MAX_EPOCHS):
         re_pred = re_pred.float()
         if model.training:
             pred = pred / sample_stds
+        # Smooth surface predictions: each surface node averages with its 2 nearest surface neighbors
+        B, N, C = pred.shape
+        pred_smooth = pred.clone()
+        for b in range(B):
+            s_mask = mask[b] & is_surface[b]  # [N]
+            if s_mask.sum() < 3:
+                continue
+            s_idx = s_mask.nonzero(as_tuple=True)[0]
+            s_pos = x[b, s_idx, :2]  # [S, 2] - surface positions
+            # Sort surface nodes by angle from centroid for 1D ordering
+            centroid = s_pos.mean(0)
+            angles = torch.atan2(s_pos[:, 1] - centroid[1], s_pos[:, 0] - centroid[0])
+            order = angles.argsort()
+            s_idx_ordered = s_idx[order]
+            # 1D convolution: average with neighbors (kernel size 3)
+            s_pred = pred[b, s_idx_ordered]  # [S, C]
+            s_smoothed = (s_pred.roll(1, 0) + s_pred + s_pred.roll(-1, 0)) / 3.0
+            pred_smooth[b, s_idx_ordered] = s_smoothed
+        pred = pred_smooth
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
@@ -743,6 +762,25 @@ for epoch in range(MAX_EPOCHS):
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
+                # Smooth surface predictions: each surface node averages with its 2 nearest surface neighbors
+                B, N, C = pred.shape
+                pred_smooth = pred.clone()
+                for b in range(B):
+                    s_mask = mask[b] & is_surface[b]  # [N]
+                    if s_mask.sum() < 3:
+                        continue
+                    s_idx = s_mask.nonzero(as_tuple=True)[0]
+                    s_pos = x[b, s_idx, :2]  # [S, 2] - surface positions
+                    # Sort surface nodes by angle from centroid for 1D ordering
+                    centroid = s_pos.mean(0)
+                    angles = torch.atan2(s_pos[:, 1] - centroid[1], s_pos[:, 0] - centroid[0])
+                    order = angles.argsort()
+                    s_idx_ordered = s_idx[order]
+                    # 1D convolution: average with neighbors (kernel size 3)
+                    s_pred = pred[b, s_idx_ordered]  # [S, C]
+                    s_smoothed = (s_pred.roll(1, 0) + s_pred + s_pred.roll(-1, 0)) / 3.0
+                    pred_smooth[b, s_idx_ordered] = s_smoothed
+                pred = pred_smooth
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis
Surface pressure predictions are noisy at the node level because each node is processed independently after attention. Physically, pressure varies smoothly along the airfoil surface (except at separation/reattachment). Post-processing predictions with a local average of nearest surface neighbors could reduce noise without the model needing to learn smoothness explicitly. This is a physics-based inductive bias.

## Instructions
After computing `pred` in both the training loop (after line ~618) and validation loop, add surface smoothing BEFORE computing the loss and BEFORE denormalization:

```python
# Smooth surface predictions: each surface node averages with its 2 nearest surface neighbors
B, N, C = pred.shape
pred_smooth = pred.clone()
for b in range(B):
    s_mask = surf_mask[b]  # [N]
    if s_mask.sum() < 3:
        continue
    s_idx = s_mask.nonzero(as_tuple=True)[0]
    s_pos = x[b, s_idx, :2]  # [S, 2] - surface positions
    # Sort surface nodes by angle from centroid for 1D ordering
    centroid = s_pos.mean(0)
    angles = torch.atan2(s_pos[:, 1] - centroid[1], s_pos[:, 0] - centroid[0])
    order = angles.argsort()
    s_idx_ordered = s_idx[order]
    # 1D convolution: average with neighbors (kernel size 3)
    s_pred = pred[b, s_idx_ordered]  # [S, C]
    s_smoothed = (s_pred.roll(1, 0) + s_pred + s_pred.roll(-1, 0)) / 3.0
    pred_smooth[b, s_idx_ordered] = s_smoothed
pred = pred_smooth
```

**Note:** The per-sample loop may slow training. If epoch time increases >15%, try applying smoothing only every other epoch, or only during validation.

Run: `python train.py --agent kohaku --wandb_name "kohaku/surface-smooth-k3" --wandb_group surface-smooth-k3`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** `588brs8i`
**Epochs completed:** 62

### Metrics at best checkpoint (epoch 62)

| Split | val/loss | surf Ux | surf Uy | surf p | vol p |
|---|---|---|---|---|---|
| val_in_dist | 14.44 | 6.32 | 0.85 | 162.02 | 29.34 |
| val_ood_cond | 16.32 | 4.85 | 0.94 | 138.46 | — |
| val_tandem_transfer | 20.53 | 7.24 | 1.52 | 199.84 | — |
| **3-split mean** | **17.10** | — | — | — | — |

### Comparison to baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss_3split | 2.1997 | 17.10 | **+14.9 (7.8x worse)** |
| surf_p in_dist | 20.03 | 162.02 | **+142 (8x worse)** |
| surf_p tandem | 40.41 | 199.84 | **+159 (5x worse)** |

### What happened

Surface smoothing caused catastrophic degradation (7-8x worse) across ALL splits including single-foil cases. This is not a border-case failure — it is systemic. Two likely root causes:

**1.  are not spatial positions**

The smoothing code uses  to get surface positions for angle-based sorting. If the first 2 input features are not the (x, y) node coordinates but something else (e.g., SDF values, flow condition encodings, or other features), then the angle computation would give arbitrary/meaningless angles. The resulting "sorting" would be random, and the roll-based smoothing would average each node with two arbitrary other surface nodes rather than its spatial neighbors. This adds noise proportional to the inter-node variance (which is large for surface pressure), explaining the 7-8x worse surface metrics.

**2. Training-side smoothing misaligns gradient signal**

Even if the sorting were correct, applying smoothing to  during training (before the loss) means the model is trained to produce outputs whose smoothed version matches the un-smoothed targets. For non-smooth target distributions, this creates a complex multi-step gradient path and may prevent the model from learning clean predictions. Training surface loss at epoch 63 was  (vs ~0.1-0.2 in baseline), confirming the model was struggling to converge.

### Suggested follow-ups

- Confirm what  actually contains (by checking ). If they are NOT the 2D spatial positions, the approach needs to use the actual position features.
- If positions are available at correct indices, also try **validation-only smoothing** (no training smoothing) so the model learns normally and smoothing only cleans up predictions at eval time.
- Consider a different smoothing approach that uses the mesh connectivity directly (e.g., from the data loader), which would be more reliable than angle-based sorting.