### PR TITLE
Regime F2: Full width + depth (n_hidden=192, n_layers=2, slice_num=48)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,8 +520,8 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=160,  # regime-h: narrower for finer routing
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_hidden=192,
+    n_layers=2,
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
     mlp_ratio=2,


### PR DESCRIPTION
## Hypothesis
Your Regime F tested n_layers=2 at n_hidden=160 on the OLD code (slice_num=32) and was too slow. Now that Regime H merged (slice_num=48), memory is only 13 GB. We can afford BOTH full width (192) and depth (2 layers) — expected ~30-35 GB, well within 96 GB. This answers your own follow-up question: does 192-dim + 2 layers work when combined with finer slicing?

## Instructions
1. Change `n_hidden=160` to `n_hidden=192`
2. Change `n_layers=1` to `n_layers=2`
3. Keep slice_num=48 (already set from Regime H merge)
4. Keep everything else identical
5. Run with `--wandb_group regime-f2`

**Expected**: ~30-35 GB memory, ~35-40s/epoch, ~45-50 epochs in 30 min. The wider+deeper model has more capacity but fewer epochs. The JIT warmup issue you identified in Regime F (epochs 1-10 showing zero loss) may still apply — if so, note the effective epoch count.

**Note**: Regime W (askeladd) tests n_hidden=192 with 1 layer, Regime X (nezuko) tests n_layers=2 at n_hidden=160. This experiment tests both together — if either W or X shows promise, this tells us whether they compound.

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10
- Model: n_hidden=160, slice_num=48, n_layers=1, 13 GB

---

## Results

**W&B run:** `edward/regime-f2-n192-l2` (ymxc51x3), best epoch 38, state=crashed (wall-clock timeout)

**Peak memory:** 21.1 GB (vs predicted 30-35 GB — lighter than expected)

| Split | mae_surf_p | vs baseline |
|-------|-----------|-------------|
| val_in_dist | 32.26 | +15.42 |
| val_ood_cond | 32.42 | +18.60 |
| val_tandem_transfer | 47.22 | +9.12 |
| val_ood_re | 42.30 | +14.48 |
| **mean3** | **37.30** | **+14.10 (+60.8%)** |

Surface MAE (Ux / Uy / p) by split (epoch 38, last W&B sync before timeout):
- val_in_dist: 9.16 / 2.13 / 32.26
- val_ood_cond: 6.45 / 1.30 / 32.42
- val_ood_re: 6.13 / 1.11 / 42.30
- val_tandem: 8.09 / 2.51 / 47.22

Volume MAE (Ux / Uy / p) by split:
- val_in_dist: 1.42 / 0.60 / 31.02
- val_ood_cond: 0.99 / 0.51 / 26.97
- val_ood_re: 1.06 / 0.56 / 59.20
- val_tandem: 2.22 / 1.10 / 46.26

val/loss (epoch 38, 4-split avg): 1.418 (vs baseline 0.8648 — large regression)

- **loss = 1.418** vs baseline 0.8648 — **REGRESSION**
- **mean3 = 37.30** vs baseline 23.2 — **REGRESSION (+60.8%)**

## What happened

The combined width+depth trade failed badly within the 30-min budget. Two issues compound:

1. **JIT warmup still present**: Epochs 1–10 showed zero training loss (same as Regime F), wasting ~8 min (epoch 1 took 135s; epochs 2-10 ~45s each). Only **28 effective training epochs** completed.
2. **Slower per-epoch training**: At ~43s/epoch (vs ~37s for the baseline 1-layer model), combined with the lost warmup time, F2 completes far fewer effective epochs.
3. **Slower convergence**: The 2-layer architecture has more parameters and appears to need substantially more epochs to converge. At epoch 38, val_loss = 1.418 — significantly higher than the baseline's 0.8648.

The model was still steadily improving at epoch 38 (not plateaued), but given the convergence rate it would need at least 80+ effective epochs to potentially reach baseline territory. The 192-dim × 2-layer configuration simply cannot converge within 30 minutes.

Note: memory was only 21.1 GB, not the predicted 30-35 GB, suggesting the memory prediction was conservative.

## Suggested follow-ups

- **Diagnose the JIT warmup bug**: The dead epochs 1–10 waste 8+ minutes on every run. Fixing this recovers significant training budget and would make all depth experiments more competitive.
- **Longer budget test**: If a 2-layer model is ever worth testing, it needs a 60-90 min budget to converge. Not feasible within current constraints unless the warmup issue is fixed.
- The width-only change (192-dim, 1-layer, Regime W) and depth-only change (160-dim, 2-layer, Regime X) are better-controlled experiments — those results will tell us which dimension (if either) is worth pursuing.