### PR TITLE
Input feature augmentation (Gaussian noise on geometric descriptors)

### DIFF
--- a/train.py
+++ b/train.py
@@ -631,6 +631,9 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
+        if model.training and epoch < 60:
+            noise_scale = 0.05 * (1 - epoch / 60)
+            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Noise on input features (saf, dsdf, not coords) regularizes feature extraction. Annealed from 0.05 to 0 over 60 epochs.
## Instructions
After normalization, add noise to features 2:25 (not coords or Fourier PE): `x[:,:,2:25] += noise_scale * randn`. Run with `--wandb_group input-feat-augment`.
## Baseline (21 improvements, Round 11 measured)
- val_loss = 0.9003, mean3_surf_p = 24.0
- in=18.8, ood=14.6, re=28.8, tan=38.6
---
## Results

W&B run: `g56zo1a8` | Peak memory: 12.2 GB | 72 epochs (~30 min)

Baseline: `2yrgvqga` (frieren/baseline-r11, 21 improvements)

**Slight positive result.** Most splits improve modestly; tandem essentially unchanged.

### Val/loss by split

| Split | Experiment | Baseline (2yrgvqga) | Delta |
|---|---|---|---|
| val_in_dist | **0.6009** | 0.6203 | -3.1% |
| val_tandem_transfer | 1.6376 | 1.6411 | -0.2% (unchanged) |
| val_ood_cond | **0.7238** | 0.7450 | -2.8% |
| val_ood_re | **0.5799** | 0.5947 | -2.5% |
| **3-split avg** | **0.9874** | 1.0021 | **-1.5%** |

### Surface pressure MAE (mean3)

| Split | Experiment | Baseline | Delta |
|---|---|---|---|
| in_dist | **17.98** | 18.76 | -4.2% |
| tandem | 39.14 | 38.61 | +1.4% |
| ood_cond | **14.35** | 14.61 | -1.8% |
| ood_re | **28.45** | 28.76 | -1.1% |
| **mean3** | **23.82** | 23.99 | **-0.7%** |

### What happened

The noise augmentation on geometric features (saf, dsdf channels 2:25) provides a small positive effect. In-distribution improves the most (-3.1% loss, -4.2% surf_p). OOD splits also improve modestly (-2.8% and -2.5%). Tandem is essentially unchanged (within noise).

The mechanism is as expected: adding Gaussian noise to the shape descriptors during training acts as regularization for the feature extractor, making representations less sensitive to fine-grained geometric perturbations and improving generalization. The annealing to zero by epoch 60 allows the model to refine its fit in later epochs without the noise constraint.

The improvement is real but small. The noise coefficient of 0.05 is modest relative to feature magnitudes; this may limit the regularization effect.

### Suggested follow-ups

- Try larger noise scale (0.1 or 0.2) to see if stronger regularization helps more.
- Try applying noise only to dsdf channels (2:6) or only to the saf channel (6:), to identify which features benefit most from augmentation.
- Combine with the tandem-weighted checkpoint selection (already merged) for potentially additive gains.
