### PR TITLE
Raw SDF as 4 additional input features (directional distance for all nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -518,7 +518,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 1 + 4 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32; +4 raw sdf
     out_dim=3,
     n_hidden=192,  # was 160
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -654,6 +654,8 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
+        raw_sdf = x[:, :, 2:6]  # directional sdf channels for all nodes
+        x = torch.cat([x, raw_sdf], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -835,6 +837,8 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
+                raw_sdf = x[:, :, 2:6]  # directional sdf channels for all nodes
+                x = torch.cat([x, raw_sdf], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -1014,6 +1018,8 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 x_n = torch.cat([x_n, curv], dim=-1)
+                raw_sdf = x_n[:, :, 2:6]
+                x_n = torch.cat([x_n, raw_sdf], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
The curvature proxy compresses 4 dsdf channels into 1 scalar for surface nodes only. Adding the raw 4 dsdf channels as ADDITIONAL features gives all nodes directional distance-to-surface information. Volume boundary-layer nodes get explicit proximity data.
## Instructions
After curvature computation, add: `raw_sdf = x[:,:,2:6]; x = torch.cat([x, raw_sdf], dim=-1)`. Update fun_dim: +4 (from +1+32 to +1+4+32). Apply same in validation.
Run with `--wandb_group raw-sdf-input`.
## Baseline (verified frontier)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7), val_loss=0.87
- 30 improvements merged. 3 consecutive plateau rounds confirmed frontier.
- Seed sweep: all seeds at 23.2-23.6. Ablations: all improvements confirmed contributing.
---
## Results

**W&B run:** `pbmkctus` (violet/raw-sdf-input, 59 epochs, ~31.9s/epoch)

Compared against r16 baseline `w39m6rig` (mean3 surf_p=23.16, loss_3split=0.8688):

| Split | loss (baseline) | loss (ours) | Δ | surf_p (baseline) | surf_p (ours) | Δ |
|---|---|---|---|---|---|---|
| val_in_dist | 0.6023 | 0.5990 | -0.5% | 17.49 | 18.70 | +6.9% |
| val_tandem_transfer | 1.6102 | 1.6700 | +3.7% | 37.67 | 39.74 | +5.5% |
| val_ood_cond | 0.7160 | 0.7012 | -2.1% | 14.33 | 13.63 | -4.9% |
| val_ood_re | 0.5467 | 0.5524 | +1.0% | 27.75 | 28.04 | +1.0% |
| **mean3** | **0.8688** | **0.8806** | **+1.4%** | **23.16** | **24.02** | **+3.7%** |

Full metrics at best checkpoint (epoch 59):

**val_in_dist:** surf_Ux=6.52, surf_Uy=1.82, surf_p=18.70, vol_Ux=1.06, vol_Uy=0.35, vol_p=18.62
**val_tandem_transfer:** surf_Ux=6.11, surf_Uy=2.13, surf_p=39.74, vol_Ux=1.92, vol_Uy=0.87, vol_p=38.69
**val_ood_cond:** surf_Ux=4.64, surf_Uy=1.28, surf_p=13.63, vol_Ux=0.72, vol_Uy=0.27, vol_p=11.85
**val_ood_re:** surf_Ux=4.05, surf_Uy=1.09, surf_p=28.04, vol_Ux=0.83, vol_Uy=0.37, vol_p=46.88

Peak memory: ~16 GB (~7% over baseline — slightly wider input)

### What happened

Negative result. Raw SDF features hurt in_dist (+6.9% surf_p) and tandem (+5.5%), while helping ood_cond (-4.9%). Mean3 is 3.7% worse overall.

This is the third consecutive experiment showing the same split pattern: ood_cond benefits while in_dist and tandem suffer. The dsdf features may be providing useful proximity signal for OOD condition generalization, but they appear to hurt standard in-distribution cases — possibly by confusing the model when the feature distribution at test time doesn't match training (dsdf channels have different statistics near/far from surfaces).

The epoch overhead is modest (31.9s vs 29.7s = +7%), so the issue is with information quality, not speed.

### Suggested follow-ups
- Try appending raw_sdf only for surface nodes (currently giving it to all nodes may add noise for volume nodes)
- Try normalized raw_sdf (per-sample normalization) to reduce distribution shift
- The consistent ood_cond benefit may hint that there's a boundary-layer representation issue; try surface-only distance encoding