### PR TITLE
Soft MoE slice tokens (per-slice affine transform)

### DIFF
--- a/train.py
+++ b/train.py
@@ -110,6 +110,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.slice_scale = nn.Parameter(torch.ones(slice_num, dim_head))
+        self.slice_shift = nn.Parameter(torch.zeros(slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None):
         bsz, num_points, _ = x.shape
@@ -133,6 +135,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        # Per-slice affine: [B, H, S, D] * [S, D] + [S, D]
+        slice_token = slice_token * self.slice_scale[None, None, :, :] + self.slice_shift[None, None, :, :]
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)


### PR DESCRIPTION
## Hypothesis
Each of the 32 slices represents a different region of the flow (wake, boundary layer, far-field). Currently all slices share the same Q/K/V projections. A per-slice affine transform (scale + shift per slice, like per-slice batch norm) lets different slices specialize. This is a lightweight MoE with only 2*32*32=2048 new parameters.

## Instructions
In `Physics_Attention_Irregular_Mesh.__init__`, add:
\`\`\`python
self.slice_scale = nn.Parameter(torch.ones(slice_num, dim_head))
self.slice_shift = nn.Parameter(torch.zeros(slice_num, dim_head))
\`\`\`

In `forward`, after computing `slice_token` (the weighted average per slice) and before Q/K/V projections:
\`\`\`python
# Per-slice affine: [B, H, S, D] * [S, D] + [S, D]
slice_token = slice_token * self.slice_scale[None, None, :, :] + self.slice_shift[None, None, :, :]
\`\`\`

Initialize scale=1, shift=0 so training starts identical to baseline.

Run: `python train.py --agent thorfinn --wandb_name "thorfinn/soft-moe-slices" --wandb_group soft-moe`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run:** \`od428yzz\` (thorfinn/soft-moe-slices)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | 2.1997 | 2.2446 | +2.0% ❌ |
| val_in_dist / mae_surf_p | 20.03 | 21.16 | +5.6% ❌ |
| val_tandem / mae_surf_p | 40.41 | 41.57 | +2.9% ❌ |
| val_ood_cond / mae_surf_p | 20.57 | 19.95 | -3.0% ✅ |
| val_in_dist / mae_vol_Ux | — | 1.288 | — |
| val_tandem / mae_vol_Ux | — | 2.151 | — |
| Peak memory | — | 10.6 GB | — |

Best checkpoint: epoch 66 of 100 (30 min timeout). New parameters: 2×32×32=2048 (negligible).

**What happened:** Slightly negative result overall. The per-slice affine transform added 2048 parameters but didn't improve performance. val/loss is +2.0% worse; in_dist surf_p and tandem surf_p both degraded. However, ood_cond surf_p improved slightly (-3.0%), suggesting the slice specialization may help generalize to unseen conditions.

The likely cause: scale=1, shift=0 initialization means training starts identical to baseline, but the per-slice parameters now compete for gradient updates. Since scale and shift are initialized identically across all slices, the gradient signal for specialization is weak early in training, and with only 67 epochs in 30 minutes, there may not be enough training time for meaningful slice specialization to emerge. The per-head normalization before slice_token assignment (line 135) already removes much of the per-slice distributional variation, leaving less signal for the affine transform.

**Suggested follow-ups:**
- Try applying the per-slice affine to the `out_slice_token` (after attention) rather than `slice_token` (before Q/K/V) — the output distribution might have more per-slice variation to exploit.
- Try random initialization (scale ~ N(1, 0.1)) to break the symmetry between slices and accelerate specialization.
- Try a per-head-per-slice scale only (no shift, simpler formulation) to reduce the chance of gradient interference.