### PR TITLE
Regime M: Gradient accumulation 2x (effective batch 8, compile mode=default)

### DIFF
--- a/train.py
+++ b/train.py
@@ -407,6 +407,7 @@ class Transolver(nn.Module):
 
 MAX_TIMEOUT = 30.0  # minutes
 MAX_EPOCHS = 100
+accum_steps = 2  # gradient accumulation steps (effective batch size = batch_size * accum_steps)
 
 
 @dataclass
@@ -530,7 +531,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
+model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -644,6 +645,8 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf = 0.0
     n_batches = 0
 
+    accum_batch = 0
+    optimizer.zero_grad()
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
@@ -779,19 +782,21 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(_base_model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        (loss / accum_steps).backward()
+        accum_batch += 1
+        if accum_batch % accum_steps == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
+            if epoch >= ema_start_epoch:
+                if ema_model is None:
+                    ema_model = deepcopy(_base_model)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
+                            ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+            global_step += 1
+            wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Gradient accumulation with effective batch size 8 dramatically improves surface pressure by providing cleaner, less noisy gradient signals. PR #1238 demonstrated a -13.7% improvement on mean3 surface pressure (20.03 vs 23.2 baseline) using this approach. The key requirement is switching \`torch.compile(mode='reduce-overhead')\` to \`torch.compile(mode='default')\` since CUDA graphs are incompatible with gradient accumulation.

## Instructions
1. Add \`accum_steps = 2\` as a constant near the top of the training config section
2. Change \`torch.compile(model, mode="reduce-overhead")\` to \`torch.compile(model, mode="default")\`
3. In the training loop, implement gradient accumulation:
   - Divide loss by \`accum_steps\` before \`.backward()\`
   - Only call \`optimizer.step()\`, \`optimizer.zero_grad()\`, EMA update, and increment \`global_step\` every \`accum_steps\` mini-batches
   - Make sure the Lookahead sync step also only triggers on actual optimizer steps
4. Keep LR=3e-3 and all other settings identical (don't scale LR for effective batch size — PR #1238 showed this works as-is)
5. Run with \`--wandb_group regime-m-grad-accum\`

**Note**: This will reduce the number of optimizer steps per epoch by 2x, so you'll see ~60 effective update steps worth of epochs instead of ~72. The cleaner gradients should more than compensate.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7
- 50+ single-variable experiments showed no improvement. This replicates the single most promising result from the plateau phase.

---

## Results

**W&B run ID:** dylgzibj
**Run name:** nezuko/regime-m-grad-accum-2x
**Epochs completed:** 61 (hit 30-min wall-clock limit)
**Peak VRAM:** 14.6 GB
**Total optimizer steps:** 10,065 (165/epoch × 61 epochs)

### Metrics at best epoch (61)

| Split | val_loss | Surface Ux MAE | Surface Uy MAE | Surface p MAE | Volume MAE (Ux/Uy/p) |
|---|---|---|---|---|---|
| in_dist | 0.621 | 4.89 | 1.60 | **18.4** | 1.15 / 0.37 / 20.3 |
| ood_cond | 0.699 | 3.32 | 1.16 | **13.7** | 0.76 / 0.28 / 12.2 |
| ood_re | 0.578 | 3.04 | 1.01 | **28.5** | 0.87 / 0.37 / 47.3 |
| tandem | 1.662 | 5.59 | 2.29 | **39.7** | 2.01 / 0.91 / 39.4 |
| **best_val_loss** | **0.890** | | | | |

### vs. Baseline

| Metric | Baseline | This Run | Delta |
|---|---|---|---|
| best_val_loss | ~0.865 | 0.890 | **+2.9% (worse)** |
| Surface p in_dist | 17.5 | 18.4 | +5.1% (worse) |
| Surface p ood_cond | 14.3 | 13.7 | -4.2% (better) |
| Surface p ood_re | 27.7 | 28.5 | +2.9% (worse) |
| Surface p tandem | 37.7 | 39.7 | +5.3% (worse) |
| Mean3 surface p | ~19.8 | 20.2 | +2.0% (worse) |

### What happened

The hypothesis did **not** replicate. Gradient accumulation (effective batch 8) produced results slightly *worse* than baseline on most metrics, not the -13.7% improvement seen in PR #1238.

Likely factors:

1. **Different codebase state.** PR #1238 ran on an earlier version of the code. The current model has several changes since then (GatedMLP2, spatial bias MLP, asymmetric hard-node mining, etc.) that may already regularize the gradients enough that enlarging the effective batch size provides little additional benefit.

2. **Fewer effective optimizer steps.** With accum_steps=2, each 30-min run delivers only ~10K gradient updates instead of ~20K. The slower convergence likely offsets any cleaner-gradient benefit within the time budget.

3. **compile mode=default overhead.** First epoch took ~100s (vs ~40s with reduce-overhead), costing us ~2 extra epochs of training time.

The implementation is correct: Lookahead sync, EMA, global_step, and wandb logging all fire only on actual optimizer steps; loss is scaled by 1/accum_steps before backward.

### Suggested follow-ups

- **Longer budget**: test accum_steps=2 with a 60-min run to see if cleaner gradients pay off given more total steps.
- **accum_steps=4** (effective batch 16): if the noise reduction story is right, a larger effective batch might show a clearer signal.
- **Try reduce-overhead compile mode with accum_steps**: the PR required mode=default to avoid CUDA graph issues, but newer PyTorch may handle this better; worth checking.