### PR TITLE
Extended warmup (10 epochs instead of 5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -517,10 +517,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The current linear LR warmup is 5 epochs. With 25 input features (including the recently added curvature proxy) and complex loss landscape, 5 epochs may be too short — the model may not have stabilized before hitting full LR. Extending to 10 epochs gives the optimizer more time to find a good initial direction before full-speed training. The cosine schedule still has 57 epochs of decay (plenty for convergence).

## Instructions
Find the warmup configuration:
```python
# Before: warmup total_iters=5 (or similar)
# After:
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
```

Also update the SequentialLR milestone:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
)
```

Run: `python train.py --agent senku --wandb_name "senku/warmup-10" --wandb_group warmup-length`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run ID**: pd76po23
**Best epoch**: 66 (30 min wall time)
**Peak GPU memory**: ~43 GB (same as baseline)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.1997 | 2.2912 | +0.092 (+4.2%) |
| surf_p in_dist | 20.03 | 21.00 | +0.97 |
| surf_p ood_cond | 20.57 | 22.85 | +2.28 |
| surf_p tandem | 40.41 | 42.33 | +1.92 |

Full breakdown at best epoch 66:

| Split | surf_Ux | surf_Uy | surf_p |
|-------|---------|---------|--------|
| val_in_dist | 0.3195 | 0.1769 | 21.00 |
| val_ood_cond | 0.2784 | 0.1980 | 22.85 |
| val_tandem | 0.6355 | 0.3377 | 42.33 |
| val_ood_re | 0.2755 | 0.2020 | 30.92 |

Note: run state is "failed" due to pre-existing visualization crash in this branch (curvature proxy dim mismatch in data/utils.py). Training metrics are valid.

### What happened

**Negative result** — extending warmup from 5 to 10 epochs made all metrics worse despite completing a similar number of epochs (66 vs ~66-83 for baseline).

Epoch count is not the issue — we got 66 epochs, comparable to baseline. The degradation comes from the warmup itself:

The cosine scheduler has T_max=75 (epochs of cosine decay after warmup ends). With 5-epoch warmup, cosine starts at epoch 5 and runs at full speed through the training budget. With 10-epoch warmup, the model spends 5 additional epochs at sub-optimal LR (still ramping from 0.1× to 1×). Those 5 epochs of slow warmup replace 5 early cosine epochs where learning is most efficient. The hypothesis assumed warmup was unstable — but the loss curves (train/loss = 0.55 at epoch 66) suggest the 5-epoch warmup was already sufficient for the model to find a good initial direction.

### Suggested follow-ups

- **Shorter warmup (3 epochs)**: If 5 is already sufficient, maybe 3 is enough and saves training time early. Low-priority since baseline 5 seems fine.
- **Cyclic warmup**: Instead of one warmup phase, use cosine warm restarts (SGDR) to periodically re-enter a warmup phase. More interesting than static warmup extension and could help escape local minima.