### PR TITLE
REVERT: Replace adaptive surf_weight with fixed ramp 5→30

### DIFF
--- a/train.py
+++ b/train.py
@@ -635,8 +635,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Fixed linear ramp: 5 → 30 over 75 epochs
+    surf_weight = 5.0 + 25.0 * min(1.0, epoch / 75)
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
Adaptive surf_weight (vol/surf ratio) was marginal. With pressure-only surface loss, the ratio dynamics changed. Test fixed linear ramp: \`surf_weight = 5.0 + 25.0 * min(1.0, epoch / 75)\`.
## Instructions
Replace the adaptive surf_weight line with the fixed ramp formula. Run with \`--wandb_group revert-adaptive-sw\`.
## Baseline (triple-plateau confirmed)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7), val_loss=0.87
- 30 real improvements merged. R16+R17+R17-paradigm = 24 experiments, 0 merges.
- This round: multi-seed exploration, ablation studies, targeted novel ideas.
---
## Results

**W&B run:** \`3olyqs0l\` (\`thorfinn/revert-adaptive-sw\`)
**Epochs:** 58 (best), ~31.5s/epoch

### Metrics at best checkpoint

| Split | val/loss | surf_p | surf_Ux | surf_Uy | vol_p |
|---|---|---|---|---|---|
| val_in_dist | 0.6266 | 17.94 | 10.79 | 2.75 | 23.03 |
| val_tandem_transfer | 1.6982 | 39.69 | 8.81 | 3.17 | 41.45 |
| val_ood_cond | 0.7302 | 14.20 | 7.61 | 1.95 | 14.16 |
| val_ood_re | 0.5686 | 27.89 | 7.23 | 1.69 | 48.08 |

**val/loss_3split:** 0.9059
**mean3_surf_p:** 23.94 (in=17.94, tan=39.69, ood=14.20)

### vs. Baseline (mean3=23.2, val_loss=0.87)

Slightly worse: mean3_surf_p 23.94 vs baseline 23.2 (+3.2%), val_loss 0.9059 vs 0.87 (+4.1%). The fixed ramp does not improve over the adaptive formula.

### What happened

The implementation replaced `surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))` with `surf_weight = 5.0 + 25.0 * min(1.0, epoch / 75)`.

The fixed ramp reaches 30 at epoch 75 and stays there. The adaptive formula typically runs around 5-10 in early epochs (when vol and surf losses are both high), then rises to 15-30 as surf_loss drops. The two schedules are actually similar in shape — both start low and increase — but the adaptive formula responds to the actual loss ratio while the fixed ramp is independent of training dynamics.

The slightly worse performance may be because:
1. **Adaptive formula overshoots when helpful**: When vol_loss is still high and surf_loss has dropped (e.g., surf_weight = 0.2/0.03 ≈ 6.7 → wait, that's low), actually both formulas are similar in range. The difference is likely modest variance rather than a systematic effect.
2. **58 epochs vs baseline's epoch count**: The 31.5s/epoch budget allows 58 epochs vs ~65+ at baseline speed, suggesting this branch is slightly slower per epoch despite removing the adaptive computation. Likely due to other branch differences.

Overall, the adaptive formula appears to be at least as good as the fixed ramp, suggesting its dynamic tracking provides mild benefit or the two are functionally equivalent.

### Suggested follow-ups

- **Keep adaptive formula**: The current adaptive approach works fine and there's no benefit to simplifying it.
- **Try surf_weight anchored higher**: A ramp from 10→40 might work better than 5→30 by emphasizing surface accuracy throughout.
- **Try surf_weight with ood_re included**: Currently val_loss_3split excludes ood_re from checkpoint selection. Including it with higher surf_weight weighting could help re generalization.