### PR TITLE
Ablation: Disable coarse loss (test if coarse loss still helps on Regime W)

### DIFF
--- a/train.py
+++ b/train.py
@@ -770,7 +770,8 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            # Ablation: coarse loss disabled (no-coarse experiment)
+            # loss = loss + 1.0 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
The coarse loss was added early in the research and has been carried through every experiment since. But it was never ablated on the Regime W architecture (n_hidden=192, slice_num=48). With the finer 48-slice routing, the coarse loss may be redundant — the model already captures multi-scale structure through its attention mechanism. Removing it simplifies the loss and frees gradient signal for the primary surface+volume objectives.

## Instructions
1. Find the coarse loss computation and disable it. Look for `coarse_loss` or `coarse_weight` in the training loop. Set `coarse_weight = 0.0` or comment out the coarse loss addition to the total loss.
2. Keep everything else identical (n_hidden=192, slice_num=48, etc.)
3. Run with `--wandb_group no-coarse`

**This is a component ablation.** If coarse loss removal hurts, it confirms the component is still useful. If it's neutral or helps, we can simplify the training pipeline.

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run ID**: `lkzfmreh`  
**Best epoch**: 60  
**Peak memory**: 15.0 GB  

### Metrics at best checkpoint

| Split | val/loss | Surface p |
|---|---|---|
| val_in_dist | 0.764 | **23.2** |
| val_ood_cond | 1.114 | **21.7** |
| val_ood_re | 0.783 | **32.0** |
| val_tandem_transfer | 2.185 | **51.3** |
| **combined val/loss** | **1.2115** | |

### vs. Baseline (Regime W)

| Metric | Baseline | No coarse | Delta |
|---|---|---|---|
| val/loss | 0.8635 | 1.2115 | **+0.348 ❌** |
| surf_p in_dist | 17.99 | 23.2 | **+5.2 ❌** |
| surf_p ood_cond | 13.50 | 21.7 | **+8.2 ❌** |
| surf_p ood_re | 27.79 | 32.0 | **+4.2 ❌** |
| surf_p tandem | 37.81 | 51.3 | **+13.5 ❌** |

### What happened

Removing the coarse loss is **strongly detrimental**. Val/loss increases by 40% (0.86→1.21) and surface pressure errors roughly double on tandem and ood_cond. The ablation unambiguously confirms that the coarse loss is a critical component of the training pipeline.

The coarse loss works by computing spatially-averaged predictions and targets over groups of 64 nodes sorted by x-coordinate. This provides two things the primary loss does not:

1. **Multi-scale supervision**: The attention mechanism aggregates information through soft slice tokens, but it may not explicitly optimize for spatial coherence at the ~64-node scale. The coarse loss directly trains the model to produce spatially smooth predictions.

2. **Regularization against local overfitting**: Without coarse pooling, the model can memorize local node-level patterns that don't generalize. The coarse loss forces predictions to be consistent at a coarser spatial scale, regularizing against this.

The tandem split suffers the most (+13.5 on surf_p), likely because tandem foils have the most complex flow structure where the coarse loss provides the strongest multi-scale constraint.

### Suggested follow-ups

- The coarse loss coefficient is currently `1.0`. Since it's clearly important, **tuning the coefficient** (0.5, 2.0) could find a better balance with the primary loss.
- The pool size of 64 nodes is fixed. **Varying pool size** (32, 128) could tune the scale at which spatial coherence is enforced.
- **Hierarchical coarse loss** at two scales (64 and 256 nodes) might help further.