### PR TITLE
T_max=55 on Regime W (gentle LR schedule alignment)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
T_max=48 showed the best in_dist (17.89 vs baseline 17.99) but hurt ood. T_max=72 hurt everything. The sweet spot may be between 48 and 62. T_max=55 (with 10 warmup) means the cosine completes around epoch 65 — still slightly beyond the 58-epoch budget but much closer than T_max=62. This gives a gentler LR decay that helps in_dist convergence without the aggressive cutoff that hurt ood at T_max=48.

## Instructions
1. Change T_max from 62 to 55 (around line 580):
   ```python
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=5e-5)
   ```
2. Keep everything else identical (n_hidden=192, slice_num=48, warmup=10, etc.)
3. Run with `--wandb_group tmax55`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**Run ID**: xtjsur9w  
**Config**: n_hidden=192, slice_num=48, n_layers=1, T_max=55  
**Epochs**: 55 (wall-clock limit at 30.0 min, ~33s/epoch)  
**Peak memory**: 15.9 GB  

### Surface MAE (pressure p) — primary metric

| Split | Baseline (T_max=62) | T_max=55 | Delta |
|---|---|---|---|
| val_in_dist | 17.99 | 18.15 | +0.16 (worse) |
| val_ood_cond | 13.50 | 13.69 | +0.19 (worse) |
| val_ood_re | 27.79 | 27.95 | +0.16 (worse) |
| val_tandem_transfer | 37.81 | 39.50 | +1.69 (worse) |
| **mean3** | **23.10** | **23.78** | **+0.68 (worse)** |

### Full Surface MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 8.66 | 2.53 | 18.15 |
| val_ood_cond | 5.60 | 1.66 | 13.69 |
| val_ood_re | 5.19 | 1.50 | 27.95 |
| val_tandem_transfer | 7.50 | 2.75 | 39.50 |

### Volume MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 1.12 | 0.37 | 19.52 |
| val_ood_cond | 0.71 | 0.28 | 11.87 |
| val_ood_re | 0.83 | 0.36 | 46.83 |
| val_tandem_transfer | 1.94 | 0.89 | 38.57 |

### val/loss
- T_max=55: **0.8797** vs Baseline: 0.8635 (worse by +0.0162)
- val/loss was still declining at epoch 55 (0.9262→0.8797 for last 10 epochs)

---

### What happened

T_max=55 is uniformly worse than T_max=62 (Regime W baseline). Every metric regressed. The val/loss gap (+0.016) and mean3 gap (+0.68) are consistent and meaningful. Notably, the tandem_transfer split took the biggest hit (+1.69 on surface p), suggesting the shorter cosine schedule undershoots transfer generalization.

Looking at the epoch budget: T_max=55 completes the cosine cycle at epoch 65, meaning the model is still in active LR decay at epoch 55 (end of training). With T_max=62, the cosine also hasn't fully completed at epoch 58 (baseline). The 7-epoch difference in T_max doesn't fully explain the gap — the slightly higher LR maintained by T_max=55 at epoch 55 vs T_max=62 at epoch 58 appears to be beneficial for the longer schedule, not the shorter one.

The trend suggests T_max should be ≥62 (or longer) for this regime. T_max=48 hurt ood; T_max=55 is uniformly worse than T_max=62. T_max=62 appears to be at or near the optimum for the current 30-minute budget.

### Suggested follow-ups

- **T_max=72 re-test with fresh eyes** — if the previous T_max=72 experiment was run at a different model quality (e.g., pre-Regime H/W), it may not be representative; could be worth revisiting
- **Increase training budget** — the val/loss is still declining at epoch 55, so more compute would help any T_max; the key constraint is the 30-min wall-clock
- **Increase slice_num to 56 or 64 with n_hidden=160** — coming back to the Regime H direction which showed finer routing helps