### PR TITLE
Local Fourier PE from saf features (foil-local coordinates)

### DIFF
--- a/train.py
+++ b/train.py
@@ -512,7 +512,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 1 + 32 + 16,  # 8 freqs * 2 coords * 2 (sin+cos) = 32; + 16 saf local Fourier PE
     out_dim=3,
     n_hidden=192,  # was 160
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -658,6 +658,12 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
+        # SAF local Fourier PE: 4 fixed frequencies on foil-local arc-length fraction (cols 2:4)
+        saf = x[:, :, 2:4]  # [B, N, 2]
+        saf_freqs = torch.tensor([1.0, 2.0, 4.0, 8.0], device=device, dtype=x.dtype)
+        saf_scaled = saf.unsqueeze(-1) * saf_freqs  # [B, N, 2, 4]
+        saf_pe = torch.cat([saf_scaled.sin().flatten(-2), saf_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+        x = torch.cat([x, saf_pe], dim=-1)
         if model.training and epoch < 60:
             noise_scale = 0.05 * (1 - epoch / 60)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -826,6 +832,12 @@ for epoch in range(MAX_EPOCHS):
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
+                # SAF local Fourier PE: 4 fixed frequencies on foil-local arc-length fraction (cols 2:4)
+                saf = x[:, :, 2:4]  # [B, N, 2]
+                saf_freqs = torch.tensor([1.0, 2.0, 4.0, 8.0], device=device, dtype=x.dtype)
+                saf_scaled = saf.unsqueeze(-1) * saf_freqs  # [B, N, 2, 4]
+                saf_pe = torch.cat([saf_scaled.sin().flatten(-2), saf_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                x = torch.cat([x, saf_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
@@ -995,6 +1007,19 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 x_n = torch.cat([x_n, curv], dim=-1)
+                raw_xy = x_n[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                vis_freqs = torch.cat([vis_model._orig_mod.fourier_freqs_fixed.to(device) if hasattr(vis_model, '_orig_mod') else vis_model.fourier_freqs_fixed.to(device), (vis_model._orig_mod.fourier_freqs_learned if hasattr(vis_model, '_orig_mod') else vis_model.fourier_freqs_learned).abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * vis_freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe], dim=-1)
+                saf = x_n[:, :, 2:4]
+                saf_freqs = torch.tensor([1.0, 2.0, 4.0, 8.0], device=device, dtype=x_n.dtype)
+                saf_scaled = saf.unsqueeze(-1) * saf_freqs
+                saf_pe = torch.cat([saf_scaled.sin().flatten(-2), saf_scaled.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, saf_pe], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
Current Fourier PE uses global xy. For tandem configs, physics is local to each foil. Using saf (signed arc-length fraction, foil-local) features for additional Fourier encoding captures this.
## Instructions
Apply 4 fixed frequencies to saf features (cols in raw x): `saf_pe = cat([sin(saf*freqs), cos(saf*freqs)])`. Add 16 saf_pe features alongside existing 32 Fourier PE. Update fun_dim += 16. Run with `--wandb_group local-fourier-pe`.
## Baseline
26 improvements merged. Round 13 baseline: mean3=23.9. 3 new merges (deeper-glu, tandem-temp, curv-spatial-bias) — combined effect unmeasured, estimated ~23.0-23.2.
---
## Results

**W&B run:** `rpoafc7q` | **Epochs:** 58 | **Memory:** 15.0 GB (+2.8 GB) | **Epoch time:** 31s (+27% vs ~24s baseline)

| Split | val/loss | surf_p MAE | surf_Ux MAE | surf_Uy MAE | vol_p MAE |
|---|---|---|---|---|---|
| val_in_dist | 0.591 | 18.24 | 5.26 | 1.51 | 18.92 |
| val_tandem_transfer | 1.583 | 38.46 | 4.76 | 1.85 | 36.43 |
| val_ood_cond | 0.693 | 14.21 | 3.03 | 1.00 | 11.62 |
| val_ood_re | 0.532 | 28.02 | 2.67 | 0.91 | 46.64 |
| **mean3 (excl ood_re)** | **0.850** | **23.64** | **4.35** | **1.45** | **22.33** |

**Baseline estimate:** mean3_surf_p ~23.0–23.2, R13 baseline 23.9
**Result:** 23.64 — better than R13 but above estimated post-merge baseline, marginal negative

### What happened

The local saf Fourier PE did not improve results. mean3_surf_p landed at 23.64, which is better than the R13 baseline (23.9) but modestly above the estimated post-merge baseline of 23.0–23.2. val/loss of 0.850 is consistent with this.

The key problem is the **cost-benefit tradeoff is unfavorable**:
- Memory increased from ~12.2 GB to 15.0 GB (+2.8 GB), due to the larger feature_cross matrix (73×73 vs 57×57) and wider preprocess MLP input.
- Epoch time increased from ~24s to ~31s (+27%), reducing training from ~72 epochs to ~58 epochs in the 30-min budget. Fewer epochs means less convergence.
- The saf features (cols 2:4) are already in the raw input — the model can already learn functions of them via the preprocess MLP. The Fourier PE provides redundant encoding that may not add much information.

The saf PE also uses unscaled saf values (range approximately [-1, 1] for arc-length fraction). The 4 frequencies [1.0, 2.0, 4.0, 8.0] may not be well-tuned to this range; frequencies like [π, 2π, 4π, 8π] might give better coverage of the [0, 1] arc-length range.

### Suggested follow-ups
- **π-scaled frequencies**: use `[π, 2π, 4π, 8π]` to give complete Fourier coverage over [0, 1] arc-length — 1, 2, 4, 8 full oscillations.
- **Fewer, learnable saf freqs**: instead of 16 fixed features, use 4 learnable frequencies → 8 dims, reducing the memory/compute cost while letting the model find the right periodicity.
- **Saf normalization**: normalize saf to [0, 1] per-sample before applying Fourier, similar to how xy is normalized in the existing Fourier PE.