### PR TITLE
Regime V: Epoch-scheduled surface weight ramp (10 -> 50 by ep30, hold at 50)

### DIFF
--- a/train.py
+++ b/train.py
@@ -622,8 +622,6 @@ ema_decay_val = 0.9
 best_metrics = {}
 global_step = 0
 train_start = time.time()
-prev_vol_loss = 1.0
-prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
 
@@ -635,8 +633,11 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Scheduled surface weight ramp: 10 → 50 over first 30 epochs, hold at 50
+    if epoch < 30:
+        surf_weight = 10.0 + (50.0 - 10.0) * (epoch / 30)
+    else:
+        surf_weight = 50.0
 
     # --- Train ---
     model.train()
@@ -804,9 +805,6 @@ for epoch in range(MAX_EPOCHS):
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
-    prev_vol_loss = epoch_vol
-    prev_surf_loss = epoch_surf
-
     # --- Validate across all splits ---
     eval_model = ema_model if ema_model is not None else model
     eval_model.eval()


### PR DESCRIPTION
## Hypothesis
The adaptive surf_weight uses instantaneous loss ratios which can oscillate. Replace with a deterministic epoch-scheduled ramp: start at surf_weight=10 (learn volume structure first), ramp linearly to 50 by epoch 30, then hold at 50. This curriculum focuses early training on flow patterns and late training on surface refinement.

## Instructions
1. Replace the adaptive surf_weight computation (around line 639) with a scheduled ramp:
   ```python
   if epoch < 30:
       surf_weight = 10.0 + (50.0 - 10.0) * (epoch / 30)
   else:
       surf_weight = 50.0
   ```
2. Remove the adaptive surf_weight code (the loss-ratio-based computation and clamping)
3. Keep everything else identical
4. Run with `--wandb_group regime-v`

**Key difference from Regime G**: Regime G used a FIXED surf_weight=30 and was 5.2% worse. This uses a RAMP to 50 — a much higher final weight that pushes harder on surface accuracy in the last 40+ epochs when volume predictions are already good. The ramp provides a structured curriculum rather than a flat value.

## Baseline
- best_val_loss: ~0.865
- Surface MAE p: in_dist=17.5, ood_cond=14.3, ood_re=27.7, tandem=37.7

---

## Results

**W&B run:** `uvcxv103`
**Best epoch:** 59 / 100 (hit wall-clock limit, 30s/epoch)
**Peak memory:** 14.7 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6856 | 12.55 | 2.80 | 18.76 | 1.60 | 0.56 | 29.66 |
| val_tandem_transfer | 1.7830 | 9.74 | 3.19 | 40.70 | 2.46 | 1.15 | 45.68 |
| val_ood_cond | 0.7937 | 8.05 | 1.83 | 14.46 | 1.00 | 0.40 | 17.00 |
| val_ood_re | 0.6155 | 7.84 | 1.67 | 28.38 | 1.07 | 0.46 | 50.59 |
| **mean3** | **1.087** | **10.11** | **2.61** | **24.64** | — | — | — |

Baseline: mean3=23.2 (in=17.5, ood=14.3, re=27.7, tan=37.7)

**What happened:** Negative result. mean3 surface_p worsened from 23.2 → 24.64. The ramp to surf_weight=50 significantly hurt the tandem split (40.7 vs 37.7 baseline) and in_dist (18.76 vs 17.5). val/loss is also worse (0.969 vs baseline 0.865).

Notable training anomaly: the first 10 epochs showed train[vol=0.0000 surf=0.0000] in the display, with val losses extremely high (~8–12). At epoch 11 the val loss abruptly dropped from ~8 to 3.3, and then declined steadily. This suggests the surf_weight=10 start (vs adaptive starting at 5) combined with progressive volume sampling may have caused numerical issues or very unusual loss landscapes in early training. The model converged from a degraded starting point, which likely hurt the final quality. The high final surf_weight of 50 also appears to overfit the surface loss at the expense of volume accuracy (vol_p is very high: 29.66, 45.68, 17.0, 50.59 — much worse than baseline).

**Suggested follow-ups:**
- Try a gentler ramp: start at 5 (same as adaptive minimum), ramp to 30 by epoch 30, hold at 30. This avoids the high surf_weight instability.
- Try restoring the adaptive weight but with a smoothed (EMA) version to reduce oscillation: `smooth_surf_weight = 0.9 * smooth_surf_weight + 0.1 * (vol_loss / surf_loss)`.
- Investigate why epochs 1-10 produce 0.0000 training losses — may be a display bug or torch.compile warmup artifact.