### PR TITLE
Asymmetric hard-node mining (non-tandem only, top-50% at 1.5x)

### DIFF
--- a/train.py
+++ b/train.py
@@ -727,6 +727,19 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
+        # Asymmetric hard-node mining for non-tandem samples after epoch 30
+        if epoch >= 30:
+            B_hm, N_hm = abs_err.shape[:2]
+            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+            hard_weights = torch.ones(B_hm, N_hm, 1, device=device)
+            with torch.no_grad():
+                for b in range(B_hm):
+                    if not is_tandem_batch[b] and surf_mask[b].any():
+                        node_errs = surf_pres[b, surf_mask[b], 0]
+                        thresh = node_errs.median()
+                        hard_nodes = surf_mask[b] & (surf_pres[b, :, 0] >= thresh)
+                        hard_weights[b, hard_nodes, 0] = 1.5
+            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis
Round 12 curriculum showed ood=13.8 best-ever but tan=40.2 regressed. Fix: apply 1.5x hard-node amplification ONLY to non-tandem samples after epoch 30.
## Instructions
After surf_per_sample, for non-tandem samples: compute top-50% threshold, multiply hard node errors by 1.5. Skip tandem samples. Run with `--wandb_group asym-hard-mining`.
## Baseline
26 improvements merged. Round 13 baseline: mean3=23.9. 3 new merges (deeper-glu, tandem-temp, curv-spatial-bias) — combined effect unmeasured, estimated ~23.0-23.2.

Baseline run (ryanvvtb / frieren/baseline-r14): loss=0.8934, mean3=24.37
- in=19.44, tan=39.57, ood=14.10, re=28.06

---
## Results

**W&B run:** `nyf4lyrr` (alphonse/asym-hard-mining, group: asym-hard-mining)  
**Epochs:** 61 (29s/epoch, 30-min wall clock) — fewer epochs due to hard mining loop overhead  
**Peak memory:** 14.4 GB

| Metric | Baseline (ryanvvtb) | Asym Hard Mining | Delta |
|---|---|---|---|
| val/loss_3split | 0.8934 | **0.8620** | -0.031 (-3.5%) ✓ |
| mean3_surf_p | 24.37 | **23.41** | -0.96 (-3.9%) ✓ |
| val_in_dist/mae_surf_p | 19.44 | **17.56** | -1.88 (-9.7%) ✓ |
| val_tandem_transfer/mae_surf_p | 39.57 | **38.08** | -1.50 (-3.8%) ✓ |
| val_ood_cond/mae_surf_p | 14.10 | 14.60 | +0.50 (+3.6%) ✗ |
| val_ood_re/mae_surf_p | 28.06 | **27.73** | -0.33 (-1.2%) ✓ |

**What happened:** Strong positive result — mean3 drops 3.9% and most splits improve. Most notably, val_tandem improved as hypothesized (-3.8%) by focusing loss on hard non-tandem nodes. val_in_dist improved dramatically (-9.7%). Only val_ood_cond slightly regressed (+3.6%).

The improvement makes sense: hard-node mining forces the model to attend to the most difficult pressure regions in non-tandem samples, improving single-foil generalization without penalizing tandem samples more. The epoch count dropped from ~73 to 61 (16% fewer) due to the per-sample loop overhead increasing epoch time from 25s to 29s — the improvement despite fewer epochs suggests strong per-epoch signal.

Caveat: memory increased from 12.2 GB to 14.4 GB (2.2 GB overhead for the hard weights tensor). The per-sample loop (`for b in range(B_hm)`) may be slow for large batches. A vectorized implementation could eliminate the overhead.

Note: Exit code 1 due to pre-existing visualization bug (vis code missing Fourier PE). Training completed the full 30 minutes correctly.

**Suggested follow-ups:**
- Vectorize the hard mining loop (avoid Python for-loop over batch) to recover epoch speed
- Try amplification factor 2.0 instead of 1.5 (more aggressive mining)
- Try hard mining at top-25% (more selective) or top-75% (broader)