### PR TITLE
GLU gating in TransolverBlock MLP (extend GLU success)

### DIFF
--- a/train.py
+++ b/train.py
@@ -187,7 +187,7 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, act=act)
         self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)


### PR DESCRIPTION
## Hypothesis
GLU-gated preprocess was a clear win (-3.2%). The TransolverBlock MLP (line 190) uses a plain MLP. Replacing it with GatedMLP should give similar benefits. Direct extension of proven success.

## Instructions
In `TransolverBlock.__init__` (line 190), replace:
```python
self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
```
with:
```python
self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, act=act)
```
Run with `--wandb_group glu-block-mlp`.
## Baseline
Current noam: 18 net improvements. Last measured mean3=25.2 (before 3 new merges). Estimated combined: mean3~23.5-24.0.
---
## Results

**W&B run ID**: kijowe3x

| Metric | This run | Baseline (estimated) |
|--------|----------|----------------------|
| best_val_loss (EMA) | 0.906 | ~0.9 (estimated) |
| mean3/mae_surf_p | 24.26 | ~23.5–24.0 |
| Best epoch | 69 | — |
| Runtime | ~32 min (timeout killed) | — |

**Surface MAE at best checkpoint (epoch 69):**

| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 5.498 | 1.340 | 18.33 |
| ood_cond | 4.290 | 1.192 | 14.89 |
| tandem_transfer | 5.887 | 1.887 | 39.55 |
| ood_re | 3.909 | 1.026 | 28.66 |

**Volume MAE at best checkpoint:**

| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 1.154 | 0.385 | 20.56 |
| ood_cond | 0.813 | 0.306 | 13.54 |
| tandem_transfer | 1.995 | 0.920 | 39.52 |

**Peak GPU memory**: No OOM.

### What happened

**Null result.** mean3_surf_p = 24.26 is at the upper end of the estimated baseline range (23.5–24.0), meaning this change did not improve performance. Comparing against recent noam experiments that also completed on this same codebase: edward/adaptive-tandem-boost=23.51, violet/surf-grad-loss=23.89, edward/pressure-only-surf=24.17. Our result at 24.26 is worse than all of these.

**Why it may not have helped**: The original MLP with n_layers=0 is already a two-linear-layer transform (linear_pre → act → linear_post). Gating is a known benefit in the *preprocess* because it gates raw input features of mixed semantics. But in the TransolverBlock, the input to the MLP is already a normalized hidden representation after physics attention — it's more homogeneous, so gating provides less benefit. The preprocess success doesn't directly generalize here.

**Simplicity criterion**: No improvement + added parameters → should not merge.

### Suggested follow-ups
- The block MLP with n_layers=0 is essentially just a 2-layer MLP with no residual. Experimenting with adding n_layers=1 (3 layers with residual) might be more useful.
- The tandem_transfer split remains the bottleneck (39.55 vs ~18-29 for other splits) — targeted experiments for tandem improvement may be worth more than architecture tweaks.