### PR TITLE
Adaptive tandem gradient weighting (dynamic boost from loss ratio)

### DIFF
--- a/train.py
+++ b/train.py
@@ -591,6 +591,8 @@ global_step = 0
 train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
+running_tandem_loss = 0.05
+running_nontandem_loss = 0.05
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -689,9 +691,14 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        is_tandem = (x[:, 0, 21].abs() > 0.01)
-        tandem_boost = torch.where(is_tandem, 1.5, 1.0).to(device)
+        is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
+        nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
+        running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
+        running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
+        adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
+        tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 


### PR DESCRIPTION
## Hypothesis
Tandem is 2x worse than other splits. Static 1.5x boost is suboptimal. Dynamically set boost = ratio of tandem/non-tandem loss, clamped [1.0, 4.0]. Auto-calibrates focus.

## Instructions
Before training loop, add: `running_tandem_loss = 0.05; running_nontandem_loss = 0.05`

Replace tandem_boost computation (~line 693) with:
```python
is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
```
Note: `surf_per_sample` must be computed BEFORE this code uses it. Run with `--wandb_group gradnorm-tandem`.
## Baseline
18 improvements merged. Estimated mean3~23.5-24.0.
---
## Results

**W&B run:** `w5ti3umi`
**Best epoch:** 73 / 73 (hit wall-clock limit at 30.4 min, 25s/epoch)
**Peak memory:** 12.2 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5927 | 5.81 | 1.43 | 17.93 | 1.15 | 0.38 | 20.08 |
| val_tandem_transfer | 1.6189 | 6.30 | 2.05 | 38.29 | 1.98 | 0.90 | 38.36 |
| val_ood_cond | 0.7286 | 4.05 | 0.98 | 14.32 | 0.81 | 0.29 | 12.85 |
| val_ood_re | 0.5795 | 3.75 | 0.82 | 28.29 | 0.90 | 0.38 | 47.60 |
| **mean3** | **0.980** | **5.39** | **1.49** | **23.51** | — | — | — |

Baseline estimated at mean3_surf_p ~23.5–24.0.

**What happened:** Essentially neutral. The adaptive boost achieved mean3_surf_p=23.51, right at the lower end of the baseline estimate. The dynamic ratio started around 1.0 and presumably converged to a stable value (tandem batches tend to have higher loss so the ratio should land >1). However, the result is indistinguishable from the static 1.5x boost — either the static 1.5x was already well-calibrated, or the running average adapts too slowly (EMA=0.9) to be meaningfully different. Tandem val/loss (1.62) is still ~2x worse than non-tandem splits, so the fundamental difficulty remains regardless of boost value.

**Suggested follow-ups:**
- Try per-sample gradient weighting (multiply loss by per-sample weight tensor) rather than per-batch scalar — currently all tandem samples in a batch get the same boost, but individual difficulty varies.
- Log the adaptive_boost value to W&B to verify the ratio actually diverges from 1.5x; if it stays near 1.5, the static boost was optimal.
- The tandem gap (38.3 vs 14-17 for other splits) may be architectural, not a loss-weighting issue — consider tandem-specific attention or separate decoder heads.