### PR TITLE
Regime Z: Vectorized per-sample norm + slice_num=64 (throughput for finer routing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -523,7 +523,7 @@ model_config = dict(
     n_hidden=160,  # regime-h: narrower for finer routing
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
-    slice_num=48,  # regime-h: more slices for finer spatial decomposition
+    slice_num=64,  # regime-z: finer spatial routing (48→64)
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -677,20 +677,21 @@ for epoch in range(MAX_EPOCHS):
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
-        # Per-sample std normalization: skip tandem samples (gap feature index 21)
+        # Per-sample std normalization: vectorized
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
-        sample_stds = torch.ones(B, 1, 3, device=device)
         channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
         tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+        sample_stds = torch.ones(B, 1, 3, device=device)
         if model.training:
-            for b in range(B):
-                valid = mask[b]
-                if is_tandem[b]:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                else:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+            valid_count = mask.float().sum(dim=1, keepdim=True).clamp(min=1)
+            masked_y = y_norm * mask.float().unsqueeze(-1)
+            y_mean = masked_y.sum(dim=1, keepdim=True) / valid_count.unsqueeze(-1)
+            y_var = ((masked_y - y_mean) ** 2 * mask.float().unsqueeze(-1)).sum(dim=1, keepdim=True) / valid_count.unsqueeze(-1)
+            sample_stds = y_var.sqrt()
+            clamps = torch.where(is_tandem[:, None, None], tandem_clamps, channel_clamps)
+            sample_stds = sample_stds.clamp(min=clamps)
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
@@ -849,19 +850,19 @@ for epoch in range(MAX_EPOCHS):
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
-                # Per-sample std normalization: skip tandem samples
+                # Per-sample std normalization: vectorized
                 raw_gap = x[:, 0, 21]
                 is_tandem = raw_gap.abs() > 0.5
                 B = y_norm.shape[0]
-                sample_stds = torch.ones(B, 1, 3, device=device)
                 channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
                 tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
-                for b in range(B):
-                    valid = mask[b]
-                    if is_tandem[b]:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                    else:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                valid_count = mask.float().sum(dim=1, keepdim=True).clamp(min=1)
+                masked_y = y_norm * mask.float().unsqueeze(-1)
+                y_mean = masked_y.sum(dim=1, keepdim=True) / valid_count.unsqueeze(-1)
+                y_var = ((masked_y - y_mean) ** 2 * mask.float().unsqueeze(-1)).sum(dim=1, keepdim=True) / valid_count.unsqueeze(-1)
+                sample_stds = y_var.sqrt()
+                clamps = torch.where(is_tandem[:, None, None], tandem_clamps, channel_clamps)
+                sample_stds = sample_stds.clamp(min=clamps)
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
The per-sample std normalization uses a Python for-loop over batch samples (~1400 iterations/epoch). Vectorizing it saves 1-2s/epoch. Combined with slice_num=64 (even finer spatial routing), the throughput gain offsets the compute cost of more slices. Regime H showed 48>32 slices; this tests whether 64 extends the trend.

## Instructions
1. Replace the training per-sample std norm loop (around lines 684-694) with vectorized version:
   ```python
   B = y_norm.shape[0]
   is_tandem = (x[:, 0, 21].abs() > 0.5)
   valid_count = mask.float().sum(dim=1, keepdim=True).clamp(min=1)
   masked_y = y_norm * mask.float().unsqueeze(-1)
   y_mean = masked_y.sum(dim=1, keepdim=True) / valid_count.unsqueeze(-1)
   y_var = ((masked_y - y_mean) ** 2 * mask.float().unsqueeze(-1)).sum(dim=1, keepdim=True) / valid_count.unsqueeze(-1)
   sample_stds = y_var.sqrt()
   channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
   tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
   clamps = torch.where(is_tandem[:, None, None], tandem_clamps, channel_clamps)
   sample_stds = sample_stds.clamp(min=clamps)
   y_norm = y_norm / sample_stds
   ```
2. Apply the same vectorization to the validation loop (around lines 856-864)
3. Change `slice_num=48` to `slice_num=64`
4. Run with `--wandb_group regime-z`

**Rationale**: This combines two orthogonal improvements: throughput (vectorization) and representation (finer routing). The vectorization is a pure speedup with identical numerical behavior.

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10
- Model: n_hidden=160, slice_num=48, 13 GB

---

## Results

**W&B run ID**: `ztmeie6j`  
**Best epoch**: 64 (baseline ~50 epochs in same window — vectorization gave ~28% more epochs)  
**Peak memory**: 13.3 GB (unchanged from baseline)  

### Metrics at best checkpoint

| Split | val/loss | Surface Ux | Surface Uy | Surface p | Volume p |
|---|---|---|---|---|---|
| val_in_dist | 0.594 | 6.0 | 1.7 | **18.3** | 19.6 |
| val_ood_cond | 0.695 | 3.3 | 1.0 | **14.0** | 12.1 |
| val_ood_re | 0.540 | 2.7 | 0.9 | **27.7** | 46.6 |
| val_tandem_transfer | 1.627 | 6.2 | 2.2 | **38.2** | 37.7 |
| **combined val/loss** | **0.8638** | | | | |

### vs. Baseline (Regime H: n_hidden=160, slice_num=48)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8648 | 0.8638 | **-0.001** ✓ |
| surf_p in_dist | 16.84 | 18.26 | +1.42 ❌ |
| surf_p ood_cond | 13.82 | 13.96 | +0.14 ≈ |
| surf_p ood_re | 27.82 | 27.66 | **-0.16** ✓ |
| surf_p tandem | 38.10 | 38.18 | +0.08 ≈ |

### What happened

**Mixed picture.** The combined val/loss is marginally better (0.8638 vs 0.8648), and the run reached epoch 64 vs ~50 for the baseline — confirming the vectorization meaningfully increased training throughput. However, in_dist surface pressure got notably worse (+1.42), while ood_re improved slightly (-0.16) and tandem/ood_cond were essentially unchanged.

Two factors are likely responsible for the mixed surface accuracy:

1. **slice_num=64 vs 48 for this model size**: At n_hidden=160 with n_head=4 and dim_head=40, each slice has only 160/64 ≈ 2.5 tokens assigned on average. This may be too sparse — the model can't build rich slice representations when each slice has so few samples. The Regime H result (48 slices) suggested more slices help, but 64 may be past the sweet spot for this hidden dim.

2. **Vectorized std uses population variance (divide by N) vs original Bessel-corrected std (divide by N-1)**: For large N (thousands of mesh nodes per sample), the difference is negligible. This is not the cause of the performance gap.

3. **Throughput gain is real**: 64 epochs vs ~50 suggests ~28% more gradient steps in the same wall time. The combined val/loss improvement (tiny but positive) reflects this.

The throughput improvement from vectorization is a clear win. The slice_num=64 effect is ambiguous — it may be hurting in_dist while providing marginal help elsewhere.

### Suggested follow-ups

- **Vectorization alone at slice_num=48**: to isolate whether the mixed results come from slice_num=64 or the vectorization itself. If the pure vectorization run (with 48 slices and more epochs) beats baseline, the vectorization should be merged.
- **slice_num=56 or 64 with larger hidden dim**: if n_hidden ever increases to 192+, slice_num=64 would have richer per-slice representations and may pay off more.
- **Bessel's correction in vectorized code**: the current vectorized code uses population variance. Switching to `(valid_count - 1)` denominator would match the original behavior exactly, potentially recovering the in_dist improvement.