### PR TITLE
MLP dropout (p=0.05 in TransolverBlock MLP)

### DIFF
--- a/train.py
+++ b/train.py
@@ -174,6 +174,7 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.mlp_dropout = nn.Dropout(p=0.05)
         self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
@@ -192,7 +193,8 @@ class TransolverBlock(nn.Module):
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
-        fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
+        mlp_out = self.mlp_dropout(self.mlp(self.ln_2(fx)))
+        fx = self.ln_2_post(mlp_out + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))


### PR DESCRIPTION
## Hypothesis
The model currently has NO dropout anywhere. At this scale (128 hidden, 1 layer, ~66 epochs), the model may be slightly overfitting to training samples. A small dropout (p=0.05) in the MLP of the TransolverBlock provides lightweight regularization that forces the model to develop more robust features. This is standard practice in transformers and has not been tested on this codebase.

## Instructions
In `TransolverBlock.__init__`, add a dropout layer:
```python
self.mlp_dropout = nn.Dropout(p=0.05)
```

In `TransolverBlock.forward`, apply dropout after the MLP and before the residual connection:
```python
# Before: fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
# After:
mlp_out = self.mlp(self.ln_2(fx))
mlp_out = self.mlp_dropout(mlp_out)
fx = self.ln_2_post(mlp_out + fx)
```

Alternatively, if the MLP is called differently, just add dropout on the MLP output before the residual add. Zero new learnable parameters.

Run: `python train.py --agent tanjiro --wandb_name "tanjiro/mlp-dropout-0.05" --wandb_group mlp-dropout`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** 4qp94hsk  
**Epochs:** 66 (30.2 min wall-clock, ~27s/epoch)  
**Peak VRAM:** 10.9 GB  

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.5462 | 0.282 | 0.173 | 20.4 | 1.249 | 0.441 | 24.8 |
| val_tandem_transfer | 3.2499 | 0.623 | 0.335 | 41.2 | 2.126 | 0.983 | 43.1 |
| val_ood_cond | 1.8856 | 0.267 | 0.195 | 20.7 | 1.032 | 0.404 | 20.4 |
| val_ood_re | 18869.6* | 0.274 | 0.201 | 31.1 | 1.020 | 0.438 | 51.1 |
| **combined (3-split)** | **2.2272** | | | | | | |

*Pre-existing branch bug (ood_re vol_loss overflow), excluded from 3-split.

**vs baseline:**
- val/loss: 2.2272 vs 2.1997 → **+1.3% (slightly worse)**
- surf_p in_dist: 20.4 vs 20.03 → **+1.8% (minor)**
- surf_p tandem: 41.2 vs 40.41 → **+2.0% (minor)**
- surf_p ood_cond: 20.7 vs 20.57 → **+0.6% (near baseline)**

**What happened:**

Essentially neutral. The val/loss degraded marginally (+1.3%) and surface MAE numbers are within ~2% of baseline across all splits. This is within run-to-run variation. The dropout did not meaningfully help or hurt.

At this scale (128 hidden, 1 layer, ~66 training epochs), the model likely is not severely overfitting — the training and validation losses trend together, suggesting the regularization is not the bottleneck. A p=0.05 dropout is very mild and may be insufficient to produce observable gains in this regime.

Peak VRAM increased slightly from 10.6 GB to 10.9 GB (+0.3 GB), likely due to storing dropout masks during the forward pass.

**Suggested follow-ups:**
- Try stronger dropout (p=0.1 or p=0.15) to see if the threshold for noticeable regularization is higher.
- Try dropout on the attention output instead of (or in addition to) the MLP output — attention dropout can sometimes be more effective.
- If overfitting is not the issue (which this result suggests), focus on model capacity increases rather than regularization.