### PR TITLE
Gradient norm clipping (max_norm=1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,7 +673,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
@@ -683,7 +683,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/grad_norm": grad_norm.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The model currently has no gradient clipping. Occasional large gradients (from tandem outlier samples or high-curvature surface nodes) may cause unstable parameter updates that hurt final convergence. Gradient norm clipping (max_norm=1.0) is standard practice in transformers and stabilizes training by bounding the magnitude of parameter updates. Combined with Lookahead and EMA, clipped gradients should produce smoother optimization trajectories.

## Instructions
In the training loop, after the backward pass and before the optimizer step, add gradient clipping. Find the `scaler.unscale_(base_opt)` or `optimizer.step()` call and add before it:

```python
# After scaler.unscale_ and before optimizer.step:
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
```

If using GradScaler with AMP, the pattern should be:
```python
scaler.unscale_(base_opt)
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
scaler.step(base_opt)
scaler.update()
```

Log the gradient norm for monitoring:
```python
grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
wandb.log({"train/grad_norm": grad_norm.item()})
```

Run: `python train.py --agent kohaku --wandb_name "kohaku/grad-clip-1.0" --wandb_group grad-clip`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run:** `mr3hxysu`
**Epochs completed:** 64

### IMPORTANT: Gradient clipping was already present in the code

Before implementing this PR, I discovered that `torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)` was already in the noam branch at line 676 (already applied before `optimizer.step()`). The only missing piece was the gradient norm logging. My implementation adds `grad_norm = ...` to capture the return value and log `train/grad_norm`.

### Metrics at best checkpoint (epoch 64)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.5922 | 0.3007 | 0.1780 | 21.09 | 1.2869 | 0.4489 | 26.29 |
| val_ood_cond | 1.9454 | 0.2717 | 0.1928 | 21.74 | 1.0386 | 0.4026 | 20.48 |
| val_tandem_transfer | 3.2575 | 0.6312 | 0.3354 | 41.25 | 2.1400 | 0.9928 | 42.94 |
| **3-split mean** | **2.2650** | — | — | — | — | — | — |

### Gradient norm statistics

| Metric | Value |
|---|---|
| Mean grad norm (before clip) | 20.0 |
| Max grad norm (before clip) | 68.9 |
| p95 grad norm | 34.5 |
| Fraction of batches clipped | **100%** |

### Comparison to baseline

| Run | val/loss_3split | Notes |
|---|---|---|
| Baseline v4 (curvature branch) | 2.1997 | May be a lucky run |
| Baseline v5 (this PR's code) | 2.2566 | Same code, different seed |
| This run (grad-clip + logging) | 2.2650 | Within noise range |

### What happened

Since gradient clipping was already present, this run is effectively a baseline measurement with grad_norm logging. The result (2.2650) is within the noise range (2.23 ± 0.03).

The gradient norm stats are informative: **100% of training steps are clipped** (mean norm = 20, clip threshold = 1.0). This means the raw gradients are consistently 20-70x above the clip threshold. The clipping is doing substantial work on every batch. This is why the model is sensitive to hyperparameters — the effective gradient magnitude is always clamped regardless of the actual loss surface.

### Suggested follow-ups

- **Ablation**: run without gradient clipping to see if removing it hurts training (it likely will, given the 100% clip rate confirms large raw gradients).
- **Higher clip threshold**: try max_norm=5.0 or 10.0, which may allow the model to take larger beneficial steps while still preventing catastrophic spikes.
- The 100% clip rate suggests the model operates in a regime where learning rate and architecture produce inherently large gradients — investigating weight initialization or architecture changes might be more impactful than clip threshold tuning.