### PR TITLE
Spectral normalization on output head layers

### DIFF
--- a/train.py
+++ b/train.py
@@ -226,9 +226,9 @@ class TransolverBlock(nn.Module):
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
+                nn.utils.parametrizations.spectral_norm(nn.Linear(hidden_dim, hidden_dim)),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
+                nn.utils.parametrizations.spectral_norm(nn.Linear(hidden_dim, out_dim)),
             )
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):


### PR DESCRIPTION
## Hypothesis
Spectral norm constrains output head Lipschitz constant, stabilizing predictions during EMA phase without shrinking weights.
## Instructions
Wrap both Linear layers in mlp2 with `nn.utils.parametrizations.spectral_norm()`.
Run with `--wandb_group spectral-norm-out`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** `8qdgbpg5` | **Best epoch:** 61/100 (30-min timeout) | **Epoch time:** ~29.6s

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.591 | 9.34 | 2.90 | **17.82** | 1.09 | 0.36 | 19.48 |
| val_tandem_transfer | 1.639 | 7.92 | 2.98 | **38.99** | 1.93 | 0.87 | 38.24 |
| val_ood_cond | 0.710 | 5.90 | 1.89 | **14.33** | 0.73 | 0.27 | 11.90 |
| val_ood_re | 0.545 | 5.55 | 1.74 | 27.74 | 0.83 | 0.36 | 46.77 |
| **mean3_surf_p** | **0.871** | | | **23.71** | | | |

**Baseline:** ~23.9 → **Result:** 23.71 → **Δ = −0.19 (0.8% improvement)**

**Peak memory:** ~12.4 GB (negligible overhead from spectral norm)

### What happened

Marginal positive result. Spectral norm on the two output head linears yields a small improvement over the true baseline (23.71 vs ~23.9). The Lipschitz constraint on the output projection appears to modestly help generalization, particularly on val_in_dist (17.82) and val_ood_cond (14.33). Tandem transfer remains high (39.0) as expected from the systematic tandem surface underweighting bug.

Epoch time is 29.6s — slightly above typical (~24-27s) due to power iteration in spectral_norm forward pass. Overhead is small.

The improvement (~0.8%) is within noise range for a 30-min run. Hard to be confident this is signal vs. variance without a longer run or multiple seeds.

Note: visualization section crashed with the pre-existing Fourier PE shape mismatch bug (same as prior runs on this branch). All training metrics are fully logged.

### Suggested follow-ups

- Increase SN iterations (n_power_iterations=3) — may improve stability further at minimal cost
- Apply spectral norm to the attention projections (in_project_slice, in_project_short) — could stabilize the physics-attention slice scores
- Try weight normalization as an alternative — different inductive bias, possibly cleaner with torch.compile
- Fix the 3 missing baseline improvements (T_max=72, progressive temp annealing, surface gradient regularization) to establish a clean baseline