### PR TITLE
Gentle warm restart: mini cosine from epoch 50 (peak 5e-4)

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -545,9 +546,16 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine1 = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=40, eta_min=5e-5)
+# Gentle restart: cosine from 5e-4 to 5e-5 over 22 epochs
+_restart_lr_max = 5e-4 / cfg.lr  # factor relative to base_lr
+_restart_lr_min = 5e-5 / cfg.lr
+cosine2 = torch.optim.lr_scheduler.LambdaLR(
+    base_opt,
+    lr_lambda=lambda ep: _restart_lr_min + (_restart_lr_max - _restart_lr_min) * (1 + math.cos(math.pi * min(ep, 22) / 22)) / 2
+)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine1, cosine2], milestones=[10, 50]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Past warm restarts failed because they restarted at full peak LR. A gentle restart at epoch 50 with peak=5e-4 (16x lower) gives controlled second exploration without destabilizing EMA.
## Instructions
Use SequentialLR: warmup(10ep) + cosine(T_max=40, to 5e-5) + cosine(T_max=22, from 5e-4 to 5e-5). Milestones=[10, 50]. Run with `--wandb_group gentle-restart`.
## Baseline
23 improvements merged. Estimated mean3~23.0-23.3. Unmeasured since wavelet-PE + input-augment merges.

Measured baseline `2yrgvqga` (frieren/baseline-r11, ~72 epochs):
- val/loss_3split: 0.9003
- mae_surf_p: in_dist=18.76, ood_cond=14.61, ood_re=28.76, tandem=38.61

---
## Results

**W&B run:** `spkoysrd` (`senku/gentle-restart`, group: `gentle-restart`)
**Epochs:** ~68 (30-min timeout)
**Peak GPU memory:** 13.1 GB
**Epoch time:** ~27s
**LR at end:** ~5.25e-5 (cosine2 nearly complete)

### Metrics at best checkpoint (~epoch 68)

| Split | val/loss | mae_surf_Ux | mae_surf_p |
|---|---|---|---|
| val_in_dist | 0.6133 | 6.330 | 17.59 |
| val_tandem_transfer | 1.6502 | 6.058 | 38.92 |
| val_ood_cond | 0.7678 | 3.692 | 15.18 |
| val_ood_re | 0.6018 | 3.378 | 28.76 |

**val/loss_3split: 0.9083** vs baseline 0.9003 → **+0.9% (neutral/slightly worse)**

### Comparison vs baseline

| Metric | Baseline | Gentle restart | Δ |
|---|---|---|---|
| val/loss_3split | 0.9003 | 0.9083 | +0.9% (neutral) |
| mae_surf_p (in_dist) | 18.76 | 17.59 | **-6.2%** (notable gain) |
| mae_surf_p (ood_cond) | 14.61 | 15.18 | +3.9% (slightly worse) |
| mae_surf_p (ood_re) | 28.76 | 28.76 | 0% (identical) |
| mae_surf_p (tandem) | 38.61 | 38.92 | +0.8% (neutral) |

### What happened
The gentle restart works as intended — the LR bump at epoch 50 is visible in the training curve (val loss transiently rises at epochs 51-52 before declining again). The restart helps val_in_dist/mae_surf_p notably (-6.2%), but hurts val_ood_cond (+3.9%), resulting in an overall neutral trade-off on val/loss_3split.

The LR schedule: warmup (0→10) → cosine1 (10→50, 3e-3→5e-5) → cosine2 (50→72, 5e-4→5e-5) is implemented using LambdaLR for cosine2 to achieve the correct peak from 5e-4 (not full 3e-3).

The run achieved ~68 epochs (27s/epoch, hit 30-min cap). cosine2 ends at epoch 72, so we missed 4 epochs of the final decay.

### Suggested follow-ups
- Extend timeout to 35 min to complete the cosine2 phase fully (would capture last 4 epochs)
- Try the restart earlier (epoch 40) before convergence slows — the restart may need more headroom to find a better basin
- Try a larger restart LR (1e-3) if the concern about destabilizing EMA is addressed by EMA decay rate