### PR TITLE
Auxiliary AoA prediction head (complement Re auxiliary)

### DIFF
--- a/train.py
+++ b/train.py
@@ -273,6 +273,7 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
 
     def initialize_weights(self):
@@ -343,11 +344,12 @@ class Transolver(nn.Module):
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
+        aoa_pred = self.aoa_head(fx.mean(dim=1))
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         fx = fx + self.out_skip(fx_pre)
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred}
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
 
 # ---------------------------------------------------------------------------
@@ -634,8 +636,10 @@ for epoch in range(MAX_EPOCHS):
             out = model({"x": x})
             pred = out["preds"]
             re_pred = out["re_pred"]
+            aoa_pred = out["aoa_pred"]
         pred = pred.float()
         re_pred = re_pred.float()
+        aoa_pred = aoa_pred.float()
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -689,6 +693,9 @@ for epoch in range(MAX_EPOCHS):
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
+        aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
+        aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
+        loss = loss + 0.01 * aoa_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Re auxiliary improved val/loss by 0.86%. AoA is the other major flow variable, especially for val_ood_cond (extreme AoA). Adding a parallel AoA prediction head forces AoA-awareness into the hidden representation.

## Instructions
1. In `Transolver.__init__` (next to re_head, ~line 275):
```python
self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
```

2. In `forward()` (~line 345), alongside re_pred:
```python
aoa_pred = self.aoa_head(fx.mean(dim=1))
```

3. Return: `{"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}`

4. In training loss (~line 694), add:
```python
aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
aoa_loss = F.mse_loss(out["aoa_pred"].float(), aoa_target)
loss = loss + 0.01 * aoa_loss
```

Run with `--wandb_group aux-aoa`.

## Baseline (n_hidden=192 + compile + learnable coord-norm Fourier PE + feature cross + T_max=76)
- best_val_loss ~= 2.03
- val_in_dist/mae_surf_p ~= 18.9
- val_ood_cond/mae_surf_p ~= 15.7
- val_ood_re/mae_surf_p ~= 28.7
- val_tandem_transfer/mae_surf_p ~= 40.2
- mean3_surf_p ~= 24.9
- ~76 epochs in 30 min

---

## Results

**W&B run:** `v3ji6qwn`  
**Epochs completed:** 70 (hit 30-min timeout; ~24s/epoch)  
**Peak memory:** 12.7 GB  

### Validation losses (3-split, lower is better)

| Split | val/loss |
|-------|----------|
| val_in_dist | 1.4215 |
| val_ood_cond | 1.5041 |
| val_tandem_transfer | 2.9818 |
| **val/loss (3-split)** | **1.9691** |

Baseline val/loss ~2.03 → **improvement: −3.0%**

### Surface MAE — pressure (most important)

| Split | Baseline | This Run | Delta |
|-------|----------|----------|-------|
| val_in_dist/mae_surf_p | ~18.9 | **18.05** | −0.85 ✓ |
| val_ood_cond/mae_surf_p | ~15.7 | **15.44** | −0.26 ✓ |
| val_ood_re/mae_surf_p | ~28.7 | 29.14 | +0.44 |
| val_tandem_transfer/mae_surf_p | ~40.2 | **38.00** | **−2.20** ✓ |
| **mean3_surf_p** | **~24.9** | **23.83** | **−1.07** ✓ |

### Surface MAE — velocity (val_in_dist)

| Field | Value |
|-------|-------|
| mae_surf_Ux | 0.275 |
| mae_surf_Uy | 0.163 |

### Volume MAE

| Split | mae_vol_p |
|-------|-----------|
| val_in_dist | 22.01 |
| val_ood_cond | 14.82 |

### What happened

Clear win. The AoA auxiliary head improved mean3_surf_p from ~24.9 → 23.83 (−4.3%) and val/loss from ~2.03 → 1.969 (−3.0%). The biggest gain was on **tandem_transfer** (mae_surf_p: 40.2 → 38.0, −5.5%), which makes sense: in tandem foil configurations the downstream foil sees flow strongly modified by the upstream foil's AoA, making AoA-awareness especially valuable for transfer cases. The in_dist and ood_cond splits also improved modestly.

The slight regression on ood_re (+0.44) is small and within noise. The model didn't finish converging (still improving at epoch 70), so this gap could close with more epochs.

The AoA auxiliary head is exactly symmetric to the Re head (same architecture, same loss weight 0.01, same pooling by mean). It forces the global hidden representation to encode AoA, complementing the Re auxiliary's role.

### Suggested follow-ups

1. **Both auxiliary heads in validation**: Currently the auxiliary losses only apply during training. Using EMA-model aux outputs for monitoring could give a diagnostic signal for convergence.
2. **Higher AoA loss weight for ood_cond**: The ood_cond split has extreme AoA values. A slightly higher weight (0.05 or 0.1) might improve that split further at the cost of modest in_dist regression.
3. **Multi-task head on AoA + Re jointly**: A single shared MLP predicting [log_re, aoa] jointly might be more parameter-efficient.