### PR TITLE
Tandem-weighted checkpoint selection (2x weight for tandem split)

### DIFF
--- a/train.py
+++ b/train.py
@@ -851,10 +851,17 @@ for epoch in range(MAX_EPOCHS):
 
     # 3-split val/loss (in_dist + tandem + ood_cond) — used for checkpoint selection
     _3split_names = ["val_in_dist", "val_tandem_transfer", "val_ood_cond"]
-    _3split_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _3split_names
-                      if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
-                              torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
-    val_loss_3split = sum(_3split_losses) / max(len(_3split_losses), 1)
+    _3split_weights = {'val_in_dist': 1.0, 'val_tandem_transfer': 2.0, 'val_ood_cond': 1.0}
+    # Compute weighted average instead of simple average
+    total_w = 0
+    weighted_sum = 0
+    for n in _3split_names:
+        loss_val = val_metrics_per_split[n][f"{n}/loss"]
+        if not (torch.tensor(loss_val).isnan() or torch.tensor(loss_val).isinf()):
+            w = _3split_weights.get(n, 1.0)
+            weighted_sum += w * loss_val
+            total_w += w
+    val_loss_3split = weighted_sum / max(total_w, 1)
     ema_val_loss = val_loss_3split if ema_val_loss == float("inf") else ema_decay_val * ema_val_loss + (1 - ema_decay_val) * val_loss_3split
 
     # 4-split val/loss (all splits including ood_re)


### PR DESCRIPTION
## Hypothesis
Tandem is the worst split (surf_p ~39). Checkpoint selection uses equal-weight 3-split average, biased toward in_dist/ood_cond. Weighting tandem 2x in the checkpoint selection biases the saved model toward tandem improvement.

## Instructions
Change the 3-split average to weighted (~line 857):
```python
_3split_weights = {'val_in_dist': 1.0, 'val_tandem_transfer': 2.0, 'val_ood_cond': 1.0}
# Compute weighted average instead of simple average
total_w = 0
weighted_sum = 0
for n in _3split_names:
    loss_val = val_metrics_per_split[n][f'{n}/loss']
    if not (torch.tensor(loss_val).isnan() or torch.tensor(loss_val).isinf()):
        w = _3split_weights.get(n, 1.0)
        weighted_sum += w * loss_val
        total_w += w
val_loss_3split = weighted_sum / max(total_w, 1)
```
Run with `--wandb_group tandem-weighted-ckpt`.
## Baseline
15 improvements on fixed noam. Estimated val_loss ~1.94-1.97.
---
## Results

W&B run: `qwa7bqy0` | Peak memory: 12.9 GB | 68 epochs (~29 min)

**Note:** val/loss_3split stored in W&B (2.1951) is the 2x-weighted average used for checkpoint selection — not directly comparable to the baseline (1.9875, simple average). Fair comparisons use unweighted averages below.

### Val/loss by split (lower is better)

| Split | Experiment | Baseline (w19k8gkx) | Δ |
|---|---|---|---|
| val_in_dist | 1.2617 | 1.2597 | +0.2% |
| val_tandem_transfer | **2.9820** | 3.0921 | **-3.6%** |
| val_ood_cond | **1.5547** | 1.6107 | **-3.5%** |
| val_ood_re | **1.3441** | 1.3778 | **-2.4%** |
| **3-split avg (unweighted)** | **1.9328** | 1.9875 | **-2.8%** |
| 4-split avg (unweighted) | 1.7856 | 1.8351 | -2.7% |

### Surface MAE (most important)

| Split | Ux | Uy | p | Δ p |
|---|---|---|---|---|
| in_dist | 0.2662 | 0.1591 | 19.48 | +1.9% |
| tandem | **0.5756** | **0.3092** | **38.71** | **-4.3%** |
| ood_cond | **0.1973** | **0.1474** | **15.62** | **-2.1%** |
| ood_re | 0.2365 | 0.1790 | 29.09 | -0.9% |

*Baseline tandem: Ux=0.6027, Uy=0.3231, p=40.45*

### Volume MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.1610 | 0.4024 | 23.25 |
| tandem | 1.9476 | 0.9008 | 39.81 |
| ood_cond | 0.8497 | 0.3183 | 15.24 |
| ood_re | 0.9284 | 0.3970 | 48.87 |

### What happened

The 2x tandem weighting in checkpoint selection worked as hypothesized. The model finds checkpoints that are simultaneously better on tandem (-3.6% loss, -4.3% surf_p) AND improves the other OOD splits too (-3.5% ood_cond, -2.4% ood_re). The in_dist split is essentially unchanged (+0.2% loss; surf_p +1.9% but Ux/Uy both improved).

This is a clean result: the bias steers checkpoint selection toward better-generalizing weights without hurting in-distribution accuracy. The improvement likely reflects that tandem cases expose the model to more challenging geometry combinations — optimizing for those checkpoints selects for more robust representations overall.

The 3-split unweighted average improves by -2.8% (1.9328 vs 1.9875), which is the fair comparison against baseline.

### Suggested follow-ups

- Try higher tandem weight (3x or 4x) — the improvement was clean with 2x, so pushing further may yield more.
- Try applying this weighting idea to the loss function itself (not just checkpoint selection): a higher surf_weight or vol_weight specifically on tandem samples during training.
- Consider using the 4-split average for checkpoint selection (include ood_re), since val_ood_re also benefits from better-generalizing checkpoints.