### PR TITLE
Coordinate-normalized Fourier PE (normalize x,y to [0,1] before encoding)

### DIFF
--- a/train.py
+++ b/train.py
@@ -598,8 +598,12 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, curv], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
+        # Normalize xy to [0,1] per-sample for consistent Fourier encoding
+        xy_min = raw_xy.amin(dim=1, keepdim=True)
+        xy_max = raw_xy.amax(dim=1, keepdim=True)
+        xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = model.fourier_freqs.abs()
-        xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
         Umag, q = _umag_q(y, mask)
@@ -737,8 +741,12 @@ for epoch in range(MAX_EPOCHS):
                 x = torch.cat([x, curv], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
+                # Normalize xy to [0,1] per-sample for consistent Fourier encoding
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = model.fourier_freqs.abs()
-                xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)


### PR DESCRIPTION
## Hypothesis
The merged PR's suggested follow-up: "Try normalizing the (x,y) coordinates before computing Fourier features — the coordinates span different scales depending on mesh extent." Currently, standardized x,y have varying ranges. Normalizing to [0,1] per-sample before sin/cos ensures consistent frequency interpretation. Multiplying by pi gives full sin/cos periods.

## Instructions
In both **training** (lines 595-599) and **validation** (lines 734-738), replace:
```python
raw_xy = x[:, :, :2]
freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
xy_scaled = raw_xy.unsqueeze(-1) * freqs
```
With:
```python
raw_xy = x[:, :, :2]
# Normalize xy to [0,1] per-sample for consistent Fourier encoding
xy_min = raw_xy.amin(dim=1, keepdim=True)
xy_max = raw_xy.amax(dim=1, keepdim=True)
xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype) * 3.14159
xy_scaled = xy_norm.unsqueeze(-1) * freqs
```

The rest stays the same (sin/cos/cat). Run with `--wandb_group coord-norm-fourier`.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

---

## Results

### v3 — rebased onto noam (n_hidden=192 + learnable Fourier freqs)

**W&B run:** `tvvjs1if`  
**Epochs completed:** 72 (hit 30-min timeout; n_hidden=192 ~24s/epoch vs 20s for 160)  
**Peak memory:** 12.4 GB  

#### Validation losses (3-split, lower is better)

| Split | val/loss |
|-------|----------|
| val_in_dist | 1.4674 |
| val_ood_cond | 1.5219 |
| val_tandem_transfer | 3.0874 |
| **val/loss (3-split)** | **2.0256** |

Old Fourier-PE-only baseline: 2.2117 → **improvement: −8.5%**

#### Surface MAE — pressure (most important)

| Split | Old Baseline | v2 (n_hidden=160) | v3 (n_hidden=192) |
|-------|-------------|-------------------|-------------------|
| val_in_dist/mae_surf_p | 19.72 | 18.95 | **18.91** |
| val_ood_cond/mae_surf_p | 20.35 | **15.21** | 15.66 |
| val_ood_re/mae_surf_p | 30.37 | 28.31 | 28.75 |
| val_tandem_transfer/mae_surf_p | 40.92 | 40.35 | **40.17** |

#### Surface MAE — velocity (val_in_dist)

| Field | Value |
|-------|-------|
| mae_surf_Ux | 0.286 |
| mae_surf_Uy | 0.165 |

#### Volume MAE (val_in_dist)

| Field | Value |
|-------|-------|
| mae_vol_p | 22.57 |
| mae_vol_Ux | N/A |

### What happened

v3 achieves val/loss_3split = 2.0256, essentially the same as v2 (2.0226). The slight gap is likely due to epoch count: n_hidden=192 runs at ~24s/epoch vs ~20s for n_hidden=160, reaching only 72 epochs vs 82. The model is still improving at epoch 72 (steady `*` markers throughout), so the larger model hasn't fully converged.

The key question was whether coord-norm is additive to learnable frequencies. The resolution combines both: `xy_norm` is passed to `model.fourier_freqs.abs()`, so the learnable frequencies now operate on [0,1]-normalized coordinates. This means the learned frequencies should converge to values appropriate for unit-scale inputs, potentially learning better coverage than our fixed `pi * 2^k`. Whether it outperforms the new baseline requires seeing the new baseline metrics — but vs the old Fourier PE baseline, all four surface pressure metrics improved.

The tandem_transfer split continues to improve (40.17 vs 40.35 in v2 vs 40.92 old baseline), suggesting the larger model generalizes better to tandem configurations.

### Suggested follow-ups

1. **Hybrid encoding**: Concatenate raw x,y (standardized) alongside the normalized Fourier PE, giving the model explicit absolute scale information alongside relative Fourier features.
2. **More frequencies**: Now that freqs are learnable and initialized appropriately for [0,1] inputs, try 6–8 frequencies. The coord-norm makes larger frequency banks more meaningful.
3. **Allow more epochs**: The n_hidden=192 model is clearly still improving at epoch 72. If compile+192 is the new base, the 30-min timeout means fewer epochs — worth checking if performance stabilizes with a faster architecture.

---

### v2 — rebased onto noam (n_hidden=160 + torch.compile, for reference)

**W&B run:** `rsi49zhi` | Epochs: 82 | val/loss_3split: **2.0226**  
Baseline for that run: 2.0996 → improvement −3.7%. ood_cond/mae_surf_p dropped to 15.21.

### v1 — original baseline (for reference)

**W&B run:** `72sah6ia` | Epochs: 63 | val/loss_3split: 2.1661  
In-dist regression at epoch 63 fully resolved by epoch 82 in v2.