### PR TITLE
FP32 precision for cosine attention (numerical stability)

### DIFF
--- a/train.py
+++ b/train.py
@@ -174,10 +174,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
         k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
         v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
-        q_norm = F.normalize(q_slice_token, dim=-1)
-        k_norm = F.normalize(k_slice_token, dim=-1)
-        attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
-        attn_weights = F.softmax(attn_logits, dim=-1)
+        with torch.amp.autocast('cuda', enabled=False):
+            q_norm = F.normalize(q_slice_token.float(), dim=-1)
+            k_norm = F.normalize(k_slice_token.float(), dim=-1)
+            attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale.float()
+            attn_weights = F.softmax(attn_logits, dim=-1).to(v_slice_token.dtype)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
         out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
 


### PR DESCRIPTION
## Hypothesis
Cosine attention uses F.normalize + softmax, both sensitive to precision. Running only the attention Q/K normalization and matmul in fp32 may improve routing quality at negligible throughput cost.
## Instructions
In Physics_Attention forward, wrap the normalize+matmul+softmax in `with torch.amp.autocast('cuda', enabled=False):` after casting to float32.
Run with `--wandb_group fp32-attention`.
## Baseline (verified frontier)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7), val_loss=0.87
- 30 improvements merged. 3 consecutive plateau rounds confirmed frontier.
- Seed sweep: all seeds at 23.2-23.6. Ablations: all improvements confirmed contributing.
---
## Results

**W&B run:** `crpxxvfk` | **Best epoch:** 60/100 (30-min timeout) | **Epoch time:** ~30.1s | **Memory:** 14.7 GB

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.618 | 5.38 | 1.41 | **18.82** | 1.10 | 0.37 | 19.34 |
| val_tandem_transfer | 1.637 | 5.40 | 1.93 | **38.53** | 1.93 | 0.88 | 38.01 |
| val_ood_cond | 0.716 | 3.52 | 1.12 | **14.19** | 0.72 | 0.28 | 12.23 |
| val_ood_re | 0.550 | 2.98 | 0.98 | 27.86 | 0.84 | 0.37 | 46.98 |
| **mean3_surf_p** | **0.880** | | | **23.85** | | | |

**Baseline:** mean3=23.2 -> **Result:** 23.85 -> **Delta = +0.65 (2.8% worse)**

### What happened

Negative. FP32 cosine attention did not help and slightly hurt performance. 60 epochs vs baseline 61 (lost one epoch to the slight fp32 overhead — ~0.5s extra per epoch × 60 epochs = 30 seconds).

Possible reasons:
1. **BF16 is sufficient**: F.normalize is numerically stable in bfloat16 for this range of values (attention logits are modest magnitude, scaled by `attn_scale=10`). There's no precision bottleneck to fix.
2. **Implicit regularization**: BF16 rounding noise may serve as a mild stochastic regularizer in the attention routing, which FP32 removes.
3. **torch.compile interaction**: Introducing the fp32 cast inside compile may disrupt the operator fusion pattern, adding slight overhead.

The epoch time increase (~0.5s) is small, but given we're at a plateau where each epoch matters, even one lost epoch is material.

### Suggested follow-ups

- Try FP32 only for the attn_logits (skip the softmax and the normalization) — the matmul may be the actual precision bottleneck
- Check if attn_scale is too aggressive (=10) and causing attention to saturate in BF16 anyway
- Numerical stability is unlikely to be the bottleneck here; focus on architecture/optimization changes instead
