### PR TITLE
Temperature ramp starting at epoch 35 (compromise timing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,11 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 35:
+        progress = min(1.0, (epoch - 35) / 25.0)
+        max_temp = 0.5 - progress * 0.35
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=max_temp)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
Progressive temp from ep30 may constrain mid-training. Starting at ep35 with same 0.15 floor is a compromise.
## Instructions
Same progressive ramp but starting at epoch 35: `if epoch >= 35: progress = min(1.0, (epoch-35)/25.0); max_temp = 0.5 - progress*0.35`
Run with `--wandb_group temp-ramp-ep35`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** `5rj1180b`
**Best epoch:** 61 / 61 (hit wall-clock limit at 30.2 min, 30s/epoch)
**Peak memory:** 14.7 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6053 | 6.66 | 1.93 | 18.72 | 1.11 | 0.37 | 19.80 |
| val_tandem_transfer | 1.6211 | 6.20 | 2.24 | 38.27 | 1.89 | 0.86 | 37.70 |
| val_ood_cond | 0.7017 | 3.50 | 1.05 | 14.01 | 0.71 | 0.27 | 11.90 |
| val_ood_re | 0.5321 | 3.10 | 0.94 | 27.58 | 0.82 | 0.35 | 46.70 |
| **mean3** | **0.943** | **5.45** | **1.74** | **23.67** | — | — | — |

True baseline: ~23.9.

**What happened:** Marginal positive. mean3_surf_p=23.67 vs estimated true baseline ~23.9, a ~0.2 unit improvement. This is within noise. The progressive ramp starting at ep35 is essentially equivalent to the hard clamp at ep50 — both produce similar results (~23.5-23.7 range across recent experiments). The temperature constraint starting earlier (ep35 vs ep50) slightly limits how freely the model can route early on, but doesn't cause the collapse that the ep30 version might. The floor of 0.15 at ep60 ensures some routing flexibility remains throughout training. No meaningful advantage over the simpler hard clamp.

**Suggested follow-ups:**
- Try removing temperature annealing entirely to see if it helps or hurts.
- The temperature is currently a shared parameter across all heads. Per-head temperature might allow more specialization.