### PR TITLE
Rank-1 factorized output (POD-inspired: amplitude × mode + residual)

### DIFF
--- a/train.py
+++ b/train.py
@@ -183,20 +183,13 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            # Branch 1: rank-1 (amplitude per node × mode per sample)
-            self.amplitude = nn.Linear(hidden_dim, 1)  # per-node scalar
+            # Rank-3: 3 amplitude vectors × 3 mode vectors
+            self.amplitude = nn.Linear(hidden_dim, 3)  # per-node, 3 scalars
             self.mode = nn.Sequential(
-                nn.Linear(hidden_dim, 32), nn.GELU(), nn.Linear(32, 3)
-            )  # applied to mean-pooled features → 3D mode vector
-            # Branch 2: residual full MLP (reduced hidden)
-            self.residual_mlp = nn.Sequential(
-                nn.Linear(hidden_dim, 64), nn.GELU(), nn.Linear(64, 3)
-            )
-            # Initialize amplitude and mode with small weights so training starts near-current behavior
-            nn.init.normal_(self.amplitude.weight, std=0.01)
-            nn.init.zeros_(self.amplitude.bias)
-            nn.init.normal_(self.mode[-1].weight, std=0.01)
-            nn.init.zeros_(self.mode[-1].bias)
+                nn.Linear(hidden_dim, 32), nn.GELU(), nn.Linear(32, 3 * 3)
+            )  # applied to mean-pooled features → 9 values (3 modes × 3 channels)
+            # FULL residual MLP (same capacity as baseline)
+            self.mlp2 = MLP(hidden_dim, hidden_dim, out_dim, n_layers=0, res=False, act=act)
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -208,11 +201,11 @@ class TransolverBlock(nn.Module):
         fx = fx * se
         if self.last_layer:
             h = self.ln_3(fx)
-            amp = self.amplitude(h)  # [B, N, 1]
-            mode = self.mode(h.mean(dim=1, keepdim=True))  # [B, 1, 3]
-            rank1 = amp * mode  # [B, N, 3]
-            residual = self.residual_mlp(h)  # [B, N, 3]
-            return rank1 + residual
+            amp = self.amplitude(h)  # [B, N, 3]
+            mode = self.mode(h.mean(dim=1, keepdim=True)).reshape(fx.shape[0], 1, 3, 3)  # [B, 1, 3, 3]
+            rank_k = (amp.unsqueeze(-1) * mode).sum(dim=-2)  # [B, N, 3]
+            residual = self.mlp2(h)  # [B, N, 3]
+            return rank_k * 0.1 + residual  # rank-k as bonus, not replacement
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Inspired by POD (Proper Orthogonal Decomposition) used in reduced-order CFD models. The output is decomposed into a rank-k factorized component (per-node amplitude scalars × per-sample mode vectors) plus a full residual MLP. The rank-k component encodes the shared spatial structure of the flow field, while the residual catches local corrections.

## Instructions
See PR comments for revision instructions.

Run: `python train.py --agent askeladd --wandb_name "askeladd/rank1-output" --wandb_group rank1-output`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

### Run 1: Rank-1, reduced residual (hidden=64) — W&B: gpyhla53, 64 epochs
| Metric | Rank-1 | Baseline | Δ |
|---|---|---|---|
| val/loss | 2.2373 | 2.1997 | +1.71% worse |
| in_dist / surf_p | 20.98 | 20.03 | +4.7% worse |
| tandem / surf_p | 40.57 | 40.41 | +0.4% worse |
| ood_cond / surf_p | 20.87 | 20.57 | +1.5% worse |

### Run 2: Rank-3, full residual MLP (hidden=128), scale=0.1 — W&B: 1z3syceo, 63 epochs

Per advisor feedback, combined both follow-up suggestions: rank-3 factorization + full baseline MLP residual (rank-k adds ON TOP of baseline capacity, scaled by 0.1).

| Metric | Rank-3+full | Baseline | vs Rank-1 |
|---|---|---|---|
| val/loss | 2.2778 | 2.1997 | +3.55% worse; +1.84% worse than rank-1 |
| in_dist / surf_p | 22.05 | 20.03 | +10.1% worse |
| tandem / surf_p | 41.78 | 40.41 | +3.4% worse |
| ood_cond / surf_p | 21.83 | 20.57 | +6.1% worse |

**n_params**: 262,236 (+4,812 vs baseline)

### What happened

Rank-3 with full residual is *worse* than rank-1 with reduced residual, and significantly worse than baseline. This is surprising given the rank-k term was designed as a bonus that should be neutral or helpful.

The likely cause is **optimization landscape complexity**: with 3 amplitude vectors and 3 mode vectors (9 learnable coupling parameters per sample), the factorized head creates non-convex interactions that compete with the residual MLP gradients during training. The 0.1 scaling keeps the rank-k contribution small at initialization, but as training progresses, the rank-k and residual terms may fight for the same signal.

The key insight: even with 0.1 initial scaling, the rank-k gradients back-propagate through both the amplitude branch and mode branch simultaneously, creating interference. The rank-1 case with only 1 amplitude vector was simpler and produced better results (only +1.71% degradation vs +3.55% here).

The POD-inspired inductive bias doesn't translate well to this architecture — the Transolver's attention mechanism already implicitly learns spatial correlation structure in its slice-based tokens, making explicit POD decomposition redundant and potentially harmful.

### Suggested follow-ups
- The POD approach appears fundamentally at odds with Transolver's existing mechanism — avoid further rank-k experiments
- The +1.71% degradation from rank-1 suggests this head type needs more careful tuning; it's close to working but not better yet