### PR TITLE
EMA from epoch 30 with decay 0.997 (longer averaging with compile)

### DIFF
--- a/train.py
+++ b/train.py
@@ -480,8 +480,8 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
-ema_decay = 0.998
+ema_start_epoch = 30
+ema_decay = 0.997
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
EMA starts at epoch 40 (set when training ran ~67 epochs, giving 27 EMA epochs). With compile running ~85 epochs, starting at epoch 30 gives 55 EMA epochs — double the averaging window. The wider 160-dim model has more parameters and may benefit from more averaging. Also slightly more aggressive decay (0.997 vs 0.998) to take advantage of the longer window.

## Instructions
Two changes (lines 483-484):
```python
ema_start_epoch = 30  # was 40
ema_decay = 0.997     # was 0.998
```

Run with `--wandb_group ema-early-30`.

## Baseline (n_hidden=160 + compile + Fourier PE)
- best_val_loss = 2.0996
- val_in_dist/mae_surf_p = 18.58
- val_ood_cond/mae_surf_p = 18.53
- val_ood_re/mae_surf_p = 29.55
- val_tandem_transfer/mae_surf_p = 41.63
- mean3_surf_p = 26.25

---

## Results

**W&B run:** kr77pja0
**Epochs completed:** 82 (30-min timeout)
**Peak memory:** 10.4 GB (same as baseline)

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | 2.0996 | 2.0810 | **-0.019 better** |
| val_in_dist/mae_surf_p | 18.58 | 17.72 | **-0.86 better** |
| val_ood_cond/mae_surf_p | 18.53 | 17.62 | **-0.91 better** |
| val_ood_re/mae_surf_p | 29.55 | 29.43 | -0.12 better |
| val_tandem_transfer/mae_surf_p | 41.63 | 40.78 | -0.85 better |
| mean3_surf_p | 26.25 | 25.37 | **-0.88 better** |

### Full surface MAE (best epoch)

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 0.2770 | 0.1685 | 17.72 |
| val_ood_cond | 0.2474 | 0.1785 | 17.62 |
| val_ood_re | 0.2631 | 0.1907 | 29.43 |
| val_tandem_transfer | 0.6090 | 0.3241 | 40.78 |

### Volume MAE (val_in_dist)
Ux: 1.0987, Uy: 0.3903, p: 22.60

### What happened

Clear win across all metrics. Starting EMA at epoch 30 (vs 40) gives 55 EMA epochs of averaging instead of ~27, and 0.997 decay (vs 0.998) allows slightly faster adaptation to recent weights while still averaging effectively. Both in-dist and ood_cond surface pressure improved by ~0.9, and tandem by 0.85. The val_ood_re improvement is small (0.12) but directionally consistent. No memory cost.

The result confirms the hypothesis: with compile enabling ~82 epochs, starting EMA earlier is a free lunch — the model has already stabilized enough by epoch 30 that averaging helps rather than hurts convergence, and the longer window provides better regularization.

### Suggested follow-ups

1. **Even earlier EMA**: Try epoch 20 — could provide even more averaging for the 82-epoch budget.
2. **Tune decay**: Try 0.995 decay with epoch 30 to see if faster adaptation (shorter effective window) is better or worse.
3. **Decay schedule**: Instead of fixed decay, try linearly ramping decay from 0.99 → 0.999 over training to start responsive and end very stable.