### PR TITLE
Multi-task zone prediction (overset mesh zone ID auxiliary)

### DIFF
--- a/train.py
+++ b/train.py
@@ -189,7 +189,7 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None):
+    def forward(self, fx, raw_xy=None, return_hidden=False):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
@@ -198,6 +198,8 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
+            if return_hidden:
+                return self.mlp2(self.ln_3(fx)), fx  # (out_dim, n_hidden)
             return self.mlp2(self.ln_3(fx))
         return fx
 
@@ -337,9 +339,10 @@ class Transolver(nn.Module):
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
-        zone_pred = self.zone_head(fx)  # [B, N, 3] — 3 zone classes
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy)
+        # Run last block and capture post-attention hidden state for zone prediction
+        fx, fx_hidden = self.blocks[-1](fx, raw_xy=raw_xy, return_hidden=True)
+        zone_pred = self.zone_head(fx_hidden)  # [B, N, 3] — applied post-attention
         fx = fx + self.out_skip(fx_pre)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "zone_pred": zone_pred}
@@ -687,7 +690,7 @@ for epoch in range(MAX_EPOCHS):
         zone_loss = F.cross_entropy(
             out["zone_pred"].float().reshape(-1, 3), zone_target.reshape(-1), ignore_index=-1
         )
-        loss = loss + 0.01 * zone_loss
+        loss = loss + 0.1 * zone_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The dataset has overset mesh zones (0=background, 1=foil1 refinement, 2=foil2 refinement). The model currently ignores this structure. Predicting zone membership as an auxiliary task forces the model to learn spatial decomposition aligned with mesh refinement — "where the physics is interesting." Different from failed boundary-type aux (#954): zones capture spatial resolution, not boundary conditions, and should be applied to the POST-attention hidden state.

## Instructions
First, check if zone_id is available in the data. Look at the `preprocess_sample_multi` function for `sample.zoneID` or similar. If available, pass it through the data pipeline.

Add a zone prediction head applied to POST-attention features:
```python
# In Transolver.__init__:
self.zone_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 3))

# In forward, after attention output:
zone_pred = self.zone_head(fx)  # [B, N, 3] — 3 zone classes
```

Add cross-entropy loss:
```python
zone_loss = F.cross_entropy(zone_pred.reshape(-1, 3), zone_target.reshape(-1), ignore_index=-1)
loss = loss + 0.01 * zone_loss
```

**If zone_id is NOT in the data pipeline**, construct a proxy: nodes with `is_surface=1` are zone 1/2, nodes with `sdf > threshold` are zone 0.

Run: `python train.py --agent gilbert --wandb_name "gilbert/zone-pred-aux" --wandb_group zone-aux`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

### Run v1: weight=0.01, pre-attention placement
**W&B run:** j8x2gpnd | **Best epoch:** 64 | **Peak memory:** ~11.0 GB

| Split | val/loss | mae_surf_p |
|---|---|---|
| val_in_dist | 1.5218 | 20.1 |
| val_tandem_transfer | 3.2882 | 42.1 |
| val_ood_cond | 1.8993 | 20.6 |
| val_ood_re | 18869.6 | 30.8 |
| **combined val/loss** | **2.2364** | |

**Baseline 2.1997 → 2.2364 (+0.037, within noise)**

### Run v2: weight=0.1, post-attention placement (revised per reviewer feedback)
**W&B run:** v8kvdj45 | **Best epoch:** 63 | **Peak memory:** ~10.9 GB

Post-attention placement: `TransolverBlock.forward` extended to return both the out_dim prediction and the pre-mlp2 n_hidden state. Zone head applied to this post-attention hidden state without detach (zone gradient flows through attention).

| Split | val/loss | mae_surf_p |
|---|---|---|
| val_in_dist | 1.6215 | 21.0 |
| val_tandem_transfer | 3.2285 | 40.7 |
| val_ood_cond | 1.8939 | 21.1 |
| val_ood_re | 18869.6 | 31.3 |
| **combined val/loss** | **2.2479** | |

**Baseline 2.1997 → 2.2479 (+0.048, slightly worse than v1)**

### What happened

Both runs are negative, and v2 (higher weight + post-attention) is actually worse than v1. The proxy labels are the root cause:

1. **Proxy quality dominates the result.** Without actual zone labels from `zoneID`, the dsdf-median split is a coarse approximation that doesn't reflect the actual mesh zone boundaries. With weight=0.1, the noisy CE signal is strong enough to actively interfere with training — the model wastes capacity trying to predict meaningless proxy categories.

2. **Post-attention zone loss is a gradient problem.** At weight=0.1 without detach, the zone gradient flows back through the entire attention block. This distorts the attention weights from what the main reconstruction loss wants, and with noisy proxy labels the interference is significant enough to hurt training.

3. **Compute cost.** 29s/epoch gives only 63 epochs vs 67 for baseline, losing ~4 training epochs worth of optimization.

The zone auxiliary task is architecturally sound (the advisor's intuition about spatial decomposition forcing is valid), but it fundamentally requires accurate zone labels. The dsdf-median proxy is not a good substitute.

### Suggested follow-ups

- **Use actual zoneID labels**: modify `preprocess_sample_multi` to extract `sample.zoneID` — real labels would likely give a meaningful signal (this requires a data/ change).
- **Try with detach**: weight=0.1 with `.detach()` prevents zone gradient from distorting attention, isolating zone_head training; may be more stable.
- **Lower weight with real labels**: once zone labels are accurate, a small weight (0.01–0.05) would be appropriate.