### PR TITLE
Surface pressure 3x channel weight (pressure-focused surface loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -645,8 +645,8 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        # 3x weight on pressure channel in surface loss only
-        channel_weights = torch.tensor([1.0, 1.0, 3.0], device=abs_err.device)  # [Ux, Uy, p]
+        # 2x weight on pressure channel in surface loss only
+        channel_weights = torch.tensor([1.0, 1.0, 2.0], device=abs_err.device)  # [Ux, Uy, p]
         abs_err_surf = abs_err * channel_weights[None, None, :]
         surf_per_sample = (abs_err_surf * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis
Surface nodes are ~1-2% of all nodes. Despite surf_weight boosting, the gradient signal from surface pressure is diluted by velocity channels. Weighting the pressure channel 3x in the surface loss (ONLY in the surface loss term, not volume) concentrates gradient where it matters most. This is distinct from any global channel weighting — it specifically amplifies pressure signal at the surface while preserving balanced training for volume and velocity.

## Instructions
In the surface loss computation (~line 648), add per-channel weighting for the surface term ONLY:

\`\`\`python
# 3x weight on pressure channel in surface loss only
channel_weights = torch.tensor([1.0, 1.0, 3.0], device=abs_err.device)  # [Ux, Uy, p]
abs_err_surf = abs_err * channel_weights[None, None, :]
surf_per_sample = (abs_err_surf * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()
\`\`\`

The volume loss (`vol_per_sample`) keeps equal channel weights — this only changes the surface loss gradient composition.

Run: `python train.py --agent thorfinn --wandb_name "thorfinn/surf-pressure-3x" --wandb_group surf-pressure-amplify`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

### Run 1: 3x pressure weight (W&B: `is0l3pkl`)

| Metric | Baseline | 3x | Delta |
|--------|----------|----|-------|
| val/loss (3-split) | 2.1997 | 2.3505 | +6.9% ❌ |
| val_in_dist / mae_surf_p | 20.03 | 20.95 | +4.6% ❌ |
| val_tandem / mae_surf_p | 40.41 | 41.40 | +2.4% ❌ |
| val_ood_cond / mae_surf_p | 20.57 | 19.77 | -3.9% ✅ |

### Run 2: 2x pressure weight — revision (W&B: `yu72nsf8`)

| Metric | Baseline | 2x | Delta |
|--------|----------|----|-------|
| val/loss (3-split) | 2.1997 | 2.3214 | +5.5% ❌ |
| val_in_dist / mae_surf_p | 20.03 | 20.02 | ≈0% |
| val_tandem / mae_surf_p | 40.41 | 40.93 | +1.3% ❌ |
| val_ood_cond / mae_surf_p | 20.57 | 22.32 | +8.5% ❌ |
| val_in_dist / mae_vol_Ux | — | 1.395 | — |
| Peak memory | — | 10.6 GB | — |

**What happened:** Both 3x and 2x are negative results overall. While 2x achieves in_dist surf_p essentially at baseline (20.02 vs 20.03), it doesn't improve it, and the val/loss is still +5.5% worse due to degraded volume MAE and ood_cond.

The 2x weight creates a mild imbalance that may help in_dist surface pressure but hurts volume accuracy (vol_Ux: 1.395 vs ~1.28 baseline) and ood generalization (ood_cond surf_p: 22.32 vs 20.57). The per-channel boosting on the surface loss changes the loss landscape in a way that the optimizer — tuned for equal-weight surface loss — doesn't handle well.

The key issue: the existing adaptive surf_weight (5–50) was calibrated for equal-channel surface loss. Adding a 2× pressure multiplier effectively increases the surface_pressure component by 2× while the adaptive weight remains the same, creating an over-weighted pressure gradient that interferes with balanced convergence.

**Suggested follow-ups:**
- Try a narrower multiplier (1.5×) with the adaptive surf_weight range reduced (e.g., 3–30) to maintain the same effective total surface gradient magnitude.
- Consider applying the pressure boost only after a warmup period (e.g., epoch > 20) when the backbone has stabilized, so early training remains balanced.