### PR TITLE
Tandem-specific preprocess branch (lightweight MoE)

### DIFF
--- a/train.py
+++ b/train.py
@@ -244,6 +244,7 @@ class Transolver(nn.Module):
             )
         else:
             self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess_tandem = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim
@@ -327,7 +328,11 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         raw_xy = x[:, :, :2]
-        fx = self.preprocess(x)
+        # Detect tandem samples: gap feature at index 21 (normalized gap != 0 means tandem)
+        is_tandem_sample = (x[:, 0, 21].abs() > 0.5)  # [B]
+        fx_single = self.preprocess(x)
+        fx_tandem = self.preprocess_tandem(x)
+        fx = torch.where(is_tandem_sample[:, None, None], fx_tandem, fx_single)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 


### PR DESCRIPTION
## Hypothesis
Tandem surf_p (42.13) is 2x worse than in_dist (20.24) — the biggest performance gap. Single-foil and tandem flows have fundamentally different physics (wake interaction, downwash). The preprocess MLP processes all samples identically. By adding a second preprocess MLP for tandem samples (selected by a hard gate on the gap feature), the model gets separate feature extraction for the two flow regimes while sharing attention and output. This is a lightweight Mixture-of-Experts approach.

## Instructions
**In Transolver.__init__** (around line 250), after the existing preprocess:
```python
# After: self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
self.preprocess_tandem = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
```

**In Transolver.forward** (around line 325), replace the single preprocess call:
```python
# Replace:
# fx = self.preprocess(x)
# With:
# Detect tandem samples: gap feature at index 21 in normalized x (raw_gap)
is_tandem_sample = (x[:, 0, 21].abs() > 0.5)  # [B] - normalized gap != 0 means tandem
fx_single = self.preprocess(x)
fx_tandem = self.preprocess_tandem(x)
fx = torch.where(is_tandem_sample[:, None, None], fx_tandem, fx_single)
```

Note: Check that index 21 corresponds to the gap feature in the normalized+curvature-appended x tensor. The original X_DIM=24, curvature is appended as dim 25 (index 24). Gap was originally at index 22 in the raw 24-dim features, but after (x - x_mean) / x_std normalization it's still at the same position. Verify: `print(x[0, 0, :])` and check which index has the gap value.

Run with `--wandb_group tandem-preprocess`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** 2dhcq98n  
**Epochs completed:** 59/100 (30-min timeout, ~29s/epoch)  
**Peak memory:** 12.1 GB

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss_3split | 2.622 | 2.2155 | +0.41 (worse) |
| val_in_dist/mae_surf_p | 25.17 | 20.24 | +4.93 (worse) |
| val_ood_cond/mae_surf_p | 29.16 | 19.72 | +9.44 (worse) |
| val_ood_re/mae_surf_p | 36.25 | 30.65 | +5.60 (worse) |
| val_tandem_transfer/mae_surf_p | 44.18 | 42.13 | +2.05 (worse) |
| val_in_dist/mae_vol_p | 30.25 | — | — |
| val_tandem_transfer/mae_vol_p | 47.19 | — | — |

Note: val_ood_re/vol_loss (~18868) is astronomically high across all runs — confirmed pre-existing issue unrelated to these changes.

### What happened

The hypothesis failed. All four splits are worse than baseline, including val_tandem_transfer which was the primary target (44.18 vs 42.13 baseline). The model was still improving at the 30-min timeout but its 3-split trajectory was clearly worse than baseline from early epochs.

Likely failure modes:
1. **Both MLPs compute for every sample.** `torch.where` masks the output but both `fx_single` and `fx_tandem` are computed for every batch. The masked path gets zero gradient, so each MLP only trains on ~half the batches effectively. Training signal per-MLP is diluted.
2. **Asymmetric architecture hurts tandem.** The tandem MLP uses `n_layers=0, res=False` while the single-foil MLP uses `n_layers=1, res=True`. Tandem physics are arguably more complex, so giving it the shallower architecture is counterproductive.
3. **Extra parameters slow convergence.** With the same 30-min budget, this model reaches worse checkpoints, suggesting the added complexity doesn't help at this parameter scale (n_hidden=128, n_layers=1).

The hard gate on index 21 (normalized gap > 0.5) works correctly — consistent with existing is_tandem logic in the training loop.

### Suggested follow-ups

- **Shared base + tandem residual correction:** instead of forking the full preprocess, add a small additive correction for tandem samples: `fx = self.preprocess(x) + is_tandem[:, None, None] * self.tandem_delta(x)`. This keeps the shared preprocess fully trained and only adds a residual for tandem, improving gradient flow.
- **Symmetric MoE:** if forking is retried, use identical architectures for both MLPs (both `n_layers=1, res=True`) to avoid the capacity mismatch — tandem flows need at least as much capacity as single-foil.
- **Tandem-specific attention slices:** partitioning attention slices (currently 32) into tandem/single groups would be a higher-capacity intervention at the right layer (where most model expressivity is).
