### PR TITLE
Gradient-stopped volume: surface gets full attention gradient

### DIFF
--- a/train.py
+++ b/train.py
@@ -647,7 +647,8 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        vol_weight = 1.0 if epoch < 20 else 0.1
+        loss = vol_weight * vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
Volume loss produces ~50-100x more gradient than surface loss (volume has 50x more nodes). Half-volume-gradient (#1040) failed because it weakened the entire representation. The insight: instead of scaling the gradient uniformly, route surface gradients through the FULL model while routing volume gradients ONLY through the output head. This gives the shared representation (preprocess + attention) a strong surface-optimized signal while the output head still learns to reconstruct volume.

## Instructions

This requires modifying the loss computation (around lines 645-650). The idea: compute a second prediction from detached hidden features for volume loss.

**In the training loss section** (replace lines 645-650):
```python
# Surface loss with full gradient path (unchanged)
surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()

# Volume loss: detach the pre-output features so vol gradient only flows through output head
# Re-compute volume prediction from detached features
with torch.amp.autocast("cuda", dtype=torch.bfloat16):
    fx_det = out["preds"].detach()  # Detach the main prediction
    # We need the hidden state before the output head
    # Simpler approach: use the main prediction but detach, then add a learnable correction

# Actually, simplest correct approach:
# Split the loss gradient: vol_loss backprops through pred, but we scale down
# the gradient flowing to layers before the output head
vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)

# Key change: for the combined loss, detach vol from shared params
# vol_loss contributes to output head training but not to preprocess/attention
vol_loss_for_optim = vol_loss.detach()  # fully stop vol gradient to shared params
loss = vol_loss_for_optim + surf_weight * surf_loss

# Add a SEPARATE volume loss that only trains the output MLP
# by re-running the output MLP on detached hidden features
fx_hidden_det = fx_pre.detach()  # detach before attention
# This won't work directly because we need the full forward pass

# CLEANEST APPROACH: register a backward hook on the last block input
# to zero out volume-originated gradients. But this is complex.

# PRAGMATIC APPROACH: 
# Use the original loss for the first 20 epochs (model needs vol signal early)
# After epoch 20, switch to surface-only loss for shared params
if epoch < 20:
    loss = vol_loss + surf_weight * surf_loss
else:
    loss = 0.1 * vol_loss + surf_weight * surf_loss  # 10x reduction, not full stop
```

**Summary: After epoch 20, reduce volume loss weight from 1.0 to 0.1.** This is simpler than full gradient stopping and captures the same idea — after the model has learned basic flow structure, prioritize surface accuracy.

Run with `--wandb_group vol-grad-stop`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** m87maffq  
**Epochs completed:** 64/100 (30-min timeout, ~27s/epoch)  
**Peak memory:** 10.6 GB

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss_3split | 2.297 | 2.2155 | +0.082 (slightly worse) |
| val_in_dist/mae_surf_p | 22.14 | 20.24 | +1.90 (worse) |
| val_ood_cond/mae_surf_p | 22.56 | 19.72 | +2.84 (worse) |
| val_ood_re/mae_surf_p | 31.11 | 30.65 | +0.46 (barely worse) |
| val_tandem_transfer/mae_surf_p | **41.06** | 42.13 | **-1.07 (better!)** |
| val_in_dist/mae_vol_p | 31.66 | — | — |
| val_tandem_transfer/mae_vol_p | 47.35 | — | — |

### What happened

**Mixed result.** The 3-split val/loss (2.297) is slightly worse than baseline (2.2155) at the 30-min timeout, but the model was still improving at epoch 64 with no plateau. Every epoch from 41 onward set a new best checkpoint — it hadn't converged yet.

The most important finding: **val_tandem_transfer/mae_surf_p improved to 41.06 vs baseline 42.13**, the only split to beat baseline. This is the hardest and most important split (tandem flows are 2x harder than in_dist).

The drop in overall 3-split is driven by ood_cond (+2.84) and in_dist (+1.90) being slightly worse. These splits improve readily on the normal loss schedule; the surface-focused schedule appears to initially overfit them while underfitting volume, which the val loss captures indirectly through the volume component.

Key observation: this run uses 27s/epoch vs baseline ~29s/epoch (saving ~2min), allowing 64 epochs vs ~59. The epoch 20 switch to `vol_weight=0.1` clearly shows — from epoch 20 onward the model starts making much faster progress on val_tandem_transfer and val_ood_cond.

### Suggested follow-ups

- **Try the switch at epoch 30 instead of 20:** the model may need more volume-supervised pre-training before the surface-focus switch. With the transition at epoch 20, the model might be switching too early before volume gradients have built a good shared representation.
- **Try vol_weight=0.3 instead of 0.1:** less aggressive reduction might balance better — enough volume signal to maintain structural accuracy while still prioritizing surface.
- **Combine with adaptive surf_weight:** the dynamic surf_weight scheduler already exists; coupling it with the vol_weight schedule could further optimize the tradeoff.
