### PR TITLE
Gradient accumulation 2 steps, SAME LR 3e-3 (smoother gradients)

### DIFF
--- a/train.py
+++ b/train.py
@@ -498,7 +498,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
+model = torch.compile(model)  # default mode: no CUDAGraphs (required for gradient accumulation)
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -594,6 +594,7 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+accum_steps = 2
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -613,7 +614,8 @@ for epoch in range(MAX_EPOCHS):
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    optimizer.zero_grad()
+    for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -737,19 +739,20 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(_base_model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        (loss / accum_steps).backward()
+        if (batch_idx + 1) % accum_steps == 0 or batch_idx == len(train_loader) - 1:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            if epoch >= ema_start_epoch:
+                if ema_model is None:
+                    ema_model = deepcopy(_base_model)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
+                            ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+            global_step += 1
+            wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Every previous accum attempt changed LR. Keep LR=3e-3 with 2-step accumulation for smoother gradients without changing optimization dynamics.
## Instructions
Add `accum_steps = 2`. Accumulate gradients over 2 micro-batches. Only optimizer.step()/zero_grad()/EMA/log on every 2nd batch. Run with `--wandb_group grad-accum-r13`.
## Baseline
23 improvements merged. Estimated mean3~23.0-23.3. Unmeasured since wavelet-PE + input-augment merges.
---
## Results

**W&B run**: `10uoiqa7` | **Epochs**: 73 | **Peak memory**: 12.2 GB

### CUDAGraphs incompatibility fix
`torch.compile(mode="reduce-overhead")` uses CUDAGraphs, which fail with gradient accumulation (error: "CUDAGraphs tensor overwritten by subsequent run"). Required changing to `torch.compile()` (default mode) to disable CUDAGraphs. This adds minor per-batch CPU overhead but does not affect correctness.

### Metrics

| Metric | Baseline-r13 | This run | Delta |
|---|---|---|---|
| val/loss_3split | 0.8935 | 0.9251 | **+3.5%** ❌ |
| mean3_surf_p | 23.85 | 24.64 | **+3.3%** ❌ |
| val_in_dist/mae_surf_p | 18.97 | 18.24 | **-3.8%** ✓ |
| val_ood_cond/mae_surf_p | 14.27 | 14.93 | +4.6% |
| val_ood_re/mae_surf_p | 28.31 | 29.12 | +2.8% |
| val_tandem_transfer/mae_surf_p | 38.32 | 40.75 | +6.3% |

*(Baseline-r13 from run djj11ngh which crashed — values are at crash point, not fully converged)*

**Full surface MAE**:
- val_in_dist: Ux=4.64, Uy=1.24, p=18.24
- val_tandem_transfer: Ux=5.50, Uy=1.99, p=40.75
- val_ood_cond: Ux=3.27, Uy=1.01, p=14.93
- val_ood_re: Ux=2.95, Uy=0.89, p=29.12

### What happened

**Negative result**: Same-LR gradient accumulation is slightly worse than the baseline. val/loss is +3.5% worse and mean3_surf_p is +3.3% worse, though val_in_dist/mae_surf_p does improve slightly (−3.8%).

The fundamental issue is the throughput-convergence tradeoff. With 2-step accumulation we make N/2 optimizer steps per epoch instead of N. With same LR, the linear scaling rule would require doubling LR to compensate for the doubled effective batch size. By keeping LR=3e-3, each epoch produces less parameter movement — effectively slower convergence per epoch. Within the 30-minute / 73-epoch budget, the model doesn't converge as far as the baseline.

The "smoother gradient" benefit is real but small — the noisier single-batch gradients in this domain (varied mesh sizes, mixed physics) are still an adequate signal for the optimizer. The tandem split suffered most (+6.3%) likely because it has fewer training examples and the slower convergence hurts more.

Note: the CUDAGraphs fix required downgrading from `reduce-overhead` to default compile mode. This is a non-trivial compatibility issue to be aware of if gradient accumulation is revisited.

### Suggested follow-ups

1. **Scaled LR with accum**: Try accum_steps=2 with LR=6e-3 (linear scaling rule). This would keep effective gradient magnitude the same and might show the benefit of smoother gradients cleanly.
2. **Fewer epochs but more compute per epoch**: If accum_steps=4 with LR=12e-3, we get the equivalent of a 4x larger batch which might generalize better to tandem/OOD.
3. **CUDAGraphs fix upstream**: The `cudagraph_mark_step_begin()` API exists in PyTorch 2.9.1 but doesn't resolve the issue in this codebase — worth investigating why, possibly a model-specific issue with `feature_cross` at line 350.
