### PR TITLE
Two-stage volume→surface refinement (re-predict surface with vol context)

### DIFF
--- a/train.py
+++ b/train.py
@@ -189,17 +189,21 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None):
+    def get_hidden(self, fx, raw_xy=None):
+        """Returns SE-gated hidden features before the output head."""
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
-        fx = fx * se
+        return fx * se
+
+    def forward(self, fx, raw_xy=None):
+        h = self.get_hidden(fx, raw_xy=raw_xy)
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
-        return fx
+            return self.mlp2(self.ln_3(h))
+        return h
 
 
 class Transolver(nn.Module):
@@ -269,6 +273,13 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.surface_refine = nn.Sequential(
+            nn.Linear(n_hidden + out_dim, 64),
+            nn.GELU(),
+            nn.Linear(64, out_dim),
+        )
+        nn.init.zeros_(self.surface_refine[-1].weight)
+        nn.init.zeros_(self.surface_refine[-1].bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -319,6 +330,7 @@ class Transolver(nn.Module):
             raise ValueError("Missing required input tensor: x")
         if condition is not None:
             raise ValueError("Transolver does not support conditioning inputs")
+        is_surface = data.get("is_surface") if isinstance(data, Mapping) else None
 
         if self.unified_pos:
             if pos is None:
@@ -337,8 +349,16 @@ class Transolver(nn.Module):
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy)
-        fx = fx + self.out_skip(fx_pre)
+        # Two-stage surface refinement: get hidden features, then first pass, then refine
+        h = self.blocks[-1].get_hidden(fx, raw_xy=raw_xy)
+        first_pass = self.blocks[-1].mlp2(self.blocks[-1].ln_3(h)) + self.out_skip(fx_pre)
+        refine_input = torch.cat([h, first_pass], dim=-1)  # [B, N, n_hidden + out_dim]
+        correction = self.surface_refine(refine_input)
+        if is_surface is not None:
+            surf_mask = is_surface.float().unsqueeze(-1)  # [B, N, 1]
+            fx = first_pass + correction * surf_mask
+        else:
+            fx = first_pass + correction
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}
 
@@ -612,7 +632,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "is_surface": is_surface})
             pred = out["preds"]
             re_pred = out["re_pred"]
         pred = pred.float()
@@ -741,7 +761,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    pred = eval_model({"x": x, "is_surface": is_surface})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
The model predicts all nodes simultaneously, but physically the far-field flow determines surface pressure (outside-in causality). A two-stage approach: (1) predict all nodes normally, (2) for surface nodes only, concatenate the first-pass prediction with the hidden features and re-predict through a small refinement MLP. This gives surface nodes access to their own initial prediction as a "draft" to refine.

## Instructions
In `Transolver.__init__`, add a surface refinement head:
```python
self.surface_refine = nn.Sequential(
    nn.Linear(n_hidden + 3, 64),  # hidden features + first-pass pred (3 channels)
    nn.GELU(),
    nn.Linear(64, 3)  # refined prediction
)
```

In `Transolver.forward`, after the main output head produces `fx`:
```python
# First-pass predictions
first_pass = fx  # [B, N, 3]

# Get hidden features from just before the output head
# (the pre-output-head features from the last block)
h = self.blocks[0].get_pre_output(...)  # need to expose pre-output features

# For surface nodes, concatenate hidden + first-pass pred
refine_input = torch.cat([h, first_pass], dim=-1)  # [B, N, hidden+3]
correction = self.surface_refine(refine_input)  # [B, N, 3]

# Apply correction only to surface nodes (mask volume corrections to 0)
fx = first_pass + correction * surf_mask.unsqueeze(-1).float()
```

The refinement is lightweight (64-dim, one hidden layer) and adds minimal compute. Initialize with small weights so training starts near first-pass behavior.

Run: `python train.py --agent norman --wandb_name "norman/two-stage-refine" --wandb_group two-stage`

## Baseline
- val/loss: 2.1997, surf_p: in_dist=20.03, ood_cond=20.57, tandem=40.41
---
## Results

**W&B run**: 3ttaxpsq (hit 30-min timeout, ~67 epochs)

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 2.1997 | 2.2295 | +1.4% worse |
| surf_p in_dist | 20.03 | 22.76 | +2.73 |
| surf_p ood_cond | 20.57 | 21.08 | +0.51 |
| surf_p tandem | 40.41 | 42.52 | +2.11 |
| surf_Ux in_dist | — | 5.08 | — |
| surf_Uy in_dist | — | 5.79 | — |
| vol MAE | — | 3.85 | — |

**What happened**: The two-stage refinement hurt performance across all metrics. The hypothesis was that a second pass over hidden features could let surface nodes refine their predictions, but in practice it appears to have disrupted the model rather than helped it. Two likely reasons:

1. **Gradient interference**: The zero-initialized correction MLP starts near identity, but its gradients still flow back through both the refinement path and the first-pass path. This creates a more complex optimization landscape for the last block, potentially slowing convergence.

2. **Redundant signal**: The hidden features `h` already encode the information used to produce `first_pass`; concatenating them doesn't add fundamentally new information — it just adds parameters and complexity. The model doesn't benefit from seeing its own intermediate representations.

The tandem surf_p degradation is especially notable (+2.11 vs +0.51 for ood_cond), suggesting the refinement mechanism may be over-fitting to individual sample patterns.

**Peak memory**: ~24 GB (within normal range).

**Suggested follow-ups**:
- Try applying the correction to all nodes (not just surface), which may help volume predictions compensate and improve convergence.
- Try a larger refinement head (e.g., 128-dim or two layers) to see if capacity matters.
- Try stopping gradient from first_pass before concatenation (`first_pass.detach()`) to prevent the gradient from flowing through two paths into the last block.
- Try a residual connection style where the refinement head only predicts a small scalar scale per node rather than a full correction.
