### PR TITLE
Orthogonal projection replication (seed=7, verify 2.24 finding)

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,7 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.output_decorr = nn.Parameter(torch.eye(3))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -339,6 +340,7 @@ class Transolver(nn.Module):
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)
+        fx = fx @ self.output_decorr
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}
 
@@ -364,9 +366,15 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 42
 
 
 cfg = sp.parse(Config)
+
+torch.manual_seed(cfg.seed)
+import random, numpy as np
+random.seed(cfg.seed)
+np.random.seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3
@@ -670,6 +678,11 @@ for epoch in range(MAX_EPOCHS):
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
+
+        decorr = model.output_decorr
+        I = torch.eye(3, device=device)
+        ortho_loss = ((decorr.T @ decorr - I) ** 2).sum()
+        loss = loss + 0.001 * ortho_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Orthogonal projection (#1001) gave val_loss=2.2400 (exactly at our 2.24 threshold). Replicate with seed=7 to see if it's consistently near or below 2.24.

## Instructions
Implement the EXACT same orthogonal projection as PR #1001:
- `self.output_decorr = nn.Parameter(torch.eye(3))`
- Applied after output head: `fx = fx @ self.output_decorr`
- Orthogonality loss: `0.001 * ((decorr.T @ decorr - I)**2).sum()`
- Set seed=7

Run: `python train.py --agent edward --wandb_name "edward/ortho-proj-seed-7" --seed 7 --wandb_group ortho-replication`

## Baseline (true mean): val_loss ≈ 2.260 ± 0.007
## PR #1001 result: val_loss = 2.2400
---
## Results

**W&B run:** sptw8n1k  
**Epochs:** 63 at 28.7s/epoch (30-min cap)

| Metric | Baseline (mean) | PR #1001 (default seed) | Seed=7 (this run) |
|---|---|---|---|
| val/loss (3-split) | 2.260 ± 0.007 | 2.2400 | 2.2643 |
| surf_p in_dist | ~20.03 | 21.15 | 21.78 |
| surf_p ood_cond | ~20.57 | 21.15 | 21.22 |
| surf_p tandem | ~40.41 | 42.03 | 43.02 |

Surface MAE by component (last/best epoch = 63):
- in_dist: Ux=0.287, Uy=0.179, p=21.78
- ood_cond: Ux=0.262, Uy=0.191, p=21.22
- tandem: Ux=0.637, Uy=0.344, p=43.02

Volume MAE: in_dist Ux=1.30, Uy=0.46, p=25.72; ood_cond Ux=1.02, Uy=0.40, p=19.42

### What happened

**The 2.2400 finding does not replicate.** Seed=7 gives val/loss=2.2643, which falls squarely within the stated baseline range of 2.260 ± 0.007 (i.e., 2.2643 is between 2.253 and 2.267). This strongly suggests PR #1001's 2.2400 was favorable random variance, not a real signal from the orthogonal projection.

Averaging the two runs: (2.2400 + 2.2643) / 2 = 2.2522. Even this average is only marginally below the baseline mean, and with n=2 the uncertainty is large.

On surface pressure specifically, both runs show regressions: in_dist surf_p = 21.15 and 21.78 (vs baseline 20.03) — consistently worse than baseline across seeds.

**Conclusion**: The orthogonal output projection does not reliably improve performance. The 2.24 result was within noise, and surface pressure MAE is degraded in both runs.

### Suggested follow-ups

- **More seeds** (3-4 total) for a proper statistical comparison, if the advisor wants a definitive answer on whether the mean is below 2.260.
- Given both seeds show surface pressure regression (21.15, 21.78 vs 20.03), the approach is likely not worth pursuing further.
- Physical channels (Ux, Uy, p) may benefit from explicit multi-task heads rather than a post-hoc linear mixing.