### PR TITLE
Soft MoE lite output (lightweight second head with gate)

### DIFF
--- a/train.py
+++ b/train.py
@@ -230,6 +230,10 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.mlp2b = nn.Linear(hidden_dim, out_dim)
+            nn.init.zeros_(self.mlp2b.weight)
+            nn.init.zeros_(self.mlp2b.bias)
+            self.output_gate = nn.Sequential(nn.Linear(hidden_dim, 1), nn.Sigmoid())
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -240,7 +244,9 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.ln_3(fx)
+            g = self.output_gate(h)
+            return g * self.mlp2(h) + (1 - g) * self.mlp2b(h)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Full soft MoE output showed potential. Lighter version: add just nn.Linear(hidden_dim, out_dim) as second head with sigmoid gate. Zero-init for safe start.
## Instructions
Add `self.mlp2b = nn.Linear(hidden_dim, out_dim)` (zero-init) and `self.output_gate = nn.Sequential(nn.Linear(hidden_dim, 1), nn.Sigmoid())`. Output: `g*mlp2(h) + (1-g)*mlp2b(h)`. Run with `--wandb_group soft-moe-output-lite`.
## Baseline
29 improvements merged. Round 14 baseline: mean3=24.4. 3 new merges (late-temp-anneal, deeper-spatial-bias, asym-hard-mining). Combined effect unmeasured.
---
## Results

**W&B run:** `gvhh75wb` (tanjiro/soft-moe-lite)
**Best epoch:** 55/100

### Key metrics vs baseline-r14 (`ryanvvtb`)

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| combined | val/loss | 0.8934 | **0.8835** | -1.1% |
| val_in_dist | surf_Ux MAE | 5.229 | 7.670 | +46.7% |
| val_in_dist | surf_Uy MAE | 1.763 | 2.171 | +23.2% |
| val_in_dist | surf_p MAE | 19.44 | 19.46 | +0.1% |
| val_in_dist | vol_Ux MAE | 1.111 | **1.093** | -1.6% |
| val_in_dist | vol_p MAE | 20.25 | **19.91** | -1.7% |
| val_tandem_transfer | surf_Ux MAE | 5.816 | 7.231 | +24.3% |
| val_tandem_transfer | surf_Uy MAE | 2.295 | 2.594 | +13.0% |
| val_tandem_transfer | surf_p MAE | 39.57 | **39.21** | -0.9% |
| val_ood_cond | surf_p MAE | 14.10 | 14.78 | +4.9% |
| val_ood_re | surf_p MAE | 28.06 | **28.03** | -0.1% |

**Peak memory:** ~15 GB (no change)

### What happened

Did not work. Surface velocity degraded severely (+46.7% Ux, +23.2% Uy in-dist). The val/loss appeared to improve (-1.1%) only because the surface loss is pressure-only — pressure barely changed (+0.1%), and the model "improved" val/loss by reducing volume errors at the cost of velocity.

**Root cause:** The gate (output_gate) initializes to ~0.5 (sigmoid of ~0 weight output). Since mlp2b is zero-initialized, the initial output is g * mlp2(h) + (1-g)*0 ≈ 0.5*mlp2(h). This halves the initial output scale. With pressure-only surface loss, the model compensates for the scale issue by adjusting mlp2 (pressure path) but has no loss signal to fix velocity degradation, so Ux/Uy suffer.

This is a gate initialization problem: "safe start" (zero-init mlp2b) is not actually safe when the gate starts at ~0.5 rather than ~1.0. The fix would be to initialize the gate bias to a large positive value (~5.0) so g≈1 initially, keeping the output equivalent to the original mlp2.

### Suggested follow-ups

- Re-run with gate bias initialized to +5.0 (so g≈1.0 initially). This would make the start truly safe.
- Alternatively, reformulate as mlp2(h) + g*mlp2b(h) (additive gate, zero-init mlp2b = true safe start with no scale change).
- The idea of a second output head is sound in principle. The safe initialization is the key fix needed.