### PR TITLE
SWA with cyclic LR in final 15 epochs (replace EMA late-phase averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -620,6 +620,9 @@ best_val = float("inf")
 ema_val_loss = float("inf")
 ema_decay_val = 0.9
 best_metrics = {}
+swa_snapshots: list[dict] = []
+swa_phase = False
+swa_scheduler = None
 global_step = 0
 train_start = time.time()
 prev_vol_loss = 1.0
@@ -798,7 +801,22 @@ for epoch in range(MAX_EPOCHS):
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
-    scheduler.step()
+    # SWA phase: switch to cyclic cosine LR after epoch 47 (1-indexed)
+    if not swa_phase and epoch == 46:
+        swa_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+            base_opt, T_0=5, T_mult=1, eta_min=5e-5
+        )
+        for pg in base_opt.param_groups:
+            pg['lr'] = 5e-4 * (0.5 if pg['lr'] < cfg.lr else 1.0)
+        swa_phase = True
+    if swa_phase:
+        swa_scheduler.step()
+        # Collect snapshot at cycle troughs: epochs 52, 57, 62 (1-indexed)
+        if (epoch + 1) in [52, 57, 62]:
+            swa_snapshots.append({k: v.clone() for k, v in _base_model.state_dict().items()})
+            print(f"  → SWA snapshot {len(swa_snapshots)} collected (epoch {epoch + 1})")
+    else:
+        scheduler.step()
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
@@ -977,6 +995,89 @@ for epoch in range(MAX_EPOCHS):
         f"val[{split_summary}]{tag}"
     )
 
