### PR TITLE
Auxiliary gap prediction head (tandem-aware representation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -276,6 +276,7 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.gap_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
         self.surface_boost = nn.Parameter(torch.tensor(0.5))
 
@@ -351,12 +352,13 @@ class Transolver(nn.Module):
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
+        gap_pred = self.gap_head(fx.mean(dim=1))
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "gap_pred": gap_pred}
 
 
 # ---------------------------------------------------------------------------
@@ -652,9 +654,11 @@ for epoch in range(MAX_EPOCHS):
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
+            gap_pred = out["gap_pred"]
         pred = pred.float()
         re_pred = re_pred.float()
         aoa_pred = aoa_pred.float()
+        gap_pred = gap_pred.float()
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -718,6 +722,9 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+        gap_target = x[:, 0, 22:23]  # gap from normalized input
+        gap_loss = F.mse_loss(gap_pred.float(), gap_target)
+        loss = loss + 0.01 * gap_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
AoA aux head is already merged and helped. Adding a gap prediction head forces gap-awareness into the representation, targeting the tandem split specifically.

## Instructions
1. In `Transolver.__init__` (next to aoa_head):
```python
self.gap_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
```
2. In forward, alongside other aux preds: `gap_pred = self.gap_head(fx.mean(dim=1))`
3. Return gap_pred in output dict
4. In training loss: `gap_target = x[:, 0, 22:23]; gap_loss = F.mse_loss(out['gap_pred'].float(), gap_target); loss = loss + 0.01 * gap_loss`

Run with `--wandb_group aux-gap-pred-v2`.

## Baseline (fixed noam: 13 merged improvements, vol_loss*0.1 and surf_boost reverted)
- This baseline includes: n_hidden=192, compile, learnable coord-norm Fourier PE, feature cross, T_max=76, spatial-sorted coarse, noise annealing, tandem-inclusive norm, aux AoA head, EMA checkpoint, learned skip gate
- NO vol_loss scaling, NO surface boost (these caused training divergence when combined)

Baseline run: `leiaq9de` (frieren/baseline-fixed)

| Split | val/loss | surf Ux | surf Uy | surf p | vol MAE |
|---|---|---|---|---|---|
| val_in_dist | 1.2414 | 0.2681 | 0.1646 | 19.46 | — |
| val_tandem_transfer | 3.0457 | 0.5837 | 0.3165 | 40.30 | — |
| val_ood_cond | 1.6318 | — | — | 16.64 | — |
| val_ood_re | 1.3826 | — | — | 29.60 | — |
| **combined** | **1.9729** | | | | |

---
## Results

**W&B run:** `epn7g4jo` — [tanjiro/aux-gap-pred](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/epn7g4jo)

**W&B group:** aux-gap-pred-v2

**Training:** 66 epochs (30 min timeout), best checkpoint at epoch 66.

**Peak memory:** ~60.2 GB (62.7% of 96 GB)

### Metrics vs Baseline

| Split | Metric | Baseline | Gap-Head | Delta |
|---|---|---|---|---|
| val_in_dist | loss | 1.2414 | 1.3570 | +0.116 |
| val_in_dist | surf Ux MAE | 0.2681 | 0.2787 | +0.011 |
| val_in_dist | surf Uy MAE | 0.1646 | 0.1680 | +0.003 |
| val_in_dist | surf p MAE | 19.46 | 19.32 | **-0.14** |
| val_in_dist | vol p MAE | 23.58 | 33.08 | +9.50 |
| val_tandem_transfer | loss | 3.0457 | 3.1801 | +0.134 |
| val_tandem_transfer | surf p MAE | 40.30 | 40.77 | +0.47 |
| val_ood_cond | loss | 1.6318 | 1.7409 | +0.109 |
| val_ood_cond | surf p MAE | 16.64 | 17.73 | +1.09 |
| val_ood_re | loss | 1.3826 | 1.4715 | +0.089 |
| val_ood_re | surf p MAE | 29.60 | 29.92 | +0.32 |
| **combined** | **val/loss** | **1.9729** | **2.0927** | **+0.119** |

### What happened

**The gap prediction head did not help — results are uniformly worse than baseline.**

Overall val/loss increased by +0.12 (worse). The only bright spot is a tiny -0.14 improvement on val_in_dist/mae_surf_p (19.46 → 19.32), which is within noise. Every other metric worsened, sometimes substantially — vol MAEs deteriorated significantly (e.g., +9.5 on val_in_dist/mae_vol_p).

The most likely explanation is that the 0.01-weighted gap_loss is adding a small gradient signal that slightly misdirects the representation, despite being very small. The model already learns gap information implicitly from the tandem-specific input features (x[:, :, -8:] includes tandem geometry). The explicit gap supervision doesn't add new signal — it just adds noise to the optimization.

Also noteworthy: volume errors degraded much more than surface errors, suggesting the gap auxiliary gradient interferes more with the volume-node representations than surface-node ones.

### Suggested follow-ups

1. **Smaller weight**: Try `0.001 * gap_loss` instead of `0.01` — the effect might be too large.
2. **Gap from tandem-only samples**: Only compute gap_loss when `is_tandem` is True, since gap=0 for single-foil cases adds zero signal but might confuse the head.
3. **Remove gap head entirely**: The AoA head helped; the gap head doesn't. The model may already encode gap information sufficiently through the tandem feature inputs.