### PR TITLE
Cosine warm restart at epoch 55 (two-phase learning)

### DIFF
--- a/train.py
+++ b/train.py
@@ -544,7 +544,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=45, T_mult=1, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
After T_max=62, the LR is near zero for the last 10 epochs. A warm restart at epoch 55 with smaller peak LR gives a second optimization phase.
## Instructions
Replace cosine scheduler with: `CosineAnnealingWarmRestarts(base_opt, T_0=45, T_mult=1, eta_min=5e-5)`
Keep warmup 10 epochs with milestones=[10]. Run with `--wandb_group warm-restart-v2`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.
---
## Results

**W&B run:** `b43kfw8a` (thorfinn/warm-restart-v2)  
**Epochs:** 72 | **Runtime:** 32 min (30-min cap)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.7639 | 7.72 | 1.94 | 23.35 | 1.315 | 0.444 | 25.64 |
| val_tandem_transfer | 1.7368 | 7.35 | 2.45 | 41.36 | 2.066 | 0.937 | 41.23 |
| val_ood_cond | 0.9292 | 5.28 | 1.37 | 19.26 | 0.887 | 0.337 | 16.19 |
| val_ood_re | 0.7031 | 4.90 | 1.21 | 31.11 | 0.966 | 0.420 | 49.52 |
| **4-split avg** | **1.0333** | | | **28.77** | | | |
| mean3_surf_p | | | | **27.99** | | | |

**Baseline-r11 (same branch, no warm restart):** 3split=0.900, mean3_surf_p=23.99

### vs Baseline
- **val/loss_3split: 1.033 vs baseline 0.900 → +14.8% WORSE**
- **mean3_surf_p: 27.99 vs baseline 23.99 → +16.7% WORSE**

### What happened

Clear negative result. The warm restart at T_0=45 hurts both the overall loss and surface pressure accuracy.

**Why it fails:** With Lookahead (k=10) + EMA (start=epoch 40, decay=0.998), the optimization is already heavily regularized. A warm restart at epoch 45 raises the LR sharply at a point when:
1. EMA has been smoothing parameters for ~5 epochs — the restart disrupts EMA convergence
2. Lookahead's slow weights are well-settled — the restart causes them to chase bad fast-weight checkpoints
3. The adaptive tandem boost is tracking running losses — a LR spike changes the loss landscape and corrupts these estimates

The single cosine annealing schedule (T_max=62) with low final LR allows the EMA to compound smoothly into the final checkpoint. The warm restart interrupts this final convergence phase.

### Suggested follow-ups
- The hypothesis that "LR near zero for last 10 epochs is wasteful" may be wrong — those final epochs are when EMA provides the most benefit
- If restarts are desired, try a very gentle restart (peak LR ~3e-4 instead of 3e-3) to avoid disrupting EMA
- Or use SWA-style averaging without actually changing the LR
