### PR TITLE
Wider model n_hidden=224 on fixed 13-improvement code

### DIFF
--- a/train.py
+++ b/train.py
@@ -475,7 +475,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 16,  # X_DIM=24 + 1 curvature proxy + 16 Fourier PE; fun_dim + space_dim must equal x.shape[-1]
     out_dim=3,
-    n_hidden=192,  # was 160
+    n_hidden=224,  # was 192
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs


### PR DESCRIPTION
## Hypothesis
n_hidden=224 showed +0.2% on old code (without tandem-norm, noise-annealing etc). On the stronger fixed baseline with 13 improvements, more capacity may help more.

## Instructions
```python
n_hidden=224,  # was 192
```
Run with `--wandb_group wider-224-v3`.
## Baseline
Fixed noam: 13 improvements merged. NO vol_loss scaling, NO surface boost.
---
## Results

**W&B run:** 9kysjw76 | **Peak GPU:** ~14 GB | **Best epoch:** 64/100

| Metric | This run |
|---|---|
| val/loss | 2.0411 |
| val_in_dist/mae_surf_p | 19.33 |
| val_ood_cond/mae_surf_p | 17.34 |
| val_ood_re/mae_surf_p | 29.69 |
| val_tandem_transfer/mae_surf_p | 41.85 |
| mean3_surf_p | 22.12 |

**What happened:** n_hidden=224 on the fixed-13 code shows val/loss=2.041. Per-epoch time is 28s vs ~26s for n_hidden=192, resulting in 64 epochs vs ~76 in 30 min. The wider model reaches competitive results (similar or marginally better than n_hidden=192 on this code) but the epoch count reduction offsets any capacity benefit. The model may benefit from the extra width but the 30-min time constraint limits it. Without comparing directly to a n_hidden=192 run on the same exact code version, the improvement is marginal.

**Suggested follow-ups:**
- Since 224 is borderline, try n_hidden=256 to see if there's a clearer signal — if 256 is also marginal, confirm 192 is the sweet spot.
- Consider the combined effect of n_hidden=224 with vol_loss=0.1 scaling (which gave a big win at n_hidden=192) — the improvements may stack.
- Try n_hidden=192 with gradient checkpointing to allow longer training at the same memory budget.