### PR TITLE
GLU-gated preprocess MLP (SwiGLU-style feature extraction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -60,6 +60,18 @@ ACTIVATION = {
 }
 
 
+class GatedMLP(nn.Module):
+    def __init__(self, n_input, n_hidden, n_output, act='gelu'):
+        super().__init__()
+        act_fn = ACTIVATION[act]
+        self.gate_proj = nn.Linear(n_input, n_hidden)
+        self.up_proj = nn.Linear(n_input, n_hidden)
+        self.down_proj = nn.Linear(n_hidden, n_output)
+        self.act = act_fn()
+    def forward(self, x):
+        return self.down_proj(torch.sigmoid(self.gate_proj(x)) * self.act(self.up_proj(x)))
+
+
 class MLP(nn.Module):
     def __init__(self, n_input, n_hidden, n_output, n_layers=1, act="gelu", res=True):
         super().__init__()
@@ -245,7 +257,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=1, res=True, act=act)
+            self.preprocess = GatedMLP(fun_dim + space_dim, n_hidden * 2, n_hidden)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
The preprocess MLP uses standard Linear->GELU->Linear. GLU (Gated Linear Unit) variants consistently outperform standard MLPs in recent work (PaLM, LLaMA use SwiGLU). Same parameter count, better feature gating.

## Instructions
Add a GatedMLP class before the Transolver class:
```python
class GatedMLP(nn.Module):
    def __init__(self, n_input, n_hidden, n_output, act='gelu'):
        super().__init__()
        act_fn = ACTIVATION[act]
        self.gate_proj = nn.Linear(n_input, n_hidden)
        self.up_proj = nn.Linear(n_input, n_hidden)
        self.down_proj = nn.Linear(n_hidden, n_output)
        self.act = act_fn()
    def forward(self, x):
        return self.down_proj(torch.sigmoid(self.gate_proj(x)) * self.act(self.up_proj(x)))
```
Replace preprocess in Transolver.__init__:
```python
self.preprocess = GatedMLP(fun_dim + space_dim, n_hidden * 2, n_hidden)
```
Run with `--wandb_group gated-preprocess`.
## Baseline
15 improvements on fixed noam. Estimated val_loss ~1.94-1.97.

Measured baseline (`leiaq9de`, frieren/baseline-fixed, ~59 epochs):
- val/loss_3split: 2.056
- mae_surf_p: in_dist=21.00, ood_cond=17.90, ood_re=30.27, tandem=40.44

---
## Results

**W&B run:** `nb1jqor0` (`senku/gated-preprocess`, group: `gated-preprocess`)
**Epochs:** 69/100 (30-min timeout)
**Peak GPU memory:** 13.1 GB (vs 13.7 GB baseline — slightly less)
**Epoch time:** ~26s

### Metrics at best checkpoint (epoch 69)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.247 | 0.270 | 0.163 | 19.06 | 1.236 | 0.425 | 23.41 |
| val_tandem_transfer | 3.030 | 0.577 | 0.315 | 38.76 | 1.989 | 0.928 | 40.02 |
| val_ood_cond | 1.566 | 0.200 | 0.151 | 15.39 | 0.874 | 0.322 | 15.19 |
| val_ood_re | 1.374 | 0.238 | 0.182 | 29.40 | 0.948 | 0.402 | 49.49 |

**val/loss_3split: 1.9476** vs baseline 2.056 → **-5.3% improvement**

### Comparison vs baseline (slice_num=32, standard MLP preprocess)

| Metric | Baseline | gated-preprocess | Δ |
|---|---|---|---|
| val/loss_3split | 2.056 | 1.948 | **-5.3%** |
| mae_surf_p (in_dist) | 21.00 | 19.06 | -9.2% |
| mae_surf_p (ood_cond) | 17.90 | 15.39 | **-14.0%** |
| mae_surf_p (ood_re) | 30.27 | 29.40 | -2.9% |
| mae_surf_p (tandem) | 40.44 | 38.76 | -4.2% |

### What happened
GLU gating works. Replacing the standard preprocess MLP with a SwiGLU-style gated variant delivers a clear improvement across all splits, with the largest gain on val_ood_cond surface pressure (-14%). The multiplicative gate allows the network to suppress irrelevant input features per-neuron, which is especially valuable during preprocessing where raw geometry/condition features have very mixed scales and relevance.

Memory actually decreased slightly (13.1 vs 13.7 GB) because the GatedMLP removes the residual linear projection present in the original MLP. Epoch time stays at 26s — no overhead.

The result confirms the LLaMA/PaLM intuition: gated MLPs are a drop-in upgrade for feature extraction in this architecture.

### Suggested follow-ups
- Apply GatedMLP to the output MLP as well (currently uses standard MLP)
- Try SiLU instead of GELU activation in the gate (SwiGLU variant)
- Combine with slice_num=48 — both are independently strong improvements