### PR TITLE
Optimizer recalibration: beta2=0.95, grad clip=0.5 (tune for slim model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -574,7 +574,7 @@ other_params = [p for n, p in model.named_parameters() if not any(k in n for k i
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
+], weight_decay=cfg.weight_decay, betas=(0.9, 0.95))
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
@@ -781,7 +781,7 @@ for epoch in range(MAX_EPOCHS):
 
         optimizer.zero_grad()
         loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:


### PR DESCRIPTION
## Hypothesis
The optimizer was tuned for the old 192-dim/32-slice/760K-param model but never recalibrated for the new 160-dim/48-slice/543K-param model. Two key issues: (1) Gradient clipping at max_norm=1.0 clips 100% of batches (discovered in PR #978), meaning the effective step size is governed by the clip threshold, not the LR schedule. Halving to 0.5 may reduce gradient noise. (2) beta2=0.999 gives a ~1000-step EMA window for the second moment, but with only ~13K total steps (62 epochs * 210 steps), adaptation is very slow. beta2=0.95 (20-step window) responds faster to changing gradient landscapes during progressive volume subsampling and surface weight ramping.

## Instructions
1. Change AdamW beta values (around line 574-577):
   ```python
   base_opt = torch.optim.AdamW([
       {'params': attn_params, 'lr': cfg.lr * 0.5},
       {'params': other_params, 'lr': cfg.lr}
   ], weight_decay=cfg.weight_decay, betas=(0.9, 0.95))
   ```
2. Change gradient clipping (around line 784):
   ```python
   torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
   ```
3. Keep everything else identical (lr=3e-3, Lookahead, EMA, etc.)
4. Run with `--wandb_group optimizer-recal`

**These two changes are complementary**: beta2=0.95 increases update variance (faster adaptation) while max_norm=0.5 decreases it (tighter control). Net effect: more responsive but stabler optimization for the slim model.

## Baseline (updated after Regime H merge)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10

---

## Results

**W&B run:** v8u5xwh3  
**Epochs completed:** 65/100 (30-min wall-clock limit; model still converging)  
**Peak memory:** 13.0 GB

### Val loss @ epoch 65
| Split | val/loss |
|---|---|
| in_dist | 0.5958 |
| ood_cond | 0.7150 |
| ood_re | 0.5409 |
| tandem | 1.6435 |
| **combined** | **0.8738** |

### Surface MAE @ epoch 65
| Split | Ux | Uy | p | p baseline |
|---|---|---|---|---|
| in_dist | 5.70 | 1.88 | 18.15 | 16.84 |
| ood_cond | 3.39 | 1.24 | 14.23 | 13.82 |
| ood_re | 2.88 | 1.09 | 27.80 | 27.82 |
| tandem | 6.14 | 2.29 | 39.20 | 38.10 |

### Volume MAE @ epoch 65
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.14 | 0.37 | 20.21 |
| ood_cond | 0.72 | 0.28 | 12.65 |
| ood_re | 0.81 | 0.36 | 47.01 |
| tandem | 1.95 | 0.90 | 38.72 |

**mean3 @ epoch 65:** (18.15 + 14.23 + 39.20) / 3 = **23.86** vs baseline **22.92** (worse)  
**best_val_loss:** 0.8738 vs baseline 0.8648 (worse)

### What happened

The recalibrated optimizer did not improve over baseline at the 65-epoch mark. Surface pressure MAE is worse on in_dist (+1.31), ood_cond (+0.41), tandem (+1.10). Only ood_re is essentially tied (27.80 vs 27.82). The combined val/loss (0.8738) is ~1% higher than the baseline (0.8648).

One positive: the run reached 65 epochs in 30 minutes (vs ~59 epochs for other recent runs), suggesting beta2=0.95 + smaller clip is not slower (and may be slightly faster per effective update). Memory was also lower at 13.0 GB.

The model was still converging at epoch 65 (all val losses declining), so the results are not conclusive about what would happen at epoch 100. However, the trajectory doesn't suggest a clear advantage over baseline — the gap was not closing rapidly in the final epochs.

On reflection: the AdamW second moment with beta2=0.95 (20-step window) may be too aggressive, causing the optimizer to "forget" reliable gradient statistics too quickly, leading to noisier updates despite the tighter clip. The 100% grad-clip observation (PR #978) may indicate the model genuinely needs large-magnitude updates in early training, and halving the clip could be impeding convergence.

**Verdict: no clear improvement over baseline.**

### Suggested follow-ups

1. **Separate the two changes**: Try beta2=0.95 alone (keep clip=1.0) to isolate whether second moment recalibration alone helps without tighter clipping.
2. **Try beta2=0.99 (middle ground)**: Between the current 0.999 and 0.95, beta2=0.99 (100-step window) may give faster adaptation without excessive noise.
3. **Keep clip=0.5 alone**: If the 100% clip rate is a problem, reducing the clip independently could be tested without changing beta2.
