### PR TITLE
APPLY: Progressive temp annealing 0.5→0.15 (proven winner, empty-merged)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,11 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 30:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            progress = min(1.0, (epoch - 30) / 30.0)
+            max_temp = 0.5 - progress * 0.35  # 0.5 → 0.15 over epochs 30-60
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=max_temp)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
Proven winner (mean3=23.6, ood=13.7) from Round 15 that was empty-merged. This applies the actual code change.

## Instructions
Replace the hard temp clamp (lines ~802-804):
```python
    if epoch >= 50:
        with torch.no_grad():
            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
```
with:
```python
    if epoch >= 30:
        with torch.no_grad():
            progress = min(1.0, (epoch - 30) / 30.0)
            max_temp = 0.5 - progress * 0.35  # 0.5 → 0.15 over epochs 30-60
            _base_model.blocks[0].attn.temperature.data.clamp_(max=max_temp)
```
Run with `--wandb_group apply-prog-temp`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** `uhl0kqfd` (tanjiro/apply-prog-temp)
**Best epoch:** 57/100

### Key metrics vs baseline-r14 (`ryanvvtb`)

| Split | Metric | Baseline | This run | Delta |
|---|---|---|---|---|
| combined | val/loss | 0.8934 | **0.8830** | -1.2% |
| val_in_dist | surf_Ux MAE | 5.229 | 5.380 | +2.9% |
| val_in_dist | surf_Uy MAE | 1.763 | **1.520** | -13.8% |
| val_in_dist | surf_p MAE | 19.44 | **18.46** | -5.0% |
| val_in_dist | vol_p MAE | 20.25 | **19.79** | -2.3% |
| val_tandem_transfer | surf_Ux MAE | 5.816 | **5.559** | -4.4% |
| val_tandem_transfer | surf_Uy MAE | 2.295 | **2.067** | -10.0% |
| val_tandem_transfer | surf_p MAE | 39.57 | **39.39** | -0.5% |
| val_ood_cond | surf_p MAE | 14.10 | 14.11 | +0.1% |
| val_ood_re | surf_p MAE | 28.06 | **28.05** | -0.0% |

**Peak memory:** ~15 GB (no change)

### What happened

Confirmed winner. Progressive temperature annealing (0.5 → 0.15 over epochs 30-60) substantially improves surface velocity (-13.8% Uy in-dist, -10.0% tandem) and surface pressure (-5.0%), vs the hard clamp at 0.25 from epoch 50.

Starting the clamp earlier (epoch 30 vs 50) and using a smooth schedule rather than a hard cutoff allows the attention to gradually tighten its slice assignments. The earlier start means more training epochs benefit from tighter attention, giving the model more time to exploit the sharper slice routing.

The only minor regression is surf_Ux +2.9% in-dist (likely noise; val is just one run). The improvement in Uy and pressure more than compensates.

### Suggested follow-ups

- Try applying the same progressive schedule to ALL blocks (not just blocks[0]).
- Explore whether starting earlier (epoch 20) or ending later (epoch 80) gives further gains.
- Check if combining progressive temp annealing with deeper spatial bias improves further.