### PR TITLE
Tandem output correction head (additive tandem-specific bias)

### DIFF
--- a/train.py
+++ b/train.py
@@ -316,6 +316,9 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.tandem_correction = nn.Sequential(nn.Linear(n_hidden + 1, 64), nn.GELU(), nn.Linear(64, out_dim))
+        nn.init.zeros_(self.tandem_correction[-1].weight)
+        nn.init.zeros_(self.tandem_correction[-1].bias)
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
@@ -393,9 +396,17 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
+        fx_hidden = fx  # save hidden rep [B, N, n_hidden] for tandem correction
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+
+        # Tandem-specific additive correction (zero-init, safe start)
+        B, N = fx_hidden.shape[:2]
+        is_tandem_flag = is_tandem.view(B, 1, 1).expand(B, N, 1)
+        tandem_corr = self.tandem_correction(torch.cat([fx_hidden, is_tandem_flag], dim=-1))
+        fx = fx + 0.1 * tandem_corr
+
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
Tandem is 2x worse than in-dist. A lightweight correction MLP conditioned on hidden features + tandem flag produces an additive output bias for tandem samples. Zero-init for safe start.
## Instructions
Add \`self.tandem_correction = nn.Sequential(nn.Linear(n_hidden+1, 64), nn.GELU(), nn.Linear(64, out_dim))\` with zero-init. Apply: \`fx = fx + 0.1 * tandem_corr\` where corr depends on is_tandem flag. Run with \`--wandb_group tandem-output-corr\`.
## Baseline
29 improvements merged. Round 14 baseline: mean3=24.4. 3 new merges (late-temp-anneal, deeper-spatial-bias, asym-hard-mining). Combined effect unmeasured.
---
## Results

**W&B run:** \`depdzuxd\` (\`thorfinn/tandem-output-corr\`)
**Epochs:** 54 (best), ~33.2s/epoch

### Metrics at best checkpoint

| Split | val/loss | surf_p | surf_Ux | surf_Uy | vol_p |
|---|---|---|---|---|---|
| val_in_dist | 0.6204 | 18.58 | 6.33 | 1.94 | 19.81 |
| val_tandem_transfer | 1.6800 | 39.95 | 6.29 | 2.51 | 39.20 |
| val_ood_cond | 0.7384 | 14.69 | 3.69 | 1.28 | 12.75 |
| val_ood_re | 0.5648 | 28.32 | 3.29 | 1.11 | 47.27 |

**val/loss_3split:** 0.9009
**mean3_surf_p:** 24.41 (in=18.58, tan=39.95, ood=14.69)

### vs. Baseline (mean3=24.4)

Essentially neutral: mean3_surf_p 24.41 vs baseline 24.4. The tandem_correction module did not measurably improve tandem or other splits.

### What happened

The correction was applied as designed (hidden features [B, N, 128] ++ is_tandem flag [B, N, 1] -> MLP -> additive bias on output). Zero-init meant no effect at epoch 0; the correction had 54 epochs to learn.

The likely reason it didn't help: is_tandem is already implicitly handled throughout the network — the tandem_temp_offset in attention and tandem_boost in training loss both condition on tandem identity. The fx_hidden features already encode tandem vs. non-tandem context well. Adding a post-hoc correction conditioned on the same binary flag provides no new information.

Additionally, tandem error (~40 surf_p) is intrinsic to the data split difficulty (unseen front foil geometry), not a bias the model can correct by re-weighting outputs.

### Suggested follow-ups

- **Condition correction on geometry features**: Use gap/stagger features (indices 21-23) directly instead of binary is_tandem — encodes *how* tandem the sample is, which the binary flag loses.
- **Diagnose tandem error source**: Check whether tandem error is in surface nodes for foil 2 (boundary ID 7, absent from SURFACE_IDS). If so, fix is at data boundary level, not architecture.
- **Remove if keeping as neutral**: The module adds ~16K params but provides no benefit. Should be removed if not merged.