### PR TITLE
Deeper preprocess MLP (n_layers=2) on fully-merged code

### DIFF
--- a/train.py
+++ b/train.py
@@ -245,7 +245,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
Preprocess deepening (n_layers=2) has been tried multiple times but never on the fully-merged code with all 15 improvements. With 192-dim hidden, feature cross, Fourier PE, and all other merges, an extra preprocess layer may now have enough downstream capacity to help.

## Instructions
**Line ~250** in Transolver.__init__, change:
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
```
(Change `n_layers=1` to `n_layers=2`)
Run with `--wandb_group deeper-preprocess-v3`.
## Baseline
This is the current noam branch with ALL 15 merged improvements. No separate baseline measurement exists yet.

---
## Results

**W&B run:** frhjhpc5 (also 1ie6cw69 — first attempt, same result)  
**Epochs completed:** 65 (timed out at 30 min)  
**Epoch time:** 27.8s (vs ~24s on prior runs — 16% slower)  
**Peak memory:** ~12.7 GB (similar to baseline)

### Metrics at best epoch (epoch 65, still declining)

| Metric | This run | PR #1078 baseline (71 ep) |
|--------|----------|--------------------------|
| val_loss_3split | 2.1186 | 1.9179 |
| mean3_surf_p | 26.32 | 23.83 |
| val_in_dist/mae_surf_p | 19.57 | ~19.15 |
| val_ood_cond/mae_surf_p | 17.62 | 14.69 |
| val_tandem_transfer/mae_surf_p | 41.76 | 38.36 |
| val_in_dist/mae_surf_Ux | 0.261 | — |
| val_in_dist/mae_surf_Uy | 0.164 | — |

### What happened

The deeper preprocess (n_layers=2) didn't help within the 30-min budget. The extra MLP layer adds ~16–19% overhead per epoch (27.8s vs ~24s), so the model only got 65 epochs instead of ~71. Metrics are worse across the board and still decreasing at timeout — the model hadn't converged.

The loss trajectory (last 5 epochs: 2.143 → 2.137 → 2.131 → 2.126 → 2.119) shows slow improvement, but there's no sign it would catch up to baseline if given more time. At a comparable epoch count (65 vs 65), the deeper preprocess is clearly slower to learn — not just slower per epoch.

This result is consistent with earlier attempts at deeper preprocess: the second layer in the preprocess MLP doesn't provide useful inductive bias at this scale. The preprocess bottleneck (fun_dim → 2×n_hidden → n_hidden) already has plenty of capacity with n_layers=1; adding a second layer increases parameter count and computation without helping expressiveness.

### Suggested follow-ups

- Try making the existing single-layer preprocess *wider* (e.g., 3×n_hidden intermediate) rather than deeper — this would add capacity without the recurrent composition overhead
- Investigate whether the bottleneck is actually in the preprocess at all vs. the Transolver attention blocks
- The 16% per-epoch slowdown suggests the second layer is not being used efficiently — consider whether gradient flow through two MLP layers is healthy (gradient norms in the preprocess layers might be informative)