### PR TITLE
Regime U: Near-surface proximity feature (smooth distance-to-foil signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -518,7 +518,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 1 + 32 + 1,  # +1 curv proxy, +32 Fourier PE, +1 near-surface proximity
     out_dim=3,
     n_hidden=192,  # was 160
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -654,6 +654,10 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
+        # Near-surface proximity: smooth scalar ~1 near surface, ~0 far away
+        dsdf_norm = x[:, :, 2:10].norm(dim=-1, keepdim=True)
+        near_surface = torch.sigmoid(5.0 * (0.2 - dsdf_norm))
+        x = torch.cat([x, near_surface], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -835,6 +839,10 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
+                # Near-surface proximity: smooth scalar ~1 near surface, ~0 far away
+                dsdf_norm = x[:, :, 2:10].norm(dim=-1, keepdim=True)
+                near_surface = torch.sigmoid(5.0 * (0.2 - dsdf_norm))
+                x = torch.cat([x, near_surface], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding


### PR DESCRIPTION
## Hypothesis
The model has only a binary is_surface flag. Volume nodes near the surface are critical for accurate surface predictions because they define boundary layer gradients. Adding a smooth near-surface proximity feature (derived from the signed distance field) allows attention to soft-focus on the boundary layer region.

## Instructions
1. After the input feature computation but before feeding into the model, compute a smooth proximity feature from the signed distance field (dsdf, indices 2-9 in x):
   ```python
   dsdf_norm = x[:, :, 2:10].norm(dim=-1, keepdim=True)  # dsdf indices 2-9
   near_surface = torch.sigmoid(5.0 * (0.2 - dsdf_norm))  # ~1 near surface, ~0 far
   x = torch.cat([x, near_surface], dim=-1)
   ```
2. Update `fun_dim` to account for the extra feature: add 1 to the current fun_dim calculation
3. Apply the same transformation in BOTH the training and validation loops
4. Run with `--wandb_group regime-u`

**Rationale**: Different from raw SDF augmentation (PR #1239 which added 4 channels). This adds a single derived scalar that provides a smooth boundary layer indicator. The boundary layer is a gradient, not a step function — the model needs to know how close each volume node is to the surface.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7

---

## Results

**W&B run ID**: pw4jzuhk
**Run name**: violet/near-surface-proximity
**Epochs completed**: 57/100 (cut off by 30-min timeout mid-epoch-58)
**Peak memory**: 14.8 GB

### Metrics at epoch 57 (best checkpoint)

| Split | val_loss | MAE Ux | MAE Uy | MAE p |
|---|---|---|---|---|
| in_dist | 0.611 | 6.86 | 1.99 | 18.4 |
| ood_cond | 0.711 | 4.03 | 1.29 | 14.1 |
| ood_re | 0.553 | 3.65 | 1.11 | 27.9 |
| tandem | 1.616 | 6.22 | 2.29 | 38.2 |

**Combined val_loss**: 0.872

Volume MAE (in_dist): Ux=1.11, Uy=0.37, p=19.6

### vs Baseline

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val_loss | ~0.865 | 0.872 | +0.007 (slightly worse) |
| Surface MAE p (in_dist) | 17.5 | 18.4 | +0.9 (worse) |
| Surface MAE p (ood_cond) | 14.3 | 14.1 | -0.2 (marginal gain) |
| Surface MAE p (ood_re) | 27.7 | 27.9 | +0.2 (comparable) |
| Surface MAE p (tandem) | 37.7 | 38.2 | +0.5 (slightly worse) |

### What happened

The near-surface proximity feature **did not help** — results are essentially flat to slightly worse across all splits. The combined val_loss (0.872) is modestly higher than baseline (~0.865), and surface pressure MAE is worse on in_dist and tandem. The only marginal improvement is ood_cond (-0.2 on pressure MAE), which is within noise.

The run was cut off at epoch 57/100, so the model may not have fully converged, but the trajectory through epochs 40-57 shows the curve flattening with no sign of approaching the baseline. The feature is likely too weak a signal to matter — or the model already implicitly learns boundary proximity from the existing dsdf channels via attention, making this explicit scalar redundant.

It is also worth noting that the existing curvature proxy curv already uses x[:,:,2:6].norm * is_surface — a related quantity — so the near_surface feature may be partially collinear with information already available to the model.

### Suggested follow-ups
- **Sharper sigmoid or larger scale**: Try sigmoid(10.0 * (0.1 - dsdf_norm)) to make the indicator more peaked near the true boundary layer.
- **Learned threshold**: Instead of a fixed 0.2 cutoff, use a learnable parameter for the threshold.
- **Apply to cross-attention**: Rather than feeding proximity as an input feature, use it to modulate attention weights between surface and volume nodes in the cross-attention layers.
- **Volume-to-surface attention weighting**: Use near_surface as an explicit mask/weight in cross-attention — let volume nodes with high proximity contribute more to surface node updates.