### PR TITLE
Lookahead k=5 on Regime W config (faster sync for fewer epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=160,  # regime-h: narrower for finer routing
+    n_hidden=192,
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
@@ -575,7 +575,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=5, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Lookahead uses k=10 (sync every 10 steps). With the wider model (n_hidden=192) running ~58 epochs at ~31s/epoch, there are only ~5-6 full Lookahead sync cycles. Halving k to 5 doubles sync frequency (~11-12 cycles), giving slow weights better coverage of the loss landscape. Zero-cost change — no memory or speed impact.

## Instructions
1. Change `n_hidden=160` to `n_hidden=192`
2. Change Lookahead k parameter (around line 578):
   ```python
   optimizer = Lookahead(base_opt, k=5, alpha=0.8)
   ```
3. Keep everything else identical
4. Run with `--wandb_group lookahead-k5-regime-w`

**Note**: Removing Lookahead entirely (Regime C) was confirmed harmful. This tests a TUNING of Lookahead, not removal.

## Baseline (current)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10

---

## Results

**W&B run:** 4zo42qc5  
**Status:** Timed out at epoch 56/100 (30-min cap, runtime 29.3 min)

### Metrics at epoch 56 (EMA model, mid-run)

| Split | val/loss | surf Ux | surf Uy | surf p | vol MAE (Ux/Uy/p) |
|-------|----------|---------|---------|--------|---------|
| in_dist | 0.6327 | 5.95 | 1.93 | 18.44 | 1.14 / 0.37 / 19.50 |
| ood_cond | 0.7172 | 3.12 | 1.07 | 14.16 | 0.72 / 0.27 / 12.02 |
| ood_re | 0.5448 | 2.59 | 0.90 | 27.82 | 0.83 / 0.36 / 46.71 |
| tandem | 1.6610 | 6.29 | 2.45 | 39.34 | 1.96 / 0.89 / 38.89 |

**mean3 (surf p, in+ood+tan / 3): 24.0 vs baseline ~22.9 — worse (+4.8%)**  
in=18.44 (+1.6), ood=14.16 (+0.34), re=27.82 (=!), tan=39.34 (+1.24)

**val/loss: 0.8889 (still improving at epoch 56 — best = last epoch)**  
**Baseline best_val_loss: 0.8648 (achieved at epoch ~100)**

**Peak GPU memory reading: ~101.9 GB** (suspicious — likely reflects other processes on GPU 0; run completed without OOM)

### What happened

The run completed 56 full epochs (29.3 min) before the timeout. n_hidden=192 slightly reduces throughput vs n_hidden=160 (56 epochs vs 58 for regime-s). EMA was active for 16 epochs (epoch 40–56), vs baseline's ~60 epochs at full convergence.

Key observations:
- **val/loss was still decreasing at epoch 56** (min = last epoch) — model was not yet converged
- **ood_re pressure exactly matches baseline** (27.82 = 27.82) — impressive given mid-training
- ood_cond pressure close to baseline (14.16 vs 13.82, +2.4%)
- in_dist and tandem further off — likely need more EMA averaging epochs to converge

The k=5 Lookahead completed 11 full sync cycles (56/5) vs 5 cycles with k=10. Whether this helped cannot be separated from the n_hidden=192 change or the mid-training cutoff.

The GPU memory reading of 101.9 GB exceeds the 96 GB GPU spec, but the run completed without OOM — this metric likely captures memory from co-running processes on the shared GPU.

**Verdict:** Inconclusive due to timeout. The trajectory is promising (still improving, re parity already achieved), but 16 EMA epochs is not enough to judge convergence.

### Suggested follow-ups

- **Isolate k=5 alone** (keep n_hidden=160): removes the confound and tests Lookahead tuning purely
- **Verify GPU exclusivity**: if multiple students are sharing GPU 0, memory readings will be unreliable and training may be slower
- **Extend timeout**: n_hidden=192 + k=5 at epoch 100 would give ~44 EMA epochs — meaningful convergence