### PR TITLE
Vol loss 0.1x on Regime W config (proven winner + wider model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=160,  # regime-h: narrower for finer routing
+    n_hidden=192,  # vol-scale-01-rw: wider model (Regime W)
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
@@ -623,6 +623,7 @@ best_metrics = {}
 global_step = 0
 train_start = time.time()
 prev_vol_loss = 1.0
+prev_vol_raw = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
@@ -636,11 +637,12 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    surf_weight = max(5.0, min(50.0, prev_vol_raw / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()
     epoch_vol = 0.0
+    epoch_vol_raw = 0.0
     epoch_surf = 0.0
     n_batches = 0
 
@@ -726,7 +728,8 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_loss_raw = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_loss = 0.1 * vol_loss_raw
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
@@ -794,6 +797,7 @@ for epoch in range(MAX_EPOCHS):
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
         epoch_vol += vol_loss.item()
+        epoch_vol_raw += vol_loss_raw.item()
         epoch_surf += surf_loss.item()
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
@@ -803,8 +807,10 @@ for epoch in range(MAX_EPOCHS):
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
     epoch_vol /= n_batches
+    epoch_vol_raw /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
+    prev_vol_raw = epoch_vol_raw
     prev_surf_loss = epoch_surf
 
     # --- Validate across all splits ---


### PR DESCRIPTION
## Hypothesis
Volume loss scaling 0.1x was the single biggest win on old code (PR #1082: mean3_surf_p -15.9%). This change was NEVER carried to the current code. Combined with Regime W's wider model (n_hidden=192 + slice_num=48), surface gradient dominance should compound with increased capacity. This directly targets the in_dist regression seen in Regime W (17.99 vs 16.84) by forcing gradients toward surface nodes.

## Instructions
1. Change `n_hidden=160` to `n_hidden=192`
2. Scale vol_loss by 0.1 in the training loop (around line 729):
   ```python
   vol_loss_raw = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
   vol_loss = 0.1 * vol_loss_raw
   ```
3. **CRITICAL**: The adaptive surf_weight uses `prev_vol_loss / max(prev_surf_loss, 1e-8)`. With 0.1x vol_loss, the ratio is 10x smaller, clamping surf_weight at 5.0. Fix by tracking the RAW vol_loss for the adaptive weight:
   - Add `epoch_vol_raw = 0.0` alongside `epoch_vol = 0.0` (around line 643)
   - Add `epoch_vol_raw += vol_loss_raw.item()` alongside the existing epoch_vol tracking
   - When computing surf_weight ratio, use `prev_vol_raw` instead of `prev_vol_loss`
4. Keep everything else identical (slice_num=48, lr=3e-3, etc.)
5. Run with `--wandb_group vol-scale-01-regime-w`

## Baseline (current)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10

---

## Results

**W&B run:** `lqqmpmpt`
**Epochs:** ~59 (30-min timeout)
**Peak VRAM:** ~15 GB

### Surface MAE (pressure) — primary metric

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| in_dist | 16.84 | 18.61 | +10.5% |
| ood_cond | 13.82 | 14.89 | +7.7% |
| ood_re | 27.82 | 27.99 | +0.6% |
| tandem | 38.10 | 39.79 | +4.4% |
| **mean3** | **22.92** | **24.43** | **+6.6% (worse)** |

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|------|
| in_dist | 8.20 | 1.90 | 18.61 |
| ood_cond | 5.41 | 1.18 | 14.89 |
| ood_re | 5.07 | 0.95 | 27.99 |
| tandem | 7.75 | 2.46 | 39.79 |

### Volume MAE (p)

| Split | This run |
|-------|----------|
| in_dist | 27.25 |
| ood_cond | 16.17 |
| ood_re | 50.09 |
| tandem | 44.68 |

### Losses

| Metric | Baseline | This run |
|--------|----------|----------|
| val/loss | 0.8648 | 0.9642 |
| train/surf_weight (final) | — | 9.15 |

### What happened

**Did not work.** Every split got worse — mean3 degraded 6.6% from 22.92 → 24.43.

The most striking failure is **ood_re vol_p = 50.09** — approximately 2.5x higher than the other splits, suggesting the model essentially stopped learning out-of-distribution volume pressure. In-dist vol_p also degraded (27.25 vs baseline ~20).

Despite the `prev_vol_raw` fix working correctly (surf_weight converged to ~9.15, not clamped at 5.0), surface MAE still worsened significantly. The hypothesis — that more surface gradient signal would improve surface accuracy — did not hold.

**Likely reason:** Volume gradients act as regularization for the shared model trunk in the current architecture. The 0.1x scaling removes most of this regularization, allowing the model to overfit surface training nodes while losing generalization. The wider model (n_hidden=192) may amplify this effect by having more capacity to overfit. PR #1082's success may have been context-specific to an older architecture.

### Suggested follow-ups

1. **0.5x vol scaling**: A gentler reduction might preserve regularization while adding surface bias. The 0.1x scale is very aggressive.
2. **Pure Regime W (no vol scaling)**: Test n_hidden=192 alone, without the vol scaling, to isolate the model width effect from the loss weighting change.
3. **Investigate what was different in PR #1082**: The original success may have depended on architecture differences not present in the current code.