### PR TITLE
GatedMLP in TransolverBlock MLP (retest on 29-improvement code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -209,7 +209,7 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, act=act)
         self.spatial_bias = nn.Sequential(
             nn.Linear(3, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),


### PR DESCRIPTION
## Hypothesis
GLU in preprocess was a huge win. The block MLP still uses plain MLP. GatedMLP in the block showed mean3=23.5 on Round 14 code (below 24.4 baseline). Retest on current 29-imp code.
## Instructions
Replace `self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)` with `self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, act=act)` in TransolverBlock.__init__. Run with `--wandb_group gated-block-mlp-r15`.
## Baseline
29 improvements merged. Round 14 baseline: mean3=24.4. 3 new merges (late-temp-anneal, deeper-spatial-bias, asym-hard-mining). Combined effect unmeasured.

**Measured baseline-r15 (e2gmhrz0):** loss3=0.8830, mean3=23.88 at ~58 epochs (still running, likely to improve).

---
## Results

**W&B run:** fol8k49h (fern/gated-block-mlp-r15)
**Epochs:** 57 in 30 min (~31.5s/epoch)
**Best checkpoint:** epoch 57, val/loss=0.8904

| Metric | Baseline-r15 (~58 ep) | GatedMLP block (57 ep) | Change |
|--------|----------------------|------------------------|--------|
| val/loss3 | 0.8830 | 0.8904 | +0.8% worse |
| mean3_surf_p | 23.88 | 24.48 | +2.5% worse |
| val_in_dist/mae_surf_Ux | — | 5.50 | — |
| val_in_dist/mae_surf_p | — | 18.91 | — |
| val_ood_cond/mae_surf_Ux | — | 3.33 | — |
| val_ood_cond/mae_surf_p | — | 14.57 | — |
| val_tandem_transfer/mae_surf_Ux | — | 5.75 | — |
| val_tandem_transfer/mae_surf_p | — | 39.97 | — |
| val_ood_re/mae_surf_p | — | 28.01 | — |

**Speed:** ~31.5s/epoch vs ~26s/epoch baseline (~21% overhead).

### What happened

The GatedMLP block does NOT help on the current 29-improvement branch. mean3=24.48 is worse than baseline (~23.88 at equal epochs), a regression of +0.60. This contrasts with PR #1172 (Round 14 code, 26 improvements) where the same change gave mean3=23.48 — a clear improvement.

The reversal is likely due to interactions with the 3 new merges:
- **asymmetric hard-node mining**: starts at epoch 30 and amplifies pressure errors for hard surface nodes. GatedMLP in the block may interact poorly with this, causing unstable gradients or over-emphasizing specific nodes.
- **deeper spatial_bias** (3-layer, now includes curvature): already extracts position-dependent features that the gated mechanism was supposed to learn. Redundant capacity.
- **late temp-anneal**: temperature annealing after epoch 50 changes the optimization dynamics in the attention. GatedMLP may converge worse under this regime.

Additionally, the 21% per-epoch slowdown means fewer training epochs (57 vs ~70 normally), which hurts more when the baseline is already feature-rich.

### Suggested follow-ups

- **Investigate interaction with asym-hard-mining**: Run GatedMLP block without asym-hard-mining to isolate the interaction. If that works, the issue is the mining interaction.
- **GatedMLP block with frozen spatial_bias**: Try fixing the spatial_bias parameters initially to see if the redundancy is the issue.
- **Skip this improvement**: The R14 code benefited but R15 does not. This improvement may have been superseded by the asym-hard-mining and deeper-spatial-bias changes.