### PR TITLE
Surface k-NN context aggregation (4 nearest neighbor features)

### DIFF
--- a/train.py
+++ b/train.py
@@ -383,6 +383,24 @@ class Transolver(nn.Module):
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
         fx = self.preprocess(x)
+
+        # Surface k-NN context aggregation: each surface node gets mean of k=4 nearest surface neighbors
+        surf_flag = (x[:, :, 12] > 0)  # surface nodes (is_surface feature, positive after normalization)
+        xy_coords = x[:, :, :2]        # [B, N, 2]
+        knn_context = torch.zeros_like(fx)
+        for b in range(fx.shape[0]):
+            sidx = surf_flag[b].nonzero(as_tuple=True)[0]  # surface indices [S]
+            s = sidx.numel()
+            if s >= 2:
+                k = min(4, s - 1)
+                xy_s = xy_coords[b, sidx]  # [S, 2]
+                with torch.no_grad():
+                    dists = torch.cdist(xy_s, xy_s)  # [S, S]
+                    dists.fill_diagonal_(float('inf'))
+                    nn_idx = dists.topk(k, largest=False).indices  # [S, k]
+                knn_context[b, sidx] = fx[b, sidx][nn_idx].mean(dim=1)  # [S, D]
+        fx = fx + 0.1 * knn_context
+
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 


### PR DESCRIPTION
## Hypothesis
Each surface node predicts independently. A lightweight k=4 nearest-neighbor feature average gives local boundary-layer context at minimal cost.
## Instructions
After preprocess, compute k=4 NN for surface nodes using torch.cdist on xy coords. Add 0.1 * knn_mean to surface node features. **Warning: may OOM on large meshes — reduce k if needed.** Run with `--wandb_group knn-surface`.
## Baseline
29 improvements merged. Round 14 baseline: mean3=24.4. 3 new merges (late-temp-anneal, deeper-spatial-bias, asym-hard-mining). Combined effect unmeasured.
---
## Results

**W&B run:** `cpllev9g` | **Epochs:** 47 | **Memory:** 15.4 GB | **Epoch time:** 38s (+57% vs ~24s baseline)

| Split | val/loss | surf_p MAE | surf_Ux MAE | surf_Uy MAE | vol_p MAE |
|---|---|---|---|---|---|
| val_in_dist | 0.679 | 20.58 | 7.36 | 2.15 | 21.04 |
| val_tandem_transfer | 1.683 | 39.52 | 7.08 | 2.65 | 39.05 |
| val_ood_cond | 0.820 | 16.67 | 4.76 | 1.36 | 13.74 |
| val_ood_re | 0.617 | 29.41 | 4.53 | 1.19 | 47.76 |
| **mean3 (excl ood_re)** | **0.950** | **25.59** | **6.40** | **2.05** | **24.61** |

**Baseline R14:** mean3_surf_p=24.4 → **result is +4.9% worse**

### What happened

Negative result. mean3_surf_p=25.59 is clearly worse than the R14 baseline of 24.4. The primary cause is **training efficiency collapse**: the k-NN computation inside the model runs at 38s/epoch vs ~24-25s baseline, reducing epochs from ~70+ to 47 in the 30-min budget. The model is under-trained.

The slowdown comes from the Python loop (4 iterations per batch) + `torch.cdist` on surface nodes inside `torch.compile`. The knn indices computation uses `torch.no_grad()` which forces the compiled graph to break and fall back to eager for that section. Every batch re-executes the Python loop, which is inefficient.

Even if training were equal, it is unclear whether the knn would help: each surface node already "sees" all other nodes implicitly through the slice-based global attention mechanism. The k-NN would only add redundant local aggregation.

Memory is unchanged (15.4 GB) since no architecture changes were made.

### Suggested follow-ups
- **Pre-compute knn indices**: instead of computing knn inside the model on every forward pass, compute the indices once at dataset load time and store them as an additional tensor. Pass as part of the input dict; the model only needs to do the feature gather (no cdist per batch).
- **Sparse knn**: limit knn to surface nodes only (already done here) but keep k=2 to further reduce cost.
- **Message-passing style**: use the knn as a graph convolution (one pass of GNN-style aggregation) only every N epochs, cached and re-used.