### PR TITLE
Asymmetric Lookahead (k=5 attn, k=10 rest)

### DIFF
--- a/train.py
+++ b/train.py
@@ -509,10 +509,14 @@ n_params = sum(p.numel() for p in model.parameters())
 
 
 class Lookahead:
-    def __init__(self, base_optimizer, k=5, alpha=0.5):
+    def __init__(self, base_optimizer, k=5, alpha=0.5, k_list=None):
         self.base_optimizer = base_optimizer
-        self.k = k
         self.alpha = alpha
+        n_groups = len(base_optimizer.param_groups)
+        if k_list is not None:
+            self.k_list = k_list
+        else:
+            self.k_list = [k] * n_groups
         self.slow_params = [
             [p.data.clone() for p in group['params']]
             for group in base_optimizer.param_groups
@@ -522,8 +526,8 @@ class Lookahead:
     def step(self):
         self.base_optimizer.step()
         self.step_count += 1
-        if self.step_count % self.k == 0:
-            for slow, group in zip(self.slow_params, self.base_optimizer.param_groups):
+        for k_i, slow, group in zip(self.k_list, self.slow_params, self.base_optimizer.param_groups):
+            if self.step_count % k_i == 0:
                 for s, p in zip(slow, group['params']):
                     s.data.add_(self.alpha * (p.data - s.data))
                     p.data.copy_(s.data)
@@ -542,7 +546,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, alpha=0.8, k_list=[5, 10])
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Attention params have 0.5x LR but same Lookahead k=10. k=5 for attention gives faster slow-weight sync relative to its optimization trajectory.
## Instructions
Modify Lookahead to accept per-group k values: `k_list=[5, 10]` (group 0=attn k=5, group 1=rest k=10). Sync each group at its own rate.
Run with `--wandb_group asymmetric-lookahead`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.

Measured baseline `2yrgvqga` (frieren/baseline-r11, ~72 epochs):
- val/loss_3split: 0.9003
- mae_surf_p: in_dist=18.76, ood_cond=14.61, ood_re=28.76, tandem=38.61

---
## Results

**W&B run:** `i6sng6dn` (`senku/asymmetric-lookahead`, group: `asymmetric-lookahead`)
**Epochs:** ~70 (30-min timeout)
**Peak GPU memory:** 13.1 GB
**Epoch time:** ~26s

### Metrics at best checkpoint (epoch 70)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 0.6105 | 5.560 | 1.856 | 18.78 | 20.47 |
| val_tandem_transfer | 1.6531 | 6.185 | 2.427 | 39.03 | 38.94 |
| val_ood_cond | 0.7474 | 3.758 | 1.315 | 14.65 | 13.24 |
| val_ood_re | 0.5833 | 3.323 | 1.165 | 28.47 | 47.65 |

**val/loss_3split: 0.8986** vs baseline 0.9003 → **-0.2% (marginal improvement, within noise)**

### Comparison vs baseline

| Metric | Baseline | Asymm. Lookahead | Δ |
|---|---|---|---|
| val/loss_3split | 0.9003 | 0.8986 | -0.2% |
| mae_surf_p (in_dist) | 18.76 | 18.78 | +0.1% (neutral) |
| mae_surf_p (ood_cond) | 14.61 | 14.65 | +0.3% (neutral) |
| mae_surf_p (ood_re) | 28.76 | 28.47 | -1.0% (slight gain) |
| mae_surf_p (tandem) | 38.61 | 39.03 | +1.1% (slight loss) |
| mae_surf_Ux (ood_cond) | 4.69 | 3.76 | **-19.8%** (velocity improvement) |
| mae_surf_Ux (ood_re) | 4.48 | 3.32 | **-25.9%** (velocity improvement) |

### What happened
The overall result is essentially neutral (0.8986 vs 0.9003, within run-to-run noise). The surface pressure MAE changes are mixed and small. The most interesting signal is a notable improvement in velocity field accuracy on the OOD splits (surf_Ux -20% to -26% on ood_cond and ood_re), which suggests attention params do benefit from faster slow-weight sync for generalization. However, this does not translate to an improvement in the headline metric (val/loss_3split) or surface pressure.

The asymmetric k values (k=5 for attention, k=10 for rest) work correctly — the Lookahead class now syncs each param group independently at its own rate.

### Suggested follow-ups
- Try k_list=[3, 10] — even faster attention sync
- The velocity improvement on OOD splits is interesting; it may matter more if the loss weighting emphasized Ux/Uy over p more strongly
- This is a clean, small change worth keeping if the baseline noise floor turns out to favor it upon longer runs