### PR TITLE
Per-group gradient clipping (tight attn, loose MLP)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,7 +673,8 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(attn_params, max_norm=0.5)
+        torch.nn.utils.clip_grad_norm_(other_params, max_norm=2.0)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:


### PR DESCRIPTION
## Hypothesis
The model uses a single max_norm=1.0 for all parameters (line 676). Variance characterization showed 100% of batches are clipped, meaning the effective step size is constrained. The attention parameters (with 0.5x LR) and preprocess/output parameters (with 1.0x LR) likely have very different gradient norms. Using per-group clipping allows each component to update at its natural scale: tighter clipping for sensitive attention params, looser for preprocess/output MLPs.

## Instructions
**Line 676**, replace:
```python
# From:
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
# To:
torch.nn.utils.clip_grad_norm_(attn_params, max_norm=0.5)
torch.nn.utils.clip_grad_norm_(other_params, max_norm=2.0)
```

Note: `attn_params` and `other_params` are already defined at lines 513-514. They are the same parameter groups used by the optimizer.

Run with `--wandb_group per-group-clip`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run ID:** cup5qjkz
**Epochs completed:** 65/100 (30-min timeout)
**Peak memory:** not captured in W&B (no OOM observed)

### Metrics at epoch 65 (last logged, loss still decreasing)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.296 | 0.183 | 21.58 | 1.308 | 0.468 | 26.54 |
| val_ood_cond | 0.275 | 0.193 | 22.25 | 1.075 | 0.415 | 20.31 |
| val_ood_re | 0.281 | 0.202 | 30.83 | 1.040 | 0.442 | 51.04 |
| val_tandem_transfer | 0.633 | 0.339 | 41.79 | 2.139 | 0.992 | 44.04 |

**val/loss (3-split):** 2.2817 (vs baseline 2.2155)

### vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | 2.2155 | 2.2817 | +0.066 (epoch 65, not converged) |
| val_in_dist/mae_surf_p | 20.24 | 21.58 | +1.34 |
| val_ood_cond/mae_surf_p | 19.72 | 22.25 | +2.53 |
| val_ood_re/mae_surf_p | 30.65 | 30.83 | +0.18 |
| val_tandem_transfer/mae_surf_p | 42.13 | 41.79 | -0.34 |

### What happened

Per-group clipping did not improve over baseline. At epoch 65 (30-min timeout), val/loss was 2.2817 vs baseline 2.2155, and surface pressure MAE was worse or equal on in-dist, ood_cond, and ood_re. The loss curve was still monotonically decreasing at cutoff (2.40 at epoch 56 → 2.28 at epoch 65), so the model had not converged — it might close some gap by epoch 100, but the trajectory does not suggest it would beat baseline.

The looser max_norm=2.0 on other_params did not cause obvious instability in the MAE metrics, but val_ood_re/vol_loss and val/loss_4split are enormously large (18868 and 4719). This appears to be pre-existing numerical instability in the OOD-Re regime rather than caused by this change.

The hypothesis that per-group clipping would let each component update at its natural scale did not materialize — the model converged at a similar or slightly slower pace compared to baseline.

### Suggested follow-ups

- Try less aggressive asymmetry (e.g., attn=0.8, other=1.5) to see if gradient norm ratio rather than absolute values is what matters.
- Investigate the enormous val_ood_re/vol_loss (18868) — this pre-existing numerical issue may be masking improvements and is worth diagnosing separately.
- Consider adaptive gradient clipping (AGC) as an alternative if norm clipping at 100% clip rate is a real concern.