### PR TITLE
Reynolds number curriculum (easy low-Re first, then full range)

### DIFF
--- a/train.py
+++ b/train.py
@@ -489,6 +489,9 @@ else:
     )
     train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
                               sampler=sampler, **loader_kwargs)
+    # Re-curriculum: extract log_Re (col 13) for each training sample
+    train_log_re = torch.tensor([float(train_ds[i][0][0, 13]) for i in range(len(train_ds))])
+    re_median = float(train_log_re.median())
 
 val_loaders = {
     name: DataLoader(subset, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
@@ -637,6 +640,17 @@ for epoch in range(MAX_EPOCHS):
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+
+    # Re-curriculum: update sampler weights (epoch 0-20: exclude hi-Re; 20-40: ramp in; 40+: full)
+    if not cfg.debug:
+        if epoch < 20:
+            hi_re_factor = 0.0
+        elif epoch < 40:
+            hi_re_factor = (epoch - 20) / 20.0
+        else:
+            hi_re_factor = 1.0
+        is_hi_re = (train_log_re > re_median).float()
+        sampler.weights = sample_weights * (1.0 - is_hi_re + hi_re_factor * is_hi_re)
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
Train on easy (low-Re, more laminar) flows first, gradually include harder high-Re cases. Re ranges 500 to 4.445M — huge dynamic range.
## Instructions
Modify WeightedRandomSampler weights based on epoch:
- Epoch 0-20: weight=0 for samples with log_Re > median
- Epoch 20-40: gradually include high-Re (weight ramp from 0 to 1)
- Epoch 40+: full dataset (all weights=1)
Run with `--wandb_group re-curriculum`.
## Baseline (Round 16 measured)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- val_loss=0.87
- Round 16 was a full plateau — ALL 12 experiments were above baseline
- PLATEAU PROTOCOL: These experiments are RADICAL ESCALATION — paradigm shifts, not incremental tweaks
---
## Results

**W&B run:** `df0ejnz0` | **Best epoch:** 60/100 (30-min timeout) | **Epoch time:** ~30.6s | **Memory:** 14.7 GB

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.615 | 6.37 | 1.87 | **18.63** | 1.10 | 0.35 | 19.71 |
| val_tandem_transfer | 1.692 | 6.33 | 2.32 | **40.51** | 1.95 | 0.89 | 39.96 |
| val_ood_cond | 0.705 | 3.95 | 1.20 | **14.22** | 0.71 | 0.27 | 12.04 |
| val_ood_re | 0.532 | 3.36 | 1.00 | 27.61 | 0.80 | 0.36 | 46.57 |
| **mean3_surf_p** | **0.886** | | | **24.45** | | | |

**Baseline:** mean3=23.2 -> **Result:** 24.45 -> **Delta = +1.25 (5.4% worse)**

### What happened

Negative result. The Re curriculum hurt performance across most splits.

1. **Exclusion phase too aggressive**: Removing all high-Re samples for 20 epochs (1/3 of the 30-min budget) trains a biased model on half the dataset. When high-Re samples are reintroduced, the model cannot recover fully within the remaining budget.

2. **Budget waste**: We ran 60 epochs. Epochs 1-20 used only ~50% of the data. Expensive trade-off for a 30-min capped run.

3. **val_in_dist degraded** (18.63 vs 17.5 baseline): The standard holdout contains mixed Re values. Early exclusion of high-Re causes underfitting on in-distribution samples.

4. **val_tandem_transfer degraded** (40.51 vs 37.7): Tandem cases span the full Re range. The curriculum creates a distribution mismatch at the critical transition.

5. **val_ood_cond neutral** (14.22 vs 14.3): Extreme AoA/gap/stagger split is least Re-sensitive — approximately tied with baseline.

6. **val_ood_re neutral** (27.61 vs 27.7): Expected — hardest split regardless of curriculum.

The fundamental issue: with a 30-min cap, curriculum learning requires learning well from a restricted distribution AND then generalizing under a different distribution in the remaining time. The budget doesn't support this.

### Suggested follow-ups

- **Inverted schedule**: Start with full data but upweight high-Re in later epochs — avoids the initial bias problem.
- **Soft weighting**: Continuous log-Re-based weight that gradually shifts emphasis, avoiding the hard transition at epoch 20.
- **Shorter exclusion phase**: Epoch 0-5 exclude, 5-15 ramp — shorter bias period, more time with full data.
