### PR TITLE
2 Transolver layers n_hidden=128 + compile (depth vs width)

### DIFF
--- a/train.py
+++ b/train.py
@@ -465,8 +465,8 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=160,  # was 128
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_hidden=128,  # was 160 — reduce width for 2-layer budget
+    n_layers=2,    # was 1
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
Width helped massively (128→160, 5.1%). But depth is qualitatively different — a second attention layer enables iterative refinement of slice assignments. Previous 2-layer attempt (#816) got only 38 epochs without compile, on much older code. With compile (~24s/epoch at 128-dim), ~75 epochs should be achievable. n_hidden=128 keeps per-epoch cost manageable.

## Instructions
Two changes in model_config (lines 468-469):
```python
n_hidden=128,  # was 160 — reduce width for 2-layer budget
n_layers=2,    # was 1
```

Everything else stays (compile, Fourier PE, etc.). The re_head prediction happens between blocks[:-1] and blocks[-1], which works automatically with 2 layers.

Run with `--wandb_group 2layer-128-compile`.

## Baseline (n_hidden=160 + compile + Fourier PE)
- best_val_loss = 2.0996
- val_in_dist/mae_surf_p = 18.58
- val_ood_cond/mae_surf_p = 18.53
- val_ood_re/mae_surf_p = 29.55
- val_tandem_transfer/mae_surf_p = 41.63
- mean3_surf_p = 26.25
- Epochs: ~85 in 30 min

---

## Results

**W&B run:** `fjky8c4v` — frieren/2layer-128-compile
**Epochs completed:** 63 / 100 (30-min timeout)
**Epoch time:** 27.2s (vs 17.4s for 1-layer n_hidden=160 with compile)
**Peak GPU memory:** 69.2 GB

### Metrics (best epoch, epoch 63)

| Metric | This run | Baseline (160d 1L) | Delta |
|--------|----------|---------------------|-------|
| val/loss | 2.1099 | 2.0996 | +0.010 (+0.5%) |
| val_in_dist/mae_surf_Ux | 0.290 | — | — |
| val_in_dist/mae_surf_Uy | 0.169 | — | — |
| val_in_dist/mae_surf_p | 19.77 | 18.58 | +1.19 (+6.4%) |
| val_in_dist/mae_vol_Ux | 1.15 | — | — |
| val_ood_cond/mae_surf_Ux | 0.248 | — | — |
| val_ood_cond/mae_surf_Uy | 0.187 | — | — |
| val_ood_cond/mae_surf_p | 18.87 | 18.53 | +0.34 (+1.8%) |
| val_ood_re/mae_surf_p | 30.51 | 29.55 | +0.96 (+3.2%) |
| val_tandem_transfer/mae_surf_p | **38.96** | 41.63 | **-2.67 (-6.4%)** |

### What happened

**Depth did not beat width.** The 2-layer 128-dim model is broadly comparable to (but slightly worse than) the 1-layer 160-dim baseline on most metrics. The training curve was still declining at epoch 63 (2.1472 → 2.1099 over the last few epochs), but the model didn't converge enough in 30 minutes to close the gap.

**Speed regression**: epoch_time_s = 27.2s for 2-layer vs 17.4s for 1-layer (same compile). The second attention layer adds ~56% per-epoch overhead, leaving only 63 epochs vs ~85 for the baseline. Fewer epochs with a smaller model (128 vs 160) means fewer gradient steps × worse per-step capacity.

**Tandem transfer is notably better** (38.96 vs 41.63, -6.4%). This is the only metric where depth clearly wins. The iterative refinement across attention layers may help for the tandem case, where geometry is more complex (two foils interacting).

**Summary**: depth doesn't compensate for reduced width + fewer epochs in the 30-min budget. Width (160) beats depth+narrow (128 × 2L) for convergence speed here.

### Suggested follow-ups

- Try 2 layers at n_hidden=160 (no width reduction). More VRAM required, but would test depth at equal capacity. However, epoch time would be ~34s, giving only ~50 epochs.
- The tandem improvement with 2 layers is interesting — if we can find a way to get 2 layers at less per-epoch cost (e.g., using a smaller slice_num), it might be worth revisiting.
- Width appears more efficient than depth for this model and data scale. The 1-layer 160-dim configuration appears to be near-optimal for the 30-min budget.