### PR TITLE
Cosine T_max=62 (align LR schedule to actual 72-epoch training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -544,7 +544,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=66, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
With warmup=10 and T_max=66, cosine period ends at epoch 76. But training runs ~72 epochs. Setting T_max=62 ensures LR reaches minimum exactly at training end (10+62=72), giving EMA cleanest convergence.

## Instructions
Line 547, change: `T_max=62` (was 66). Run with `--wandb_group tmax-align-72`.
## Baseline
18 improvements merged. Estimated mean3~23.5-24.0.
---
## Results

**W&B run:** `xbj50yag`
**Epochs:** ~70/100 (hit 30-min timeout at ~1755s, ~25s/epoch)
**Peak memory:** 12.2 GB

| Metric | This run | Baseline (est.) |
|---|---|---|
| val/loss (last, 3-split) | 0.9051 | — (different scale) |
| val_in_dist/mae_surf_p | 18.25 | — |
| val_ood_cond/mae_surf_p | 14.76 | — |
| val_ood_re/mae_surf_p | 28.61 | — |
| val_tandem_transfer/mae_surf_p | 38.60 | — |
| **mean3_surf_p** | **20.54** | **~23.5–24.0 (est.)** |

### What happened

mean3_surf_p of 20.54 is notably better than the estimated baseline of 23.5–24.0. However, since no exact baseline run metrics are provided in the PR, this comparison is uncertain.

The T_max=62 alignment means the cosine LR reaches eta_min at exactly the expected end of training (~epoch 72), rather than at epoch 76 (past the actual training end). This gives EMA slightly cleaner convergence over the final epochs since the model parameters are updated with a fully decayed LR.

Note: val/loss = 0.9051 is on a different scale than previous PRs (~2.0) — this 18-improvement branch appears to have a different loss normalization (likely different surf_weight or vol scaling).

**No `best_val_loss` logged** — timed out before EMA checkpoint summary was written.

### Suggested follow-ups

- **Run without timeout** to get `best_val_loss` from EMA and a proper comparison.
- **T_max sweep**: Try T_max=58 or T_max=64 to verify the sensitivity to this alignment.
- **Establish explicit baseline**: Run the branch without the T_max change to get exact comparison numbers.