### PR TITLE
Gradient clip max_norm=10.0 (10x higher than current 1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,7 +673,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=10.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
@@ -683,7 +683,10 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if global_step % 10 == 0:
+            log_dict["train/grad_norm"] = grad_norm.item()
+        wandb.log(log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Same as grad-clip-5 but testing a higher threshold. With max_norm=10.0, most batches will still be clipped (raw mean=20), but now ~50% of the gradient magnitude passes through. This tests whether the model benefits from being closer to its natural gradient scale while still having protection against the worst outliers (max raw norm=68.9 would be clipped to 10).

## Instructions
Find the gradient clipping line (~line 676). Change max_norm=1.0 to max_norm=10.0 and log gradient norms.

Run: python train.py --agent alphonse --wandb_name alphonse/grad-clip-10 --wandb_group grad-clip-sweep

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
- Current clip: max_norm=1.0, mean raw norm=20, 100% batches clipped
---
## Results

**W&B run:** 9rijfxjf
**Epochs completed:** ~63/100 (30-min timeout)
**Observed grad_norm:** mean ~9.49 (most batches clipped at 10.0)

### Metrics at best checkpoint (epoch ~63)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.630 | 0.302 | 0.177 | 21.88 | 1.270 | 0.458 | 26.72 |
| tandem_transfer | 3.307 | 0.637 | 0.342 | 42.96 | 2.148 | 0.997 | 45.67 |
| ood_cond | 1.944 | 0.272 | 0.189 | 21.34 | 1.043 | 0.410 | 20.05 |
| **3split avg** | **2.2936** | — | — | — | — | — | — |

**Baseline comparison:**
- val/loss: 2.2936 vs 2.1997 — **regression (+0.0939)**
- mae_surf_p in_dist: 21.88 vs 20.03 — **regression (+1.85)**
- mae_surf_p tandem: 42.96 vs 40.41 — **regression (+2.55)**

### What happened

Relaxing gradient clipping to max_norm=10.0 did not improve performance. val/loss at epoch 63 is 2.2936, 4.3% worse than baseline (2.1997). The model was still converging at cutoff but behind baseline on all surface pressure metrics.

The final logged grad_norm of ~9.49 confirms most gradient steps are still clipped at 10.0 (raw mean=20). Counterintuitively, the strict 1.0 clip of the baseline appears to be an effective regularizer, forcing small consistent steps that prevent overshooting good weight configurations.

### Suggested follow-ups
- Test max_norm=5 as middle ground
- Per-layer gradient clipping (attention vs MLP)
- Confirm with grad-clip-5 whether any relaxation helps