### PR TITLE
Deeper preprocess MLP (n_layers=2 on wider model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -245,7 +245,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
Preprocess deepening (0→1 layer) was an early win. On old code, n_layers=2 reached val/loss=2.094 (-0.3% vs old baseline). With n_hidden=192, the preprocess has 192*2=384 hidden dim and each residual layer is 192x192. More capacity to extract feature interactions from the 41 input features (especially the Fourier PE).

## Instructions
**Line 248** in Transolver.__init__, change:
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
```
(Change `n_layers=1` to `n_layers=2`)

Run with `--wandb_group preprocess-2layer`.

## Baseline (n_hidden=192 + compile + learnable Fourier PE)
- best_val_loss = ~2.07
- mean3_surf_p = ~25.3
- Epochs: ~76 in 30 min

---

## Results

**W&B run:** `q60cagp4` | **Epochs:** 71/100 (30 min timeout) | **Peak memory:** 13.8 GB

### Surface Pressure MAE (most important)

| Split | Baseline (192) | This run (192 + 2-layer preprocess) | Delta |
|---|---|---|---|
| val_in_dist | ~? | 19.08 | — |
| val_ood_cond | ~? | 19.76 | — |
| val_ood_re | ~? | 29.86 | — |
| val_tandem_transfer | ~? | 41.15 | — |
| **mean3_surf_p** | **~25.3** | **26.66** | **+1.36 ❌** |

### val/loss (3-split average)

| | Baseline | This run | Delta |
|---|---|---|---|
| best_val_loss | ~2.07 | **2.1292** | +0.059 ❌ |

### Volume MAE (mae_vol_p)

| Split | This run |
|---|---|
| val_in_dist | 22.18 |
| val_ood_cond | 16.84 |
| val_ood_re | 49.16 |
| val_tandem_transfer | 41.89 |

Note: Visualization crashed post-training (pre-existing issue in `data/utils.py`). Training metrics are valid.

### What happened

**Negative result.** Adding a second preprocess layer regressed mean3_surf_p from ~25.3 to 26.66, losing the gains from the n_hidden=192 upgrade and returning to near the n_hidden=160 baseline level (~26.25).

The extra preprocess layer also slowed each epoch by ~3s (26s vs ~23s for baseline), resulting in 71 epochs instead of ~76. However, even accounting for this training disadvantage, the wider preprocess didn't help — the model was still improving at epoch 68 but couldn't match the baseline's quality even with n_layers=1.

One interpretation: the bottleneck is not feature extraction capacity in the preprocess but rather the attention/MLP capacity in the Transolver blocks. The preprocess already extracts adequate representations with n_layers=1 for the 41 input features, and adding more capacity here is wasteful. Alternatively, the deeper preprocess may be oversmoothing the Fourier PE signals before the main model sees them.

### Suggested follow-ups
1. **n_layers=0 preprocess**: Going the other direction — a single linear projection might be even better, as it preserves all raw feature information for the attention blocks to process directly.
2. **n_layers=2 with n_hidden=256**: Test whether deeper preprocess benefits from even wider channels (if attention width is the constraint, not preprocess depth).
3. **Larger hidden_dim in preprocess only**: Instead of n_hidden*2 bottleneck, try n_hidden*4 as the intermediate dimension with n_layers=1 to give more feature mixing without extra depth.