### PR TITLE
lr=4e-3 on Regime W (test higher LR for wider model)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 4e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The base LR of 3e-3 was tuned for multiple configurations. With 100% gradient clipping at max_norm=1.0, the effective step size depends on the clip threshold more than the scheduled LR. A higher base LR (4e-3) may help the wider model explore further before the cosine decay locks it in. This tests the OPPOSITE direction from frieren's lr=2e-3 — together they bracket the optimal LR for the Regime W config.

## Instructions
1. Change `lr=3e-3` to `lr=4e-3` (affects both groups: attention at lr*0.5=2e-3, others at 4e-3)
2. Keep everything else identical (n_hidden=192, slice_num=48, etc.)
3. Run with `--wandb_group lr-4e3`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** `q6318i9h`
**Epochs:** ~61 (30-min timeout)
**Peak VRAM:** ~15 GB

*Note: W&B run state shows "failed" due to a visualization crash after training completed (shape mismatch in vis_model, line 1018 — pre-existing issue, unrelated to the lr change). All training and validation metrics are fully valid.*

### Surface MAE (pressure) — primary metric

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| in_dist | 17.99 | 18.26 | +1.5% |
| ood_cond | 13.50 | 13.86 | +2.7% |
| ood_re | 27.79 | 28.04 | +0.9% |
| tandem | 37.81 | 38.53 | +1.9% |
| **mean3** | **23.10** | **23.55** | **+1.9% (worse)** |

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|------|
| in_dist | 5.98 | 1.74 | 18.26 |
| ood_cond | 3.33 | 0.90 | 13.86 |
| ood_re | 2.84 | 0.75 | 28.04 |
| tandem | 5.98 | 2.17 | 38.53 |

### Volume MAE (p)

| Split | This run |
|-------|----------|
| in_dist | 19.40 |
| ood_cond | 11.95 |
| ood_re | 46.94 |
| tandem | 38.47 |

### Losses

| Metric | Baseline | This run |
|--------|----------|----------|
| val/loss | 0.8635 | 0.8716 |
| train/surf_weight (final) | — | 5.85 |

### What happened

**Did not work.** lr=4e-3 is marginally worse than lr=3e-3 across all splits. The degradation is small (+1.9% mean3) compared to the vol scaling failure (+6.6%), but consistent — every split got slightly worse.

Combined with frieren's lr=2e-3 result (needed to check), this brackets the LR search around 3e-3. The cosine schedule likely compensates for higher LR differences, and gradient clipping (max_norm=1.0) limits the practical effect of LR on large-gradient steps. The default 3e-3 appears to be well-tuned for this architecture.

Note: final surf_weight was 5.85 (near the minimum clamp of 5.0), suggesting vol loss relative to surf loss remained low, keeping adaptive weighting near the floor.

### Suggested follow-ups

1. **Check frieren's lr=2e-3 result**: If lr=2e-3 is also worse than 3e-3, the baseline LR is confirmed optimal and further LR search isn't worthwhile.
2. **Warmup schedule**: A brief linear warmup (e.g., 5 epochs) might allow temporarily higher LR without the instability, combining the benefit of both 3e-3 and 4e-3.
3. **Weight decay sweep**: With LR confirmed, trying small weight decay (1e-5, 1e-4) could be the next hyperparameter to tune.