### PR TITLE
Gradient-stopped volume after epoch 40 (full surface focus in late training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -691,6 +691,8 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        if epoch >= 40:
+            vol_loss = vol_loss.detach()
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss


### PR DESCRIPTION
## Hypothesis
In late training, volume predictions are good. Detaching vol_loss removes volume gradient from shared params, letting surface dominate EMA phase.
## Instructions
After vol_loss computation (~line 693): `if epoch >= 40: vol_loss = vol_loss.detach()`
Run with `--wandb_group vol-detach-late`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.
---
## Results

**W&B run:** `6ewwm6q5` (gilbert/vol-detach-late)
**Epochs:** 73 / 100 (30-min timeout)
**Peak memory:** 12.2 GB
**Baseline:** `frieren/baseline-r11` (2yrgvqga)

### Metrics

| Split | val/loss | surf p |
|---|---|---|
| val_in_dist | 0.669 | 18.38 |
| val_ood_cond | 0.802 | 14.99 |
| val_tandem_transfer | 1.716 | 39.20 |
| val_ood_re | 0.646 | 28.83 |
| **4-split mean** | **0.958** | **mean3: 24.19** |

### Comparison to baseline (`frieren/baseline-r11`)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| 4-split val/loss | 0.900 | 0.958 | **+0.058 (+6.4%) WORSE** |
| mean3 surf_p | 23.99 | 24.19 | **+0.20 (+0.8%) WORSE** |

### What happened

Negative result. Detaching vol_loss after epoch 40 hurt both val/loss and surface pressure.

The intuition was that volume accuracy is already good by epoch 40, so removing its gradient would "free" the model to focus on surface pressure. In practice the opposite happened: without volume gradients in late training, shared model parameters degrade on volume accuracy, which also degrades surface prediction (the model shares all representation layers). The 6.4% increase in val/loss reflects this vol_loss degradation propagating back through evaluation metrics.

Surface pressure mean3 also slightly worsened (+0.20), meaning the freed gradient capacity did not translate to better surface learning — likely because the coarse pooling and other auxiliary losses already do this balancing.

### Suggested follow-ups

- **Soft volume freeze instead of detach:** Use `vol_loss * 0.1` after epoch 40 instead of detach, which reduces but does not zero volume gradients.
- **Surface-only loss boost in late training:** Rather than removing vol gradients, try increasing surf_weight from 5 to 10 after epoch 40 to rebalance without discarding volume information.
- **Detach after epoch 60:** If epoch 40 is too early (volume may not yet be converged), try epoch 60 when fewer new-checkpoint epochs remain.