### PR TITLE
Soft MoE output (2 heads with learned gating)

### DIFF
--- a/train.py
+++ b/train.py
@@ -224,6 +224,12 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.mlp2b = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, out_dim),
+            )
+            self.output_gate = nn.Sequential(nn.Linear(hidden_dim, 1), nn.Sigmoid())
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -234,7 +240,9 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            g = self.output_gate(h)
+            return g * self.mlp2(h) + (1 - g) * self.mlp2b(h)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Hard split output heads failed 6+ times. Soft routing: 2 output MLPs with sigmoid gate that learns which head to trust per node. Gate init at 0.5 (equal mix).
## Instructions
Add \`self.mlp2b\` (copy of mlp2) and \`self.output_gate = nn.Sequential(nn.Linear(hidden_dim, 1), nn.Sigmoid())\`. Output: \`g*mlp2(h) + (1-g)*mlp2b(h)\`. Run with \`--wandb_group soft-moe-output\`.
## Baseline
26 improvements merged. Round 13 baseline: mean3=23.9. 3 new merges (deeper-glu, tandem-temp, curv-spatial-bias) — combined effect unmeasured, estimated ~23.0-23.2.
---
## Results

**W&B run:** pulg8slx
**Best epoch:** 55 (stopped by 30-min wall clock; still improving every epoch)
**Peak GPU memory:** 15.1 GB (+2.7 GB vs ~12.4 GB baseline — doubled output head)
**Epoch time:** ~31s/epoch (vs ~26s baseline — ~20% slower)

### Metrics at best checkpoint (epoch 55)

| Split | Loss | Surf p MAE | Surf Ux MAE | Vol p MAE |
|---|---|---|---|---|
| val_in_dist | 0.6155 | **18.61** | 4.336 | 19.59 |
| val_ood_cond | 0.7080 | **14.08** | 2.942 | 12.31 |
| val_ood_re | 0.5601 | **28.17** | 2.588 | 46.98 |
| val_tandem_transfer | 1.6489 | **39.16** | 5.092 | 37.91 |

**surf_p mean3:** (18.61 + 14.08 + 28.17) / 3 = **20.29**
vs baseline estimate 23.0–23.2 → **~2.7–3.0 unit improvement (~13%)**

**val/loss:** 0.8831 — lowest among recent runs (baseline 0.9003)

### What happened

The soft MoE output shows a clear positive signal despite running only 55 epochs (vs 64–70 for other experiments), constrained by slower iteration speed (~31s/epoch from two output head forward passes). **mean3 = 20.29** is the best result so far, and val/loss = 0.8831 beats the stated baseline.

The gate allows the model to blend two different output representations per node, rather than committing to one. With sigmoid init at 0.5 (equal mix), the two heads can specialize gradually. The improvement on ood_cond (14.08 vs ~14.6 baseline) and ood_re (28.17 vs ~28.8) is notable.

**Cost concern:** +2.7 GB memory (15.1 vs 12.4 GB) and ~20% slower epochs. This means ~9 fewer epochs in the 30-min budget. If adopted, the performance gain seems to more than compensate given the strong results even with fewer epochs.

### Suggested follow-ups

- Try a smaller gate (hidden_dim/4 → 1) to reduce compute overhead while preserving the routing capability
- Try applying the gate on a per-channel basis (3 gates, one per output) for finer-grained routing
- Combine with surface_embed (from #1170) which also showed strong results