### PR TITLE
2 Transolver layers at n_hidden=160 + compile (depth revisited)

### DIFF
--- a/train.py
+++ b/train.py
@@ -466,8 +466,8 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=192,  # was 160
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_hidden=160,  # was 192
+    n_layers=2,    # was 1
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
2 layers at n_hidden=128 failed (-2.8% at 63 epochs). But with n_hidden=160 (wider) + compile (faster), 2 layers should get ~65 epochs. More importantly, all features (Fourier PE, curvature, learnable freqs) were absent from previous 2-layer attempts. A second attention layer enables iterative slice refinement — qualitatively different from width.

## Instructions
Two changes in model_config (lines 469-470):
```python
n_hidden=160,  # was 192
n_layers=2,    # was 1
```
Everything else stays. Run with `--wandb_group 2layer-160-compile`.

## Baseline (n_hidden=192 + compile + learnable Fourier PE)
- best_val_loss = ~2.07
- val_in_dist/mae_surf_p = 17.4
- val_ood_cond/mae_surf_p = 18.4
- val_ood_re/mae_surf_p = 29.5
- val_tandem_transfer/mae_surf_p = 40.2
- mean3_surf_p = ~25.3
- Epochs: ~76 in 30 min with compile

---

## Results

**W&B run:** u6iuah9p
**Epochs completed:** 53 (30-min timeout; slower than expected at 32-33s/epoch)
**Peak memory:** 15.2 GB (+4.8 GB vs 1-layer baseline at ~10.4 GB)

### Metrics vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | ~2.07 | 2.1654 | +0.095 worse |
| val_in_dist/mae_surf_p | 17.4 | 20.31 | +2.91 worse |
| val_ood_cond/mae_surf_p | 18.4 | 20.49 | +2.09 worse |
| val_ood_re/mae_surf_p | 29.5 | 30.85 | +1.35 worse |
| val_tandem_transfer/mae_surf_p | 40.2 | 39.12 | -1.08 better |
| mean3_surf_p | ~25.3 | 26.64 | +1.34 worse |

### Full surface MAE (best epoch)

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 0.2942 | 0.1747 | 20.31 |
| val_ood_cond | 0.2580 | 0.1906 | 20.49 |
| val_ood_re | 0.2700 | 0.2016 | 30.85 |
| val_tandem_transfer | 0.5981 | 0.3207 | 39.12 |

### Volume MAE (val_in_dist)
Ux: 1.0993, Uy: 0.3944, p: 23.56

### What happened

The 2-layer model did not beat baseline at 53 epochs. This is primarily a convergence-time issue — the run only completed 53 epochs vs the baseline's ~76 (2 layers at 160-dim takes 33s/epoch vs 21s/epoch for 1 layer at 192-dim, even with compile). The model was still clearly improving at epoch 53 (loss monotonically decreasing), so this is an underfitted snapshot.

Memory was notably higher: 15.2 GB vs ~10.4 GB for the 1-layer baseline (+46%). This is a significant cost.

The tandem split improved (-1.08 on surf_p), consistent with previous results suggesting depth helps tandem generalization specifically. However, in-dist and ood_cond got significantly worse at this epoch count.

The hypothesis that depth + modern features (Fourier PE, curvature) would improve on the previous 2-layer attempt appears directionally correct — the 2-layer 128-dim baseline was worse, but 2-layer 160-dim is showing better tandem results. However, within the 30-min budget, width wins.

### Suggested follow-ups

1. **Reduce width further**: Try n_hidden=128 with n_layers=2 to hit ~65+ epochs within budget, accepting smaller model capacity for more iterations.
2. **Accept memory cost, increase time**: The 2-layer model would likely beat baseline given ~85+ epochs — if budget allows extended runs, it could be worth revisiting.
3. **Depth in preprocess only**: Instead of 2 full attention layers, try n_layers=1 + deeper preprocess MLP (n_layers=3 in MLP) for more depth without the full attention memory cost.