### PR TITLE
Higher Fourier frequencies: add 64.0 and 128.0 to fixed backbone

### DIFF
--- a/train.py
+++ b/train.py
@@ -288,7 +288,7 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
-        self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
+        self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0, 64.0, 128.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
     def initialize_weights(self):
@@ -486,7 +486,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 1 + 40,  # 10 freqs (6 fixed + 4 learned) * 2 coords * 2 = 40
     out_dim=3,
     n_hidden=192,  # was 160
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min


### PR DESCRIPTION
## Hypothesis
Wavelet-PE's max fixed freq is 32.0. Adding 64.0 and 128.0 captures fine-scale features (leading edge, trailing edge). 10 total freqs = 40 PE features.
## Instructions
Extend fixed freqs: `[0.5, 2.0, 8.0, 32.0, 64.0, 128.0]`. Update fun_dim: `X_DIM - 2 + 1 + 40`. Run with `--wandb_group highfreq-fourier`.
## Baseline
23 improvements merged. Estimated mean3~23.0-23.3. Unmeasured since wavelet-PE + input-augment merges.
---
## Results

**W&B run:** `ijvkmhgs`
**Best epoch:** 70 / 70 (hit wall-clock limit at 30.1 min, 25s/epoch)
**Peak memory:** 12.4 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6031 | 5.90 | 1.23 | 17.83 | 1.16 | 0.39 | 19.31 |
| val_tandem_transfer | 1.7007 | 5.74 | 1.69 | 39.80 | 2.03 | 0.93 | 39.35 |
| val_ood_cond | 0.7723 | 3.24 | 1.00 | 15.19 | 0.79 | 0.30 | 13.51 |
| val_ood_re | 0.5759 | 3.07 | 0.91 | 28.53 | 0.85 | 0.37 | 47.50 |
| **mean3** | **0.959** | **4.96** | **1.31** | **24.27** | — | — | — |

Baseline: val_loss=0.9003, mean3_surf_p=24.0 (in=18.8, ood=14.6, tan=38.6).

**What happened:** Negative result — mean3_surf_p=24.27 slightly worse than baseline 24.0. val/loss 0.9130 vs 0.9003. The high-frequency components (64.0 and 128.0) hurt generalization. At normalized [0,1] coordinates, sin(128·t) oscillates 128 times — this is near the Nyquist limit for CFD mesh resolution (the mesh has O(10^4) nodes per case), so aliasing artifacts are plausible. The tandem split was most affected (39.80 vs 38.6 baseline), suggesting the very high freqs introduce overfitting on complex geometries. In-dist improved slightly (17.83 vs 18.8) but at the cost of generalization.

**Suggested follow-ups:**
- The current fixed-freq ceiling of 32.0 already captures roughly 32 cycles across the domain. This is likely sufficient for the mesh resolution. Stick with the existing 4-fixed + 4-learned setup.
- If more frequencies are desired, try learned-only expansion (more learned freqs that can settle to medium values) rather than fixing high ones.