### PR TITLE
FiLM conditioning: Re+AoA modulate hidden features

### DIFF
--- a/train.py
+++ b/train.py
@@ -278,6 +278,10 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
         self.surface_boost = nn.Parameter(torch.tensor(0.5))
+        self.film_net = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * n_hidden))
+        nn.init.zeros_(self.film_net[-1].weight)
+        nn.init.zeros_(self.film_net[-1].bias)
+        self.film_net[-1].bias.data[:n_hidden] = 1.0  # gamma=1, beta=0
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -344,6 +348,10 @@ class Transolver(nn.Module):
         surf_indicator = (x[:, :, 12:13] > 0).float()
         fx = fx * (1.0 + self.surface_boost.abs() * surf_indicator)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+        re_aoa = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)  # [B, 2]
+        film_out = self.film_net(re_aoa)
+        gamma, beta = film_out.chunk(2, dim=-1)
+        fx = gamma.unsqueeze(1) * fx + beta.unsqueeze(1)
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)


### PR DESCRIPTION
## Hypothesis
Re and AoA fundamentally change flow physics but enter as 2 of 41 input features. FiLM computes per-sample scale/shift from Re+AoA to modulate the hidden representation. Zero-initialized output ensures identity transform at init.

## Instructions
1. In `Transolver.__init__` (~line 275), add:
```python
self.film_net = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * n_hidden))
nn.init.zeros_(self.film_net[-1].weight)
nn.init.zeros_(self.film_net[-1].bias)
self.film_net[-1].bias.data[:n_hidden] = 1.0  # gamma=1, beta=0
```

2. In `forward()` after `fx = fx * self.placeholder_scale...` (~line 339):
```python
re_aoa = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)  # [B, 2]
film_out = self.film_net(re_aoa)
gamma, beta = film_out.chunk(2, dim=-1)
fx = gamma.unsqueeze(1) * fx + beta.unsqueeze(1)
```
Run with `--wandb_group film-re-aoa`.
## Baseline
- best_val_loss ~= 2.03, mean3_surf_p ~= 24.9
---
## Results

### v1 (pre-rebase, old noam)
**W&B run:** `d25w29dd`  
**Epochs:** 69 | **Runtime:** 29 min

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol MAE |
|---|---|---|---|---|---|
| val_in_dist | 1.5241 | 0.319 | 0.171 | 20.20 | ~8.6 |
| val_tandem_transfer | 2.9871 | 0.578 | 0.311 | 38.36 | ~14.1 |
| val_ood_cond | 1.3963 | 0.204 | 0.151 | 14.15 | ~4.8 |
| val_ood_re | 18869* | 0.241 | 0.184 | 28.49 | — |
| **3-split avg** | **1.9692** | | | **24.23** | |

*val_ood_re anomaly (~18868) was pre-existing on old noam.

vs baseline: **val/loss_3split −3.0%, mean3_surf_p −2.7%**

---

### v2 (rebased on updated noam — 7 new merges)
**W&B run:** `3ux3vrng`  
**Epochs:** 69 | **Runtime:** 32 min (30-min cap hit, clean checkpoint saved)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.3345 | 0.281 | 0.161 | 18.70 | 1.681 | 0.604 | 33.10 |
| val_tandem_transfer | 3.2222 | 0.610 | 0.329 | 40.56 | 2.475 | 1.212 | 48.70 |
| val_ood_cond | 1.6153 | 0.196 | 0.148 | 15.68 | 1.180 | 0.433 | 19.42 |
| val_ood_re | **1.4022** | 0.237 | 0.181 | 29.02 | 1.220 | 0.488 | 52.55 |
| **3-split avg** | **2.0573** | | | **24.98** | | | |
| **4-split avg** | **1.8935** | | | **26.00** | | | |

### What happened

**v1 was a clear win** on old noam (−3% 3-split, −2.7% mean3_surf_p). The FiLM layer is sound.

**v2 on updated noam is harder to interpret** because 7 new features landed simultaneously (surf-boost, vol-loss-01x, noise-anneal, aux-aoa, tandem-psnorm, etc.) — these change training dynamics significantly. Two observations:

1. **val_ood_re anomaly is gone** — thanks to tandem-psnorm (#1078). val_ood_re/loss is now 1.4022 (was ~18869). The 4-split metric is now meaningful (1.8935).

2. **3-split is 2.057 vs stated baseline 2.03** — FiLM is at parity with the old baseline, not improving it. This is expected: the 7 merged features already incorporate surf-boost and other complementary ideas, so FiLM's contribution is being absorbed into a tighter competition. Without a clean noam-without-FiLM control run on the new branch, I can't say whether FiLM is net-positive or neutral here.

val_in_dist surface p improved notably (18.70 vs v1's 20.20); tandem_transfer regressed (40.56 vs v1's 38.36), likely because vol-loss-01x (#1082) shifts gradient emphasis away from volume (which tandem relies on more for interpolation).

### Suggested follow-ups
- **Run noam baseline without FiLM** to get a true apples-to-apples comparison on the updated branch.
- **Apply FiLM per attention layer** for deeper conditioning.
- **Condition on aggregate foil geometry** (chord, camber) for geometry-aware modulation.
