### PR TITLE
Gradient clip max_norm=3.0 (3x higher than current 1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,7 +673,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=3.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
@@ -683,7 +683,10 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if global_step % 10 == 0:
+            log_dict["train/grad_norm"] = grad_norm.item()
+        wandb.log(log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The gradient clip sweep is testing 5.0, 10.0, and no-clip. This fills in the gap at max_norm=3.0 — a more conservative increase that may find the sweet spot between stability and expressiveness. With mean raw gradient norm=20, max_norm=3.0 still clips ~85% of batches but allows 3x the step size. This is the most conservative change in the sweep and therefore the most likely to improve without destabilizing.

## Instructions
Find the gradient clipping line (~line 676):
```python
# Before: torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
# After:
grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=3.0)
```

Log gradient norms:
```python
if step % 10 == 0:
    wandb.log({"train/grad_norm": grad_norm.item()}, commit=False)
```

Run: `python train.py --agent askeladd --wandb_name "askeladd/grad-clip-3" --wandb_group grad-clip-sweep`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
- Current clip: max_norm=1.0, mean raw norm=20, 100% batches clipped
---
## Results

**W&B run**: y4tub61j
**Epochs**: 67 (run state=failed due to end-of-process RuntimeError unrelated to training; all epoch metrics valid)
**Grad norm stats**: mean raw norm=20.52, max=54.36, min=1.45 (virtually all batches clipped at 3.0)

| Metric | max_norm=3.0 | Baseline (1.0) | Δ |
|---|---|---|---|
| val/loss | 2.2690 | 2.1997 | **+3.15% worse** |
| in_dist / surf_p | 21.23 | 20.03 | +6.0% worse |
| tandem / surf_p | 42.49 | 40.41 | +5.1% worse |
| ood_cond / surf_p | 21.41 | 20.57 | +4.1% worse |
| in_dist / surf_Ux | 0.292 | 0.295 | +1.0% better |

**Volume MAE (in_dist):** Ux=1.288, Uy=0.457, p=26.21

### What happened

max_norm=3.0 is clearly worse across all surface metrics. The raw gradient norms average ~20.5 (virtually identical to the baseline's ~20 from the PR description), meaning nearly all batches are still being clipped. Allowing 3x larger steps causes more aggressive parameter updates that apparently hurt the fine-grained pressure prediction.

The current max_norm=1.0 provides stronger effective regularization — it prevents any single batch from dominating the optimization trajectory, which appears beneficial for this dataset where surface pressure prediction requires careful, stable convergence. Increasing the clip only adds noise to the optimization path.

### Suggested follow-ups
- Given that all tested clip values (3.0, 5.0, 10.0, no-clip) are likely worse, the sweep will probably confirm that 1.0 is optimal
- Consider testing **max_norm=0.5** — a more conservative clip than current — to see if even tighter gradient control helps
- The consistently high raw gradient norms (~20) suggest the model may benefit from **gradient noise reduction** at the source (e.g., smaller batch size, more gradient accumulation steps)