### PR TITLE
Batch size 8 + gradient checkpointing (smoother gradients)

### DIFF
--- a/train.py
+++ b/train.py
@@ -35,6 +35,7 @@ from einops import rearrange
 from timm.layers import trunc_normal_
 from tqdm import tqdm
 from torch.utils.data import DataLoader, WeightedRandomSampler
+from torch.utils.checkpoint import checkpoint as ckpt_fn
 import simple_parsing as sp
 
 from data.utils import visualize
@@ -332,7 +333,7 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy)
+            fx = ckpt_fn(block, fx, raw_xy, use_reentrant=False)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
@@ -354,9 +355,9 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 6e-3
     weight_decay: float = 0.0
-    batch_size: int = 4
+    batch_size: int = 8
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
     stats_file: str = "data/split_stats.json"


### PR DESCRIPTION
## Hypothesis
With 1 Transolver layer using ~10 GB of 96 GB VRAM, there is enormous memory headroom. Doubling batch size from 4 to 8 gives smoother gradients (2x more samples per update). To maintain the same effective learning rate per sample, also double the LR to 6e-3. Use gradient checkpointing on the TransolverBlock to manage any additional memory. The key insight: same number of gradient steps per epoch, but each step sees 2x more data.

## Instructions
**In Config** (line 357-359), change:
```python
batch_size: int = 8
lr: float = 6e-3
```

**In Transolver.forward** (around line 330), add gradient checkpointing:
```python
from torch.utils.checkpoint import checkpoint as ckpt_fn

# Replace the block loop:
# for block in self.blocks[:-1]:
#     fx = block(fx, raw_xy=raw_xy)
# With:
for block in self.blocks[:-1]:
    fx = ckpt_fn(block, fx, raw_xy, use_reentrant=False)
```

Note: The import can go at the top of the file. The attn_params LR multiplier is relative (0.5x), so it will automatically scale to 3e-3.

Run with `--wandb_group batch8-ckpt`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** tkj60je8
**Epochs completed:** 63 (30-minute timeout)
**Peak memory:** 21.1 GB (vs ~10 GB baseline — doubled as expected with batch_size=8)

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| best_val_loss | 2.2155 | 2.4474 | +0.23 worse |
| val_in_dist/mae_surf_p | 20.24 | 28.4 | +8.2 worse |
| val_ood_cond/mae_surf_p | 19.72 | 21.2 | +1.5 worse |
| val_ood_re/mae_surf_p | 30.65 | 32.2 | +1.6 worse |
| val_tandem_transfer/mae_surf_p | 42.13 | 42.9 | +0.8 worse |

Notably, val_ood_re/loss = **37038.7** — the model diverged catastrophically on the OOD Reynolds number split.

### What happened

The hypothesis did not work. The 2x linear LR scaling (3e-3 -> 6e-3) was too aggressive and caused training instability, most visible in val_ood_re diverging (loss 37k). The OOD Re split contains the most distributional shift, and a large LR makes the model fragile to it.

Gradient checkpointing worked correctly — memory was 21.1 GB vs ~10 GB at batch=4, consistent with 2x batch size. The memory management part of the hypothesis was sound.

The problem is the LR. Linear scaling of LR with batch size is a common heuristic (from large-batch SGD) but is not always safe for Adam-based optimizers or for small networks with high gradient variance. 63 epochs vs likely 80-90 for the baseline also means less convergence time, but the instability on val_ood_re suggests the model trained poorly overall.

### Suggested follow-ups

1. **Batch=8 with original lr=3e-3** (no scaling): test whether the larger batch itself helps without the destabilizing LR increase.
2. **Square-root scaling**: try lr=4.2e-3 (3e-3 x sqrt(2)) — a more conservative heuristic for Adam.
3. **LR warmup**: if higher LR is desired, add a warmup schedule to prevent early instability.
4. **Cyclical/cosine LR**: the current scheduler with doubled base LR may be overshooting on the warmup phase.