### PR TITLE
Checkpoint selection by mean surface pressure MAE

### DIFF
--- a/train.py
+++ b/train.py
@@ -800,6 +800,14 @@ for epoch in range(MAX_EPOCHS):
                               torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
     val_loss_3split = sum(_3split_losses) / max(len(_3split_losses), 1)
 
+    # 3-split mean surface pressure MAE — used for checkpoint selection
+    _3split_surf_p = []
+    for n in _3split_names:
+        sp = val_metrics_per_split[n].get(f"{n}/mae_surf_p", float("inf"))
+        if not (torch.tensor(sp).isnan() or torch.tensor(sp).isinf()):
+            _3split_surf_p.append(sp)
+    mean_surf_p = sum(_3split_surf_p) / max(len(_3split_surf_p), 1)
+
     # 4-split val/loss (all splits including ood_re)
     _4split_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in VAL_SPLIT_NAMES
                       if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
@@ -814,6 +822,7 @@ for epoch in range(MAX_EPOCHS):
         "train/surf_loss": epoch_surf,
         "val/loss": val_loss_3split,
         "val/loss_3split": val_loss_3split,
+        "val/mean_surf_p": mean_surf_p,
         "val/loss_4split": val_loss_4split,
         "lr": scheduler.get_last_lr()[0],
         "epoch_time_s": dt,
@@ -829,9 +838,9 @@ for epoch in range(MAX_EPOCHS):
         peak_mem_gb = 0.0
 
     tag = ""
-    if val_loss_3split < best_val:
-        best_val = val_loss_3split
-        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split}
+    if mean_surf_p < best_val:
+        best_val = mean_surf_p
+        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split, "mean_surf_p": mean_surf_p}
         for split_metrics in val_metrics_per_split.values():
             for k, v in split_metrics.items():
                 best_metrics[f"best_{k}"] = v


### PR DESCRIPTION
## Hypothesis
Checkpoint selection currently uses val_loss (combined vol + surf_weight * surf, 3-split average). But our primary metric is mae_surf_p. The val_loss can select checkpoints that are good for volume but suboptimal for surface pressure. Selecting the checkpoint by mean mae_surf_p across the 3 main splits directly aligns the saved model with our actual optimization target.

## Instructions
After computing `val_metrics_per_split` (around line 800), add surface-pressure-based checkpoint selection:

```python
# After _3split_names and val_loss_3split computation, add:
_3split_surf_p = []
for n in _3split_names:
    sp = val_metrics_per_split[n].get(f"{n}/mae_surf_p", float("inf"))
    if not (torch.tensor(sp).isnan() or torch.tensor(sp).isinf()):
        _3split_surf_p.append(sp)
mean_surf_p = sum(_3split_surf_p) / max(len(_3split_surf_p), 1)
```

Change the checkpoint selection criterion (line 832):
```python
# Replace: if val_loss_3split < best_val:
if mean_surf_p < best_val:
```

Initialize `best_val` as `float("inf")` (should already be).

Keep logging `val_loss_3split` as `val/loss` for comparison. Also add:
```python
metrics["val/mean_surf_p"] = mean_surf_p
```

Update `best_metrics` to include `val_loss` for reporting:
```python
best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split, "mean_surf_p": mean_surf_p}
```

Run with `--wandb_group ckpt-by-surfp`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** q89on3lb
**W&B group:** ckpt-by-surfp
**Peak memory:** 10.6 GB
**Epochs completed:** 62/100 (hit 30-minute timeout, run still converging)

### Metrics at best checkpoint (epoch 62)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.302 | 0.178 | 21.83 | 1.302 | 0.470 | 25.82 |
| val_ood_cond | 0.268 | 0.188 | 21.29 | 1.063 | 0.409 | 19.66 |
| val_ood_re | 0.276 | 0.201 | 31.40 | 1.034 | 0.440 | 51.54 |
| val_tandem_transfer | 0.650 | 0.342 | 42.34 | 2.199 | 1.007 | 44.27 |

- val_loss_3split = 2.2997 (vs baseline 2.2155)
- mean_surf_p (3-split) = 28.49

### Comparison vs baseline

| Split | Baseline mae_surf_p | This run (epoch 62) | Delta |
|---|---|---|---|
| val_in_dist | 20.24 | 21.83 | +1.59 worse |
| val_ood_cond | 19.72 | 21.29 | +1.57 worse |
| val_ood_re | 30.65 | 31.40 | +0.75 worse |
| val_tandem_transfer | 42.13 | 42.34 | +0.21 worse |

### What happened

The criterion change was implemented correctly and `val/mean_surf_p` was logged throughout training. However, the run hit the 30-minute timeout at epoch 62/100 while both metrics were still monotonically decreasing — **no divergence between the two criteria was observed**. Both `val_loss_3split` and `mean_surf_p` selected the same epoch as best (epoch 62, the last completed). This means the hypothesis could not be properly tested: we never reached a point where one criterion would pick a different checkpoint than the other.

The epoch-62 metrics are worse than baseline across all splits, but this is expected — baseline ran to convergence (100 epochs) while this run stopped at 62. The `val_ood_re` split shows an anomalously large loss (~18869) indicating a numerical instability in its volume component, but surface metrics look normal.

**Key finding:** At 62 epochs, `val_loss_3split` and `mean_surf_p` are perfectly correlated in their per-epoch ranking. If vol and surf losses track together throughout training, the combined val_loss may already implicitly select good surface pressure checkpoints, and this criterion change would provide no benefit.

### Suggested follow-ups

- Run a longer experiment to see if the two criteria diverge in the later stages of training
- Check correlation between `val_loss_3split` and `mean_surf_p` across multiple runs — if they always agree, this change is redundant
- If the numerical instability in `val_ood_re` is fixed, it would make comparisons cleaner