### PR TITLE
APPLY: Cosine T_max=72 (proven winner from Round 15, code was empty-merged)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=72, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
This is a PROVEN WINNER (mean3=23.5, tan=37.5) from Round 15 that was merged as an empty placeholder commit. The code change was never applied. This PR actually applies it.

## Instructions
**Line 580**, change:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
```
to:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=72, eta_min=5e-5)
```
Run with `--wandb_group apply-tmax72`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).

**Measured baselines:**
- baseline-r15 (e2gmhrz0): loss3=0.8830, mean3=23.88 (crashed ~58 epochs, WITHOUT any of 3 missing changes)
- baseline-r16 (w39m6rig): loss3=0.8688, mean3=23.16 (running ~59 epochs — appears to incorporate more changes)

---
## Results

**W&B run:** 1k7jzk9g (fern/apply-tmax72)
**Epochs:** 60 in 30 min (~24s/epoch, same as baseline)
**Best checkpoint:** epoch 60, val/loss=0.8799

| Metric | Baseline-r15 (~58 ep) | T_max=72 (60 ep) | Change |
|--------|----------------------|-------------------|--------|
| val/loss3 | 0.8830 | 0.8799 | -0.3% |
| mean3_surf_p | 23.88 | 24.12 | +1.0% worse |
| val_in_dist/mae_surf_Ux | — | 7.73 | — |
| val_in_dist/mae_surf_p | — | 18.82 | — |
| val_ood_cond/mae_surf_Ux | — | 4.79 | — |
| val_ood_cond/mae_surf_p | — | 14.05 | — |
| val_tandem_transfer/mae_surf_Ux | — | 6.99 | — |
| val_tandem_transfer/mae_surf_p | — | 39.49 | — |
| val_ood_re/mae_surf_p | — | 28.23 | — |

**Speed:** ~24s/epoch, same as baseline.

### What happened

T_max=72 alone does NOT improve over the current baseline. mean3=24.12 vs baseline 23.88 is a small regression (+0.24, +1%). This contradicts the Round 15 result (mean3=23.5) where T_max=72 was a clear winner.

The discrepancy likely comes from context: when T_max=72 was first tested in Round 15 (on ~20 improvements), it extended the cosine decay window meaningfully given the training horizon. On the current 32-improvement branch with different LR dynamics (late temp annealing, asymmetric loss), T_max=72 may not align as well. With ~60 epochs in the 30-min budget, T_max=72 means the cosine decay is still mid-cycle at training end, whereas T_max=62 would complete one full cycle — and the baseline dynamics may now favor a completed cycle.

The loss3 is slightly improved (0.8799 vs 0.8830, -0.3%) but mean3 is slightly worse. The tandem_transfer pressure (39.49 vs ~40.45 from older baseline) improved, consistent with the original finding, but this isn't the full picture.

### Suggested follow-ups

- **Apply all three missing changes together**: T_max=72 + progressive temp + surf-grad-reg in one run may restore the original win — the three changes might have positive interactions that cancel individual regressions.
- **T_max=82 or 90**: With ~60 epoch budget and current dynamics, a longer T_max might align the LR schedule better to actual training length.
- **Revisit after other fixes**: If the progressive temp and surf-grad changes are applied first, re-test T_max=72 on that improved baseline.