### PR TITLE
Domain-adversarial training (force domain-invariant hidden representation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -60,6 +60,17 @@ ACTIVATION = {
 }
 
 
+class GRL(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, alpha):
+        ctx.alpha = alpha
+        return x
+
+    @staticmethod
+    def backward(ctx, grad):
+        return -ctx.alpha * grad, None
+
+
 class GatedMLP(nn.Module):
     def __init__(self, n_input, n_hidden, n_output, act='gelu'):
         super().__init__()
@@ -318,6 +329,7 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.domain_classifier = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 3))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -392,12 +404,13 @@ class Transolver(nn.Module):
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
+        domain_pred = self.domain_classifier(GRL.apply(fx.mean(dim=1), 1.0))  # [B, 3]
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "domain_pred": domain_pred}
 
 
 # ---------------------------------------------------------------------------
@@ -693,14 +706,23 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        # Domain labels: 0=single, 1=tandem, 2=cruise (derived from gap and Re features)
+        domain_label = torch.zeros(x.shape[0], dtype=torch.long, device=device)
+        is_tandem_dom = x[:, 0, 21].abs() > 0.5
+        is_cruise_dom = (~is_tandem_dom) & ((x[:, 0, 13].abs() > 1.5) | (x[:, 0, 14].abs() > 1.5))
+        domain_label[is_tandem_dom] = 1
+        domain_label[is_cruise_dom] = 2
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
+            domain_pred = out["domain_pred"]
         pred = pred.float()
         re_pred = re_pred.float()
         aoa_pred = aoa_pred.float()
+        domain_pred = domain_pred.float()
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -778,6 +800,8 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+        domain_loss = F.cross_entropy(domain_pred, domain_label)
+        loss = loss + 0.01 * domain_loss
 
         optimizer.zero_grad()
         loss.backward()
@@ -1014,6 +1038,14 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 x_n = torch.cat([x_n, curv], dim=-1)
+                raw_xy_v = x_n[:, :, :2]
+                xy_min_v = raw_xy_v.amin(dim=1, keepdim=True)
+                xy_max_v = raw_xy_v.amax(dim=1, keepdim=True)
+                xy_norm_v = (raw_xy_v - xy_min_v) / (xy_max_v - xy_min_v + 1e-8)
+                freqs_v = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled_v = xy_norm_v.unsqueeze(-1) * freqs_v
+                fourier_pe_v = torch.cat([xy_scaled_v.sin().flatten(-2), xy_scaled_v.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_v], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
The model overfits to domain-specific features. A gradient-reversed domain classifier (Ganin et al. 2016) forces the hidden representation to be domain-invariant, improving OOD generalization.
## Instructions
1. Add domain classifier: `nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 3))` predicting domain (single/tandem/cruise from gap+Re)
2. Use gradient reversal: `loss += 0.01 * domain_loss` but negate gradients flowing to main model
3. Implement GRL as: `class GRL(torch.autograd.Function): @staticmethod forward(ctx,x,alpha): return x; @staticmethod backward(ctx,grad): return -alpha*grad, None`
Run with `--wandb_group domain-adversarial`.
## Baseline (Round 16 measured)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- val_loss=0.87
- Round 16 was a full plateau — ALL 12 experiments were above baseline
- PLATEAU PROTOCOL: These experiments are RADICAL ESCALATION — paradigm shifts, not incremental tweaks
---
## Results

**W&B run:** `8vkanpr5` (kohaku/domain-adversarial, group: domain-adversarial)
**Runtime:** 30.7 min (timeout)
**Model params:** 769,659 (+6,275 for domain_classifier)
**Peak memory:** ~12 GB (GPU)

### val/loss (best epoch): 0.8741

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 6.23 | 1.99 | 17.78 | 1.09 | 0.36 | 19.59 |
| val_ood_cond | 3.81 | 1.37 | 13.88 | 0.70 | 0.27 | 11.68 |
| val_ood_re | 3.25 | 1.18 | 28.38 | 0.83 | 0.36 | 47.00 |
| val_tandem_transfer | 6.05 | 2.47 | 39.80 | 1.92 | 0.88 | 39.14 |

### Comparison to baseline (in=17.5, ood=14.3, re=27.7, tan=37.7)

| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 17.5 | 17.78 | +0.28 (~+1.6%, slightly worse) |
| val_ood_cond | 14.3 | 13.88 | -0.42 (~-2.9%, better) |
| val_ood_re | 27.7 | 28.38 | +0.68 (~+2.5%, slightly worse) |
| val_tandem_transfer | 37.7 | 39.80 | +2.10 (~+5.6%, worse) |

val/loss: 0.8741 vs baseline 0.87 (essentially equal).

### What happened

The domain-adversarial training didn't improve over baseline. The val/loss matches the baseline almost exactly (0.8741 vs 0.87), and the pressure MAE is mixed: slightly better on val_ood_cond (-2.9%) but slightly worse on the other three splits (worst: tandem_transfer +5.6%).

Several factors likely limit this approach:

1. **Heuristic domain labels**: Single/tandem/cruise domains are inferred from gap and Re features after normalization. The thresholds (|gap|>0.5 for tandem, |Re|>1.5 or |AoA|>1.5 for cruise) are imprecise. If domain labels are noisy, the domain classifier learns nothing useful and the GRL provides only gradient noise.

2. **Fixed alpha=1.0 from epoch 0**: The standard DANN schedules alpha from 0 to 1 to avoid early-training instability. Starting at alpha=1.0 fully inverts domain gradients immediately, which can destabilize learning when the encoder hasn't converged yet.

3. **Small domain head + 30 min budget**: Only ~60 epochs, which may be insufficient for the domain-invariant representation to emerge and for the main predictor to recover from the GRL noise.

4. **Only 3 domains**: This is a coarse split. The actual variation within 'cruise' (OOD Re vs OOD conditions) is significant and is treated as one domain.

The GRL appears to add noise rather than meaningful regularization at this training scale.

### Suggested follow-ups

- Use a DANN-style alpha schedule: alpha = 2/(1+exp(-10*p)) - 1 where p = epoch/MAX_EPOCHS, to ramp up domain adversarial pressure gradually.
- Try source labels from the data loader if available, rather than heuristic feature thresholds.
- Try a stronger domain classifier (deeper MLP) with the alpha schedule to see if better domain separation can be learned.
- Try a weaker coefficient (0.001 instead of 0.01) to reduce gradient noise from imprecise domain labels.