### PR TITLE
Relative slice position encoding (spatial bias in slice-token attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -112,8 +112,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.dist_decay = nn.Parameter(torch.tensor(1.0))
 
-    def forward(self, x, spatial_bias=None):
+    def forward(self, x, spatial_bias=None, raw_xy=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -143,6 +144,14 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         q_norm = F.normalize(q_slice_token, dim=-1)
         k_norm = F.normalize(k_slice_token, dim=-1)
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
+        if raw_xy is not None:
+            # Mean position per slice: (bsz, heads, slice_num, 2)
+            raw_xy_exp = raw_xy.unsqueeze(1).expand(-1, self.heads, -1, -1)
+            slice_pos = torch.einsum('bhnc,bhng->bhgc', raw_xy_exp, slice_weights) / (slice_norm + 1e-5).unsqueeze(-1)
+            # Pairwise distance between slices: (bsz, heads, slice_num, slice_num)
+            rel_dist = (slice_pos.unsqueeze(-2) - slice_pos.unsqueeze(-3)).norm(dim=-1)
+            pos_bias = -self.dist_decay.abs() * rel_dist
+            attn_logits = attn_logits + pos_bias
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
         out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
@@ -193,7 +202,7 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
+        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, raw_xy=raw_xy) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))


### PR DESCRIPTION
## Hypothesis
Slice-token attention has NO positional info. Adjacent slices do not know they are neighbors. Adding pairwise distance bias from mean slice positions lets attention learn that nearby regions should communicate. Novel — never tried in 700+ experiments.

## Instructions
1. In `Physics_Attention_Irregular_Mesh.__init__`, add: `self.dist_decay = nn.Parameter(torch.tensor(1.0))`

2. In `forward()`, after computing `slice_token` and before the attention computation, add relative position bias:
```python
# Mean position per slice
slice_pos = torch.einsum("bhnc,bhng->bhgc", raw_xy_exp, slice_weights) / (slice_norm + 1e-5).unsqueeze(-1)
# Pairwise distance
rel_dist = (slice_pos.unsqueeze(-2) - slice_pos.unsqueeze(-3)).norm(dim=-1)
pos_bias = -self.dist_decay.abs() * rel_dist
# Add to attention logits before softmax
```
This requires passing raw_xy positions into the attention module. Run with `--wandb_group rel-slice-pos`.
## Baseline
15 improvements on fixed noam. Estimated val_loss ~1.94-1.97.
---
## Results

**W&B run:** `haqgs86u`
**Epochs:** ~65/100 (hit 30-min timeout at ~1757s, ~27s/epoch)
**Peak memory:** 12.9 GB (vs ~12.5 GB baseline — +0.4 GB for pairwise distance matrix)

| Metric | This run | Baseline (est.) |
|---|---|---|
| val/loss (last, 3-split) | 1.9988 | ~1.94–1.97 |
| val_in_dist/mae_surf_p | 19.996 | — |
| val_ood_cond/mae_surf_p | 16.328 | — |
| val_ood_re/mae_surf_p | 29.335 | — |
| val_tandem_transfer/mae_surf_p | 39.737 | — |
| **mean3_surf_p** | **21.89** | — |

### What happened

The relative slice position bias did not improve over the estimated baseline. val/loss of 1.9988 is slightly above the expected 1.94–1.97 range, suggesting a neutral-to-slightly-negative result.

Two compounding factors likely explain this:
1. **Slowdown**: The pairwise distance computation (O(slice_num²) = O(32²) = 1024 per head) added ~2s/epoch overhead, reducing epochs from ~69 to ~65 within the 30-minute budget — fewer training steps.
2. **Redundancy with spatial_bias**: The existing `spatial_bias` mechanism in `TransolverBlock` already learns a mapping from raw_xy to slice logit biases. This pre-existing spatial encoding may already capture the spatial adjacency information, leaving little room for the additional distance-based attention bias to contribute.

**No `best_val_loss` logged** — run timed out before EMA final evaluation.

### Suggested follow-ups

- **Cheaper position encoding**: Instead of per-pair distances (O(G²)), encode each slice position independently and add as a bias to Q or K (O(G)). This would eliminate the slowdown.
- **Learnable bandwidth**: Replace `dist_decay.abs()` with a per-head or per-layer learned kernel (RBF, inverse-distance, etc.) for more expressive distance weighting.
- **Remove spatial_bias to avoid redundancy**: Try this position bias as a replacement for the existing `spatial_bias` mechanism rather than adding on top of it.