### PR TITLE
Cosine warmup (smooth LR ramp, replace linear)

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -531,7 +532,11 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+def cosine_warmup(epoch):
+    if epoch < 10:
+        return 0.1 + 0.9 * (1 - math.cos(math.pi * epoch / 10)) / 2
+    return 1.0
+warmup_scheduler = torch.optim.lr_scheduler.LambdaLR(base_opt, cosine_warmup)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=66, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]


### PR DESCRIPTION
## Hypothesis
Linear warmup has a sharp transition at milestone. Cosine warmup produces a smooth S-curve. Standard in vision transformers. Never tried in 700+ experiments.

## Instructions
Replace the warmup scheduler with a cosine warmup lambda:
```python
import math
def cosine_warmup(epoch):
    if epoch < 10:
        return 0.1 + 0.9 * (1 - math.cos(math.pi * epoch / 10)) / 2
    return 1.0
warmup_scheduler = torch.optim.lr_scheduler.LambdaLR(base_opt, cosine_warmup)
```
Keep milestones=[10], T_max=66, everything else unchanged. Run with `--wandb_group cosine-warmup`.
## Baseline (15 merged improvements on fixed noam)
- Estimated val_loss ~1.94-1.97 (combined effect unmeasured)
- n_hidden=192, compile, 8 learnable Fourier freq (32 PE), feature cross, coord-norm, noise annealing, tandem-inclusive norm, aux AoA, EMA-smoothed ckpt, learned skip gate, spatial-sorted coarse, warmup 10ep, T_max=66, eta_min=5e-5

---
## Results

**W&B run:** vzfe8ghp  
**Epochs completed:** 70 (timed out at 30 min; 25.1s/epoch)  
**Peak memory:** ~12.7 GB

### Metrics (best epoch = epoch 70, still declining)

| Metric | Cosine warmup | Linear warmup baseline (frieren/w19k8gkx) |
|--------|---------------|------------------------------------------|
| val_loss_3split | 1.9666 | 1.9875 |
| mean3_surf_p | 25.27 | 25.17 |
| val_in_dist/mae_surf_p | 19.22 | 19.11 |
| val_ood_cond/mae_surf_p | 16.08 | 15.96 |
| val_tandem_transfer/mae_surf_p | 40.52 | 40.45 |
| val/loss_4split | 1.8137 | — |
| val_in_dist/mae_vol_p | 22.69 | — |
| val_tandem_transfer/mae_vol_p | 41.76 | — |

### What happened

No meaningful difference. The cosine warmup shows loss3=1.9666 vs the linear warmup baseline's 1.9875 (~0.02 better), but mean3_surf_p is essentially identical (25.27 vs 25.17 — within run-to-run noise). The per-split surface pressure values differ by <0.2 in all cases.

This is expected: with only 10 warmup epochs, the precise shape of the LR ramp matters very little. By epoch 10, both schedulers arrive at the same learning rate, and the subsequent 60+ epochs of cosine decay dominate. The S-curve vs linear ramp only differs in the transient behavior during epochs 1–9, which has negligible effect on final metrics at epoch 70.

### Suggested follow-ups

- Warmup shape is unlikely to be a useful lever here; deprioritize further warmup experiments
- More impactful: try extending the cosine T_max so the decay still targets 0 at the actual end of training (~76 epochs for 30-min budget)
- The val_loss_3split was still declining at epoch 70 (1.9818 → 1.9747 → 1.9722 → 1.9670 → 1.9666) — better convergence may matter more than warmup shape