### PR TITLE
Conservative FiLM conditioning (0.1x scaling, proven OOD benefit)

### DIFF
--- a/train.py
+++ b/train.py
@@ -288,6 +288,9 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.film_net = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * n_hidden))
+        nn.init.zeros_(self.film_net[-1].weight)
+        nn.init.zeros_(self.film_net[-1].bias)
         self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0]))
 
     def initialize_weights(self):
@@ -352,6 +355,10 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+        re_aoa = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)
+        film_out = self.film_net(re_aoa)
+        gamma, beta = film_out.chunk(2, dim=-1)
+        fx = (1.0 + 0.1 * gamma.unsqueeze(1)) * fx + 0.1 * beta.unsqueeze(1)
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy)


### PR DESCRIPTION
## Hypothesis
FiLM showed -7.3% ood_cond on old code but regressed in-dist. Conservative 0.1x scaling on gamma/beta should capture OOD benefit without in-dist regression.

## Instructions
1. In `Transolver.__init__` (~after aoa_head):
```python
self.film_net = nn.Sequential(nn.Linear(2, 64), nn.GELU(), nn.Linear(64, 2 * n_hidden))
nn.init.zeros_(self.film_net[-1].weight)
nn.init.zeros_(self.film_net[-1].bias)
```

2. In forward(), after placeholder_scale/shift:
```python
re_aoa = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)
film_out = self.film_net(re_aoa)
gamma, beta = film_out.chunk(2, dim=-1)
fx = (1.0 + 0.1 * gamma.unsqueeze(1)) * fx + 0.1 * beta.unsqueeze(1)
```
Run with `--wandb_group film-conservative`.
## Baseline
18 improvements merged. Estimated mean3~23.5-24.0.
---
## Results

**W&B run:** `vhs1n3q6` (gilbert/film-conservative)
**Epochs:** 71 / 100 (30-min timeout)
**Peak memory:** 12.2 GB
**Baseline:** `frieren/baseline-r10` (is53rpdt) — same code, no FiLM

### Metrics

| Split | val/loss | surf p | vs baseline surf p |
|---|---|---|---|
| val_in_dist | 0.647 | 19.83 | **+2.26 (worse)** |
| val_ood_cond | 0.722 | 14.03 | **-0.91 (better)** |
| val_tandem_transfer | 1.655 | 39.17 | **-1.28 (better)** |
| val_ood_re | 0.597 | 28.67 | -0.12 (better) |
| **4-split mean** | **0.905** | **mean3: 24.35** | vs baseline 24.32 |

### Comparison to baseline (`frieren/baseline-r10`)

| Metric | Baseline | FiLM 0.1x | Delta |
|---|---|---|---|
| 4-split val/loss | 0.910 | 0.905 | **-0.005 (-0.5%)** |
| mean3 surf_p | 24.32 | 24.35 | +0.03 (flat) |

### What happened

Hypothesis partially confirmed, partially refuted. FiLM conditioning does help ood_cond (-0.91) and tandem_transfer (-1.28) in surface pressure, matching the earlier finding of OOD benefit. However, the 0.1x conservative scaling did **not** eliminate the in-dist regression — val_in_dist surface pressure got worse (+2.26). The OOD benefit and in-dist regression largely cancel out, leaving mean3_surf_p essentially unchanged (+0.03).

The 4-split val/loss improved marginally (-0.5%), driven by gains on ood_cond, tandem_transfer, and ood_re. Overall this is a near-neutral result for surface pressure but slightly positive for loss.

Memory was unchanged (12.2 GB). The zero-initialized FiLM network adds minimal overhead.

### Suggested follow-ups

- **Even more conservative scaling (0.05x):** If 0.1x still causes in-dist pressure regression, a smaller scale may avoid it entirely while retaining OOD gains.
- **FiLM only on last block:** Apply FiLM conditioning after the final Transolver block rather than at preprocess output, so it does not corrupt all-layer representations.
- **Separate gamma/beta for pressure channel only:** FiLM modulates all n_hidden channels equally; conditioning only the pressure output head might target the OOD benefit more precisely.