### PR TITLE
Asymmetric pinball loss for surface pressure (tau=0.45)

### DIFF
--- a/train.py
+++ b/train.py
@@ -704,11 +704,16 @@ for epoch in range(MAX_EPOCHS):
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        err_raw = pred - y_norm
+        abs_err = err_raw.abs()
         if epoch < 10:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
+            err_raw = err_raw * sample_mask
+        # Asymmetric pinball loss (tau=0.45) for surface pressure only
+        err_p = err_raw[:, :, 2:3]
+        surf_pres_abs = torch.where(err_p > 0, 0.45 * err_p, 0.55 * (-err_p))
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -728,14 +733,14 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_per_sample = (surf_pres_abs * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+            surf_pres = surf_pres_abs  # pinball pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
@@ -1014,6 +1019,14 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 x_n = torch.cat([x_n, curv], dim=-1)
+                raw_xy_v = x_n[:, :, :2]
+                xy_min_v = raw_xy_v.amin(dim=1, keepdim=True)
+                xy_max_v = raw_xy_v.amax(dim=1, keepdim=True)
+                xy_norm_v = (raw_xy_v - xy_min_v) / (xy_max_v - xy_min_v + 1e-8)
+                freqs_v = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled_v = xy_norm_v.unsqueeze(-1) * freqs_v
+                fourier_pe_v = torch.cat([xy_scaled_v.sin().flatten(-2), xy_scaled_v.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_v], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
Replace L1 on surface pressure with pinball loss at tau=0.45. This slightly penalizes under-prediction more than over-prediction — physically motivated since under-predicting suction peaks is more dangerous. Velocity channels and volume loss stay as L1.
## Instructions
For surface pressure loss only, replace abs_err with: `torch.where(err > 0, 0.45 * err, 0.55 * (-err))` where err = pred - target.
Run with `--wandb_group quantile-pressure`.
## Baseline (verified frontier)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7), val_loss=0.87
- 30 improvements merged. 3 consecutive plateau rounds confirmed frontier.
- Seed sweep: all seeds at 23.2-23.6. Ablations: all improvements confirmed contributing.
---
## Results

**W&B run:** `tq8g9nfx` (kohaku/quantile-pressure, group: quantile-pressure)
**Runtime:** 30.8 min (timeout)
**Model params:** 763,384 (no change — loss function only)
**Peak memory:** ~12 GB (GPU)

### val/loss (best epoch): 0.8654

Note: val/loss is NOT directly comparable to baseline val/loss because the surface loss now uses pinball instead of L1. The mae_surf_p metrics (computed as L1 MAE regardless of training loss) are the fair comparison.

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 5.97 | 1.67 | 17.76 | 1.05 | 0.35 | 19.15 |
| val_ood_cond | 3.04 | 0.99 | 14.00 | 0.71 | 0.27 | 11.75 |
| val_ood_re | 2.67 | 0.83 | 27.88 | 0.82 | 0.36 | 46.67 |
| val_tandem_transfer | 5.80 | 2.22 | 38.54 | 1.90 | 0.86 | 37.53 |

### Comparison to baseline (in=17.5, ood=14.3, re=27.7, tan=37.7)

| Split | Baseline surf_p | This run surf_p | Delta |
|---|---|---|---|
| val_in_dist | 17.5 | 17.76 | +0.26 (~+1.5%, slightly worse) |
| val_ood_cond | 14.3 | 14.00 | -0.30 (~-2.1%, better) |
| val_ood_re | 27.7 | 27.88 | +0.18 (~+0.6%, essentially same) |
| val_tandem_transfer | 37.7 | 38.54 | +0.84 (~+2.2%, slightly worse) |

### What happened

Mixed results — consistent with the plateau observed in recent rounds. The pinball loss (tau=0.45) produces a slight improvement on val_ood_cond but is essentially unchanged or slightly worse on other splits. The overall pattern matches previous experiments in this plateau phase.

The pinball loss makes sense physically (under-predicting suction peaks is dangerous), but the effect on the eval MAE is subtle. The training loss is now measuring something slightly different from the eval metric (asymmetric vs symmetric), which could lead to miscalibration. The model may learn to bias predictions slightly toward over-prediction to minimize the asymmetric training loss, but the gain in physical safety doesn't show up as a clear improvement in symmetric MAE.

One concern: the val/loss metric now includes the asymmetric surface loss, making direct comparison to the 0.87 baseline val/loss meaningless. The clean comparison is on the mae_surf_p values, which show no consistent improvement.

### Suggested follow-ups

- Try tau=0.35 (stronger bias toward under-prediction being penalized more heavily) to see if a larger asymmetry helps.
- Apply the asymmetric loss to the hard-node mining threshold computation as well (currently the threshold is based on abs_err which doesn't exist anymore for pressure — the code was updated to use surf_pres_abs consistently, but one could also compute hard nodes based on the signed error direction).
- Consider using the pinball loss only for tandem transfer samples where the pressure errors are largest.