### PR TITLE
Lower LR 1e-3 with existing clip=1.0 (effective LR recalibration)

### DIFF
--- a/train.py
+++ b/train.py
@@ -354,7 +354,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 1e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
We discovered that 100% of training batches are gradient-clipped at max_norm=1.0 (mean raw norm=20). This means the configured LR of 3e-3 is not the effective LR — the actual step size is dominated by the clip threshold. Since the grad clip sweep tests higher clip values, this experiment tests the complementary direction: lower the configured LR to 1e-3 while keeping clip=1.0.

With clip=1.0 dominating, the effective step size should be similar to baseline (both clipped to norm 1.0). BUT the cosine annealing schedule decays relative to the initial LR: with LR=1e-3, the schedule reaches lower LRs in late training (eta_min remains 1e-4, so the decay range is 1e-3→1e-4 vs 3e-3→1e-4). In practice, the very late epochs will have LR below the clip-effective rate, creating a gentler fine-tuning phase that may improve EMA quality.

## Instructions
Change the learning rate:
\`\`\`python
# Before: lr = 3e-3
# After: lr = 1e-3
\`\`\`

Keep all other settings (clip=1.0, cosine T_max, warmup=5) unchanged.

Run: `python train.py --agent thorfinn --wandb_name "thorfinn/lr-1e-3-clip-1" --wandb_group lr-clip-interaction`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
- Clip: max_norm=1.0, mean raw norm=20, 100% batches clipped
---
## Results

**W&B run:** \`e133vr06\` (thorfinn/lr-1e-3-clip-1)

| Metric | Baseline (lr=3e-3) | This run (lr=1e-3) | Delta |
|--------|-------------------|-------------------|-------|
| val/loss (3-split) | 2.1997 | 2.4638 | +12.0% ❌ |
| val_in_dist / mae_surf_p | 20.03 | 23.56 | +17.6% ❌ |
| val_tandem / mae_surf_p | 40.41 | 42.92 | +6.2% ❌ |
| val_ood_cond / mae_surf_p | 20.57 | 22.74 | +10.5% ❌ |
| val_in_dist / mae_vol_Ux | — | 1.578 | — |
| Peak memory | — | 10.6 GB | — |

Best checkpoint: epoch 66 of 100 (30 min timeout).

**What happened:** Large negative result. Reducing LR from 3e-3 to 1e-3 significantly hurt performance across all metrics (+12% val/loss, +17.6% in_dist surf_p).

The hypothesis that "effective LR is the same because everything is clipped" doesn't hold in practice. The reason: while the gradient *direction* is clip-dominated (step size is capped by max_norm=1.0), the actual parameter update also involves the Adam preconditioner (per-parameter adaptive scaling from the second moment estimate). The LR directly scales the preconditioned update. With LR=1e-3, the effective step size in the Adam-preconditioned space is 3× smaller than at LR=3e-3, even when gradient norms are clipped. The clip controls the raw norm; Adam's momentum and variance estimates still amplify the signal in directions of consistent gradient.

Additionally, the cosine decay range 1e-3→1e-4 means the model only has 10× dynamic range in LR, vs 30× for 3e-3→1e-4. The early warmup and high initial training phases are much less aggressive, slowing convergence in the 30-minute window.

**Suggested follow-ups:**
- The hypothesis about gentle late-epoch fine-tuning seems plausible but needs more epochs to manifest — not testable in 30 min.
- The right way to get lower effective LR at convergence may be to reduce eta_min (e.g., eta_min=1e-5) rather than changing the initial LR.
- LR=2e-3 might find a sweet spot if LR matters independently of clip.