### PR TITLE
Per-slice output projection (slice-specialized decoding)

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,6 +124,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.slice_scale = nn.Parameter(torch.ones(1, 1, slice_num, dim_head))
+        self.slice_shift = nn.Parameter(torch.zeros(1, 1, slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None):
         bsz, num_points, _ = x.shape
@@ -158,6 +160,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
         out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
+        out_slice_token = out_slice_token * self.slice_scale + self.slice_shift
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")


### PR DESCRIPTION
## Hypothesis
Each of 32 slices represents a different physical region. Per-slice learned scale+shift before output MLP lets each specialize.
## Instructions
In Physics_Attention_Irregular_Mesh.__init__: `self.slice_scale = nn.Parameter(torch.ones(1,1,slice_num,dim_head)); self.slice_shift = nn.Parameter(torch.zeros(1,1,slice_num,dim_head))`
In forward, after out_slice_token before unmixing: `out_slice_token = out_slice_token * self.slice_scale + self.slice_shift`
Run with `--wandb_group slice-specialized`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.
---
## Results

**W&B run:** `9n0rvf9q`
**Epochs:** ~70/100 (hit 30-min timeout at ~1755s, ~25s/epoch)
**Peak memory:** 12.2 GB (unchanged)

| Metric | This run | Baseline (est.) |
|---|---|---|
| val/loss (last, 3-split) | 0.9055 | ~0.90 (est.) |
| val_in_dist/mae_surf_p | 18.83 | — |
| val_ood_cond/mae_surf_p | 14.96 | — |
| val_ood_re/mae_surf_p | 28.70 | — |
| val_tandem_transfer/mae_surf_p | 39.60 | — |
| **mean3_surf_p** | **20.83** | **~23.0–23.3 (est.)** |

### What happened

val/loss=0.9055 and mean3_surf_p=20.83 are slightly worse than the comparable tmax-align-72 run (0.9051 / 20.54) run on the same 21-improvement branch. The difference is minimal (~0.3% val/loss, 1.4% mean3_surf_p), suggesting the per-slice scale+shift provides no measurable improvement.

The per-slice learned scale+shift adds only ~3072 parameters (2 × 1×1×32×48 for slice_num=32, dim_head=48) — very lightweight. The neutral result is likely because the existing `slice_residual_scale` and attention mechanics already provide adequate per-slice adaptation. The parameters may be initializing to identity (ones/zeros) and not learning to diverge meaningfully within 70 epochs.

**No `best_val_loss` logged** — timed out before EMA checkpoint summary was written.

### Suggested follow-ups

- **Per-head separate scales**: Use shape (1, heads, slice_num, dim_head) instead of (1, 1, slice_num, dim_head) to allow head-specific specialization.
- **After unmixing instead**: Apply scale/shift per-node after the scatter-back (out_x) rather than per-slice, which may provide more targeted node-level specialization.
- **Longer training**: With 70 epochs, the scale/shift parameters may not have enough time to differentiate from identity — a longer run might show more benefit.