### PR TITLE
Surface correction head (lightweight output refinement for surface nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,13 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.surf_correction = nn.Sequential(
+            nn.Linear(n_hidden, n_hidden // 2),
+            nn.GELU(),
+            nn.Linear(n_hidden // 2, out_dim),
+        )
+        nn.init.zeros_(self.surf_correction[-1].weight)
+        nn.init.zeros_(self.surf_correction[-1].bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -356,14 +363,15 @@ class Transolver(nn.Module):
         x = data.get("x")
         pos = data.get("pos", pos)
         condition = data.get("condition", condition)
-        return x, pos, condition
+        is_surface = data.get("is_surface", None)
+        return x, pos, condition, is_surface
 
     def _validate_output_dims(self, preds):
         if sum(self.output_dims) != preds.shape[-1]:
             raise ValueError("Sum of output_dims must match preds last dimension")
 
     def forward(self, data, pos=None, condition=None):
-        x, pos, condition = self._unpack_inputs(data, pos=pos, condition=condition)
+        x, pos, condition, is_surface = self._unpack_inputs(data, pos=pos, condition=condition)
         if x is None:
             raise ValueError("Missing required input tensor: x")
         if condition is not None:
@@ -396,6 +404,9 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        if is_surface is not None:
+            surf_f = is_surface.float().unsqueeze(-1)  # [B, N, 1]
+            fx = fx + self.surf_correction(fx_pre) * surf_f
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
@@ -694,7 +705,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "is_surface": is_surface})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -865,7 +876,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    pred = eval_model({"x": x, "is_surface": is_surface})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
@@ -1014,8 +1025,16 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 x_n = torch.cat([x_n, curv], dim=-1)
+                raw_xy_v = x_n[:, :, :2]
+                xy_min_v = raw_xy_v.amin(dim=1, keepdim=True)
+                xy_max_v = raw_xy_v.amax(dim=1, keepdim=True)
+                xy_norm_v = (raw_xy_v - xy_min_v) / (xy_max_v - xy_min_v + 1e-8)
+                freqs_v = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled_v = xy_norm_v.unsqueeze(-1) * freqs_v
+                fourier_pe_v = torch.cat([xy_scaled_v.sin().flatten(-2), xy_scaled_v.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_v], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
-                pred = vis_model({"x": x_n})["preds"].float()
+                pred = vis_model({"x": x_n, "is_surface": is_surf_dev})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
                 y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
             samples.append((x[:, :2], y_true, y_pred, is_surface))


### PR DESCRIPTION
## Hypothesis
A small MLP that produces an additive correction for surface nodes, applied after the main output. Zero-init for safe start.
## Instructions
Add `self.surf_correction = nn.Sequential(nn.Linear(n_hidden, n_hidden//2), nn.GELU(), nn.Linear(n_hidden//2, out_dim))` with zero-init. Add correction to surface node predictions: `fx += surf_correction(fx_pre) * is_surface`.
Run with `--wandb_group surf-correction`.
## Baseline
32 improvements merged BUT 3 winner code changes were discovered to be empty placeholder merges. The actual code is missing T_max=72, progressive temp annealing, and surface gradient regularization. True baseline ~23.9 (not 23.0 as estimated).
---
## Results

**W&B run:** `83hp4s26` (kohaku/surf-correction, group: surf-correction)
**Runtime:** 30.7 min (timeout)
**Model params:** 782,203 (+18,819 for surf_correction, +2.4%)
**Peak memory:** ~12 GB (GPU)

### val/loss (best epoch): 0.8514

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 10.61 | 1.83 | 17.73 | 1.08 | 0.36 | 18.98 |
| val_ood_cond | 7.71 | 1.39 | 13.97 | 0.70 | 0.27 | 11.89 |
| val_ood_re | 6.93 | 1.25 | 27.50 | 0.82 | 0.36 | 46.59 |
| val_tandem_transfer | 15.27 | 2.42 | 37.91 | 1.91 | 0.87 | 37.50 |

### What happened

The surf correction runs at val/loss=0.8514, in the same range as recent noam-branch experiments (gilbert/local-fourier-pe: 0.8497, alphonse/wavelet-fourier-pe: 0.8793). Direct baseline comparison is hard—no clean no-modification baseline run exists on the current branch. But these experiments are not apples-to-apples since they make different changes.

The correction head is small (18K params, zero-initialized), starting neutral. After ~30 min / ~60 epochs, pressure MAE is marginally better than gilbert's run across all splits (e.g., val_in_dist surf_p: 17.73 vs 18.24), but velocity (Ux) is worse—likely explained by the different experiment types rather than the correction head.

One design note: surf_correction takes fx_pre (pre-block features), not post-block features. This limits what it can correct—the blocks have more context. The correction is essentially applying a static input-based residual rather than a representation-based residual.

Also fixed a pre-existing bug: Fourier PE was missing from the visualization code's preprocessing, causing the final plot step to crash.

### Suggested follow-ups

- Apply surf_correction to **post-block fx** before the skip gate—richer features, can correct block-level errors.
- Try a stronger correction head or per-channel gating.
- Run a clean noam-branch baseline (no modifications) to properly anchor comparisons.