### PR TITLE
RoPE position encoding in slice-token attention

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,6 +124,19 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.rope_dim = dim_head // 2
+
+    def _apply_rope(self, x, seq_len):
+        d = self.rope_dim
+        pos = torch.arange(seq_len, device=x.device, dtype=x.dtype).unsqueeze(0).unsqueeze(0).unsqueeze(-1)
+        freqs = 1.0 / (10000 ** (torch.arange(0, d, 2, device=x.device, dtype=x.dtype) / d))
+        angles = pos * freqs
+        cos_a, sin_a = angles.cos(), angles.sin()
+        x1, x2, x_rest = x[..., :d:2], x[..., 1:d:2], x[..., d:]
+        rx1 = x1 * cos_a - x2 * sin_a
+        rx2 = x1 * sin_a + x2 * cos_a
+        rotated = torch.stack([rx1, rx2], dim=-1).flatten(-2)
+        return torch.cat([rotated, x_rest], dim=-1)
 
     def forward(self, x, spatial_bias=None):
         bsz, num_points, _ = x.shape
@@ -152,6 +165,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
         k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
         v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
+        q_slice_token = self._apply_rope(q_slice_token, q_slice_token.shape[2])
+        k_slice_token = self._apply_rope(k_slice_token, k_slice_token.shape[2])
         q_norm = F.normalize(q_slice_token, dim=-1)
         k_norm = F.normalize(k_slice_token, dim=-1)
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale


### PR DESCRIPTION
## Hypothesis
Slice-token attention has NO position info — treats all 32 slices as an unordered set. RoPE (rotary position encoding) injects relative position into Q/K, letting the model learn that nearby slices should attend more. Proven in LLMs, never tried here.

## Instructions
1. In `Physics_Attention_Irregular_Mesh.__init__`, add: `self.rope_dim = dim_head // 2`

2. Add helper method to the class:
```python
def _apply_rope(self, x, seq_len):
    d = self.rope_dim
    pos = torch.arange(seq_len, device=x.device, dtype=x.dtype).unsqueeze(0).unsqueeze(0).unsqueeze(-1)
    freqs = 1.0 / (10000 ** (torch.arange(0, d, 2, device=x.device, dtype=x.dtype) / d))
    angles = pos * freqs
    cos_a, sin_a = angles.cos(), angles.sin()
    x1, x2, x_rest = x[..., :d:2], x[..., 1:d:2], x[..., d:]
    rx1 = x1 * cos_a - x2 * sin_a
    rx2 = x1 * sin_a + x2 * cos_a
    rotated = torch.stack([rx1, rx2], dim=-1).flatten(-2)
    return torch.cat([rotated, x_rest], dim=-1)
```

3. In `forward()`, after computing q_slice_token and k_slice_token, apply RoPE:
```python
q_slice_token = self._apply_rope(q_slice_token, q_slice_token.shape[2])
k_slice_token = self._apply_rope(k_slice_token, k_slice_token.shape[2])
```
Run with `--wandb_group rope-slice-attn`.
## Baseline
Current noam: 18 net improvements. Last measured mean3=25.2 (before 3 new merges). Estimated combined: mean3~23.5-24.0.

Actual baseline run used: `is53rpdt` (frieren/baseline-r10, val/loss=0.9097)
Note: Current codebase uses pressure-only surface loss, so Ux/Uy MAEs are high for all runs — only surface pressure is meaningful for direct comparison.

---
## Results

**W&B run:** `yl25orhr` — [tanjiro/rope-slice-attn](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/yl25orhr)

**W&B group:** rope-slice-attn

**Training:** 69 epochs (30 min timeout), best checkpoint at epoch 69.

**Peak memory:** ~72.1 GB (75.1% of 96 GB) vs baseline ~62.1 GB (+10 GB).

### Metrics vs Baseline

| Split | Metric | Baseline | RoPE | Delta |
|---|---|---|---|---|
| val_in_dist | loss | 0.5884 | 0.6188 | +0.030 |
| val_in_dist | surf Ux MAE | 6.18 | 5.49 | **-0.69** |
| val_in_dist | surf p MAE | 17.57 | 18.81 | +1.25 |
| val_in_dist | vol p MAE | 20.70 | 21.37 | +0.68 |
| val_tandem_transfer | loss | 1.6825 | 1.6811 | **-0.001** |
| val_tandem_transfer | surf Ux MAE | 6.24 | 5.75 | **-0.49** |
| val_tandem_transfer | surf p MAE | 40.45 | 39.94 | **-0.52** |
| val_tandem_transfer | vol p MAE | 41.08 | 40.23 | **-0.85** |
| val_ood_cond | loss | 0.7696 | 0.7730 | +0.003 |
| val_ood_cond | surf p MAE | 14.94 | 15.15 | +0.21 |
| val_ood_re | loss | 0.5982 | 0.5967 | **-0.002** |
| val_ood_re | surf p MAE | 28.79 | 28.59 | **-0.20** |
| **combined** | **val/loss** | **0.9097** | **0.9174** | **+0.008** |

### What happened

**RoPE did not consistently help — mixed results, net slightly worse.**

The overall val/loss worsened marginally (+0.008). The picture is split by dataset:
- **In-distribution (val_in_dist)**: Surface pressure got worse (+1.25 on surf_p), Ux improved (-0.69). Net worse.
- **Tandem transfer**: Small improvements across the board — surf_p -0.52, vol_p -0.85, Ux -0.49. The most interesting result.
- **OOD conditions**: Essentially neutral.
- **OOD Re**: Marginal improvements.

The key issue is that **slices are not a natural sequence**. In LLMs, RoPE is applied to token positions in a 1D sequence where "distance" is semantically meaningful (token at position 3 is closer to token 4 than to token 10). Slices in Transolver are formed by soft assignments from spatial positions — they're more like semantic clusters than ordered positions. Injecting ordinal position assumptions into an unordered set is likely counterproductive, especially for in-distribution performance.

The +10 GB memory cost is not justified by the results.

### Suggested follow-ups

1. **No RoPE**: The slice dimension is not an ordered sequence; positional encoding may be the wrong inductive bias here.
2. **Learnable slice embeddings**: Instead of RoPE (which assumes order), try adding learnable slice bias vectors — effectively giving each slice a learned "identity" rather than an ordinal position.
3. **Spatial RoPE on node dimension**: Apply RoPE to the node dimension sorted by x-coordinate, rather than the slice dimension. Nodes do have meaningful spatial ordering.