### PR TITLE
Curriculum hard-example mining (focus on worst 30% surface nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -676,6 +676,18 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
+        # Curriculum: after epoch 30, amplify hardest 30% of surface nodes by 2x
+        if epoch >= 30:
+            surf_p_err = abs_err[:, :, 2]  # pressure error [B, N]
+            hard_weight = torch.ones(surf_mask.shape[0], surf_mask.shape[1], device=device)
+            for b in range(surf_mask.shape[0]):
+                s_errs = surf_p_err[b][surf_mask[b]]
+                if s_errs.numel() > 1:
+                    threshold = s_errs.quantile(0.70)
+                    is_hard = surf_mask[b] & (surf_p_err[b] >= threshold)
+                    hard_weight[b] = torch.where(is_hard, hard_weight[b].new_full((), 2.0), hard_weight[b])
+            abs_err = abs_err * hard_weight.unsqueeze(-1)
+
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
         if epoch < 40:


### PR DESCRIPTION
## Hypothesis
After epoch 30, amplify loss on the hardest 30% of surface nodes by 2x. Progressive curriculum focuses late EMA phase on the nodes that dominate MAE.
## Instructions
After surf_err computation, for epoch>=30: compute per-sample top-30% threshold, multiply abs_err for those nodes by 2.0. Run with `--wandb_group curriculum-hard-nodes`.
## Baseline (21 improvements, Round 11 measured)
- val_loss = 0.9003, mean3_surf_p = 24.0
- in=18.8, ood=14.6, re=28.8, tan=38.6

Actual baseline run: `2yrgvqga` (frieren/baseline-r11, val/loss=0.9003)

---
## Results

**W&B run:** `etz6awf0` — [tanjiro/curriculum-hard-nodes](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/etz6awf0)

**W&B group:** curriculum-hard-nodes

**Training:** 68 epochs (30 min timeout), best checkpoint at epoch 68.

**Peak memory:** ~79.6 GB (82.9% of 96 GB) — same as baseline (no extra params).

### Metrics vs Baseline

| Split | Metric | Baseline | Curriculum | Delta |
|---|---|---|---|---|
| val_in_dist | loss | 0.6203 | 0.6330 | +0.013 |
| val_in_dist | surf p MAE | 18.76 | 18.42 | **-0.34** |
| val_in_dist | vol p MAE | 20.89 | 22.27 | +1.38 |
| val_tandem_transfer | loss | 1.6411 | 1.6811 | +0.040 |
| val_tandem_transfer | surf p MAE | 38.61 | 40.19 | **+1.58** |
| val_tandem_transfer | vol p MAE | 38.74 | 40.60 | +1.86 |
| val_ood_cond | loss | 0.7450 | 0.7227 | **-0.022** |
| val_ood_cond | surf p MAE | 14.61 | 13.81 | **-0.80** |
| val_ood_re | loss | 0.5947 | 0.5812 | **-0.014** |
| val_ood_re | surf p MAE | 28.76 | 28.17 | **-0.59** |
| **combined** | **val/loss** | **0.9003** | **0.9045** | **+0.0042** |

### What happened

**Split result: OOD improved, tandem degraded, net slightly worse.**

The curriculum mining helped OOD splits significantly (ood_cond surf_p: -0.80, ood_re surf_p: -0.59) but hurt the tandem transfer split badly (+1.58 on surf_p). The in-distribution split also got slightly worse on volume (+1.38 on vol_p) despite slight improvement on surface pressure.

**Why the split behavior?** The hard-node 2x amplification seems to work differently across flow regimes:
- **Non-tandem (OOD) flows**: Hard nodes are genuine outliers that benefit from extra emphasis. Amplifying them helps the model focus on the trickiest regions.
- **Tandem flows**: Hard nodes are systematically large-error nodes (tandem pressure is inherently harder). Amplifying them 2x creates very large gradients that destabilize training for the tandem regime specifically.

The tandem cases already have `adaptive_boost` applied (1x–4x based on running loss ratio), so adding 2x on top of tandem hard nodes creates excessively large loss contributions.

**Verdict: Does not help** — the improvement on OOD is not worth the degradation on tandem transfer.

### Suggested follow-ups

1. **Exclude tandem from hard-node curriculum**: Only apply the 2x amplification to non-tandem samples (`~is_tandem_batch`), since tandem already gets boosted by the adaptive_boost mechanism.
2. **Softer amplification (1.5x instead of 2x)**: The 2x multiplier may be too aggressive; try a gentler curriculum.
3. **Later start (epoch 50 instead of 30)**: The EMA checkpoint starts providing stable guidance later; maybe the curriculum should start after EMA stabilizes.
4. **Hard-node selection by relative percentile**: Instead of top-30%, use nodes exceeding 2x the mean error for that sample — this is more adaptive to sample difficulty.