### PR TITLE
torch.compile + batch_size=8 with sqrt LR scaling

### DIFF
--- a/train.py
+++ b/train.py
@@ -354,9 +354,9 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 4.2e-3
+    lr: float = 3e-3
     weight_decay: float = 0.0
-    batch_size: int = 8
+    batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
     stats_file: str = "data/split_stats.json"
@@ -519,10 +519,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=7)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[7]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The model uses ~10 GB of 96 GB VRAM. `torch.compile(mode='reduce-overhead')` can yield 20-40% speedup on small models by fusing kernels. Combined with batch_size=8, the speedup from compile should compensate for halved steps-per-epoch. If compile gives 30% speedup, we go from ~67 epochs at 27s to ~87 epochs at ~21s — more epochs AND smoother gradients. Previous batch_size=8 attempt (#1039) failed because it used linear LR scaling (2x); we use sqrt scaling (1.41x) which is safer with Adam.

**IMPORTANT**: A previous torch.compile attempt (#1023) crashed. If compile causes issues, try `mode='default'` instead of `mode='reduce-overhead'`.

## Instructions

1. **After model creation** (line 475), add torch.compile:
```python
model = Transolver(**model_config).to(device)
model = torch.compile(model, mode='reduce-overhead')
```

2. **Change Config** (lines 357-359):
```python
batch_size: int = 8
lr: float = 4.2e-3   # sqrt(2) * 3e-3 = 4.24e-3, rounded
```

3. **Extend warmup** slightly (line 520):
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=7)
```
And update milestones (line 523):
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[7])
```

4. **EMA must use the underlying model**, not the compiled wrapper. After compile, keep a reference:
```python
_model_unwrapped = model._orig_mod if hasattr(model, '_orig_mod') else model
```
Use `_model_unwrapped` for the EMA updates and checkpointing.

5. If torch.compile causes errors, fall back to `torch.compile(model, mode='default')` or `torch.compile(model, backend='eager')`.

Run with `--wandb_group compile-batch8`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

### Attempt 1: compile + batch_size=8 (W&B: `ehqo5bth`)
Epoch time: 18.1s. 92 epochs in 30 min. But batch_size=8 hurt convergence (fewer gradient steps, high VRAM usage 91.9 GB). val/loss=2.303, surf_p_id=24.17 — worse than baseline.

### Attempt 2: compile + batch_size=4 (W&B: `y21qoy7r`) — after advisor revision request

**W&B run:** `y21qoy7r` — frieren/compile-b4
**Epochs completed:** ~96 / 100 (30-min timeout)
**Epoch time:** 17.4s (vs ~27s baseline = **36% speedup**)
**Peak GPU memory:** 57.1 GB (vs 39.8 GB baseline)

### Metrics (best epoch, epoch 96)

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | **2.1348** | 2.2155 | **-0.081 (-3.6%)** |
| val_in_dist/mae_surf_Ux | 0.267 | — | — |
| val_in_dist/mae_surf_Uy | 0.169 | — | — |
| val_in_dist/mae_surf_p | **18.45** | 20.24 | **-1.79 (-8.8%)** |
| val_in_dist/mae_vol_Ux | 1.13 | — | — |
| val_ood_cond/mae_surf_Ux | 0.250 | — | — |
| val_ood_cond/mae_surf_Uy | 0.188 | — | — |
| val_ood_cond/mae_surf_p | **18.46** | 19.72 | **-1.26 (-6.4%)** |
| val_ood_re/mae_surf_p | **29.28** | 30.65 | **-1.37 (-4.5%)** |
| val_tandem_transfer/mae_surf_p | **41.09** | 42.13 | **-1.04 (-2.5%)** |

### What happened

**Clear win across all metrics.** torch.compile alone (batch_size=4, lr=3e-3) gives a 36% per-epoch speedup, enabling ~96 epochs vs 62 baseline — 55% more training. Every metric improved.

**Speedup is real**: epoch_time_s dropped from ~27s to 17.4s. With 331 batches/epoch, that's ~52ms/batch vs ~82ms/batch, a substantial kernel fusion benefit from `mode='reduce-overhead'`.

**Why attempt 1 failed, attempt 2 succeeded**: The batch_size=8 change halved gradient steps (15k vs 20k total), which outweighed the epoch gain. With batch_size=4 unchanged, we get the full benefit of more epochs with identical per-step quality.

**Memory**: 57.1 GB (up from 39.8 GB). The increase is from compile's internal buffers/caching — still well within 96 GB.

### Suggested follow-ups

- This is a solid optimization to keep in the baseline — it's free throughput with no model changes and universal metric improvement.
- Could try `mode='default'` vs `mode='reduce-overhead'` to see if there's a tradeoff.
- With more epochs available, could try larger T_max in the cosine scheduler (e.g., T_max=95) to keep LR decaying longer before the new stopping point.