### PR TITLE
Online hard example mining (top 30% hardest nodes per batch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -628,6 +628,18 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
+        # OHEM: focus on top 30% hardest nodes (skip first 10 warmup epochs)
+        per_node_loss = abs_err.mean(dim=-1)  # [B, N]
+        if epoch >= 10:
+            for b in range(B):
+                valid = per_node_loss[b][mask[b]]
+                if valid.numel() > 0:
+                    threshold = torch.quantile(valid, 0.7)
+                    hard_mask = per_node_loss[b] >= threshold
+                    mask[b] = mask[b] & hard_mask
+                    surf_mask[b] = surf_mask[b] & hard_mask
+            vol_mask = mask & ~is_surface  # recompute after OHEM
+
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
         if epoch < 40:


### PR DESCRIPTION
## Hypothesis
Most volume nodes are easy (far-field near-uniform flow). Training on them wastes gradient capacity. OHEM (Online Hard Example Mining) focuses learning on the hardest 30% of nodes per sample, providing more informative gradients per step. This is standard in dense prediction (segmentation, detection) and directly applicable to CFD where boundary layers and separation regions are the "hard objects."

## Instructions
After computing `abs_err` for all nodes (~line 623), compute per-node difficulty and mask:

```python
# Per-node scalar loss (mean across 3 channels)
per_node_loss = abs_err.mean(dim=-1)  # [B, N]

# Only activate OHEM after epoch 10 (stable warmup first)
if epoch >= 10:
    # Find 70th percentile threshold per sample
    for b in range(B):
        valid = per_node_loss[b][mask[b]]
        if valid.numel() > 0:
            threshold = torch.quantile(valid, 0.7)
            hard_mask = per_node_loss[b] >= threshold
            mask[b] = mask[b] & hard_mask
            # Also update surf_mask to only include hard surface nodes
            surf_mask[b] = surf_mask[b] & hard_mask
```

This keeps top 30% hardest nodes for loss computation. Metrics logging uses the ORIGINAL masks (not OHEM-filtered) for fair comparison.

Run: `python train.py --agent tanjiro --wandb_name "tanjiro/ohem-hard-nodes" --wandb_group ohem`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** tmu22a5i  
**Epochs:** 65 (30.0 min wall-clock, ~28s/epoch)  
**Peak VRAM:** 10.6 GB  

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 2.5198 | 0.491 | 0.307 | 34.3 | 1.717 | 0.654 | 39.0 |
| val_tandem_transfer | 4.4882 | 0.866 | 0.499 | 56.4 | 2.567 | 1.244 | 56.8 |
| val_ood_cond | 2.8193 | 0.420 | 0.282 | 30.4 | 1.393 | 0.542 | 30.1 |
| val_ood_re | 18870.3* | 0.406 | 0.269 | 37.4 | 1.296 | 0.546 | 58.3 |
| **combined (3-split)** | **3.2758** | | | | | | |

*Pre-existing branch bug (ood_re vol_loss overflow), excluded from 3-split.

**vs baseline:**
- val/loss: 3.2758 vs 2.1997 → **+49.0% (much worse)**
- surf_p in_dist: 34.3 vs 20.03 → **+71.2%**
- surf_p tandem: 56.4 vs 40.41 → **+39.6%**
- surf_p ood_cond: 30.4 vs 20.57 → **+47.8%**

**What happened:**

Strong negative result. OHEM caused significant performance regression across all metrics.

The core issue is that OHEM at 30% retention is extremely aggressive for this problem. The Transolver model needs to learn spatial continuity — the predictions at all nodes (not just hard ones) must form coherent flow fields. By training only on the hardest 30% of nodes:

1. **Spatial coverage breaks down**: The model receives signal from a very sparse, biased subset of nodes. The model learns to predict only "hard" patterns, losing calibration on easy (far-field) regions.
2. **Surface over-focusing**: With surf_mask also filtered to hard nodes, the model disproportionately trains on extreme surface nodes. The easy mid-surface nodes (which are the majority) get no gradient signal, causing the model to lose calibration there.
3. **Interaction with progressive subsampling**: The existing volume subsampling (10%→100%) is applied BEFORE OHEM, further reducing the effective training set.
4. **Non-stationarity**: The "hard" nodes change every batch, causing inconsistent gradient signal that may destabilize training.

For CFD flow fields, OHEM conflicts with the goal of learning smooth, globally consistent predictions. The model needs training signal from all regions to produce good full-field predictions.

**Suggested follow-ups:**
- Use OHEM with much lighter retention (e.g., 80-90%) to gently upweight hard nodes without catastrophically dropping easy ones.
- Instead of binary masking, use soft weighting: `weight = (per_node_loss / mean_loss).clamp(0.5, 2.0)` to upweight hard nodes without zeroing easy ones.
- Apply OHEM only to volume nodes (not surface), keeping all surface nodes for surface-accurate gradients.