### PR TITLE
Seed lottery (seed=137) — test basin diversity

### DIFF
--- a/train.py
+++ b/train.py
@@ -496,6 +496,8 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
+torch.manual_seed(137); torch.cuda.manual_seed_all(137)
+import random; random.seed(137); import numpy as np; np.random.seed(137)
 model = Transolver(**model_config).to(device)
 model = torch.compile(model, mode="reduce-overhead")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model


### PR DESCRIPTION
## Hypothesis
With 21 stacked improvements, a different seed may find a better optimization basin.
## Instructions
Add before model creation:
```python
torch.manual_seed(137); torch.cuda.manual_seed_all(137)
import random; random.seed(137); import numpy as np; np.random.seed(137)
```
Run with `--wandb_group seed-lottery`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.

**Actual baseline (frieren/is53rpdt):** loss3=0.9097, mean3=24.32

---
## Results

**W&B run:** rb4mmdnc (fern/seed-137)
**Epochs:** 74 in 30 min (~24.3s/epoch, same as baseline)
**Best checkpoint:** epoch 74

| Metric | Baseline (is53rpdt) | Seed-137 | Change |
|--------|---------------------|----------|--------|
| val/loss3 | 0.9097 | 0.8982 | -1.3% |
| mean3_surf_p | 24.32 | 24.09 | -0.9% |
| val_in_dist/mae_surf_Ux | 6.18 | 5.97 | -3.4% |
| val_in_dist/mae_surf_p | 17.57 | 17.73 | +0.9% |
| val_ood_cond/mae_surf_Ux | 4.81 | 3.79 | -21% |
| val_ood_cond/mae_surf_p | 14.94 | 14.79 | -1.0% |
| val_tandem_transfer/mae_surf_Ux | 6.24 | 6.19 | -0.8% |
| val_tandem_transfer/mae_surf_p | 40.45 | 39.74 | -1.8% |
| val_ood_re/mae_surf_p | — | 28.49 | — |

**Memory:** same as baseline (identical architecture, no seed overhead)

### What happened

Seed=137 shows a small but consistent improvement over baseline. loss3 improved 1.3% (0.9097→0.8982), mean3_surf_p improved 0.9% (24.32→24.09). Most splits improved slightly, with the notable exception of val_in_dist/mae_surf_p which regressed slightly (+0.16). The large ood_cond/Ux drop (-21%) is surprising for a seed change but could be noise.

The improvement is marginal and a single run can't separate lucky seed from run-to-run variance. Speed is identical (~24.3s/epoch).

Note: initial debug runs crashed (hard-killed mid-startup caused a shape mismatch error). Third run with proper internal timeout completed cleanly at 74 epochs.

### Suggested follow-ups

- **Multi-seed comparison**: Run seeds 0, 42, 137, 1337 to measure true variance. If baseline variance >1%, this is noise; if <0.5%, seed=137 is a real winner.
- **Ensemble**: If different seeds find complementary solutions, a 2-model mean-ensemble could capture gains without longer training.