### PR TITLE
Gradient clip max_norm=5.0 (5x higher than current 1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,7 +673,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=5.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
@@ -683,7 +683,10 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if global_step % 10 == 0:
+            log_dict["train/grad_norm"] = grad_norm.item()
+        wandb.log(log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
**CRITICAL DISCOVERY:** Gradient clipping at max_norm=1.0 is already in the code, and **100% of training batches are clipped** (mean raw gradient norm=20, p95=34.5). The effective step size is ~20x lower than what the LR implies. Raising max_norm to 5.0 allows the model to take 5x larger steps, potentially enabling faster convergence and better final metrics. The raw gradients are stable (max=68.9, not diverging), suggesting higher clip thresholds are safe.

## Instructions
Find the gradient clipping line (~line 676):
```python
# Before: torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
# After:
grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=5.0)
```

Also log the gradient norm for analysis:
```python
if step % 10 == 0:
    wandb.log({"train/grad_norm": grad_norm.item()}, commit=False)
```

Run: `python train.py --agent kohaku --wandb_name "kohaku/grad-clip-5" --wandb_group grad-clip-sweep`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
- Current clip: max_norm=1.0, mean raw norm=20, 100% batches clipped
---
## Results

**W&B run:** `8b2mglpj`
**Epochs completed:** 64

### Metrics at best checkpoint (epoch 64)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.5933 | 0.2987 | 0.1804 | 21.91 | 1.2973 | 0.4662 | 26.71 |
| val_ood_cond | 1.9304 | 0.2674 | 0.1911 | 21.50 | — | — | — |
| val_tandem_transfer | 3.2764 | 0.6259 | 0.3401 | 42.46 | — | — | — |
| **3-split mean** | **2.2667** | — | — | — | — | — | — |

### Gradient norm statistics (max_norm=5.0)

| Metric | max_norm=1.0 (PR #968) | max_norm=5.0 (this run) |
|---|---|---|
| Mean grad norm | 20.0 | 20.2 |
| Max grad norm | 68.9 | 65.4 |
| p95 grad norm | 34.5 | 34.6 |
| Fraction clipped | 100% | 86% |

### Comparison to baseline

| Run | val/loss_3split | Notes |
|---|---|---|
| Baseline v4 | 2.1997 | May be a lucky run |
| Baseline v5 | 2.2566 | Same code, different seed |
| max_norm=1.0 (PR #968) | 2.2650 | Within noise |
| max_norm=5.0 (this run) | **2.2667** | Within noise |

### What happened

Raising max_norm from 1.0 to 5.0 did not improve results. The val/loss_3split of 2.2667 is essentially identical to the max_norm=1.0 run (2.2650), and both are within the baseline noise range (~2.23 ± 0.03).

**Why no improvement?** Even with max_norm=5.0, 86% of batches are still clipped (vs 100% at max_norm=1.0). The raw gradient distribution is heavy-tailed: the vast majority of batches produce gradients in the 5-70x range, and the clip threshold only affects the top tail. The effective step size has improved modestly (5x instead of 1x in some cases, 1x in 14% of batches), but this change wasn't large enough to move the final loss out of the noise floor.

**What does this tell us?** The model produces large, consistent gradients throughout training. This is likely a feature of the architecture (no BatchNorm/LayerNorm in the right places, or the mesh-based attention mechanism inherently produces large activations). Simply raising the clip threshold is not enough — the root cause may be in the architecture or learning rate schedule.

### Suggested follow-ups

- Try max_norm=None (no clipping) as an ablation to confirm clipping IS helping at all.
- Try max_norm=20 (matching the mean gradient norm) to allow most batches to take full steps.
- Investigate whether BF16 quantization is causing artificially large gradients at certain layers.