### PR TITLE
Regime H: slice_num=48, n_hidden=160 (finer routing, narrower)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,10 +520,10 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=192,  # was 160
+    n_hidden=160,  # regime-h: narrower for finer routing
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
-    slice_num=32,  # was 64 — fewer slices for faster attention, more epochs
+    slice_num=48,  # regime-h: more slices for finer spatial decomposition
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],


### PR DESCRIPTION
## Hypothesis
More slices = finer spatial routing. Trade width for granularity. 48 slices at 160-dim may find better spatial decomposition.
## Instructions
Change: slice_num=48, n_hidden=160. Run with `--wandb_group regime-h`.
## Baseline (verified frontier, 4 consecutive plateau rounds)
- mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)
- 50 single-variable experiments failed to improve. This round tests MULTI-VARIABLE regime changes.
---
## Results

**W&B run:** `askeladd/regime-h-slice48-hidden160` (vn84qw4a), best epoch 62/63, state=crashed (wall-clock timeout; epoch 63 synced locally but not to W&B)

| Split | mae_surf_p | vs baseline |
|-------|-----------|-------------|
| val_in_dist | 16.84 | -0.66 (-3.8%) |
| val_ood_cond | 13.82 | -0.48 (-3.4%) |
| val_tandem_transfer | 38.10 | +0.40 (+1.1%) |
| val_ood_re | 27.82 | +0.12 (+0.4%) |
| **mean3** | **22.9** | **-0.3 (-1.3%)** |

- **val/loss = 0.8648** (vs baseline ~0.87)
- **Peak memory: 13.0 GB** (~14% of 96 GB)
- 62 epochs in ~29 min (~28s/epoch), ~543k params

### Surface MAE detail

| Field | val_in_dist | val_ood_cond | val_ood_re | val_tandem |
|-------|------------|--------------|-----------|------------|
| Ux    | 5.78       | 3.05         | 2.58      | 5.85       |
| Uy    | 2.20       | 1.24         | 1.06      | 2.55       |
| p     | 16.84      | 13.82        | 27.82     | 38.10      |

### Volume MAE detail

| Field | val_in_dist | val_ood_cond | val_ood_re | val_tandem |
|-------|------------|--------------|-----------|------------|
| Ux    | 1.10       | 0.72         | 0.82      | 1.94       |
| Uy    | 0.37       | 0.27         | 0.36      | 0.88       |
| p     | 18.80      | 12.20        | 47.01     | 37.73      |

### What happened

The 48-slice / 160-dim configuration improves mean3 by 0.3 points (23.2 → 22.9, -1.3%). Real but modest. The improvement concentrates in in-distribution and ood_cond (-3-4%), while ood_re and tandem barely change. The model converged steadily over 62 epochs with monotonically improving val/loss throughout.

Finer spatial routing (48 slices vs 32) appears to help, but narrowing from 192 to 160 dims recovers some of the gain as regularization rather than pure capacity improvement. The net result is a small win.

Memory is very lean at 13.0 GB vs 96 GB available — the smaller model leaves substantial headroom.

### Suggested follow-ups
- **slice_num=48, n_hidden=192** — keep finer routing, restore full width. Isolates whether gain comes from slices or reduced model size (regularization).
- **slice_num=64, n_hidden=160** — test narrower width alone without extra slices.
- **n_layers=2 with this config** — 13 GB footprint leaves ~83 GB free; a second layer at these smaller dims may be affordable and extract more benefit.