### PR TITLE
EMA from epoch 25 with decay 0.997 (longer averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -481,8 +481,8 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
-ema_decay = 0.998
+ema_start_epoch = 25  # was 40
+ema_decay = 0.997     # was 0.998
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
EMA starts at epoch 40 (set for 67-epoch budget). With compile running ~76 epochs, starting at 25 gives 51 EMA epochs (vs 36 currently). Wider 192-dim model benefits more from weight averaging. EMA early showed -0.9% on old code.

## Instructions
Two changes (lines 484-485):
```python
ema_start_epoch = 25  # was 40
ema_decay = 0.997     # was 0.998
```
Run with `--wandb_group ema-25`.

## Baseline (n_hidden=192 + compile + learnable Fourier PE)
- best_val_loss = ~2.07
- val_in_dist/mae_surf_p = 17.4
- val_ood_cond/mae_surf_p = 18.4
- val_ood_re/mae_surf_p = 29.5
- val_tandem_transfer/mae_surf_p = 40.2
- mean3_surf_p = ~25.3
- Epochs: ~76 in 30 min with compile

---

## Results

**W&B run:** `6wedwvn3` (71 epochs, hit 30-min timeout)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss (3-split) | ~2.07 | 2.0902 | +0.020 ↑ slightly worse |
| val_in_dist/mae_surf_p | 17.4 | 18.17 | +0.77 ↑ worse |
| val_ood_cond/mae_surf_p | 18.4 | 18.73 | +0.33 ↑ slightly worse |
| val_ood_re/mae_surf_p | 29.5 | 29.86 | +0.36 ↑ slightly worse |
| val_tandem_transfer/mae_surf_p | 40.2 | 39.94 | -0.26 ↓ slightly better |
| val_in_dist/mae_surf_Ux | — | 0.280 | — |
| val_in_dist/mae_surf_Uy | — | 0.161 | — |
| val_in_dist/mae_vol_p | — | 21.47 | — |
| Peak memory | — | 12.4 GB | — |

**What happened:**

Starting EMA at epoch 25 instead of 40 slightly hurt performance on most splits. Only tandem_transfer improved marginally.

The likely cause: EMA averages weights over time, which is most beneficial when the model is in its "refinement" phase (making small consistent improvements). Between epochs 25-40, the model is still learning rapidly — val_loss drops from ~3 to ~2 in this range. Including those noisy early weights in the EMA degrades the averaged model.

The slightly faster decay (0.997 vs 0.998) means the EMA "forgets" older weights 40% faster (`1-0.997=0.003` vs `1-0.998=0.002`), reducing the smoothing effect. This combination — more early noise + less averaging — explains the slight regression.

The original ema_start=40 is better calibrated to when the model has reached its learning plateau, even with the faster compile-enabled training.

**Suggested follow-ups:**
- Try ema_start=35 as a middle ground — still more EMA epochs than 40, but avoids the noisiest early phase
- Try keeping ema_start=40 but ema_decay=0.9985 (slower decay, more smoothing) — if EMA helps, more averaging might help more
- The 5 extra epochs saved by starting at 25 vs 40 are probably not worth the quality loss