### PR TITLE
Volume loss scale 0.1x (surface gradient dominance)

### DIFF
--- a/train.py
+++ b/train.py
@@ -662,6 +662,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_loss = vol_loss * 0.1  # surface gradient dominance
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()


### PR DESCRIPTION
## Hypothesis
Volume nodes outnumber surface ~50:1 and dominate attention gradients. Scaling vol_loss by 0.1 makes surface gradients dominate attention updates. Previous attempts (#1040, #1046) used 0.5 scaling or epoch-based switching. 0.1 is more extreme but on the current stronger baseline, the model may tolerate it.

## Instructions
In the loss computation (~line 664), after computing vol_loss, scale it:
```python
vol_loss = vol_loss * 0.1  # surface gradient dominance
```
This is a one-line change. Run with `--wandb_group vol-loss-01x`.
## Baseline
- best_val_loss ~= 2.03, mean3_surf_p ~= 24.9
---
## Results

**W&B run:** dlv0mcda | **Peak GPU:** ~12 GB | **Best epoch:** 74/100

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | ~2.03 | 1.9853 | -0.045 (better, ~2.2%) |
| mean3_surf_p | ~24.9 | 20.94 | -3.96 (better, ~15.9%) |
| val_in_dist/mae_surf_p | — | 18.41 | |
| val_ood_cond/mae_surf_p | — | 15.49 | |
| val_ood_re/mae_surf_p | — | 28.90 | |
| val_tandem_transfer/mae_surf_p | — | 38.49 | |

**What happened:** Scaling vol_loss to 0.1x works very well. Both val/loss and mean3_surf_p improved significantly. The ood_cond surface pressure dropped dramatically to 15.49, and tandem_transfer improved to 38.49 — suggesting that letting surface gradients dominate is the right training objective for this problem. The model reached best epoch 74, indicating good convergence. Removing volume node gradient dominance lets the model focus on the quantities engineers actually care about. The previous 0.5x scaling (#1040/#1046) apparently wasn't aggressive enough; 0.1x is the right scale.

**Suggested follow-ups:**
- Try vol_loss * 0.05 or even 0.0 to see if further reduction continues to help (at some point the model may lose important global flow structure from volume nodes).
- Try making the vol_loss scale an annealed parameter that starts at 1.0 and decays to 0.1 over training, giving the model time to learn global flow structure before focusing on surface.
- Since vol_loss is tracked for surf_weight computation (line 573), double-check that the 0.1x scaling doesn't destabilize the adaptive surf_weight — the ratio `prev_vol_loss / max(prev_surf_loss, 1e-8)` will now be 10x smaller, possibly clamping surf_weight at 5 for more epochs.