### PR TITLE
Extended warmup to 10 epochs (from 5) on fixed code

### DIFF
--- a/train.py
+++ b/train.py
@@ -531,10 +531,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=76, eta_min=5e-5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=66, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
With 13 merged changes, the 5-epoch warmup may be too short. Extending to 10 gives more time to stabilize.

## Instructions
1. Change warmup: \`warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)\`
2. Update milestones: \`milestones=[10]\`
3. Adjust T_max: \`T_max=66\` (76 - 10)
Run with \`--wandb_group warmup-10ep-v2\`.

## Baseline
Fixed noam: 13 improvements.
---
## Results

**W&B run:** yx9m6o4i
**Best epoch:** 72 / 100
**Training time:** 30.3 min (hit timeout, stopped at epoch 72)
**Peak GPU memory:** ~88 GB (CUDA graph caching from 331 distinct input sizes)

### Metrics at best checkpoint

| Split | Loss | Surf Ux MAE | Surf Uy MAE | Surf p MAE | Vol Ux MAE | Vol Uy MAE | Vol p MAE |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.2105 | 0.251 | 0.163 | 18.16 | 1.165 | 0.403 | 22.56 |
| val_ood_cond | 1.6043 | 0.197 | 0.152 | 16.63 | 0.877 | 0.320 | 15.52 |
| val_ood_re | 1.3617 | 0.236 | 0.181 | 29.38 | 0.950 | 0.396 | 49.03 |
| val_tandem_transfer | 3.0209 | 0.583 | 0.313 | 39.02 | 1.997 | 0.907 | 41.55 |
| **combined val/loss** | **1.9452** | | | | | | |

### What happened

Training ran for 30.3 min and hit the timeout at epoch 72. The model converged well — combined val loss of 1.9452 is competitive. The extended 10-epoch warmup appears reasonable: no obvious early instability.

The run exited with code 1 due to a post-training visualization crash (pre-existing shape mismatch bug in `feature_cross`: 84905×25 vs 41×41 expected when visualization input differs from training batch shapes). Training and all metrics are fully valid.

Best checkpoint at epoch 72 is quite late — the model may still have been improving at timeout. Without a direct 5-epoch warmup comparison on the same fixed codebase it's hard to isolate the warmup effect vs. the 13 accumulated improvements.

### Suggested follow-ups

- Run a matched 5-epoch warmup on the same codebase to isolate the effect
- Consider running without the 30-min cap to see if the curve plateaus post-epoch 72
- Fix the visualization shape mismatch in `feature_cross` (affects all visualization runs)