### PR TITLE
Inverse-distance-weighted volume loss (boundary layer focus)

### DIFF
--- a/train.py
+++ b/train.py
@@ -642,7 +642,25 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        # Inverse-distance weighting: upweight volume nodes near the surface (boundary layer)
+        with torch.no_grad():
+            vol_pos = x[:, :, :2]  # [B, N, 2] normalized positions
+            vol_weights = torch.ones(B, x.shape[1], device=device)
+            for b in range(B):
+                s_idx = surf_mask[b].nonzero(as_tuple=True)[0]
+                if len(s_idx) > 0:
+                    s_pos = vol_pos[b, s_idx]  # [S, 2]
+                    if len(s_idx) > 500:  # subsample to keep cdist fast
+                        s_pos = s_pos[torch.randperm(len(s_idx), device=device)[:500]]
+                    dists = torch.cdist(vol_pos[b].unsqueeze(0), s_pos.unsqueeze(0)).squeeze(0)
+                    dist_to_surf = dists.min(dim=-1).values  # [N]
+                    inv_dist = 1.0 / (dist_to_surf + 0.01)
+                    valid = mask[b]
+                    if valid.sum() > 0:
+                        inv_dist = inv_dist / inv_dist[valid].mean()
+                    vol_weights[b] = inv_dist
+
+        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1) * vol_weights.unsqueeze(-1)).sum() / (vol_mask_train.float() * vol_weights).sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()


### PR DESCRIPTION
## Hypothesis
Volume nodes near the surface carry the boundary layer — the most physically important region. Errors there directly propagate to surface predictions. An inverse-distance weighting in the volume loss upweights these critical nodes without changing the surface loss at all.

## Instructions
In the volume loss computation, add distance-based weighting:

```python
# Compute distance from each volume node to nearest surface node
with torch.no_grad():
    vol_pos = x[:, :, :2]  # [B, N, 2] — positions
    # For each node, find min distance to any surface node in that sample
    dist_to_surf = torch.full((B, N), 1e6, device=device)
    for b in range(B):
        s_idx = surf_mask[b].nonzero(as_tuple=True)[0]
        if len(s_idx) > 0:
            s_pos = vol_pos[b, s_idx]  # [S, 2]
            all_pos = vol_pos[b]  # [N, 2]
            dists = torch.cdist(all_pos.unsqueeze(0), s_pos.unsqueeze(0)).squeeze(0)  # [N, S]
            dist_to_surf[b] = dists.min(dim=-1).values
    
    # Inverse-distance weights for volume nodes (normalize to mean=1)
    vol_weights = 1.0 / (dist_to_surf + 0.01)
    vol_weights = vol_weights / vol_weights[mask].mean()

# Apply to volume loss
vol_per_sample = (abs_err * mask.unsqueeze(-1) * vol_weights.unsqueeze(-1)).sum(dim=(1,2)) / (mask * vol_weights).sum(dim=1).clamp(min=1)
```

**Note:** The cdist computation may be slow for large N. If epoch time increases >20%, subsample to 500 surface nodes for distance computation.

Run: `python train.py --agent nezuko --wandb_name "nezuko/inv-dist-vol-loss" --wandb_group inv-dist-vol`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** ar6fz3el | Runtime: 1926s (~32.1 min, ~58 epochs, 33s/epoch)
*(Run state shows "failed" due to SIGTERM at timeout — data is valid)*
*Note: cdist overhead reduced epochs from baseline ~63 to ~58 epochs.*

### Metrics vs baseline

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|---|---|---|---|---|---|
| **in_dist** | 1.6608 | 0.316 | 0.182 | **22.07** | 27.75 |
| **ood_cond** | 2.0357 | 0.299 | 0.196 | **22.60** | 21.90 |
| **ood_re** | — | — | — | **31.74** | — |
| **tandem** | 3.3803 | 0.654 | 0.345 | **43.05** | 45.64 |
| **val/loss (3-split)** | **2.3589** | | | | |

| Metric | Baseline | Inv-dist vol weight | Δ |
|---|---|---|---|
| val/loss | 2.1997 | 2.3589 | +7.2% ❌ |
| surf_p in_dist | 20.03 | 22.07 | +10.2% ❌ |
| surf_p ood_cond | 20.57 | 22.60 | +9.9% ❌ |
| surf_p tandem | 40.41 | 43.05 | +6.5% ❌ |

### What happened

Negative result. Inverse-distance weighting of volume nodes hurt all metrics.

There are two factors at play:

1. **Epoch penalty**: The per-batch cdist computation (~5000 nodes × 500 surface nodes × batch_size) added overhead, reducing epochs from ~63 to ~58. Even modest overhead matters when training is capped at 30 minutes.

2. **Misaligned objective**: Upweighting near-surface volume nodes in the volume loss doesn't translate to better surface predictions. The surface loss is already explicitly computed on surface nodes with a 5-50× weight multiplier. The volume loss is a secondary objective whose primary role is field regularization — not a mechanism through which surface accuracy is controlled. Shifting volume loss focus toward the boundary layer doesn't provide the model with better surface gradient signal.

Additionally, inverse-distance weights create non-uniform loss scales that can interfere with the optimizer. Nodes directly adjacent to the surface get very high weights (1/0.01 = 100× before normalization), which may cause gradient instability for the highest-weight nodes.

### Suggested follow-ups
- The boundary layer weighting idea is sound but needs to be applied to the *surface loss*, not the volume loss — e.g., weight surface nodes by local curvature or by distance from leading/trailing edge where pressure gradients are steepest
- Pre-computing distances (not per-batch) would eliminate the overhead penalty, enabling fair comparison
- Alternatively, use zone masks (leading edge, trailing edge, flat region) rather than continuous distance weights