### PR TITLE
Preprocess LayerNorm (normalize before placeholder scaling)

### DIFF
--- a/train.py
+++ b/train.py
@@ -244,6 +244,7 @@ class Transolver(nn.Module):
             )
         else:
             self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+        self.preprocess_ln = nn.LayerNorm(n_hidden)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim
@@ -328,6 +329,7 @@ class Transolver(nn.Module):
 
         raw_xy = x[:, :, :2]
         fx = self.preprocess(x)
+        fx = self.preprocess_ln(fx)  # normalize preprocess output
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 


### PR DESCRIPTION
## Hypothesis
The preprocess MLP maps 25-dim input to 128-dim hidden. This goes through placeholder_scale/shift before attention, but the preprocess output has no normalization ensuring well-behaved distribution across samples and flow regimes. A LayerNorm after preprocess (before placeholder scaling) normalizes the representation, improving OOD generalization. Sandwich norms (#775) added pre/post attention norms, but the preprocess→attention interface remains unnormalized.

## Instructions
In `Transolver.__init__`, add after `self.preprocess` definition (~line 246):
```python
self.preprocess_ln = nn.LayerNorm(n_hidden)
```

In `Transolver.forward`, after `fx = self.preprocess(x)` (~line 330):
```python
fx = self.preprocess(x)
fx = self.preprocess_ln(fx)  # normalize preprocess output
fx_pre = fx
fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
```

Minimal parameters (256: 128 weight + 128 bias), negligible compute.

Run: `python train.py --agent violet --wandb_name "violet/preprocess-layernorm" --wandb_group preprocess-layernorm`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run ID**: `1v6wli2j`
**Epochs completed**: 62 (best), 30.0 min
**Peak memory**: 10.5 GB
**Note**: Visualization crash is a known limitation of the curvature proxy branch.

### Metrics vs Baseline

| Metric | Baseline | + preprocess LN | Δ |
|---|---|---|---|
| val/loss | 2.1997 | **2.3129** | +5.1% 🔴 |
| in_dist surf_p | 20.03 Pa | **22.10 Pa** | +10.3% 🔴 |
| ood_cond surf_p | 20.57 Pa | **22.28 Pa** | +8.3% 🔴 |
| tandem surf_p | 40.41 Pa | **43.41 Pa** | +7.4% 🔴 |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

The preprocess LayerNorm **hurts significantly** — worse across all metrics (5-10%). The best epoch came earlier (62 vs 66), suggesting the model converged to a worse local optimum.

The issue is that LayerNorm after preprocess normalizes away the magnitude information that the `placeholder_scale/shift` mechanism relies on. The placeholder parameters are learned to modulate hidden features by magnitude, but LayerNorm forces unit variance before that scaling, collapsing the information the placeholder was encoding. The result is essentially a redundant normalization → scale → shift chain where the normalization defeats the purpose of the scale.

Additionally, the model already has sandwich LayerNorm (pre+post norm) in every TransolverBlock. Adding another norm at the preprocess→block interface creates excessive normalization that squashes gradients and reduces representational capacity.

### Suggested follow-ups

- **Preprocess output activation**: Instead of LayerNorm, a stronger output activation (e.g., replacing the last tanh in preprocess MLP with GELU) might improve representation range without the normalization penalty.
- **No additional norms needed**: The existing sandwich norms appear sufficient. The preprocess output feeding into placeholder scale/shift is working well as-is.