### PR TITLE
Regime K2: Weight decay 1e-4 (regularize the slim 543K-param model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -412,7 +412,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-4
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
The current model has weight_decay=0. With the slim Regime H configuration (543K params, n_hidden=160, slice_num=48), adding light weight decay (1e-4) could improve generalization — especially on the harder splits (ood_re and tandem) where the smaller model might be memorizing training patterns rather than learning generalizable features.

## Instructions
1. Change `weight_decay=0` to `weight_decay=1e-4` in the optimizer configuration
2. Keep everything else identical (lr=3e-3, n_hidden=160, slice_num=48, etc.)
3. Run with `--wandb_group regime-k2`

**Rationale**: Weight decay is the most fundamental regularization technique and has never been tested on the new slim model. The 543K-param model may behave differently from the old 760K-param model — the reduced capacity might benefit from light L2 regularization to prevent overfitting to the 1322 training samples. The ood_re (+0.12) and tandem (+0.40) slight regressions from Regime H could be regularization-related.

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10
- Model: n_hidden=160, slice_num=48, weight_decay=0, ~543K params

---

## Results

**W&B run:** oy5uk6cs | **Epochs:** 65 | **Group:** regime-k2

*(Note: run state shows 'crashed' — this is a post-training visualization error in the existing vis code, not a training failure. Best checkpoint was saved successfully at epoch 65.)*

### Validation losses (best checkpoint, epoch 65)

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 0.5982 | 5.89 | 1.78 | 17.75 |
| val_ood_cond | 0.6770 | 3.12 | 1.09 | 13.52 |
| val_ood_re | 0.5456 | 2.57 | 0.89 | 27.74 |
| val_tandem_transfer | 1.6541 | 5.99 | 2.21 | 39.74 |
| **mean (val/loss)** | **0.8687** | | | |

**mean3 surf_p (in+ood+re)/3 = 19.67** (baseline 19.49) — **marginally worse**
**val/loss = 0.8687** (baseline 0.8648) — **marginally worse**

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.09 | 0.36 | 18.89 |
| val_ood_cond | 0.71 | 0.28 | 12.06 |
| val_ood_re | 0.82 | 0.36 | 46.77 |
| val_tandem_transfer | 1.94 | 0.90 | 38.91 |

**Peak memory:** ~13.0 GB (same as baseline)

### What happened

Neutral-to-slightly-negative result. Weight decay 1e-4 did not improve generalization.

Per-split breakdown vs baseline:
- **in_dist**: 17.75 vs 16.84 — worse (+0.91)
- **ood_cond**: 13.52 vs 13.82 — **better** (-0.30)
- **ood_re**: 27.74 vs 27.82 — **better** (-0.08)
- **tandem**: 39.74 vs 38.10 — worse (+1.64)

The ood_cond and ood_re splits show marginal improvement, but in_dist and tandem both regress. The overall val/loss slightly worsened (0.8687 vs 0.8648). The hypothesis was that the 543K-param model was memorizing training patterns, but the evidence doesn't support it — weight decay hurts in-dist performance, which suggests the model isn't over-fitting (or at least not in a way that L2 regularization can fix).

The tandem regression (+1.64) is the most notable result: if anything, weight decay hurt the hardest split, not helped it. This could mean the tandem generalization gap is structural (domain shift), not regularization-related.

### Suggested follow-ups

- Try stronger weight decay (1e-3) — 1e-4 may be too weak to matter; if regularization helps at all, it might need a larger push
- The tandem regression is the concerning direction — suggest investigating whether dropout (e.g., 0.05-0.1 in the MLP) works differently from L2 weight decay for this task
- The in_dist regression suggests the model needs every parameter's freedom to fit the training distribution; capacity may be the actual bottleneck rather than over-fitting