### PR TITLE
torch.compile + 8 Fourier frequency bands (throughput + features combo)

### DIFF
--- a/train.py
+++ b/train.py
@@ -463,7 +463,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 1 + 32,  # X_DIM=24 + 1 curvature proxy + 32 Fourier PE (8 bands); fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
     n_hidden=160,  # was 128
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -597,9 +597,9 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, curv], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
         raw_xy = x[:, :, :2]
-        freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
-        xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+        freqs = 2.0 ** torch.arange(8, device=x.device, dtype=x.dtype)
+        xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 8]
+        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 32]
         x = torch.cat([x, fourier_pe], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
@@ -736,9 +736,9 @@ for epoch in range(MAX_EPOCHS):
                 x = torch.cat([x, curv], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 frequencies
                 raw_xy = x[:, :, :2]
-                freqs = 2.0 ** torch.arange(4, device=x.device, dtype=x.dtype)
+                freqs = 2.0 ** torch.arange(8, device=x.device, dtype=x.dtype)
                 xy_scaled = raw_xy.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 32]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
Combining two proven levers: torch.compile gives 33% throughput improvement (18s/epoch vs 27s, ~89 epochs), and more Fourier frequency bands extend the winning technique. 8 bands add 32 features (vs 16 currently) capturing finer spatial detail. Compile compensates for the slight per-epoch slowdown from extra features. This is the most likely "double win" combination.

## Instructions
1. **Add torch.compile** after model creation (line 475):
\`\`\`python
model = Transolver(**model_config).to(device)
model = torch.compile(model, mode="reduce-overhead")
\`\`\`

2. **Add near top** (after imports):
\`\`\`python
torch.set_float32_matmul_precision('high')
\`\`\`

3. **In training** (line 596) and **validation** (line 735), change:
\`\`\`python
freqs = 2.0 ** torch.arange(8, device=x.device, dtype=x.dtype)  # was 4
\`\`\`

4. **Update fun_dim** (line 464):
\`\`\`python
fun_dim=X_DIM - 2 + 1 + 32,  # was +16, now +32 for 8 frequency bands
\`\`\`

5. **Handle EMA with compiled model** (use \`model._orig_mod\` if needed).

If compile causes issues, try \`mode='default'\`. Run with \`--wandb_group compile-8freq\`.

## Baseline (after Fourier PE merge)
- best_val_loss = 2.2117
- val_in_dist/mae_surf_p = 19.72
- val_ood_cond/mae_surf_p = 20.35
- val_ood_re/mae_surf_p = 30.37
- val_tandem_transfer/mae_surf_p = 40.92

**Updated noam baseline** (compile + n_hidden=160): val_loss = 2.0996

---

## Results

### Run v1 (n_hidden=128 + compile + 8 freq bands)

**W&B run:** \`0s6iz4t4\`
**Epochs completed:** ~95 of 100 (30-min timeout)
**Peak GPU memory:** 8.8 GB
**Epoch time:** ~18 s/epoch

| Split | mae_surf_p | Old baseline | Delta |
|---|---|---|---|
| val_in_dist | 18.2 | 19.72 | **-1.5 (better)** |
| val_ood_cond | 19.4 | 20.35 | **-1.0 (better)** |
| val_ood_re | 30.7 | 30.37 | +0.3 |
| val_tandem_transfer | 42.3 | 40.92 | +1.4 |

**val/loss (3-split):** 2.1746 vs old baseline 2.2117 — **better by 1.7%**

### Run v2 (n_hidden=160 + compile + 8 freq bands, rebased on updated noam)

**W&B run:** \`zxorbwb4\`
**Epochs completed:** ~82 of 100 (30-min timeout)
**Peak GPU memory:** 10.6 GB
**Epoch time:** ~21 s/epoch (wider model = 3s slower than n_hidden=128)

| Split | mae_surf_p | Old baseline | Delta |
|---|---|---|---|
| val_in_dist | 20.5 | 19.72 | +0.8 |
| val_ood_cond | 19.2 | 20.35 | **-1.1 (better)** |
| val_ood_re | 30.4 | 30.37 | -0.0 |
| val_tandem_transfer | 40.7 | 40.92 | -0.2 |

**val/loss (3-split):** 2.1737 vs new noam baseline 2.0996 — **worse by 3.5%**

### What happened

**v1 beat the old baseline; v2 did not beat the new (wider) baseline.**

- With n_hidden=128, 8 Fourier bands gave clear gains on in_dist and ood_cond because the additional spatial features added information the smaller model couldn't otherwise capture. This combination beat the old baseline by 1.7%.

- After noam merged n_hidden=160 + compile (baseline 2.0996), the 8-band feature no longer helps — it actually hurts by ~3.5%. The wider n_hidden=160 model already has enough capacity to extract spatial patterns from 4-band Fourier PE. Adding 16 extra input features (32 vs 16) introduces more optimization complexity without benefit, and the wider model's epoch time (~21s vs ~18s) means fewer epochs in the 30-min window.

- The v2 run was still improving at epoch 82, but the trajectory suggests it would need significantly more epochs to match the baseline.

**Conclusion:** 8 Fourier bands are beneficial for the n_hidden=128 architecture but redundant/harmful for n_hidden=160. The wider model absorbs spatial structure better from fewer features.

### Suggested follow-ups
- Try exactly 6 Fourier bands (24 features) with n_hidden=160 — a middle ground that adds some detail without slowing convergence too much
- Investigate why the tandem mae_surf_p improved in v2 (40.72) vs old baseline (40.92) even though overall val/loss is worse — tandem may benefit from the extra features differently