### PR TITLE
Regime N: FP32 output head (higher precision for final predictions)

### DIFF
--- a/train.py
+++ b/train.py
@@ -240,7 +240,10 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            # Run output head in full precision for better surface accuracy
+            with torch.amp.autocast("cuda", enabled=False):
+                fx = self.mlp2(self.ln_3(fx.float()))
+            return fx
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The entire forward pass runs in bfloat16 (3-digit mantissa / 7 bits). The output head (ln_3 + mlp2) converts hidden features to final [Ux, Uy, p] predictions, where small numerical errors in bf16 directly become surface pressure MAE. Running the output head in float32 while keeping attention in bf16 should improve prediction precision at near-zero throughput cost, since the output head is tiny relative to attention.

## Instructions
1. In the `TransolverBlock.forward` method, find the section where `self.last_layer` is True (the output head path)
2. Before the output head computation (`self.mlp2(self.ln_3(fx))`), cast `fx` to float32 and exit the autocast context:
   ```python
   if self.last_layer:
       # Run output head in full precision for better surface accuracy
       with torch.amp.autocast("cuda", enabled=False):
           fx = self.mlp2(self.ln_3(fx.float()))
   ```
3. Make sure the loss computation also uses float32 values from the output head (the model output should already be float32 after this change)
4. Keep all other settings identical
5. Run with `--wandb_group regime-n-fp32-output`

**Note**: This was tested early in the project (PR #955, round ~15) when val_loss was 2.19 — a very different baseline. The current model is 30 merged improvements later and operating in a regime where precision improvements matter more. bf16 has only 7 bits of mantissa vs 23 for fp32 — in the output head this precision loss directly translates to MAE.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7

---

## Results

**W&B run:** qr2jd5mq
**Epochs completed:** 58/100 (30-min timeout)
**Peak memory:** 16.4 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.879 | ~0.865 | +1.7% (worse) |
| Surface MAE p (in_dist) | 18.23 | 17.5 | +4.2% (worse) |
| Surface MAE p (ood_cond) | 14.39 | 14.3 | +0.6% (≈same) |
| Surface MAE p (ood_re) | 28.16 | 27.7 | +1.7% (worse) |
| Surface MAE p (tandem) | 38.86 | 37.7 | +3.1% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 7.98 | 2.23 | 18.23 |
| ood_cond | 5.03 | 1.57 | 14.39 |
| ood_re | 4.53 | 1.41 | 28.16 |
| tandem | 7.16 | 2.76 | 38.86 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.12 | 0.36 | 19.72 |
| ood_cond | 0.74 | 0.28 | 12.54 |
| ood_re | 0.82 | 0.36 | 47.08 |
| tandem | 1.92 | 0.88 | 37.89 |

### What happened

The FP32 output head did not improve results — all surface MAE metrics are marginally worse or essentially the same as baseline. The hypothesis was reasonable (bf16's 7-bit mantissa vs fp32's 23-bit directly impacts the output head precision), but the gains didn't materialize in practice.

Possible reasons:
1. **The bottleneck is elsewhere.** At val_loss ~0.865, the error likely comes from model capacity or feature representation, not from the 16-bit rounding in the tiny output head. The output MLP is just 2 linear layers — the feature space errors from attention/MLP are far larger than the fp32 precision gain.
2. **Train/val loss mismatch.** Training loss is computed in bf16 regardless, so gradient signals are still bf16-precision, meaning fp32 inference doesn't help optimization quality either.
3. **Was already tested and rejected.** PR #955 tested this at a much higher loss level (2.19) and presumably didn't merge, suggesting it wasn't useful then either. The current model is stronger but the pattern holds.

The change is minimal (4 lines) and adds near-zero overhead, but since it doesn't help, it's not worth keeping.

### Suggested follow-ups

- **Mixed precision in loss computation:** Cast model output AND targets to float32 before computing loss, to see if the gradient signal improves.
- **FP32 for the last N transformer layers:** Instead of just the output head, run the last 1-2 transformer blocks in fp32 — the features entering the output head might have precision-limited quality.
- **Investigate ood_re volume MAE p = 47:** This is unusually high compared to other splits. Worth understanding whether this is a data distribution issue or a model failure mode.