### PR TITLE
Regime P: Channel-weighted surface loss (add velocity signal to surface gradient)

### DIFF
--- a/train.py
+++ b/train.py
@@ -728,21 +728,23 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_pres_err = abs_err[:, :, 2:3]
+        surf_vel_err = 0.3 * abs_err[:, :, 0:1] + 0.1 * abs_err[:, :, 1:2]
+        surf_combined = surf_pres_err + surf_vel_err
+        surf_per_sample = (surf_combined * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
-            surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
-            surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
-            thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
+            surf_combined_flat = surf_combined[:, :, 0]  # [B, N]
+            surf_combined_masked = surf_combined_flat.masked_fill(~surf_mask, float('nan'))
+            thresh = torch.nanmedian(surf_combined_masked, dim=1).values  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
-            hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
+            hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_combined_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            surf_per_sample = (surf_combined * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis
The surface loss currently uses only the pressure channel. Adding small weights on surface velocity channels (0.3x for Ux, 0.1x for Uy) would provide richer gradient signal about the boundary layer velocity profile, which is physically coupled to pressure via the momentum equation. This should improve surface pressure accuracy indirectly.

## Instructions
1. Find where `surf_per_sample` is computed using only pressure errors (around line 731, `abs_err[:, :, 2:3]`)
2. Change to a weighted combination of all surface channels:
   ```python
   surf_pres_err = abs_err[:, :, 2:3]
   surf_vel_err = 0.3 * abs_err[:, :, 0:1] + 0.1 * abs_err[:, :, 1:2]
   surf_combined = surf_pres_err + surf_vel_err
   surf_per_sample = (surf_combined * surf_mask.unsqueeze(-1)).sum(dim=(1,2)) / surf_mask.sum(dim=1).clamp(min=1).float()
   ```
3. Also update the hard-mining block (epoch >= 30) to use `surf_combined` instead of just pressure for computing which nodes are "hard"
4. Keep everything else identical
5. Run with `--wandb_group regime-p`

**Physics rationale**: The momentum equations couple velocity and pressure at the boundary. Currently the model receives no gradient signal about surface velocities, so the hidden representation near the surface is optimized only for pressure. Adding velocity signal forces the model to learn better near-wall flow features.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7

---

## Results

**W&B run ID**: `htfwcrcf`
**Epochs completed**: 58 / 100 (30-min timeout)
**Peak memory**: ~14.8 GB

### Metrics at best val/loss checkpoint

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|---|---|---|---|---|---|
| val_in_dist | 0.6067 | 0.29 | 0.20 | 18.29 | 19.66 |
| val_ood_cond | 0.7137 | 0.23 | 0.19 | 14.19 | 12.33 |
| val_ood_re | 0.5600 | 0.26 | 0.20 | 28.16 | 47.18 |
| val_tandem_transfer | 1.6549 | 0.64 | 0.37 | 39.47 | 39.07 |

**Best val/loss**: 0.8838 (baseline: ~0.865)
**mean3 (in, ood\_cond, tandem) surf\_p**: (18.29 + 14.19 + 39.47) / 3 = **24.0** (baseline: 23.2)

### What happened

The hypothesis did not improve pressure accuracy — mean3 worsened from 23.2 → 24.0. The channel-weighted loss blends velocity errors into the surface training signal, but this appears to dilute the pressure gradient rather than enrich it. The model ends up optimizing a mixed objective that trades off pressure accuracy for velocity accuracy.

Surface velocity MAE is noticeably good (Ux: 0.23–0.64, Uy: 0.19–0.37), which confirms the velocity channels are being trained effectively. However, pressure is the metric that matters most, and it regressed. The physics rationale (momentum coupling) is plausible in principle, but the current weighting (0.3 Ux + 0.1 Uy) may be too large — it steals gradient budget from pressure.

The training loss budget is now spread across all three channels at the surface, whereas before it was focused entirely on pressure. Net result: pressure optimization is slightly worse despite better velocity fitting.

### Suggested follow-ups

- **Tiny velocity weights**: Try surf_vel_err = 0.05 * Ux + 0.02 * Uy — barely perceptible, but still provides a coupling gradient without significantly diluting the pressure signal.
- **Separate velocity auxiliary loss**: Add a small (0.05x) separate auxiliary term for surface velocities without changing the pressure-based hard mining target, so the two objectives don't compete.
- **Hard-mining on pressure only**: Even if combined loss is used for training, revert hard mining to use pressure-only threshold (as in baseline). The hard-mining selection criterion may be more important than the loss weighting.