### PR TITLE
lr=2e-3 on Regime W (gentler LR for wider model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 2e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The wider model (n_hidden=192, ~760K params) may need a lower LR than the 3e-3 that was tuned for smaller configs. The 100% gradient clipping rate at max_norm=1.0 means the effective step size is determined by the clip threshold. With more parameters, the gradient norms may be different, and lr=2e-3 (2/3 of current) gives the optimizer a gentler trajectory. This is the simplest possible hyperparameter change and has NEVER been tested on the Regime W configuration.

## Instructions
1. Change `lr=3e-3` to `lr=2e-3` (this affects both parameter groups: attention at lr*0.5=1e-3, others at 2e-3)
2. Keep everything else identical
3. Run with `--wandb_group lr-2e3`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run ID**: `tk76m19x`
**Epochs completed**: 58 / 100 (30.0 min timeout)
**Peak memory**: 15.0 GB

### Metrics at best checkpoint (epoch 58)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | Δ surf_p vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 0.6209 | 5.22 | 1.80 | 19.01 | +1.02 |
| val_ood_cond | 0.7251 | 3.33 | 1.11 | 14.05 | +0.55 |
| val_ood_re | 0.5588 | 3.11 | 0.98 | 28.01 | +0.22 |
| val_tandem_transfer | 1.6218 | 4.88 | 2.18 | 38.34 | +0.53 |

**Best val/loss**: 0.8816 (baseline: 0.8635 → **worse by 0.018**)
**mean3 surf_p (in, ood_cond, tandem)**: (19.01 + 14.05 + 38.34) / 3 = **23.80** (baseline: 23.10 → **worse by 0.70**)

### What happened

lr=2e-3 performs slightly worse than the baseline lr=3e-3 across all splits. The result is close but uniformly negative. The hypothesis is not supported — the wider model doesn't benefit from a lower LR.

Two observations:

1. **Still improving at cutoff.** The checkpoint was updated on every epoch through epoch 58, meaning the model hadn't plateaued. The cosine schedule for lr=2e-3 converges more slowly, so we were 7 epochs behind the baseline trajectory at the 30-min cutoff. The final metrics likely understate what lr=2e-3 would achieve with full convergence.

2. **Gradient clipping argument doesn't hold here.** The gradient clipping at max_norm=1.0 doesn't fully equalize effective step sizes — it just prevents large gradient norm steps. Most steps during fine-grained convergence are likely below the clipping threshold, so the LR still matters. But the empirical result shows lr=3e-3 is already doing fine on Regime W. The wider model doesn't appear to generate larger gradients that require a lower LR.

The differences are small enough to be within run-to-run noise (a single run), but the consistent direction (lr=2e-3 is worse on all 4 splits) makes it unlikely to be noise.

### Suggested follow-ups

- **lr=4e-3 or 5e-3**: Try slightly *higher* LR to compensate for the fact that wider models have more parameters to optimize. The wider model may actually benefit from more aggressive early updates.
- **Longer run (if timeout extended)**: The model was still converging at epoch 58. Running lr=2e-3 for 70+ epochs might yield competitive results — the slower start may trade off for better final convergence.
- **Per-layer LR scaling**: Instead of a uniform LR reduction, only reduce the LR for the wider hidden layers while keeping the attention LR at 0.5x. The extra width is in the MLP/projection layers, not the attention.