### PR TITLE
Coordinate rotation augmentation (physics-preserving, ±15°)

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -588,6 +589,17 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        # Coordinate rotation augmentation (physics-preserving, ±15°)
+        rot_cos, rot_sin = 1.0, 0.0
+        if model.training and torch.rand(1).item() < 0.5:
+            theta = (torch.rand(1).item() * 30 - 15) * math.pi / 180
+            rot_cos, rot_sin = math.cos(theta), math.sin(theta)
+            x_new = x.clone()
+            x_new[:, :, 0] = rot_cos * x[:, :, 0] - rot_sin * x[:, :, 1]
+            x_new[:, :, 1] = rot_sin * x[:, :, 0] + rot_cos * x[:, :, 1]
+            x_new[:, :, 2] = rot_cos * x[:, :, 2] - rot_sin * x[:, :, 3]
+            x_new[:, :, 3] = rot_sin * x[:, :, 2] + rot_cos * x[:, :, 3]
+            x = x_new
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
@@ -595,6 +607,11 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
+            if rot_cos != 1.0:  # rotation was applied
+                y_new = y_norm.clone()
+                y_new[:, :, 0] = rot_cos * y_norm[:, :, 0] - rot_sin * y_norm[:, :, 1]
+                y_new[:, :, 1] = rot_sin * y_norm[:, :, 0] + rot_cos * y_norm[:, :, 1]
+                y_norm = y_new
             noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 


### PR DESCRIPTION
## Hypothesis
All previous augmentation attempts (mixup, noise, feature dropout) were non-physical or destroyed signal. Coordinate rotation IS a physics-preserving transformation for 2D flow: rotate the mesh by angle θ, also rotate (Ux, Uy) by θ, but pressure is scalar and stays unchanged. This is a free data augmentation exploiting a genuine symmetry the model currently cannot exploit.

## Instructions
During training, with probability 0.5, apply a random rotation θ ~ Uniform(-15°, +15°) to positions (features 0-1), SAF features (2-3), and target velocities (y_norm channels 0-1). Pressure unchanged.

Run: `python train.py --agent frieren --wandb_name "frieren/coord-rotation-aug" --wandb_group coord-rotation`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** `uatl0tud` (frieren/coord-rotation-aug)
**Epochs:** 66 (30-min wall-clock limit)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.648 | 0.303 | 0.192 | **22.67** | 1.362 | 0.497 | 27.99 |
| val_ood_cond | 2.034 | 0.265 | 0.208 | **22.38** | 1.081 | 0.431 | 20.52 |
| val_ood_re | overflow | 0.279 | 0.211 | **31.81** | 1.090 | 0.456 | 51.58 |
| val_tandem_transfer | 3.327 | 0.636 | 0.350 | **42.61** | 2.207 | 1.013 | 45.18 |
| **combined val/loss** | **2.3363** | | | | | | |

**vs baseline (2.1997):**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 2.1997 | 2.3363 | **+0.137 (+6.2%)** |
| surf_p in_dist | 20.03 | 22.67 | **+2.64 (+13.2%)** |
| surf_p ood_cond | 20.57 | 22.38 | **+1.81 (+8.8%)** |
| surf_p ood_re | 30.90 | 31.81 | **+0.91 (+2.9%)** |
| surf_p tandem | 40.41 | 42.61 | **+2.20 (+5.4%)** |

**Peak GPU memory:** ~10.6 GB

### What happened

Negative result. Coordinate rotation augmentation hurt all metrics by 3-13%. This contradicts the hypothesis that rotation is a "free" physics-preserving augmentation.

**Why rotation didn't help**:

1. **The dataset already covers AoA variation**: The training set includes samples at various angles of attack, effectively encoding a range of flow orientations. Applying ±15° rotation creates augmented samples that closely resemble real samples at slightly different AoA — not new generalization signal, but potentially OOD variations relative to the dataset distribution.

2. **Normalization breaks exact rotation symmetry**: After `x = (x - stats["x_mean"]) / stats["x_std"]`, the coordinate axes have different scale factors (std_x ≠ std_y in general). Rotation in this space is not the same as rotation in physical space. Features 0 and 1 have different standard deviations, so a 15° rotation in normalized space corresponds to a different angle in physical space.

3. **Curvature proxy inconsistency**: The curvature is computed as `x[:, :, 2:6].norm()`, using features 2-5. We rotated features 2-3 (SAF) but left 4-5 unchanged. While the 2-norm is rotation-invariant for [2,3] and [4,5] separately, the full 4-dim norm may not be exactly preserved if 4-5 aren't also part of the same rotation group.

4. **Rotation of y_norm after physics normalization**: The velocity is normalized using per-sample Umag and dynamic pressure q. After this normalization, the "direction" of velocity in normalized space doesn't correspond cleanly to a physical rotation angle. Rotating normalized velocities may introduce inconsistencies.

5. **Clone-based approach**: Using `x_new = x.clone()` and then doing in-place operations is correct, but may have increased per-batch time slightly.

### Suggested follow-ups

- **Rotation in raw (unnormalized) space**: Apply rotation BEFORE `x = (x - stats["x_mean"]) / stats["x_std"]` to avoid normalization-scale mismatch. This requires accessing the raw x before the normalization step.
- **Larger rotation range**: If ±15° closely mirrors existing AoA coverage, ±30° or ±45° might provide genuinely novel samples. However, larger angles may be OOD relative to airfoil physics.
- **Accept that augmentation doesn't help**: Multiple augmentation attempts (mixup, noise, rotation) have all failed. The model may already be well-matched to the dataset size, and augmentation adds distributional noise rather than useful diversity.