### PR TITLE
Dual directional curvature (separate leading/trailing edge signals)

### DIFF
--- a/train.py
+++ b/train.py
@@ -461,7 +461,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 2 + 16,  # X_DIM=24 + 2 dual curvature + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=128,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -588,9 +588,10 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        # Dual curvature proxy: separate norms of dsdf pairs (2:4) and (4:6) for surface nodes
+        curv_a = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        curv_b = x[:, :, 4:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        x = torch.cat([x, curv_a, curv_b], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
         raw_xy = x[:, :, :2]
         freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
@@ -727,9 +728,10 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                # Dual curvature proxy: separate norms of dsdf pairs (2:4) and (4:6) for surface nodes
+                curv_a = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                curv_b = x[:, :, 4:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv_a, curv_b], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
                 raw_xy = x[:, :, :2]
                 freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)


### PR DESCRIPTION
## Hypothesis
The curvature proxy uses norm of dsdf channels 2:6, collapsing directional information. The first pair (2:4) and second pair (4:6) encode orthogonal directional components. Computing separate norms gives two curvature signals distinguishing leading-edge (high pressure, stagnation) from trailing-edge (separation, wake) geometry.

## Instructions
Replace the curvature computation in **training** (line 592-593) and **validation** (line 731-732):
```python
# From:
curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
x = torch.cat([x, curv], dim=-1)
# To:
curv_a = x[:, :, 2:4].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
curv_b = x[:, :, 4:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
x = torch.cat([x, curv_a, curv_b], dim=-1)
```

Update **fun_dim** (line 464):
```python
fun_dim=X_DIM - 2 + 2 + 16,  # +2 dual curvature (was +1), +16 Fourier PE
```

Run with `--wandb_group dual-curvature`.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

---

## Results

**W&B run:** mc7kk8hu  
**Epochs completed:** 63/100 (30-min timeout, ~27-28s/epoch)  
**Peak memory:** 10.9 GB

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss_3split | 2.244 | 2.2117 | +0.032 (slightly worse) |
| val_in_dist/mae_surf_p | 20.74 | 19.72 | +1.02 (slightly worse) |
| val_ood_cond/mae_surf_p | 20.99 | 20.35 | +0.64 (slightly worse) |
| val_ood_re/mae_surf_p | 30.97 | 30.37 | +0.60 (slightly worse) |
| val_tandem_transfer/mae_surf_p | 41.83 | 40.92 | +0.91 (slightly worse) |
| val_in_dist/mae_vol_p | 24.25 | — | — |
| val_tandem_transfer/mae_vol_p | 43.38 | — | — |

### What happened

**No meaningful improvement.** All four splits are slightly worse than baseline by small margins (0.6–1.0 units of mae_surf_p). The model was still improving at epoch 63 — most epochs from 41 onward updated the best checkpoint, suggesting convergence wasn't reached. With more training the gap could close further, but the trajectory doesn't show a clear signal that dual curvature helps.

The likely reason: the dsdf channels 2:6 are already present in the input x fed to the preprocess MLP. The model can already compute directional curvature signals implicitly through learned linear combinations of those channels. The explicit dual curvature proxy just pre-computes what the first layer of the MLP can already learn, providing redundant information without additional geometric insight.

The added channel (+1 extra feature) slightly increases model input dimensionality, which may marginally slow convergence at fixed n_hidden=128. The effect is small enough that the runs are essentially at parity.

### Suggested follow-ups

- **Cross-channel curvature product:** instead of separate norms, compute `curv_a * curv_b` as a signed cross-directional signal, which would be non-redundant with the raw channels.
- **Second-order features:** curvature rate of change along the airfoil surface (gradient of curvature) might provide more geometric structure — especially for the leading-edge stagnation point.
- **Skip the curvature proxy altogether:** if the channels 2:6 are directly available in x, the preprocess MLP can learn the relevant geometric features end-to-end. The single curvature proxy may actually hurt more than help by compressing information too early.
