### PR TITLE
Gradient clip max_norm=2.0 (conservative increase from 1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,7 +673,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=2.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
@@ -683,7 +683,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/grad_norm": grad_norm.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Fills in the grad clip sweep at max_norm=2.0. With mean raw gradient norm=20, this still clips ~90% of batches but doubles the effective step size. The most conservative increase in the sweep (1.0→3.0→5.0→10.0→∞). If 3.0 is optimal, 2.0 gives a nearby data point.

## Instructions
```python
# Change: max_norm=1.0 → max_norm=2.0
grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=2.0)
```
Log grad norms. Run: `python train.py --agent frieren --wandb_name "frieren/grad-clip-2" --wandb_group grad-clip-sweep`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** `e8x4xixz` (frieren/grad-clip-2)
**Epochs:** 66 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.642 | 0.312 | 0.180 | **22.18** | 1.291 | 0.463 | 26.46 |
| val_ood_cond | 1.882 | 0.265 | 0.189 | **21.16** | 1.034 | 0.393 | 19.66 |
| val_ood_re | overflow | 0.276 | 0.198 | **30.99** | 1.034 | 0.435 | 50.89 |
| val_tandem_transfer | 3.282 | 0.631 | 0.340 | **42.03** | 2.111 | 0.984 | 44.16 |
| **combined val/loss** | **2.2687** | | | | | | |

**vs baseline (2.1997, max_norm=1.0):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.1997 | 2.2687 | **+0.069 (+3.1%)** |
| surf_p in_dist | 20.03 | 22.18 | **+2.15 (+10.7%)** |
| surf_p ood_cond | 20.57 | 21.16 | **+0.59 (+2.9%)** |
| surf_p tandem | 40.41 | 42.03 | **+1.62 (+4.0%)** |

**Peak GPU memory:** ~10.6 GB

**Gradient norm statistics:**
- Mean raw grad norm: 20.51, median: 21.23, p90: 31.97, max: 87.86
- Batches clipped at 2.0: 21,382 / 21,867 = **97.8%**

### What happened

Negative result. max_norm=2.0 performs slightly worse than baseline (max_norm=1.0) by +3.1% val/loss and +10.7% surf_p in_dist. The difference could be within run-to-run variance, but the direction is consistently worse across all metrics.

**Key finding — almost all batches still clipped**: 97.8% of batches have raw gradient norm > 2.0. The median raw grad norm is 21.23, nearly 10x the clip threshold. This means:
1. Doubling from 1.0 to 2.0 doubles the effective step size, but doesn't change the gradient direction at all (the direction is normalized either way)
2. The only effect is larger update magnitude, which at 2.0 may be slightly too aggressive for fine convergence

**Why baseline max_norm=1.0 may be better**: The raw gradients average ~20 norm, and both 1.0 and 2.0 clip them down to nearly the same direction. The difference is purely in learning rate scaling. At 2.0, the effective LR doubles, which might cause overshooting in the later training epochs where the cosine-decayed LR is already small. This could explain the slight degradation.

**Context for the sweep**: With 97.8% clipping at max_norm=2.0, any value from 1.0 to ~20 will effectively clip nearly all gradients. The "no-clip" condition would be the meaningful comparison — it would allow occasional high-gradient batches to take larger steps, which might actually help escape plateaus.

### Suggested follow-ups

- **Confirm with no-clip baseline**: With max_norm=∞ (or very large), the raw gradient directions and magnitudes are unmodified. This is the true comparison to understand if gradient clipping helps at all.
- **Clip based on percentile**: Rather than fixed max_norm, clip at the median grad norm each epoch (adaptive clipping). This would allow ~50% of batches to take larger steps proportionally.
- **Separate LR from clip**: The clip threshold and effective LR interact. If doubling the clip doubles effective LR, consider halving the learning rate alongside increasing the clip to decouple the effects.