### PR TITLE
Spatial node dropout (10% volume nodes masked during training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -611,6 +611,15 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        # Stochastic node dropout: mask 10% of volume nodes
+        if model.training:
+            N = x.shape[1]
+            node_drop_mask = torch.rand(B, N, device=device) < 0.1
+            node_drop_mask = node_drop_mask & ~is_surface  # never drop surface nodes
+            node_drop_mask = node_drop_mask & mask          # only drop valid nodes
+            x = x * (~node_drop_mask).float().unsqueeze(-1)  # zero dropped features
+            mask = mask & ~node_drop_mask  # exclude from loss computation
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
             pred = out["preds"]


### PR DESCRIPTION
## Hypothesis
The model may overfit to specific node distributions in training meshes. Randomly dropping 10% of volume nodes (zeroing features and excluding from loss) during training forces predictions from incomplete neighborhoods — spatial regularization analogous to feature dropout but in the node dimension. Should improve generalization to OOD meshes. Surface nodes are NEVER dropped.

## Instructions
In the training loop, after normalizing `x` and before the forward pass (~line 593):

```python
# Stochastic node dropout: mask 10% of volume nodes
if model.training:
    node_drop_mask = torch.rand(B, N, device=device) < 0.1
    node_drop_mask = node_drop_mask & ~is_surface  # never drop surface nodes
    node_drop_mask = node_drop_mask & mask          # only drop valid nodes
    x = x * (~node_drop_mask).float().unsqueeze(-1)  # zero dropped features
    mask = mask & ~node_drop_mask  # exclude from loss computation
```

This affects training only — validation is unchanged. The mask computation is cheap (one rand + two logical ops).

Run: `python train.py --agent gilbert --wandb_name "gilbert/node-dropout-0.1" --wandb_group node-dropout`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** n5j6t992
**Best epoch:** 67 / 100 (30-min timeout)
**Peak memory:** ~10.7 GB

### Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 1.7218 | — | — | 23.6 |
| val_tandem_transfer | 3.3535 | — | — | 42.1 |
| val_ood_cond | 2.0227 | — | — | 23.6 |
| val_ood_re | 18869.7 | — | — | 31.7 |
| **combined val/loss (3-split)** | **2.3660** | | | |

**Baseline val/loss: 2.1997 → This run: 2.3660 (+0.166, significantly worse)**

Note: Visualization crashed post-training (pre-existing issue: curvature proxy not applied in `visualize()` function).

Comparison vs baseline (surf_p):
- in_dist: 23.6 vs 20.03 — worse (+3.6)
- tandem: 42.1 vs 40.41 — worse (+1.7)
- ood_cond: 23.6 vs 20.57 — worse (+3.0)
- ood_re: 31.7 — slightly worse

### What happened

10% volume node dropout significantly degrades performance — a clear negative result. The val/loss is +0.166 worse (well outside noise) and mae_surf_p is substantially worse across all splits.

The hypothesis that dropping nodes provides regularization does not hold here. Two reasons:

1. **The mesh is not redundant at 10% dropout.** CFD meshes are designed to have sufficient resolution to represent the flow field — volume nodes adjacent to the surface are critical for predicting surface pressure through the pressure field gradient. Dropping 10% of volume nodes removes important local context that the model needs.

2. **Zeroing features is not the same as dropout.** True dropout randomly zeros activations within the network (which are redundant by design with large networks). Here we zero entire input nodes, which directly corrupts the input distribution. The model is forced to predict from a degraded input, without learning to reconstruct missing nodes.

3. **The train/val distribution shift.** Val uses full meshes, but training uses 10% fewer nodes. This systematic discrepancy is different from dropouts training-only effect on activations.

### Suggested follow-ups

- **Lower dropout rate (1-2%)**: 10% may be too aggressive; 1-2% would be less disruptive.
- **Feature dropout instead**: drop individual feature channels (e.g., zero random DSDF channels) rather than whole nodes.