### PR TITLE
Orthogonal output projection (decorrelate Ux, Uy, p channels)

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,7 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.output_decorr = nn.Parameter(torch.eye(3))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -339,6 +340,7 @@ class Transolver(nn.Module):
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)
+        fx = fx @ self.output_decorr  # [B, N, 3] @ [3, 3] = [B, N, 3]
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}
 
@@ -670,6 +672,10 @@ for epoch in range(MAX_EPOCHS):
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
+
+        I = torch.eye(3, device=device)
+        ortho_loss = ((model.output_decorr.T @ model.output_decorr - I) ** 2).sum()
+        loss = loss + 0.001 * ortho_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The shared output MLP creates implicit correlations between Ux, Uy, p gradients. A learnable 3×3 matrix that linearly mixes output channels, constrained to be orthogonal, would decorrelate the channels. This prevents negative transfer between output tasks (pressure vs velocity) — a well-known issue in multi-task learning.

## Instructions
In `Transolver.__init__`, add:
```python
self.output_decorr = nn.Parameter(torch.eye(3))
```

In `Transolver.forward`, after the output head produces predictions:
```python
# Apply decorrelation transform to output channels
fx = fx @ self.output_decorr  # [B, N, 3] @ [3, 3] = [B, N, 3]
```

Add orthogonality regularization to the loss:
```python
I = torch.eye(3, device=device)
ortho_loss = ((self.model.output_decorr.T @ self.model.output_decorr - I) ** 2).sum()
loss = loss + 0.001 * ortho_loss
```

Identity initialization means training starts identical to baseline.

Run: `python train.py --agent violet --wandb_name "violet/ortho-proj-head" --wandb_group ortho-output`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run ID**: `86fw0yel`
**Epochs completed**: 66 (best), 30.2 min
**Peak memory**: 10.5 GB
**Note**: Visualization crash is a known limitation of the curvature proxy branch.

### Metrics vs Baseline

| Metric | Baseline | + ortho projection | Δ |
|---|---|---|---|
| val/loss | 2.1997 | **2.2400** | +1.8% 🔴 |
| in_dist surf_p | 20.03 Pa | **21.15 Pa** | +5.6% 🔴 |
| ood_cond surf_p | 20.57 Pa | **21.15 Pa** | +2.8% |
| ood_re surf_p | — | **30.56 Pa** | — |
| tandem surf_p | 40.41 Pa | **42.03 Pa** | +4.0% 🔴 |

*(ood_re total loss remains overflowed — pre-existing issue on this branch)*

### What happened

The orthogonal output projection **does not help** — slightly worse across all major metrics. The decorrelation transform learns away from the identity but doesn't find a better projection. This suggests:

1. **Channel correlations are useful**: Ux, Uy, and p ARE physically correlated (via Bernoulli's equation, continuity), so forcing decorrelation removes informative channel dependencies that the model should exploit.

2. **The model already handles multi-task learning adequately**: The shared output MLP with separate output heads (`output_dims=[1,1,1]`) already separates the channels while learning shared representations. Adding a post-hoc linear mixing layer adds parameters without structural benefit.

3. **Orthogonality is too restrictive**: A 3×3 orthogonal matrix with 9 DOF (constrained to 3 DOF by orthogonality) provides little expressive power — essentially just a rotation of the output space. For 3 channels, this is not enough to meaningfully decorrelate complex nonlinear outputs.

The identity initialization ensures we start identical to the baseline, but gradient updates push `output_decorr` away from identity in unhelpful directions.

### Suggested follow-ups

- **Separate output heads per field**: Instead of a shared output MLP producing all 3 channels, use 3 separate heads (one per field). This is a structural change that could reduce negative transfer more effectively.
- **Channel attention on output**: A learned 3-channel attention that reweights field contributions per node might be more flexible than a fixed linear transform.