### PR TITLE
Regime G: Remove hard-mining, no noise, surf_weight fixed at 30 (clean training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -635,8 +635,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Fixed surface weight
+    surf_weight = 30.0
 
     # --- Train ---
     model.train()
@@ -664,18 +664,9 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]
@@ -733,16 +724,6 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
-            surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
-            surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
-            thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
-            thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
-            hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
-            hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis
Ablations showed each component helps individually. But the combination of hard-mining + noise annealing + adaptive surf_weight creates a complex training landscape. Simplify: remove hard-mining, turn off noise entirely, use fixed high surf_weight=30.
## Instructions
Remove vectorized hard-mining block. Set noise to zero always. Replace adaptive surf_weight with fixed 30.0. Run with `--wandb_group regime-g`.
## Baseline (verified frontier, 4 consecutive plateau rounds)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- 50 single-variable experiments failed to improve. This round tests MULTI-VARIABLE regime changes.
---
## Results

**W&B run:** `1uk74twg` (thorfinn/regime-g-clean, group: regime-g)
**Peak memory:** 14.7 GB
**Training:** 61 epochs, 30.1 min

### Surface MAE (mae_surf_p, primary metric)

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 17.7 | 17.5 | +0.2 |
| val_ood_cond | 14.7 | 14.3 | +0.4 |
| val_ood_re | 28.2 | 27.7 | +0.5 |
| val_tandem_transfer | 40.9 | 37.7 | +3.2 |
| **mean3 (in+ood+tan)/3** | **24.4** | **23.2** | **+1.2** |

### Full Surface MAE breakdown (best checkpoint, epoch 61)

| Split | Ux | Uy | p | val/loss |
|-------|-----|-----|-----|---------|
| val_in_dist | 10.0 | 2.6 | 17.7 | 0.6534 |
| val_ood_cond | 6.2 | 1.6 | 14.7 | 0.7779 |
| val_ood_re | 5.8 | 1.3 | 28.2 | 0.6027 |
| val_tandem_transfer | 8.5 | 2.9 | 40.9 | 1.7640 |

**val/loss (4-split avg):** 0.9495

### What happened

The simplified regime is consistently slightly worse across all splits, with tandem taking the largest hit (+3.2 mae_surf_p, ~8.5% relative regression). Overall mean3 regresses 23.2 → 24.4.

Removing hard-mining likely hurt tandem most: it boosted pressure gradient signal on difficult non-tandem nodes, sharpening training in ways that aided generalization. Removing noise annealing reduced regularization. Fixed surf_weight=30 falls within the adaptive range, so that alone is unlikely to explain the regression.

The hypothesis that these components add unnecessary complexity is not supported — each carries meaningful signal.

### Suggested follow-ups
- Ablate surf_weight alone (fixed 30, keep noise + hard-mining) to test whether the adaptive weight is expendable.
- Ablate noise only (remove noise, keep hard-mining + adaptive weight) to isolate the noise contribution.
- If hard-mining is the key contributor, simplify it to a fixed top-50% fraction without tandem asymmetry — same concept, less code.