### PR TITLE
Gradient clip max_norm=0.5 (tighter clipping — test other direction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,7 +673,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
@@ -683,7 +683,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/grad_norm": grad_norm.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The grad clip sweep tests higher max_norm values (2, 3, 5, 10, none). Early results show no-clip is +10.4% worse — raw gradients are too large. This tests the OPPOSITE direction: max_norm=0.5 (half the current 1.0). If the baseline max_norm=1.0 is already a good tradeoff, going tighter should be slightly worse. But if there is a regime where even tighter clipping helps (more stable updates, better convergence), this finds it. Either way, this completes the sweep on the low end.

## Instructions
```python
# Change: max_norm=1.0 → max_norm=0.5
grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
```
Log grad norms. Run: `python train.py --agent tanjiro --wandb_name "tanjiro/grad-clip-0.5" --wandb_group grad-clip-sweep`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
- Current clip: max_norm=1.0, mean raw norm=20, 100% batches clipped
---
## Results

**W&B run:** 80k0ib73  
**Epochs:** 67 (30.5 min wall-clock, ~27s/epoch)  
**Peak VRAM:** 10.6 GB  

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6228 | 0.300 | 0.181 | 21.3 | 1.274 | 0.451 | 25.6 |
| val_tandem_transfer | 3.2398 | 0.629 | 0.336 | 41.1 | 2.121 | 0.985 | 44.0 |
| val_ood_cond | 1.7808 | 0.250 | 0.181 | **19.3** | 0.988 | 0.388 | 18.9 |
| val_ood_re | 18869.5* | 0.268 | 0.196 | 30.3 | 0.998 | 0.430 | 50.7 |
| **combined (3-split)** | **2.2145** | | | | | | |

*Pre-existing branch bug (ood_re vol_loss overflow), excluded from 3-split.

**vs baseline:**
- val/loss: 2.2145 vs 2.1997 → **+0.7% (essentially neutral)**
- surf_p in_dist: 21.3 vs 20.03 → **+6.3% (worse)**
- surf_p tandem: 41.1 vs 40.41 → **+1.7% (minor)**
- surf_p ood_cond: **19.3 vs 20.57 → -6.2% (improved!)**

**What happened:**

Mixed result. Overall val/loss is essentially unchanged (+0.7%), but the results diverge by split: in_dist surface pressure regressed (+6.3%) while ood_cond surface pressure improved significantly (-6.2%). Tandem was minor.

The hypothesis that tighter clipping hurts is not confirmed for ood_cond — if anything, max_norm=0.5 appears slightly better for OOD generalization. This could be because:
1. Smaller, more stable updates help the model converge to a more generalizable minimum
2. The gradient noise is slightly different, by chance landing in a better basin for ood_cond
3. The in_dist regression and ood_cond improvement may be a tradeoff inherent to this level of clipping

The grad norm logging showed that with max_norm=0.5, nearly all batches are still clipped (raw norms ~20 >> 0.5), so effective update sizes are halved vs baseline.

**Suggested follow-ups:**
- Try max_norm=0.7 or 0.8 as intermediate values to see if there is a sweet spot between 0.5 and 1.0
- Focus analysis on ood_cond surf_p specifically to understand why tighter clipping helps OOD but not in-distribution