### PR TITLE
AdamW beta2=0.95 on Regime W (faster second-moment adaptation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -574,7 +574,7 @@ other_params = [p for n, p in model.named_parameters() if not any(k in n for k i
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
+], weight_decay=cfg.weight_decay, betas=(0.9, 0.95))
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)


### PR DESCRIPTION
## Hypothesis
beta2=0.999 gives a ~1000-step EMA window for the second moment. With ~12K total steps (58 epochs * 210 steps), adaptation is slow. beta2=0.95 (20-step window) responds faster to changing gradient landscapes during surface weight ramping and noise annealing. Testing ONLY this change (no clip change — the previous experiment bundled two changes and it was unclear which hurt).

## Instructions
1. Change AdamW betas from (0.9, 0.999) to (0.9, 0.95):
   ```python
   base_opt = torch.optim.AdamW([
       {'params': attn_params, 'lr': cfg.lr * 0.5},
       {'params': other_params, 'lr': cfg.lr}
   ], weight_decay=cfg.weight_decay, betas=(0.9, 0.95))
   ```
2. Do NOT change gradient clipping (keep max_norm=1.0)
3. Keep everything else identical
4. Run with `--wandb_group beta2-095`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** j7ikz3bt  
**Epochs completed:** 58/100 (external timeout killed mid-epoch 59)  
**Peak memory:** 15.1 GB

### Val loss @ epoch 58
| Split | val/loss |
|---|---|
| in_dist | 0.6281 |
| ood_cond | 0.7034 |
| ood_re | 0.5558 |
| tandem | 1.6560 |
| **combined** | **0.8858** |

### Surface MAE @ epoch 58
| Split | Ux | Uy | p | p baseline |
|---|---|---|---|---|
| in_dist | 4.70 | 1.42 | 18.85 | 17.99 |
| ood_cond | 2.65 | 0.79 | 13.86 | 13.50 |
| ood_re | 2.24 | 0.65 | 28.02 | 27.79 |
| tandem | 5.31 | 2.09 | 39.33 | 37.81 |

### Volume MAE @ epoch 58
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.16 | 0.38 | 19.58 |
| ood_cond | 0.75 | 0.28 | 12.24 |
| ood_re | 0.85 | 0.37 | 46.91 |
| tandem | 1.95 | 0.89 | 38.57 |

**mean3 @ epoch 58:** (18.85 + 13.86 + 39.33) / 3 = **24.01** vs baseline **23.10** (worse)  
**val/loss:** 0.8858 vs baseline 0.8635 (worse)

### What happened

beta2=0.95 alone does not improve over the Regime W baseline. At epoch 58, all surface pressure MAE values are worse than baseline: in_dist (+0.86), ood_cond (+0.36), ood_re (+0.23), tandem (+1.52). The combined val/loss is 2.6% higher than baseline.

The model was still converging at epoch 58, but the gap to baseline was not closing rapidly. Looking at the val losses in the final 5 epochs (53→58):
- val_in_dist: 0.644 → 0.628 (still improving)
- val_tandem: 1.670 → 1.656 (still improving)

The improvement rate is too slow to overcome the ~0.022 val/loss gap to baseline by epoch 100.

The 20-step EMA window (beta2=0.95) appears to introduce too much noise in the second moment estimates. This likely causes the optimizer to take inconsistent step sizes, slowing convergence compared to the smoother 1000-step window (beta2=0.999). The hypothesis that beta2=0.999 is "too slow to adapt" is not supported — the default settings appear better matched to this training regime.

Combining with the previous optimizer-recal experiment (beta2=0.95 + clip=0.5): both experiments confirm that the default beta2=0.999 is the better choice. Tightening the clip (0.5) doesn't compensate for the noisier second moment.

**Verdict: beta2=0.95 hurts, not helps. The default beta2=0.999 should be kept.**

### Suggested follow-ups

1. **Try beta2=0.99 (middle ground)**: If 0.999 is too slow and 0.95 is too noisy, beta2=0.99 (100-step window) might balance both. Though given these results, this seems unlikely to help.
2. **Leave optimizer alone**: These two experiments strongly suggest the optimizer (lr, betas, clip) is not the bottleneck. Focus future experiments on model architecture or data augmentation changes.
3. **Investigate gradient distribution**: Understanding the actual gradient magnitude distribution (not just whether clipping fires at 100%) might reveal whether the optimizer is actually the limiting factor.
