### PR TITLE
Boundary-layer-aware volume loss weighting (proximity boost)

### DIFF
--- a/train.py
+++ b/train.py
@@ -628,6 +628,11 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
+        # Proximity weighting: exponential decay by distance from surface
+        dsdf_mag = x[:, :, 2:6].norm(dim=-1)  # first 4 dsdf channels
+        vol_prox_weight = (1.0 + 2.0 * torch.exp(-dsdf_mag / 0.3)) * vol_mask.float()
+        vol_prox_weight = vol_prox_weight / vol_prox_weight.sum().clamp(min=1) * vol_mask.sum().clamp(min=1).float()
+
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
         if epoch < 40:
@@ -642,7 +647,10 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        if model.training:
+            vol_loss = (abs_err * vol_prox_weight.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        else:
+            vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()


### PR DESCRIPTION
## Hypothesis
The model treats all volume nodes equally, but aerodynamically the boundary layer (thin region near the surface) determines surface pressure via pressure-velocity coupling. The dsdf features encode signed distance from the surface. By weighting volume loss inversely with distance from surface using an exponential decay, we focus the model on the boundary layer. Better boundary layer accuracy should cascade to better surface pressure.

## Instructions
After computing `vol_mask` (line 628) and before the volume loss computation, add proximity weighting:

```python
# After line 628: vol_mask = mask & ~is_surface
# Add:
dsdf_mag = x[:, :, 2:6].norm(dim=-1)  # first 4 dsdf channels
vol_prox_weight = (1.0 + 2.0 * torch.exp(-dsdf_mag / 0.3)) * vol_mask.float()
vol_prox_weight = vol_prox_weight / vol_prox_weight.sum().clamp(min=1) * vol_mask.sum().clamp(min=1).float()
```

Then replace the volume loss computation. Find where vol_loss is computed (it should be around line 635-640):
```python
# Replace standard vol_loss with weighted version:
vol_loss = (abs_err * vol_prox_weight.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
```

Do NOT apply this weighting to the validation volume loss — only training.

Run with `--wandb_group boundary-layer-vol`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** `gb7x86q8` (62 epochs, hit 30-min timeout)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss (3-split) | 2.2155 | 2.3233 | +0.108 ↑ worse |
| val_in_dist/mae_surf_p | 20.24 | 22.95 | +2.71 ↑ worse |
| val_ood_cond/mae_surf_p | 19.72 | 22.59 | +2.87 ↑ worse |
| val_ood_re/mae_surf_p | 30.65 | 31.15 | +0.50 ↑ worse |
| val_tandem_transfer/mae_surf_p | 42.13 | 43.43 | +1.30 ↑ worse |
| val_in_dist/mae_surf_Ux | — | 0.309 | — |
| val_in_dist/mae_surf_Uy | — | 0.178 | — |
| val_in_dist/mae_vol_p | — | 27.61 | — |
| Peak memory | — | 10.6 GB | — |

Note: `val_ood_re/vol_loss` = 18868 (enormous). This appears to be a pre-existing issue with the OOD-Re split (the 3-split val/loss excludes it; baseline's best_val_loss of 2.2155 also likely excluded it).

**What happened:**

The proximity weighting hurt across all splits. Surface pressure MAE degraded by 2–3 points on in-dist and ood-cond, the two most reliable splits.

The core issue: re-normalizing the volume loss to upweight near-surface nodes simultaneously downweights far-field nodes. Far-field pressure gradients drive surface pressure in external aerodynamics (Bernoulli / pressure-velocity coupling is nonlocal). By making the model attend less to far-field volume nodes during training, we starved it of the global pressure information it needs to predict surface pressure accurately.

The normalization formula ensures the total weight sum is preserved, but the distribution shift from uniform → boundary-layer-concentrated was enough to meaningfully hurt generalization. The decay scale of 0.3 is aggressive — it creates ~3× more weight for nodes immediately adjacent to the surface.

**Suggested follow-ups:**
- Try a much softer decay (scale 1.0–2.0 instead of 0.3) so the far-field nodes aren't heavily penalized
- Try the opposite: upweight *far-field* volume nodes (inverse weighting), since far-field pressure may be underfit
- Instead of re-normalizing to preserve total weight, try an additive boost (e.g. `weight = 1 + 0.5 * exp(-dsdf/0.3)` without renormalization) so far-field nodes still get full gradient signal