### PR TITLE
Continuous curvature for all nodes (remove surface masking)

### DIFF
--- a/train.py
+++ b/train.py
@@ -588,8 +588,8 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for all nodes
+        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True)
         x = torch.cat([x, curv], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
@@ -721,8 +721,8 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for all nodes
+                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True)
                 x = torch.cat([x, curv], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
The curvature proxy (line 592) is masked to surface nodes only via `* is_surface.float().unsqueeze(-1)`. Volume nodes get zero curvature. But the dsdf norm captures geometric information for ALL nodes — distance from surface and local geometry gradient. Removing the masking gives volume nodes access to this geometric gradient info, which should help boundary layer prediction. Better boundary layer accuracy cascades to better surface pressure via the shared representation.

## Instructions
Two one-line changes:

**Line 592** (training):
```python
# Change:
curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
# To:
curv = x[:, :, 2:6].norm(dim=-1, keepdim=True)
```

**Line 725** (validation):
```python
# Change:
curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
# To:
curv = x[:, :, 2:6].norm(dim=-1, keepdim=True)
```

That's it — two lines. Run with `--wandb_group continuous-curv-v2`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** irbgfhsd
**Epochs completed:** 63/100 (hit 30-min timeout; run was still converging)
**Peak GPU memory:** ~32 GB

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | 2.2155 | 2.3218 | +0.106 (worse) |
| val_in_dist/mae_surf_p | 20.24 | 21.60 | +1.36 (worse) |
| val_ood_cond/mae_surf_p | 19.72 | 21.35 | +1.63 (worse) |
| val_ood_re/mae_surf_p | 30.65 | 31.17 | +0.52 (worse) |
| val_tandem_transfer/mae_surf_p | 42.13 | 43.44 | +1.31 (worse) |
| val_in_dist/mae_surf_Ux | -- | 0.315 | -- |
| val_in_dist/mae_surf_Uy | -- | 0.182 | -- |
| val_in_dist/mae_vol_p | -- | 25.79 | -- |

**What happened:** The change did not improve results. At epoch 63 all surface pressure MAE values are higher than baseline across every split. The val/loss curve was still descending (2.33 -> 2.32 in the last few epochs) but at this rate it is unlikely to close the ~0.1 gap to baseline by epoch 100. The hypothesis that volume nodes would benefit from the dsdf gradient magnitude as a geometric signal does not hold. The dsdf norm is already implicitly available to the model through the raw x[:,:,2:6] channels. Unmasking the curvature feature adds a non-zero value for all volume nodes, but it just duplicates information the model already has access to, and may add noise. Surface nodes benefit from the curvature proxy because it amplifies a semantically meaningful boundary indicator; for volume nodes the same feature has weaker semantic meaning.

**Suggested follow-ups:**
- Try a learned weighting: instead of hard masking or no masking, let the model learn to weight the curvature feature per node type (e.g., multiply by a learned scalar, or use the surface flag as a soft gate with sigmoid).
- Try continuous decay: weight curvature by inverse distance to surface so boundary layer nodes get partial signal rather than zero, giving a smooth falloff rather than a hard cut.
- The surface masking appears genuinely useful -- consider whether other input features would benefit from similar surface-only specialization.