### PR TITLE
Feature cross residual scale 0.2 (up from 0.1)

### DIFF
--- a/train.py
+++ b/train.py
@@ -335,7 +335,7 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         x_cross = x * self.feature_cross(x)
-        x = x + 0.1 * x_cross  # residual with small scale
+        x = x + 0.2 * x_cross  # residual with small scale
         raw_xy = x[:, :, :2]
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip


### PR DESCRIPTION
## Hypothesis
Feature cross uses 0.1 residual scale. With the full 13-improvement code, a stronger signal (0.2) may let the quadratic interactions contribute more.

## Instructions
In Transolver.forward, change:
```python
x = x + 0.2 * x_cross  # was 0.1
```
Run with `--wandb_group feature-cross-02`.
## Baseline
Fixed noam: 13 improvements merged. NO vol_loss scaling, NO surface boost.
---
## Results

**W&B run:** `nt7txibj`
**Epochs:** ~69/100 (hit 30-min timeout at ~1755s, ~25s/epoch with compile)
**Peak memory:** 12.5 GB

| Metric | This run |
|---|---|
| val/loss (last, 3-split) | 2.0122 |
| val_in_dist/mae_surf_p | 19.29 |
| val_ood_cond/mae_surf_p | 17.34 |
| val_ood_re/mae_surf_p | 30.12 |
| val_tandem_transfer/mae_surf_p | 40.94 |
| **mean3_surf_p** | **22.25** |
| val_in_dist/mae_surf_Ux | 0.277 |
| val_in_dist/mae_surf_Uy | 0.160 |

### What happened

The 0.2 cross-scale run achieved val/loss=2.0122 and mean3_surf_p=22.25. The baseline PR body does not include explicit metric numbers for the 0.1 scale on this cleaned-up noam branch, so a direct delta comparison is not possible. Comparing to the previously known noam baseline (~2.03 val/loss, ~24.9 mean3_surf_p from similar-era PRs), the result looks like a modest improvement in val/loss and a notable improvement in mean3_surf_p — though the baselines may not be directly comparable since the "fixed noam" branch may have a different feature cross scale already.

The training loss was still decreasing at timeout (epoch 69: in_dist=1.27, ood_cond=1.67, ood_re=1.41), suggesting further improvement with more epochs.

**No `best_val_loss` was logged** — the run timed out before EMA final evaluation could write the summary metric. The reported val/loss is the last epoch's non-EMA value.

### Suggested follow-ups

- **Run without timeout** to complete the full 100 epochs and get a proper EMA-based `best_val_loss`.
- **Sweep over scale values** (e.g. 0.05, 0.1, 0.15, 0.2, 0.3) to find the optimal residual scale.
- **Explicit baseline comparison**: Run the fixed noam branch as-is (0.1 scale) to get a direct comparison number.