### PR TITLE
Boundary-type positional encoding (learned embedding for node types)

### DIFF
--- a/train.py
+++ b/train.py
@@ -289,6 +289,7 @@ class Transolver(nn.Module):
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0]))
+        self.boundary_embed = nn.Embedding(2, 8)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -485,7 +486,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 1 + 32 + 8,  # 8 freqs * 2 coords * 2 (sin+cos) = 32, + 8 boundary embed
     out_dim=3,
     n_hidden=192,  # was 160
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -630,7 +631,8 @@ for epoch in range(MAX_EPOCHS):
         freqs = model.fourier_freqs.abs()
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
-        x = torch.cat([x, fourier_pe], dim=-1)
+        boundary_emb = _base_model.boundary_embed(is_surface.long())
+        x = torch.cat([x, fourier_pe, boundary_emb], dim=-1)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -795,7 +797,8 @@ for epoch in range(MAX_EPOCHS):
                 freqs = model.fourier_freqs.abs()
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
-                x = torch.cat([x, fourier_pe], dim=-1)
+                boundary_emb = _base_model.boundary_embed(is_surface.long())
+                x = torch.cat([x, fourier_pe, boundary_emb], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
is_surface (1 bit) discards richer boundary info. An 8-dim learned embedding for surface vs volume nodes adds free geometric signal.
## Instructions
Add `self.boundary_embed = nn.Embedding(2, 8)` in Transolver.__init__. In training/val, create boundary type from is_surface: `boundary_emb = model.boundary_embed(is_surface.long())`, concat to x. Update fun_dim += 8.
Run with `--wandb_group boundary-embed`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.
---
## Results

**W&B run:** `uab0v0m8`
**Best epoch:** 69 / 69 (hit wall-clock limit at 30.3 min, 26s/epoch)
**Peak memory:** 12.4 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6236 | 5.94 | 1.61 | 18.89 | 1.18 | 0.40 | 21.03 |
| val_tandem_transfer | 1.6283 | 6.45 | 2.09 | 38.62 | 2.01 | 0.91 | 38.35 |
| val_ood_cond | 0.7652 | 4.16 | 1.05 | 14.81 | 0.82 | 0.30 | 13.30 |
| val_ood_re | 0.5974 | 3.77 | 0.89 | 28.70 | 0.91 | 0.39 | 47.84 |
| **mean3** | **0.939** | **5.52** | **1.58** | **24.11** | — | — | — |

Baseline estimated at mean3_surf_p ~23.0–23.3.

**What happened:** Negative result — mean3_surf_p=24.11 is ~0.8–1.1 units worse than baseline. The boundary embedding adds no useful signal. Likely reasons: (1) the model already encodes surface/volume identity implicitly through the `curv` feature (curvature proxy = 0 for volume nodes, nonzero for surface), so the boundary embedding is redundant; (2) the extra input dimension slightly increases the model's effective complexity without a corresponding increase in training budget — we got only 69 epochs vs ~73-76 for the baseline due to torch.compile recompilation overhead. The 16-parameter embedding adds almost zero capacity but disrupts learned representations.

**Suggested follow-ups:**
- If the goal is richer boundary signal, try appending `is_surface.float().unsqueeze(-1)` as an explicit scalar feature (1 channel, no embedding) — the curvature proxy may already do this, but an explicit flag might be more direct.
- A multi-class boundary encoding (surface/near-surface/volume based on SDF distance) might be more informative than binary — volume nodes near the surface have different flow characteristics.