### PR TITLE
T_max=48 (align cosine LR schedule to 58-epoch budget)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=48, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
The cosine scheduler has T_max=62, tuned for the slim model (n_hidden=160) that ran ~62 epochs. With the wider model (n_hidden=192) at ~31s/epoch, training only completes ~58 epochs. At epoch 58, the LR is ~8e-5 instead of the target 5e-5 eta_min — the model never gets the final fine-tuning phase. T_max=48 (with 10 warmup epochs) completes the cosine cycle at epoch 58, ensuring the LR reaches minimum exactly at the training budget. This alignment was a proven winner before (PR #662).

## Instructions
1. Change the cosine scheduler T_max (around line 580):
   \`\`\`python
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=48, eta_min=5e-5)
   \`\`\`
2. Keep warmup at 10 epochs (unchanged)
3. Keep everything else identical (n_hidden=192, slice_num=48, etc.)
4. Run with \`--wandb_group tmax48-align\`

**Note**: The 10-epoch warmup + 48-epoch cosine = cycle completes at epoch 58, exactly matching the wider model's 30-min budget. This ensures every epoch contributes meaningful learning.

## Baseline (updated after Regime W merge)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run ID:** y7vr8bfs
**Run name:** nezuko/tmax48-align
**Epochs completed:** 59 (hit 30-min wall-clock limit; prediction was ~58)
**Peak VRAM:** 15.0 GB
**Epoch time:** ~31s

*Note: Run ended with a crash in the post-training visualization code (shape mismatch in vis model forward pass — unrelated to training results). The best checkpoint was saved before the crash.*

### Metrics at best epoch (59)

| Split | val_loss | Surface Ux MAE | Surface Uy MAE | Surface p MAE | Volume MAE (Ux/Uy/p) |
|---|---|---|---|---|---|
| in_dist | 0.594 | 5.75 | 1.98 | **17.9** | 1.10 / 0.37 / 19.2 |
| ood_cond | 0.703 | 3.23 | 1.19 | **13.8** | 0.72 / 0.27 / 12.0 |
| ood_re | 0.554 | 2.76 | 1.00 | **28.1** | 0.83 / 0.37 / 47.0 |
| tandem | 1.617 | 5.82 | 2.32 | **38.3** | 1.93 / 0.88 / 37.9 |
| **best_val_loss** | **0.8671** | | | | |

### vs. Baseline

| Metric | Baseline | This Run | Delta |
|---|---|---|---|
| best_val_loss | 0.8635 | 0.8671 | +0.4% (essentially same) |
| Surface p in_dist | 17.99 | 17.9 | -0.5% (marginally better) |
| Surface p ood_cond | 13.50 | 13.8 | +2.2% (worse) |
| Surface p ood_re | 27.79 | 28.1 | +1.1% (worse) |
| Surface p tandem | 37.81 | 38.3 | +1.3% (worse) |

### What happened

No meaningful improvement. The T_max=48 alignment produced results statistically indistinguishable from the T_max=62 baseline. The scheduler completed exactly at epoch 58 as intended, and we ran 59 epochs — but the LR alignment didn't produce a measurable benefit.

Two interpretations:
1. **The gap between T_max=62 and T_max=48 is small in practice.** With the wider model (~31s/epoch), T_max=62 misses eta_min by only ~10 epochs at the end of training. The cosine curve is very flat near the minimum — the LR difference between epoch 58 and epoch 72 is only ~3×10⁻⁵, which likely has negligible effect on convergence.
2. **The model is already well-converged at epoch 58.** The performance gap may not be about LR but about something else entirely.

The run also crashed in the visualization code after training finished (mat1/mat2 shape mismatch at line 378/1018), likely a stale checkpoint issue with the wider model's fun_dim. This is a pre-existing bug and didn't affect training results.

### Suggested follow-ups

- **eta_min tuning**: try a lower eta_min (e.g. 1e-5 or 2e-5) to give the model a sharper final fine-tuning phase — the current 5e-5 may still be too high for the final epochs.
- **Longer warmup**: the 10-epoch warmup uses start_factor=0.1, reaching LR=3e-3 at epoch 10. With n_hidden=192, a slightly slower warmup (e.g. 15 epochs) might help stability.
- **Investigate the vis crash**: the shape mismatch in the forward pass at line 378 (84905x25 vs 57x57) suggests fun_dim is computed differently than the saved model expects — worth fixing in a cleanup PR.