### PR TITLE
Warmup 8 epochs (from 10) on Regime W (mild warmup reduction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[8]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The 10-epoch warmup was tuned for the old model. With the wider model getting ~58 epochs, 10 warmup epochs consume 17% of the budget. Warmup=5 was already assigned to gilbert (more aggressive). This tests warmup=8, a gentler 20% reduction that frees 2 more productive training epochs without the risk of too-short warmup.

## Instructions
1. Change warmup total_iters from 10 to 8:
   ```python
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
   ```
2. Change milestones from [10] to [8]:
   ```python
   scheduler = torch.optim.lr_scheduler.SequentialLR(base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[8])
   ```
3. Keep everything else identical
4. Run with `--wandb_group warmup8`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** cqx6i7ni
**Epochs completed:** 59/100 (30-min timeout)
**Peak memory:** ~22 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8669 | 0.8635 | +0.4% (slightly worse) |
| Surface MAE p (in_dist) | 17.82 | 17.99 | -1.0% (slightly better) |
| Surface MAE p (ood_cond) | 14.26 | 13.50 | +5.6% (worse) |
| Surface MAE p (ood_re) | 27.88 | 27.79 | +0.3% (≈same) |
| Surface MAE p (tandem) | 38.09 | 37.81 | +0.7% (≈same) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 4.91 | 1.44 | 17.82 |
| ood_cond | 2.85 | 0.92 | 14.26 |
| ood_re | 2.37 | 0.77 | 27.88 |
| tandem | 5.49 | 2.03 | 38.09 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.09 | 0.36 | 19.49 |
| ood_cond | 0.72 | 0.27 | 12.34 |
| ood_re | 0.82 | 0.36 | 46.93 |
| tandem | 1.91 | 0.87 | 37.72 |

### What happened

Mixed/neutral result. Reducing warmup from 10 to 8 epochs gave marginally better in_dist p (17.99→17.82, -1%) but notably worse ood_cond p (13.50→14.26, +5.6%). Overall val_loss is 0.8669 vs 0.8635 baseline — essentially the same within noise.

The 1 extra productive epoch (from getting 59 vs 58 epochs) didn't meaningfully change outcomes. The ood_cond regression suggests the 8-epoch warmup may be slightly too aggressive for the ood_cond split — the model doesn't warm up fully before the cosine decay begins for that distribution.

Overall: no clear benefit from reducing warmup by 2 epochs. The result is noisy and the baseline is better on ood_cond (the most improved split in recent experiments).

### Suggested follow-ups

- **Try warmup=12:** If 10 is the right order of magnitude, maybe slightly more warmup would improve ood_cond. However, this is likely just noise.
- **Separate warmup sensitivity test:** Compare warmup=5 (gilbert's experiment), warmup=8 (this), and warmup=10 (baseline) side-by-side to understand if warmup really matters.
- **Focus on ood_cond improvements:** ood_cond p at 13.50 in the baseline is a recent win. Experiments that regress this split should be treated with caution.