### PR TITLE
Test-time node dropout ensemble (5x inference, zero training cost)

### DIFF
--- a/train.py
+++ b/train.py
@@ -864,9 +864,18 @@ for epoch in range(MAX_EPOCHS):
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
 
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
-                pred = pred.float()
+                # Test-time node dropout ensemble: 5 passes, each masking 20% of volume nodes
+                vol_nodes = mask & ~is_surface  # [B, N] — volume nodes to optionally mask
+                N_TTA = 5
+                pred_accum = None
+                for _tta in range(N_TTA):
+                    x_tta = x.clone()
+                    drop = (torch.rand(x.shape[:2], device=device) < 0.2) & vol_nodes
+                    x_tta[drop] = 0.0
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        pred_i = eval_model({"x": x_tta})["preds"].float()
+                    pred_accum = pred_i if pred_accum is None else pred_accum + pred_i
+                pred = pred_accum / N_TTA
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis
Average predictions from 5 random 80% volume-node subsamples. Surface nodes always kept. This creates an implicit ensemble with ZERO training cost.
## Instructions
In validation loop only: run 5 forward passes, each masking a random 20% of volume nodes. Average the 5 surface predictions. This adds ~5x validation time but zero training cost. Run with \`--wandb_group test-time-node-dropout\`.
## Baseline (Round 16 measured)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- val_loss=0.87
- Round 16 was a full plateau — ALL 12 experiments were above baseline
- PLATEAU PROTOCOL: These experiments are RADICAL ESCALATION — paradigm shifts, not incremental tweaks
---
## Results

**W&B run:** \`tvcr43zi\` (\`thorfinn/test-time-node-dropout\`)
**Epochs:** 42 (best), ~51.5s/epoch (vs baseline ~33s — 5x val overhead as expected)

### Metrics at best checkpoint

| Split | val/loss | surf_p | surf_Ux | vol_p |
|---|---|---|---|---|
| val_in_dist | 1.257 | 29.95 | 9.69 | 104.2 |
| val_tandem_transfer | 2.209 | 45.53 | 8.56 | 108.7 |
| val_ood_cond | 1.242 | 20.57 | 6.34 | 45.1 |
| val_ood_re | 1.011 | 32.73 | 6.11 | 75.9 |

**val/loss_3split:** 1.430
**mean3_surf_p:** 32.02 (in=29.95, tan=45.53, ood=20.57)

### vs. Baseline (mean3=23.2, val_loss=0.87)

Strongly negative: mean3_surf_p 32.02 (+38%) and val_loss 1.43 (+64%). Volume errors are catastrophically large (vol_p up 5-10×).

### What happened

The TTA was implemented by zeroing out the entire feature vector (including x,y coordinates) for 20% of randomly selected volume nodes per pass, then averaging predictions across 5 passes.

The zeroing-out approach is catastrophically destructive for this architecture:

1. **Position zeroing corrupts the Fourier PE**: The Fourier positional encoding is computed from `raw_xy = x[:, :, :2]`. Zeroing the whole feature vector sets `raw_xy` of dropped nodes to negative values (the normalized global mean x,y), not to (0,0). The PE then places all dropped nodes at a spurious location, creating a "phantom cluster" of nodes.

2. **Slice attention corruption**: Transolver builds slice tokens from ALL N nodes. If 20% have garbage positions, the slice tokens are corrupted, causing incorrect predictions at ALL nodes — not just the dropped ones. This explains why even surface errors are 1.7× worse.

3. **The model was never trained with masked inputs**: During training, all nodes are always present. The out-of-distribution zeroed inputs are outside what the model has learned to handle.

The "ensemble" benefit (variance reduction) is completely overwhelmed by the "noise injection" harm (corrupted attention context).

### Suggested follow-ups

- **Correct masking**: Zero only the non-positional features (indices 2+), leaving xy-coordinates intact. The slice attention would see nodes at correct positions with neutral (zero-mean) features — much less disruptive.
- **Train-time dropout + TTA**: The approach only works if the model is trained with node dropout, building robustness to missing context. Inference-only TTA without training-time preparation cannot work for attention-based models where all nodes jointly compute context.
- **Prediction averaging without masking**: Simply run 5 identical forward passes with different dropout seeds (if the model has dropout). This branch has dropout=0, so there's nothing to vary without masking.