### PR TITLE
Regime Q: Label smoothing on pressure targets (reduce outlier node influence)

### DIFF
--- a/train.py
+++ b/train.py
@@ -693,7 +693,7 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
             smooth_alpha = 0.02
-            y_mean_sample = (y_norm * mask.float().unsqueeze(-1)).sum(dim=1, keepdim=True) / mask.float().sum(dim=1, keepdim=True).clamp(min=1)
+            y_mean_sample = (y_norm * mask.float().unsqueeze(-1)).sum(dim=1, keepdim=True) / mask.float().sum(dim=1, keepdim=True).clamp(min=1).unsqueeze(-1)
             y_norm = (1 - smooth_alpha) * y_norm + smooth_alpha * y_mean_sample
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
Per-sample std normalization creates large normalized targets in the tails for high-variance samples (high-Re, tandem). A small label smoothing factor (0.02) blending targets toward the per-sample mean would reduce the influence of extreme outlier nodes while preserving the overall distribution shape.

## Instructions
1. After computing `y_norm` (around line 672) and after per-sample std normalization, add label smoothing during training only:
   ```python
   if model.training:
       smooth_alpha = 0.02
       y_mean_sample = (y_norm * mask.float().unsqueeze(-1)).sum(dim=1, keepdim=True) / mask.float().sum(dim=1, keepdim=True).clamp(min=1)
       y_norm = (1 - smooth_alpha) * y_norm + smooth_alpha * y_mean_sample
   ```
2. Make sure this is applied ONLY during training (not validation)
3. Keep everything else identical
4. Run with `--wandb_group regime-q`

**Rationale**: Stagnation/suction regions have extreme Cp values (-10+) that dominate the loss. Smoothing by 0.02 barely changes the distribution mean but clips gradient contribution from extreme tails. Different from Huber loss (PR #1194) which worked in loss space — this works in target space.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7

---

## Results

**W&B run:** `bcgvxy8w` (fern/regime-q-label-smoothing-0.02)
**Epochs completed:** ~61/100 (hit 30-min timeout)
**Peak VRAM:** 14.7 GB

**Note:** The PR instructions had a shape bug (`[B,1,3] / [B,1]` → broadcast mismatch). Fixed with `.unsqueeze(-1)` on the denominator.

### Surface MAE pressure (primary metric)
| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| in_dist | 21.7 | 17.5 | **+4.2 (+24%)** |
| ood_cond | 14.8 | 14.3 | +0.5 |
| ood_re | 28.2 | 27.7 | +0.5 |
| tandem | 39.9 | 37.7 | +2.2 |
| **mean3** | **25.5** | **23.2** | **+2.3 (+10%)** |

### Surface MAE (Ux, Uy, p)
| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 6.83 | 1.75 | 21.7 |
| ood_cond | 4.31 | 1.09 | 14.8 |
| ood_re | 3.77 | 0.91 | 28.2 |
| tandem | 6.49 | 2.29 | 39.9 |

### Volume MAE (Ux, Uy, p)
| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 1.15 | 0.38 | 21.9 |
| ood_cond | 0.73 | 0.28 | 12.7 |
| ood_re | 0.83 | 0.37 | 46.9 |
| tandem | 1.93 | 0.89 | 39.6 |

**val/loss:** 0.9136

### What happened

Label smoothing at alpha=0.02 made things worse, not better. mean3 regressed by 10%, and in_dist pressure MAE deteriorated severely (+24%). The hypothesis was that blending extreme outlier nodes toward the per-sample mean would reduce gradient noise; instead it appears to have made the learning signal blurry.

The mechanism: label smoothing nudges the target from the actual normalized value toward the sample-mean. For in-distribution samples at moderate Reynolds numbers, the pressure distribution around the airfoil has important sharp features (stagnation point high pressure, suction peak low pressure). Pulling these toward the mean during training corrupts the signal for these physically important nodes. The 0.02 alpha seems small but apparently disrupts learning of the sharpest pressure gradients.

Notably, in_dist suffered the most (+24%) while ood_re was barely affected (+1.8%). This may suggest that in-distribution samples have more consistent sharp features that get systematically blurred, while ood_re has higher natural variance and the smoothing has less relative impact.

### Suggested follow-ups
1. **Apply smoothing only to pressure channel:** the Ux/Uy predictions also got worse; pressure-specific smoothing might be safer
2. **Much smaller alpha (0.005-0.01):** 0.02 may be too large even though it looks small
3. **Conditional smoothing (tandem-only):** tandem samples are the hardest; applying smoothing only there might help without hurting in-dist
4. **Loss-space clipping instead:** gradient clipping or loss clipping on extreme surface pressure nodes rather than target smoothing