### PR TITLE
4-split checkpoint selection (include val_ood_re)

### DIFF
--- a/train.py
+++ b/train.py
@@ -849,12 +849,12 @@ for epoch in range(MAX_EPOCHS):
         }
         val_loss_sum += split_loss
 
-    # 3-split val/loss (in_dist + tandem + ood_cond) — used for checkpoint selection
-    _3split_names = ["val_in_dist", "val_tandem_transfer", "val_ood_cond"]
-    _3split_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _3split_names
-                      if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
-                              torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
-    val_loss_3split = sum(_3split_losses) / max(len(_3split_losses), 1)
+    # 4-split val/loss (all splits) — used for checkpoint selection
+    _checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names
+    _checkpoint_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _checkpoint_names
+                          if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
+                                  torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
+    val_loss_3split = sum(_checkpoint_losses) / max(len(_checkpoint_losses), 1)
     ema_val_loss = val_loss_3split if ema_val_loss == float("inf") else ema_decay_val * ema_val_loss + (1 - ema_decay_val) * val_loss_3split
 
     # 4-split val/loss (all splits including ood_re)


### PR DESCRIPTION
## Hypothesis
Checkpoint selection excludes val_ood_re (historically had broken vol_loss ~18869). Recent runs show val_ood_re is now well-behaved. Including all 4 splits gives better generalization signal for checkpoint selection.

## Instructions
Change the checkpoint selection to use all 4 splits (~line 853-857):
\`\`\`python
_checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names
_checkpoint_losses = [val_metrics_per_split[n][f'{n}/loss'] for n in _checkpoint_names
                      if not (torch.tensor(val_metrics_per_split[n][f'{n}/loss']).isnan() or
                              torch.tensor(val_metrics_per_split[n][f'{n}/loss']).isinf())]
val_loss_3split = sum(_checkpoint_losses) / max(len(_checkpoint_losses), 1)
\`\`\`
Run with \`--wandb_group ckpt-4split\`.
## Baseline
15 improvements on fixed noam. Estimated val_loss ~1.94-1.97.
---
## Results

**W&B run:** twb8oq4b
**Best epoch:** 68 (training stopped at 30-min wall-clock limit; still improving at cutoff)
**Peak GPU memory:** 12.9 GB

### Metrics at best checkpoint (epoch 68)

| Split | Loss | Surf Ux MAE | Surf Uy MAE | Surf p MAE | Vol Ux MAE | Vol Uy MAE | Vol p MAE |
|---|---|---|---|---|---|---|---|
| val_in_dist | 1.2311 | 0.264 | 0.163 | 18.82 | 1.158 | 0.397 | 21.74 |
| val_ood_cond | 1.6107 | 0.206 | 0.152 | 16.66 | 0.862 | 0.319 | 15.37 |
| val_ood_re | 1.3461 | 0.235 | 0.181 | 29.14 | 0.932 | 0.398 | 48.90 |
| val_tandem_transfer | 3.0004 | 0.579 | 0.314 | 39.07 | 1.964 | 0.895 | 39.58 |
| **val/loss (4-split ckpt)** | **1.7971** | | | | | | |
| val/loss (3-split equiv.) | 1.9474 | | | | | | |

### What happened

The hypothesis is confirmed: **val_ood_re is now well-behaved** (loss 1.35, no sign of the historic blowup). Including it in checkpoint selection did not cause instability — the checkpoint was updated every epoch up to the cutoff (`*` on all last epochs), indicating the 4-split EMA was always improving.

The 3-split equivalent loss at epoch 68 is 1.9474, matching the baseline estimate of 1.94-1.97. The 4-split checkpoint metric (1.7971) is a different quantity so shouldn't be compared directly against the 3-split baseline. Performance is on par.

Note: the W&B run shows state "running" because the process hit the internal 30-min wall clock limit and exited before `wandb.finish()` could be called; all per-epoch history is fully synced.

### Suggested follow-ups

- Adopt 4-split checkpoint selection as the new baseline — it's safe and uses more generalization signal
- Since the model was still improving at epoch 68, investigate whether the checkpoint selection timing changes with 4-split (i.e. does it pick a later or earlier epoch than 3-split?)
- The val_ood_re vol_p MAE (48.9) remains high — volume prediction on OOD Reynolds numbers is still the main weakness