### PR TITLE
Fourier spectral loss on surface pressure (frequency-weighted DFT)

### DIFF
--- a/train.py
+++ b/train.py
@@ -671,6 +671,31 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
 
+        spectral_loss = torch.tensor(0.0, device=device)
+        for b in range(B):
+            s_idx = surf_mask[b].nonzero(as_tuple=True)[0]
+            if len(s_idx) < 8:
+                continue
+            # Order surface nodes by SAF (arc-length) for 1D signal
+            saf_vals = x[b, s_idx, 2]  # SAF x-component as proxy for ordering
+            order = saf_vals.argsort()
+
+            pred_p = pred[b, s_idx[order], 2]  # predicted pressure, ordered
+            true_p = y_norm[b, s_idx[order], 2]  # target pressure, ordered
+
+            # 1D DFT
+            fft_pred = torch.fft.rfft(pred_p)
+            fft_true = torch.fft.rfft(true_p)
+
+            # Frequency weights: gently upweight high frequencies
+            n_freq = fft_pred.shape[0]
+            freq_weight = 1.0 + 0.5 * torch.arange(n_freq, device=device).float() / max(n_freq - 1, 1)
+
+            spectral_loss += ((fft_pred - fft_true).abs() * freq_weight).mean()
+
+        spectral_loss = spectral_loss / B
+        loss = loss + 0.1 * spectral_loss
+
         optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
L1 loss in physical space treats all spatial frequencies equally. The model likely gets low frequencies right early but struggles with high frequencies (sharp gradients at leading edge, suction peaks). A spectral loss on surface pressure — computed via 1D DFT along the airfoil — explicitly penalizes high-frequency errors with gentle upweighting.

## Instructions
Add spectral loss after re_loss block. Uses 1D DFT on ordered surface pressure nodes with frequency upweighting (weight=1+0.5*freq_idx/n_freq). Loss weight: 0.1.

Run: python train.py --agent alphonse --wandb_name alphonse/fourier-spectral-loss --wandb_group spectral-loss

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** njvsy4pn
**Epochs completed:** ~61/100 (30-min timeout)

### Metrics at best checkpoint (epoch ~61)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 1.662 | 0.309 | 0.190 | 21.74 | 1.382 | 0.501 | 28.10 |
| tandem_transfer | 3.337 | 0.657 | 0.352 | 41.47 | 2.272 | 1.035 | 44.49 |
| ood_cond | 2.026 | 0.295 | 0.204 | 22.47 | 1.163 | 0.440 | 22.17 |
| **3split avg** | **2.3417** | — | — | — | — | — | — |

**Baseline comparison:**
- val/loss: 2.3417 vs 2.1997 — **regression (+0.1420)**
- mae_surf_p in_dist: 21.74 vs 20.03 — **regression (+1.71)**
- mae_surf_p tandem: 41.47 vs 40.41 — **regression (+1.06)**
- mae_surf_p ood_cond: 22.47 vs 20.57 — **regression (+1.90)**

**Peak memory:** Not logged (no OOM).

### What happened

The Fourier spectral loss significantly regresses vs baseline — 6.4% worse on val/loss. Two main issues:

1. **Compute overhead**: The per-sample DFT loop (one per batch sample, per training step) adds overhead, reducing the number of epochs completed from ~64 (baseline) to ~61. Fewer training epochs means less convergence.

2. **Noisy node ordering**: The PR uses x[b, s_idx, 2] (normalized dsdf feature 0) as a proxy for arc-length ordering. This is an indirect proxy — the first dsdf component encodes the x-gradient of the signed distance field, not arc-length itself. The resulting node ordering may not produce a smooth 1D signal suitable for DFT analysis, making the spectral loss add noise rather than meaningful signal.

3. **Weight mismatch**: The spectral loss weight of 0.1 is 10x larger than the stagnation loss (0.5) and Bernoulli loss (0.001) in earlier experiments. At this scale, the spectral loss dominates and likely overwhelms the main L1 surface loss.

The spectral loss idea is sound in principle but needs better implementation: a reliable arc-length parameterization, and/or panel-based ordering from the geometry data.

### Suggested follow-ups
- **Better ordering**: Use the original mesh connectivity (if available) or NACA geometry coordinates to get proper arc-length ordering instead of dsdf proxy.
- **Lower weight**: Try 0.01 or 0.001 so the spectral loss acts as a gentle regularizer rather than competing with the main loss.
- **2D spectral loss**: Apply FFT in 2D on the full field rather than a 1D DFT on surface nodes — avoids the ordering problem entirely.