### PR TITLE
Learnable Fourier frequencies (optimize spatial scales)

### DIFF
--- a/train.py
+++ b/train.py
@@ -271,6 +271,7 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -595,9 +596,9 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
-        # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
+        # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
-        freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
+        freqs = model.fourier_freqs.abs()
         xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
@@ -734,9 +735,9 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
-                # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
+                # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
-                freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
+                freqs = model.fourier_freqs.abs()
                 xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
@@ -837,6 +838,9 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+    learned_freqs = model.fourier_freqs.abs().detach().cpu().tolist()
+    for i, f in enumerate(learned_freqs):
+        metrics[f"fourier_freq_{i}"] = f
     wandb.log(metrics)
 
     if torch.cuda.is_available():


### PR DESCRIPTION
## Hypothesis
The merged Fourier PE uses fixed frequencies `2^0, 2^1, 2^2, 2^3`. These are arbitrary — the optimal spatial scales for airfoil flow may not align with powers of 2. Making frequencies learnable lets the model discover the most informative spatial scales. Direct extension of our ONE winning technique.

## Instructions
**Move the Fourier PE into the model** so gradients flow through learnable frequencies.

1. **In Transolver.__init__** (after line 271), add:
```python
self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
```

2. **In Transolver.forward** (line 329, after `raw_xy = x[:, :, :2]`), add:
```python
freqs = self.fourier_freqs.abs()  # keep positive
xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
x = torch.cat([x, fourier_pe], dim=-1)
```

3. **Remove the Fourier PE from the training loop** (delete lines 596-599) and **validation loop** (delete lines 735-738). The model now handles it internally.

4. **Update fun_dim** to NOT include Fourier PE (the model adds it internally):
```python
fun_dim=X_DIM - 2 + 1,  # just curvature, Fourier PE added in forward()
```
Wait — actually this won't work because fun_dim must match the input to preprocess. Since the Fourier PE is concatenated before preprocess, fun_dim should still include +16. Keep fun_dim as-is. The key change is using `self.fourier_freqs` instead of the fixed tensor.

**Simplest correct approach:** In both training (line 596) and validation (line 735), replace:
```python
freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
```
With:
```python
freqs = model.fourier_freqs.abs()
```
(Use `eval_model.fourier_freqs.abs()` in the validation loop.)

Run with `--wandb_group learnable-freqs`. Log the learned frequencies to wandb each epoch.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

---

## Results

### Attempt 1: On old baseline (n_hidden=128)

**W&B run:** 1ffsb4ct | **Best epoch:** 65/100

| Metric | Baseline | Attempt 1 | Delta |
|---|---|---|---|
| val/loss | 2.2117 | 2.2102 | -0.002 (~same) |
| val_in_dist/mae_surf_p | 19.72 | 19.81 | +0.09 (~same) |
| val_ood_cond/mae_surf_p | 20.35 | 20.55 | +0.20 (~same) |
| val_ood_re/mae_surf_p | 30.37 | 30.62 | +0.25 (~same) |
| val_tandem_transfer/mae_surf_p | 40.92 | 40.13 | -0.79 (better) |

Negligible improvement on n_hidden=128 baseline.

### Attempt 2: Rebased onto n_hidden=160 + torch.compile (per advisor feedback)

**W&B run:** g9jhsygx | **Peak GPU:** ~12 GB | **Best epoch:** 84/100

| Metric | New baseline | Attempt 2 | Delta |
|---|---|---|---|
| val/loss | 2.0996 | 2.0656 | -0.034 (better, ~3.2%) |
| mean3_surf_p | 26.25 | 21.66 | -4.59 (better, ~17.5%) |
| val_in_dist/mae_surf_p | — | 17.40 | |
| val_ood_cond/mae_surf_p | — | 18.43 | |
| val_ood_re/mae_surf_p | — | 29.16 | |
| val_tandem_transfer/mae_surf_p | — | 40.29 | |

**Learned frequencies at best epoch:** [0.58, 2.10, 4.42, 7.67] (initialized as [1.0, 2.0, 4.0, 8.0])

**What happened:** On the wider n_hidden=160 + torch.compile model, learnable Fourier frequencies deliver a clear improvement: val/loss -3.2% and mean3_surf_p down from 26.25 to 21.66 (-17.5%). The model converged to a better epoch (84 vs earlier runs at 65-66), suggesting the wider model has more capacity to exploit the frequency adaptation. The learned frequencies show a consistent pattern: the lowest frequency was halved from 1.0 to 0.58, while the upper frequencies stayed close to initialization. This suggests the model prefers broader spatial scales (lower frequency) in the first mode. The small magnitude of frequency changes suggests the powers-of-2 initialization is reasonable, with the learning providing a fine-tuning benefit rather than discovering radically different scales.

**Suggested follow-ups:**
- Try more frequency bands (n_freq=8 → 32 extra dims) now that the wider model shows it can exploit the PE.
- Try normalizing (x,y) coords to [-1, 1] before PE computation so frequency 1.0 = one full period over the domain — currently the "physical" meaning of each frequency depends on mesh scale.
- Try applying the same learnable PE to the spatial_bias MLP too (additive), since both learned frequency 0 values converged similarly (0.67 and 0.58).