### PR TITLE
Cosine warm restarts (SGDR T_0=20, T_mult=2)

### DIFF
--- a/train.py
+++ b/train.py
@@ -518,9 +518,9 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+restart_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=20, T_mult=2, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_scheduler, restart_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The current cosine schedule decays LR monotonically from 3e-3 to 1e-4. Once in the low-LR regime, the model can only make tiny updates and may be stuck in a local minimum. Cosine warm restarts (SGDR, Loshchilov & Hutter 2017) periodically resets the LR, allowing the model to escape local minima and explore different loss landscape regions. With T_0=20 and T_mult=2, the schedule does: restart at epoch 20, then at epoch 60 (=20+40). This gives two opportunities to escape while still having long enough decay periods for convergence.

## Instructions
Replace the cosine scheduler setup. Find where `CosineAnnealingLR` is created and replace with:

```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
    base_opt, T_0=20, T_mult=2, eta_min=1e-4
)
```

Keep the warmup scheduler and SequentialLR wrapper if present — the warm restarts should start after the 5-epoch warmup:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
restart_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=20, T_mult=2, eta_min=1e-4)
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, restart_scheduler], milestones=[5]
)
```

Run: `python train.py --agent alphonse --wandb_name "alphonse/cosine-warm-restarts" --wandb_group warm-restarts`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** 2zpxdr98
**Epochs completed:** ~63/100 (30-min timeout)

### Metrics at best checkpoint (epoch ~63)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.669 | 0.316 | 0.187 | 21.77 | 1.383 | 0.476 | 27.58 |
| tandem_transfer | 3.287 | 0.629 | 0.341 | 41.98 | 2.177 | 1.013 | 44.75 |
| ood_cond | 1.930 | 0.256 | 0.190 | 21.39 | 1.074 | 0.412 | 20.79 |
| **3split avg** | **2.2952** | — | — | — | — | — | — |

**Baseline comparison:**
- val/loss: 2.2952 vs 2.1997 — **regression (+0.0955)**
- mae_surf_p in_dist: 21.77 vs 20.03 — **regression (+1.74)**
- mae_surf_p tandem: 41.98 vs 40.41 — **regression (+1.57)**
- mae_surf_p ood_cond: 21.39 vs 20.57 — **regression (+0.82)**

**Peak memory:** Not logged (no OOM).

### What happened

Cosine warm restarts regressed vs baseline. At epoch 63, val/loss is 2.2952 — 4.3% worse than baseline (2.1997). The model was still converging at the 30-minute cutoff (2.34→2.31→2.30 over last 3 epochs), but well behind baseline.

The LR restarts appear to disrupt the model's fine-tuning phase. With the SequentialLR setup, restarts occur at global epochs 25 (restart_scheduler epoch 20) — right when the model is transitioning from coarse to fine optimization. The LR bump causes the model to lose precision it built during the initial cosine decay.

Looking at the loss trajectory around the first restart (epoch ~25): val/loss jumped from ~5.7 to 5.9 before recovering — the restart caused a visible setback. The baseline monotonic decay maintains a smooth transition to fine-grained updates without these disruptions.

The warm restarts hypothesis assumes the model is stuck in a local minimum, but in practice this model appears to be making steady progress throughout training. There's no evidence of plateauing that would warrant escape mechanisms.

### Suggested follow-ups

- **Later restart**: T_0=40 would push the first restart to epoch 45, after the model has converged more. Less disruption to early training.
- **Cyclic LR with small amplitude**: Instead of full restarts, use a narrow band (3e-4 to 1e-4) cycling fast — keeps the LR low while allowing small oscillations to escape local optima without destabilizing.
- **Plateau detection restart**: Only restart when val_loss hasn't improved for N epochs — avoids restarting when the model is still making progress.