### PR TITLE
Paired-foil swap augmentation (double tandem diversity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -617,6 +617,13 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
+        # Foil-swap augmentation: randomly swap foil identities for tandem samples
+        is_tandem_aug = x[:, 0, 22].abs() > 0.5
+        swap_mask = is_tandem_aug & (torch.rand(x.shape[0], device=device) > 0.5)
+        if swap_mask.any():
+            tmp = x[swap_mask, :, 14].clone(); x[swap_mask, :, 14] = x[swap_mask, :, 18]; x[swap_mask, :, 18] = tmp
+            tmp = x[swap_mask, :, 15:18].clone(); x[swap_mask, :, 15:18] = x[swap_mask, :, 19:22]; x[swap_mask, :, 19:22] = tmp
+
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)


### PR DESCRIPTION
## Hypothesis
Physics is approximately symmetric under foil relabeling. Randomly swapping foil identities (AoA, NACA, negate gap) for 50% of tandem samples doubles effective tandem diversity. Directly targets tandem gap.
## Instructions
In training loop, after loading x, before normalization:
\`\`\`python
is_tandem_aug = x[:, 0, 22].abs() > 0.5
swap_mask = is_tandem_aug & (torch.rand(x.shape[0], device=device) > 0.5)
if swap_mask.any():
    tmp = x[swap_mask, :, 14].clone(); x[swap_mask, :, 14] = x[swap_mask, :, 18]; x[swap_mask, :, 18] = tmp
    tmp = x[swap_mask, :, 15:18].clone(); x[swap_mask, :, 15:18] = x[swap_mask, :, 19:22]; x[swap_mask, :, 19:22] = tmp
\`\`\`
Run with \`--wandb_group foil-swap-aug\`.
## Baseline
21 improvements merged. Last measured mean3=24.3 (before 3 new merges). Estimated ~23.0-23.3.
---
## Results

**W&B run:** htd53sbx
**Best epoch:** 70 (stopped by 30-min wall clock; still improving)
**Peak GPU memory:** 12.2 GB

### Metrics at best checkpoint (epoch 70)

| Split | Loss | Surf Ux MAE | Surf Uy MAE | Surf p MAE | Vol Ux MAE | Vol p MAE |
|---|---|---|---|---|---|---|
| val_in_dist | 0.6203 | 5.719 | 1.401 | 19.09 | 1.166 | 21.46 |
| val_ood_cond | 0.8628 | 4.226 | 1.059 | 16.72 | 0.856 | 15.13 |
| val_ood_re | 0.6495 | 3.806 | 0.879 | 29.86 | 0.916 | 48.82 |
| val_tandem_transfer | 1.6749 | 5.995 | 1.975 | 39.63 | 2.014 | 40.09 |

**surf_p mean3 (in_dist + ood_cond + ood_re):** (19.09 + 16.72 + 29.86) / 3 = **21.89**
vs baseline estimate 23.0–23.3 → **~1.1–1.4 unit improvement (~5-6%)**

### What happened

The foil-swap augmentation shows a modest positive effect on surf_p. **mean3 = 21.89 vs estimated baseline 23.0–23.3**. The model trained stably with all epochs improving (`*` on all epochs through 70), suggesting the augmentation doesn't confuse training.

The augmentation was applied only to training data (not validation), which is correct. With ~210/1322 tandem training samples (~16%), roughly 105 samples per epoch get swapped on average, providing moderate diversity boost.

**Note on surf_Ux/Uy:** Large velocity MAE on surface (6x baseline) is the pre-existing effect of pressure-only surf_loss (#1116) — not caused by this change.

**val_tandem_transfer surf_p = 39.63** — slightly worse than other recent runs (~39.0-39.2), suggesting the swap augmentation may not perfectly represent the true tandem symmetry. The foil swap may not be a perfect symmetry (e.g., gap sign conventions, which foil is "upstream" in the tandem pair).

### Suggested follow-ups

- Investigate if the swap should also negate the gap sign (column 22?) to maintain physical consistency
- Try a harder tandem augmentation: apply swap + negate gap simultaneously rather than just swapping foil features
- Combine with pressure_skip (from prior PR) as both target the hardest metrics