### PR TITLE
Halve volume loss gradient to preprocess (surface priority)

### DIFF
--- a/train.py
+++ b/train.py
@@ -647,7 +647,8 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        vol_loss_scaled = vol_loss * 0.5 + vol_loss.detach() * 0.5  # halves vol gradient magnitude
+        loss = vol_loss_scaled + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
The volume loss produces ~50-100x more gradient signal than surface loss (many more volume nodes). Even with adaptive surface weighting, the preprocess MLP gradients are dominated by volume reconstruction. By halving the gradient magnitude from vol_loss to the preprocess parameters, we shift the preprocess MLP's optimization priority toward surface accuracy. This is gentler than full gradient detachment — a 0.5 scaling rather than zero.

## Instructions
Find where \`loss\` is assembled from \`vol_loss\` and \`surf_loss\` (around line 650):

\`\`\`python
# Replace:
# loss = vol_loss + surf_weight * surf_loss
# With:
vol_loss_scaled = vol_loss * 0.5 + vol_loss.detach() * 0.5  # halves vol gradient magnitude
loss = vol_loss_scaled + surf_weight * surf_loss
\`\`\`

Keep the coarse_loss and re_loss additions as-is (they follow the main loss line).

**Important**: Only apply this to training, not validation. The val metrics should use the original vol_loss for apples-to-apples comparison.

Run with \`--wandb_group half-vol-grad\`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** \`1iqynat0\`
**Epochs completed:** ~62 of 100 (30-min timeout)
**Peak GPU memory:** 10.6 GB

### Metrics (best checkpoint, epoch 62)

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Delta |
|---|---|---|---|---|
| val_in_dist | 1.63 | 22.7 | 20.24 | +2.5 (worse) |
| val_ood_cond | 1.94 | 21.7 | 19.72 | +2.0 (worse) |
| val_ood_re | 18869 (anomalous) | 31.4 | 30.65 | +0.7 (worse) |
| val_tandem_transfer | 3.28 | 41.7 | 42.13 | -0.4 (slightly better) |

**val/loss (3-split):** ~2.28 vs baseline 2.2155 — worse by ~3%

Note: val_ood_re/vol_loss = ~18869 throughout training (present from epoch 1). This appears to be a pre-existing anomaly in that split — the 3-split val/loss correctly excludes it for checkpoint selection.

### What happened

The hypothesis **did not work** — halving the volume loss gradient made surface accuracy worse, not better.

The three in-distribution and OOD-condition splits all show higher mae_surf_p vs baseline (~10% worse). The reasoning behind the hypothesis was sound: volume loss does dominate gradients. But weakening those signals apparently hurts the model's ability to learn the spatial flow structure that the surface accuracy ultimately depends on. The preprocess MLP needs strong volume supervision to build a good latent representation; degrading that gradient source degrades everything downstream.

The effect was consistent — not noisy or borderline — so this direction seems genuinely counterproductive.

### Suggested follow-ups
- Try the inverse: slightly upweight vol_loss gradient (e.g., 1.5x or 2x) since strong volume supervision seems to help
- Try gradient surgery / projection: instead of scaling, project vol gradients to be orthogonal to surf gradients for the shared preprocess MLP parameters
- Apply the halving only to parameters exclusive to the volume decoding head (not the shared preprocess MLP), so surface-relevant parameters are unaffected