### PR TITLE
Regime Y: batch_size=6 (exploit 83 GB memory headroom for smoother gradients)

### DIFF
--- a/train.py
+++ b/train.py
@@ -413,7 +413,7 @@ MAX_EPOCHS = 100
 class Config:
     lr: float = 3e-3
     weight_decay: float = 0.0
-    batch_size: int = 4
+    batch_size: int = 6
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
     stats_file: str = "data/split_stats.json"


### PR DESCRIPTION
## Hypothesis
With 83 GB of free memory after Regime H, batch_size=6 is easily affordable (~19 GB estimated). A 50% larger batch provides smoother gradients while keeping the same well-tuned lr=3e-3. Past batch_size=8 failures always changed LR — this keeps it identical.

## Instructions
1. Change batch_size from 4 to 6 (command line: \`--batch_size 6\`)
2. Do NOT change the learning rate — keep lr=3e-3 exactly
3. Keep everything else identical
4. Run with \`--wandb_group regime-y\`

**Critical**: Do NOT scale the learning rate. The hypothesis is that larger batch + same LR = smoother gradients that find better minima. Past failures (Regime D, PR #1238 reimplementation) always reduced LR alongside batch increase, which slowed convergence.

**Expected**: ~19 GB memory, faster epochs (fewer batches per epoch), potentially MORE epochs in 30 min.

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10
- Model: n_hidden=160, slice_num=48, batch_size=4, 13 GB

---

## Results

**W&B run:** l5rp2843
**Epochs completed:** 63/100 (30-min timeout)
**Peak memory:** 19.6 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8730 | 0.8648 | +0.9% (worse) |
| Surface MAE p (in_dist) | 19.55 | 16.84 | +16.1% (worse) |
| Surface MAE p (ood_cond) | 13.77 | 13.82 | -0.4% (marginally better) |
| Surface MAE p (ood_re) | 28.03 | 27.82 | +0.8% (≈same) |
| Surface MAE p (tandem) | 38.45 | 38.10 | +0.9% (≈same) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 5.81 | 1.71 | 19.55 |
| ood_cond | 2.79 | 0.97 | 13.77 |
| ood_re | 2.36 | 0.84 | 28.03 |
| tandem | 5.62 | 2.27 | 38.45 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.18 | 0.39 | 20.23 |
| ood_cond | 0.74 | 0.28 | 12.14 |
| ood_re | 0.85 | 0.37 | 46.80 |
| tandem | 1.95 | 0.89 | 37.94 |

### What happened

batch_size=6 did not improve results. Despite running 63 epochs vs the baseline's ~58 (5 more epochs due to fewer batches per epoch, as expected), the surface MAE p in_dist degraded notably (+16%) while other splits were essentially the same or marginally better/worse.

Memory increased from ~13 GB to 19.6 GB, confirming the estimate.

Why it likely didn't work:
1. **Gradient noise isn't the bottleneck at this stage.** With batch_size=4 already providing decent gradient estimates, going to 6 doesn't change the learning dynamics meaningfully. The model has likely converged to similar optima regardless of batch size within the 30-min budget.
2. **Same LR with 50% larger batch may slightly overtrain in_dist.** The effective learning rate relative to gradient magnitude slightly increases with larger batches at the same LR, which can lead to overshooting in certain splits.
3. **The baseline result is clean** — the 5 extra epochs from fewer batches/epoch didn't compensate for any batch size effect.

### Suggested follow-ups

- **batch_size=8 with proportional LR scaling (lr=4e-3):** Follow the sqrt scaling rule — the real test for whether gradient smoothing helps is with properly calibrated LR. The prior "failures" may have reduced LR too aggressively.
- **Try warm batch restart:** Start with batch_size=4 for the first N epochs then switch to 6, to benefit from both fine-grained early gradients and smoother late-stage training.
- **Investigate in_dist regression at larger batch:** The notable in_dist p degradation (+16%) is suspicious — worth checking if it's consistent or just noise by repeating the run.