### PR TITLE
Tandem loss boost 3x (increase weight on tandem samples)

### DIFF
--- a/train.py
+++ b/train.py
@@ -644,7 +644,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_boost = torch.where(is_tandem, 3.0, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Tandem surf_p (40.41) is 2x worse than in_dist (20.03). The model likely under-weights tandem because they're a minority of training data. Boosting the loss weight on tandem samples by 3x forces the model to allocate more capacity to the harder tandem predictions. This targets our weakest metric directly.

## Instructions
Find where tandem_boost is computed/applied in the training loop. Increase the tandem multiplier:

```python
# Look for tandem_boost or similar — it may already exist
# If tandem_boost exists, change from current value to 3.0:
tandem_boost = torch.where(is_tandem, torch.tensor(3.0, device=device), torch.tensor(1.0, device=device))
```

If tandem_boost does not exist, add it after detecting tandem samples and multiply the per-sample loss by this boost.

Run: `python train.py --agent senku --wandb_name "senku/tandem-boost-3x" --wandb_group tandem-boost`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run ID**: rygh8po4
**Best epoch**: 65 (30 min wall time)
**Peak GPU memory**: ~43 GB (same as baseline)

Note: `tandem_boost` already existed in the baseline branch at 1.5x. This PR changed it from 1.5x to 3.0x.

| Metric | Baseline (1.5x) | This run (3.0x) | Delta |
|--------|----------------|-----------------|-------|
| val/loss (3-split) | 2.1997 | 2.2686 | +0.069 (+3.1%) |
| surf_p in_dist | 20.03 | 20.24 | +0.21 |
| surf_p ood_cond | 20.57 | 20.75 | +0.18 |
| surf_p tandem | 40.41 | 43.38 | +2.97 |

Full breakdown at best epoch 65:

| Split | surf_Ux | surf_Uy | surf_p |
|-------|---------|---------|--------|
| val_in_dist | 0.2884 | 0.1780 | 20.24 |
| val_ood_cond | 0.2660 | 0.1876 | 20.75 |
| val_tandem | 0.6347 | 0.3365 | 43.38 |
| val_ood_re | 0.2769 | 0.1987 | 30.62 |

Note: run state is "failed" due to pre-existing visualization crash in this branch (curvature proxy dim mismatch). Training metrics are valid.

### What happened

**Negative result** — increasing tandem boost from 1.5x to 3.0x made tandem predictions significantly worse (+2.97 surf_p), contrary to the hypothesis. In_dist and ood_cond were almost unchanged (+0.21, +0.18).

Two likely causes:

1. **Overfitting to tandem training distribution**: Tripling the tandem loss weight forces the model to fit tandem training samples more aggressively. But the tandem validation set (`val_tandem_transfer`) uses an out-of-distribution front foil shape not seen in training. Overweighting tandem training samples drives the model to memorize tandem-specific patterns that do not generalize to the OOD front foil.

2. **Loss landscape distortion**: With 3x boost on ~15-20% of training samples, the gradient direction is heavily skewed toward tandem. This may destabilize the optimization balance between single-foil and tandem configurations, hurting the overall model.

The baseline 1.5x was likely already a well-calibrated tradeoff. The tandem problem is fundamentally an OOD transfer problem, not an under-weighting problem — boosting the weight does not give the model new information about the unseen front foil shapes.

### Suggested follow-ups

- **Reduce boost back toward 1.0x**: Test 1.0x (no boost) vs 1.5x (baseline) to understand if the existing boost is helping. It is possible the 1.5x baseline boost is already hurting.
- **Data augmentation for tandem**: Instead of reweighting, augment tandem training samples (e.g., mirroring foil geometry) to increase effective tandem diversity.
- **Tandem-specific head**: Add a separate output head or adapter for tandem configurations so the model can specialize without hurting single-foil performance.