### PR TITLE
FiLM conditioning: Re + AoA modulate hidden features after LayerNorm

### DIFF
--- a/train.py
+++ b/train.py
@@ -165,6 +165,15 @@ class TransolverBlock(nn.Module):
         super().__init__()
         self.last_layer = last_layer
         self.ln_1 = nn.LayerNorm(hidden_dim)
+        self.film_fc = nn.Sequential(
+            nn.Linear(2, 32),  # input: [log_Re, AoA0]
+            nn.GELU(),
+            nn.Linear(32, 2 * hidden_dim)  # output: gamma (scale) and beta (shift)
+        )
+        # Zero-init so FiLM starts as identity transform
+        nn.init.zeros_(self.film_fc[-1].weight)
+        nn.init.zeros_(self.film_fc[-1].bias)
+        self.film_fc[-1].bias.data[:hidden_dim] = 1.0  # gamma=1, beta=0 initially
         self.attn = Physics_Attention_Irregular_Mesh(
             hidden_dim,
             heads=num_heads,
@@ -189,9 +198,14 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None):
+    def forward(self, fx, raw_xy=None, cond=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
+        fx_normed = self.ln_1(fx)
+        if cond is not None:
+            film = self.film_fc(cond)  # [B, 2*hidden_dim]
+            gamma, beta = film.chunk(2, dim=-1)  # each [B, hidden_dim]
+            fx_normed = gamma.unsqueeze(1) * fx_normed + beta.unsqueeze(1)
+        fx = self.ln_1_post(self.attn(fx_normed, spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -327,17 +341,19 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         raw_xy = x[:, :, :2]
+        # Extract flow regime conditioning: log_Re (index 13) and AoA0 (index 14)
+        cond = x[:, 0, [13, 14]]  # [B, 2] — sample-level features (same for all nodes)
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy)
+            fx = block(fx, raw_xy=raw_xy, cond=cond)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, cond=cond)
         fx = fx + self.out_skip(fx_pre)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}


### PR DESCRIPTION
## Hypothesis
Reynolds number and angle of attack fundamentally change the flow physics — they should modulate the model's internal representation, not just appear as input features. FiLM (Feature-wise Linear Modulation) from conditional image generation learns per-layer affine transforms conditioned on flow parameters. Applied after each LayerNorm, this injects flow-regime awareness deep into the model. Previous FiLM attempts (#957, #401) were on much older code. Zero-initialized output ensures it starts as identity (no harm at init).

## Instructions

**In TransolverBlock.__init__** (around line 165), add FiLM layer:
```python
# After self.ln_1 = nn.LayerNorm(hidden_dim):
self.film_fc = nn.Sequential(
    nn.Linear(2, 32),  # input: [log_Re, AoA0]
    nn.GELU(),
    nn.Linear(32, 2 * hidden_dim)  # output: gamma (scale) and beta (shift)
)
# Zero-init so FiLM starts as identity transform
nn.init.zeros_(self.film_fc[-1].weight)
nn.init.zeros_(self.film_fc[-1].bias)
self.film_fc[-1].bias.data[:hidden_dim] = 1.0  # gamma=1, beta=0 initially
```

**In TransolverBlock.forward** (line 192-194), modify to accept and apply FiLM conditioning:
```python
def forward(self, fx, raw_xy=None, cond=None):
    sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
    fx_normed = self.ln_1(fx)
    if cond is not None:
        film = self.film_fc(cond)  # [B, 2*hidden_dim]
        gamma, beta = film.chunk(2, dim=-1)  # each [B, hidden_dim]
        fx_normed = gamma.unsqueeze(1) * fx_normed + beta.unsqueeze(1)
    fx = self.ln_1_post(self.attn(fx_normed, spatial_bias=sb) + fx)
    fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
    se = fx.mean(dim=1, keepdim=True)
    se = F.gelu(self.se_fc1(se))
    se = torch.sigmoid(self.se_fc2(se))
    fx = fx * se
    if self.last_layer:
        return self.mlp2(self.ln_3(fx))
    return fx
```

**In Transolver.forward** (lines 329-340), extract conditioning and pass to blocks:
```python
raw_xy = x[:, :, :2]
# Extract flow regime conditioning: log_Re (index 13) and AoA0 (index 14)
cond = x[:, 0, [13, 14]]  # [B, 2] — sample-level features (same for all nodes)

fx = self.preprocess(x)
fx_pre = fx
fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]

for block in self.blocks[:-1]:
    fx = block(fx, raw_xy=raw_xy, cond=cond)

re_pred = self.re_head(fx.mean(dim=1))
fx = self.blocks[-1](fx, raw_xy=raw_xy, cond=cond)
fx = fx + self.out_skip(fx_pre)
```

Run with `--wandb_group film-cond-bn`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run ID:** o3jww1nc
**Epochs completed:** 63/100 (30-min timeout)
**Peak memory:** not captured in W&B (no OOM observed)

### Metrics at epoch 63 (last logged, loss still decreasing)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.323 | 0.198 | 22.70 | 1.419 | 0.498 | 28.67 |
| val_ood_cond | 0.285 | 0.195 | 21.82 | 1.174 | 0.432 | 21.33 |
| val_ood_re | 0.287 | 0.201 | 31.65 | 1.144 | 0.458 | 51.86 |
| val_tandem_transfer | 0.679 | 0.362 | 45.70 | 2.268 | 1.065 | 47.03 |

**val/loss (3-split):** 2.3931 (vs baseline 2.2155)

### vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | 2.2155 | 2.3931 | +0.178 |
| val_in_dist/mae_surf_p | 20.24 | 22.70 | +2.46 |
| val_ood_cond/mae_surf_p | 19.72 | 21.82 | +2.10 |
| val_ood_re/mae_surf_p | 30.65 | 31.65 | +1.00 |
| val_tandem_transfer/mae_surf_p | 42.13 | 45.70 | +3.57 |

### What happened

FiLM conditioning did not improve over baseline. At epoch 63 (30-min timeout), val/loss was 2.3931 vs baseline 2.2155, and surface pressure MAE was worse across all splits — notably tandem transfer +3.57 and in-dist +2.46. The loss was still declining at cutoff (2.40 at epoch 62 → 2.39 at epoch 63), but the convergence pace is notably slower than baseline. Even extrapolating to epoch 100, it seems unlikely to reach baseline performance.

The zero-initialization with gamma=1 was meant to make FiLM start as identity, but the model still converged more slowly — likely because the FiLM path adds significant new parameters (2×hidden_dim outputs per block) that need time to specialize. The additional parameters may be hurting optimization more than the conditioning is helping.

It's also worth noting that log_Re (index 13) is already present as an input feature and used by the auxiliary Re-prediction head — so the model likely already leverages this information through the preprocess MLP. FiLM may be redundant with this existing mechanism.

### Suggested follow-ups

- Try a lightweight version: single shared FiLM layer applied once at the start (before the blocks) rather than per-block, to reduce parameter overhead.
- Try conditioning only on log_Re (drop AoA0) since Re has a clearer effect on the loss landscape.
- Investigate whether the OOD-Re tandem_transfer degradation is correlated with FiLM gamma values diverging — if gamma saturates in certain Re regimes, that could explain the gap.