### PR TITLE
EMA decay 0.9995 on Regime W (slower averaging for wider model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.9995
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
EMA decay=0.998 has a half-life of ~500 steps (~2.5 epochs). With the wider model getting 58 epochs and EMA starting at epoch 40, only ~18 EMA epochs contribute. Increasing decay to 0.9995 (half-life ~2000 steps, ~10 epochs) means the EMA model more conservatively averages the trajectory, better capturing the long-term convergence trend. Earlier EMA (epoch 30) was tested and hurt — but with slower decay, the model at epoch 40 should still be dominated by recent good checkpoints.

## Instructions
1. Change EMA decay from 0.998 to 0.9995 (find ema_decay, around line 539):
   ```python
   ema_decay = 0.9995
   ```
2. Keep EMA start at epoch 40 (unchanged)
3. Keep everything else identical
4. Run with `--wandb_group ema-0.9995`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run ID**: lvraikeo
**Run name**: violet/ema-0.9995
**Epochs completed**: 57/100 (cut off by 30-min timeout)
**Peak memory**: 15.0 GB

### Metrics at epoch 57 (best checkpoint)

| Split | val_loss | MAE Ux | MAE Uy | MAE p |
|---|---|---|---|---|
| in_dist | 0.614 | 8.29 | 2.30 | 18.4 |
| ood_cond | 0.728 | 4.96 | 1.61 | 14.6 |
| ood_re | 0.559 | 4.67 | 1.48 | 28.2 |
| tandem | 1.645 | 6.84 | 2.68 | 39.0 |

**Combined val_loss**: 0.886

Volume MAE (in_dist): Ux=1.14, Uy=0.38, p=20.2

### vs Baseline (Regime W, EMA decay=0.998)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val_loss | 0.8635 | 0.886 | +0.022 (worse) |
| Surface MAE p (in_dist) | 17.99 | 18.4 | +0.4 (slightly worse) |
| Surface MAE p (ood_cond) | 13.50 | 14.6 | +1.1 (worse) |
| Surface MAE p (ood_re) | 27.79 | 28.2 | +0.4 (slightly worse) |
| Surface MAE p (tandem) | 37.81 | 39.0 | +1.2 (worse) |

### What happened

EMA decay=0.9995 **did not help** — all metrics are worse than baseline across all splits. The combined val_loss (0.886) is higher than baseline (0.8635), and surface pressure MAE is notably worse on ood_cond (+1.1) and tandem (+1.2).

The slower EMA decay (half-life ~10 epochs vs ~2.5 for 0.998) appears to over-smooth the trajectory. With EMA starting at epoch 40 and running ~17 more epochs before timeout, the 0.9995 decay actually integrates checkpoints from epochs 40-57 nearly equally weighted — meaning the earlier, less-converged epoch-40 model contributes substantially to the final average. This dilutes the quality of later checkpoints rather than distilling the best of the trajectory.

The baseline 0.998 decay effectively discards checkpoints older than ~5 epochs, acting as a recent-history filter. That tighter window is better suited to the fast convergence dynamics of this model.

### Suggested follow-ups
- **Intermediate decay**: Try 0.9990 (half-life ~1000 steps, ~5 epochs) as a middle ground between 0.998 and 0.9995.
- **Later EMA start**: If using slow decay, start EMA later (epoch 45-48) so the averaging window only covers well-converged checkpoints.
- **Decay warmup**: Start EMA at 0.998 and gradually ramp to 0.9995 over the last 10 epochs, blending fast early updates with slow late averaging.