### PR TITLE
Gumbel-Softmax sparse slice routing (sparser node-to-slice assignment)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.gumbel_temp = 2.0  # annealed externally; training only
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -165,7 +166,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_logits = self.in_project_slice(x_mid) / temp
         if spatial_bias is not None:
             slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
-        slice_weights = self.softmax(slice_logits)
+        if self.training:
+            gumbel_noise = -torch.log(-torch.log(torch.rand_like(slice_logits).clamp(min=1e-10)) + 1e-10)
+            slice_weights = F.softmax((slice_logits + gumbel_noise) / self.gumbel_temp, dim=-1)
+        else:
+            slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -398,6 +403,10 @@ class Transolver(nn.Module):
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+
+    def set_gumbel_temp(self, temp: float):
+        for block in self.blocks:
+            block.attn.gumbel_temp = temp
 
 
 # ---------------------------------------------------------------------------
@@ -799,6 +808,8 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    gumbel_temp = max(0.5, 2.0 - 1.5 * (epoch + 1) / 60.0)
+    _base_model.set_gumbel_temp(gumbel_temp)
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)


### PR DESCRIPTION
## Hypothesis
Softmax produces dense soft assignments. Gumbel-Softmax with temperature annealing (2.0→0.5 over 60 epochs) produces SPARSER routing, concentrating information in fewer slices per node.
## Instructions
In Physics_Attention forward, replace `softmax(slice_logits)` with:
- Training: `softmax((logits + gumbel_noise) / gumbel_temp)` where temp anneals 2.0→0.5
- Inference: standard softmax
Pass epoch number through to attention module. Run with `--wandb_group gumbel-softmax`.
## Baseline (Round 16 measured)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- val_loss=0.87
- Round 16 was a full plateau — ALL 12 experiments were above baseline
- PLATEAU PROTOCOL: These experiments are RADICAL ESCALATION — paradigm shifts, not incremental tweaks
---
## Results

**W&B run:** `f0ipheu7` (violet/gumbel-softmax, 59 epochs, ~30.4s/epoch)

Compared against r16 baseline `w39m6rig` (mean3 surf_p=23.16, loss_3split=0.8688):

| Split | loss (baseline) | loss (ours) | Δ | surf_p (baseline) | surf_p (ours) | Δ |
|---|---|---|---|---|---|---|
| val_in_dist | 0.6023 | 0.6190 | +2.8% | 17.49 | 18.67 | +6.7% |
| val_tandem_transfer | 1.6102 | 1.6733 | +3.9% | 37.67 | 40.04 | +6.3% |
| val_ood_cond | 0.7160 | 0.7038 | -1.7% | 14.33 | 14.13 | -1.4% |
| val_ood_re | 0.5467 | 0.5559 | +1.7% | 27.75 | 28.10 | +1.3% |
| **mean3** | **0.8688** | **0.8880** | **+2.2%** | **23.16** | **24.28** | **+4.8%** |

Full metrics at best checkpoint (epoch 59):

**val_in_dist:** surf_Ux=4.96, surf_Uy=1.75, surf_p=18.67, vol_Ux=1.15, vol_Uy=0.37, vol_p=20.06
**val_tandem_transfer:** surf_Ux=5.21, surf_Uy=2.10, surf_p=40.04, vol_Ux=1.96, vol_Uy=0.89, vol_p=39.29
**val_ood_cond:** surf_Ux=2.50, surf_Uy=1.07, surf_p=14.13, vol_Ux=0.72, vol_Uy=0.27, vol_p=11.73
**val_ood_re:** surf_Ux=2.04, surf_Uy=0.94, surf_p=28.10, vol_Ux=0.84, vol_Uy=0.36, vol_p=46.74

Peak memory: ~15 GB (same as baseline — Gumbel noise is elementwise)

### What happened

Negative result. Gumbel-Softmax routing hurt all splits except ood_cond (-1.4%). Tandem transfer was hit hardest (+6.3% surf_p). val/loss_3split is 2.2% worse than baseline.

The mechanism likely explains the failure: the existing attention temperature is already quite small (0.3–0.6 per head), so the effective softmax at baseline is already fairly sharp. Adding Gumbel noise divided by a high temperature (2.0 at epoch 0) makes routing very stochastic early on, preventing the model from establishing coherent slice assignments during the critical early learning phase. The tandem samples are especially sensitive — they have a distinctive gap feature that requires stable routing to cluster correctly.

Additionally, the combined effective temperature during early training is  ≈ 0.5 * 2.0 = 1.0 (twice baseline softness), which is significantly more uniform routing.

### Suggested follow-ups
- Try lower starting Gumbel temp (1.2→0.8) to avoid disrupting early learning
- Try applying Gumbel noise only after warmup (epoch 20+) when routing is more established
- Try Gumbel noise without extra temperature rescaling: just add noise at inference-equivalent scale