### PR TITLE
Baseline seed=99 (variance characterization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -364,9 +364,14 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int | None = None
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed is not None:
+    torch.manual_seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Additional baseline variance data point. No code changes except seed.

## Instructions
```python
torch.manual_seed(99)
torch.cuda.manual_seed_all(99)
```
Run: `python train.py --agent thorfinn --wandb_name "thorfinn/baseline-seed-99" --seed 99 --wandb_group baseline-variance`

## Baseline (true mean): val_loss ≈ 2.260 ± 0.007
---
## Results

**W&B run:** `89wdqpgc`
**Best epoch:** 67

### Validation metrics at best epoch

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.6717 | 0.320 | 0.181 | 21.59 | 1.306 | 0.446 | 25.75 |
| val_tandem_transfer | 3.2009 | 0.617 | 0.330 | 40.33 | 2.120 | 0.967 | 43.09 |
| val_ood_cond | 1.9310 | 0.279 | 0.194 | 22.60 | 1.073 | 0.413 | 20.03 |
| val_ood_re | 18869.6* | 0.274 | 0.202 | 31.36 | 1.034 | 0.438 | 51.04 |

*val_ood_re vol_loss overflow is a known pre-existing bug.

**val/loss (3-split): 2.2679** vs. true mean 2.260 ± 0.007

### Analysis

Result is 2.2679, which is ~1.1σ above the reported mean. Within expected variance. No code changes beyond adding `--seed` support to Config and seeding before data loading. Variance comes from weight initialization and batch sampling order.

In-dist surf_p (21.59) and tandem surf_p (40.33) are consistent with other baseline runs.