### PR TITLE
Zero noise after epoch 50 (clean EMA gradients)

### DIFF
--- a/train.py
+++ b/train.py
@@ -671,9 +671,13 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            if epoch >= 50:
+                vel_noise = 0.0
+                p_noise = 0.0
+            else:
+                noise_progress = min(1.0, epoch / 50)
+                vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
+                p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 


### PR DESCRIPTION
## Hypothesis
Residual noise at ep50+ corrupts EMA averaging. Zero noise gives 10+ clean-gradient epochs for EMA.
## Instructions
Change noise computation: `if epoch >= 50: vel_noise = 0.0; p_noise = 0.0` else use current annealing to epoch 50.
Run with `--wandb_group noise-zero-ep50`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** jo7cxyxu | **Epochs:** 58 | **Group:** noise-zero-ep50

### Validation losses (best checkpoint, epoch 58)

| Split | loss | mae_surf_p |
|---|---|---|
| val_in_dist | 0.6222 | 19.2 |
| val_ood_cond | 0.7053 | 14.1 |
| val_ood_re | 0.5435 | 27.8 |
| val_tandem_transfer | 1.6649 | 39.8 |
| **mean (val/loss_3split)** | **0.8840** | |

### Volume MAE (W&B summary)

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.12 | 0.37 | 19.79 |
| val_ood_cond | 0.73 | 0.27 | 12.14 |
| val_ood_re | 0.84 | 0.36 | 46.87 |
| val_tandem_transfer | 1.94 | 0.89 | 39.05 |

**mean3 surf_p = 20.4** (true baseline: 23.9) — improvement

**Peak memory:** ~13.1 GB (no change)

### What happened

Training ran to completion (58 epochs). The hypothesis is sound: removing output label noise after epoch 50 gives EMA a clean signal for its final ~8-10 epochs. The noise schedule was also updated to anneal to zero by epoch 50 (previously by epoch 60), ensuring a cleaner transition.

val/loss_3split = 0.8840, mean3 surf_p = 20.4, which beats the baseline of 23.9. However, the improvement is modest compared to other recent changes (slice-diversity got 19.8, lookahead-alpha got 19.9). This suggests the noise zeroing contributes positively but is not the dominant factor.

Note: The x-feature noise at line 668-669 (input noise, not output noise) still uses the epoch<60 schedule; the PR only asked to modify vel_noise/p_noise.

### Suggested follow-ups

- Also zero x-feature noise after epoch 50 (same rationale)
- Try zeroing at epoch 40 (coincides with EMA start) instead of 50
- Check if noise at epoch 50+ actually hurts: run with noise annealing to epoch 60 as control