### PR TITLE
EMA decay 0.999 (smoother exponential moving average)

### DIFF
--- a/train.py
+++ b/train.py
@@ -477,7 +477,7 @@ model = Transolver(**model_config).to(device)
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.999
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
The current EMA decay is 0.998 (established in #858). A higher decay of 0.999 averages over a longer history (~1000 vs ~500 parameter updates), producing a smoother model. With ~27 epochs of EMA (from epoch 40 to 67, ~27*300=8100 steps), decay=0.999 averages the last ~1000 steps (12% of post-EMA training). This could help if the training trajectory is noisy in late epochs, producing a model that generalizes better.

The tradeoff: 0.999 is slower to adapt, so if the model is still improving rapidly at the end, 0.998 captures more of the recent progress. But our models typically plateau around epoch 60, so the smoothing may help.

## Instructions
Find the EMA decay parameter:
```python
# Before: ema_decay = 0.998
# After: ema_decay = 0.999
```

Single number change. May be in Args dataclass or passed via `--ema_decay`.

Run: `python train.py --agent gilbert --wandb_name "gilbert/ema-999" --wandb_group ema-decay`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** f4jhcfb6
**Best epoch:** 67 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_p |
|---|---|---|
| val_in_dist | 1.5927 | 20.5 |
| val_tandem_transfer | 3.2612 | 41.6 |
| val_ood_cond | 1.8962 | 21.2 |
| val_ood_re | 18869.6 | 31.3 |
| **combined val/loss (3-split)** | **2.2501** | | |

**Baseline val/loss: 2.1997 → This run: 2.2501 (+0.050, slightly worse)**

### What happened

Increasing EMA decay from 0.998 to 0.999 is slightly worse than the baseline. The longer-history averaging does not help here.

The hypothesis was that 0.999 would smooth out late-training noise and generalize better. However, the result suggests the opposite: with only ~27 epochs of EMA averaging (epochs 40–67), decay=0.999 means the slow weights lag significantly behind the fast weights. By the final epoch, the EMA model is still catching up to where the fast model was several hundred steps ago, potentially missing the best minima the fast model found.

With decay=0.998, the EMA window is ~500 steps — large enough to smooth noise but small enough to track late improvements. With 0.999, the window grows to ~1000 steps, roughly 3 full epochs. Since our models still improve slightly up to epoch 60–65, the slower EMA adaptation means it never fully captures the converged state within the 30-min budget.

The +0.050 delta is at the edge of single-run noise (~0.05 threshold), so this could be statistical, but the direction is consistently negative.

### Suggested follow-ups

- **Stay at ema_decay=0.998.** The current value appears optimal for the 30-min training budget.
- **Try ema_decay=0.9985**: a midpoint between 0.998 and 0.999 — may offer slightly more smoothing without the lag penalty.
- **Longer training**: if we had 50+ epochs of EMA averaging, 0.999 might converge to a better average. But within 30 min, 0.998 captures more of the late improvements.