### PR TITLE
EMA decay 0.995 (more aggressive averaging with current code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -491,7 +491,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.995
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
EMA-smoothed checkpoint is already merged with decay=0.998. More aggressive decay (0.995) tracks recent weights more closely. The 13 improvements create different training dynamics that may benefit from faster EMA adaptation.

## Instructions
Change EMA decay (~line 489):
```python
ema_decay = 0.995  # was 0.998
```
Run with `--wandb_group ema-decay-0995-v2`.
## Baseline
Fixed noam: 13 improvements merged. NO vol_loss scaling, NO surface boost.
---
## Results

**W&B run:** `lwe3d3eq` (gilbert/ema-decay-0995-v2)
**Epochs:** 72 / 100 (30-min timeout)
**Peak memory:** 12.5 GB

### Metrics

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.237 | 0.266 | 0.161 | 18.24 | 1.162 | 0.403 | 22.56 |
| val_ood_cond | 1.630 | 0.208 | 0.154 | 16.41 | 0.852 | 0.324 | 15.55 |
| val_tandem_transfer | 3.069 | 0.591 | 0.317 | 40.90 | 2.007 | 0.918 | 41.17 |
| val_ood_re | 1.381 | 0.241 | 0.182 | 29.35 | 0.925 | 0.396 | 48.89 |
| **mean3** | **1.979** | | | **25.18** | | | |

### Notable: val_ood_re is now normal

`val_ood_re/loss = 1.381` — no longer ~18869. This is a consequence of the 13 upstream improvements already merged into this branch (physics normalization / per-sample scaling fixes). All 4 splits are now meaningful.

### Comparison

No direct ema_decay=0.998 baseline exists on this codebase to isolate the ema change. The closest available reference is `frieren/baseline-fixed` (val/loss_3split=2.172, mean3_surf_p≈28.1), which runs the same fixed-noam code without EMA. Among all runs with fixed ood_re, this run (1.979) is the best 3-split val/loss seen so far.

| Metric | frieren/baseline-fixed | This run (0.995) | Delta |
|---|---|---|---|
| mean3 val/loss | 2.172 | 1.979 | **-0.193 (-8.9%)** |
| tandem_transfer surf_p | 40.62 | 40.90 | +0.28 (+0.7%) |

The large gap vs frieren/baseline-fixed is likely driven by EMA itself (frieren may not have EMA at all) rather than 0.995 vs 0.998 specifically.

### What happened

Cannot cleanly attribute the performance to ema_decay=0.995 vs 0.998 without the matching 0.998 baseline on this code. However, the run is the strongest seen on the fixed-noam codebase. EMA at 0.995 (tracking recent weights faster) appears at least not harmful, and may be beneficial given the richer training dynamics of the 13-improvement codebase.

Tandem transfer surf_p (40.90) remains the worst split and is unchanged from the raw baseline — this code does not include the 2x tandem boost, which was on a separate branch.

### Suggested follow-ups

- **Run ema_decay=0.998 baseline on this code** to cleanly measure the delta from 0.995.
- **Combine: ema_decay=0.995 + tandem_boost=2.0x** — both are positive on their respective baselines; stacking may compound gains.
- **Try ema_decay=0.99 or 0.992** — if 0.995 is better than 0.998, the trend may continue further.
- **Track val_ood_re separately** now that it is meaningful — the 4-split metric (1.829) could replace 3-split as the primary checkpoint criterion.