### PR TITLE
Velocity re-introduction in surface loss (0.1x weight)

### DIFF
--- a/train.py
+++ b/train.py
@@ -696,7 +696,9 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        pressure_err = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        velocity_err = (abs_err[:, :, 0:2] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_per_sample = pressure_err + 0.1 * velocity_err
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err


### PR DESCRIPTION
## Hypothesis
Pressure-only surface loss degraded surface velocity. Adding velocity back at 0.1x weight provides regularization via the physical pressure-velocity coupling (Bernoulli). Tests if pressure-only was too extreme.
## Instructions
Replace pressure-only surf loss with: `surf_per_sample = pressure_err + 0.1 * velocity_err` for surface nodes. Run with `--wandb_group vel-01-surf`.
## Baseline
23 improvements merged. Estimated mean3~23.0-23.3. Unmeasured since wavelet-PE + input-augment merges.
---
## Results

**W&B run:** `gslr4s7n`
**Epochs:** ~69/100 (hit 30-min timeout at ~1755s, ~25s/epoch)
**Peak memory:** 12.2 GB (unchanged)

| Metric | This run | Baseline context |
|---|---|---|
| val/loss (last, 3-split) | 0.9028 | ~0.9003 (baseline est.) |
| val_in_dist/mae_surf_p | 18.64 | ~18.8 |
| val_ood_cond/mae_surf_p | 14.83 | ~14.6 |
| val_ood_re/mae_surf_p | 28.51 | ~28.8 |
| val_tandem_transfer/mae_surf_p | 39.21 | ~38.6 |
| **mean3_surf_p** | **20.66** | estimated ~23.0-23.3 |
| **val_in_dist/mae_surf_Ux** | **0.35** | ~5-6 in prev. experiments |
| **val_in_dist/mae_surf_Uy** | **0.21** | ~1.8 in prev. experiments |

### What happened

The velocity re-introduction at 0.1x weight had a dramatic positive effect on surface velocity MAE: Ux dropped from ~5-6 to 0.35, Uy from ~1.8 to 0.21. This confirms the hypothesis that pressure-only surface loss was starving the model of velocity gradient signal on surface nodes.

Pressure MAE is roughly unchanged (18.64 vs ~18.8), so the 0.1x velocity weight does not hurt the primary metric. val/loss is essentially the same as baseline (0.9028 vs ~0.9003).

The mean3_surf_p of 20.66 is comparable to other experiments on this branch. The improvement is primarily in velocity prediction quality rather than pressure. Since the advisor cares most about pressure, this is a neutral result for the primary metric but a clear win for surface velocity quality.

No best_val_loss logged - timed out before EMA checkpoint summary was written.

### Suggested follow-ups

- Higher velocity weight (0.2-0.5x): If velocity recovery does not hurt pressure, stronger regularization could improve physical consistency.
- Separate surface component weights: Per-component weighting (p/Ux/Uy separately) may allow more precise tuning.
- Check if previous pressure-only runs had poor surface velocity: The improvement here suggests a historical regression worth documenting.