### PR TITLE
Hard-mining boost 2.0x (stronger focus on difficult surface nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -741,7 +741,7 @@ for epoch in range(MAX_EPOCHS):
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
-            hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
+            hard_weights = (hard_mask.float() * 1.0 + 1.0).unsqueeze(-1)  # 2.0 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)


### PR DESCRIPTION
## Hypothesis
The current hard-mining boosts difficult surface nodes by 1.5x (above median error). With the wider model (n_hidden=192), there is more capacity to learn hard examples. Increasing the boost to 2.0x focuses even more gradient signal on the most difficult nodes — stagnation points, leading edges, separation regions — where the model needs the most help.

## Instructions
1. Find the hard-mining boost factor in the training loop (around lines 737-745). The current code has a 1.5x multiplier for hard nodes. Change it to 2.0x:
   ```python
   # Where it applies the boost (look for the 1.5 multiplier):
   # Change 1.5 to 2.0
   ```
2. Keep the non-tandem asymmetry (only apply to non-tandem, as in current code)
3. Keep everything else identical (n_hidden=192, slice_num=48, etc.)
4. Run with `--wandb_group hard-mining-2x`

**Rationale**: Hard-mining was a merged improvement (PR #1175, #1188). The 1.5x boost was tuned for the old 192-dim/32-slice model. With finer 48-slice routing, the model can better differentiate spatial regions, making stronger boosting potentially more effective.

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** `rug40za1` (thorfinn/hard-mining-2x, group: hard-mining-2x)
**Peak memory:** 15.0 GB
**Training:** 59 epochs, 30.5 min

### Surface MAE (mae_surf_p, primary metric)

| Split | This run | Baseline | Delta |
|-------|----------|----------|-------|
| val_in_dist | 18.9 | 18.0 | +0.9 |
| val_ood_cond | 14.1 | 13.5 | +0.6 |
| val_ood_re | 27.7 | 27.8 | -0.1 |
| val_tandem_transfer | 40.5 | 37.8 | +2.7 |
| **mean3 (in+ood+tan)/3** | **24.5** | **23.1** | **+1.4** |

### Full Surface MAE breakdown (best checkpoint, epoch 59)

| Split | Ux | Uy | p | val/loss |
|-------|-----|-----|-----|---------|
| val_in_dist | 6.6 | 2.1 | 18.9 | 0.6163 |
| val_ood_cond | 3.7 | 1.4 | 14.1 | 0.7053 |
| val_ood_re | 3.4 | 1.3 | 27.7 | 0.5424 |
| val_tandem_transfer | 6.5 | 2.4 | 40.5 | 1.6905 |

**val/loss (4-split avg):** 0.8886 (baseline 0.8635)

### What happened

The 2.0x boost is worse than the baseline 1.5x on all splits except ood_re (-0.1, essentially same). val/loss regresses from 0.8635 → 0.8886, and mean3 from 23.1 → 24.5. Tandem suffers the most (+2.7) despite hard-mining being non-tandem only, suggesting that over-weighting non-tandem hard nodes may be distorting the shared representation in ways that hurt tandem generalization.

The 1.5x multiplier appears to be better calibrated for this architecture and dataset. A stronger boost concentrates too much gradient on already-identified hard nodes, potentially at the expense of the model's general representational quality.

### Suggested follow-ups
- Try 1.25x as a softer boost to understand the gradient, since 1.5x = baseline and 2.0x = worse.
- Alternatively, try making the boost adaptive based on how far above median the error is (instead of a binary hard/soft split).
- Try applying the 2.0x boost only on a random subset of hard nodes (stochastic hard mining) to reduce overfitting to specific hard nodes.