### PR TITLE
Proximity-biased volume subsampling (keep near-surface nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -669,7 +669,9 @@ for epoch in range(MAX_EPOCHS):
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)
-            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
+            dsdf_norm = x[vol_indices[:, 0], vol_indices[:, 1], 2:10].norm(dim=-1)
+            keep_probs = dsdf_norm / (dsdf_norm.sum() + 1e-8)
+            perm = torch.multinomial(keep_probs, n_keep, replacement=False)
             vol_mask_train = torch.zeros_like(vol_mask)
             if n_keep > 0:
                 vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True


### PR DESCRIPTION
## Hypothesis
Progressive subsampling randomly drops volume nodes, but boundary-layer nodes carry the most physical info. Using dsdf magnitude to prioritize near-surface nodes during early-epoch subsampling focuses early training on the physically important region.

## Instructions
In the progressive resolution section (~line 667), replace random permutation with proximity-weighted sampling:
```python
dsdf_norm = x[vol_indices[:, 0], vol_indices[:, 1], 2:10].norm(dim=-1)
keep_probs = dsdf_norm / (dsdf_norm.sum() + 1e-8)
perm = torch.multinomial(keep_probs, n_keep, replacement=False)
```
Run with `--wandb_group proximity-vol-sub`.
## Baseline
15 improvements on fixed noam. Estimated val_loss ~1.94-1.97.
---
## Results

**W&B run:** `f1vnldxl` (gilbert/proximity-vol-sub)
**Epochs:** 71 / 100 (30-min timeout)
**Peak memory:** 13.0 GB

### Metrics

| Split | val/loss | surf Ux | surf Uy | surf p |
|---|---|---|---|---|
| val_in_dist | 1.231 | 0.259 | 0.163 | 18.85 |
| val_ood_cond | 1.616 | 0.211 | 0.149 | 16.17 |
| val_tandem_transfer | 3.057 | 0.592 | 0.320 | 39.89 |
| val_ood_re | 1.375 | 0.247 | 0.181 | 28.99 |
| **mean3** | **1.968** | | | **24.97** |

### Comparison to baseline (`frieren/baseline-15imp`, random subsampling)

| Metric | Baseline (random) | This run (dsdf-weighted) | Delta |
|---|---|---|---|
| mean3 val/loss | 1.988 | 1.968 | **-0.019 (-1.0%)** |
| mean3 surf_p | 25.17 | 24.97 | **-0.20 (-0.8%)** |

### What happened

Marginal positive result — both val/loss and surface pressure improved slightly over random volume subsampling, but the gap is small (~1%) and likely within run-to-run noise for a 30-minute experiment. Each individual split improved for in_dist and tandem_transfer pressure, while ood_cond pressure was slightly worse (16.17 vs 15.96 baseline).

**Note on directionality:** The implementation uses `keep_probs = dsdf_norm` (higher dsdf → higher keep probability). If dsdf features at indices 2:10 are unsigned distance-like values (larger = farther from surface), then this biases sampling toward keeping far-from-surface nodes preferentially, not near-surface nodes as stated in the hypothesis. This may explain why the improvement is small — the actual effect may be opposite to intent, or dsdf features at these indices encode something other than distance.

Memory increased slightly (13.0 GB vs ~12.5 GB for recent runs), possibly due to multinomial sampling overhead vs randperm.

### Suggested follow-ups

- **Verify dsdf feature directionality:** Check what x[:,:,2:10] actually encodes. If large values = far from surface, the fix is `keep_probs = 1/(dsdf_norm + eps)` to actually prioritize near-surface nodes.
- **Test inverted weighting:** Try `keep_probs = 1/(dsdf_norm + 1e-4)` to genuinely bias toward near-surface (boundary layer) nodes during early training.
- **Uniform baseline confirmation:** The 1% improvement over random is within noise; a second run with random sampling would confirm whether this effect is real.