### PR TITLE
Regime F: n_hidden=160, n_layers=2 (trade width for depth)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,8 +520,8 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=192,  # was 160
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_hidden=160,
+    n_layers=2,
     n_head=4,
     slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
Every width-for-depth trade has failed in isolation. But combined with the full 30-improvement stack, 2 layers at 160-dim with all other optimizations may find a better regime.
## Instructions
Change: n_hidden=160, n_layers=2. Keep everything else (compile, GLU, spatial bias, etc). Run with `--wandb_group regime-f`.
## Baseline (verified frontier, 4 consecutive plateau rounds)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- 50 single-variable experiments failed to improve. This round tests MULTI-VARIABLE regime changes.
---
## Results

**W&B run:** `edward/regime-f-n160-l2` (hgu7c7hk), best epoch 43, state=crashed (wall-clock timeout)

**Peak memory:** 17.8 GB

| Split | mae_surf_p | vs baseline |
|-------|-----------|-------------|
| val_in_dist | 21.92 | +4.42 |
| val_ood_cond | 17.41 | +3.11 |
| val_tandem_transfer | 39.30 | +1.60 |
| val_ood_re | 29.62 | +1.92 |
| **mean3** | **26.21** | **+3.01 (+13.0%)** |

Surface MAE (Ux / Uy / p) by split (epoch 42, last W&B sync before timeout):
- val_in_dist: 8.11 / 2.19 / 21.92
- val_ood_cond: 4.99 / 1.40 / 17.41
- val_ood_re: 4.56 / 1.21 / 29.62
- val_tandem: 7.34 / 2.59 / 39.30

Volume MAE (Ux / Uy / p) by split:
- val_in_dist: 1.20 / 0.40 / 22.37
- val_ood_cond: 0.76 / 0.30 / 14.78
- val_ood_re: 0.85 / 0.39 / 48.27
- val_tandem: 1.95 / 0.90 / 38.81

val/loss (epoch 43 best checkpoint): in=0.687, ood=0.839, re=0.615, tan=1.655, 4-split avg≈0.949

- **loss3 = 0.949** (vs baseline ~0.87 — regression)
- **mean3 = 26.21** vs baseline 23.2 — **REGRESSION (+13.0%)**

## What happened

The width-for-depth trade failed, consistent with prior isolated experiments. Two compounding factors:

1. **Fewer effective epochs within 30-min budget**: Epochs 1–10 showed train losses of 0.0 (JIT compilation stalls), wasting ~6 minutes. Combined with the slightly slower 2-layer forward pass (~39s/epoch vs ~36s), only ~33 real training epochs completed.
2. **No capacity advantage**: 160-dim × 2 layers provides no measurable benefit over 192-dim × 1 layer. The extra depth does not compensate for the narrower width in this training budget.

At epoch 43 the model was still steadily improving (not plateaued), so it is under-trained rather than fundamentally broken. But within 30 minutes it cannot catch the baseline.

## Suggested follow-ups

- Try 192-dim, 2-layer to isolate whether the width cut (160→192) or the depth addition is the primary cost.
- Try 128-dim, 3-layer — if depth ever helps, it may only emerge at greater depth.
- Investigate the JIT warmup issue (epochs 1–10 show zero training loss) — fixing this would recover ~6 minutes for all runs.