### PR TITLE
Surf_weight clamp max=30 (prevent over-weighting surface loss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -636,7 +636,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    surf_weight = max(5.0, min(30.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
The adaptive surf_weight is clamped to [5, 50]. In late training, it can reach 30-50x, potentially over-focusing on surface accuracy at the expense of volume quality. Clamping max to 30 (from 50) prevents extreme surface weights that may destabilize the loss landscape. The Regime G ablation (fixed surf_weight=30) showed 30 is close to the sweet spot. This lets the adaptive mechanism work but with a tighter ceiling.

## Instructions
1. Find the surf_weight clamping (around line 641). Change the max from 50 to 30:
   ```python
   surf_weight = max(5.0, min(30.0, surf_weight))  # was min(50.0, ...)
   ```
2. Keep everything else identical
3. Run with `--wandb_group surf-clamp-30`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** `dsq82lj6`
**Best epoch:** 59 / 100 (hit wall-clock limit, 31s/epoch)
**Peak memory:** 15.0 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5928 | 4.68 | 1.44 | 17.61 | 1.09 | 0.36 | 19.06 |
| val_tandem_transfer | 1.6526 | 5.20 | 1.88 | 39.31 | 1.93 | 0.89 | 38.74 |
| val_ood_cond | 0.7190 | 3.15 | 1.00 | 14.41 | 0.71 | 0.27 | 12.18 |
| val_ood_re | 0.5468 | 2.67 | 0.85 | 27.87 | 0.81 | 0.36 | 46.92 |
| **mean3** | **0.988** | **4.34** | **1.44** | **23.78** | — | — | — |

Baseline (Regime W): mean3=23.10 (in=17.99, ood=13.50, tan=37.81, re=27.79), val/loss=0.8635

**What happened:** Negative result. mean3 surface_p worsened from 23.10 → 23.78, and val/loss worsened from 0.8635 → 0.8778. The tandem split regressed significantly (39.31 vs 37.81) and ood_cond got slightly worse (14.41 vs 13.50). In_dist improved slightly (17.61 vs 17.99).

Lowering the surf_weight ceiling to 30 hurt tandem transfer, which requires the model to learn harder surface configurations. The higher adaptive weights (up to 50) in Regime W appear to be benefiting the tandem foil cases specifically — restricting to 30 denies the model the ability to push harder on surface accuracy when it needs to. This suggests the adaptive ceiling of 50 is doing useful work for the more challenging samples.

**Suggested follow-ups:**
- Try raising the ceiling instead (e.g., max=70 or 100) — if 50 is already doing useful work, maybe even more surface emphasis in late training would help.
- Try a split ceiling: apply max=30 for non-tandem samples but allow higher for tandem, to prevent the tandem regression.
- Try keeping max=50 but raising the floor from 5 to 10, to prevent over-low surf_weight in early training.