### PR TITLE
4D spatial bias (add dsdf anisotropy to slice routing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -210,7 +210,7 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
-        self.spatial_bias = nn.Sequential(nn.Linear(2, 32), nn.GELU(), nn.Linear(32, slice_num))
+        self.spatial_bias = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, slice_num))
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -372,6 +372,11 @@ class Transolver(nn.Module):
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = x[:, :, :2]
+        # Add curvature (norm of dsdf channels) and anisotropy (max/min ratio) for 4D spatial bias
+        dsdf = x[:, :, 2:6]
+        curv = dsdf.norm(dim=-1, keepdim=True)
+        aniso = dsdf.max(dim=-1, keepdim=True).values / (dsdf.min(dim=-1, keepdim=True).values.abs() + 0.1)
+        raw_xy = torch.cat([raw_xy, curv, aniso], dim=-1)  # [B, N, 4]
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]


### PR DESCRIPTION
## Hypothesis
Curvature spatial bias was a win. Add dsdf anisotropy as 4th feature: max(dsdf[2:6]) / (min(dsdf[2:6]) + 0.1), capturing shape directionality.
## Instructions
Change spatial_bias to `nn.Linear(4, 32)`. Compute aniso and pass to blocks. Run with `--wandb_group spatial-bias-4d`.
## Baseline
26 improvements merged. Round 13 baseline: mean3=23.9. 3 new merges (deeper-glu, tandem-temp, curv-spatial-bias) — combined effect unmeasured, estimated ~23.0-23.2.
---
## Results

**W&B run:** `7ei5b27l` (tanjiro/spatial-bias-4d)
**Best epoch:** 57/100

### Key metrics vs baseline-r13 (`djj11ngh`)

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| combined | val/loss | 0.8935 | **0.8877** | -0.7% |
| val_in_dist | surf_Ux MAE | 5.581 | 6.512 | +16.7% |
| val_in_dist | surf_Uy MAE | 1.656 | 1.814 | +9.5% |
| val_in_dist | surf_p MAE | 18.97 | **17.97** | -5.3% |
| val_in_dist | vol_Ux MAE | 1.202 | **1.095** | -8.9% |
| val_in_dist | vol_p MAE | 20.76 | **19.56** | -5.8% |
| val_tandem_transfer | surf_Ux MAE | 5.945 | 6.129 | +3.1% |
| val_tandem_transfer | surf_Uy MAE | 2.081 | 2.278 | +9.4% |
| val_tandem_transfer | surf_p MAE | 38.32 | 38.93 | +1.6% |
| val_ood_cond | surf_p MAE | 14.27 | 14.77 | +3.5% |
| val_ood_re | surf_p MAE | 28.31 | 28.38 | +0.2% |

**Peak memory:** ~15 GB (no change from baseline)

### What happened

Mixed result — not a clear win. The 4D spatial bias (adding curvature + anisotropy) improved surface pressure (-5.3%) and volume metrics (-5.8%, -8.9%), but surface velocity degraded significantly: surf_Ux +16.7%, surf_Uy +9.5%. The overall val/loss barely moved (-0.7%) because the surface loss only tracks pressure.

The problematic feature is likely the anisotropy ratio (max/min). When dsdf channels are near zero (interior volume nodes or nodes far from both foils), the denominator adds only 0.1, so the ratio can be very large or noisy. This could inject instability into the spatial bias routing, especially for velocity-sensitive surface nodes.

Interestingly, the curvature component alone (from PR #1161) improved ALL metrics including velocity. Adding the aniso ratio appears to hurt velocity routing specifically.

**Note:** Since noam's base still has nn.Linear(2, 32), I added BOTH curv and aniso to go to 4D (not just aniso building on a pre-existing 3D). The experiment bundles both.

### Suggested follow-ups

- Ablate curv-only 3D vs curv+aniso 4D on the same base to isolate the aniso contribution.
- If aniso is to blame for velocity degradation, try clamping the ratio: clamp(aniso, 0, 5) or using softplus normalization.
- Consider using the 4D directional dsdf vector (the 4 raw channels, not a scalar ratio) instead of a scalar aniso proxy.