### PR TITLE
Gradient accumulation 2x with SAME LR (effective batch 8)

### DIFF
--- a/train.py
+++ b/train.py
@@ -485,7 +485,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
+model = torch.compile(model, mode="default")  # reduce-overhead (cudagraphs) incompatible with grad accum
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -571,6 +571,8 @@ model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
+ACCUM_STEPS = 2
+
 best_val = float("inf")
 ema_val_loss = float("inf")
 ema_decay_val = 0.9
@@ -597,6 +599,7 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf = 0.0
     n_batches = 0
 
+    optimizer.zero_grad()
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
@@ -714,19 +717,20 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(_base_model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        (loss / ACCUM_STEPS).backward()
+        if (n_batches + 1) % ACCUM_STEPS == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            if epoch >= ema_start_epoch:
+                if ema_model is None:
+                    ema_model = deepcopy(_base_model)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
+                            ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+            global_step += 1
+            wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Previous grad accum failed because LR was changed. Using SAME LR=3e-3 with 2-step accumulation gives smoother gradients without changing optimization dynamics. Key: EMA/scheduler update only on optimizer steps.

## Instructions
Add `ACCUM_STEPS = 2` before training loop. Modify backward/step:
```python
(loss / ACCUM_STEPS).backward()
if (n_batches + 1) % ACCUM_STEPS == 0:
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    optimizer.step()
    optimizer.zero_grad()
    # Move EMA update INSIDE this block
    if epoch >= ema_start_epoch:
        ...  # existing EMA code
    global_step += 1
    wandb.log({...})
# Remove the original optimizer.step/zero_grad/EMA/log from outside the block
```
Scheduler.step() stays once per epoch. Run with `--wandb_group grad-accum-2x-same-lr`.
## Baseline (15 merged improvements on fixed noam)
- Estimated val_loss ~1.94-1.97 (combined effect unmeasured)
- n_hidden=192, compile, 8 learnable Fourier freq (32 PE), feature cross, coord-norm, noise annealing, tandem-inclusive norm, aux AoA, EMA-smoothed ckpt, learned skip gate, spatial-sorted coarse, warmup 10ep, T_max=66, eta_min=5e-5
---
## Results

**W&B run ID**: c27ybili

| Metric | This run | Baseline |
|--------|----------|----------|
| val/loss_3split | 2.0041 | ~1.94–1.97 |
| mean3/mae_surf_p (computed) | 24.85 | ~25.47 |
| Runtime | ~32 min (timeout killed) | 30 min |

**Surface MAE by split:**

| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 0.2895 | 0.1642 | 18.94 |
| ood_cond | 0.2066 | 0.1569 | 16.76 |
| tandem_transfer | 0.5994 | 0.3168 | 38.87 |
| ood_re | 0.2427 | 0.1824 | 29.89 |

**Volume MAE by split:**

| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 1.2687 | 0.4192 | 23.17 |
| ood_cond | 0.9122 | 0.3294 | 15.37 |
| tandem_transfer | 2.0772 | 0.9465 | 41.37 |

**Peak GPU memory**: No OOM. Similar to baseline.

### What happened

**Critical finding**: `torch.compile(mode="reduce-overhead")` uses CUDAGraphs, which is fundamentally incompatible with gradient accumulation. The error: *"accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run"*. Adding `cudagraph_mark_step_begin()` before each forward call doesn't help — it causes forward-pass-1 tensors to be overwritten by CUDA graph reuse before backward runs on them.

**Fix required**: Changed compile mode from `"reduce-overhead"` to `"default"`. This disables CUDAGraphs but makes each epoch ~12% slower. The run was timeout-killed at ~32 min.

**Mixed results**: val/loss_3split 2.004 is worse than baseline (~1.94), but mean3_surf_p 24.85 is marginally better (~25.47). The results are confounded by slower training — fewer effective epochs in 30 minutes without CUDAGraphs. Cannot cleanly attribute any difference to gradient accumulation itself.

The hypothesis is essentially untestable under the current constraints: gradient accumulation requires disabling the key speed optimization (CUDAGraphs), making the comparison apples-to-oranges.

### Suggested follow-ups
- To test larger effective batch size cleanly, use a larger DataLoader batch size (avoids the compile incompatibility entirely).
- If grad accum is desired, run with `torch.compile(mode="default")` as baseline so both conditions are equal.
- tandem_transfer surf_p (38.87) is the bottleneck for mean3_surf_p — worth targeting specifically.