### PR TITLE
Self-distillation from EMA teacher (consistency loss after epoch 40)

### DIFF
--- a/train.py
+++ b/train.py
@@ -671,6 +671,15 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
 
+        if epoch >= ema_start_epoch and ema_model is not None:
+            with torch.no_grad():
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    ema_pred = ema_model({"x": x})["preds"].float()
+            # Consistency: MSE between online and EMA on surface nodes only
+            consist_err = (pred - ema_pred.detach()) ** 2
+            consist_loss = (consist_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = loss + 0.1 * consist_loss
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
The EMA model is currently only used at evaluation. But its predictions are smoother and more stable than the online model. Using the EMA model as a teacher during training — adding an MSE consistency loss between online and EMA predictions on surface nodes — provides self-distillation that regularizes learning. Related to Mean Teacher (Tarvainen & Valpola 2017). The teacher adapts with training, unlike static label smoothing.

## Instructions
After the EMA update in the training loop (~line 684), add consistency loss (only after epoch 40 when EMA starts):

```python
if epoch >= ema_start_epoch and ema_model is not None:
    with torch.no_grad():
        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
            ema_pred = ema_model({"x": x})["preds"].float()
    # Consistency: MSE between online and EMA on surface nodes only
    consist_err = (pred - ema_pred.detach()) ** 2
    consist_loss = (consist_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
    loss = loss + 0.1 * consist_loss
```

**Warning:** The EMA forward pass will slow each epoch by ~30%. This means ~50 epochs instead of 66 for epochs 40+. The tradeoff is regularization quality vs epoch count. If epoch time is too high, reduce to applying every other epoch:
```python
if epoch >= ema_start_epoch and ema_model is not None and step % 2 == 0:
```

Run: `python train.py --agent senku --wandb_name "senku/self-distill-ema" --wandb_group self-distill`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run ID**: c8uj1g63
**Best epoch**: 61 (30 min wall time)
**Peak GPU memory**: ~43.4 GB (same as baseline)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.1997 | 2.2887 | +0.089 (+4.0%) |
| surf_p in_dist | 20.03 | 22.67 | +2.64 |
| surf_p ood_cond | 20.57 | 21.09 | +0.52 |
| surf_p tandem | 40.41 | 41.99 | +1.58 |

Full breakdown at best epoch 61:

| Split | surf_Ux | surf_Uy | surf_p |
|-------|---------|---------|--------|
| val_in_dist | 0.2980 | 0.1802 | 22.67 |
| val_ood_cond | 0.2650 | 0.1924 | 21.09 |
| val_tandem | 0.6340 | 0.3428 | 41.99 |
| val_ood_re | 0.2767 | 0.2026 | 31.52 |

Note: run state is "failed" due to pre-existing visualization crash in this branch (curvature proxy feature dim mismatch in data/utils.py). Training metrics are valid.

### What happened

**Negative result** — self-distillation from the EMA teacher made all metrics worse across every split.

Two likely causes:

1. **Epoch starvation**: The EMA forward pass at every step adds ~30% overhead from epoch 40 onward. We completed 61 epochs in 30 min vs ~83 epochs for the unmodified baseline. The model simply had fewer gradient steps to converge.

2. **Circular regularization**: The EMA teacher is a lagged exponential average of the online model itself — it carries no external information the online model does not already have. Penalizing the online model for diverging from its own smoothed past pushes it toward temporal conservatism that competes with fitting the training labels. Unlike typical knowledge distillation (pretrained-teacher → student), here the teacher and student co-evolve from random init, so the teacher cannot provide a better training signal than the labels.

The PR instructions noted the epoch-count tradeoff and suggested applying every-other-step if time was too high — this run applied every step, which was too aggressive.

### Suggested follow-ups

- **Every-other-step variant**: Apply consistency loss at `step % 2 == 0` as the PR suggests, halving the overhead and restoring ~70 epochs. Would isolate whether regularization quality can compensate for epoch loss.
- **Post-convergence only**: Start consistency loss later (epoch 60+) as a final fine-tuning pass after the model has already converged on labels, avoiding interference during main learning.
- **Stronger teacher**: Use a separately pretrained EMA (from a prior run checkpoint) so the teacher carries external knowledge not derived from the current training.