### PR TITLE
Regime A: lr=1.5e-3, T_max=80, warmup=15 (slower deeper convergence)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 1.5e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=15)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=80, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Current lr=3e-3 may overshoot in late training. Half the LR with longer schedule to reach deeper minima.
## Instructions
Change: lr=1.5e-3, T_max=80, warmup total_iters=15, milestones=[15]. Run with `--wandb_group regime-a`.
## Baseline (verified frontier, 4 consecutive plateau rounds)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- 50 single-variable experiments failed to improve. This round tests MULTI-VARIABLE regime changes.
---
## Results

**W&B run:** aoyto1j1
**Epochs completed:** 56/100 (30-min timeout hit during epoch 57 training)
**Peak memory:** ~14.7 GB

### Metrics at checkpoint (epoch 56)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_p |
|---|---|---|---|---|---|
| val_in_dist | 0.6766 | 4.60 | 2.14 | 20.61 | 21.47 |
| val_ood_cond | 0.7884 | 3.19 | 1.41 | 15.44 | 13.25 |
| val_ood_re | 0.5893 | 2.99 | 1.26 | 28.79 | 47.94 |
| val_tandem_transfer | 1.7165 | 5.24 | 2.66 | 40.11 | 39.29 |
| **combined val/loss** | **0.9427** | | | | |

**mean3 (in, ood, tan):** 25.4 vs baseline 23.2 — **WORSE**

### Comparison vs baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| mean3 | 23.2 | 25.4 | +2.2 worse |
| in mae_surf_p | 17.5 | 20.6 | +3.1 worse |
| ood mae_surf_p | 14.3 | 15.4 | +1.1 worse |
| re mae_surf_p | 27.7 | 28.8 | +1.1 worse |
| tan mae_surf_p | 37.7 | 40.1 | +2.4 worse |

### What happened

The hypothesis did not improve on baseline within the 30-minute budget. Halving the LR (1.5e-3 vs 3e-3) with a longer cosine schedule (T_max=80) slows convergence — the model was still improving monotonically at epoch 56 but was meaningfully behind baseline on all surface pressure metrics. The longer warmup (15 vs 10 epochs) also delays the main learning phase.

The core problem: the 30-min timeout caps the run at ~56 epochs, but with this slower schedule the model needs the full 80+ epochs to potentially reach deeper minima. At epoch 56, cosine annealing is still around 0.4 of peak LR — the beneficial late-phase annealing was never reached.

The val/loss was declining monotonically through epoch 56, suggesting the hypothesis isn't fundamentally broken — just incompatible with the 30-min budget at 100-epoch length.

### Suggested follow-ups

- If budget allows, run this regime longer (45-50 min) to see if slower annealing pays off; the run needs ~50 min for 100 epochs at 30s/epoch.
- Test a moderate compromise: lr=2e-3, T_max=70, warmup=12 — slightly slower than baseline but should converge within 30 min.
- Investigate whether baseline lr=3e-3 actually overshoots: check if val loss plateaus or oscillates in late epochs of previous baseline runs.