### PR TITLE
Learned surface node feature amplification (boost surface in hidden space)

### DIFF
--- a/train.py
+++ b/train.py
@@ -274,6 +274,7 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
+        self.surface_boost = nn.Parameter(torch.tensor(0.5))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -336,6 +337,9 @@ class Transolver(nn.Module):
         raw_xy = x[:, :, :2]
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
+        # Amplify surface node features (is_surface is at normalized input index 12)
+        surf_indicator = (x[:, :, 12:13] > 0).float()
+        fx = fx * (1.0 + self.surface_boost.abs() * surf_indicator)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:


### PR DESCRIPTION
## Hypothesis
Surface nodes are ~5% of total but are the primary metric. After preprocess, surface nodes get diluted in attention. A learnable scale factor (initialized to 0.5) amplifies surface features going into attention.

## Instructions
1. In `Transolver.__init__` (~line 275), add:
```python
self.surface_boost = nn.Parameter(torch.tensor(0.5))
```

2. In `forward()`, after `fx = self.preprocess(x)` and `fx_pre = fx` (~line 338), add:
```python
# Amplify surface node features (is_surface is at normalized input index 12)
surf_indicator = (x[:, :, 12:13] > 0).float()
fx = fx * (1.0 + self.surface_boost.abs() * surf_indicator)
```
This boosts surface nodes by ~1.5x initially (learnable). Run with `--wandb_group surf-boost`.
## Baseline
- best_val_loss ~= 2.03, mean3_surf_p ~= 24.9
---
## Results

**W&B run:** jsubkrmu  
**Epochs completed:** 72 (30-min wall-clock timeout)  
**Peak GPU memory:** ~10.6 GB

### Metrics vs Baseline

| Split | Metric | Baseline (~192) | This run | Delta |
|---|---|---|---|---|
| val_in_dist | mae_surf_p | 17.41 | 18.15 | +0.74 slightly worse |
| val_ood_cond | mae_surf_p | 18.40 | 15.54 | **-2.86 much better** |
| val_ood_re | mae_surf_p | 29.48 | 29.19 | -0.29 slightly better |
| val_tandem_transfer | mae_surf_p | 40.20 | 39.01 | -1.19 better |
| — | best_val_loss | 2.0702 | 1.9599 | **-0.1103 much better** |

### Full surface MAE (best checkpoint, epoch 72)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.259 | 0.164 | 18.15 |
| val_ood_cond | 0.218 | 0.157 | **15.54** |
| val_ood_re | 0.246 | 0.186 | 29.19 |
| val_tandem_transfer | 0.571 | 0.312 | 39.01 |

### Volume MAE (best checkpoint)

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.073 | 0.388 | 21.74 |
| val_ood_cond | 0.828 | 0.318 | **15.03** |
| val_ood_re | 0.897 | 0.396 | 48.92 |
| val_tandem_transfer | 1.902 | 0.879 | 39.98 |

### What happened

The surface boost worked well, with a notable improvement on val_ood_cond:

- **val/loss dropped from 2.0702 to 1.9599** (5.3% improvement)
- **val_ood_cond mae_surf_p: 18.40 → 15.54** (−2.86, a dramatic improvement on OOD conditions)
- val_ood_cond volume pressure also improved substantially: 16.80 → 15.03
- val_tandem_transfer improved: 40.20 → 39.01
- val_ood_re mae_surf_p slightly improved: 29.48 → 29.19
- val_in_dist is marginally worse (+0.74), which may be noise or a slight trade-off

The hypothesis is confirmed: amplifying surface node representations in hidden space helps the attention mechanism give more weight to the surface nodes that matter for the loss. The ood_cond improvement is especially striking — this split has extreme AoA/gap/stagger conditions where surface boundary layers are harder to predict, and giving the model stronger surface signals appears to help generalize.

The val_ood_re vol_loss anomaly (18868) persists — still a structural issue independent of this change.

### Suggested follow-ups

- Try initializing `surface_boost` at a larger value (e.g., 1.0) to see if more initial amplification helps, or let the model tune it during training and log the learned value
- Apply the boost after the placeholder scale/shift (currently before it) to see if order matters
- Consider applying the boost only to the pressure dimension of the output (since pressure surface MAE drives the loss), but this would require more architectural changes
