### PR TITLE
Global offset head (predict sample-level shift separately)

### DIFF
--- a/train.py
+++ b/train.py
@@ -269,6 +269,11 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.global_offset = nn.Sequential(
+            nn.Linear(n_hidden, 32),
+            nn.GELU(),
+            nn.Linear(32, out_dim)
+        )
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -328,6 +333,7 @@ class Transolver(nn.Module):
 
         raw_xy = x[:, :, :2]
         fx = self.preprocess(x)
+        offset = self.global_offset(fx.mean(dim=1, keepdim=True))  # [B, 1, out_dim]
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
@@ -339,6 +345,7 @@ class Transolver(nn.Module):
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)
+        fx = fx + offset
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}
 


### PR DESCRIPTION
## Hypothesis
After Cp normalization and z-scoring, the model predicts the full normalized field. Much of this is the sample-level mean (which varies with Re, AoA). A separate lightweight head that predicts a global [Ux, Uy, p] offset from the mean hidden representation factors out the sample-level shift. The main output head can then focus on spatial variation (deviations from the mean), reducing the effective prediction complexity. This is inspired by mean-field decomposition in physics.

## Instructions
**In Transolver.__init__** (after the blocks definition, around line 260), add:
```python
self.global_offset = nn.Sequential(
    nn.Linear(n_hidden, 32),
    nn.GELU(),
    nn.Linear(32, out_dim)
)
```

**In Transolver.forward** (after the preprocess but before the blocks), compute and add the offset:
```python
# After fx = self.preprocess(x) and before the blocks loop:
# Compute global offset from mean hidden features
offset = self.global_offset(fx.mean(dim=1, keepdim=True))  # [B, 1, out_dim]

# After the last block produces the final output (after mlp2), add offset:
# Find where the final prediction is computed and add:
# pred = pred + offset
```

The exact location depends on the forward method. Look for where `self.blocks[-1]` produces the final output (around line 335-340). The offset should be added to the final prediction tensor.

Run with `--wandb_group global-offset`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** gwknr1xe  
**Epochs completed:** 66 (30-min wall-clock timeout)  
**Peak GPU memory:** 10.6 GB

### Metrics vs Baseline

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 20.24 | 21.27 | +1.03 worse |
| val_ood_cond | mae_surf_p | 19.72 | 21.48 | +1.76 worse |
| val_ood_re | mae_surf_p | 30.65 | 31.14 | +0.49 worse |
| val_tandem_transfer | mae_surf_p | 42.13 | 41.48 | -0.65 better |
| — | best_val_loss | 2.2155 | 2.2590 | +0.0435 worse |

### Full surface MAE (best checkpoint)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.301 | 0.177 | 21.27 |
| val_ood_cond | 0.270 | 0.189 | 21.48 |
| val_ood_re | 0.279 | 0.201 | 31.14 |
| val_tandem_transfer | 0.631 | 0.336 | 41.48 |

### Volume MAE (best checkpoint)

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.297 | 0.456 | 26.47 |
| val_ood_cond | 1.054 | 0.393 | 19.88 |
| val_ood_re | 1.036 | 0.437 | 51.22 |
| val_tandem_transfer | 2.133 | 0.989 | 44.11 |

### What happened

The global offset head did not help — performance is marginally worse across almost all splits. The most striking issue is the val_ood_re vol_loss, which exploded to **18868** (surf_loss was fine at 0.076, but vol_loss = 18868). This caused val/loss_4split = 4719 vs the 3-split val/loss = 2.26.

The offset is computed from `fx.mean(dim=1)` right after preprocess, before the Transformer blocks have processed the input. For in-distribution samples this appears to be roughly neutral, but for extreme out-of-distribution Reynolds numbers the pre-block mean representation is apparently very different from training, causing the volume predictions to diverge catastrophically. The surface predictions are not equally affected, probably because surface nodes have stronger local signals.

The core hypothesis — that factoring out a global sample-level mean would help — appears not to hold here, at least when the offset is derived from pre-Transformer features. The main head may already be learning the sample-level shift via the existing `re_head` auxiliary signal and the placeholder scale/shift parameters, leaving little for the offset to capture.

### Suggested follow-ups

- Try computing the offset from a **post-block** mean representation (after the last transformer block, before the final MLP) — this would give the offset access to more spatially-aware features and might better capture the sample-level mean.
- Alternatively, condition the offset explicitly on the Reynolds number and AoA scalars rather than deriving it from the mesh node features, since those global conditions are the primary driver of the mean field.
- The vol_loss blowup for ood_re is worth investigating separately — it may indicate a numerical instability in the volume predictions unrelated to the offset head.
