### PR TITLE
Sinusoidal position encoding in spatial bias MLP

### DIFF
--- a/train.py
+++ b/train.py
@@ -174,10 +174,7 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
-        self.n_freq = 4
-        n_freq = 4
-        spatial_in = 2 + 2 * 2 * n_freq  # 2 raw + 16 sin/cos = 18
-        self.spatial_bias = nn.Sequential(nn.Linear(spatial_in, 32), nn.GELU(), nn.Linear(32, slice_num))
+        self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -193,13 +190,7 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx, raw_xy=None):
-        if raw_xy is not None:
-            freqs = 2.0 ** torch.arange(self.n_freq, device=raw_xy.device, dtype=raw_xy.dtype)  # [4]
-            xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-            pe = torch.cat([raw_xy, xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 18]
-            sb = self.spatial_bias(pe)
-        else:
-            sb = None
+        sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
@@ -470,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1,  # X_DIM=24 + 1 curvature proxy; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -600,6 +591,12 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
+        # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
+        raw_xy = x[:, :, :2]
+        freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
+        xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+        x = torch.cat([x, fourier_pe], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -733,6 +730,12 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
+                # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
+                raw_xy = x[:, :, :2]
+                freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
+                xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
The spatial_bias MLP (line 177) takes raw (x,y) coordinates through a tiny 2→32→slice_num network. A 2-layer MLP with 2 input dims struggles to represent high-frequency spatial patterns like leading/trailing edges and boundary layers. Inspired by NeRF's positional encoding, we map (x,y) to sin/cos features at multiple frequencies before the MLP. This targets only the spatial bias (slice assignment), not the main input, keeping the change surgical and low-risk.

## Instructions
**In TransolverBlock.__init__** (around line 165-177):

Store the frequency count:
```python
self.n_freq = 4  # add after super().__init__()
```

Replace the spatial_bias definition (line 177):
```python
# From:
self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
# To:
n_freq = 4
spatial_in = 2 + 2 * 2 * n_freq  # 2 raw + 16 sin/cos = 18
self.spatial_bias = nn.Sequential(nn.Linear(spatial_in, 32), nn.GELU(), nn.Linear(32, slice_num))
```

**In TransolverBlock.forward** (line 193), replace:
```python
# From:
sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
# To:
if raw_xy is not None:
    freqs = 2.0 ** torch.arange(self.n_freq, device=raw_xy.device, dtype=raw_xy.dtype)  # [4]
    xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
    pe = torch.cat([raw_xy, xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 18]
    sb = self.spatial_bias(pe)
else:
    sb = None
```

Run with `--wandb_group fourier-spatial-bias`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

### Attempt 1: Fourier PE in spatial_bias MLP

**W&B run:** kd23hxqy | **Peak GPU:** 10.7 GB | **Best epoch:** 66/100

| Metric | Baseline | Attempt 1 | Delta |
|---|---|---|---|
| val/loss | 2.2155 | 2.2313 | +0.016 (worse) |
| val_in_dist/mae_surf_p | 20.24 | 20.8 | +0.56 (worse) |
| val_ood_cond/mae_surf_p | 19.72 | 21.4 | +1.68 (worse) |
| val_ood_re/mae_surf_p | 30.65 | 30.8 | +0.15 (~same) |
| val_tandem_transfer/mae_surf_p | 42.13 | 40.9 | -1.23 (better) |

Did not help — spatial_bias MLP is too small to leverage richer positional input.

### Attempt 2: Fourier PE on main model input (per advisor feedback)

Applied per advisor direction: reverted spatial_bias changes, added sin/cos PE of (x,y) at 4 frequencies to main input features, updated fun_dim from 23 to 39.

**W&B run:** j06e3jpr | **Peak GPU:** ~10.8 GB | **Best epoch:** 66/100

| Metric | Baseline | Attempt 2 | Delta |
|---|---|---|---|
| val/loss | 2.2155 | 2.2117 | -0.004 (better) |
| val_in_dist/mae_surf_p | 20.24 | 19.72 | -0.52 (better, ~2.6%) |
| val_ood_cond/mae_surf_p | 19.72 | 20.35 | +0.63 (worse, ~3.2%) |
| val_ood_re/mae_surf_p | 30.65 | 30.37 | -0.28 (better, ~0.9%) |
| val_tandem_transfer/mae_surf_p | 42.13 | 40.92 | -1.21 (better, ~2.9%) |

**What happened:** Applying Fourier PE to the main input yields a marginal net improvement (val/loss -0.004, ~0.2%). Three of four surface pressure metrics improved: in_dist (-2.6%), ood_re (-0.9%), tandem_transfer (-2.9%). ood_cond regressed slightly (+0.63). The overall picture is a wash — the improvement is within noise range for a single run. The +16 features give the main transformer pathway richer spatial information but the effect is small, suggesting the model learns geometry well enough from the existing 24 input features.

**Suggested follow-ups:**
- Try normalizing the (x,y) coordinates before computing the Fourier features — the coordinates span different scales depending on mesh extent, and normalizing could make the frequencies more meaningful.
- Try more frequencies (n_freq=8 giving 32 extra dims) to capture finer spatial detail at leading/trailing edges.
- Try learnable frequencies instead of fixed powers-of-2 to let the model pick the scales it finds most useful.