### PR TITLE
Regime T: Compressed cosine decay + higher LR floor (T_max=50, eta_min=2e-4)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=50, eta_min=2e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
The current cosine schedule (T_max=62, eta_min=5e-5) creates a dead zone: the last 10 epochs run at near-zero LR that barely moves the model. Compressing the cosine phase (T_max=50) and raising the LR floor (2e-4) means the model decays faster BUT maintains a meaningfully higher LR during the EMA averaging phase (epochs 40-72). EMA/SWA theory says averaging diverse-but-good checkpoints is better than averaging near-identical converged ones.

## Instructions
1. Change the scheduler configuration (around lines 579-583):
   ```python
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=50, eta_min=2e-4)
   scheduler = torch.optim.lr_scheduler.SequentialLR(
       base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
   )
   ```
2. Keep everything else identical (warmup=10, lr=3e-3, Lookahead, EMA from ep40)
3. Run with `--wandb_group regime-t`

**Key insight from failed regimes**: A/E/I all tried SLOWER or RESTARTING schedules. This goes the opposite direction — FASTER decay to a HIGHER floor. Compatible with the 30-min budget by design.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7

---

## Results

**W&B run:** `axjkilxx` (thorfinn/regime-t-compressed-cosine, group: regime-t)
**Peak memory:** 14.7 GB
**Training:** 61 epochs, 30.2 min

### Surface MAE (mae_surf_p, primary metric)

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 18.3 | 17.5 | +0.8 |
| val_ood_cond | 14.5 | 14.3 | +0.2 |
| val_ood_re | 27.8 | 27.7 | +0.1 |
| val_tandem_transfer | 39.8 | 37.7 | +2.1 |
| **mean3 (in+ood+tan)/3** | **24.2** | **23.2** | **+1.0** |

### Full Surface MAE breakdown (best checkpoint, epoch 61)

| Split | Ux | Uy | p | val/loss |
|-------|-----|-----|-----|---------|
| val_in_dist | 6.4 | 1.9 | 18.3 | 0.5951 |
| val_ood_cond | 3.8 | 1.3 | 14.5 | 0.7196 |
| val_ood_re | 3.3 | 1.1 | 27.8 | 0.5501 |
| val_tandem_transfer | 6.7 | 2.5 | 39.8 | 1.6743 |

**val/loss (4-split avg):** 0.8848 (baseline ~0.865)

### What happened

The compressed schedule did not beat the frontier. val/loss is 0.8848 vs baseline ~0.865 — essentially tied or marginally worse. Physical surface MAE is worse in all splits, with tandem regressing the most (+2.1) and ood_re being essentially the same (+0.1).

The intuition that a higher LR floor during EMA would produce more diverse checkpoints to average is not validated. A possible explanation: with T_max=50, the cosine decay finishes at epoch 60. After that, the LR is flat at 2e-4 (vs continuing to decay from 5e-5). But the training loss variance actually tells the story — surf losses around 0.023-0.025 in late epochs vs the slower schedule's similar values. The EMA diversity argument may require a longer training run to manifest.

### Suggested follow-ups
- Try a cycle/warm restart approach (CosineAnnealingWarmRestarts) to explicitly create LR variation during EMA phase rather than relying on floor level.
- Try EMA starting earlier (epoch 20-30) to capture more of the high-LR trajectory.
- Try an even more aggressive floor (5e-4) to amplify the diversity effect, if the theory is right.