### PR TITLE
Regime C: Remove Lookahead, lr=4e-3 (pure AdamW)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 4e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -541,45 +541,16 @@ ema_decay = 0.998
 n_params = sum(p.numel() for p in model.parameters())
 
 
-class Lookahead:
-    def __init__(self, base_optimizer, k=5, alpha=0.5):
-        self.base_optimizer = base_optimizer
-        self.k = k
-        self.alpha = alpha
-        self.slow_params = [
-            [p.data.clone() for p in group['params']]
-            for group in base_optimizer.param_groups
-        ]
-        self.step_count = 0
-
-    def step(self):
-        self.base_optimizer.step()
-        self.step_count += 1
-        if self.step_count % self.k == 0:
-            for slow, group in zip(self.slow_params, self.base_optimizer.param_groups):
-                for s, p in zip(slow, group['params']):
-                    s.data.add_(self.alpha * (p.data - s.data))
-                    p.data.copy_(s.data)
-
-    def zero_grad(self):
-        self.base_optimizer.zero_grad()
-
-    @property
-    def param_groups(self):
-        return self.base_optimizer.param_groups
-
-
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-base_opt = torch.optim.AdamW([
+optimizer = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.1, total_iters=10)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Lookahead may be constraining late-training convergence. Pure AdamW with slightly higher LR.
## Instructions
Replace Lookahead with raw AdamW. lr=4e-3. Keep everything else. Run with `--wandb_group regime-c`.
## Baseline (verified frontier, 4 consecutive plateau rounds)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- 50 single-variable experiments failed to improve. This round tests MULTI-VARIABLE regime changes.
---
## Results

**W&B run:** 2t5k2nku  
**Epochs completed:** 57/100 (hit 30-min wall-clock limit; killed mid-epoch 58)  
**Peak memory:** 14.7 GB

### Val loss @ epoch 57
| Split | val/loss |
|---|---|
| in_dist | 0.6525 |
| ood_cond | 0.7647 |
| ood_re | 0.5694 |
| tandem | 1.7149 |

### Surface MAE @ epoch 57
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 6.39 | 1.85 | 19.31 |
| ood_cond | 3.95 | 1.25 | 15.33 |
| ood_re | 3.21 | 1.05 | 28.48 |
| tandem | 6.60 | 2.40 | 40.43 |

### Volume MAE @ epoch 57
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.13 | 0.40 | 20.76 |
| ood_cond | 0.74 | 0.29 | 12.92 |
| ood_re | 0.82 | 0.37 | 47.40 |
| tandem | 2.02 | 0.92 | 40.06 |

**mean3 @ epoch 57:** (19.31 + 15.33 + 40.43) / 3 = **25.0** vs baseline **23.2** (worse)

### What happened

The run was cut off at epoch 57/100 due to the 30-minute timeout, making this an incomplete evaluation. At epoch 57, surface pressure MAE is worse than baseline across all splits — tandem (40.43 vs 37.7), in_dist (19.31 vs 17.5), ood_cond (15.33 vs 14.3), ood_re (28.48 vs 27.7). All val losses were still declining at epoch 57, so the model had not converged.

Two interpretations are possible: (1) pure AdamW at lr=4e-3 converges more slowly in early-to-mid training and would close the gap given all 100 epochs; (2) Lookahead's slow-weight stabilization genuinely helps and removing it leads to a worse optimum. The incomplete run can't distinguish these. What is clear: at the 30-min mark, removing Lookahead is not beneficial.

### Suggested follow-ups

1. **Compare at a fixed epoch budget (e.g., 57 epochs)**: Run baseline (Lookahead + lr=3e-3) and pure AdamW side-by-side capped at the same number of epochs for a fair comparison.
2. **Try lr=3e-3 pure AdamW**: If lr=4e-3 is converging more slowly, testing the same LR without Lookahead isolates the optimizer effect.
3. **Keep Lookahead, increase lr to 4e-3**: Decouples LR increase from Lookahead removal — tests whether the higher LR alone can improve over the baseline.
