### PR TITLE
Per-sample loss scaling by difficulty (easy samples dampened)

### DIFF
--- a/train.py
+++ b/train.py
@@ -642,12 +642,17 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_per_sample = (abs_err * vol_mask_train.unsqueeze(-1)).sum(dim=(1, 2)) / vol_mask_train.sum(dim=1).clamp(min=1).float()
+        vol_loss = vol_per_sample.mean()
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        per_sample_total = vol_per_sample + surf_weight * surf_per_sample * tandem_boost
+        with torch.no_grad():
+            batch_mean = per_sample_total.mean()
+            difficulty_weight = (per_sample_total / (batch_mean + 1e-8)).clamp(0.5, 3.0)
+        loss = (per_sample_total * difficulty_weight).mean()
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
Some training samples are easy (simple angles of attack, single foil) while others are hard (high AoA, tandem with complex interactions). Currently all samples contribute equally to the gradient. Scaling each sample loss by its difficulty (measured as the running-average loss for that sample) focuses training on the samples the model struggles with most, similar to curriculum learning or focal loss.

## Instructions
Maintain a per-sample loss history using an exponential moving average:
```python
# Initialize before training loop
sample_loss_ema = {}  # map sample_id -> EMA of loss

# In training loop, after computing per-sample loss
for b in range(B):
    sid = batch_ids[b]  # need to track sample IDs from the dataloader
    current_loss = vol_per_sample[b].item() + surf_per_sample[b].item()
    if sid not in sample_loss_ema:
        sample_loss_ema[sid] = current_loss
    else:
        sample_loss_ema[sid] = 0.9 * sample_loss_ema[sid] + 0.1 * current_loss
    
    # Difficulty weight: higher loss -> higher weight (capped at 3x)
    difficulty = min(3.0, sample_loss_ema[sid] / (mean_ema + 1e-8))
```

If sample IDs aren't easily accessible, use a simpler approach: scale each sample's loss by its relative difficulty within the batch:
```python
# Within-batch difficulty scaling
with torch.no_grad():
    per_sample_total = vol_per_sample + surf_per_sample  # [B]
    batch_mean = per_sample_total.mean()
    difficulty_weight = (per_sample_total / (batch_mean + 1e-8)).clamp(0.5, 3.0)
loss = (per_sample_total * difficulty_weight).mean()
```

Run: `python train.py --agent kohaku --wandb_name "kohaku/per-sample-lr-scale" --wandb_group per-sample-difficulty`

## Baseline (true mean)
- val/loss: ~2.26±0.007, surf_p: in_dist≈20.5, ood_cond≈20.5, tandem≈41.5
---
## Results

**W&B run:** `g4zh0z0i` (kohaku/per-sample-lr-scale)

### Metrics (best epoch by val/loss_3split)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy |
|---|---|---|---|---|---|---|
| in_dist | 1.7498 | 0.331 | 0.192 | 24.09 | 1.358 | 0.473 |
| ood_cond | 2.1717 | 0.313 | 0.208 | 25.11 | 1.194 | 0.459 |
| tandem_transfer | 3.3257 | 0.647 | 0.348 | 42.48 | 2.139 | 0.992 |
| **val/loss_3split** | **2.4157** | — | — | — | — | — |

Baseline: val/loss_3split ≈ 2.26 → **this run: +0.16 worse (-7%)**.

Surface pressure vs baseline: in_dist 24.09 vs ~20.5, ood_cond 25.11 vs ~20.5, tandem 42.48 vs ~41.5. All worse.

Note: `val_ood_re/vol_loss` exploded to ~18868 (catastrophic for that split), though this is excluded from the 3-split metric. Something about the training dynamic destabilized OOD-Re predictions specifically.

**Peak memory:** N/A (not logged)

### What happened

The within-batch difficulty scaling **did not help** — it made things measurably worse across all three val splits.

The core problem is that within-batch difficulty weighting is noisy and potentially destabilizing:
- A batch of size 4 has high variance in per-sample losses just from random sampling, not from true difficulty differences.
- The clamp [0.5, 3.0] means one sample can get 6x the weight of another in the same batch based on batch-local noise.
- This creates inconsistent gradient signal across steps, effectively making the learning rate highly variable per sample per step.
- The `tandem_boost` + `surf_weight` are already doing sample-level weighting for the known hard cases; adding another difficulty layer competes with this.

The true cross-epoch EMA approach (primary instruction) would avoid this noise, but requires sample IDs from the dataloader, which are not currently available.

### Suggested follow-ups

- **Add sample IDs to the dataloader**: The EMA approach from the primary instruction is the correct one. If `data/prepare_multi.py` can expose sample indices, we could track per-sample EMAs across epochs and do proper curriculum learning.
- **Focal loss on nodes**: Instead of weighting samples, weight individual nodes by prediction difficulty. Nodes with persistently high error get upweighted within each sample. This is node-level curriculum and more stable than batch-level.
- **Soft bootstrapping**: Replace target with a blend of ground truth and model prediction for easy samples (β·ŷ + (1-β)·y), which effectively down-weights easy samples without changing gradient variance.