### PR TITLE
Separate pressure output head (dedicated MLP for key metric)

### DIFF
--- a/train.py
+++ b/train.py
@@ -183,10 +183,12 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
+            # Separate heads: velocity (2 channels) and pressure (1 channel)
+            self.head_velocity = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 2)
+            )
+            self.head_pressure = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 1)
             )
 
     def forward(self, fx, raw_xy=None):
@@ -198,7 +200,10 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            vel = self.head_velocity(h)   # [B, N, 2]
+            pres = self.head_pressure(h)  # [B, N, 1]
+            return torch.cat([vel, pres], dim=-1)  # [B, N, 3]
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The current output head is a single MLP that maps hidden_dim → 3 channels [Ux, Uy, p]. But pressure is the most important metric and has fundamentally different characteristics from velocity — it spans a wider range, has sharper gradients near the leading edge, and is the primary target for surface accuracy. Giving pressure its own dedicated output MLP lets the network specialize the final projection for the key metric, rather than sharing output weights across all channels.

This is architecturally orthogonal to the gradient decoupling experiment (#943, frieren) which works at the loss level. This works at the output level — the model gets separate learned representations for "how to predict pressure" and "how to predict velocity."

## Instructions
In `TransolverBlock.__init__`, replace the output head (the `mlp2` definition under `if self.last_layer`):

```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    # Separate heads: velocity (2 channels) and pressure (1 channel)
    self.head_velocity = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 2)
    )
    self.head_pressure = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 1)
    )
```

In `TransolverBlock.forward`, replace the output head call (the `self.mlp2(self.ln_3(fx))` section):

```python
if self.last_layer:
    h = self.ln_3(fx)
    vel = self.head_velocity(h)   # [B, N, 2]
    pres = self.head_pressure(h)  # [B, N, 1]
    return torch.cat([vel, pres], dim=-1)  # [B, N, 3]
```

Remove the old `self.mlp2` definition. The parameter count increases slightly (two MLPs instead of one, but pressure head outputs 1 channel vs 3, so total is similar).

Run: `python train.py --agent askeladd --wandb_name "askeladd/separate-pressure-head" --wandb_group separate-pressure-head`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run**: no3s6zb9
**Epochs**: 63 (run state=failed due to end-of-process RuntimeError unrelated to training; all epoch metrics valid)
**Parameters**: 273,936 (+16,512 / +6.4% vs baseline 257,424)

| Metric | This run | Baseline | Δ |
|---|---|---|---|
| val/loss | 2.2692 | 2.1997 | **+3.16% worse** |
| in_dist / surf_p | 21.74 | 20.03 | +8.5% worse |
| tandem / surf_p | 41.98 | 40.41 | +3.9% worse |
| ood_cond / surf_p | 21.08 | 20.57 | +2.5% worse |
| in_dist / surf_Ux | 0.298 | 0.295 | +1.0% worse |
| in_dist / surf_Uy | 0.175 | 0.179 | +2.2% better |

**Volume MAE (in_dist):** Ux=1.288, Uy=0.455, p=25.78

### What happened

The separate pressure head hurt across all splits. The shared output head appears to be beneficial — cross-channel weight sharing helps the network learn correlated representations for velocity and pressure (e.g., continuity equation linking divergence of velocity to pressure). Separating them removes this implicit regularization and forces the model to learn redundant hidden representations, adding 16K parameters without any benefit.

63 epochs vs 67 baseline — slightly fewer because the larger head is marginally slower per epoch.

The surface pressure result is particularly striking: in_dist/surf_p degraded 8.5%, which is the opposite of what the hypothesis predicted. This suggests the Transolver's hidden representations at the last layer already encode pressure-specific features without needing a dedicated output path.

### Suggested follow-ups
- The shared MLP head is well-suited for this task — cross-channel coupling is a feature, not a bug
- A lighter touch: try a **residual pressure correction** — keep the shared head but add a small auxiliary branch that predicts a pressure residual and adds it back. This adds capacity without removing the shared representation
- Alternatively, try a **pressure-weighted loss inside the output head** (soft attention over output channels) to focus gradients on pressure without splitting the head