### PR TITLE
GatedMLP in TransolverBlock MLP (extend GLU to block)

### DIFF
--- a/train.py
+++ b/train.py
@@ -209,7 +209,7 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim)
         self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)


### PR DESCRIPTION
## Hypothesis
GatedMLP2 in preprocess was best Round 13 result. The block MLP still uses standard MLP. Use single-layer GatedMLP (not GatedMLP2) in block MLP to keep FLOPs manageable.
## Instructions
Replace `self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)` with `self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim)`.
Run with `--wandb_group gated-block-mlp-v2`.
## Baseline
26 improvements merged. Round 13 baseline: mean3=23.9. 3 new merges (deeper-glu, tandem-temp, curv-spatial-bias) — combined effect unmeasured, estimated ~23.0-23.2.

**Measured baselines:**
- baseline-r13 (djj11ngh): loss3=0.8935, mean3=23.85 (~70 epochs)
- baseline-r14 (ryanvvtb): loss3=0.8934, mean3=24.37 (~59 epochs, newer branch)

---
## Results

**W&B run:** 08u8is4j (fern/gated-block-mlp-v2)
**Epochs:** 58 best checkpoint in 30 min (~31s/epoch vs baseline ~26s/epoch)
**Best checkpoint:** epoch 58, val/loss=0.8771

| Metric | Baseline-r14 (59 ep) | GatedMLP block (58 ep) | Change |
|--------|---------------------|------------------------|--------|
| val/loss3 | 0.8934 | **0.8771** | -1.8% |
| mean3_surf_p | 24.37 | **23.48** | -3.7% |
| val_in_dist/mae_surf_Ux | — | 5.63 | — |
| val_in_dist/mae_surf_p | 19.44 | 17.91 | -7.9% |
| val_ood_cond/mae_surf_Ux | — | 2.86 | — |
| val_ood_cond/mae_surf_p | 14.10 | **14.13** | ~flat |
| val_tandem_transfer/mae_surf_Ux | — | 5.44 | — |
| val_tandem_transfer/mae_surf_p | 39.57 | **38.40** | -3.0% |
| val_ood_re/mae_surf_p | — | 28.24 | — |

**Epoch speed:** ~31s/epoch vs ~26s/epoch baseline. GatedMLP adds ~19% per-epoch overhead (fewer epochs: 58 vs ~70 normally). Despite fewer epochs, final metrics are better.
**Memory:** ~same as baseline (one gate+up+down vs one linear — comparable parameters).

### What happened

Replacing the standard MLP in TransolverBlock with a single-layer GatedMLP clearly improves the model. loss3 drops from 0.8934 to 0.8771 (-1.8%) and mean3_surf_p drops from 24.37 to 23.48 (-3.7%). The tandem_transfer pressure MAE improves by 3% (39.57→38.40) and in_dist pressure improves by 8% (19.44→17.91). Only ood_cond/mae_surf_p is essentially flat.

The epoch slowdown (~19% per epoch) is offset by better convergence per epoch. The model appears to learn more efficiently with gated MLPs throughout — consistent with the pattern seen in the preprocess layer.

This is a genuine win. The gating mechanism in the attention block's feed-forward helps the model selectively amplify relevant features per position.

### Suggested follow-ups

- **GatedMLP2 in block**: Try the residual two-layer variant (GatedMLP2) in the block MLP — may converge even better but slower per epoch.
- **Both preprocess + block GLU**: Already tested for preprocess; this PR adds block. Together they fully replace MLP throughout.
- **Longer training**: With 70 epochs (matching baseline-r13 budget), the gap should widen further — the model is still converging at epoch 58.