### PR TITLE
Per-head temperature initialization diversity

### DIFF
--- a/train.py
+++ b/train.py
@@ -127,7 +127,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
-        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        self.temperature = nn.Parameter(torch.tensor([0.3, 0.4, 0.5, 0.6]).view(1, heads, 1, 1))
         self.tandem_temp_offset = nn.Parameter(torch.zeros(1, 1, 1, 1))
 
         self.in_project_x = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
4 attention heads share same temp init (0.5). Different init values let heads specialize at different sharpness levels.
## Instructions
Change temp init from `torch.ones([1,heads,1,1]) * 0.5` to `torch.tensor([0.3, 0.4, 0.5, 0.6]).view(1,heads,1,1)`.
Run with `--wandb_group per-head-temp`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** `9xldxnqc` (violet/per-head-temp, 61 epochs, ~29.7s/epoch)

Compared against r16 baseline `w39m6rig` (mean3 surf_p=23.16, loss_3split=0.8688):

| Split | loss (baseline) | loss (ours) | Δ | surf_p (baseline) | surf_p (ours) | Δ |
|---|---|---|---|---|---|---|
| val_in_dist | 0.6023 | 0.5964 | -1.0% | 17.49 | 18.18 | +3.9% |
| val_tandem_transfer | 1.6102 | 1.6106 | +0.0% | 37.67 | 38.07 | +1.1% |
| val_ood_cond | 0.7160 | 0.6844 | -4.4% | 14.33 | 13.75 | -4.1% |
| val_ood_re | 0.5467 | 0.5262 | -3.7% | 27.75 | 27.48 | -1.0% |
| **mean3** | **0.8688** | **0.8544** | **-1.7%** | **23.16** | **23.33** | **+0.7%** |

Full metrics at best checkpoint (epoch 61):

**val_in_dist:** surf_Ux=5.52, surf_Uy=1.80, surf_p=18.18, vol_Ux=1.11, vol_Uy=0.36, vol_p=19.53
**val_tandem_transfer:** surf_Ux=5.71, surf_Uy=2.30, surf_p=38.07, vol_Ux=1.92, vol_Uy=0.87, vol_p=37.69
**val_ood_cond:** surf_Ux=3.09, surf_Uy=1.07, surf_p=13.75, vol_Ux=0.71, vol_Uy=0.27, vol_p=11.69
**val_ood_re:** surf_Ux=2.63, surf_Uy=0.88, surf_p=27.48, vol_Ux=0.81, vol_Uy=0.36, vol_p=46.58

Peak memory: ~15 GB (identical to baseline — initialization-only change)

### What happened

Mixed result. val/loss_3split improved by 1.7%, but the primary metric (mean3 surf_p) degraded slightly (+0.7%). The per-head temperature diversity shows a clear split: ood_cond and ood_re improve noticeably (-4.1% and -1.0% surf_p respectively), while in_dist and tandem both regress (+3.9% and +1.1%).

Interpretation: the sharpest head (init=0.6) seems to benefit OOD generalization by learning to focus on distinct features, but the asymmetric initialization may hurt the heads that need to cooperate on in-distribution data. The volume loss metrics improved more uniformly (-1% to -4%) than surface metrics, suggesting the learned specialization helps dense field prediction but not precise surface reconstruction.

This is not a clear win — the most important metric (surface pressure across all splits) is essentially unchanged relative to the current baseline.

### Suggested follow-ups
- Try symmetric diversity: [0.4, 0.45, 0.55, 0.6] to avoid the extremes
- Try learned diversity: initialize all at 0.5 but add a small head-specific learnable offset (4 params total)
- Try wider range [0.2, 0.4, 0.6, 0.8] — perhaps the range of 0.3 is too narrow to meaningfully differentiate