### PR TITLE
Deeper preprocess MLP (n_layers=2) on fixed 13-improvement code

### DIFF
--- a/train.py
+++ b/train.py
@@ -245,7 +245,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
Preprocess deepening to n_layers=2 adds a second 192x192 residual layer. On the fixed code with all 13 improvements, the extra capacity should help extract richer features.

## Instructions
Change preprocess MLP (~line 250):
```python
self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=2, res=True, act=act)
```
Run with `--wandb_group deeper-preprocess-v4`.
## Baseline
Fixed noam: 13 improvements merged. NO vol_loss scaling, NO surface boost.
---
## Results

**W&B run:** tppnvvpw
**Epochs completed:** 64 (timeout)
**Peak memory:** 14.0 GB
**Baseline run (frieren/baseline-fixed):** leiaq9de

| Metric | n_layers=2 | Baseline (n_layers=1) | Delta |
|---|---|---|---|
| val/loss_3split | 2.0065 | **1.9730** | +0.034 (+1.7%) |
| val_in_dist/loss | **1.2265** | 1.2414 | -0.015 (-1.2%) |
| val_tandem_transfer/loss | 3.1130 | **3.0457** | +0.067 (+2.2%) |
| val_ood_cond/loss | 1.6799 | **1.6318** | +0.048 (+2.9%) |
| val_ood_re/loss | 1.4123 | **1.3826** | +0.030 (+2.1%) |
| val_in_dist/mae_surf_p | **18.92** | 19.46 | -0.54 (-2.8%) |
| val_ood_cond/mae_surf_p | 17.51 | **16.64** | +0.87 (+5.2%) |
| val_ood_re/mae_surf_p | 30.02 | **29.60** | +0.42 (+1.4%) |
| val_tandem_transfer/mae_surf_p | 40.84 | **40.30** | +0.54 (+1.3%) |
| mean3_surf_p | 25.76 | **25.47** | +0.29 |

**What happened:** Mixed / net negative. Deeper preprocess wins on val_in_dist (-1.2% loss, -2.8% surf_p) but loses on all OOD and tandem-transfer splits. The combined val/loss_3split is worse by +0.034. Mean surface pressure across the three comparable splits (mean3_surf_p) is 25.76 vs 25.47 — slightly worse. Memory increased from ~12.9 GB to 14.0 GB.

The in-distribution gain suggests the extra layer helps fit the training distribution, but the OOD degradation indicates it may be slightly overfitting — the second residual layer adds capacity without improving generalization. With only 64 epochs before timeout the model may not have fully converged, but the OOD trend is clear enough to call this not an improvement.

**Suggested follow-ups:**
- Try n_layers=2 with stronger regularization (higher dropout or weight decay) to reduce OOD overfitting.
- Try a smaller hidden dim for the second layer (e.g. 192→96) to add depth without doubling capacity.