### PR TITLE
Wider model n_hidden=224 (continued capacity scaling)

### DIFF
--- a/train.py
+++ b/train.py
@@ -466,7 +466,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=192,  # was 160
+    n_hidden=224,  # was 192
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs


### PR DESCRIPTION
## Hypothesis
n_hidden 128→160 gave -5.1%, 160→192 gave -1.4%. Capacity trend not saturating. n_hidden=224 with mlp_ratio=2 keeps FFN proportional. n_hidden=256/mlp_ratio=1 failed because FFN was crippled, not because of width.

## Instructions
**Line 469**, one change:
```python
n_hidden=224,  # was 192
```
Monitor epoch time. Aim for >65 epochs in 30 min. Run with `--wandb_group wider-224`.

## Baseline (n_hidden=192 + compile + learnable Fourier PE)
- best_val_loss = ~2.07
- val_in_dist/mae_surf_p = 17.4
- val_ood_cond/mae_surf_p = 18.4
- val_ood_re/mae_surf_p = 29.5
- val_tandem_transfer/mae_surf_p = 40.2
- mean3_surf_p = ~25.3
- Epochs: ~76 in 30 min with compile

---

## Results

**W&B run:** p7su19n5  
**Epochs completed:** 66 (30-min wall-clock timeout)  
**Peak GPU memory:** ~10.6 GB

### Metrics vs Baseline (n_hidden=192)

| Split | Metric | Baseline (192) | This run (224) | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 17.41 | 18.17 | +0.76 worse |
| val_ood_cond | mae_surf_p | 18.40 | 18.55 | +0.15 slightly worse |
| val_ood_re | mae_surf_p | 29.48 | 29.47 | ~same |
| val_tandem_transfer | mae_surf_p | 40.20 | 39.49 | -0.71 better |
| — | best_val_loss | 2.0702 | 2.0736 | +0.0034 slightly worse |

### Full surface MAE (best checkpoint, epoch 66)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.273 | 0.165 | 18.17 |
| val_ood_cond | 0.245 | 0.180 | 18.55 |
| val_ood_re | 0.257 | 0.193 | 29.47 |
| val_tandem_transfer | 0.594 | 0.319 | 39.49 |

### Volume MAE (best checkpoint)

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.100 | 0.387 | 22.04 |
| val_ood_cond | 0.909 | 0.362 | 17.09 |
| val_ood_re | 0.911 | 0.409 | 49.33 |
| val_tandem_transfer | 1.941 | 0.891 | 40.50 |

### What happened

Capacity scaling is plateauing at n_hidden=224. Results are essentially flat vs n_hidden=192 — slight improvement on tandem_transfer (-0.71) but slight regression on in_dist (+0.76) and val/loss marginally worse (2.0736 vs 2.0702).

The likely reason is the epoch budget: n_hidden=224 completed only 66 epochs vs 76 at n_hidden=192. The wider model is ~15% slower per epoch, and with the 30-min timeout, the model simply had less training time — which appears to matter more than the extra capacity at this scale.

The capacity curve (128: 20.24 → 160: 18.58 → 192: 17.41 → 224: 18.17 mae_surf_p in_dist) suggests n_hidden=192 is the sweet spot given the 30-minute training budget. Going wider only helps if compensated by enough epochs.

### Suggested follow-ups

- n_hidden=192 appears to be the optimal width given the current epoch budget; treat it as the new strong baseline
- If the training budget increases (e.g., 60 min), n_hidden=224 or 256 might benefit from the extra capacity
- The tandem_transfer improvement at 224 (39.49 vs 40.20) is interesting and may not be noise — wider models might generalize better to the tandem geometry specifically
