### PR TITLE
Cosine annealing T_max=67 (align with actual epoch count)

### DIFF
--- a/train.py
+++ b/train.py
@@ -518,7 +518,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=67, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=5e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
The cosine scheduler uses T_max=75 (line 521), but training actually runs ~67 epochs in 30 minutes. The LR never reaches its minimum (eta_min=1e-4) — at epoch 67 it's ~2.4e-4 instead of 1e-4. Setting T_max=67 aligns the schedule with reality: LR reaches minimum at the actual training end. The EMA model (starting epoch 40) will then average over weights trained at lower LR in final epochs, potentially improving stability.

## Instructions
**Line 521**, one change:
```python
# From:
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
# To:
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=67, eta_min=1e-4)
```

That's the only change. Run with `--wandb_group tmax-67`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

### Experiment 1: T_max=67, eta_min=1e-4 (original PR)

**W&B run:** cnvtwwk8  
**Epochs completed:** 62 (timeout mid-epoch 63)  
**Peak memory:** 10.6 GB

| Metric | T_max=67 | Baseline | Delta |
|---|---|---|---|
| best_val_loss (3split) | 2.2483 | 2.2155 | +0.0328 |
| val_in_dist/mae_surf_p | 21.55 | 20.24 | +1.31 |
| val_ood_cond/mae_surf_p | 20.21 | 19.72 | +0.49 |
| val_ood_re/mae_surf_p | 31.20 | 30.65 | +0.55 |
| val_tandem_transfer/mae_surf_p | 41.17 | 42.13 | -0.96 |

### Experiment 2: T_max=75, eta_min=5e-4 (revision per advisor)

**W&B run:** d6rqjsa1  
**Epochs completed:** ~64 (timeout)  
**Peak memory:** 10.6 GB

| Metric | eta_min=5e-4 | Baseline | Delta |
|---|---|---|---|
| best_val_loss (3split) | 2.3319 | 2.2155 | +0.1164 |
| val_in_dist/mae_surf_p | 22.66 | 20.24 | +2.42 |
| val_ood_cond/mae_surf_p | 22.40 | 19.72 | +2.68 |
| val_ood_re/mae_surf_p | 32.00 | 30.65 | +1.35 |
| val_tandem_transfer/mae_surf_p | 42.21 | 42.13 | +0.08 |

**What happened:** Both changes made things worse. The eta_min=5e-4 run was notably worse than even the T_max=67 run — a higher LR floor (5e-4 vs 1e-4) prevents the model from settling into a sharp minimum. Late-epoch training with LR ~5.5e-4 (vs ~2.4e-4 at epoch 67 in baseline) is too noisy to refine surface pressure predictions, which require high precision. The EMA model averaging over weights trained at a higher LR floor appears to hurt rather than help, as those weights are less converged.

The baseline (T_max=75, eta_min=1e-4) remains the best configuration for the LR schedule. The cosine annealing schedule is already well-tuned.

**Suggested follow-ups:**
- LR schedule tuning is likely not the highest-leverage lever here. The val_ood_re surface pressure (30.65) is stuck much higher than val_in_dist (20.24), suggesting a domain gap issue rather than a convergence issue.
- Consider architecture changes (e.g. more expressive attention for Reynolds number OOD) or data augmentation targeting Re-OOD conditions.