### PR TITLE
Gradient accumulation 4x with LR 6e-3 (effective batch 16)

### DIFF
--- a/train.py
+++ b/train.py
@@ -354,7 +354,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 6e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -517,10 +517,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )
 
 # --- wandb ---
@@ -580,6 +580,8 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
+    accum_steps = 4
+    optimizer.zero_grad()
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
@@ -671,10 +673,12 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
+        loss_scaled = loss / accum_steps
+        loss_scaled.backward()
+        if (n_batches + 1) % accum_steps == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(model)


### PR DESCRIPTION
## Hypothesis
Previous grad accumulation (2 steps, same LR) didn't change dynamics. The real power of larger effective batches is enabling proportionally higher LR (linear scaling rule). With 4x accumulation and LR=6e-3 (2x current), we get qualitatively different optimization: less noisy gradients taking larger steps. The effective batch goes from 4 to 16 samples.

## Instructions
Set accumulation_steps=4 and LR=6e-3:

```python
lr = 6e-3  # 2x current, following linear scaling rule
accumulation_steps = 4
```

Modify the training loop to accumulate:
```python
loss = loss / accumulation_steps  # normalize loss for accumulation
scaler.scale(loss).backward()

if (step + 1) % accumulation_steps == 0:
    scaler.unscale_(base_opt)
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    scaler.step(base_opt)
    scaler.update()
    base_opt.zero_grad()
    scheduler.step()  # step scheduler every optimizer step
```

Adjust warmup to 10 epochs for stability with higher LR.

Run: `python train.py --agent edward --wandb_name "edward/grad-accum-4x-lr6e3" --wandb_group grad-accum`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** yj1b03nv  
**Epochs:** 63 at 28.3s/epoch (30-min cap)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss (3-split) | 2.1997 | 2.4966 | +13.5% |
| surf_p in_dist | 20.03 | 24.34 | +21.5% |
| surf_p ood_cond | 20.57 | 24.14 | +17.3% |
| surf_p tandem | 40.41 | 42.27 | +4.6% |

Surface MAE by component (best epoch = 63):
- in_dist: Ux=0.352, Uy=0.203, p=24.34
- ood_cond: Ux=0.299, Uy=0.210, p=24.14
- tandem: Ux=0.679, Uy=0.358, p=42.27

Volume MAE: in_dist Ux=1.50, Uy=0.54, p=30.03; ood_cond Ux=1.21, Uy=0.46, p=22.39

**Memory:** ~same as baseline (accumulation reduces peak gradient memory, no change in forward-pass footprint)

### What happened

**Negative.** val/loss increased 13.5% and all surface metrics degraded significantly. This matches the 2-step accumulation failure (PR #908, +7.3%) but is worse.

The core problem is the 30-minute training budget. With accum_steps=4, the optimizer updates only every 4 batches, so the model sees only ~5,166 optimizer steps (63 epochs x 82 steps/epoch) instead of ~20,853 in a normal run. Despite the higher LR, this 4x reduction in optimizer steps dominates and severely underfits.

The epoch time (28.3s) was identical to the 2-step run, confirming the bottleneck is step starvation not throughput. The higher LR did not rescue it.

Adapting the PR code to bfloat16 (no GradScaler needed) was straightforward.

### Suggested follow-ups

- **LR increase alone (no accumulation):** Test LR=6e-3 without accum_steps to isolate the LR effect without the step-count penalty.
- **Gradient accumulation only helps if epoch time is the bottleneck**, not step count. On this hardware within 30 minutes, accumulation is net-negative.