### PR TITLE
Wavelet-Fourier PE: 4 fixed log-spaced + 4 learnable frequencies

### DIFF
--- a/train.py
+++ b/train.py
@@ -288,7 +288,8 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
-        self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0]))
+        self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
+        self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -627,7 +628,7 @@ for epoch in range(MAX_EPOCHS):
         xy_min = raw_xy.amin(dim=1, keepdim=True)
         xy_max = raw_xy.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-        freqs = model.fourier_freqs.abs()
+        freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
@@ -792,7 +793,7 @@ for epoch in range(MAX_EPOCHS):
                 xy_min = raw_xy.amin(dim=1, keepdim=True)
                 xy_max = raw_xy.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = model.fourier_freqs.abs()
+                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
@@ -897,7 +898,7 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
-    learned_freqs = model.fourier_freqs.abs().detach().cpu().tolist()
+    learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f
     wandb.log(metrics)


### PR DESCRIPTION
## Hypothesis
Proven -3.2% on old code (mean3=23.5, re=27.6 best ever!). Never tested on current 21-improvement code. Fixed log-spaced [0.5,2,8,32] guarantees multi-scale coverage.
## Instructions
Replace fourier_freqs init with two tensors:
```python
self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
```
Replace `model.fourier_freqs.abs()` everywhere with:
```python
freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
```
Keep fun_dim unchanged (8 freqs = 32 PE features). Run with `--wandb_group wavelet-pe-r12`.
## Baseline (21 improvements, Round 11 measured)
- val_loss = 0.9003, mean3_surf_p = 24.0
- in=18.8, ood=14.6, re=28.8, tan=38.6
---
## Results

**W&B run:** 58vxzcot
**Epochs completed:** 63 / 100 (30-min timeout, ~24.6s/epoch)

### Best checkpoint metrics (min val/loss)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.5859 | 6.49 | 1.38 | **17.69** | 1.14 | 0.38 | 19.72 |
| val_ood_cond | 0.7260 | 3.96 | 1.12 | **14.32** | 0.80 | 0.29 | 12.88 |
| val_ood_re | 0.5825 | 3.58 | 0.94 | **28.49** | 0.89 | 0.38 | 47.46 |
| val_tandem_transfer | 1.6424 | 6.19 | 1.84 | 38.59 | 1.96 | 0.88 | 38.65 |

**Overall val/loss (3-split): 0.8842**
**mean3 surf_p: 20.16**

### Comparison vs. baseline-r11 (2yrgvqga, 21 improvements)

| Metric | Baseline-r11 | Wavelet-PE | Delta |
|--------|-------------|------------|-------|
| val/loss | 0.9003 | 0.8842 | **-0.0161 (better)** |
| mean3 surf_p | 20.71 | 20.16 | **-0.55 (better)** |
| in-dist surf_p | 18.76 | 17.69 | **-1.07 (better)** |
| ood_cond surf_p | 14.61 | 14.32 | **-0.29 (better)** |
| ood_re surf_p | 28.76 | 28.49 | **-0.27 (better)** |
| tandem surf_p | 38.61 | 38.59 | ~same |
| vol_Ux (in-dist) | 1.16 | 1.14 | -0.02 (better) |

**All splits improved.** This is a clear win.

### Final learned frequencies
The 4 learnable freqs adapted from init [1.0, 3.0, 6.0, 16.0] to: **1.46, 3.18, 6.25, 16.10** — they barely moved from initialization, suggesting the init values were already well-placed. The fixed freqs [0.5, 2.0, 8.0, 32.0] fill in the gaps nicely.

### What happened

Fixing 4 log-spaced frequencies guarantees multi-scale coverage that pure learning might miss (learning can collapse frequencies or fail to reach the right scales). The hybrid approach — fixed structural anchors + learnable fine-tuning — gives consistently better results across all splits. in-dist surf_p shows the biggest gain (-1.07).

### Suggested follow-ups

- Test with more fixed freqs (e.g., 6 fixed + 2 learnable) to see if more coverage helps
- Try higher fixed frequencies (e.g., include 64.0) given the geometry might have fine features
- The learned freqs barely moved from init — consider removing the learnable component entirely and just using fixed log-spaced freqs (simpler)