### PR TITLE
Regime D: batch_size=8, lr=2e-3 (larger batch, adjusted LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,9 +411,9 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 2e-3
     weight_decay: float = 0.0
-    batch_size: int = 4
+    batch_size: int = 8
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
     stats_file: str = "data/split_stats.json"


### PR DESCRIPTION
## Hypothesis
batch_size=8 halves gradient steps but gives cleaner gradients. Lower LR compensates.
## Instructions
Change: batch_size=8, lr=2e-3 (for both groups proportionally). Run with `--wandb_group regime-d`.
## Baseline (verified frontier, 4 consecutive plateau rounds)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- 50 single-variable experiments failed to improve. This round tests MULTI-VARIABLE regime changes.
---
## Results

**Status: CRASHED — CUDA OOM**

| Metric | Result | Baseline |
|--------|--------|----------|
| val/loss | N/A (OOM) | — |
| Surface MAE Ux | N/A | — |
| Surface MAE Uy | N/A | — |
| Surface MAE p | N/A | — |
| Volume MAE | N/A | — |
| Peak VRAM | ~95 GB (OOM) | ~91 GB |

**W&B run:** 90xgmxdx (crashed epoch 1, no validation metrics)

**What happened:**

batch_size=8 is infeasible on these 96 GB GPUs. The model already uses ~91 GB of VRAM at batch_size=4. Doubling to 8 requires ~2x the activation memory, which exhausted the 94.97 GB available. The crash occurred during the first training batch — never reached validation.

Error: `torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 1.32 GiB. GPU 0 has 277.88 MiB free of 94.97 GiB total.`

**Suggested follow-ups:**
- **Gradient accumulation** (accum_steps=2 with batch_size=4): simulates effective batch of 8 without the memory cost — same cleaner-gradient hypothesis but feasible
- **batch_size=6**: might just barely fit; would give some gradient smoothing with less memory overhead than 8