### PR TITLE
Stochastic node subsampling at inference (test-time averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -740,9 +740,23 @@ for epoch in range(MAX_EPOCHS):
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
 
+                n_tta = 5
+                B_val, N_val = x.shape[0], x.shape[1]
+
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
-                pred = pred.float()
+                    # Always include original full prediction
+                    pred_full = eval_model({"x": x})["preds"].float()
+
+                    preds_tta = [pred_full]
+                    for _ in range(n_tta - 1):
+                        # Randomly mask 20% of volume nodes (keep all surface + masked nodes)
+                        keep = torch.rand(B_val, N_val, device=device) < 0.8
+                        keep = keep | is_surface | ~mask  # always keep surface and padding
+                        x_masked = x * keep.unsqueeze(-1).float()
+                        pred_i = eval_model({"x": x_masked})["preds"].float()
+                        preds_tta.append(pred_i)
+
+                    pred = torch.stack(preds_tta).mean(0)
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis
At inference, randomly subsample 80% of volume nodes 5 times, predict, and average. This exploits the fact that the Transolver slice attention assigns different weight distributions when different subsets of nodes are present — creating diversity without adding noise. Surface nodes are ALWAYS kept. This is a zero-training-cost improvement — only the validation loop changes. Similar in spirit to MC Dropout but exploiting the model's attention structure.

## Instructions

**Only modify the validation loop** (around lines 715-760). Replace the single prediction with TTA averaging:

```python
n_tta = 5
B_val, N_val = x.shape[0], x.shape[1]

with torch.amp.autocast("cuda", dtype=torch.bfloat16):
    pred_full = eval_model({"x": x})["preds"].float()
    
    preds_tta = [pred_full]
    for _ in range(n_tta - 1):
        keep = torch.rand(B_val, N_val, device=device) < 0.8
        keep = keep | is_surface | ~mask
        x_masked = x * keep.unsqueeze(-1).float()
        pred_i = eval_model({"x": x_masked})["preds"].float()
        preds_tta.append(pred_i)
    
    pred = torch.stack(preds_tta).mean(0)
```

Run with `--wandb_group node-tta`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** neis9k8a
**Epochs completed:** 48 (30-minute timeout)
**Peak memory:** 10.6 GB (same as baseline — TTA is zero extra memory under no_grad)

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| best_val_loss | 2.2155 | 3.0897 | +0.87 worse |
| val_in_dist/mae_surf_p | 20.24 | 34.9 | +14.7 worse |
| val_ood_cond/mae_surf_p | 19.72 | 29.6 | +9.9 worse |
| val_ood_re/mae_surf_p | 30.65 | 36.3 | +5.7 worse |
| val_tandem_transfer/mae_surf_p | 42.13 | 49.0 | +6.9 worse |

Notably, val_ood_re/loss = **18870** — the OOD Re split diverged again, which appears to be a model-level issue unrelated to TTA.

### What happened

The hypothesis did not work as designed. The core problem is a measurement artifact: placing TTA (5x forward passes) in the **validation loop** means each epoch takes ~38s instead of ~25s, so the 30-minute limit allows only 48 epochs vs ~72+ for the baseline. The model at epoch 48 is simply undertrained.

The memory and compute overhead of TTA are sound (10.6 GB, no extra memory). The technique itself might have merit — but only if applied to a **fully converged model** at inference time, not in the training loop.

The masking approach (zeroing out 20% of volume node features) may also be too disruptive. Unlike dropout, which scales the remaining activations to maintain expected values, zeroing features changes the expected input distribution the model sees, potentially causing distribution shift rather than beneficial diversity.

### Suggested follow-ups

1. **Post-hoc TTA only**: Train normally (no TTA in val loop), then at inference apply TTA to the best checkpoint. This separates training from evaluation properly.
2. **Reduce n_tta**: If TTA in val loop is desired for checkpoint selection, use n_tta=2 to limit overhead to ~2x slowdown.
3. **Feature noise instead of masking**: Rather than zeroing features, add small Gaussian noise to volume nodes — this preserves the input distribution better.
4. **OOD Re instability**: The val_ood_re loss diverging (18870) appears to be a systematic issue across experiments, likely a model architecture or normalization problem unrelated to this hypothesis.