### PR TITLE
Attention temperature curriculum: warm→cold over training

### DIFF
--- a/train.py
+++ b/train.py
@@ -95,7 +95,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.register_buffer('temperature', torch.ones([1, heads, 1, 1]) * 0.5)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
@@ -575,6 +575,20 @@ for epoch in range(MAX_EPOCHS):
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
+    # Temperature schedule: 1.0 → 0.15 over epochs 0-50, then hold at 0.15
+    if epoch < 10:
+        temp_val = 1.0  # soft attention during tandem-free phase
+    elif epoch < 50:
+        temp_val = 1.0 - 0.85 * (epoch - 10) / 40  # linear anneal
+    else:
+        temp_val = 0.15  # sharp attention for fine-tuning phase
+
+    for block in model.blocks:
+        block.attn.temperature.fill_(temp_val)
+    if ema_model is not None:
+        for block in ema_model.blocks:
+            block.attn.temperature.fill_(temp_val)
+
     # --- Train ---
     model.train()
     epoch_vol = 0.0
@@ -683,7 +697,7 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/temperature": temp_val, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
The temperature parameter controlling attention sharpness is currently learned (initialized at 0.5). But temperature should evolve with training: early on, soft attention (high temperature) helps exploration and gradient flow across all slices. Later, sharp attention (low temperature) creates specialized slices. This is analogous to simulated annealing. Combined with the existing tandem curriculum (no tandem for first 10 epochs), this creates a structured learning progression: explore broadly first, specialize later.

## Instructions

**In Physics_Attention_Irregular_Mesh.__init__** (line 98), change temperature from Parameter to buffer:
\`\`\`python
# Replace:
# self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
# With:
self.register_buffer('temperature', torch.ones([1, heads, 1, 1]) * 0.5)
\`\`\`

**In the training loop** (after the epoch starts, around line 575), set temperature based on epoch:
\`\`\`python
# Temperature schedule: 1.0 → 0.15 over epochs 0-50, then hold at 0.15
if epoch < 10:
    temp_val = 1.0  # soft attention during tandem-free phase
elif epoch < 50:
    temp_val = 1.0 - 0.85 * (epoch - 10) / 40  # linear anneal
else:
    temp_val = 0.15  # sharp attention for fine-tuning phase

for block in model.blocks:
    block.attn.temperature.fill_(temp_val)
# If using EMA model, update its temperature too
if ema_model is not None:
    for block in ema_model.blocks:
        block.attn.temperature.fill_(temp_val)
\`\`\`

**Remove temperature from learnable parameters.** It's currently picked up by \`attn_params\` on line 513. Since it's now a buffer (not a Parameter), it won't be in \`model.named_parameters()\` — no change needed there.

**Log temperature for monitoring:**
\`\`\`python
wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "train/temperature": temp_val, "global_step": global_step})
\`\`\`

Run with \`--wandb_group temp-curriculum\`.

## Baseline
- best_val_loss = 2.2155
- val_in_dist/mae_surf_p = 20.24
- val_ood_cond/mae_surf_p = 19.72
- val_ood_re/mae_surf_p = 30.65
- val_tandem_transfer/mae_surf_p = 42.13

---

## Results

**W&B run:** \`nlmtdhde\`
**Epochs completed:** ~66 of 100 (30-min timeout)
**Peak GPU memory:** 10.3 GB (vs 10.6 GB baseline — slight reduction from removing temperature as a parameter)

### Metrics (best checkpoint, epoch 66)

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Delta |
|---|---|---|---|---|
| val_in_dist | 1.65 | 22.1 | 20.24 | +1.9 (worse) |
| val_ood_cond | 1.89 | 20.6 | 19.72 | +0.9 (worse) |
| val_ood_re | 18869 (anomalous) | 31.7 | 30.65 | +1.1 (worse) |
| val_tandem_transfer | 3.29 | 42.0 | 42.13 | -0.1 (marginal) |

**val/loss (3-split):** 2.2781 vs baseline 2.2155 — worse by ~2.8%

Note: val_ood_re/vol_loss is anomalously large (~18869) throughout training — same pre-existing issue seen in baseline and prior experiments.

### What happened

The temperature curriculum **did not beat the baseline**. Surface accuracy was slightly worse across all splits. However, several observations complicate this:

1. **Training was still improving at timeout** — every epoch from 38 onwards set a new best checkpoint. This suggests neither this run nor (presumably) the baseline had converged within 30 minutes. The comparison may be unfair if the baseline ran for different effective epochs.

2. **Better than the half-vol-grad run** — this approach achieved 2.2781 vs half-vol-grad's 2.2834 val/loss, and mae_surf_p improved notably on ood_cond (20.6 vs 21.7) and in_dist (22.1 vs 22.7). So the curriculum schedule is at least not hurting as badly.

3. **Epoch speed improved slightly** — 26 s/epoch vs 27 s/epoch (removing temperature as a Parameter saved a small amount of optimizer overhead).

The anneal schedule (0–10 soft, 10–50 linear, 50+ sharp) may have interacted poorly with the 30-min training window: the model spends epochs 0–50 still in the soft-to-sharp transition, meaning it only gets 16 epochs (~6 minutes) at the final sharp temperature. The model may not have had enough time to exploit the sharp attention regime.

### Suggested follow-ups
- Compress the schedule to match the timeout window: e.g., 0–5 soft, 5–30 linear anneal, 30+ sharp — so most of training operates in the specialized (sharp) regime
- Try a cosine schedule instead of linear for the temperature anneal, which spends more time at the extremes
- Try fixing temperature at different constant values (0.15, 0.5, 1.0) to isolate whether the schedule itself helps or if a fixed lower temperature is sufficient