### PR TITLE
Regime X: Two Transolver layers at slim config (n_layers=2)

### DIFF
--- a/train.py
+++ b/train.py
@@ -521,7 +521,7 @@ model_config = dict(
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
     n_hidden=160,  # regime-h: narrower for finer routing
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_layers=2,       # regime-x: 2 layers for hierarchical spatial decomposition
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
With only 13 GB of 96 GB used, a second Transolver layer is affordable. The 1-layer bottleneck forces the model to decompose spatial structure AND produce predictions in a single attention pass. A second layer enables hierarchical decomposition: layer 1 for coarse spatial grouping, layer 2 for refinement within groups.

## Instructions
1. Change \`n_layers=1\` to \`n_layers=2\`
2. Keep n_hidden=160, slice_num=48, everything else identical
3. Run with \`--wandb_group regime-x\`

**Expected**: ~20-25 GB memory (well within budget). Epoch time will increase but should get ~35-40 epochs in 30 min. The auxiliary Re/AoA prediction heads will now operate on post-attention features (from layer 1) instead of raw preprocessed features, making them more meaningful.

**Note**: Regime F (edward) is also testing n_layers=2 but on the OLD code (slice_num=32, n_hidden=160). This tests depth on the new Regime H foundation (slice_num=48).

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10
- Model: n_hidden=160, slice_num=48, n_layers=1, ~543K params, 13 GB

---

## Results

**W&B run ID:** clyhl1yp
**Run name:** nezuko/regime-x-n-layers-2
**Epochs completed:** 45 (hit 30-min wall-clock limit)
**Peak VRAM:** 18.3 GB (was 13 GB with n_layers=1; +5.3 GB as expected)
**Epoch time:** ~38-42s (vs ~28s for n_layers=1; ~40% slower)

### Metrics at best epoch (45)

| Split | val_loss | Surface Ux MAE | Surface Uy MAE | Surface p MAE | Volume MAE (Ux/Uy/p) |
|---|---|---|---|---|---|
| in_dist | 0.639 | 8.34 | 2.25 | **19.7** | 1.10 / 0.38 / 20.1 |
| ood_cond | 0.776 | 5.20 | 1.38 | **15.8** | 0.72 / 0.29 / 13.6 |
| ood_re | 0.584 | 4.95 | 1.27 | **28.9** | 0.81 / 0.36 / 47.6 |
| tandem | 1.641 | 7.70 | 2.68 | **38.3** | 1.90 / 0.87 / 37.9 |
| **best_val_loss** | **0.910** | | | | |

### vs. Baseline

| Metric | Baseline | This Run | Delta |
|---|---|---|---|
| best_val_loss | 0.8648 | 0.910 | **+5.2% (worse)** |
| Surface p in_dist | 16.84 | 19.7 | +17.0% (worse) |
| Surface p ood_cond | 13.82 | 15.8 | +14.3% (worse) |
| Surface p ood_re | 27.82 | 28.9 | +3.9% (worse) |
| Surface p tandem | 38.10 | 38.3 | +0.5% (roughly same) |

### What happened

The hypothesis did **not** work — n_layers=2 is significantly worse than baseline on all metrics except tandem. There are two compounding factors:

1. **Fewer epochs.** The 2-layer model is ~40% slower per epoch (~40s vs ~28s), so we only ran 45 epochs vs the ~61 the 1-layer model gets in 30 minutes. The EMA model kicks in at epoch 40, so the 2-layer model had only 5 epochs of EMA refinement vs ~21 for the 1-layer model. The val_loss was still dropping rapidly at epoch 45 (val_in_dist: 0.932 at epoch 40 → 0.639 at epoch 45), suggesting the model was still mid-convergence.

2. **Harder optimization.** The 2-layer model has more parameters and needs more gradient updates to converge. Within the 30-min budget, the extra capacity is a liability rather than an asset.

The memory increase is modest and well within budget (18.3 GB vs 13 GB), so the hypothesis is not constrained by resources — it's constrained by the time budget. This might look very different with a 60-min run.

### Suggested follow-ups

- **Test n_layers=2 with a 60-min budget**: the loss curve is still descending sharply at epoch 45. If given another 15-20 epochs, this model might overtake the 1-layer baseline.
- **n_layers=2 with n_hidden=128** (fewer parameters per layer): keeps total parameter count similar to the 1-layer n_hidden=160 baseline, potentially allowing faster convergence while still getting two-layer hierarchy.
- **Check regime-f results** (edward, n_layers=2 on old code): if that experiment shows a benefit, the question is whether slice_num=48 interacts badly with depth.