### PR TITLE
Ablation: Disable auxiliary Re/AoA heads (test if aux loss helps on Regime W)

### DIFF
--- a/train.py
+++ b/train.py
@@ -774,10 +774,10 @@ for epoch in range(MAX_EPOCHS):
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
+        # aux disabled: loss = loss + 0.01 * re_loss
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
-        loss = loss + 0.01 * aoa_loss
+        # aux disabled: loss = loss + 0.01 * aoa_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The auxiliary prediction heads for Reynolds number and angle of attack were added to provide extra gradient signal. But on the Regime W architecture, they may be consuming model capacity without improving the primary task. With n_hidden=192 and 48 slices, the model has enough capacity that the auxiliary signal might be noise rather than signal. Removing them simplifies the architecture and redirects all capacity to the primary CFD prediction.

## Instructions
1. Find the auxiliary loss heads (Re/AoA prediction, usually `aux_weight` or `aux_loss` in the training loop). Set `aux_weight = 0.0` or disable the auxiliary loss entirely.
2. Keep everything else identical
3. Run with `--wandb_group no-aux`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** `edward/no-aux` (gw78xru1), best epoch 57 (47 effective epochs past JIT warmup); W&B synced through epoch 55

**Peak memory:** 14.8 GB

| Split | mae_surf_p | vs baseline |
|-------|-----------|-------------|
| val_in_dist | 18.23 | +0.24 |
| val_ood_cond | 14.77 | +1.27 |
| val_tandem_transfer | 39.85 | +2.04 |
| val_ood_re | 28.08 | +0.29 |
| **mean3** | **24.28** | **+1.09 (+4.7%)** |

Surface MAE (Ux / Uy / p) by split (epoch 55, last W&B sync):
- val_in_dist: 7.01 / 1.75 / 18.23
- val_ood_cond: 4.05 / 1.18 / 14.77
- val_ood_re: 3.47 / 1.01 / 28.08
- val_tandem: 7.01 / 2.40 / 39.85

Volume MAE (Ux / Uy / p) by split:
- val_in_dist: 1.09 / 0.37 / 19.50
- val_ood_cond: 0.73 / 0.28 / 12.42
- val_ood_re: 0.82 / 0.36 / 46.86
- val_tandem: 1.95 / 0.89 / 39.26

val/loss (epoch 55): 0.8927 (vs baseline 0.8635); epoch 57 text log: val_in_dist=0.592, ood_cond=0.729, ood_re=0.549, tandem=1.660

Epochs 56-57 (from text log, not synced to W&B) showed continued improvement — estimated epoch 57 combined loss ≈ 0.882.

- **val/loss ≈ 0.882-0.893** vs baseline 0.8635 — **regression**
- **mean3 = 24.28** (epoch 55) vs baseline 23.19 — **REGRESSION (+4.7%)**

## What happened

Removing the auxiliary Re/AoA loss **hurts** — the model performs worse without it. The auxiliary signal is providing useful gradient regularization, not noise. Specifically:
- ood_cond and tandem suffer most (+1.3 and +2.0 on mae_surf_p), suggesting the auxiliary loss helps generalize to new conditions
- in_dist and ood_re are nearly unchanged (+0.2 and +0.3), so the aux signal mainly helps OOD generalization

The weight is small (0.01 × re_loss + 0.01 × aoa_loss), so the capacity cost is minimal. The auxiliary signal appears to be a lightweight but effective regularizer that helps the model better internalize physical parameters (Re, AoA), which then improves extrapolation.

This is a useful **positive finding**: the auxiliary heads should be kept. Their removal degrades OOD performance.

## Suggested follow-ups

- Try increasing aux weight (0.01 → 0.05 or 0.1) to test if stronger auxiliary signal helps further.
- Try using only Re prediction (remove AoA) to see which contributes more.
- The ood_re split is relatively unaffected (AoA-independent at different Reynolds numbers), consistent with the Re auxiliary loss helping ood_re while the AoA loss helps tandem and ood_cond.