### PR TITLE
Wider n_hidden=224 (capacity test on triple-plateau code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=192,  # was 160
+    n_hidden=224,  # was 192
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs


### PR DESCRIPTION
## Hypothesis
Every width increase helped (128→160→192). But 224 was tested on earlier code and was neutral. On the current 30-improvement code, the capacity curve may be different.
## Instructions
`n_hidden=224` in model_config. Everything else stays. Run with `--wandb_group wider-224-r18`.
## Baseline (triple-plateau confirmed)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7), val_loss=0.87
- 30 real improvements merged. R16+R17+R17-paradigm = 24 experiments, 0 merges.
- This round: multi-seed exploration, ablation studies, targeted novel ideas.
---
## Results

**W&B run:** `gy641kmu` (violet/wider-224-r18, 53 epochs, ~34.4s/epoch)

Compared against r16 baseline `w39m6rig` (mean3 surf_p=23.16, loss_3split=0.8688):

| Split | loss (baseline) | loss (ours) | Δ | surf_p (baseline) | surf_p (ours) | Δ |
|---|---|---|---|---|---|---|
| val_in_dist | 0.6023 | 0.6331 | +5.1% | 17.49 | 18.81 | +7.6% |
| val_tandem_transfer | 1.6102 | 1.6634 | +3.3% | 37.67 | 39.14 | +3.9% |
| val_ood_cond | 0.7160 | 0.7090 | -1.0% | 14.33 | 14.42 | +0.6% |
| val_ood_re | 0.5467 | 0.5660 | +3.5% | 27.75 | 28.16 | +1.5% |
| **mean3** | **0.8688** | **0.8929** | **+2.8%** | **23.16** | **24.12** | **+4.2%** |

Full metrics at best checkpoint (epoch 53):

**val_in_dist:** surf_Ux=6.66, surf_Uy=1.98, surf_p=18.81, vol_Ux=1.13, vol_Uy=0.36, vol_p=19.78
**val_tandem_transfer:** surf_Ux=6.58, surf_Uy=2.31, surf_p=39.14, vol_Ux=1.95, vol_Uy=0.88, vol_p=38.38
**val_ood_cond:** surf_Ux=3.99, surf_Uy=1.19, surf_p=14.42, vol_Ux=0.74, vol_Uy=0.28, vol_p=12.22
**val_ood_re:** surf_Ux=3.55, surf_Uy=1.05, surf_p=28.16, vol_Ux=0.85, vol_Uy=0.37, vol_p=46.79

Peak memory: ~18 GB (estimated — +16% over n_hidden=192)

### What happened

Negative result. n_hidden=224 is worse than n_hidden=192 across almost all metrics (mean3 surf_p +4.2%). The key bottleneck is speed: 34.4s/epoch vs ~30s/epoch (+15% overhead), yielding only 53 epochs vs ~60 for the baseline within the 30-minute budget. Fewer epochs means less optimization.

The model has 7.8M parameters at 224 vs 5.5M at 192 (+42%), but the 30-minute time budget doesn't allow this wider model to converge as well. The capacity increase does not compensate for fewer training steps.

This confirms the observation that n_hidden=192 is near the optimal width for the 30-minute regime. Going narrower (192 → 160 → 128) was worse; going wider (192 → 224) is also worse — just for different reasons (speed vs capacity).

### Suggested follow-ups
- Try n_hidden=208 as a middle ground (smaller overhead, some added capacity)
- Accept that 192 is near-optimal for 30-min budget and focus elsewhere
- If multi-GPU / longer runs were allowed, 224+ might help — architecture change alone won't help given the time constraint