### PR TITLE
GatedMLP in block MLP + T_max=72 combined

### DIFF
--- a/train.py
+++ b/train.py
@@ -209,7 +209,7 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim)
         self.spatial_bias = nn.Sequential(
             nn.Linear(3, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=72, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
GatedMLP in block showed 23.5 in R14 but 24.5 in R15. The R15 test had T_max=62 (suboptimal). With T_max=72 applied, more epochs with meaningful LR may help block GLU converge.
## Instructions
Apply T_max=72 (line 580) AND replace block MLP with GatedMLP. Run with \`--wandb_group gated-block-tmax72\`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** \`dbd46wbu\` (\`thorfinn/gated-block-tmax72\`)
**Epochs:** 54 (best), ~33.4s/epoch

### Metrics at best checkpoint

| Split | val/loss | surf_p | surf_Ux | surf_Uy | vol_p |
|---|---|---|---|---|---|
| val_in_dist | 0.6370 | 18.38 | 6.48 | 1.67 | 19.45 |
| val_tandem_transfer | 1.6439 | 38.81 | 6.10 | 2.15 | 38.03 |
| val_ood_cond | 0.7709 | 15.40 | 3.38 | 1.04 | 13.00 |
| val_ood_re | 0.5774 | 28.49 | 2.87 | 0.85 | 47.50 |

**val/loss_3split:** 0.9073
**mean3_surf_p:** 24.20 (in=18.38, tan=38.81, ood=15.40)

### vs. Baseline (~23.9)

Slightly worse: mean3_surf_p 24.20 vs baseline ~23.9. The combination of GatedMLP block + T_max=72 did not improve over baseline.

### What happened

Both changes were applied: `self.mlp = GatedMLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim)` in TransolverBlock, and T_max=62 → T_max=72 in the cosine scheduler.

The result is slightly worse than the true R16 baseline (~23.9). The expected synergy — GatedMLP converging better with a longer cosine schedule — did not materialize within the 30-minute budget.

Possible reasons:
1. **GatedMLP is larger, not smaller**: For hidden_dim=128, mlp_ratio=2, GatedMLP uses two 128→256 projections + one 256→128, vs MLP's 128→256 + 256→128. That's ~50% more block-MLP parameters, slowing throughput slightly and possibly adding noise early in training.
2. **T_max=72 raises LR at epoch 54**: Under T_max=72, the LR at epoch 54 is higher than under T_max=62 — meaning less convergence at the checkpoint. This partially offsets the benefit of a longer schedule that can't fully pay off within the time budget.
3. **R14 gated-block 23.5 may not replicate on R16 noam**: The R14 result was on an older branch with fewer baseline improvements; the current R16 noam may interact differently with the block change.

### Suggested follow-ups

- **Isolate T_max=72 alone**: Test T_max=72 without GatedMLP to see if the schedule change alone helps (an isolated branch exists for this).
- **Use GatedMLP2 instead of GatedMLP**: GatedMLP2 keeps the same first-layer structure but adds a residual gated layer, which may be a better block-MLP replacement.
- **Accept the neutral result**: The R14 23.5 gated-block result may have been noise or favorable initialization. The combination does not clearly improve the baseline.