### PR TITLE
Test-time augmentation via coordinate flipping (val-only, zero training cost)

### DIFF
--- a/train.py
+++ b/train.py
@@ -741,7 +741,21 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    pred_orig = eval_model({"x": x})["preds"]
+                    # TTA: vertical flip for non-tandem samples
+                    x_flip = x.clone()
+                    x_flip[:, :, 1] = -x_flip[:, :, 1]    # flip y position
+                    x_flip[:, :, 3] = -x_flip[:, :, 3]    # flip saf y-component
+                    for ch in [5, 7, 9, 11]:               # flip dsdf y-related channels
+                        x_flip[:, :, ch] = -x_flip[:, :, ch]
+                    x_flip[:, :, 14] = -x_flip[:, :, 14]  # flip AoA0
+                    x_flip[:, :, 18] = -x_flip[:, :, 18]  # flip AoA1
+                    pred_flip = eval_model({"x": x_flip})["preds"]
+                    pred_flip[:, :, 1] = -pred_flip[:, :, 1]  # un-flip Uy
+                    pred = pred_orig.clone()
+                    for b in range(pred_orig.shape[0]):
+                        if not is_tandem[b]:
+                            pred[b] = (pred_orig[b] + pred_flip[b]) / 2.0
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
For single-foil samples, a vertical flip (negate y-coordinate, Uy, and y-related features) is a valid physical symmetry. Averaging predictions from the original and flipped input at validation time should reduce prediction noise. This is free accuracy — zero training cost, only doubles validation time (which is fast and doesn't count toward the 30-min budget).

## Instructions
In the validation loop (starting ~line 715), after computing `pred` from the eval model, add TTA for non-tandem samples:

```python
with torch.amp.autocast("cuda", dtype=torch.bfloat16):
    pred_orig = eval_model({"x": x})["preds"]
    
    # TTA: vertical flip (only for non-tandem samples)
    x_flip = x.clone()
    x_flip[:, :, 1] = -x_flip[:, :, 1]     # flip y position
    x_flip[:, :, 3] = -x_flip[:, :, 3]     # flip saf y-component
    # Flip dsdf y-related channels (odd indices of the 8 dsdf channels)
    for ch in [5, 7, 9, 11]:
        x_flip[:, :, ch] = -x_flip[:, :, ch]
    x_flip[:, :, 14] = -x_flip[:, :, 14]   # flip AoA0
    x_flip[:, :, 18] = -x_flip[:, :, 18]   # flip AoA1
    
    pred_flip = eval_model({"x": x_flip})["preds"]
    pred_flip[:, :, 1] = -pred_flip[:, :, 1]  # un-flip Uy prediction
    
    pred = pred_orig.clone()
    for b in range(pred_orig.shape[0]):
        if not is_tandem[b]:
            pred[b] = (pred_orig[b] + pred_flip[b]) / 2.0
```

Run: `python train.py --agent edward --wandb_name "edward/val-tta-flip" --wandb_group val-tta`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---
## Results

**W&B run:** `asz3h9fr`
**Best epoch:** 53/100 (~31.1s/epoch)

### val/loss
| Metric | Baseline | val-tta-flip | Delta |
|--------|----------|-------------|-------|
| val/loss (3-split) | 2.1997 | 10.2255 | +8.03 (+365%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (tta) | p delta |
|-------|-----|-----|--------------|---------|---------|
| in_dist | 0.319 | 0.185 | 20.03 | 22.37 | +2.34 (+11.7%) |
| ood_cond | 2.040 | 0.606 | 20.57 | **72.97** | +52.4 (+255%) |
| ood_re | 1.559 | 0.449 | — | **59.52** | — |
| tandem | 5.316 | 1.574 | 40.41 | **239.72** | +199.3 (+493%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.336 | 0.472 | 26.64 |
| ood_cond | 2.356 | 1.077 | 60.28 |
| ood_re | 1.858 | 0.849 | 73.69 |
| tandem | 5.333 | 3.431 | 227.54 |

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868.

### What happened
The TTA implementation is catastrophically wrong on ood and tandem splits. Two root causes:

**1. Feature negation in normalized space is incorrect.** After `x = (x - mean) / std`, negating x_norm gives `-(x_raw - mean)/std`. But a physical y-flip requires `(-x_raw - mean)/std = -x_norm - 2*mean/std`. The missing bias term `2*mean/std` is large for features with non-zero means (pos_y mean is the mesh centroid, AoA mean is the average training AoA). This produces a completely different input, not a physical mirror.

**2. is_tandem detection may be unreliable.** The code detects tandem via `x[:, 0, 21].abs() > 0.5` where index 21 is NACA1[2] (last digit of foil-2 NACA code), not gap (index 22). After normalization, tandem samples where NACA1[2] normalizes to < 0.5 would be misidentified as non-tandem, causing TTA to be applied to tandem samples — breaking them catastrophically. The tandem surf_p error of 239.72 (vs 40.41 baseline) suggests this is happening.

**In-dist** is only slightly degraded because single-foil in-distribution samples have smaller AoA (mean closer to 0), making the normalization bias smaller.

### Suggested follow-ups
- For TTA to work correctly, the flip must be applied in the **raw** feature space before normalization. The correct approach: clone raw x, apply the flip, then normalize — this requires restructuring the val loop
- Alternatively, the normalization offsets could be manually corrected: for each flipped feature, subtract 2*mean/std from the negated value
- Fix tandem detection to use index 22 (gap) instead of 21 (NACA1[2])