### PR TITLE
Stochastic Weight Averaging in final 15 epochs (complement EMA)

### DIFF
--- a/train.py
+++ b/train.py
@@ -504,6 +504,9 @@ from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
 ema_decay = 0.998
+swa_model = None
+swa_start_epoch = 55
+swa_n = 0
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -737,6 +740,15 @@ for epoch in range(MAX_EPOCHS):
                 with torch.no_grad():
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+        if epoch >= swa_start_epoch and (epoch - swa_start_epoch) % 3 == 0:
+            if swa_model is None:
+                swa_model = deepcopy(_base_model)
+                swa_n = 1
+            else:
+                swa_n += 1
+                with torch.no_grad():
+                    for sp, mp in zip(swa_model.parameters(), _base_model.parameters()):
+                        sp.data.add_((mp.data - sp.data) / swa_n)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -752,7 +764,7 @@ for epoch in range(MAX_EPOCHS):
     prev_surf_loss = epoch_surf
 
     # --- Validate across all splits ---
-    eval_model = ema_model if ema_model is not None else model
+    eval_model = swa_model if swa_model is not None else (ema_model if ema_model is not None else model)
     eval_model.eval()
     model.eval()
     val_metrics_per_split: dict[str, dict] = {}


### PR DESCRIPTION
## Hypothesis
EMA with exponential decay favors recent weights. SWA averages uniformly from checkpoints, finding wider optima. Starting SWA at epoch 55 (every 3 epochs) complements EMA for flatter minima.

## Instructions
After EMA init (~line 506), add:
```python
swa_model = None
swa_start_epoch = 55
swa_n = 0
```
After EMA update in training loop, add:
```python
if epoch >= swa_start_epoch and (epoch - swa_start_epoch) % 3 == 0:
    if swa_model is None:
        swa_model = deepcopy(_base_model)
        swa_n = 1
    else:
        swa_n += 1
        with torch.no_grad():
            for sp, mp in zip(swa_model.parameters(), _base_model.parameters()):
                sp.data.add_((mp.data - sp.data) / swa_n)
```
Use swa_model for eval when available. Run with `--wandb_group swa-final`.
## Baseline
18 improvements merged. Estimated mean3~23.5-24.0.

Measured baseline `is53rpdt` (frieren/baseline-r10):
- val/loss_3split: 0.9097
- mae_surf_p: in_dist=17.57, ood_cond=14.94, ood_re=28.79, tandem=40.45

---
## Results

**W&B run:** `wplmyfb1` (`senku/swa-final`, group: `swa-final`)
**Epochs:** 70/100 (30-min timeout)
**Peak GPU memory:** 13.1 GB
**Epoch time:** ~26s

### Metrics at best checkpoint (epoch 70)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.632 | 7.877 | 2.259 | 18.44 | 1.210 | 0.400 | 21.11 |
| val_tandem_transfer | 1.669 | 7.387 | 2.543 | 39.33 | 2.017 | 0.914 | 39.57 |
| val_ood_cond | 0.781 | 5.951 | 1.757 | 15.63 | 0.833 | 0.316 | 14.12 |
| val_ood_re | 0.608 | 5.610 | 1.613 | 29.07 | 0.915 | 0.396 | 48.26 |

**val/loss_3split: 0.9223** vs baseline 0.9097 → **+1.4% worse**

### Comparison vs baseline

| Metric | Baseline | SWA | Δ |
|---|---|---|---|
| val/loss_3split | 0.9097 | 0.9223 | +1.4% (worse) |
| mae_surf_p (in_dist) | 17.57 | 18.44 | +5.0% (worse) |
| mae_surf_p (ood_cond) | 14.94 | 15.63 | +4.6% (worse) |
| mae_surf_p (ood_re) | 28.79 | 29.07 | +1.0% (worse) |
| mae_surf_p (tandem) | 40.45 | 39.33 | **-2.8% (better)** |

### What happened
SWA did not help and is slightly worse than baseline. The likely root cause is an implementation mismatch: the SWA update is placed inside the per-batch training loop, so `swa_n` increments ~330 times per epoch (once per batch). By the end of epoch 55 (the first SWA epoch), `swa_n` ≈ 330, which means all subsequent updates contribute negligibly small corrections (`(mp - sp) / 330+`). The SWA model effectively freezes to the model state at the end of epoch 55, rather than uniformly averaging snapshots from epochs 55, 58, 61...

This explains the plateau in val metrics after epoch 55: epochs 56-67 show nearly identical val losses (0.6636→0.6318 over 15 epochs vs 1.25→0.63 in 55 epochs), because eval is using the frozen epoch-55 SWA snapshot, not the improving live model.

Additionally, using SWA for eval while saving EMA for checkpoint creates an inconsistency — what is validated is not what is saved.

### Suggested follow-ups
- Implement per-epoch SWA: move the SWA update outside the batch loop (after `scheduler.step()`), so `swa_n` increments once per eligible epoch, not once per batch
- Alternatively, use `torch.optim.swa_utils.AveragedModel` which handles this correctly
- If per-epoch SWA is tried, also save the SWA model for consistency