### PR TITLE
Late-stage pressure boost (epoch>50: 1.5x pressure in surface loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -645,7 +645,13 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        if epoch >= 50:
+            # Late-stage pressure boost: 1.5x on pressure, 0.8x on velocity
+            channel_weights = torch.tensor([0.8, 0.8, 1.5], device=abs_err.device)
+            abs_err_surf = abs_err * channel_weights[None, None, :]
+        else:
+            abs_err_surf = abs_err  # normal balanced training
+        surf_per_sample = (abs_err_surf * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Pressure-focused surface loss improves OOD pressure but hurts velocity when applied throughout training. A two-phase approach: train normally for 50 epochs (building solid velocity + pressure foundation), then boost pressure in the surface loss for the final ~17 epochs. The EMA (starting epoch 40) captures the early balanced model, and the late-stage boost fine-tunes the online model toward pressure without losing the velocity knowledge already in EMA.

## Instructions
In the surface loss computation (~line 648), add an epoch-conditional pressure boost:

```python
if epoch >= 50:
    # Late-stage pressure boost: 1.5x on pressure, 0.8x on velocity
    channel_weights = torch.tensor([0.8, 0.8, 1.5], device=abs_err.device)
    abs_err_surf = abs_err * channel_weights[None, None, :]
else:
    abs_err_surf = abs_err  # normal balanced training
surf_per_sample = (abs_err_surf * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
```

Run: `python train.py --agent edward --wandb_name "edward/late-pressure-boost" --wandb_group late-pressure-boost`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41

---
## Results

**W&B run:** `xdizz6n6`
**Best epoch:** 63/100 (~29.4s/epoch)

### val/loss
| Metric | Baseline | late-pressure-boost | Delta |
|--------|----------|---------------------|-------|
| val/loss (3-split) | 2.1997 | 2.3024 | +0.1027 (+4.7%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (boost) | p delta |
|-------|-----|-----|--------------|-----------|---------|
| in_dist | 0.295 | 0.181 | 20.03 | 20.57 | +0.54 (+2.7%) |
| ood_cond | 0.294 | 0.198 | 20.57 | 22.89 | +2.32 (+11.3%) |
| ood_re | 0.284 | 0.205 | — | 31.60 | — |
| tandem | 0.644 | 0.343 | 40.41 | 40.89 | +0.48 (+1.2%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.320 | 0.464 | 26.90 |
| ood_cond | 1.116 | 0.425 | 21.66 |
| ood_re | 1.067 | 0.448 | 51.60 |
| tandem | 2.164 | 1.000 | 43.94 |

**Peak memory:** No change.

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868 — same persistent instability.

### What happened
Late-stage pressure boost hurts: val/loss +4.7%, ood_cond surf_p +11.3%. The only mildly positive signal is that in_dist surf_p and tandem surf_p are close to baseline (+2.7% and +1.2%), suggesting the pressure boost might marginally help in-distribution but hurts generalization.

The disruption hypothesis likely explains this: after 50 epochs of balanced training, the model's internal representations are tuned for the balanced loss. Suddenly weighting pressure 1.5x and downweighting velocity 0.8x for the final 13 epochs shifts the gradient landscape enough to partially degrade the learned features, especially for OOD conditions that require robust velocity predictions. The EMA model (updated since epoch 40) accumulates the disturbed gradients and degrades.

The two-phase idea also adds a new hyperparameter (transition epoch=50) that wasn't tuned. With only ~63 epochs in the budget, epoch 50 leaves only 13 epochs of pressure-boosted training — potentially too little to see benefit and too much to avoid disruption.

### Suggested follow-ups
- Try starting the pressure boost later (epoch 60 instead of 50) to give less disruption time
- Try a gentler boost (channel_weights=[0.95, 0.95, 1.1]) to reduce disruption
- Alternatively, try freezing the EMA model at epoch 50 and only boosting the online model, so the EMA retains the balanced representation