### PR TITLE
Progressive mesh resolution (start with 50% nodes, full at epoch 30)

### DIFF
--- a/train.py
+++ b/train.py
@@ -611,6 +611,19 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        # Progressive resolution: 50% -> 100% over first 30 epochs
+        node_frac = min(1.0, 0.5 + 0.5 * epoch / 30)
+        if node_frac < 1.0 and model.training:
+            # Subsample volume nodes (keep ALL surface nodes)
+            for b in range(B):
+                vol_idx = (mask[b] & ~is_surface[b]).nonzero(as_tuple=True)[0]
+                n_keep = int(vol_idx.shape[0] * node_frac)
+                if n_keep < vol_idx.shape[0]:
+                    perm = torch.randperm(vol_idx.shape[0], device=device)[:n_keep]
+                    drop_idx = vol_idx[~torch.isin(torch.arange(vol_idx.shape[0], device=device), perm)]
+                    mask[b, drop_idx] = False
+                    x[b, drop_idx] = 0  # zero dropped nodes
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
             pred = out["preds"]
@@ -627,20 +640,7 @@ for epoch in range(MAX_EPOCHS):
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
-
-        # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
-            vol_indices = vol_mask.nonzero(as_tuple=False)
-            n_vol = vol_indices.shape[0]
-            n_keep = max(int(n_vol * vol_keep_ratio), 1)
-            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
-            vol_mask_train = torch.zeros_like(vol_mask)
-            if n_keep > 0:
-                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
-        else:
-            vol_mask_train = vol_mask
+        vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)


### PR DESCRIPTION
## Hypothesis
The model currently sees all ~4000 nodes from epoch 1. A progressive curriculum that starts with 50% of nodes (randomly subsampled, keeping all surface nodes) and increases to 100% by epoch 30 would: (1) give faster early epochs for more iterations in the same wall time, (2) force the model to learn from coarse representations first, building spatial awareness before fine detail. This is the spatial equivalent of progressive image resolution training (ProGAN/StyleGAN).

## Instructions
In the training loop, compute a node fraction based on epoch:
```python
# Progressive resolution: 50% -> 100% over first 30 epochs
node_frac = min(1.0, 0.5 + 0.5 * epoch / 30)

if node_frac < 1.0 and model.training:
    # Subsample volume nodes (keep ALL surface nodes)
    for b in range(B):
        vol_idx = (mask[b] & ~surf_mask[b]).nonzero(as_tuple=True)[0]
        n_keep = int(vol_idx.shape[0] * node_frac)
        if n_keep < vol_idx.shape[0]:
            perm = torch.randperm(vol_idx.shape[0], device=device)[:n_keep]
            drop_idx = vol_idx[~torch.isin(torch.arange(vol_idx.shape[0], device=device), perm)]
            mask[b, drop_idx] = False
            x[b, drop_idx] = 0  # zero dropped nodes
```

This is different from the existing volume subsampling (which is for memory) — this is a training curriculum that starts coarse and refines.

Run: `python train.py --agent senku --wandb_name "senku/progressive-resolution" --wandb_group progressive-resolution`

## Baseline (true mean)
- val/loss: ~2.26±0.007, surf_p: in_dist≈20.5, ood_cond≈20.5, tandem≈41.5
---
## Results

**W&B run ID**: r10r1nz1
**Best epoch**: 66 (30 min wall time)
**Peak GPU memory**: ~43 GB (same as baseline)

Note: This branch already had a progressive resolution approach (5%→100% over 40 epochs, loss-only). This PR replaced it with 50%→100% over 30 epochs with input zeroing (modifies `mask` and `x` before the forward pass, so the model actually sees sparser inputs during early epochs).

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss (3-split) | ~2.26 | 2.2631 | ~0.00 (within noise) |
| surf_p in_dist | ~20.5 | 20.97 | +0.47 |
| surf_p ood_cond | ~20.5 | 20.81 | +0.31 |
| surf_p tandem | ~41.5 | 41.73 | +0.23 |

Full breakdown at best epoch 66:

| Split | surf_Ux | surf_Uy | surf_p |
|-------|---------|---------|--------|
| val_in_dist | 0.2949 | 0.1824 | 20.97 |
| val_ood_cond | 0.2602 | 0.1883 | 20.81 |
| val_tandem | 0.6315 | 0.3364 | 41.73 |
| val_ood_re | 0.2733 | 0.1985 | 30.62 |

Note: run state is "failed" due to pre-existing visualization crash in this branch (curvature proxy dim mismatch). Training metrics are valid.

### What happened

**Neutral result** — the new progressive curriculum (50%→100% over 30 epochs, with input zeroing) performs essentially the same as the existing approach it replaced (5%→100% over 40 epochs, loss-only). Val/loss of 2.2631 is within the stated baseline noise band (~2.26±0.007). Surface metrics are marginally worse but not significantly.

Two observations:

1. **Input zeroing does not help**: Zeroing dropped nodes in `x` before the forward pass forces the model to see sparse inputs during early epochs. This was intended to force coarse-first representations, but may instead confuse the model since zero-padded positions look similar to masked positions, potentially harming early learning.

2. **50% start is conservative**: Starting at 50% nodes still requires the model to process nearly half the mesh from epoch 1. The speed benefit of skipping 50% of volume nodes in the loss is modest. The original 5%→100% approach had a much more aggressive speedup in early epochs (95% fewer volume nodes), potentially allowing more gradient steps in the same wall time.

Both approaches appear to be roughly neutral. The progressive curriculum idea may not be the right lever for this model — the Transolver attention mechanism may already implicitly attend to the most informative nodes regardless of curriculum.

### Suggested follow-ups

- **Ablation: no progressive resolution**: Test completely removing the progressive curriculum to see if it provides any benefit at all vs. full vol nodes from epoch 1.
- **Surface-only early training**: Instead of randomly subsampling volume nodes, train on surface nodes only for first 10 epochs, then add volume. This directly optimizes our most important metric from the start.