### PR TITLE
Quantile-focused surface loss (3x amplification on worst 10% nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -691,7 +691,15 @@ for epoch in range(MAX_EPOCHS):
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem = (x[:, 0, 21].abs() > 0.01)
         tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_err_per_node = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1))
+        B = surf_err_per_node.shape[0]
+        for b in range(B):
+            s_nodes = surf_err_per_node[b, surf_mask[b], 0]
+            if s_nodes.numel() > 0:
+                q90 = s_nodes.quantile(0.9)
+                boost = torch.where(surf_err_per_node[b, :, 0] > q90, 3.0, 1.0)
+                surf_err_per_node[b, :, 0] = surf_err_per_node[b, :, 0] * boost
+        surf_per_sample = surf_err_per_node.sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Pressure error is heavy-tailed (stagnation points, suction peaks). Amplifying loss on the worst-predicted 10% of surface nodes targets the tail that dominates MAE.

## Instructions
Replace the surface loss computation (~line 694) with:
```python
surf_err_per_node = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1))
B = surf_err_per_node.shape[0]
for b in range(B):
    s_nodes = surf_err_per_node[b, surf_mask[b], 0]
    if s_nodes.numel() > 0:
        q90 = s_nodes.quantile(0.9)
        boost = torch.where(surf_err_per_node[b, :, 0] > q90, 3.0, 1.0)
        surf_err_per_node[b, :, 0] = surf_err_per_node[b, :, 0] * boost
surf_per_sample = surf_err_per_node.sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
surf_loss = (surf_per_sample * tandem_boost).mean()
```
Run with `--wandb_group quantile-loss`.
## Baseline
Current noam: 18 net improvements. Last measured mean3=25.2 (before 3 new merges). Estimated combined: mean3~23.5-24.0.
---
## Results

**W&B run:** c6efvcsc  
**Epochs completed:** 70 (timed out at 30 min; 25.1s/epoch — +4% slower vs baseline)  
**Peak memory:** ~12.7 GB

### Metrics vs round-10 baseline (frieren/is53rpdt, 73 ep, 24.1s/ep)

| Metric | Quantile-loss | Baseline-r10 | Δ |
|--------|--------------|--------------|---|
| val_loss_3split | 0.9439 | 0.9097 | +0.034 (worse) |
| mean3_surf_p | 24.80 | 24.32 | +0.48 (worse) |
| val_in_dist/mae_surf_p | 19.26 | 17.57 | +1.69 (worse) |
| val_ood_cond/mae_surf_p | 15.72 | 14.94 | +0.78 (worse) |
| val_tandem_transfer/mae_surf_p | 39.42 | 40.45 | **-1.03 (better)** |
| val_in_dist/mae_vol_p | 24.18 | 20.70 | +3.48 (worse) |
| val_tandem_transfer/mae_vol_p | 41.67 | 41.08 | +0.59 (worse) |

### What happened

The quantile-focused loss doesn't improve mean3_surf_p. Overall it's worse than baseline by 0.48 on the primary metric. The only improvement is on val_tandem_transfer/mae_surf_p (-1.03), which makes intuitive sense: tandem samples have more complex pressure distributions with peaks and stagnation zones that the 3x hard-node focus would preferentially target.

However, val_in_dist and val_ood_cond are worse — the extra focus on 10% hard nodes likely over-specializes the model toward outlier pressure values at the expense of moderate-error nodes that are more numerous. The training signal becomes noisier (q90 threshold shifts batch-to-batch) and the per-batch for-loop adds ~4% epoch overhead, giving 3 fewer epochs within the 30-min budget.

The in-place tensor modification (`surf_err_per_node[b, :, 0] = ...`) inside the training loop appears to function correctly (no gradient errors in 70 epochs).

### Suggested follow-ups

- If tandem-transfer is specifically the target, a tandem-conditional surface weight (stronger boost for tandem samples) might be cleaner than a hard quantile threshold
- A softer focal variant (`loss * (1 + α * err/err_mean)`) avoids the per-batch loop overhead and the instability of the hard q90 threshold
- Consider whether volume loss (which degraded significantly, +3.48 on val_in_dist/mae_vol_p) is being implicitly traded against surface pressure