### PR TITLE
Regime W: Restore width at 48 slices (n_hidden=192, slice_num=48)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=160,  # regime-h: narrower for finer routing
+    n_hidden=192,  # regime-w: full width with finer routing
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition


### PR DESCRIPTION
## Hypothesis
Regime H proved 48 slices with 160-dim beats 32 slices with 192-dim. Restoring n_hidden=192 while keeping slice_num=48 combines finer spatial routing AND full representational capacity. This was your top suggested follow-up from Regime H.

## Instructions
1. Change `n_hidden=160` back to `n_hidden=192` (the only change from current noam HEAD)
2. Keep slice_num=48 (already set from Regime H merge)
3. Keep everything else identical
4. Run with `--wandb_group regime-w`

**Expected**: ~15-18 GB memory (well within 96 GB), ~55-60 epochs in 30 min. This isolates whether the Regime H gain came from finer slicing (we expect yes) or from reduced width (regularization effect).

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10
- Model: n_hidden=160, slice_num=48, ~543K params, 13 GB memory

---

## Results

**Run ID**: 1bvqn8ct  
**Config**: n_hidden=192, slice_num=48, n_layers=1  
**Epochs**: 58 (wall-clock limit at 30.1 min, ~31s/epoch)  
**Peak memory**: 15.0 GB  

### Surface MAE (pressure p) — primary metric

| Split | Baseline (Regime H) | Regime W | Delta |
|---|---|---|---|
| val_in_dist | 16.84 | 17.99 | +1.15 (worse) |
| val_ood_cond | 13.82 | 13.50 | -0.32 (better) |
| val_ood_re | 27.82 | 27.79 | -0.03 (approx same) |
| val_tandem_transfer | 38.10 | 37.81 | -0.29 (better) |
| **mean3** | **22.92** | **23.10** | **+0.18 (worse)** |

### Full Surface MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 6.12 | 1.62 | 17.99 |
| val_ood_cond | 3.94 | 1.21 | 13.50 |
| val_ood_re | 3.73 | 1.06 | 27.79 |
| val_tandem_transfer | 6.29 | 2.27 | 37.81 |

### Volume MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 1.10 | 0.36 | 18.76 |
| val_ood_cond | 0.72 | 0.27 | 11.82 |
| val_ood_re | 0.81 | 0.36 | 46.71 |
| val_tandem_transfer | 1.94 | 0.88 | 37.54 |

### val/loss
- Regime W: **0.8635** vs Baseline: 0.8648 (marginally better, -0.0013)

---

### What happened

Regime W essentially ties Regime H. The val/loss is nearly identical (0.8635 vs 0.8648), and mean3 surface pressure is slightly worse (23.10 vs 22.92). In-dist pressure regressed by +1.15 MAE with the wider model, while tandem and ood_cond improved slightly. No clear win.

This suggests the Regime H gain came primarily from **finer spatial routing (slice_num=48)**, not the reduced width. Restoring full width (192-dim) did not add meaningful capacity — the extra parameters appear to hurt slightly on in-distribution generalization, possibly a mild overfitting effect at 58 epochs.

The narrow 160-dim model appears to have better inductive bias at this regime (48 slices, 1 layer, 30-min budget).

### Suggested follow-ups

- **Increase slice_num further** (e.g., 64 with n_hidden=160) — if finer routing is the key driver, more slices could continue to improve
- **Try n_layers=2 with slice_num=48, n_hidden=160** — now that we have the right slice regime, deeper may help (if the 30-min budget allows enough epochs)
- **Longer training for Regime H** — 63 epochs may not be fully converged; the model might benefit from a longer run or a cosine annealing schedule