### PR TITLE
GatedMLP3 preprocess (3 gated hidden layers — push depth further)

### DIFF
--- a/train.py
+++ b/train.py
@@ -90,6 +90,27 @@ class GatedMLP2(nn.Module):
         return self.down(h)
 
 
+class GatedMLP3(nn.Module):
+    """GatedMLP with three gated layers: first projects input, then two residual gated layers."""
+    def __init__(self, n_input, n_hidden, n_output, act='gelu'):
+        super().__init__()
+        act_fn = ACTIVATION[act]
+        self.gate1 = nn.Linear(n_input, n_hidden)
+        self.up1 = nn.Linear(n_input, n_hidden)
+        self.gate2 = nn.Linear(n_hidden, n_hidden)
+        self.up2 = nn.Linear(n_hidden, n_hidden)
+        self.gate3 = nn.Linear(n_hidden, n_hidden)
+        self.up3 = nn.Linear(n_hidden, n_hidden)
+        self.down = nn.Linear(n_hidden, n_output)
+        self.act = act_fn()
+
+    def forward(self, x):
+        h = torch.sigmoid(self.gate1(x)) * self.act(self.up1(x))
+        h = h + torch.sigmoid(self.gate2(h)) * self.act(self.up2(h))
+        h = h + torch.sigmoid(self.gate3(h)) * self.act(self.up3(h))
+        return self.down(h)
+
+
 class MLP(nn.Module):
     def __init__(self, n_input, n_hidden, n_output, n_layers=1, act="gelu", res=True):
         super().__init__()
@@ -279,7 +300,7 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = GatedMLP2(fun_dim + space_dim, n_hidden * 2, n_hidden)
+            self.preprocess = GatedMLP3(fun_dim + space_dim, n_hidden * 2, n_hidden)
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim


### PR DESCRIPTION
## Hypothesis
GatedMLP2 was the best Round 13 result. Push depth further with a 3rd gated residual layer.
## Instructions
Create GatedMLP3 extending GatedMLP2 with third gated layer. Replace preprocess. Run with `--wandb_group glu-preprocess-3layer`.
## Baseline
26 improvements merged. Round 13 baseline: mean3=23.9. 3 new merges (deeper-glu, tandem-temp, curv-spatial-bias) — combined effect unmeasured, estimated ~23.0-23.2.
---
## Results

**W&B run**: `b069vkws` | **Epochs**: 53 (30-min limit) | **Peak memory**: ~12.2 GB

### Metrics vs Round-13 reference (djj11ngh, crashed)

| Metric | r13 reference | GatedMLP3 | Delta |
|---|---|---|---|
| val/loss_3split | 0.8935 | 0.8858 | **-0.9%** ✓ |
| mean3_surf_p | 23.85 | 23.82 | **-0.1%** ~ |
| val_in_dist/mae_surf_p | 18.97 | 18.41 | **-3.0%** ✓ |
| val_ood_cond/mae_surf_p | 14.27 | 14.50 | +1.6% |
| val_ood_re/mae_surf_p | 28.31 | 28.32 | ~0% |
| val_tandem_transfer/mae_surf_p | 38.32 | 38.56 | +0.6% |

**Full surface MAE** (best checkpoint, epoch 53):
- val_in_dist: loss=0.605, mae_surf_p=18.41
- val_tandem_transfer: loss=1.647, mae_surf_p=38.56
- val_ood_cond: loss=0.732, mae_surf_p=14.50
- val_ood_re: loss=0.559, mae_surf_p=28.32

### What happened

**Neutral result**: GatedMLP3 matches the r13 crashed-baseline but likely falls behind the estimated current baseline (~23.0-23.2). The core problem is the compute-epoch tradeoff: GatedMLP3 runs at ~32-34s/epoch vs GatedMLP2's ~28s/epoch (+14-21% slower per epoch), which cuts the 30-minute budget from ~65 epochs down to 53 epochs. The extra expressiveness of the third gated layer doesn't compensate for the reduced number of training iterations within the time budget.

val/loss_3split of 0.8858 is marginally better than the r13 reference (-0.9%), and in-dist pressure improves slightly. But tandem and OOD-cond are slightly worse. Against the estimated current baseline (which includes deeper-glu + tandem-temp + curv-spatial-bias merges), GatedMLP3 is likely neutral to slightly negative.

The GatedMLP3 architecture itself looks well-behaved: training is stable, no instabilities, and the model converges properly. The issue is purely throughput.

### Suggested follow-ups

1. **Wider hidden dim instead of deeper**: If the budget allows more FLOPs, try n_hidden=160 or n_hidden=192 with GatedMLP2, which can amortize the hidden state cost differently. Depth adds serial computation that can't be parallelized within a single forward pass.
2. **Bottleneck gated layer**: Keep 3 layers but halve the width of the middle gated layer (`gate2/up2: n_hidden → n_hidden//2 → n_hidden`), reducing computation while maintaining depth.
3. **Measure actual r14 baseline**: A confirmed baseline run with the 3 new merges would clarify whether GatedMLP3 is truly neutral or slightly negative.
