### PR TITLE
Homoscedastic multi-task loss (learned loss weights, Kendall 2018)

### DIFF
--- a/train.py
+++ b/train.py
@@ -474,6 +474,10 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 
+log_var_vol = nn.Parameter(torch.zeros(1, device=device))
+log_var_surf = nn.Parameter(torch.zeros(1, device=device))
+log_var_coarse = nn.Parameter(torch.zeros(1, device=device))
+
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
@@ -512,9 +516,11 @@ class Lookahead:
 
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+loss_params = [log_var_vol, log_var_surf, log_var_coarse]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
+    {'params': other_params, 'lr': cfg.lr},
+    {'params': loss_params, 'lr': cfg.lr, 'weight_decay': 0.0},
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
@@ -571,9 +577,6 @@ for epoch in range(MAX_EPOCHS):
         break
 
     t0 = time.time()
-
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()
@@ -647,12 +650,12 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
+        coarse_loss = torch.tensor(0.0, device=device)
         if n_groups > 1:
             # Pool predictions and targets over groups of 64 nodes
             pred_trunc = pred[:, :n_groups * coarse_pool_size]
@@ -665,11 +668,15 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
+
+        # Homoscedastic multi-task loss (Kendall et al. 2018)
+        loss = (torch.exp(-log_var_vol) * vol_loss + 0.5 * log_var_vol +
+                torch.exp(-log_var_surf) * surf_loss + 0.5 * log_var_surf +
+                torch.exp(-log_var_coarse) * coarse_loss + 0.5 * log_var_coarse +
+                0.01 * re_loss)
 
         optimizer.zero_grad()
         loss.backward()
@@ -683,7 +690,10 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "global_step": global_step,
+                   "learned/vol_weight": torch.exp(-log_var_vol).item(),
+                   "learned/surf_weight": torch.exp(-log_var_surf).item(),
+                   "learned/coarse_weight": torch.exp(-log_var_coarse).item()})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The current loss combines `vol_loss + surf_weight * surf_loss + coarse_loss + 0.01 * re_loss` with surf_weight heuristically set by loss ratio (clamped 5-50). Kendall et al. (2018) showed that learning task weights via homoscedastic uncertainty (`1/(2*sigma^2) * loss + log(sigma)`) automatically balances multi-task losses at optimal ratios, replacing the fragile heuristic.

## Instructions
After model definition (~line 475), add learnable log-variance parameters:
```python
log_var_vol = nn.Parameter(torch.zeros(1, device=device))
log_var_surf = nn.Parameter(torch.zeros(1, device=device))
log_var_coarse = nn.Parameter(torch.zeros(1, device=device))
```

Add these to the optimizer (in the param groups):
```python
loss_params = [log_var_vol, log_var_surf, log_var_coarse]
# Add to existing optimizer param group or create a new one
```

Replace the loss combination (~line 668):
```python
loss = (torch.exp(-log_var_vol) * vol_loss + 0.5 * log_var_vol +
        torch.exp(-log_var_surf) * surf_loss + 0.5 * log_var_surf +
        torch.exp(-log_var_coarse) * coarse_loss + 0.5 * log_var_coarse +
        0.01 * re_loss)
```

Remove the heuristic `surf_weight` computation entirely. Log the learned weights to W&B each epoch:
```python
wandb.log({"learned/vol_weight": torch.exp(-log_var_vol).item(),
           "learned/surf_weight": torch.exp(-log_var_surf).item(),
           "learned/coarse_weight": torch.exp(-log_var_coarse).item()})
```

Run: `python train.py --agent nezuko --wandb_name "nezuko/homoscedastic-loss" --wandb_group homoscedastic-loss`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** mb7ubb54 | Runtime: 1920s (~32 min, ~67 epochs, 28.6s/epoch)
*(Run state shows "failed" due to SIGTERM at timeout — data is valid)*

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|---|---|---|---|---|---|
| **in_dist** | 1.671 | 0.323 | 0.191 | **23.16** | 22.70 |
| **ood_cond** | 1.969 | 0.277 | 0.204 | **21.78** | 16.70 |
| **ood_re** | — | 0.281 | 0.210 | **31.51** | 48.93 |
| **tandem** | 3.278 | 0.641 | 0.346 | **42.26** | 40.41 |
| **val/loss (3-split)** | **2.3061** | | | | |

| Metric | Baseline | Homoscedastic | Δ |
|---|---|---|---|
| val/loss | 2.1997 | 2.3061 | +4.8% ❌ |
| surf_p in_dist | 20.03 | 23.16 | +15.6% ❌ |
| surf_p ood_cond | 20.57 | 21.78 | +5.9% ❌ |
| surf_p tandem | 40.41 | 42.26 | +4.6% ❌ |

### Learned weights at convergence
| Task | Weight (exp(-log_var)) | Effective surf/vol ratio |
|---|---|---|
| vol | 2.74 | — |
| surf | 3.21 | 1.17× vol |
| coarse | 3.82 | 1.39× vol |

### What happened

Negative result. The homoscedastic formulation converged to a surf/vol weight ratio of ~1.17, dramatically lower than the baseline's adaptive 5-50 range. This means surface loss gets nearly equal weight to volume loss, rather than the intended 5-50× priority.

The theoretical justification (maximizing likelihood by balancing task uncertainties) conflicts with the engineering requirement: we NEED to over-weight surface, not just balance it. Kendall et al.'s framework works when all tasks contribute equally to the objective. Here, surface accuracy is the primary goal and the loss should reflect that.

The model also learned to up-weight the coarse loss (3.82) above both vol and surf — an unintended consequence where the optimizer finds the easiest gradient signal (smooth coarse features) and amplifies it.

The learnable log-variance parameters allow the optimizer to effectively "turn down" the surface loss in favor of easier tasks, which is the opposite of what we want.

### Suggested follow-ups
- Keep the adaptive surf_weight heuristic (it's working well) but try learning only a single log_var for volume to add principled uncertainty
- Try constraining surf_weight via a lower bound: initialize log_var_surf at a negative value (e.g., log(1/5) ≈ -1.6) to bias toward higher surf weight
- The coarse_weight inflating to 3.82 is interesting — suggests the current coarse weight of 1.0 is too low