### PR TITLE
EMA + fast model ensemble at inference (free ensemble)

### DIFF
--- a/train.py
+++ b/train.py
@@ -820,7 +820,10 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    if ema_model is not None:
+                        pred = 0.5 * eval_model({"x": x})["preds"] + 0.5 * model({"x": x})["preds"]
+                    else:
+                        pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
Average EMA model and fast model predictions at inference. Both models exist in memory — this is a free ensemble that reduces variance, especially on OOD splits.
## Instructions
At validation: `pred = 0.5 * eval_model(x) + 0.5 * model(x)` when ema_model is available. Zero training cost. Run with `--wandb_group ema-fast-ensemble`.
## Baseline
23 improvements merged. Estimated mean3~23.0-23.3. Unmeasured since wavelet-PE + input-augment merges.

Baseline run (djj11ngh / frieren/baseline-r13): loss=0.8935, mean3=23.85
- in=18.97, tan=38.32, ood=14.27, re=28.31

---
## Results

**W&B run:** `xar6t1c4` (alphonse/ema-fast-ensemble, group: ema-fast-ensemble)  
**Epochs:** 70 (28s/epoch, 30-min wall clock)  
**Peak memory:** 12.2 GB

| Metric | Baseline (djj11ngh) | EMA+Fast Ensemble | Delta |
|---|---|---|---|
| val/loss_3split | 0.8935 | 0.9035 | +0.010 (+1.1%) ✗ |
| mean3_surf_p | 23.85 | 24.13 | +0.28 (+1.2%) ✗ |
| val_in_dist/mae_surf_p | 18.97 | **18.07** | -0.90 (-4.8%) ✓ |
| val_tandem_transfer/mae_surf_p | 38.32 | 39.59 | +1.27 (+3.3%) ✗ |
| val_ood_cond/mae_surf_p | 14.27 | 14.72 | +0.45 (+3.2%) ✗ |
| val_ood_re/mae_surf_p | 28.31 | 28.60 | +0.29 (+1.0%) ✗ |

**What happened:** The EMA+fast ensemble doesn't help — mean3 and loss_3split are slightly worse (+1.1-1.2%). The same pattern recurs: val_in_dist improves but OOD/tandem splits regress. The likely explanation: the fast model (current training weights) is highly correlated with the EMA model (smoothed version), so averaging them provides little diversity benefit. Worse, the fast model at any checkpoint is noiser than the EMA and may introduce variance into the OOD predictions. Pure EMA appears to be better for OOD generalization. 

Additionally, the ensemble only activates after epoch 40 (when EMA starts), creating inconsistency: the best checkpoint selected during early training (epochs 1-40) uses fast-only validation, while later epochs use the average — the comparison isn't apples-to-apples.

Note: Exit code 1 due to pre-existing visualization bug (vis code missing Fourier PE). Training completed the full 30 minutes correctly.

**Suggested follow-ups:**
- Try diversity-promoting ensemble: add a small amount of input noise to one path (`x + eps * randn`) before the fast model call
- Instead of 50/50 average, try EMA-weighted blend that starts at 100% EMA and gradually includes fast model
- Investigate why val_in_dist consistently improves even when OOD doesn't