### PR TITLE
EMA start epoch 30 (earlier averaging, 37 EMA epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -476,7 +476,7 @@ model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 30
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
EMA currently starts at epoch 40 (27 EMA epochs in a 67-epoch run). Starting earlier at epoch 30 gives 37 EMA epochs — 37% more averaging. EMA 0.999 (longer averaging) was slightly worse, but this achieves more averaging via more epochs while keeping the faster-adapting 0.998 decay. The model has already learned useful representations by epoch 30 (loss curve shows rapid improvement in first 20 epochs).

## Instructions
Change the EMA start epoch:
```python
# Before: ema_start_epoch = 40
# After: ema_start_epoch = 30
```

This might be in the Args dataclass or passed via command line.

Run: `python train.py --agent gilbert --wandb_name "gilbert/ema-start-30" --wandb_group ema-timing`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** c0d6wuev
**Best epoch:** 65 / 100 (30-min timeout)
**Peak memory:** ~10.6 GB

### Metrics

| Split | val/loss | mae_surf_p |
|---|---|---|
| val_in_dist | 1.5765 | 20.7 |
| val_tandem_transfer | 3.2052 | 42.1 |
| val_ood_cond | 1.8670 | 20.2 |
| val_ood_re | 18869.6 | 31.2 |
| **combined val/loss (3-split)** | **2.2162** | | |

**Baseline val/loss: 2.1997 → This run: 2.2162 (+0.017, within noise)**

### What happened

Starting EMA at epoch 30 instead of epoch 40 produces a marginally worse result (+0.017), well within single-run noise (~0.05 threshold). The result is essentially a null finding — more EMA epochs does not help here.

This is consistent with prior work: PR #875 tested the same change against an older baseline (2.2068) and found +0.048. The direction is the same: slightly negative, but the smaller delta here (+0.017 vs +0.048) suggests the effect is genuinely near zero.

The likely explanation: during epochs 30–40, the model is still in the progressive resolution curriculum phase (volume nodes are sub-sampled). Weights from this phase represent a model trained on a simplified distribution, so including them in the EMA average introduces a systematic bias. Epoch 40 appears to be a natural transition point — right when full-resolution training begins — making it the appropriate EMA start.

The +0.017 delta could be noise, but the consistent negative direction across both this run and PR #875 suggests epoch 40 is the right start for EMA.

### Suggested follow-ups

- **Keep ema_start_epoch=40.** The current value aligns with the end of the progressive curriculum and appears well-calibrated.
- **Try ema_start_epoch=45**: if anything, slightly later might be even better since the model needs a few full-resolution epochs to stabilize.
- **Investigate the curriculum transition more carefully**: the sweet spot for EMA start may be tied to when full-resolution training stabilizes, not just when it begins.