### PR TITLE
8 learnable Fourier frequencies (32 PE features) on fixed code

### DIFF
--- a/train.py
+++ b/train.py
@@ -276,7 +276,7 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
-        self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
+        self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0]))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -473,7 +473,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
+    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
     n_hidden=192,  # was 160
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min


### PR DESCRIPTION
## Hypothesis
8 learnable frequencies showed -2.9% on pre-Round-6 code. Testing on the fixed 13-improvement baseline.

## Instructions
1. Change fourier_freqs init to 8 frequencies: `self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0]))`
2. Update fun_dim: `fun_dim=X_DIM - 2 + 1 + 32` (32 features for 8 freqs)
Run with `--wandb_group 8freq-v3`.
## Baseline
Fixed noam: 13 improvements merged. NO vol_loss scaling, NO surface boost.

---
## Results

**W&B run:** 0l1uv27d  
**Epochs completed:** 68 (timeout)  
**Peak memory:** 12.9 GB  
**Baseline run (frieren/baseline-fixed):** leiaq9de

| Metric | 8-freq v3 | Baseline (4 freqs) | Delta |
|---|---|---|---|
| best_val_loss (3split) | **1.9494** | 1.9729 | **-0.024 (-1.2%)** |
| val/loss_4split | **1.8002** | — | — |
| val_in_dist/mae_surf_p | **18.82** | 19.46 | **-0.64 (-3.3%)** |
| val_ood_cond/mae_surf_p | **16.01** | 16.64 | **-0.63 (-3.8%)** |
| val_ood_re/mae_surf_p | **29.53** | 29.60 | -0.07 |
| val_tandem_transfer/mae_surf_p | **39.44** | 40.30 | **-0.86 (-2.1%)** |
| mean3_surf_p | **24.76** | 25.47 | **-0.71** |

**What happened:** Clear win on all metrics. 8 learnable Fourier frequencies consistently outperform 4 frequencies on the fixed 13-improvement baseline. Every split improved: val_in_dist (-3.3%), val_ood_cond (-3.8%), val_ood_re (-0.07), val_tandem_transfer (-2.1%). Overall val_loss improved by -1.2% and mean3_surf_p by -0.71. This confirms the v1 result was not a fluke — 8 learnable frequencies provide a robust improvement across codebases. Memory cost is 12.9 GB (same as 4-freq baseline with n_hidden=192).

**Suggested follow-ups:**
- Try 12 or 16 learnable frequencies.
- Check the learned frequency values after training to understand what scales the model gravitates toward.