### PR TITLE
Seed sweep: seed=137 (frontier verification)

### DIFF
--- a/train.py
+++ b/train.py
@@ -529,6 +529,8 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
+torch.manual_seed(137); torch.cuda.manual_seed_all(137)
+import random; random.seed(137); import numpy as np; np.random.seed(137)
 model = Transolver(**model_config).to(device)
 model = torch.compile(model, mode="reduce-overhead")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model


### PR DESCRIPTION
## Purpose
Second seed for frontier verification.

## Implementation
Added before `model = Transolver(...)`:
```python
torch.manual_seed(137); torch.cuda.manual_seed_all(137)
import random; random.seed(137); import numpy as np; np.random.seed(137)
```

## Results

**W&B run:** `fern/seed-137-r18` (w40a25qs), best epoch 61, state=failed (wall-clock timeout)

| Split | mae_surf_p | vs baseline |
|-------|-----------|-------------|
| val_in_dist | 19.03 | +1.53 |
| val_ood_cond | 13.36 | -0.94 |
| val_tandem_transfer | 38.54 | +0.84 |
| val_ood_re | 27.42 | -0.28 |
| **mean3** | **23.64** | **+0.44 (+1.9%)** |

- **loss3 = 0.8542** (vs baseline 0.87 — improved)
- **mean3 = 23.64** vs baseline 23.2 — **slight regression (+1.9%)**

## Analysis
Seed variance is substantial here. Seed=137 gives loss3=0.8542 (better checkpoint metric) but mean3=23.64 (+0.44 worse). Mixed picture:
- ood_cond improves (-0.94)
- in_dist regresses (+1.53)
- tandem regresses (+0.84)

This is consistent with normal seed variance at the frontier (±1-2%). No strong signal either way — seed=137 does not unlock better performance than the default seed at this architecture.

Combined with the seed=42 run (frieren) for multi-seed statistics to confirm whether the frontier has truly plateaued.