### PR TITLE
Weight decay 1e-5 on Regime W (light regularization for wider model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -412,7 +412,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 3e-3
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
Weight decay 1e-4 on the slim model (n_hidden=160) showed mixed results — ood_cond improved but tandem regressed. On the wider model (n_hidden=192, ~760K params), a 10x lighter weight decay (1e-5) may provide just enough regularization to help in_dist without the tandem penalty.

## Instructions
1. Change `weight_decay=0` to `weight_decay=1e-5` in the optimizer configuration
2. Keep everything else identical (n_hidden=192, slice_num=48, lr=3e-3, etc.)
3. Run with `--wandb_group wd-1e5`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** 6quh02bo | **Epochs:** 58 (timeout) | **Group:** wd-1e5

### Validation losses (best checkpoint, epoch 58)

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 0.6052 | 6.43 | 1.86 | 18.04 |
| val_ood_cond | 0.6948 | 3.05 | 1.08 | 13.97 |
| val_ood_re | 0.5451 | 2.46 | 0.88 | 27.71 |
| val_tandem_transfer | 1.6330 | 5.91 | 2.12 | 38.65 |
| **mean (val/loss)** | **0.8695** | | | |

**mean3 surf_p (in+ood+re)/3 = 19.91** (baseline 19.76) — **marginally worse**
**val/loss = 0.8695** (baseline 0.8635) — **worse**

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.11 | 0.36 | 19.64 |
| val_ood_cond | 0.73 | 0.27 | 12.00 |
| val_ood_re | 0.84 | 0.37 | 46.79 |
| val_tandem_transfer | 1.90 | 0.87 | 38.68 |

**Peak memory:** ~15.0 GB

### What happened

Negative result. Weight decay 1e-5 on the wider n_hidden=192 model did not improve over baseline.

Per-split vs Regime W baseline (in=17.99, ood=13.50, re=27.79, tan=37.81):
- **in_dist**: 18.04 vs 17.99 — essentially identical (+0.05)
- **ood_cond**: 13.97 vs 13.50 — slightly worse (+0.47)
- **ood_re**: 27.71 vs 27.79 — marginally better (-0.08)
- **tandem**: 38.65 vs 37.81 — worse (+0.84)

The tandem split worsened vs baseline, which contradicts the hypothesis. The overall val/loss increased by +0.006. This is consistent with the K2 result: neither 1e-4 nor 1e-5 weight decay helps this model, suggesting the generalization gap is not caused by over-fitting.

Both the slim (160) and wide (192) Regime W/H variants appear to be in an under-fitting or undercapacity regime rather than over-fitting. Weight decay consistently hurts in_dist or tandem without compensating elsewhere.

### Suggested follow-ups

- Weight decay appears to be a dead end for this architecture — stop exploring it
- The tandem regression in both K2 and this run suggests structural domain shift (tandem vs non-tandem) is the bottleneck, not regularization
- The only way to reduce tandem gap is likely domain-specific: tandem-specific augmentation, explicit tandem features, or more tandem training data weight