### PR TITLE
Wider model n_hidden=160 + torch.compile

### DIFF
--- a/train.py
+++ b/train.py
@@ -40,6 +40,8 @@ import simple_parsing as sp
 from data.utils import visualize
 from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
 
+torch.set_float32_matmul_precision('high')
+
 
 # ---------------------------------------------------------------------------
 # Transolver model (inlined so students can
@@ -463,7 +465,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=128,
+    n_hidden=160,  # was 128
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
@@ -473,6 +475,8 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
+model = torch.compile(model, mode="reduce-overhead")
+_base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
@@ -683,10 +687,10 @@ for epoch in range(MAX_EPOCHS):
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:
-                ema_model = deepcopy(model)
+                ema_model = deepcopy(_base_model)
             else:
                 with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), model.parameters()):
+                    for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})


### PR DESCRIPTION
## Hypothesis
With 1 layer and 128 hidden, the model uses ~10 GB of 96 GB VRAM. The Fourier PE just proved richer input representation helps — a wider hidden dimension gives more capacity to exploit those features. Combined with torch.compile for 33% speedup (proven in #1042), the per-epoch slowdown from wider layers is compensated by compile's kernel fusion.

## Instructions

1. **Change model_config** (line 466):
```python
n_hidden=160,  # was 128
```

2. **Add torch.compile** after model creation (line 475):
```python
model = Transolver(**model_config).to(device)
model = torch.compile(model, mode="reduce-overhead")
```

3. **Add near the top** (after imports):
```python
torch.set_float32_matmul_precision('high')
```

4. **Handle EMA with compiled model.** After compile, the underlying model is wrapped. For EMA updates (line 678-684), use the underlying parameters:
```python
# If needed, access underlying model:
_base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
```

Everything else stays the same (batch_size=4, lr=3e-3). If compile causes issues, try `mode='default'` instead of `mode='reduce-overhead'`.

Run with `--wandb_group wider-160-compile`.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

---

## Results

**W&B run:** 591jdv6f  
**Epochs completed:** 85 (30-min wall-clock timeout)  
**Peak GPU memory:** ~10.6 GB (similar to baseline)

### Metrics vs Baseline

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 19.72 | 18.58 | -1.14 better |
| val_ood_cond | mae_surf_p | 20.35 | 18.53 | -1.82 better |
| val_ood_re | mae_surf_p | 30.37 | 29.55 | -0.82 better |
| val_tandem_transfer | mae_surf_p | 40.92 | 41.63 | +0.71 slightly worse |
| — | best_val_loss | 2.2117 | 2.0996 | -0.1121 better |

### Full surface MAE (best checkpoint, epoch 85)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.255 | 0.166 | 18.58 |
| val_ood_cond | 0.247 | 0.181 | 18.53 |
| val_ood_re | 0.260 | 0.194 | 29.55 |
| val_tandem_transfer | 0.615 | 0.329 | 41.63 |

### Volume MAE (best checkpoint)

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.078 | 0.382 | 22.26 |
| val_ood_cond | 0.919 | 0.361 | 17.36 |
| val_ood_re | 0.920 | 0.409 | 49.75 |
| val_tandem_transfer | 1.964 | 0.915 | 42.86 |

### What happened

This worked well. Wider hidden dimension (160 vs 128) combined with `torch.compile` is a clear win:

- **val/loss improved from 2.2117 → 2.0996** (5% improvement)
- Surface pressure MAE improved meaningfully on in-dist (-1.14) and ood_cond (-1.82) and ood_re (-0.82)
- More epochs completed (85 vs ~66 in previous runs), suggesting compile does compensate for the wider layer cost
- Training throughput was ~19-20 it/s vs ~13-15 it/s without compile — roughly 33% speedup, consistent with the hypothesis
- The val_ood_re vol_loss (18869) is the same anomaly seen in other runs — this appears to be a pre-existing issue unrelated to this change
- CUDAGraph dynamic shape warning appeared (51 distinct sizes) but did not affect correctness
- tandem_transfer is slightly worse (+0.71 on mae_surf_p), but the gains elsewhere outweigh this

The extra capacity from wider hidden dimension is clearly being used productively — the model generalizes better to OOD conditions, suggesting the bottleneck was parameter count not just architecture.

### Suggested follow-ups

- Try n_hidden=192 or 256 — if capacity is the bottleneck, more width might continue to help (VRAM headroom is large at ~10 GB used of 96 GB available)
- Try `mode='default'` instead of `reduce-overhead` to avoid the CUDAGraph dynamic shape issue, which might matter if the warning causes some overhead for certain batch sizes
- Investigate why val_ood_re vol_loss consistently explodes (18868) across runs — this seems decoupled from surface loss (surf_loss=0.07 is normal) and affects only volume predictions for high-Re samples
