### PR TITLE
Seed sweep: seed=11 (frontier exploration)

### DIFF
--- a/train.py
+++ b/train.py
@@ -529,6 +529,8 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
+torch.manual_seed(11); torch.cuda.manual_seed_all(11)
+import random; random.seed(11); import numpy as np; np.random.seed(11)
 model = Transolver(**model_config).to(device)
 model = torch.compile(model, mode="reduce-overhead")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model


### PR DESCRIPTION
## Purpose
Best-of-N seed selection. If any seed finds mean3 < 23.0, that's an actionable improvement.

## Implementation
Added before `model = Transolver(...)`:
```python
torch.manual_seed(11); torch.cuda.manual_seed_all(11)
import random; random.seed(11); import numpy as np; np.random.seed(11)
```

## Results

**W&B run:** `fern/seed-11` (t2v2koru), best epoch 61, state=failed (wall-clock timeout)

| Split | mae_surf_p | vs baseline |
|-------|-----------|-------------|
| val_in_dist | 17.88 | +0.38 |
| val_ood_cond | 13.58 | -0.72 |
| val_tandem_transfer | 39.20 | +1.50 |
| val_ood_re | 27.84 | +0.14 |
| **mean3** | **23.55** | **+0.35 (+1.5%)** |

- **loss3 = 0.8715** (vs baseline 0.87 — similar)
- **mean3 = 23.55** vs baseline 23.2 — **slight regression (+1.5%)**

## Analysis
Seed=11 does not break below 23.0. Combined seed sweep picture:
- default seed: 23.2
- seed=137 (r18): 23.64
- seed=11: 23.55

All seeds cluster at 23.2–23.6, confirming this is genuine frontier behaviour, not a lucky seed. No seed finds mean3 < 23.0. The plateau is real.

tandem_transfer remains the hardest split (39.20) — systematic gap vs single-foil splits, not seed-dependent noise.