### PR TITLE
Regime R: LayerNorm inside output head (stabilize pre-activation distribution)

### DIFF
--- a/train.py
+++ b/train.py
@@ -227,6 +227,7 @@ class TransolverBlock(nn.Module):
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
+                nn.LayerNorm(hidden_dim),
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )


### PR DESCRIPTION
## Hypothesis
The output head is `Linear(n_hidden, n_hidden) -> GELU -> Linear(n_hidden, 3)`. The intermediate representation after the first linear layer has variable magnitude across samples. Adding LayerNorm between the first linear and GELU would standardize the pre-activation distribution, improving output consistency across flow conditions.

## Instructions
1. In `TransolverBlock.__init__`, when `self.last_layer` is True, modify `self.mlp2` to include LayerNorm:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim),
           nn.LayerNorm(hidden_dim),
           nn.GELU(),
           nn.Linear(hidden_dim, out_dim),
       )
   ```
2. Keep the existing `self.ln_3` applied before `self.mlp2` in forward (that stays as-is)
3. Keep everything else identical
4. Run with `--wandb_group regime-r`

**Rationale**: Minimal change (<1K extra params, no speed impact). If the intermediate representation has variable magnitude, GELU operates in different regimes for different samples. LayerNorm normalizes this, which should especially help OOD samples where hidden feature magnitudes may shift.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7

---

## Results

**W&B run:** 34eo2b0b  
**Epochs completed:** 59/100 (30-min wall-clock limit; training still converging)  
**Peak memory:** 16.3 GB (+1.6 GB vs regime-c's ~14.7 GB)

### Val loss @ epoch 59
| Split | val/loss |
|---|---|
| in_dist | 0.6072 |
| ood_cond | 0.7233 |
| ood_re | 0.5549 |
| tandem | 1.6605 |
| **combined** | **0.8865** |

### Surface MAE @ epoch 59
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 7.62 | 2.30 | 17.78 |
| ood_cond | 4.04 | 1.21 | 14.72 |
| ood_re | 3.74 | 1.13 | 28.04 |
| tandem | 6.92 | 2.61 | 39.14 |

### Volume MAE @ epoch 59
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.12 | 0.38 | 19.55 |
| ood_cond | 0.72 | 0.28 | 12.32 |
| ood_re | 0.84 | 0.37 | 47.01 |
| tandem | 1.99 | 0.92 | 39.37 |

**mean3 @ epoch 59:** (17.78 + 14.72 + 39.14) / 3 = **23.88** vs baseline **23.2** (slightly worse)  
**best_val_loss:** 0.8865 vs baseline ~0.865 (essentially matched)

### What happened

The LayerNorm in the output head did not improve over baseline. At epoch 59, surface pressure MAE is slightly worse across all splits: in_dist (+0.28), ood_cond (+0.42), ood_re (+0.34), tandem (+1.44). The combined val/loss (0.8865) is very close to the baseline (~0.865), which is consistent with a marginal difference.

The hypothesis specifically predicted improvement on OOD samples, but that's where we see the weakest performance relative to baseline (tandem +1.44 MAE-p is the biggest miss). This contradicts the rationale: adding normalization between the two linear layers didn't meaningfully stabilize the OOD behavior.

One concern: the extra LayerNorm adds ~1.6 GB memory with negligible speed benefit. At 59/100 epochs the run hadn't fully converged, but the gap vs baseline is consistent across all splits and doesn't appear to be closing.

**Verdict: no improvement, not worth the added complexity/memory.**

### Suggested follow-ups

1. **Longer training or reduced epoch budget**: Both this run and regime-c ran out of time at ~57-59 epochs. A 60-epoch training cap would give a fairer apples-to-apples comparison with the baseline.
2. **LayerNorm on output only (remove input ln_3)**: The block already applies `self.ln_3` before `self.mlp2` in forward. Having two consecutive LayerNorms (ln_3 then the one inside mlp2) may be redundant. Testing just a single LayerNorm inside mlp2 without the outer ln_3 could be cleaner.
3. **Output head architectural change**: If normalizing the intermediate representation is the goal, a residual connection inside the output MLP (hidden += proj(hidden)) might be more effective than LayerNorm.
