### PR TITLE
Asymmetric noise: boost velocity, reduce pressure noise

### DIFF
--- a/train.py
+++ b/train.py
@@ -595,7 +595,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
+            noise_scale = torch.tensor([0.015, 0.015, 0.002], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)


### PR DESCRIPTION
## Hypothesis
Current target noise is [0.01, 0.01, 0.005] for [Ux, Uy, p]. Pressure is the most important metric. Higher noise on velocity channels provides regularization for the shared representation without directly corrupting the pressure signal. By boosting velocity noise 50% while cutting pressure noise 60%, the pressure gradients are cleaner while velocity noise still regularizes the shared layers.

## Instructions
```python
# From:
noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
# To:
noise_scale = torch.tensor([0.015, 0.015, 0.002], device=device)
```

That's the only change. Run with `--wandb_group asymmetric-noise`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** ltjxnlwr
**Epochs completed:** 62 (30-min timeout)
**Peak memory:** 10.6 GB

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | 2.2155 | 2.3143 | +0.099 worse |
| val_in_dist/mae_surf_p | 20.24 | 22.16 | +1.92 worse |
| val_ood_cond/mae_surf_p | 19.72 | 22.20 | +2.48 worse |
| val_ood_re/mae_surf_p | 30.65 | 31.75 | +1.10 worse |
| val_tandem_transfer/mae_surf_p | 42.13 | 42.42 | +0.29 worse |

### Full surface MAE (best epoch)

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 0.3068 | 0.1839 | 22.16 |
| val_ood_cond | 0.2785 | 0.1948 | 22.20 |
| val_ood_re | 0.2804 | 0.2074 | 31.75 |
| val_tandem_transfer | 0.6474 | 0.3427 | 42.42 |

### Volume MAE (val_in_dist)
Ux: 1.3161, Uy: 0.4761, p: 26.65

### What happened

The hypothesis did not work — every metric is worse than baseline. Surface pressure MAE increased across all four splits, and val_loss increased by ~0.10. Reducing pressure noise from 0.005 to 0.002 made things worse, not better.

The rationale was that cleaner pressure targets would improve pressure accuracy. But the result suggests the original pressure noise (0.005) was beneficial as regularization, not harmful. The asymmetric change disrupted a balance — adding more velocity noise did not compensate for the reduced pressure regularization. The model may need noise on the pressure channel to avoid overfitting in-distribution pressure patterns, explaining the degraded OOD performance especially on val_ood_cond (+2.48).

### Suggested follow-ups

1. **Symmetric noise sweep**: Try uniform reductions, e.g. [0.008, 0.008, 0.004] — to see if less noise overall helps.
2. **Zero pressure noise**: Try [0.01, 0.01, 0.0] as an extreme test to see if pressure noise is doing anything at all.
3. **More velocity noise only**: Try [0.02, 0.02, 0.005] — keep pressure noise intact but double velocity noise to test the regularization effect in isolation.