### PR TITLE
Tandem-specific learned temperature offset in attention

### DIFF
--- a/train.py
+++ b/train.py
@@ -110,6 +110,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, 1, 1, 1))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
@@ -125,7 +126,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
-    def forward(self, x, spatial_bias=None):
+    def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -140,7 +141,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        slice_logits = self.in_project_slice(x_mid) / self.temperature
+        temp = self.temperature
+        if tandem_mask is not None:
+            temp = (temp + self.tandem_temp_offset * tandem_mask).clamp(min=1e-4)
+        slice_logits = self.in_project_slice(x_mid) / temp
         if spatial_bias is not None:
             slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
         slice_weights = self.softmax(slice_logits)
@@ -203,9 +207,9 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb) + fx)
+        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -350,18 +354,22 @@ class Transolver(nn.Module):
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = x[:, :, :2]
+
+        # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
+        is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
+
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
Tandem flows need different clustering sharpness. A learnable scalar shifts attention temperature for tandem samples only (detected by gap feature).
## Instructions
Add `self.tandem_temp_offset = nn.Parameter(torch.zeros(1,1,1,1))`. Apply offset in slice_logits when sample is tandem. Run with `--wandb_group tandem-temp-offset`.
## Baseline
23 improvements merged. Estimated mean3~23.0-23.3. Unmeasured since wavelet-PE + input-augment merges.
---
## Results

**W&B run:** `hrrwqpzc` | **Epochs:** 71 | **Memory:** 12.2 GB

| Split | val/loss | surf_p MAE | surf_Ux MAE | surf_Uy MAE | vol_p MAE |
|---|---|---|---|---|---|
| val_in_dist | 0.627 | 17.96 | 4.08 | 1.25 | 20.46 |
| val_tandem_transfer | 1.642 | 38.61 | 4.74 | 1.67 | 38.60 |
| val_ood_cond | 0.731 | 14.44 | 3.00 | 0.91 | 12.76 |
| val_ood_re | 0.583 | 28.60 | 2.89 | 0.81 | 47.39 |
| **mean3 (excl ood_re)** | **0.896** | **23.67** | **3.94** | **1.28** | **23.94** |

**Baseline estimate:** mean3_surf_p ~23.0–23.3 → **result is +0.37–0.67 worse (marginal regression, ~1.6–2.9%)**

### What happened

The tandem-specific temperature offset did not improve results. mean3_surf_p landed at 23.67 vs the estimated baseline of 23.0–23.3, a marginal regression. val/loss 0.896 is also slightly above what the baseline estimate implies.

The core issue is likely **insufficient gradient signal**. `tandem_temp_offset` is a single scalar (shape `[1,1,1,1]`) shared across all heads and all tandem samples. The signal telling it which direction to go (sharper or softer clustering) is weak and noisy — the model can adapt through many other pathways (spatial bias, slice weights, attention scale) that are already well-tuned. With one degree of freedom, the optimizer likely makes little use of it.

Tandem transfer loss (1.642) remains the dominant challenge, and there is no clear improvement there vs. non-tandem splits.

The `tandem_temp_offset` converged to near-zero, meaning the model found little use for it.

### Suggested follow-ups
- **Per-head offset**: shape `[1, n_head, 1, 1]` would give 4 independent temperature shifts; each head might specialize differently for tandem geometry.
- **Input-conditioned offset**: instead of a fixed parameter, use the tandem gap/stagger features (x[:,0,21:23]) to predict a temperature offset via a tiny MLP — makes the offset a function of the actual flow geometry rather than a binary flag.
- **Tandem-specific layer norm**: learnable scale/shift in LayerNorm conditioned on tandem flag, which is a wider bottleneck for tandem-specific representation.