+
+# --- SWA final evaluation ---
+if swa_snapshots:
+    print(f"\nAveraging {len(swa_snapshots)} SWA snapshots for final evaluation...")
+    swa_state = {k: sum(s[k].float() for s in swa_snapshots) / len(swa_snapshots)
+                 for k in swa_snapshots[0]}
+    swa_eval = deepcopy(_base_model)
+    swa_eval.load_state_dict(swa_state)
+    swa_eval.eval()
+    swa_split_losses = []
+    swa_log: dict = {}
+    for split_name, vloader in val_loaders.items():
+        vv, vs, nb = 0.0, 0.0, 0
+        ms = torch.zeros(3, device=device)
+        mv = torch.zeros(3, device=device)
+        ns = torch.zeros(3, device=device)
+        nv = torch.zeros(3, device=device)
+        with torch.no_grad():
+            for x, y, is_surface, mask in vloader:
+                x, y = x.to(device), y.to(device)
+                is_surface, mask = is_surface.to(device), mask.to(device)
+                x = (x - stats["x_mean"]) / stats["x_std"]
+                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv], dim=-1)
+                raw_xy = x[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs = torch.cat([swa_eval.fourier_freqs_fixed.to(device), swa_eval.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                x = torch.cat([x, fourier_pe], dim=-1)
+                Umag, q = _umag_q(y, mask)
+                y_phys = _phys_norm(y, Umag, q)
+                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                raw_gap = x[:, 0, 21]
+                is_tandem = raw_gap.abs() > 0.5
+                B = y_norm.shape[0]
+                ss = torch.ones(B, 1, 3, device=device)
+                cc = torch.tensor([0.1, 0.1, 0.5], device=device)
+                tc = torch.tensor([0.3, 0.3, 1.0], device=device)
+                for b in range(B):
+                    valid = mask[b]
+                    ss[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tc if is_tandem[b] else cc)
+                y_ns = y_norm / ss
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred = swa_eval({"x": x})["preds"].float()
+                ae = (pred / ss - y_ns).abs().nan_to_num(0.0)
+                vm = mask & ~is_surface
+                sm = mask & is_surface
+                vv += min((ae * vm.unsqueeze(-1)).sum().item() / vm.sum().clamp(min=1).item(), 1e6)
+                vs += min((ae[:, :, 2:3] * sm.unsqueeze(-1)).sum().item() / sm.sum().clamp(min=1).item(), 1e6)
+                nb += 1
+                po = _phys_denorm(pred * phys_stats["y_std"] + phys_stats["y_mean"], Umag, q)
+                err = (po - y.clamp(-1e6, 1e6)).abs()
+                fin = err.isfinite()
+                err = err.where(fin, torch.zeros_like(err))
+                ms += (err * sm.unsqueeze(-1)).sum(dim=(0, 1))
+                mv += (err * vm.unsqueeze(-1)).sum(dim=(0, 1))
+                ns += (sm.unsqueeze(-1) * fin).sum(dim=(0, 1)).float()
+                nv += (vm.unsqueeze(-1) * fin).sum(dim=(0, 1)).float()
+        vv /= max(nb, 1)
+        vs /= max(nb, 1)
+        sl = vv + cfg.surf_weight * vs
+        ms /= ns.clamp(min=1)
+        mv /= nv.clamp(min=1)
+        swa_split_losses.append(sl)
+        swa_log.update({
+            f"swa/{split_name}/loss": sl,
+            f"swa/{split_name}/mae_surf_Ux": ms[0].item(),
+            f"swa/{split_name}/mae_surf_Uy": ms[1].item(),
+            f"swa/{split_name}/mae_surf_p": ms[2].item(),
+            f"swa/{split_name}/mae_vol_p": mv[2].item(),
+        })
+        print(f"  SWA {split_name}: loss={sl:.4f}  mae_surf_p={ms[2].item():.2f}")
+    swa_val_total = sum(swa_split_losses) / len(swa_split_losses)
+    swa_log["swa/val_loss"] = swa_val_total
+    print(f"SWA val/loss={swa_val_total:.4f}  EMA best={best_val:.4f}")
+    wandb.log({**swa_log, "global_step": global_step})
+    if swa_val_total < best_val:
+        torch.save(swa_state, model_path)
+        best_val = swa_val_total
+        print("SWA model saved as new best checkpoint!")
 
 # --- Final summary ---
 total_time = (time.time() - train_start) / 60.0


### PR DESCRIPTION
## Hypothesis
The current EMA (decay=0.998 from epoch 40) averages over a smoothly decaying LR trajectory. SWA instead collects weight snapshots at cyclic LR troughs and averages them uniformly, finding wider minima that generalize better (Izmailov et al. 2018). With the slim model completing ~62 epochs in 30 min, the EMA phase (epochs 40-62) may not be optimal. SWA with 5-epoch mini-cycles in the final 15 epochs explores more diverse weight configurations.

## Instructions
1. After epoch 47, switch the LR scheduler from cosine decay to cyclic cosine with mini-cycles:
   ```python
   # In training loop, at epoch 47:
   swa_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
       base_opt, T_0=5, T_mult=1, eta_min=5e-5
   )
   # Set initial LR for SWA phase to 5e-4 (not the full 3e-3)
   for pg in base_opt.param_groups:
       pg['lr'] = 5e-4 * (0.5 if 'lr' in pg and pg['lr'] < cfg.lr else 1.0)
   ```
2. At each cycle trough (epochs 52, 57, 62), deep-copy the model state_dict and store it
3. At training end, average all collected snapshots uniformly:
   ```python
   swa_state = {}
   for key in snapshots[0]:
       swa_state[key] = sum(s[key] for s in snapshots) / len(snapshots)
   model.load_state_dict(swa_state)
   ```
4. Use this SWA-averaged model for final validation instead of the EMA model
5. Keep EMA active for epochs 40-47 as a fallback — compare SWA vs EMA in your results
6. Run with `--wandb_group swa-cyclic`

**Note**: If implementing the cyclic scheduler is complex, a simpler alternative: just collect weight snapshots every 5 epochs from epoch 47 onward (at epochs 47, 52, 57, 62) using a constant LR of 2e-4, then average them.

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10

---

## Results

**W&B run ID**: `ru197m62`
**Epochs completed**: 65 / 100 (30.3 min timeout)
**Peak memory**: 13.0 GB

### EMA checkpoint (best epoch 65)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | Δ surf_p vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 0.6700 | 8.64 | 2.31 | 20.13 | +3.29 |
| val_ood_cond | 0.7786 | 5.46 | 1.55 | 15.52 | +1.70 |
| val_ood_re | 0.5904 | 5.00 | 1.37 | 28.86 | +1.04 |
| val_tandem_transfer | 1.6470 | 7.38 | 2.81 | 39.33 | +1.23 |

**Best val/loss**: 0.9215 (baseline: 0.8648 → **worse**)
**mean3 surf_p (in, ood_cond, tandem)**: (20.13 + 15.52 + 39.33) / 3 = **25.0** (baseline: 22.92 → **worse**)

### SWA evaluation (3 snapshots at epochs 52, 57, 62)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|---|---|---|---|---|---|
| val_in_dist | 0.8439 | 9.54 | 2.46 | 26.83 | 25.98 |
| val_ood_cond | 0.9987 | 6.15 | 1.63 | 20.29 | 16.33 |
| val_ood_re | 0.7498 | 5.77 | 1.48 | 32.55 | 49.91 |
| val_tandem_transfer | 1.8168 | 7.89 | 2.93 | 43.42 | 42.28 |

**SWA val/loss**: 1.1023 (vs EMA 1.0104 → SWA is **worse**, EMA checkpoint kept)
**SWA mean3 surf_p**: (26.83 + 20.29 + 43.42) / 3 = **30.2** (much worse than baseline)

### What happened

Both EMA (mean3=25.0) and SWA (mean3=30.2) are worse than the baseline (22.92). Two things went wrong:

1. **LR reset disrupted convergence.** At epoch 47, the SWA phase raises the LR from the cosine-decayed ~0.1e-3 back up to 5e-4 (a ~5x jump). This is visible in the training loss: epoch 47 has train_vol=0.195, then epoch 48 spikes to 0.246. The model was disturbed just as it was nearing convergence, and the remaining 18 epochs (47–65) were partly spent re-converging under the new cyclic LR, not refining.

2. **Snapshots capture a non-converged trajectory.** The SWA snapshots at epochs 52, 57, 62 are all taken during this disrupted re-convergence phase — the model hadn't re-stabilized after the LR reset. Averaging weights across a cyclic schedule that's still adapting (vs. a genuinely multi-modal landscape) produces a worse result than any individual point.

The EMA model (which was frozen at epoch 47 via the existing EMA mechanism and continued accumulating from the SWA phase) still outperforms SWA significantly.

**In short**: the cyclic LR + snapshot averaging works best when the model is already well-converged before SWA starts, and when the LR is low enough not to disturb the basin. Both conditions were violated here.

### Suggested follow-ups

- **Later SWA start with lower restart LR**: Start SWA at epoch 55+ after deeper convergence, and use a restart LR of 1e-4 (not 5e-4) to reduce disruption.
- **SWA without cyclic restart**: Skip the LR reset entirely — just collect checkpoints every 5 epochs from epoch 50 onward using the *existing* cosine LR (which is naturally near minimum by then). This captures the smoother EMA-like diversity without the disruption.
- **Multi-checkpoint EMA**: Instead of hard snapshots, run EMA from epoch 30 instead of 40, with a slower decay (0.999 instead of 0.998), to accumulate more of the convergence trajectory.