### PR TITLE
Curvature-conditioned attention temperature

### DIFF
--- a/train.py
+++ b/train.py
@@ -125,7 +125,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
-    def forward(self, x, spatial_bias=None):
+    def forward(self, x, spatial_bias=None, temp_offset=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -140,7 +140,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_logits = self.in_project_slice(x_mid) / self.temperature
+        temp = self.temperature
+        if temp_offset is not None:
+            temp = (temp + temp_offset.view(bsz, self.heads, 1, 1)).clamp(min=1e-4)
+        slice_logits = self.in_project_slice(x_mid) / temp
         if spatial_bias is not None:
             slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
         slice_weights = self.softmax(slice_logits)
@@ -203,9 +206,9 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None):
+    def forward(self, fx, raw_xy=None, temp_offset=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
+        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, temp_offset=temp_offset) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -288,6 +291,9 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.curv_temp_mlp = nn.Sequential(nn.Linear(1, 16), nn.GELU(), nn.Linear(16, n_head))
+        nn.init.zeros_(self.curv_temp_mlp[-1].weight)
+        nn.init.zeros_(self.curv_temp_mlp[-1].bias)
         self.fourier_freqs = nn.Parameter(torch.tensor([0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0]))
 
     def initialize_weights(self):
@@ -353,14 +359,19 @@ class Transolver(nn.Module):
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
+        # Curvature-conditioned attention temperature offset
+        curv_proxy = x[:, :, 2:6].norm(dim=-1)  # [B, N]
+        curv_mean = curv_proxy.mean(dim=1, keepdim=True)  # [B, 1]
+        temp_offset = self.curv_temp_mlp(curv_mean)  # [B, n_head]
+
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy)
+            fx = block(fx, raw_xy=raw_xy, temp_offset=temp_offset)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, temp_offset=temp_offset)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
Modulate attention sharpness by curvature: high curvature (near surface) → sharp attention, low curvature (far field) → soft. Uses existing curvature proxy.
## Instructions
Add small MLP: curvature→per-head temperature offset. Apply before slice_logits computation. Run with `--wandb_group curv-temp-modulation`.
## Baseline (21 improvements, Round 11 measured)
- val_loss = 0.9003, mean3_surf_p = 24.0
- in=18.8, ood=14.6, re=28.8, tan=38.6
---
## Results

**W&B run:** `v4jujq09` (gilbert/curv-temp-mod)
**Epochs:** 72 / 100 (30-min timeout)
**Peak memory:** 12.2 GB

### Implementation

Added `curv_temp_mlp` (Linear(1,16) → GELU → Linear(16, n_head), zero-initialized) to Transolver. In forward, computes per-sample mean curvature `x[:,:,2:6].norm(dim=-1).mean(dim=1)` → shape [B,1], applies MLP to get temp_offset [B, n_head], adds to self.temperature (clamped min=1e-4) before slice_logits division. Passed through to each TransolverBlock and Physics_Attention.

### Metrics

| Split | val/loss | surf p | vs baseline |
|---|---|---|---|
| val_in_dist | 0.626 | 19.27 | +0.47 (worse) |
| val_ood_cond | 0.721 | 14.31 | -0.29 (better) |
| val_tandem_transfer | 1.697 | 40.57 | +1.97 (worse) |
| val_ood_re | 0.595 | 28.55 | -0.25 (better) |
| **4-split mean** | **0.910** | **mean3: 24.72** | +0.72 |

### Comparison to baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.900 | 0.910 | **+0.010 (+1.1%) WORSE** |
| mean3 surf_p | 24.0 | 24.72 | **+0.72 (+3.0%) WORSE** |

### What happened

Negative result. The curvature-conditioned temperature modulation slightly degraded both val/loss (+1.1%) and surface pressure (+3.0%).

The most likely issue with this implementation: the curvature is averaged per-sample across ALL nodes (surface + volume), producing a global scalar that applies a uniform temperature shift to every node in the batch. This means:
1. The per-node curvature signal is lost through averaging — nodes near surfaces and far-field nodes get the same temperature offset
2. The temperature change is batch-wide, not spatially-local as the hypothesis intended

The hypothesis was that nodes near high-curvature surfaces should have sharper attention than far-field nodes, which requires per-node (not per-sample) temperature modulation. A proper per-node version would need to compute the offset inside the attention block itself (where we have access to node-level features), not as a pre-computed scalar.

Tandem transfer got notably worse (+1.97 surf_p), possibly because tandem foils have different geometry patterns that the single-scalar curvature proxy does not capture well.

### Suggested follow-ups

- **Per-node temperature modulation:** Compute curvature offset inside `Physics_Attention`, directly from node features `x`, giving each node its own temperature rather than a batch-wide scalar.
- **Spatial-bias approach:** Instead of modulating `self.temperature`, add a curvature-conditioned term to `spatial_bias` (already implemented for xy) — this already exists as a per-node [B, N, slice_num] term that gets added to slice_logits.
- **Simpler route:** Just concatenate the curvature scalar to the spatial_bias MLP input, so spatial bias is conditioned on curvature without changing the temperature mechanism.