### PR TITLE
Separate pressure output head (decouple Ux/Uy/p gradients)

### DIFF
--- a/train.py
+++ b/train.py
@@ -197,11 +197,8 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.mlp2_vel = nn.Sequential(nn.Linear(hidden_dim, hidden_dim//2), nn.GELU(), nn.Linear(hidden_dim//2, 2))
+            self.mlp2_p = nn.Sequential(nn.Linear(hidden_dim, hidden_dim//2), nn.GELU(), nn.Linear(hidden_dim//2, 1))
 
     def forward(self, fx, raw_xy=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -212,7 +209,7 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            return torch.cat([self.mlp2_vel(self.ln_3(fx)), self.mlp2_p(self.ln_3(fx))], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Shared output MLP forces velocity and pressure to compete for weights. With pressure-only surface loss, separate heads decouple gradients.
## Instructions
In TransolverBlock.__init__ when last_layer=True, replace mlp2 with:
```python
self.mlp2_vel = nn.Sequential(nn.Linear(hidden_dim, hidden_dim//2), nn.GELU(), nn.Linear(hidden_dim//2, 2))
self.mlp2_p = nn.Sequential(nn.Linear(hidden_dim, hidden_dim//2), nn.GELU(), nn.Linear(hidden_dim//2, 1))
```
In forward: `return torch.cat([self.mlp2_vel(self.ln_3(fx)), self.mlp2_p(self.ln_3(fx))], dim=-1)`
Run with `--wandb_group split-output-head`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.

Actual baseline used: `is53rpdt` (frieren/baseline-r10, val/loss=0.9097)

---
## Results

**W&B run:** `4ev42bjd` — [tanjiro/split-output-head](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/4ev42bjd)

**W&B group:** split-output-head

**Training:** 67 epochs (30 min timeout), best checkpoint at epoch 67.

**Peak memory:** ~78.2 GB (81.4% of 96 GB) vs baseline ~62.1 GB (+16 GB).

### Metrics vs Baseline

| Split | Metric | Baseline | Split-Head | Delta |
|---|---|---|---|---|
| val_in_dist | loss | 0.5884 | 0.6032 | +0.015 |
| val_in_dist | surf Ux MAE | 6.18 | 4.55 | **-1.64** |
| val_in_dist | surf Uy MAE | 1.65 | 1.08 | **-0.57** |
| val_in_dist | surf p MAE | 17.57 | 18.02 | +0.45 |
| val_tandem_transfer | loss | 1.6825 | 1.6496 | **-0.033** |
| val_tandem_transfer | surf Ux MAE | 6.24 | 5.55 | **-0.68** |
| val_tandem_transfer | surf Uy MAE | 2.09 | 1.84 | **-0.25** |
| val_tandem_transfer | surf p MAE | 40.45 | 39.25 | **-1.20** |
| val_tandem_transfer | vol p MAE | 41.08 | 39.67 | **-1.41** |
| val_ood_cond | loss | 0.7696 | 0.7553 | **-0.014** |
| val_ood_cond | surf Ux MAE | 4.81 | 4.01 | **-0.80** |
| val_ood_cond | surf p MAE | 14.94 | 14.76 | **-0.18** |
| val_ood_re | loss | 0.5982 | 0.5767 | **-0.022** |
| val_ood_re | surf p MAE | 28.79 | 28.13 | **-0.66** |
| **combined** | **val/loss** | **0.9097** | **0.8962** | **-0.0135** |

### What happened

**Worked well — clear improvement on all OOD and tandem splits, only slight regression on val_in_dist.**

The overall val/loss improved from 0.9097 → 0.8962 (-0.0135). The split head theory is validated: decoupling pressure and velocity gradients helps the model learn both better.

Key findings:
- **Surface velocity improved dramatically** across all splits (Ux: -1.6 on val_in_dist, -0.7 on tandem_transfer, -0.8 on ood_cond). With a shared head and pressure-only surface loss, the velocity pathway was being co-opted by the pressure optimization — the split head frees this.
- **Tandem transfer pressure improved**: 40.45 → 39.25 (-1.20). This is meaningful.
- **OOD Re pressure improved**: 28.79 → 28.13 (-0.66).
- **In-dist pressure regressed slightly**: 17.57 → 18.02 (+0.45). The in-distribution regime may have benefited from the shared representation somewhat.
- **Memory cost**: +16 GB over baseline (78 GB total). Acceptable but non-trivial.

Overall this is a positive result — the hypothesis that separate heads decouple gradient competition is confirmed. The consistent improvement on transfer/OOD splits suggests better generalization.

### Suggested follow-ups

1. **Narrower velocity head**: `mlp2_vel` could be even smaller (hidden_dim//4 instead of //2) since velocity is less complex to model in this domain.
2. **Shared trunk, split late**: Try sharing the first linear layer and only splitting at the final projection — reduces parameter count while still decoupling final gradients.
3. **Three separate heads (Ux, Uy, p)**: Fully decouple all three output fields.
4. **Check memory**: The +16 GB increase is significant. If memory is the bottleneck for future experiments, consider whether this is worth keeping.