### PR TITLE
Cosine T_max alignment (67 epochs to match actual training length)

### DIFF
--- a/train.py
+++ b/train.py
@@ -518,7 +518,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=67, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
The cosine LR schedule uses T_max=75, but training consistently completes ~67 epochs in 30 minutes. This means the LR never reaches its designed minimum — at epoch 67/75, the LR is still ~1.4e-4 instead of the target eta_min=1e-4. Setting T_max=67 aligns the schedule with the actual training length, ensuring the full cosine decay is utilized. The late epochs get slightly lower LR, which could improve convergence and EMA quality.

This was identified as a follow-up from the exponential LR experiment (PR #950).

## Instructions
Change the cosine annealing scheduler T_max from 75 to 67.

Run: `python train.py --agent norman --wandb_name "norman/tmax-67" --wandb_group tmax-align`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** 3uu2mcwk (state: failed — hit timeout)

| Metric | Baseline (T_max=75) | T_max=67 | Delta |
|--------|---------------------|----------|-------|
| val/loss | 2.1997 | 2.2241 | +0.024 (+1.1%) |
| in_dist surf_p | 20.03 | 20.87 | +0.84 |
| tandem surf_p | 40.41 | 42.06 | +1.65 |
| ood_cond surf_p | 20.57 | 21.29 | +0.72 |
| ood_re surf_p | — | 30.85 | — |

**Full surface MAE:**
- in_dist: Ux=0.289, Uy=0.176, p=20.87
- tandem: Ux=0.636, Uy=0.338, p=42.06
- ood_cond: Ux=0.260, Uy=0.186, p=21.29
- ood_re: Ux=0.268, Uy=0.200, p=30.85

**Full volume MAE:**
- in_dist: Ux=1.294, Uy=0.451, p=26.14
- tandem: Ux=2.165, Uy=1.000, p=44.49
- ood_cond: Ux=1.023, Uy=0.405, p=19.77
- ood_re: Ux=1.022, Uy=0.442, p=51.09

**Peak memory:** not logged

### What happened
Aligning T_max=67 with the actual training length slightly hurts performance — val/loss +1.1%, in_dist surf_p +0.84, tandem surf_p +1.65. The run also hit the 30-min timeout (consistent with "failed" state).

The original T_max=75 actually provides a gentler, slower LR decay through the training window. With T_max=75, the LR at epoch 67 is ~1.4e-4, which is higher than eta_min=1e-4. With T_max=67, the LR drops lower during the same training window — apparently too low too fast. The EMA model benefits from slightly more learning signal in the late epochs where it's being averaged.

The cosine schedule with T_max slightly beyond the training horizon acts as implicit LR warmdown tuning — it's actually slightly better than perfectly aligning to 67 epochs.

### Suggested follow-ups
- If LR schedule tuning is worth pursuing, cosine with restarts (T_0=20) might provide multiple mini-cycles
- The current T_max=75 seems well-calibrated; not worth changing