### PR TITLE
Split pressure output head (retest on current 21-improvement code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -197,10 +197,15 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
+            self.mlp2_vel = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
+                nn.Linear(hidden_dim, 2),
+            )
+            self.mlp2_p = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, 1),
             )
 
     def forward(self, fx, raw_xy=None):
@@ -212,7 +217,8 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx_ln = self.ln_3(fx)
+            return torch.cat([self.mlp2_vel(fx_ln), self.mlp2_p(fx_ln)], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Separate MLP heads for velocity (2ch) and pressure (1ch) decouple gradients. Showed improvement on Round 10 code. Retest on current code.
## Instructions
Replace mlp2 with mlp2_vel(→2) and mlp2_p(→1). Concat outputs. Run with \`--wandb_group split-head-r12\`.
## Baseline (21 improvements, Round 11 measured)
- val_loss = 0.9003, mean3_surf_p = 24.0
- in=18.8, ood=14.6, re=28.8, tan=38.6
---
## Results

**W&B run:** n2s1k3dy
**Best epoch:** 66 (stopped by 30-min wall clock; still improving)
**Peak GPU memory:** 13.1 GB (+0.9 GB vs recent runs, from two separate output heads)

### Metrics at best checkpoint (epoch 66)

| Split | Loss | Surf Ux MAE | Surf Uy MAE | Surf p MAE | vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 0.6277 | 4.424 | 1.046 | **18.93** | +0.13 |
| val_ood_cond | 0.7478 | 3.582 | 1.030 | **14.83** | +0.23 |
| val_ood_re | 0.6110 | 3.281 | 0.956 | **29.14** | +0.34 |
| val_tandem_transfer | 1.6719 | 4.838 | 1.612 | **40.05** | +1.45 |

**surf_p mean3:** (18.93 + 14.83 + 29.14) / 3 = **20.97**
**val/loss:** 0.9146 vs baseline 0.9003 (+0.014)

### What happened

The split heads are **essentially neutral** — no meaningful improvement over the baseline. The individual surf_p values are within 0-0.3 of the baseline for in_dist/ood_cond/ood_re, and slightly worse on tandem (+1.45). val/loss is also marginally higher (0.9146 vs 0.9003).

This is consistent with the hypothesis not holding on the current codebase. The decoupled gradient benefit from Round 10 may have been superseded by the pressure-only surf_loss (#1116), which already focuses gradient signal on pressure — making a separate pressure head redundant.

The slight memory increase (13.1 GB vs ~12.2 GB) comes from the additional parameters in mlp2_vel + mlp2_p (vs single mlp2).

### Suggested follow-ups

- The split head idea may interact with the pressure-only surf_loss — try without it
- If the pressure fast-path (pressure_skip from prior PR) is adopted, split heads might become redundant
- Try a larger pressure head (hidden_dim → pressure) and smaller velocity head to further specialize