### PR TITLE
Surface-only Fourier PE (zero for volume nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -596,6 +596,7 @@ for epoch in range(MAX_EPOCHS):
         freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
         xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+        fourier_pe = fourier_pe * is_surface.float().unsqueeze(-1)  # surface-only
         x = torch.cat([x, fourier_pe], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
@@ -735,6 +736,7 @@ for epoch in range(MAX_EPOCHS):
                 freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
                 xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                fourier_pe = fourier_pe * is_surface.float().unsqueeze(-1)  # surface-only
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
The Fourier PE success and curvature proxy success share a pattern: surface feature enrichment works. Applying Fourier PE only to surface nodes concentrates the model's feature capacity on the ~5% of nodes that matter most. This mirrors how curvature proxy is surface-only and worked, while extending curvature to all nodes (#1032) failed.

## Instructions
In both **training** (line 598) and **validation** (line 737), after computing fourier_pe, add surface masking:
```python
fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
fourier_pe = fourier_pe * is_surface.float().unsqueeze(-1)  # surface-only
x = torch.cat([x, fourier_pe], dim=-1)
```

No fun_dim change needed. Run with `--wandb_group surf-only-fourier`.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

---

## Results

**W&B run:** `c30n4xyk` | **Epochs:** 66/100 (30 min timeout) | **Peak memory:** 10.9 GB

### Surface Pressure MAE (most important)

| Split | Baseline | This run | Delta |
|---|---|---|---|
| val_in_dist | 19.72 | 20.89 | +1.17 ❌ |
| val_ood_cond | 20.35 | 21.71 | +1.36 ❌ |
| val_ood_re | 30.37 | 31.29 | +0.92 ❌ |
| val_tandem_transfer | 40.92 | 42.15 | +1.23 ❌ |

### val/loss (3-split average, excl. diverged val_ood_re)

| | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | 2.2117 | **2.2989** | +0.087 ❌ |

### Volume MAE (mae_vol_p)

| Split | This run |
|---|---|
| val_in_dist | 28.30 |
| val_ood_cond | 20.85 |
| val_ood_re | 52.22 |
| val_tandem_transfer | 45.82 |

Note: Visualization crashed post-training with a shape mismatch in `data/utils.py` (pre-existing issue — same as PR #1039, caused by the baseline Fourier PE changing input_dim and the read-only viz code not accounting for it). Training metrics are valid.

### What happened

**Clear negative result.** Surface-only Fourier PE made every metric worse by ~1-1.4 units of surface pressure MAE.

The hypothesis was wrong: the analogy between curvature proxy (surface-only) and Fourier PE breaks down because they serve fundamentally different purposes. Curvature is semantically meaningful only on surfaces — volume nodes have no curvature, so giving them a zero is correct. Fourier PE, on the other hand, provides positional identity for every node in the flow field. Zeroing PE on 95% of nodes (all volume nodes) strips those nodes of their spatial context, degrading the model's ability to learn the flow field geometry.

The model sees volume nodes with no positional encoding and can only distinguish them via their raw (x,y) coords and physics features — this is a strictly worse representation. The degraded volume accuracy then propagates to surface accuracy through the joint optimization.

### Suggested follow-ups
1. **Additive surface PE**: Keep full PE on all nodes, but *add* an extra learned surface-only feature on top (e.g., curvature, normals, or a learned surface embedding) rather than replacing volume PE with zeros.
2. **Surface PE amplification**: Keep volume PE but *scale up* surface PE (e.g., multiply surface PE by 2×) to give surface nodes more positional weight without crippling volume nodes.
3. **Learned surface token**: Replace the manual PE-zeroing with a learnable binary surface flag embedded into the feature space, letting the model learn how to use surface vs. volume spatial information differently.