### PR TITLE
Gradient-weighted surface loss (weight by dp/ds magnitude)

### DIFF
--- a/train.py
+++ b/train.py
@@ -692,7 +692,26 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        if epoch >= 5:
+            grad_weights = torch.ones(B, abs_err.shape[1], device=device)
+            for b in range(B):
+                s_mask = surf_mask[b]
+                if s_mask.sum() < 2:
+                    continue
+                s_idx = s_mask.nonzero(as_tuple=True)[0]
+                s_x = raw_xy[b, s_idx, 0]
+                s_p = y_phys[b, s_idx, 2]
+                sort_order = s_x.argsort()
+                s_p_sorted = s_p[sort_order]
+                dp = torch.diff(s_p_sorted)
+                grad_mag = torch.cat([dp.abs(), dp[-1:].abs()])
+                unsort = sort_order.argsort()
+                grad_mag = grad_mag[unsort]
+                mean_grad = grad_mag.mean().clamp(min=1e-8)
+                grad_weights[b, s_idx] = 1.0 + 2.0 * grad_mag / mean_grad
+            surf_per_sample = (abs_err[:, :, 2] * surf_mask.float() * grad_weights).sum(dim=1) / surf_mask.sum(dim=1).clamp(min=1).float()
+        else:
+            surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err


### PR DESCRIPTION
## Hypothesis
Physics-informed: regions with high dp/ds (leading edge, suction peak) matter more for integrated forces. Weight surface loss by local pressure gradient magnitude from ground truth.
## Instructions
Compute pressure gradient along x-sorted surface nodes. Use gradient magnitude as loss weight: `weight = 1 + 2 * grad / mean(grad)`. Apply from epoch 5. Run with `--wandb_group gradient-weighted-surf`.
## Baseline (21 improvements, Round 11 measured)
- val_loss = 0.9003, mean3_surf_p = 24.0
- in=18.8, ood=14.6, re=28.8, tan=38.6
---
## Results

**W&B run**: `jhreogsi` | **Epochs**: 73 | **Peak memory**: 12.2 GB

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss_3split | 0.9003 | 1.1049 | **+22.8%** ❌ |
| mean3_surf_p | 24.0 | 26.87 | **+11.9%** ❌ |
| val_in_dist/mae_surf_p | 18.8 | 20.22 | +7.6% |
| val_ood_cond/mae_surf_p | 14.6 | 18.43 | +26.2% |
| val_ood_re/mae_surf_p | 28.8 | 30.85 | +7.1% |
| val_tandem_transfer/mae_surf_p | 38.6 | 41.97 | +8.7% |

**Full surface MAE**:
- val_in_dist: Ux=8.77, Uy=2.66, p=20.22
- val_tandem_transfer: Ux=8.15, Uy=3.14, p=41.97
- val_ood_cond: Ux=6.75, Uy=2.03, p=18.43
- val_ood_re: Ux=6.56, Uy=1.81, p=30.85

### What happened

**Negative result**: Gradient-weighted surface loss made things worse on all splits. val/loss is +22.8% above baseline and mean3_surf_p degrades by ~12%.

The core problem is the x-coordinate sort approximation. Airfoil surfaces have two sides (upper and lower) with heavily overlapping x-coordinates. When surface nodes are sorted by x, the sorted order interleaves upper and lower surface at each chord station, producing large pressure jumps at those interleaving points that have nothing to do with real dp/ds along the arc. The computed `grad_mag` is therefore noise-dominated, not geometry-dominated.

Additionally, `1 + 2 * grad/mean` allows weights 10–20× the mean at the stagnation point (where dp/ds truly is extreme). These extreme weights make the loss landscape sharp around a few nodes and destabilize convergence, especially for OOD splits. The `ood_cond` split hurt the most (+26.2%), suggesting overfitting to in-distribution pressure patterns at high-gradient nodes.

### Suggested follow-ups

1. **Fix arc-length sort**: Compute cumulative `sqrt(dx² + dy²)` along surface nodes and sort by that, handling upper/lower surface separately. This gives a correct dp/ds.
2. **Cap the weights**: `min(1 + 2 * grad/mean, 4.0)` to prevent extreme upweighting at stagnation.
3. **Softer weighting**: Use `1 + 0.5 * grad/mean` instead of `1 + 2 *` to reduce the destabilizing effect while still providing signal.
4. **Start later**: Apply gradient weighting from epoch 20+ rather than 5, after the model has learned the basic pressure field shape and the weights become more meaningful.
