### PR TITLE
T_max=72 on Regime W config (align LR schedule to wider model epoch count)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=160,  # regime-h: narrower for finer routing
+    n_hidden=192,  # regime-w: wider model
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=72, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
T_max=62 was tuned for the slim 160-dim model (~62 epochs). The wider 192-dim model runs ~58 epochs due to slower per-epoch time. With T_max=62, the LR reaches the floor by epoch 55, wasting the last 3 epochs at near-zero LR. T_max=72 keeps LR at ~5e-4 at epoch 58 instead of 5e-5 — a 10x difference. This provides stronger gradient signal during the EMA averaging phase. T_max=72 was a proven winner on older code (PR #1191: -4% tandem).

## Instructions
1. Change `n_hidden=160` to `n_hidden=192`
2. Change T_max (around line 580):
   ```python
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=72, eta_min=5e-5)
   ```
3. Keep everything else identical
4. Run with `--wandb_group tmax72-regime-w`

**Key**: This is NOT the same as Regime E (which used T_max=72 at the old slim config). The wider model benefits from the longer schedule because it has more parameters to optimize.

## Baseline (current)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10

---

## Results

**W&B run ID**: hlmeao5s
**Run name**: violet/tmax72-regime-w
**Epochs completed**: 56/100 (cut off by 30-min timeout)
**Peak memory**: 15.0 GB

### Metrics at epoch 56 (best checkpoint)

| Split | val_loss | MAE Ux | MAE Uy | MAE p |
|---|---|---|---|---|
| in_dist | 0.639 | 6.91 | 1.81 | 19.8 |
| ood_cond | 0.739 | 3.85 | 1.13 | 14.7 |
| ood_re | 0.576 | 3.41 | 0.97 | 28.4 |
| tandem | 1.636 | 6.52 | 2.24 | 38.3 |

**Combined val_loss**: 0.897
**LR at final epoch**: 0.000469 (schedule not yet exhausted, as intended)

Volume MAE (in_dist): Ux=1.14, Uy=0.37, p=20.7

### vs Baseline (Regime W, T_max=62)

| Metric | Baseline (T_max=62) | This run (T_max=72) | Delta |
|---|---|---|---|
| val_loss | 0.8648 | 0.897 | +0.032 (worse) |
| Surface MAE p (in_dist) | 16.84 | 19.8 | +3.0 (worse) |
| Surface MAE p (ood_cond) | 13.82 | 14.7 | +0.9 (worse) |
| Surface MAE p (ood_re) | 27.82 | 28.4 | +0.6 (slightly worse) |
| Surface MAE p (tandem) | 38.10 | 38.3 | +0.2 (comparable) |

### What happened

T_max=72 **did not help** — all splits are worse than baseline at comparable epoch counts. The combined val_loss (0.897) is meaningfully higher than baseline (0.8648), and surface pressure MAE is notably worse on in_dist (+3.0).

The run was cut off at epoch 56, and the LR was still at 0.000469 (schedule not exhausted), confirming the design intent was satisfied. But the slower LR decay of T_max=72 appears to hurt rather than help: the model converges more slowly in the critical early-mid epochs (epochs 20-40), where most of the validation improvement happens. With T_max=62, the faster LR decay acts as an implicit regularizer that helps the model settle into a better minimum earlier.

This is consistent with the hypothesis being wrong: the 192-dim model at 56 epochs reaches nearly the same epoch count as the 160-dim model at 62 epochs (the LR floor coincides with timeout anyway), so realigning T_max provides little practical benefit. The Regime W baseline (T_max=62) has already been optimized for the actual training duration.

### Suggested follow-ups
- **Verify the baseline**: The Regime W baseline (0.8648) is strong — confirm it used exactly n_hidden=192 with T_max=62.
- **Longer warmup**: If the schedule needs extending, try increasing warmup from 10 to 12-14 epochs to reduce the initial LR ramp aggressiveness.
- **Cyclic LR**: Instead of a longer cosine, try a brief cosine restart (T_0=30, T_mult=2) to escape local minima without sacrificing early convergence.