### PR TITLE
Snapshot ensemble (3 cosine valleys, weight-average at minima)

### DIFF
--- a/train.py
+++ b/train.py
@@ -475,9 +475,8 @@ model_config = dict(
 model = Transolver(**model_config).to(device)
 
 from copy import deepcopy
-ema_model = None
-ema_start_epoch = 40
-ema_decay = 0.998
+snapshots = []
+snapshot_avg_model = None
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -518,7 +517,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=22, T_mult=1, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
@@ -675,13 +674,6 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -691,13 +683,23 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    # Snapshot ensemble: save model at each cosine cycle minimum
+    if (epoch + 1) % 22 == 0:
+        snapshots.append({k: v.clone() for k, v in model.state_dict().items()})
+        if len(snapshots) == 3:
+            avg_state = {}
+            for key in snapshots[0]:
+                avg_state[key] = sum(s[key] for s in snapshots) / len(snapshots)
+            snapshot_avg_model = deepcopy(model)
+            snapshot_avg_model.load_state_dict(avg_state)
+            snapshot_avg_model = snapshot_avg_model.to(device)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
 
     # --- Validate across all splits ---
-    eval_model = ema_model if ema_model is not None else model
+    eval_model = snapshot_avg_model if snapshot_avg_model is not None else model
     eval_model.eval()
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}
@@ -835,7 +837,7 @@ for epoch in range(MAX_EPOCHS):
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v
-        save_model = ema_model if ema_model is not None else model
+        save_model = snapshot_avg_model if snapshot_avg_model is not None else model
         torch.save(save_model.state_dict(), model_path)
         tag = f" * -> {model_path}"
 
@@ -872,9 +874,12 @@ if best_metrics:
     model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
     plot_dir = Path("plots") / run.id
     # Visualize from val_in_dist — same distribution as original val_ds
-    images = visualize(model, val_splits["val_in_dist"], stats, device,
-                       n_samples=2 if cfg.debug else 4, out_dir=plot_dir)
-    if images:
-        wandb.log({"val_predictions": [wandb.Image(str(p)) for p in images], "global_step": global_step})
+    try:
+        images = visualize(model, val_splits["val_in_dist"], stats, device,
+                           n_samples=2 if cfg.debug else 4, out_dir=plot_dir)
+        if images:
+            wandb.log({"val_predictions": [wandb.Image(str(p)) for p in images], "global_step": global_step})
+    except RuntimeError as e:
+        print(f"Visualization skipped (input dim mismatch — visualize() doesn't add curvature feature): {e}")
 
 wandb.finish()


### PR DESCRIPTION
## Hypothesis
We currently train with a single cosine schedule and pick one best checkpoint. Snapshot ensembles (Huang et al. 2017) use cyclical LR, save models at each cycle minimum, and average their weights. Different cycles converge to different basins — their average generalizes better. Key difference from SWA (tried, failed): we average only at EXACT cycle minima (not running average) and use sharp cosine valleys.

## Instructions
Replace the single cosine schedule with 3 cosine cycles of T_max=22 each (66 epochs total):

```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
    base_opt, T_0=22, T_mult=1, eta_min=1e-4
)
```

Save snapshots at cycle minima (epochs 22, 44, 66):
```python
snapshots = []
if (epoch + 1) % 22 == 0:
    snapshots.append({k: v.clone() for k, v in model.state_dict().items()})
```

After training, average the 3 snapshots:
```python
avg_state = {}
for key in snapshots[0]:
    avg_state[key] = sum(s[key] for s in snapshots) / len(snapshots)
eval_model.load_state_dict(avg_state)
```

Use this averaged model for all validation. Keep warmup (5 epochs) before the cycles start.

Run: `python train.py --agent fern --wandb_name "fern/snapshot-ensemble" --wandb_group snapshot-ensemble`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41

---
## Results

**W&B run:** lt051cqh | **State:** finished | **Best epoch:** 49 | **Peak memory:** ~same as baseline (deepcopy at epoch 66 is transient)

### Best checkpoint metrics (epoch 49 — regular model, before snapshot avg)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 1.8752 | 0.356 | 0.201 | **25.69** | 1.474 | 0.535 | 30.92 |
| ood_cond | 2.2202 | 0.317 | 0.211 | **25.15** | 1.216 | 0.465 | 23.00 |
| tandem | 3.4678 | 0.676 | 0.363 | **44.06** | 2.325 | 1.076 | 45.95 |
| **3-split** | **2.5211** | | | | | | |

### Comparison to baseline

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.1997 | 2.5211 | **+14.6% worse** |
| in_dist surf_p | 20.03 | 25.69 | +28% |
| ood_cond surf_p | 20.57 | 25.15 | +22% |
| tandem surf_p | 40.41 | 44.06 | +9% |

### Snapshot-averaged model (epoch 66) — final val/loss: 3.1244 (+42% vs baseline)

The snapshot average at epoch 66 was significantly worse than the best regular model at epoch 49:
- in_dist surf_p: 33.45 (vs 25.69 at best epoch)
- ood_cond surf_p: 29.68 (vs 25.15 at best epoch)
- tandem surf_p: 46.39 (vs 44.06 at best epoch)

### What happened

**Snapshot ensembling failed** — the snapshot-averaged model was notably worse than even the best checkpoint from the regular model mid-training (2.52 vs 2.20 baseline). Two issues:

1. **Cyclical LR hurts convergence**: CosineAnnealingWarmRestarts forces LR back to peak at each restart, causing the model to regress after each cycle. The single cosine schedule allows smooth convergence to lower loss. The best epoch (49) was reached between the 2nd and 3rd cycle, before the 3rd restart could degrade it.

2. **Weight averaging across basins backfires**: The 3 cycle-end snapshots are in meaningfully different regions of weight space (each restart moves the model away). Averaging them places the weights in a region between basins — which can be a high-loss valley rather than a usable solution. This is the known failure mode of snapshot ensembling vs. true parallel ensembles.

The success of snapshot ensembling (Huang et al. 2017) was on image classifiers with simpler loss landscapes and more stable basins. For this physics-based regression problem with complex multi-physics outputs, the cyclical restarts seem to be net harmful.

### Suggested follow-ups

- **SWA with flat tail**: Instead of cyclical restarts, run normal cosine schedule for 50 epochs then switch to constant low LR + running weight average for the final 16 epochs. This avoids restart disruption while still getting weight averaging benefits.
- **Longer single cosine**: If the model hasn't converged by epoch 66 with the current schedule (T_max=75), the issue is schedule length — try T_max=100 once 30-min timeout allows more epochs.
- **Polyak averaging**: Apply EMA-style averaging throughout training — that already captures most of the benefit without cyclical restarts disrupting convergence.