### PR TITLE
Distance-to-surface input feature for volume nodes

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 1 + 1 + 16,  # +1 curvature, +1 wall_dist, +16 Fourier PE
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -591,6 +591,9 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
+        # Wall-distance proxy: dsdf norm for volume nodes (complement surface curvature)
+        wall_dist = x[:, :, 2:6].norm(dim=-1, keepdim=True) * (~is_surface.bool()).float().unsqueeze(-1)
+        x = torch.cat([x, wall_dist], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
         raw_xy = x[:, :, :2]
         freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
@@ -730,6 +733,9 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
+                # Wall-distance proxy: dsdf norm for volume nodes (complement surface curvature)
+                wall_dist = x[:, :, 2:6].norm(dim=-1, keepdim=True) * (~is_surface.bool()).float().unsqueeze(-1)
+                x = torch.cat([x, wall_dist], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
                 raw_xy = x[:, :, :2]
                 freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)


### PR DESCRIPTION
## Hypothesis
Curvature proxy (#911) was a successful feature for surface nodes. Volume nodes near the surface carry the boundary layer — the most physically important region. A wall-distance feature (dsdf norm) for volume nodes gives them explicit proximity information. This is the complement to curvature: curvature for surface, distance for volume. Unlike loss weighting (which failed in #1037), this is an INPUT FEATURE that the model can learn to use.

## Instructions
After curvature computation (line 593 in training, line 732 in validation), add:
```python
# Wall-distance proxy: dsdf norm for volume nodes (complement surface curvature)
wall_dist = x[:, :, 2:6].norm(dim=-1, keepdim=True) * (~is_surface.bool()).float().unsqueeze(-1)
x = torch.cat([x, wall_dist], dim=-1)
```

Update **fun_dim** (line 464):
```python
fun_dim=X_DIM - 2 + 1 + 1 + 16,  # +1 curvature, +1 wall_dist, +16 Fourier PE
```

Run with `--wandb_group wall-dist-feature`.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

---

## Results

**W&B run:** 3aq7u2od  
**Epochs completed:** 63 (timeout)  
**Peak memory:** 10.9 GB (vs 10.6 GB baseline, +0.3 GB for extra feature)

| Metric | wall_dist | Baseline | Delta |
|---|---|---|---|
| best_val_loss (3split) | 2.2680 | 2.2117 | +0.0563 |
| val_in_dist/mae_surf_p | 20.30 | 19.72 | +0.58 |
| val_ood_cond/mae_surf_p | 20.44 | 20.35 | +0.09 |
| val_ood_re/mae_surf_p | 31.00 | 30.37 | +0.63 |
| val_tandem_transfer/mae_surf_p | 41.91 | 40.92 | +0.99 |

**What happened:** The wall-distance feature did not improve over baseline — all metrics are slightly worse. The dsdf channels (indices 2:6) in x already encode distance-to-surface information, so the explicit norm of these channels for volume nodes is largely redundant. Adding a duplicate representation of already-available information appears to confuse the model's first layer rather than helping it. The curvature proxy works because it provides *new* compressed information (surface shape) not trivially derivable from a single scalar. Wall-distance adds no new information beyond what's already in channels 2:6.

The +0.3 GB memory increase is negligible.

**Suggested follow-ups:**
- If boundary-layer features are desired, a more informative feature might be a signed distance (preserving direction) or the actual distance in physical units rather than a norm of normalized dsdf.
- Alternatively, skip the feature engineering direction and look at architectural changes for the volume nodes (e.g. different attention patterns near the surface).