### PR TITLE
Learned sigmoid gate on preprocess-to-output skip

### DIFF
--- a/train.py
+++ b/train.py
@@ -270,6 +270,8 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
+        self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
+        nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
@@ -345,7 +347,8 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
-        fx = fx + self.out_skip(fx_pre)
+        gate = self.skip_gate(fx_pre)
+        fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred}
 


### PR DESCRIPTION
## Hypothesis
The preprocess skip uses zero-init linear uniformly. A learned sigmoid gate lets the model control per-node how much to use the shortcut vs attention output. High-curvature nodes (edges) may benefit more from direct path.

## Instructions
1. In `Transolver.__init__` (~line 270, after out_skip):
```python
self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
```

2. In `forward()` line 348, change:
```python
# From: fx = fx + self.out_skip(fx_pre)
# To:
gate = self.skip_gate(fx_pre)
fx = fx + gate * self.out_skip(fx_pre)
```
Run with `--wandb_group learned-skip-gate`.
## Baseline
- best_val_loss ~= 2.03, mean3_surf_p ~= 24.9
---
## Results

**W&B run:** `39bs1yit`
**Epochs:** ~70/100 (hit 30-min timeout at ~1744s, ~24.4s/epoch with compile)
**Peak memory:** 12.4 GB

| Metric | This run | Baseline | Δ |
|---|---|---|---|
| val/loss (last) | 1.9984 | ~2.03 | **-1.6%** |
| val_in_dist/mae_surf_p | 18.98 | — | — |
| val_ood_cond/mae_surf_p | 16.68 | — | — |
| val_ood_re/mae_surf_p | 29.63 | — | — |
| val_tandem_transfer/mae_surf_p | 39.68 | — | — |
| **mean3_surf_p** | **21.76** | **~24.9** | **-12.6%** |

### What happened

The learned sigmoid gate (initialized nearly closed at bias=−2.0, sigmoid(−2)≈0.12) shows a substantial improvement: mean3_surf_p drops from ~24.9 to 21.76, a 12.6% relative improvement. The val/loss also improved from ~2.03 to ~2.00. The gate allows the model to learn per-node how much to route through the skip vs. the attention output, which appears to help significantly — likely because high-curvature surface nodes and boundary-layer adjacent nodes benefit from direct feature path.

**Note on val_ood_re/vol_loss:** The ood_re split has a runaway vol_loss (~18869) throughout training. This appears to be a pre-existing numerical issue in the noam branch (likely from the proximity weighting). It does not affect the surf metrics, which are the primary evaluation criterion.

The run timed out at ~70 epochs (no `best_val_loss` was logged since EMA checkpoint summary was not written before timeout). The val metrics at epoch 70 are the final reported numbers.

### Suggested follow-ups

- **Let it finish**: Run without timeout — with ~76 total epochs and EMA from epoch 40, another 6+ epochs would allow proper EMA accumulation and a `best_val_loss` measurement.
- **Per-head gate**: Currently one gate scalar per node; could try separate gates per output dimension or per Transolver block for more granular routing.
- **Investigate ood_re vol_loss**: The val_ood_re/vol_loss is ~18869 throughout; worth investigating if proximity weighting interacts badly with ood samples.