### PR TITLE
FiLM conditioning: Re+AoA modulate hidden features (proven -3.0%)

### DIFF
--- a/train.py
+++ b/train.py
@@ -277,6 +277,10 @@ class Transolver(nn.Module):
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs = nn.Parameter(torch.tensor([1.0, 2.0, 4.0, 8.0]))
+        self.film_net = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * n_hidden))
+        nn.init.zeros_(self.film_net[-1].weight)
+        nn.init.zeros_(self.film_net[-1].bias)
+        self.film_net[-1].bias.data[:n_hidden] = 1.0  # gamma=1, beta=0
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -340,6 +344,11 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+
+        re_aoa = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)
+        film_out = self.film_net(re_aoa)
+        gamma, beta = film_out.chunk(2, dim=-1)
+        fx = gamma.unsqueeze(1) * fx + beta.unsqueeze(1)
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)


### PR DESCRIPTION
## Hypothesis
FiLM showed -3.0% and best-ever ood_cond=14.1 on old code. Testing on fixed baseline.

## Instructions
1. In `Transolver.__init__`:
```python
self.film_net = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * n_hidden))
nn.init.zeros_(self.film_net[-1].weight)
nn.init.zeros_(self.film_net[-1].bias)
self.film_net[-1].bias.data[:n_hidden] = 1.0  # gamma=1, beta=0
```
2. In forward() after placeholder_scale/shift:
```python
re_aoa = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)
film_out = self.film_net(re_aoa)
gamma, beta = film_out.chunk(2, dim=-1)
fx = gamma.unsqueeze(1) * fx + beta.unsqueeze(1)
```
Run with `--wandb_group film-v3`.
## Baseline
Fixed noam: 13 improvements merged. NO vol_loss scaling, NO surface boost.
---
## Results

**W&B run:** 28dbt44o
**Baseline run:** leiaq9de (frieren/baseline-fixed, same branch)
**Epochs completed:** 67 (30-min timeout)
**Peak memory:** 12.5 GB (+0.0 GB vs baseline)

### Metrics vs Baseline

| Metric | Baseline | FiLM v3 | Delta |
|---|---|---|---|
| val/loss_3split | 1.9729 | 1.9802 | +0.007 (tied, within noise) |
| val_in_dist/mae_surf_p | 19.46 | 19.75 | +0.29 slightly worse |
| val_ood_cond/mae_surf_p | 16.64 | **15.42** | **-1.22 better (-7.3%)** |
| val_ood_re/mae_surf_p | 29.60 | **28.90** | **-0.70 better (-2.4%)** |
| val_tandem_transfer/mae_surf_p | 40.30 | 40.61 | +0.31 slightly worse |
| mean3_surf_p | 25.47 | 25.26 | -0.21 slightly better |

### Full surface MAE (best epoch)

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 0.2868 | 0.1633 | 19.75 |
| val_ood_cond | 0.1890 | 0.1453 | 15.42 |
| val_ood_re | 0.2299 | 0.1776 | 28.90 |
| val_tandem_transfer | 0.6026 | 0.3263 | 40.61 |

### Volume MAE (val_in_dist)
Ux: 1.2317, Uy: 0.4111, p: 23.11

### What happened

Mixed/borderline positive result. FiLM conditioning (Re, AoA → gamma/beta scale-and-shift of hidden features) clearly helps **OOD performance**: ood_cond improved -7.3%, ood_re improved -2.4%. However, it slightly hurts in-distribution performance (+0.29 in_dist, +0.31 tandem), and the overall val_loss is essentially unchanged (1.9802 vs 1.9729).

The OOD improvement makes physical sense: FiLM conditions the hidden representation on Reynolds number and angle-of-attack, allowing the model to adapt its feature processing to the flow regime. At OOD conditions (extreme Re or AoA), this adaptation matters most.

The ood_cond improvement (15.42 vs baseline 16.64) didn't reach the claimed best-ever 14.1 — that may have been a different baseline configuration or lucky checkpoint. But the directional improvement is consistent.

The slight in-dist regression suggests FiLM may be trading off in-dist precision for OOD generalization. No memory overhead.

### Suggested follow-ups

1. **Tune FiLM scale**: Try a learnable initial scale (e.g. 0.1 * gamma instead of gamma) to make the conditioning more conservative and reduce in-dist regression.
2. **FiLM at each attention block**: Instead of once after preprocess, apply FiLM conditioning before each TransolverBlock for adaptive modulation at every depth.
3. **Include gap features**: For tandem samples, include the foil gap (index 21) as a third FiLM input to help with tandem-specific conditioning.