### PR TITLE
Regime E: EMA from ep25 + decay=0.997 + T_max=72 (longer EMA window)

### DIFF
--- a/train.py
+++ b/train.py
@@ -535,8 +535,8 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
-ema_decay = 0.998
+ema_start_epoch = 25
+ema_decay = 0.997
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=72, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
Earlier EMA start + slightly faster decay + longer LR schedule = more epochs of productive averaging.
## Instructions
Change: ema_start_epoch=25, ema_decay=0.997, T_max=72. Run with `--wandb_group regime-e`.
## Baseline (verified frontier, 4 consecutive plateau rounds)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- 50 single-variable experiments failed to improve. This round tests MULTI-VARIABLE regime changes.
---
## Results

**W&B run:** inhta48l  
**Status:** Timed out at epoch 55/100 (30-min cap)

### Metrics at epoch 55 (EMA model, mid-run)

| Split | val/loss | surf Ux | surf Uy | surf p | vol MAE (Ux/Uy/p) |
|-------|----------|---------|---------|--------|---------|
| in_dist | 0.6440 | 6.09 | 1.58 | 19.6 | 1.13 / 0.37 / 20.3 |
| ood_cond | 0.7364 | 3.45 | 1.02 | 14.6 | 0.75 / 0.28 / 12.5 |
| ood_re | 0.5606 | 3.12 | 0.85 | 28.3 | 0.83 / 0.36 / 47.2 |
| tandem | 1.6969 | 6.59 | 2.15 | 40.5 | 1.97 / 0.90 / 39.2 |

**mean3 (surf p, in+ood+tan / 3): 24.9 vs baseline 23.2 — worse (+7%)**
in=19.6 (+2.1), ood=14.6 (+0.3), re=28.3 (+0.6), tan=40.5 (+2.8)

**Peak memory:** ~87.8 GB (of 96 GB)

### What happened

The run hit the 30-minute timeout at epoch 55/100 — results are mid-training, not final. This makes fair comparison to the baseline impossible. The core problem: with T_max=72 (vs 62 baseline), the cosine LR schedule at epoch 55 is further from its minimum (45/72 steps complete vs ~45/52 for baseline at epoch 55). The model is operating in a higher-LR regime with more active weight updates, so it hasn't converged to its best checkpoint. The EMA model (active since epoch 25, 30 epochs of averaging) is averaging over a noisier trajectory than the baseline EMA model was.

All 4 splits show worse performance at epoch 55 vs baseline. But since T_max=72 is designed to shift productive learning later in training, the final-epoch comparison would be more meaningful — which we can't see due to the timeout.

**Verdict:** Inconclusive. The T_max=72 change is structurally incompatible with the 30-minute training cap — the schedule only completes at epoch ~82, well past the timeout.

### Suggested follow-ups

- **Isolate ema_start_epoch=25**: test earlier EMA alone (keep T_max=62) — compatible with timeout and gives more EMA averaging time at the same convergence point
- **Isolate ema_decay=0.997**: slightly faster decay alone may help or hurt independently
- **Shorten T_max to fit the cap**: if ~55 epochs fit in 30 min, try T_max=45 or T_max=50 to ensure the schedule completes within the budget