### PR TITLE
Warmup 5 epochs (from 10) on Regime W (more productive training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The 10-epoch warmup was tuned for the old model that had ~72 epochs. The wider model (n_hidden=192) only gets ~58 epochs in 30 min. Halving warmup to 5 epochs frees 5 more epochs for productive training at full LR. This means the cosine decay starts earlier and has more of the budget to work with.

## Instructions
1. Change warmup total_iters from 10 to 5:
   ```python
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
   ```
2. Change the milestones for SequentialLR from [10] to [5]:
   ```python
   scheduler = torch.optim.lr_scheduler.SequentialLR(base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5])
   ```
3. Keep everything else identical
4. Run with `--wandb_group warmup5`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---
## Results

**W&B run:** `5933qukv` (`gilbert/warmup5`, group: `warmup5`)

**Epochs completed:** 58 (hit 30-min timeout; ~30-31s/epoch)

**Peak memory:** 15.0 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | This run | Baseline (Regime W) | Δ |
|-------|----------|---------------------|---|
| val_in_dist | 18.00 | 17.99 | ~0 (tied) |
| val_ood_cond | 14.33 | 13.50 | +0.83 (slightly worse) |
| val_ood_re | 27.92 | 27.79 | +0.13 (tied) |
| val_tandem_transfer | 37.83 | 37.81 | ~0 (tied) |
| **mean3** | **23.4** | **23.1** | **+0.3** |

### Full Surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 5.45 | 1.97 | 18.00 |
| val_ood_cond | 3.58 | 1.24 | 14.33 |
| val_ood_re | 3.09 | 1.09 | 27.92 |
| val_tandem_transfer | 6.07 | 2.46 | 37.83 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.12 | 0.36 | 19.87 |
| val_ood_cond | 0.73 | 0.28 | 12.10 |
| val_ood_re | 0.83 | 0.37 | 46.80 |
| val_tandem_transfer | 1.92 | 0.88 | 37.82 |

### Val loss
- val/loss: 0.868 vs baseline 0.864 (Δ=+0.004, nearly tied)
- val_in_dist: 0.595, val_ood_cond: 0.709, val_ood_re: 0.544, val_tandem_transfer: 1.623

---

### What happened

**Near-null result.** Shortening warmup from 10 to 5 epochs makes essentially no difference. Three out of four splits (in_dist, ood_re, tandem) are tied with baseline to within noise. Only ood_cond is marginally worse (+0.83 on p-MAE).

val/loss = 0.868 vs 0.864 baseline — a difference of 0.004 that is well within run-to-run variance. This run achieved 58 epochs, the same as the baseline would get on Regime W.

The hypothesis that warmup epochs are "wasted" training steps doesn't hold — the warmup phase affects gradient stability during the critical early optimization phase. Reducing it from 10 to 5 epochs neither meaningfully helps (freeing ~160s of effective training) nor hurts stability. The LR schedule change appears orthogonal to performance at this scale.

### Suggested follow-ups

- **Warmup=1 or no warmup**: If warmup doesn't matter, go all the way and test no warmup at all. This would be a stronger signal.
- **Longer cosine tail**: Rather than shortening warmup, extend cosine T_max beyond 62 to give the final LR decay more epochs to work with.
- **Combine with other changes**: Warmup adjustment is unlikely to be a standalone win — better tested in combination with architectural changes that produce a clear signal.