### PR TITLE
Cosine T_max=76, eta_min=5e-5 (align LR schedule + sharper convergence)

### DIFF
--- a/train.py
+++ b/train.py
@@ -523,7 +523,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=75, eta_min=1e-4)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=76, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )


### PR DESCRIPTION
## Hypothesis
T_max=75 means LR hits minimum at epoch 75. With 76 actual epochs, one epoch is wasted. Also, lowering eta_min from 1e-4 to 5e-5 sharpens the final convergence phase.

## Instructions
**Line 526**, change:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=76, eta_min=5e-5)
```
Run with `--wandb_group tmax-76-etamin`.

## Baseline (n_hidden=192 + compile + learnable Fourier PE)
- best_val_loss = ~2.07
- mean3_surf_p = ~25.3
- Epochs: ~76 in 30 min

---

## Results

**W&B run:** ub9phcql  
**Epochs completed:** 72 (timeout)  
**Peak memory:** 12.4 GB (same as baseline)

| Metric | T_max=76, eta_min=5e-5 | Baseline | Delta |
|---|---|---|---|
| best_val_loss (3split) | **2.0537** | ~2.07 | **-0.016** |
| val_in_dist/mae_surf_p | 18.38 | ~18.6 | -0.22 |
| val_ood_cond/mae_surf_p | 18.11 | ~18.5 | -0.39 |
| val_ood_re/mae_surf_p | 29.54 | ~29.6 | -0.06 |
| val_tandem_transfer/mae_surf_p | **39.34** | ~41.6 | **-2.26** |
| mean3_surf_p | **25.27** | ~25.3 | **-0.03** |

**What happened:** Positive result. Aligning T_max with the actual epoch count (76) and lowering eta_min to 5e-5 slightly improved overall convergence. The most notable gain is on val_tandem_transfer (-2.26 Pa, -5.4%), suggesting the sharper convergence in the final epochs (LR approaching 5e-5 vs 1e-4 previously) helps the model generalize to tandem foil configurations. val_ood_cond also improved (-0.39). Overall val_loss improved by ~0.8% and mean3_surf_p by 0.03.

The run completed 72 epochs (vs ~76 baseline) — slightly fewer, possibly due to compile overhead variation. The LR at epoch 72 with T_max=76 is just above 5e-5, so the schedule was almost fully used.

**Suggested follow-ups:**
- Since this worked, could try T_max=72 to perfectly align, and test with eta_min=1e-5 to see if even sharper convergence helps.
- The tandem_transfer improvement is encouraging — this split has been hardest to improve.