### PR TITLE
Surface weight ramp-up schedule (start low, increase over training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -572,8 +572,12 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Adaptive surface weight with curriculum ramp: start at 1.0, reach dynamic value by epoch 30
+    dynamic_sw = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    if epoch < 30:
+        surf_weight = 1.0 + (dynamic_sw - 1.0) * (epoch / 30)
+    else:
+        surf_weight = dynamic_sw
 
     # --- Train ---
     model.train()
@@ -683,7 +687,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/surf_weight_effective": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The current surf_weight is computed dynamically as vol_loss/surf_loss (clamped 5-50) every epoch. In early training, when both losses are high and noisy, this ratio oscillates and may cause unstable gradient signals. A scheduled approach — starting with a low fixed surf_weight (1.0) and linearly ramping to the dynamic value over the first 30 epochs — would let the model first learn stable volume features, then gradually shift focus to the surface. This "curriculum" approach (volume first, surface later) aligns with the physics: volume features provide context for surface prediction.

## Instructions
In the training loop where `surf_weight` is computed (around line ~630-640), replace the dynamic computation with a scheduled ramp:

```python
# Compute the dynamic target surf_weight as before
dynamic_sw = (vol_loss.detach() / surf_loss.detach().clamp(min=1e-6)).clamp(5, 50)

# Ramp from 1.0 to dynamic value over first 30 epochs
ramp = min(1.0, epoch / 30)
surf_weight = 1.0 + (dynamic_sw - 1.0) * ramp

# After epoch 30, use full dynamic weight
```

Alternatively, if simpler:
```python
if epoch < 30:
    surf_weight = 1.0 + (dynamic_sw.item() - 1.0) * (epoch / 30)
else:
    surf_weight = dynamic_sw.item()
```

Log the effective surf_weight: `wandb.log({"train/surf_weight_effective": surf_weight})`

Run: `python train.py --agent askeladd --wandb_name "askeladd/surf-weight-schedule" --wandb_group surf-weight-schedule`

## Baseline
- val/loss: 2.1997
- surf_p MAE: in_dist=20.03, ood_cond=20.57, tandem=40.41

---

## Results

**W&B run**: ctkiduds
**Epochs**: 67 (run state=failed due to end-of-process RuntimeError unrelated to training; all epoch metrics valid)

| Metric | This run | Baseline | Δ |
|---|---|---|---|
| val/loss | 2.2402 | 2.1997 | **+1.84% worse** |
| in_dist / surf_p | 20.24 | 20.03 | +1.0% worse |
| tandem / surf_p | 40.51 | 40.41 | +0.2% worse |
| ood_cond / surf_p | 21.30 | 20.57 | +3.5% worse |
| in_dist / surf_Ux | 0.288 | 0.295 | +2.4% better |
| in_dist / surf_Uy | 0.176 | 0.179 | +1.7% better |

**Volume MAE (in_dist):** Ux=1.277, Uy=0.459, p=25.25

### What happened

This is the closest result to baseline among recent experiments (+1.84% vs the 3-8% degradation of other runs). The ramp-up helped surface velocity (Ux, Uy both improved), but surface pressure degraded slightly, particularly on ood_cond (+3.5%).

The current adaptive dynamic weight (starting at ~5 due to initial prev_vol/prev_surf ≈ 1.0/0.2) appears to be providing sufficient early-training surface signal. Starting at 1.0 for 30 epochs delays surface optimization long enough to cause a slight deficit that doesn't fully recover.

A key insight: the existing system already provides a "natural ramp" because in early epochs the vol/surf ratio is near its minimum clamped value (5), and it increases as training progresses. The proposed schedule overrides this with an artificial low start (1.0), which is actually *lower* than the existing minimum (5).

### Suggested follow-ups
- Instead of ramping from 1.0, try starting from 5.0 (the natural minimum) and ramping to the dynamic value — this would be less disruptive than going below the natural clamped minimum
- Or try the opposite: start at a high fixed value (e.g., 20) for the first 20 epochs to force early surface focus, then switch to dynamic