### PR TITLE
Tandem surface loss boost 2.0x (up from 1.5x)

### DIFF
--- a/train.py
+++ b/train.py
@@ -678,7 +678,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        tandem_boost = torch.where(is_tandem, 2.0, 1.0).to(device)
         surf_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Tandem transfer is still the weakest split. Increasing tandem_boost from 1.5 to 2.0 puts more training pressure on tandem samples.

## Instructions
Change tandem_boost (~line 685):
```python
tandem_boost = torch.where(is_tandem, 2.0, 1.0).to(device)  # was 1.5
```
Run with `--wandb_group tandem-boost-v2`.
## Baseline
Fixed noam: 13 improvements merged. NO vol_loss scaling, NO surface boost.
---
## Results

**W&B run:** `bxqniluz` (thorfinn/tandem-boost-v2)  
**Epochs:** 72 | **Runtime:** 32 min (30-min cap, clean checkpoint saved)  
**Params:** 580,215

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.2865 | 0.276 | 0.166 | 19.98 | 1.235 | 0.438 | 25.56 |
| val_tandem_transfer | 3.0577 | 0.587 | 0.318 | 39.40 | 2.031 | 0.947 | 41.00 |
| val_ood_cond | 1.6451 | 0.212 | 0.151 | 16.22 | 0.895 | 0.342 | 16.09 |
| val_ood_re | 1.3930 | 0.245 | 0.182 | 29.35 | 0.963 | 0.413 | 49.60 |
| **3-split avg** | **1.9964** | | | **25.20** | | | |
| **4-split avg** | **1.8456** | | | **26.24** | | | |

### vs Baseline

No control run for fixed noam without the boost change. The stated baseline (~2.03, mean3_surf_p ~24.9) is from the old noam. On the new fixed noam:

- **val/loss_3split: 1.9964** — ~−1.7% vs stated baseline (2.03)
- **mean3_surf_p: 25.20** — slightly worse than stated baseline (24.9)
- **val_ood_re normalized**: 1.3930 (no longer an anomaly; tandem-psnorm was included in the base)

For reference, gilbert's tandem-boost-2x run on the older noam got 3split=1.9464, mean3_surf_p=23.70 — a better result, but on a different (older) base that still had the val_ood_re anomaly.

### What happened

Weak neutral result. Increasing tandem_boost from 1.5 to 2.0 doesn't clearly help:

- tandem_transfer/mae_surf_p: 39.40 (unclear improvement without baseline on same branch)
- val_ood_cond regressed vs FiLM-v2 baseline (16.22 vs 15.68) — the extra tandem pressure appears to trade off OOD cond performance
- val_in_dist stayed comparable

The signal is ambiguous: the 3-split loss is below the old stated baseline, but mean3_surf_p is marginally worse. A 2.0x multiplier may be reaching the point where it tilts the training distribution too far toward tandem at the expense of other splits.

### Suggested follow-ups
- **Try intermediate boost (1.75×)** — the sweet spot between 1.5 and 2.0 may be lower
- **Tandem-specific data augmentation** rather than loss weighting, to avoid the trade-off against other splits
- **Run a control baseline on fixed-noam** to get apples-to-apples comparison for all future experiments on this branch
