### PR TITLE
Output head dropout p=0.05 (regularize wider model for in_dist)

### DIFF
--- a/train.py
+++ b/train.py
@@ -228,6 +228,7 @@ class TransolverBlock(nn.Module):
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
+                nn.Dropout(0.05),
                 nn.Linear(hidden_dim, out_dim),
             )
 


### PR DESCRIPTION
## Hypothesis
The in_dist regression from 16.84→17.99 when restoring width (192) is an overfitting signature: the wider model has ~760K params vs 543K before, training for 4 fewer epochs. The model currently has ZERO dropout anywhere. Adding lightweight dropout (p=0.05) specifically in the output head regularizes the prediction boundary where the wider model may memorize training-distribution patterns.

## Instructions
1. In the output head MLP (the `self.mlp2` in `TransolverBlock.__init__` when `self.last_layer` is True), add dropout after GELU:
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim),
           nn.GELU(),
           nn.Dropout(0.05),
           nn.Linear(hidden_dim, out_dim),
       )
   ```
2. Keep everything else identical (n_hidden=192, slice_num=48, etc.)
3. Run with `--wandb_group dropout-output-005`

**Rationale**: This is the lightest possible regularization — 5% dropout only in the output head. Weight decay was previously tested and hurt (PR #849). MLP dropout was tested only at n_hidden=128 on ancient code (val_loss ~2.2). No dropout experiment has been run at current model quality.

## Baseline (updated after Regime W merge)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**Run ID**: 27bo3e2g  
**Config**: n_hidden=192, slice_num=48, n_layers=1, Dropout(0.05) in output head  
**Epochs**: 55 (wall-clock limit at 30.4 min, ~33s/epoch)  
**Peak memory**: 16.4 GB  

### Surface MAE (pressure p) — primary metric

| Split | Baseline (Regime W) | Dropout 0.05 | Delta |
|---|---|---|---|
| val_in_dist | 17.99 | 19.05 | +1.06 (worse) |
| val_ood_cond | 13.50 | 15.01 | +1.51 (worse) |
| val_ood_re | 27.79 | 27.78 | -0.01 (same) |
| val_tandem_transfer | 37.81 | 39.43 | +1.62 (worse) |
| **mean3** | **23.10** | **24.50** | **+1.40 (worse)** |

### Full Surface MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 6.99 | 1.94 | 19.05 |
| val_ood_cond | 4.94 | 1.35 | 15.01 |
| val_ood_re | 4.60 | 1.25 | 27.78 |
| val_tandem_transfer | 6.56 | 2.62 | 39.43 |

### Volume MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 1.12 | 0.37 | 20.68 |
| val_ood_cond | 0.74 | 0.28 | 12.45 |
| val_ood_re | 0.84 | 0.37 | 46.86 |
| val_tandem_transfer | 1.95 | 0.89 | 38.88 |

### val/loss
- Dropout 0.05: **0.9000** vs Baseline: 0.8635 (worse by +0.0365)
- val/loss was monotonically decreasing throughout (still improving at final epoch)

---

### What happened

Output head dropout p=0.05 hurt across the board. Every split deteriorated: mean3 increased by +1.40, val/loss increased by +0.0365. The in_dist regression that motivated this experiment (16.84→17.99) was not fixed — it got worse (→19.05).

Notable observation: training losses were logged as 0.0000 for the first 10 epochs (visible in the log), then suddenly jumped to normal values at epoch 11. This suggests the LR warmup + dropout combination causes near-zero gradient flow in early training, effectively wasting ~5 minutes of the 30-min budget. This gave the model only ~45 effective learning epochs vs Regime W's 58 epochs, which may partially explain the gap.

However, even accounting for fewer effective epochs, the trajectory at epoch 55 (val/loss=0.9000) compared to Regime W's epoch 58 (val/loss=0.8635) shows the dropout is genuinely hurting, not just slowing warmup.

**Conclusion**: The in_dist regression in Regime W is not an overfitting signature fixable by output dropout. The model appears to be underfitting (still improving at epoch 55), not overfitting. Dropout of any kind is counterproductive in this setting.

### Suggested follow-ups

- **More epochs at Regime W** — if val/loss was still declining at epoch 55 here (and at 58 for Regime W), more compute time would help; the model is still in the convergence regime
- **Increase slice_num to 64 with n_hidden=160** — the finer routing hypothesis hasn't been exhausted; Regime H showed slices help, try pushing further
- **Cosine annealing with longer T_max** — current schedule may not be optimally decaying; a longer cosine cycle might let the model converge further in 30 minutes