### PR TITLE
Factored preprocess: 3 parallel branches (geometry + conditions + position)

### DIFF
--- a/train.py
+++ b/train.py
@@ -285,7 +285,10 @@ class Transolver(nn.Module):
                 act=act,
             )
         else:
-            self.preprocess = GatedMLP2(fun_dim + space_dim, n_hidden * 2, n_hidden)
+            # Factored preprocess: 3 parallel specialized branches
+            self.geom_branch = GatedMLP2(11, n_hidden * 2 // 3, n_hidden // 3)   # dsdf+saf+curvature
+            self.cond_branch = GatedMLP2(11, n_hidden * 2 // 3, n_hidden // 3)   # Re, AoA, NACA, gap
+            self.pos_branch = GatedMLP2(34, n_hidden * 2 // 3, n_hidden // 3)    # xy + Fourier PE
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim
@@ -382,7 +385,14 @@ class Transolver(nn.Module):
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
-        fx = self.preprocess(x)
+        geom_feats = torch.cat([x[:, :, 2:12], x[:, :, 24:25]], dim=-1)   # [B, N, 11]
+        cond_feats = x[:, :, 13:24]                                          # [B, N, 11]
+        pos_feats = torch.cat([x[:, :, 0:2], x[:, :, 25:57]], dim=-1)      # [B, N, 34]
+        fx = torch.cat([
+            self.geom_branch(geom_feats),
+            self.cond_branch(cond_feats),
+            self.pos_branch(pos_feats),
+        ], dim=-1)  # [B, N, n_hidden]
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 


### PR DESCRIPTION
## Hypothesis
57 input features are processed by a single MLP, which may create representational bottlenecks. Factoring into 3 specialized branches (geometry: dsdf+saf+curvature→64, conditions: Re+AoA+NACA+gap→64, position: xy+Fourier PE→64) lets each branch specialize.
## Instructions
Replace the single GatedMLP2 preprocess with 3 parallel GatedMLP branches:
- \`geom_branch\`: features [2:12, 24] (dsdf, saf, curvature) → 64 dims
- \`cond_branch\`: features [13:24] (Re, AoA, NACA, gap, stagger) → 64 dims
- \`pos_branch\`: features [0:2, 25:57] (xy + Fourier PE) → 64 dims
Concatenate: 64+64+64 = 192. Run with \`--wandb_group input-decomposition\`.
## Baseline (Round 16 measured)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- val_loss=0.87
- Round 16 was a full plateau — ALL 12 experiments were above baseline
- PLATEAU PROTOCOL: These experiments are RADICAL ESCALATION — paradigm shifts, not incremental tweaks
---
## Results

**W&B run:** \`4m9vzez1\` (alphonse/input-decomposition, group: input-decomposition)
**Epochs:** 56 (32s/epoch, 30-min wall clock)
**Peak memory:** 15.6 GB

| Metric | Baseline (R16, ~23.2) | Factored Preprocess | Delta |
|---|---|---|---|
| val/loss_3split | 0.87 | 0.9214 | +0.051 (+5.9%) ✗ |
| mean3_surf_p | 23.2 | 25.10 | +1.90 (+8.2%) ✗ |
| val_in_dist/mae_surf_p | 17.5 | 20.07 | +2.57 (+14.7%) ✗ |
| val_tandem_transfer/mae_surf_p | 37.7 | 40.32 | +2.62 (+7.0%) ✗ |
| val_ood_cond/mae_surf_p | 14.3 | 14.90 | +0.60 (+4.2%) ✗ |
| val_ood_re/mae_surf_p | 27.7 | 28.57 | +0.87 (+3.1%) ✗ |

**What happened:** Clear regression across all splits (+8.2% mean3). The factored preprocess is significantly worse than the single unified MLP. This is the opposite of the hypothesis.

The core issue: by splitting features into isolated branches, we lose cross-feature interactions that are critical for this task. CFD predictions depend on how geometry (foil shape) interacts with flow conditions (Re, AoA) — e.g., the pressure distribution on a thick airfoil at high AoA is qualitatively different from a thin airfoil. A single MLP that sees all 57 features can model these joint interactions; separate branches cannot. The per-branch networks are also shallower (GatedMLP2 with 128-dim hidden vs original 384-dim hidden per branch), reducing capacity.

Additionally, feature index 12 was excluded from all branches, which may have discarded a useful feature.

The single GatedMLP2 with all 57 features and 384-dim hidden appears to be a better inductive bias for this task — the "representational bottleneck" concern is not justified here.

Note: Exit code 1 due to pre-existing visualization bug. Training completed the full 30 minutes correctly.

**Suggested follow-ups:**
- The unified MLP approach is better; explore capacity increases (wider hidden, 3-layer) rather than feature decomposition
- If decomposition is desired, try a bottleneck-then-expand architecture where branches first compress to 32 then expand, with interactions at the merge point
- Add feature-mixing between branches via a small cross-attention or outer product layer at the output