### PR TITLE
Attention LR ratio 0.3x (lower attn LR for wider model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -572,7 +572,7 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
+    {'params': attn_params, 'lr': cfg.lr * 0.3},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)


### PR DESCRIPTION
## Hypothesis
The current code uses lr * 0.5 for attention parameters. With the wider model (n_hidden=192) and finer slicing (48), each attention head processes larger feature vectors. The 0.5x ratio was tuned at n_hidden=192 + slice_num=32. With slice_num=48, the attention has more slots but each head still has 48-dim keys/values. A lower ratio (0.3x, giving attn LR ~9e-4) may prevent the attention from overshooting on in_dist patterns while still converging properly for OOD.

## Instructions
1. Change the attention LR from lr * 0.5 to lr * 0.3 (around line 574):
   ```python
   base_opt = torch.optim.AdamW([
       {'params': attn_params, 'lr': cfg.lr * 0.3},
       {'params': other_params, 'lr': cfg.lr}
   ], weight_decay=cfg.weight_decay)
   ```
2. Keep everything else identical (n_hidden=192, slice_num=48, etc.)
3. Run with `--wandb_group attn-lr-03x`

**Rationale**: The in_dist regression (+1.15) when widening from 160→192 may be caused by the attention learning too aggressively for the in_dist distribution. Lower attention LR = more conservative attention patterns = better in_dist generalization.

## Baseline (updated after Regime W merge)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** 91jva5rd
**Epochs completed:** 58/100 (30-min timeout)
**Peak memory:** ~22 GB (n_hidden=192)

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8829 | 0.8635 | +2.2% (worse) |
| Surface MAE p (in_dist) | 18.72 | 17.99 | +4.1% (worse) |
| Surface MAE p (ood_cond) | 14.44 | 13.50 | +7.0% (worse) |
| Surface MAE p (ood_re) | 27.74 | 27.79 | -0.2% (≈same) |
| Surface MAE p (tandem) | 39.18 | 37.81 | +3.6% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 5.78 | 1.79 | 18.72 |
| ood_cond | 3.35 | 1.23 | 14.44 |
| ood_re | 2.98 | 1.09 | 27.74 |
| tandem | 5.69 | 2.23 | 39.18 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.08 | 0.37 | 19.99 |
| ood_cond | 0.73 | 0.28 | 12.02 |
| ood_re | 0.83 | 0.37 | 46.58 |
| tandem | 1.93 | 0.88 | 38.31 |

### What happened

Lower attention LR (0.3x) did not improve results — all metrics are worse than baseline, including the in_dist split that the hypothesis aimed to fix. Reducing attention LR from 0.5x to 0.3x slowed attention convergence enough that the model underfit within the 30-minute budget.

The hypothesis (that attention was overshooting for in_dist patterns) was not confirmed. The in_dist regression is likely not a learning rate issue — the attention is not learning too aggressively, but rather the wider model (n_hidden=192) simply needs more training time to fully converge on in_dist patterns with the current architecture.

### Suggested follow-ups

- **Try attn LR = 0.7x instead:** If 0.5x doesn't help in_dist, maybe the problem is the attention is learning *too slowly* already, and a slight increase would help. The current 0.5x may be conservative enough that it's already on the "too slow" side.
- **Investigate in_dist regression separately:** The in_dist worse-than-baseline result (17.99→18.72 in the Regime W baseline) may not be attention-related at all. A longer training run might reveal the 192-wide model needs more epochs to match the 160-wide model's in_dist accuracy.
- **Return to 0.5x:** The current 0.5x LR ratio appears to be a reasonable compromise — changing it in either direction seems risky without a clear understanding of what's driving the in_dist regression.