### PR TITLE
EMA start ep30 + decay 0.997 on Regime W (broader averaging window)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=160,  # regime-h: narrower for finer routing
+    n_hidden=192,  # regime-w: wider than regime-h for more capacity
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
@@ -535,8 +535,8 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
-ema_decay = 0.998
+ema_start_epoch = 30
+ema_decay = 0.997
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
EMA starts at epoch 40 with decay=0.998. With the wider model (~58 epochs), this gives only 18 EMA epochs — a narrow window. Starting at epoch 30 with slightly faster decay (0.997) gives 28 EMA epochs (55% more averaging) with a more responsive window. The wider model's in_dist regression (+1.15 surf_p) looks like late-training instability — more aggressive weight averaging should stabilize it.

## Instructions
1. Change `n_hidden=160` to `n_hidden=192`
2. Change EMA start epoch (find ema_start_epoch, around line 538):
   ```python
   ema_start_epoch = 30
   ```
3. Change EMA decay (find ema_decay, around line 539):
   ```python
   ema_decay = 0.997
   ```
4. Keep everything else identical
5. Run with `--wandb_group ema-early-regime-w`

## Baseline (current)
- best_val_loss: 0.8648
- Surface MAE p: in_dist=16.84, ood_cond=13.82, ood_re=27.82, tandem=38.10

---

## Results

**W&B run:** `o7fb0fas`
**Best epoch:** 57 / 100 (hit wall-clock limit, 31s/epoch)
**Peak memory:** 15.0 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6044 | 7.47 | 2.07 | 17.87 | 1.09 | 0.36 | 18.96 |
| val_tandem_transfer | 1.6295 | 6.87 | 2.43 | 38.65 | 1.94 | 0.88 | 38.07 |
| val_ood_cond | 0.7243 | 3.90 | 1.35 | 14.45 | 0.73 | 0.27 | 12.27 |
| val_ood_re | 0.5502 | 3.46 | 1.19 | 27.86 | 0.83 | 0.36 | 46.83 |
| **mean3** | **0.986** | **6.08** | **1.95** | **23.66** | — | — | — |

Baseline (Regime W): mean3=22.92 (in=16.84, ood=13.82, tan=38.10, re=27.82), val/loss=0.8648

**What happened:** Negative result. mean3 surface_p worsened from 22.92 → 23.66, and val/loss worsened from 0.8648 → 0.8771. All splits regressed slightly: in_dist (16.84 → 17.87), ood_cond (13.82 → 14.45), tandem (38.10 → 38.65), ood_re (27.82 → 27.86).

The earlier EMA start (ep30 vs ep40) with faster decay (0.997 vs 0.998) did not help. This suggests the instability hypothesis was wrong — the Regime W in_dist regression is not due to late-training instability but rather to the model's inherent capacity or optimization trajectory. Starting EMA earlier may actually be hurting by averaging over a noisier mid-training regime, diluting what would otherwise be a well-converged checkpoint.

Note: as observed in previous experiments, epochs 1-10 showed train[vol=0.0000 surf=0.0000] in the log display (recurring display/formatting artifact in this model configuration), with normal training resuming from epoch 11.

**Suggested follow-ups:**
- Try the Regime W n_hidden=192 configuration as-is (ep40, decay=0.998) to establish a clean Regime W baseline — the current baseline numbers may be from a different run.
- Try ema_start_epoch=35 (midpoint) to find where the EMA window helps vs hurts.
- Investigate the 0.0000 train loss display for epochs 1-10 — this is a recurring anomaly that may indicate a real issue with early training.