### PR TITLE
Zero noise after epoch 55 (clean EMA convergence)

### DIFF
--- a/train.py
+++ b/train.py
@@ -620,10 +620,10 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+        if model.training and epoch < 55:
+            noise_progress = min(1.0, epoch / 55)
+            vel_noise = 0.015 * (1 - noise_progress)
+            p_noise = 0.008 * (1 - noise_progress)
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 


### PR DESCRIPTION
## Hypothesis
Noise annealing keeps residual noise (0.003/0.001) even at epoch 60+. For the final ~17 EMA epochs (40-72), any noise corrupts fine convergence. Hard cutoff at epoch 55 (well before EMA benefits compound) enables clean final training.

## Instructions
Change noise injection to:
```python
if model.training and epoch < 55:
    noise_progress = min(1.0, epoch / 55)
    vel_noise = 0.015 * (1 - noise_progress)
    p_noise = 0.008 * (1 - noise_progress)
    noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
    y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
```
Run with `--wandb_group noise-cutoff-55`.
## Baseline
15 improvements on fixed noam. Estimated val_loss ~1.94-1.97.
---
## Results

**W&B run:** `vcj10gxv` (thorfinn/noise-cutoff-55)  
**Epochs:** 71 | **Runtime:** 32 min (30-min cap, clean checkpoint saved)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.2616 | 0.271 | 0.164 | 19.33 | 1.188 | 0.409 | 23.21 |
| val_tandem_transfer | 3.0571 | 0.580 | 0.320 | 39.50 | 1.969 | 0.912 | 40.81 |
| val_ood_cond | 1.6089 | 0.203 | 0.152 | 16.79 | 0.849 | 0.317 | 15.22 |
| val_ood_re | 1.3552 | 0.238 | 0.181 | 29.08 | 0.926 | 0.393 | 48.74 |
| **3-split avg** | **1.9758** | | | **25.21** | | | |
| **4-split avg** | **1.8207** | | | **26.17** | | | |

### vs Baseline
- **val/loss_3split: 1.9758** — within stated baseline range (1.94-1.97); marginal
- **mean3_surf_p: 25.21** — comparable to other recent fixed-noam runs (~25.2)

### What happened

Neutral result. The hard cutoff at epoch 55 does not produce a measurable improvement over the annealing-to-residual approach.

The hypothesis was that residual noise (0.003/0.001 from the prior schedule) corrupts fine EMA convergence in the final epochs. In practice, removing it provides no clear benefit — the 3-split (1.976) is within the expected baseline variance. The val_in_dist improved slightly (19.33 surf_p vs ~19-20 on comparable runs) but tandem_transfer and ood_cond did not improve.

One possible explanation: the residual noise may act as a mild regularizer that prevents the model from memorizing the most recent batch gradients, and removing it entirely allows mild overfitting in the final epochs. Alternatively, the EMA already smooths out late-epoch noise and the cutoff makes no difference either way.

### Suggested follow-ups
- **Try noise cutoff at epoch 45 or 40** — if the benefit is real, an earlier clean window may show it more clearly
- **Warm restart at epoch 55** — zero noise + small LR reset to let the model re-settle without noise pressure
- **No noise at all** — compare a zero-noise baseline to understand if noise helps early training
