### PR TITLE
Learned per-channel output scaling (3 learnable scale params)

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,7 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.output_scale = nn.Parameter(torch.ones(3))  # [Ux, Uy, p]
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -339,6 +340,7 @@ class Transolver(nn.Module):
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)
+        fx = fx * self.output_scale[None, None, :]  # learned per-channel scaling
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}
 


### PR DESCRIPTION
## Hypothesis
The output head predicts [Ux, Uy, p] at different scales. A learned per-channel scale parameter (initialized to 1.0) after the output head lets the model adjust its output range for each channel independently, without architectural changes. The pressure channel might benefit from a different effective output scale than velocity. This is a 3-parameter change.

## Instructions
In `Transolver.__init__`, add:
```python
self.output_scale = nn.Parameter(torch.ones(3))  # [Ux, Uy, p]
```

In `Transolver.forward`, after the output head returns predictions:
```python
fx = self.blocks[0](fx, spatial_bias=sb)  # existing
fx = fx * self.output_scale[None, None, :]  # learned per-channel scaling
```

Run: `python train.py --agent edward --wandb_name "edward/output-scale-learned" --wandb_group output-scaling`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41

---
## Results

**W&B run:** `7ofadah0`
**Best epoch:** 63/100 (~28.4s/epoch)

### val/loss
| Metric | Baseline | output-scale | Delta |
|--------|----------|-------------|-------|
| val/loss (3-split) | 2.1997 | 2.3007 | +0.1010 (+4.6%) |

### Surface MAE
| Split | Ux | Uy | p (baseline) | p (scale) | p delta |
|-------|-----|-----|--------------|-----------|---------|
| in_dist | 0.306 | 0.183 | 20.03 | 22.77 | +2.74 (+13.7%) |
| ood_cond | 0.275 | 0.190 | 20.57 | 21.19 | +0.62 (+3.0%) |
| ood_re | 0.278 | 0.199 | — | **30.81** | ~−0.1 |
| tandem | 0.644 | 0.347 | 40.41 | 42.25 | +1.84 (+4.6%) |

### Volume MAE
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.318 | 0.470 | 27.25 |
| ood_cond | 1.053 | 0.398 | 19.75 |
| ood_re | 1.035 | 0.434 | 50.74 |
| tandem | 2.179 | 1.009 | 44.43 |

**Peak memory:** Negligible increase — 3 extra parameters.

**Note on ood_re:** val_ood_re/vol_loss spikes to ~18868 — same persistent instability.

### What happened
Learned output scaling hurts: val/loss +4.6%, in_dist surf_p +13.7%, tandem surf_p +4.6%. The only marginal improvement is ood_re surf_p (~30.81 vs ~30.90 baseline, -0.3%).

The 3-parameter output scale initialized to 1.0 gives the model freedom to scale each output channel. However, this freedom appears to be detrimental: the model may find local optima where the output_scale deviates from 1.0 in ways that overfit to training distribution but hurt validation. The feature also adds overhead (~28.4s vs 25s/epoch), reducing training to 63 epochs.

More fundamentally, the output is already in a well-normalized space (phys-normalized Cp space). Adding a global scale on top of this doesn't provide useful additional capacity — the output head's linear layer already subsumes any fixed scaling. What the model would need is input-conditional scaling, not a fixed learned scalar.

### Suggested follow-ups
- Output scaling might be more useful if it's condition-dependent: e.g., scale as a function of Re or AoA
- Zero-init the output_scale (nn.Parameter(torch.zeros(3))) and apply as multiplicative bias: pred * (1 + output_scale) — guarantees starting at baseline