### PR TITLE
12 learnable Fourier frequencies (48 PE features)

### DIFF
--- a/train.py
+++ b/train.py
@@ -276,7 +276,7 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
-        self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0]))
+        self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 16.0]))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -473,7 +473,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 1 + 48,  # 12 freqs * 2 coords * 2 (sin+cos) = 48
     out_dim=3,
     n_hidden=192,  # was 160
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min


### PR DESCRIPTION
## Hypothesis
4→8 frequencies each gave wins. Testing if the scaling continues to 12 (48 PE features).

## Instructions
1. Change fourier_freqs init: `self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 16.0]))`
2. Update fun_dim: `fun_dim=X_DIM - 2 + 1 + 48` (12*2*2=48)
Run with `--wandb_group 12freq`.
## Baseline (15 merged improvements on fixed noam)
- Estimated val_loss ~1.94-1.97 (combined effect unmeasured)
- n_hidden=192, compile, 8 learnable Fourier freq (32 PE), feature cross, coord-norm, noise annealing, tandem-inclusive norm, aux AoA, EMA-smoothed ckpt, learned skip gate, spatial-sorted coarse, warmup 10ep, T_max=66, eta_min=5e-5

Baseline run used for comparison: `leiaq9de` (frieren/baseline-fixed, val/loss=1.9729)

---
## Results

**W&B run:** `2sc4xerr` — [tanjiro/12freq](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/2sc4xerr)

**W&B group:** 12freq

**Training:** 65 epochs (30 min timeout), best checkpoint at epoch 65.

**Peak memory:** ~82.8 GB (86.2% of 96 GB) — significant increase vs ~60 GB for 8-freq baseline.

### Metrics vs Baseline

| Split | Metric | Baseline | 12-freq | Delta |
|---|---|---|---|---|
| val_in_dist | loss | 1.2414 | 1.2736 | +0.032 |
| val_in_dist | surf Ux MAE | 0.2681 | 0.2859 | +0.018 |
| val_in_dist | surf Uy MAE | 0.1646 | 0.1636 | -0.001 |
| val_in_dist | surf p MAE | 19.46 | 19.19 | **-0.27** |
| val_in_dist | vol p MAE | 23.58 | 23.10 | **-0.48** |
| val_tandem_transfer | loss | 3.0457 | 3.0609 | +0.015 |
| val_tandem_transfer | surf p MAE | 40.30 | 39.95 | **-0.35** |
| val_ood_cond | loss | 1.6318 | 1.6181 | **-0.014** |
| val_ood_cond | surf p MAE | 16.64 | 16.25 | **-0.39** |
| val_ood_re | loss | 1.3826 | 1.3889 | +0.006 |
| val_ood_re | surf p MAE | 29.60 | 29.73 | +0.13 |
| **combined** | **val/loss** | **1.9729** | **1.9842** | **+0.011** |

### What happened

**Mixed result: surface pressure improved, but overall val/loss marginally worsened.**

The most important metric — surface pressure MAE — improved in 3 of 4 splits:
- val_in_dist: 19.46 → 19.19 (-0.27)
- val_tandem_transfer: 40.30 → 39.95 (-0.35)
- val_ood_cond: 16.64 → 16.25 (-0.39)
- val_ood_re: 29.60 → 29.73 (+0.13, slightly worse)

The overall val/loss (which combines all channels) went up marginally (+0.011). The degradation comes mainly from surface Ux getting worse (+0.018 on val_in_dist). Volume MAEs were slightly better or neutral.

The pressure improvements are consistent and meaningful — the higher-frequency PE features appear to help the model represent fine-scale pressure variations, particularly in the tandem and OOD-condition regimes.

**Memory cost is significant**: 82.8 GB vs ~60 GB at 8 freqs. This is close to the 96 GB limit and may be a concern for future experiments that want to combine this with other changes.

**Verdict:** Modest signal, high memory cost. The 8→12 freq scaling shows diminishing returns compared to 4→8. The pressure improvement is real but marginal relative to the memory increase.

### Suggested follow-ups

1. **Rebalance loss to weight pressure**: If surface Ux degraded while pressure improved, the loss weighting might be steering the model suboptimally. Try a pressure-specific surface weight.
2. **12 freqs at n_hidden=160**: Check if the improvement is real when memory-constrained by reducing model size.
3. **16 freqs (64 PE)**: If 12 shows continued pressure improvement, test the limit — but memory will likely OOM at 96 GB.
4. **Keep 8 freqs**: The 4→8 improvement was clean and clear; the 8→12 improvement is marginal. The 8-freq baseline may be the sweet spot.