### PR TITLE
APPLY ALL THREE: T_max=72 + progressive temp + surface gradient loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=72, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )
@@ -748,6 +748,20 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 
+        if epoch >= 10:
+            grad_loss = 0.0
+            for b in range(pred.shape[0]):
+                s_mask_b = surf_mask[b]
+                if s_mask_b.sum() > 2:
+                    s_pred = pred[b, s_mask_b, 2]
+                    s_xy = x[:, :, :2][b, s_mask_b]
+                    cx, cy = s_xy[:, 0].mean(), s_xy[:, 1].mean()
+                    angles = torch.atan2(s_xy[:, 1] - cy, s_xy[:, 0] - cx)
+                    sort_idx = angles.argsort()
+                    diffs = (s_pred[sort_idx][1:] - s_pred[sort_idx][:-1]).abs()
+                    grad_loss = grad_loss + diffs.mean()
+            loss = loss + 0.01 * (grad_loss / max(pred.shape[0], 1))
+
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64
         B, N, C = pred.shape
@@ -799,9 +813,11 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 30:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            progress = min(1.0, (epoch - 30) / 30.0)
+            max_temp = 0.5 - progress * 0.35
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=max_temp)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
All 3 proven winners that were empty-merged, applied together. Tests compounding.

## Instructions
Apply ALL three changes from PRs #2, #3, #4 simultaneously:
1. T_max=72 (line 580)
2. Progressive temp annealing (replace hard clamp with smooth ramp)
3. Surface gradient regularization (add after surf_loss)
Run with \`--wandb_group apply-all-three\`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** \`2327x7j9\` (alphonse/apply-all-three, group: apply-all-three)
**Epochs:** 57 (33s/epoch, 30-min wall clock)
**Peak memory:** 15.6 GB

| Metric | Baseline (ryanvvtb r14) | All Three | Delta |
|---|---|---|---|
| val/loss_3split | 0.8934 | **0.8894** | -0.004 (-0.4%) ~ |
| mean3_surf_p | 24.37 | **24.14** | -0.23 (-0.9%) ~ |
| val_in_dist/mae_surf_p | 19.44 | **18.11** | -1.33 (-6.8%) ✓ |
| val_tandem_transfer/mae_surf_p | 39.57 | **39.13** | -0.44 (-1.1%) ~ |
| val_ood_cond/mae_surf_p | 14.10 | 15.19 | +1.09 (+7.7%) ✗ |
| val_ood_re/mae_surf_p | 28.06 | 28.41 | +0.35 (+1.2%) ✗ |

**What happened:** Negative result — the three changes do not compound. The combined result (mean3=24.14) is only a marginal improvement over r14 baseline (24.37), and likely no improvement or even a regression vs the estimated noam branch baseline (~23.9). Individual experiments showed T_max=72 giving mean3=23.47 and progressive temp giving 23.57, so both did better alone than they do together.

The surface gradient regularization appears to be hurting ood_cond (+7.7% worse). The progressive temp ramp (starting at epoch 30) may interfere with the gradient regularization — both apply significant changes during the critical mid-training phase (epochs 30-50), possibly causing conflicting optimization dynamics.

Specifically, the ood_cond regression (+7.7%) is concerning — it suggests the gradient smoothness constraint is harming generalization to out-of-distribution conditions. The smoothness regularization may be fitting the training distribution's surface topology rather than learning transferable features.

Note: Exit code 1 due to pre-existing visualization bug. Training completed the full 30 minutes correctly.

**Suggested follow-ups:**
- Try T_max=72 alone (already done, strong result) — apply that cleanly
- Try surface gradient reg alone without the progressive temp (isolate which hurts)
- Try hard clamp at epoch 50 (original late-temp-anneal approach) + T_max=72 — the proven combination
- The surface gradient regularization from epoch 10 may be too early; try from epoch 30 or 40