### PR TITLE
SiLU activation everywhere (replace GELU)

### DIFF
--- a/train.py
+++ b/train.py
@@ -187,7 +187,7 @@ class TransolverBlock(nn.Module):
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
+                nn.SiLU(),  # was nn.GELU()
                 nn.Linear(hidden_dim, out_dim),
             )
 
@@ -196,7 +196,7 @@ class TransolverBlock(nn.Module):
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
-        se = F.gelu(self.se_fc1(se))
+        se = F.silu(self.se_fc1(se))  # was F.gelu
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
@@ -270,7 +270,7 @@ class Transolver(nn.Module):
         nn.init.zeros_(self.out_skip.bias)
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
-        self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.SiLU(), nn.Linear(32, 1))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -472,6 +472,7 @@ model_config = dict(
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
+    act="silu",  # was default "gelu"
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis
Every MLP uses GELU activation. SiLU (Swish) has smoother gradients near zero and is used in most modern architectures (Llama, Mistral, etc.). This is a completely orthogonal direction from width/depth/feature changes. Never tried in any of our 600+ experiments. Zero compute cost.

## Instructions
1. **Line 473** in model_config, add:
```python
act="silu",  # was default "gelu"
```

2. **Line 199** in TransolverBlock.forward, change:
```python
se = F.silu(self.se_fc1(se))  # was F.gelu
```

3. **Lines 189-190** in TransolverBlock.__init__, change the output mlp2:
```python
self.mlp2 = nn.Sequential(
    nn.Linear(hidden_dim, hidden_dim),
    nn.SiLU(),  # was nn.GELU()
    nn.Linear(hidden_dim, out_dim),
)
```

4. **Line 273** in Transolver.__init__, change re_head:
```python
self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.SiLU(), nn.Linear(32, 1))
```

Run with `--wandb_group silu-activation`.

## Baseline (n_hidden=160 + compile + Fourier PE)
- best_val_loss = 2.0996
- val_in_dist/mae_surf_p = 18.58
- val_ood_cond/mae_surf_p = 18.53
- val_ood_re/mae_surf_p = 29.55
- val_tandem_transfer/mae_surf_p = 41.63
- mean3_surf_p = 26.25

---

## Results

**W&B run:** glcnkrie  
**Epochs completed:** 83 (vs ~63 for GELU baseline — SiLU is ~25% faster!)  
**Peak memory:** 10.4 GB (vs ~10.6 GB baseline)

| Metric | SiLU | Baseline (GELU) | Delta |
|---|---|---|---|
| best_val_loss (3split) | 2.1160 | 2.0996 | +0.0164 |
| val_in_dist/mae_surf_p | 19.18 | 18.58 | +0.60 |
| val_ood_cond/mae_surf_p | **17.86** | 18.53 | **-0.67** |
| val_ood_re/mae_surf_p | 29.75 | 29.55 | +0.20 |
| val_tandem_transfer/mae_surf_p | **40.63** | 41.63 | **-1.00** |
| mean3_surf_p | 25.89 | 26.25 | **-0.36** |

**What happened:** Mixed result. SiLU is ~25% faster per epoch (20s vs 27s), enabling 83 epochs vs ~63 for GELU in the same 30-minute budget. The overall val_loss is marginally worse (+0.016, +0.8%), but 2 of 4 splits show clear surface pressure improvement: val_ood_cond (-0.67, -3.6%) and val_tandem_transfer (-1.00, -2.4%). The mean3_surf_p (average of in_dist, ood_cond, tandem) improved: 25.89 vs 26.25.

The val_in_dist regression (+0.60) partially offsets these gains. The faster training is a genuine free benefit — if the model were given a comparable epoch count to GELU, SiLU would likely converge further. Overall this is a mild positive with the throughput advantage being the clearest win.

**Suggested follow-ups:**
- Since SiLU gives ~25% more epochs in the same wall-clock budget, this activation change is worth merging for throughput alone.
- val_ood_re is still stuck at ~29.75 (Reynolds number OOD) — architectural changes are likely needed to close this gap, not activation changes.