### PR TITLE
Baseline variance: seed=42 (characterize noise floor)

### DIFF
--- a/train.py
+++ b/train.py
@@ -364,12 +364,17 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int | None = None
 
 
 cfg = sp.parse(Config)
 
 if cfg.debug:
     MAX_EPOCHS = 3
+
+if cfg.seed is not None:
+    torch.manual_seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))


### PR DESCRIPTION
## Hypothesis
The baseline val_loss=2.1997 may be a lucky seed. The grad-clip-5 experiment found that a baseline rerun (same code, different seed) gives val_loss=2.2566 — a 2.6% difference from seed alone. Near-neutral experiments (MLP dropout, attn dropout) give val_loss ~2.22-2.27. We need to characterize the seed variance to know when improvements are real vs noise.

**This is a pure baseline rerun with seed=42.** No code changes.

## Instructions
Run the baseline with explicit seed=42:
```bash
python train.py --agent kohaku --wandb_name "kohaku/baseline-seed-42" --seed 42 --wandb_group baseline-variance
```

If `--seed` is not a command line arg, set it in the code:
```python
torch.manual_seed(42)
torch.cuda.manual_seed_all(42)
```

**Report all metrics in detail** — this run establishes the noise floor for evaluating future experiments.

## Baseline
- val/loss: 2.1997 (seed unknown), surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
- Suspected noise range: val_loss ≈ 2.23 ± 0.03
---
## Results

**W&B run:** `tmsabbuz`
**Epochs completed:** 63 (run state: crashed/timeout at 30 min)
**Implementation note:** `--seed` was not a command-line arg; added `seed: int | None = None` to Config and called `torch.manual_seed(cfg.seed)` / `torch.cuda.manual_seed_all(cfg.seed)` after parsing.

### Metrics at best checkpoint (epoch 63)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6232 | 0.3036 | 0.1776 | 21.03 | 1.2933 | 0.4599 | 25.84 |
| val_ood_cond | 1.9001 | 0.2579 | 0.1879 | 21.06 | 1.0343 | 0.3984 | 19.33 |
| val_tandem_transfer | 3.2365 | 0.6220 | 0.3340 | 41.73 | 2.1221 | 0.9791 | 43.58 |
| **3-split mean** | **2.2532** | — | — | — | — | — | — |

### Noise floor characterization (all runs on curvature-proxy code)

| Run | val/loss_3split |
|---|---|
| Baseline v4 (curvature PR merge) | 2.1997 |
| Baseline v5 (random seed) | 2.2566 |
| seed=42 (this run) | **2.2532** |
| grad-clip-1.0 (random seed) | 2.2650 |
| grad-clip-5.0 (random seed) | 2.2667 |

Excluding the v4 baseline: mean=2.260, std≈0.007, range=2.253–2.267  
Including v4: mean=2.248, std≈0.025, range=2.200–2.267

### What happened

seed=42 gives val/loss_3split=2.2532, consistent with recent runs (2.25–2.27 range). The v4 baseline (2.1997) remains an outlier — it is 0.06 below the mean of all other runs. This could be:
1. A lucky random seed (if the v4 run used a particularly favorable initialization)
2. A code difference — v4 was the commit that INTRODUCED the curvature proxy; subsequent baseline reruns may include additional tweaks from other PRs that slightly raised the noise floor

**Revised noise floor estimate:** val/loss_3split ≈ 2.26 ± 0.01 (tight cluster of 4 runs). To claim a real improvement, a result would need to beat ~2.24 (2σ below mean), not just 2.20 (the outlier v4 result).

### Suggested follow-ups

- Run seed=0 or seed=1337 for one more data point to confirm the tight cluster.
- Investigate why v4 gave 2.1997 — check git log for code differences at that commit vs current noam HEAD.
- Use val/loss_3split ≤ 2.24 as the new "real improvement" threshold in future experiment writeups.