### PR TITLE
Multi-head output with head dropout (implicit output ensemble)

### DIFF
--- a/train.py
+++ b/train.py
@@ -183,11 +183,13 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.n_output_heads = 3
+            self.mlp2_heads = nn.ModuleList([
+                nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
+                for _ in range(self.n_output_heads)
+            ])
+            for i, head in enumerate(self.mlp2_heads):
+                head[-1].bias.data += 0.01 * torch.randn_like(head[-1].bias.data) * (i + 1)
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -198,7 +200,14 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx_ln = self.ln_3(fx)
+            head_preds = [head(fx_ln) for head in self.mlp2_heads]
+            if self.training:
+                drop_idx = torch.randint(0, self.n_output_heads, (1,)).item()
+                active = [p for i, p in enumerate(head_preds) if i != drop_idx]
+                return sum(active) / len(active)
+            else:
+                return sum(head_preds) / self.n_output_heads
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Instead of one output MLP predicting [Ux, Uy, p], use 3 independent output heads that each predict all 3 channels, then average them. During training, randomly drop 1 of 3 heads per batch (like DropPath on outputs). Each head is forced to independently solve the problem, creating an implicit ensemble. At inference, all 3 heads contribute. This is inspired by multi-head attention's success — diversity in the output space.

## Instructions

**In TransolverBlock.__init__** (around lines 184-190), replace the last_layer output MLP:
```python
if self.last_layer:
    self.ln_3 = nn.LayerNorm(hidden_dim)
    # Replace single mlp2 with 3 heads
    self.mlp2_heads = nn.ModuleList([
        nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
        for _ in range(3)
    ])
    self.n_output_heads = 3
```

**In TransolverBlock.forward** (around line 200-201), replace the last_layer output:
```python
if self.last_layer:
    fx_ln = self.ln_3(fx)
    head_preds = [head(fx_ln) for head in self.mlp2_heads]
    
    if self.training:
        # Drop 1 random head during training
        drop_idx = torch.randint(0, self.n_output_heads, (1,)).item()
        active = [p for i, p in enumerate(head_preds) if i != drop_idx]
        return sum(active) / len(active)
    else:
        # Average all heads at inference
        return sum(head_preds) / self.n_output_heads
```

**Initialize with diversity**: The orthogonal init should give different starting points. But to ensure more diversity, you can add different small random biases to each head:
```python
for i, head in enumerate(self.mlp2_heads):
    head[-1].bias.data += 0.01 * torch.randn_like(head[-1].bias.data) * (i + 1)
```

Run with `--wandb_group multihead-output`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** `hviukqfb` (60 epochs, hit 30-min timeout)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss (3-split) | 2.2155 | 2.3595 | +0.144 ↑ worse |
| val_in_dist/mae_surf_p | 20.24 | 23.13 | +2.89 ↑ worse |
| val_ood_cond/mae_surf_p | 19.72 | 21.39 | +1.67 ↑ worse |
| val_ood_re/mae_surf_p | 30.65 | 31.50 | +0.85 ↑ worse |
| val_tandem_transfer/mae_surf_p | 42.13 | 42.15 | +0.02 ≈ same |
| val_in_dist/mae_surf_Ux | — | 0.331 | — |
| val_in_dist/mae_surf_Uy | — | 0.188 | — |
| val_in_dist/mae_vol_p | — | 27.30 | — |
| Peak memory | — | 12.0 GB | +1.4 GB |

**What happened:**

The multi-head output ensemble did not improve over baseline — all surface MAE metrics are worse. The hypothesis didn't work.

Three likely reasons:

1. **The output head is a tiny fraction of the model.** The attention blocks and intermediate MLPs dominate capacity. Tripling the output head adds negligible parameters and almost no expressive power. Diversity in the output space can't compensate for a bottleneck that doesn't exist there.

2. **Head dropout at the output hurts gradient flow.** Dropping one of three heads per batch means the surviving 2 heads together predict the target — their average must match. This is similar to applying dropout on the final prediction, which adds noise to an already-clean regression target and generally hurts CFD regression. Unlike intermediate dropout (which regularizes representations), output dropout directly corrupts the loss signal.

3. **The diversity init is negligible.** Adding `0.01 * randn * (i+1)` to biases doesn't create meaningfully different heads — they converge to nearly identical solutions after a few gradient steps, making the ensemble degenerate to a single head with extra compute.

Memory increased ~1.4 GB due to 3× output MLP activations stored during training.

**Suggested follow-ups:**
- If ensembling is the goal, train 2-3 full runs independently and average their predictions at inference (true ensemble, not a single-model approximation)
- Apply diversity more aggressively: different input projections per head, or auxiliary losses that push heads to disagree on held-out samples
- Drop the head dropout idea but keep 3 heads with a consistency regularizer (minimize variance across heads), which might help the model learn smoother predictions