### PR TITLE
REVERT: Remove noise annealing (fixed noise [0.01, 0.01, 0.005])

### DIFF
--- a/train.py
+++ b/train.py
@@ -671,10 +671,7 @@ for epoch in range(MAX_EPOCHS):
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
+            noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)


### PR DESCRIPTION
## Hypothesis
Noise annealing (0.015→0.003) was merged on earlier baseline. With 29 other stacked improvements, it may now be counterproductive. Revert to fixed noise.
## Instructions
Replace the noise annealing block with fixed noise: \`noise_scale = torch.tensor([0.01, 0.01, 0.005], device=device)\`. Remove the epoch-dependent noise_progress computation. Run with \`--wandb_group revert-noise-anneal\`.
## Baseline (triple-plateau confirmed)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7), val_loss=0.87
- 30 real improvements merged. R16+R17+R17-paradigm = 24 experiments, 0 merges.
- This round: multi-seed exploration, ablation studies, targeted novel ideas.
---
## Results

**W&B run:** \`hf0wrl7r\` (\`nezuko/revert-noise-anneal\`)
**Best epoch:** 57 | **Best val/loss (EMA):** 0.8913
**Runtime:** 30.3 min (timeout)

### Surface MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 6.37 | 2.11 | 19.16 |
| ood_cond | 3.68 | 1.30 | 14.52 |
| tandem_transfer | 5.96 | 2.44 | 39.56 |
| ood_re | 3.43 | 1.18 | 27.99 |

**mean3_surf_p = 24.41** (in_dist + ood_cond + tandem_transfer average)

### Volume MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.12 | 0.37 | 19.58 |
| ood_cond | 0.73 | 0.28 | 12.48 |
| tandem_transfer | 1.95 | 0.89 | 38.99 |

### Comparison to Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| mean3_surf_p | 23.2 | 24.41 | +1.21 (worse) |
| val_loss | 0.87 | 0.89 | +0.02 (worse) |

### What happened

Negative result — fixed noise performs worse than annealed noise across all splits. The hypothesis that noise annealing might be counterproductive with 29 stacked improvements was incorrect.

In_dist pressure degraded most: 17.5 → 19.16 (+1.66). Tandem also worsened: 37.7 → 39.56 (+1.86). The noise annealing schedule (high noise early → low noise late) appears to be earning its keep by:
1. High early noise (0.015) provides stronger regularization during model initialization
2. Low late noise (0.003) allows fine-grained fitting near convergence

The fixed intermediate noise (0.01) is a compromise that underserves both phases. The annealing should be kept.

### Suggested follow-ups

- Try further annealing — e.g. end at near-zero (0.001→0.0001) to see if even lower late noise helps
- Try faster anneal schedule (ramp over 40 epochs instead of 60)
- The ood_cond result (14.52 vs baseline 14.3) is nearly identical — noise may not matter much there, but matters a lot for in_dist and tandem