### PR TITLE
FP32 output head (selective autocast for final projection)

### DIFF
--- a/train.py
+++ b/train.py
@@ -182,12 +182,12 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
-            self.ln_3 = nn.LayerNorm(hidden_dim)
+            self.ln_3 = nn.LayerNorm(hidden_dim).float()
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
-            )
+            ).float()
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -198,7 +198,8 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            with torch.amp.autocast("cuda", enabled=False):
+                return self.mlp2(self.ln_3(fx.float()))
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The entire forward pass runs in bfloat16, but surface predictions need high precision. BFloat16 has only 7 bits of mantissa — for pressure values spanning hundreds of Pa, quantization error in the final linear projection directly becomes prediction error. Running the output head in float32 while keeping the attention backbone in bfloat16 improves numerical precision where it matters most, without slowing the bottleneck operations.

Note: The float64 surface loss experiment (#916) was neutral, but that changed only the loss computation. This changes the output head computation itself, where bfloat16 quantization error in the final linear happens before the loss.

## Instructions
In `TransolverBlock.forward`, change the last_layer branch to exit autocast before the output head.

Run: `python train.py --agent norman --wandb_name "norman/fp32-output-head" --wandb_group fp32-output-head`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** ss9n5vbi (state: failed — hit timeout)

| Metric | Baseline | FP32 head | Delta |
|--------|----------|-----------|-------|
| val/loss | 2.1997 | 2.2653 | +0.066 (+3.0%) |
| in_dist surf_p | 20.03 | 21.82 | +1.79 |
| tandem surf_p | 40.41 | 43.08 | +2.67 |
| ood_cond surf_p | 20.57 | 20.63 | +0.06 |
| ood_re surf_p | — | 30.98 | — |

**Full surface MAE:**
- in_dist: Ux=0.284, Uy=0.183, p=21.82
- tandem: Ux=0.638, Uy=0.343, p=43.08
- ood_cond: Ux=0.254, Uy=0.189, p=20.63
- ood_re: Ux=0.266, Uy=0.200, p=30.98

**Full volume MAE:**
- in_dist: Ux=1.285, Uy=0.467, p=26.71
- tandem: Ux=2.154, Uy=0.996, p=45.52
- ood_cond: Ux=1.055, Uy=0.406, p=19.32
- ood_re: Ux=1.060, Uy=0.443, p=51.13

**Peak memory:** not logged

### What happened
FP32 output head does not improve performance — val/loss is 3.0% worse, in_dist surf_p +1.79, tandem surf_p +2.67. The run also hit the 30-min timeout, meaning fewer epochs completed than baseline.

The hypothesis about bfloat16 quantization error is theoretically reasonable, but the normalized target values (y_norm) are O(1) magnitude after Cp normalization and per-sample std normalization. At this scale, bfloat16 has ~0.3% relative error, which is negligible compared to the model error itself. The FP32 output head also adds dtype casting overhead per forward pass, likely slowing training slightly.

### Suggested follow-ups
- If numerical precision is a concern, profiling whether bf16 actually causes convergence issues vs marginal effects would be useful
- Bigger gains likely come from features or architecture changes rather than precision tuning