### PR TITLE
Gradient accumulation 2 steps + sqrt-scaled LR (effective batch 8)

### DIFF
--- a/train.py
+++ b/train.py
@@ -354,7 +354,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 4.24e-3  # sqrt(2) * 3e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -557,6 +557,7 @@ model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
+ACCUM_STEPS = 2
 best_val = float("inf")
 best_metrics = {}
 global_step = 0
@@ -580,6 +581,7 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
+    optimizer.zero_grad()
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
@@ -677,19 +679,22 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
 
-        optimizer.zero_grad()
+        loss = loss / ACCUM_STEPS
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+
+        if (n_batches + 1) % ACCUM_STEPS == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            if epoch >= ema_start_epoch:
+                if ema_model is None:
+                    ema_model = deepcopy(model)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_model.parameters(), model.parameters()):
+                            ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+            global_step += 1
+            wandb.log({"train/loss": loss.item() * ACCUM_STEPS, "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Batch_size=8 with doubled LR failed (#1039), and batch8 with sqrt LR failed with compile (#1042). But gradient accumulation achieves the same effective batch without changing memory. With 2 accumulation steps (effective batch=8) and sqrt-scaled LR (4.24e-3), each optimizer.step() sees 2x more data for smoother gradients while maintaining the same number of parameter updates per epoch.

## Instructions
1. **Change lr** (line 357):
```python
lr: float = 4.24e-3  # sqrt(2) * 3e-3
```

2. **Add accumulation constant** before training loop:
```python
ACCUM_STEPS = 2
```

3. **In the training loop** (around lines 674-686), modify the backward/step:
```python
loss = loss / ACCUM_STEPS
loss.backward()

if (n_batches + 1) % ACCUM_STEPS == 0:
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    optimizer.step()
    optimizer.zero_grad()
    if epoch >= ema_start_epoch:
        if ema_model is None:
            ema_model = deepcopy(model)
        else:
            with torch.no_grad():
                for ep, mp in zip(ema_model.parameters(), model.parameters()):
                    ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
    global_step += 1
    wandb.log({"train/loss": loss.item() * ACCUM_STEPS, "train/surf_weight": surf_weight, "global_step": global_step})
```

Remove the original optimizer.step/zero_grad/EMA/log from outside the if block.

Run with `--wandb_group grad-accum-2x`.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

---

## Results

**W&B run ID:** eckoxze8
**Epochs completed:** 66/100 (30-min timeout)
**Peak memory:** not captured in W&B (no OOM observed)

### Metrics at epoch 66 (last logged, loss still decreasing)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 0.312 | 0.182 | 20.32 | 1.252 | 0.441 | 25.55 |
| val_ood_cond | 0.278 | 0.192 | 20.81 | 1.028 | 0.404 | 19.02 |
| val_ood_re | 0.276 | 0.204 | 31.14 | 1.029 | 0.450 | 51.31 |
| val_tandem_transfer | 0.646 | 0.340 | 40.48 | 2.158 | 0.972 | 42.42 |

**val/loss (3-split):** 2.2447 (vs baseline 2.2117)

### vs Baseline (Fourier PE merged)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | 2.2117 | 2.2447 | +0.033 (epoch 66, not converged) |
| val_in_dist/mae_surf_p | 19.72 | 20.32 | +0.60 |
| val_ood_cond/mae_surf_p | 20.35 | 20.81 | +0.46 |
| val_ood_re/mae_surf_p | 30.37 | 31.14 | +0.77 |
| val_tandem_transfer/mae_surf_p | 40.92 | 40.48 | **-0.44** |

### What happened

Gradient accumulation (ACCUM_STEPS=2) with sqrt-scaled LR (4.24e-3) converges competitively. At epoch 66, val/loss=2.2447 vs baseline 2.2117 — a gap of only 0.033. The loss curve was still steadily decreasing at cutoff (2.2570 → 2.2447 in the last 2 epochs), suggesting the model could plausibly reach or beat baseline by epoch 100.

The tandem_transfer/mae_surf_p was actually better than baseline (40.48 vs 40.92), suggesting that the smoother gradients from larger effective batch helped OOD generalization. In-dist and ood_cond are slightly behind (within 0.6 Pa), likely because convergence is just a few epochs short.

Implementation note: an `optimizer.zero_grad()` call was also added at the start of each epoch (before the pbar loop) to prevent leftover gradients from the previous epoch's last odd batch from bleeding into the next epoch, since 331 batches is odd relative to ACCUM_STEPS=2.

### Suggested follow-ups

- Run full 100 epochs (or use a longer timeout) — the model appeared to still be converging and may reach baseline or better.
- Try ACCUM_STEPS=4 (effective batch=16) for even smoother gradients.
- Since tandem transfer improved, check if this helps on other OOD splits with more epochs.