### PR TITLE
Learned loss weighting (homoscedastic uncertainty)

### DIFF
--- a/train.py
+++ b/train.py
@@ -507,6 +507,11 @@ ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())
 
+# Kendall et al. 2018: learnable homoscedastic uncertainty weights
+log_var_vol = nn.Parameter(torch.zeros(1, device=device))
+log_var_surf = nn.Parameter(torch.zeros(1, device=device))
+log_var_coarse = nn.Parameter(torch.zeros(1, device=device))
+
 
 class Lookahead:
     def __init__(self, base_optimizer, k=5, alpha=0.5):
@@ -540,7 +545,7 @@ attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['W
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
+    {'params': other_params + [log_var_vol, log_var_surf, log_var_coarse], 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
@@ -700,7 +705,8 @@ for epoch in range(MAX_EPOCHS):
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        loss = (torch.exp(-log_var_vol) * vol_loss + 0.5 * log_var_vol +
+                torch.exp(-log_var_surf) * surf_loss + 0.5 * log_var_surf)
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
@@ -724,7 +730,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + torch.exp(-log_var_coarse) * coarse_loss + 0.5 * log_var_coarse
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
@@ -745,7 +751,9 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight,
+                   "train/log_var_vol": log_var_vol.item(), "train/log_var_surf": log_var_surf.item(),
+                   "train/log_var_coarse": log_var_coarse.item(), "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Replace hand-tuned loss weights with learnable log-variance parameters per task (vol, surf, coarse). Kendall et al. 2018 approach.
## Instructions
Add `log_var_vol, log_var_surf, log_var_coarse` as nn.Parameters. Loss = sum(exp(-log_var_i) * loss_i + 0.5 * log_var_i). Run with `--wandb_group learned-loss-weights`.
## Baseline (21 improvements, Round 11 measured)
- val_loss = 0.9003, mean3_surf_p = 24.0
- in=18.8, ood=14.6, re=28.8, tan=38.6
---
## Results

**W&B run:** `avwvby85` (`senku/learned-loss-weights`, group: `learned-loss-weights`)
**Epochs:** ~69 (30-min timeout)
**Peak GPU memory:** 13.1 GB
**Epoch time:** ~26s

### Metrics at best checkpoint (epoch 69)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 0.6005 | 3.478 | 0.930 | 18.47 |
| val_tandem_transfer | 1.6479 | 4.173 | 1.443 | 39.25 |
| val_ood_cond | 0.7509 | 3.201 | 0.850 | 15.04 |
| val_ood_re | 0.6169 | 3.013 | 0.741 | 29.35 |

**val/loss_3split: 0.9041** vs baseline 0.9003 → **+0.4% (essentially neutral)**

### Learned log_var values (final)

| Parameter | Value | Effective weight (exp(-lv)) |
|---|---|---|
| log_var_vol | -1.115 | 3.05 |
| log_var_surf | -2.754 | 15.7 |
| log_var_coarse | -1.928 | 6.87 |

### Comparison vs baseline

| Metric | Baseline | Learned weights | Δ |
|---|---|---|---|
| val/loss_3split | 0.9003 | 0.9041 | +0.4% (neutral) |
| mae_surf_p (in_dist) | 18.76 | 18.47 | **-1.6%** (slight gain) |
| mae_surf_p (ood_cond) | 14.61 | 15.04 | +2.9% (slightly worse) |
| mae_surf_p (ood_re) | 28.76 | 29.35 | +2.1% (slightly worse) |
| mae_surf_p (tandem) | 38.61 | 39.25 | +1.7% (slightly worse) |

### What happened
Neutral result — learned loss weighting does not improve over the hand-tuned adaptive approach. 

The learned log_var values converge to effective weights: surf ≈ 15.7×, coarse ≈ 6.9×, vol ≈ 3.0×. This is actually plausible and similar to what the existing adaptive `surf_weight` (clamped 5-50) achieves. However, the optimization trajectory differs: with fixed-weight baselines the gradient signal is consistent throughout training, while learned weights introduce an extra optimization variable that can delay convergence.

The Kendall approach is designed for tasks with truly heteroscedastic uncertainty (different noise scales). Here, the loss scales are already well-calibrated by the adaptive `surf_weight` mechanism, leaving little room for the learned weighting to add value.

### Suggested follow-ups
- Try without the existing `surf_weight` adaptive mechanism (set it to a fixed value), letting log_var_surf be the sole weighting — currently there is double-weighting
- The log_var values converge to sensible values, suggesting the approach works mathematically; the issue is that baseline already has good weighting