### PR TITLE
Feature dropout (randomly zero 1 input channel per forward pass)

### DIFF
--- a/train.py
+++ b/train.py
@@ -611,6 +611,12 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        if model.training:
+            # Feature dropout: randomly zero one input channel per batch
+            drop_ch = torch.randint(0, x.shape[-1], (1,)).item()
+            x = x.clone()
+            x[:, :, drop_ch] = 0.0
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
             pred = out["preds"]


### PR DESCRIPTION
## Hypothesis
Node dropout failed (corrupts spatial input). Feature dropout is different: randomly zero one of the 25 input channels per forward pass during training. This forces the model to not rely on any single feature, improving robustness. With 25 features, dropping 1 is only 4% of information — a mild regularizer that might help OOD generalization where some features shift.

## Instructions
In the training loop, after constructing x but before the forward pass:

```python
if model.training:
    # Randomly zero one input channel per batch
    drop_ch = torch.randint(0, x.shape[-1], (1,)).item()
    x = x.clone()
    x[:, :, drop_ch] = 0.0
```

Never drop during validation. Note: the curvature proxy (channel 24) and key position features (channels 0-1) could be important — if results are poor, try protecting these channels:
```python
    protected = {0, 1, 24}  # x, y, curvature
    drop_ch = torch.randint(0, x.shape[-1] - len(protected), (1,)).item()
    # ... map to non-protected channel
```

Run: `python train.py --agent nezuko --wandb_name "nezuko/feature-dropout" --wandb_group feature-dropout`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** udujgg0b | Runtime: 1910s (~31.8 min, ~63 epochs, 30s/epoch)
*(Run state shows "failed" due to SIGTERM at timeout — data is valid)*

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|---|---|---|---|---|---|
| **in_dist** | 1.9615 | 0.359 | 0.209 | **28.42** | 32.65 |
| **ood_cond** | 2.1082 | 0.279 | 0.205 | **23.72** | 21.00 |
| **ood_re** | — | — | — | **34.39** | — |
| **tandem** | 3.3819 | 0.644 | 0.351 | **42.36** | 43.88 |
| **val/loss (3-split)** | **2.4838** | | | | |

| Metric | Baseline | Feature dropout | Δ |
|---|---|---|---|
| val/loss | 2.1997 | 2.4838 | +12.9% ❌ |
| surf_p in_dist | 20.03 | 28.42 | +41.9% ❌ |
| surf_p ood_cond | 20.57 | 23.72 | +15.3% ❌ |
| surf_p tandem | 40.41 | 42.36 | +4.8% ❌ |

### What happened

Negative result. Feature dropout severely degraded performance, with surface pressure in-distribution worsening by +41.9%.

The core problem: these input features are not redundant — they encode distinct physical quantities. The 25 channels carry position (x, y), SDF gradients (channels 2-5), Reynolds number (channel 13), gap geometry (channel 21), foil-2 features (channels 17-24), and curvature proxy (channel 24). When any one of these is dropped randomly, the model receives corrupted physics inputs that don't correspond to any valid physical state.

Feature dropout makes sense for correlated or redundant features (e.g., in NLP where word embeddings overlap). Here, dropping channel 13 (Reynolds number) removes the primary flow condition — the model must predict velocity and pressure with no Re information. This is fundamentally different from dropout in the hidden layers, which only affects learned representations.

The result is not surprising given that this is a physics-informed task: every input dimension has specific physical meaning. Standard data augmentation strategies (masking, dropout) that work in computer vision don't transfer to physics-encoded inputs.

### Suggested follow-ups
- Instead of feature dropout, try adding Gaussian noise to specific features (smoother regularizer, doesn't fully corrupt inputs)
- Dropout on learned intermediate representations (attention or MLP hidden states) is safer — these are already in a learned space without hard physical constraints
- The in-dist degradation (+41.9%) is much worse than OOD splits, suggesting the model over-fits when input features are complete, and the noise helps OOD slightly — but the overall cost is too high