### PR TITLE
Deeper GLU preprocess (2 gated hidden layers)

### DIFF
--- a/train.py
+++ b/train.py
@@ -72,6 +72,24 @@ class GatedMLP(nn.Module):
         return self.down_proj(torch.sigmoid(self.gate_proj(x)) * self.act(self.up_proj(x)))
 
 
+class GatedMLP2(nn.Module):
+    """GatedMLP with a residual second gated layer."""
+    def __init__(self, n_input, n_hidden, n_output, act='gelu'):
+        super().__init__()
+        act_fn = ACTIVATION[act]
+        self.gate1 = nn.Linear(n_input, n_hidden)
+        self.up1 = nn.Linear(n_input, n_hidden)
+        self.gate2 = nn.Linear(n_hidden, n_hidden)
+        self.up2 = nn.Linear(n_hidden, n_hidden)
+        self.down = nn.Linear(n_hidden, n_output)
+        self.act = act_fn()
+
+    def forward(self, x):
+        h = torch.sigmoid(self.gate1(x)) * self.act(self.up1(x))
+        h = h + torch.sigmoid(self.gate2(h)) * self.act(self.up2(h))
+        return self.down(h)
+
+
 class MLP(nn.Module):
     def __init__(self, n_input, n_hidden, n_output, n_layers=1, act="gelu", res=True):
         super().__init__()
@@ -257,7 +275,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = GatedMLP(fun_dim + space_dim, n_hidden * 2, n_hidden)
+            self.preprocess = GatedMLP2(fun_dim + space_dim, n_hidden * 2, n_hidden)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
GLU preprocess was a win. Standard MLP depth-2 always failed. GLU with 2 gated layers (residual) has never been tested — gating mechanism prevents gradient degradation.
## Instructions
Create GatedMLP2 with residual gated second layer. Replace preprocess. Run with `--wandb_group deeper-glu`.
## Baseline
23 improvements merged. Estimated mean3~23.0-23.3. Unmeasured since wavelet-PE + input-augment merges.
---
## Results

W&B run: `3x7ydmtk` | Peak memory: 14.5 GB | 61 epochs (~30 min)

Baseline: `djj11ngh` (frieren/baseline-r13, 23 improvements, mean3=23.85)

**Positive result.** Most splits improve notably; tandem unchanged.

### Val/loss by split

| Split | Experiment | Baseline (djj11ngh) | Delta |
|---|---|---|---|
| val_in_dist | **0.5837** | 0.6352 | **-8.1%** |
| val_tandem_transfer | **1.6303** | 1.6401 | -0.6% (unchanged) |
| val_ood_cond | **0.6834** | 0.7258 | **-5.8%** |
| val_ood_re | **0.5186** | 0.5728 | **-9.5%** |
| **3-split avg** | **0.9658** | 1.0004 | **-3.5%** |

### Surface pressure MAE (mean3)

| Split | Experiment | Baseline | Delta |
|---|---|---|---|
| in_dist | **17.80** | 18.97 | **-6.2%** |
| tandem | 38.90 | 38.32 | +1.5% |
| ood_cond | **13.59** | 14.27 | **-4.8%** |
| ood_re | **27.23** | 28.31 | **-3.8%** |
| **mean3** | **23.43** | 23.85 | **-1.8%** |

### Memory and speed

- Memory: 14.5 GB vs ~12.2 GB baseline (+2.3 GB)
- Epoch time: ~29-30s vs ~26s baseline (fewer epochs in 30-min budget: 61 vs ~69)
- Despite fewer epochs, all non-tandem splits improve significantly

### What happened

The GatedMLP2 preprocess (two gated layers with residual) works well. The gating mechanism in the second layer prevents gradient degradation that killed standard MLP depth-2, while the residual connection allows clean gradient flow. In-distribution improves by -8.1% loss (-6.2% surf_p), and out-of-distribution splits also benefit substantially (-5.8%, -9.5% loss). Tandem is essentially unchanged.

The improvement is likely because a deeper gated preprocess can build richer per-node feature representations before the Transolver attention layers, giving the attention mechanism better-structured inputs to work with. The gating acts as learned feature selection at each layer.

Memory increase (+2.3 GB) comes from the additional parameters and activations in the second gated layer. This is within the acceptable budget (96 GB available).

### Suggested follow-ups

- Try GatedMLP2 with larger hidden dimension (n_hidden * 3 or * 4 in the intermediate) to see if width also helps.
- Try a third gated layer (GatedMLP3) with diminishing returns in mind.
- Check if GatedMLP2 also helps in TransolverBlock MLPs (not just preprocess).
