### PR TITLE
Tandem surface loss boost 2.0x (up from 1.5x)

### DIFF
--- a/train.py
+++ b/train.py
@@ -663,7 +663,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_boost = torch.where(is_tandem, 2.0, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Tandem transfer has the worst mae_surf_p (~40.2). The current tandem_boost is 1.5x (line ~666). Increasing to 2.0x puts more training pressure on tandem samples. This was tried early (#572) but on much weaker code. On the current strong baseline, the extra tandem pressure may push tandem_transfer without hurting other splits.

## Instructions
Find the tandem_boost line (~line 666):
```python
tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
```
Change to:
```python
tandem_boost = torch.where(is_tandem, 2.0, 1.0).to(device)
```
Run with `--wandb_group tandem-boost-2x`.

## Baseline
- best_val_loss ~= 2.03, mean3_surf_p ~= 24.9
---
## Results

**W&B run:** `b6ip72ex` (gilbert/tandem-boost-2x)
**Epochs:** 75 / 100 (30-min timeout)
**Peak memory:** 12.7 GB

### Metrics

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.384 | 0.260 | 0.161 | 17.63 | 1.118 | 0.392 | 22.13 |
| val_ood_cond | 1.474 | 0.214 | 0.154 | 14.74 | 0.859 | 0.329 | 15.07 |
| val_tandem_transfer | 2.981 | 0.573 | 0.311 | 38.72 | 1.954 | 0.902 | 40.65 |
| val_ood_re | 18869 | 0.245 | 0.181 | 28.37 | 0.919 | 0.400 | 48.96 |
| **mean3** | **1.946** | | | **23.70** | | | |

### Comparison to baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| mean3 val/loss | ~2.03 | 1.946 | **-0.084 (-4.1%)** |
| mean3 surf_p | ~24.9 | 23.70 | **-1.20 (-4.8%)** |

### What happened

Positive result — both mean3 val/loss and mean3 surf_p improved over the baseline. However, the hypothesis was specifically that 2x boost would push down tandem_transfer surface pressure. The actual tandem_transfer mae_surf_p dropped from ~40.2 to 38.72 (2.4% improvement), which is modest. In comparison, spatial-coarse (which ran on the same baseline with different changes) achieved 38.53 on tandem_transfer surface pressure with a weaker 1.5x boost, suggesting spatial coherence in the coarse loss is more important for tandem generalization than raw sample weight.

The gains from 2x boost are mostly on in_dist (surf_p 18.23→17.63) and ood_cond (surf_p 15.55→14.74), not primarily on tandem_transfer. This makes sense: doubling the tandem weight during training forces the model to trade off representation across all splits, not just tandem. The biggest relative gain appears to be ood_cond pressure (-5.2%), likely because ood_cond and tandem share some flow physics.

Memory and speed unchanged: 12.7 GB, 24 s/epoch.

### Suggested follow-ups

- **Combine both changes:** Apply the 2x tandem boost on top of spatial-coarse sorting — both are positive modifications, so stacking may be additive.
- **Try 3x boost:** If 1.5x → 2.0x already helped, pushing further may further reduce tandem surface pressure.
- **Per-field boosting:** The tandem penalty applies equally to Ux, Uy, p; since surf_p drives most of the error, a pressure-only tandem boost may be more targeted.
- **Tandem-specific surface weight:** The current surf_weight=5 applies to all splits; a split-specific surf_weight for tandem (e.g., 8x) could be more direct than a sample boost.