### PR TITLE
Ablation: Disable noise annealing entirely (test if noise still helps on Regime W)

### DIFF
--- a/train.py
+++ b/train.py
@@ -664,18 +664,11 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+        # noise annealing disabled (ablation: no-noise)
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+        # target noise annealing disabled (ablation: no-noise)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
Noise annealing was confirmed helpful on old code (Regime G ablation showed removing it hurt). But the Regime W model (n_hidden=192, slice_num=48) has different capacity and routing. The noise may now be adding variance that prevents fine convergence, especially during the EMA phase. Testing complete removal to check if noise is still net-positive on the current architecture.

## Instructions
1. Find the noise annealing code in the training loop (usually adds Gaussian noise to input features based on epoch). Set the noise level to 0 at all epochs, or disable the noise code block entirely.
2. Keep everything else identical
3. Run with `--wandb_group no-noise`

**Note**: Regime G tested removing noise + hard-mining + adaptive surf_weight all at once (3 changes). This isolates noise removal alone.

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** 45vy6z7o | **Epochs:** 60 (timeout mid-epoch 61) | **Group:** no-noise

*(Note: best_val_loss not populated in W&B summary due to timeout during vis code; metrics are from last logged epoch 60, which is also the best checkpoint.)*

### Validation losses (best checkpoint, epoch 60)

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 0.5996 | 6.06 | 1.65 | 17.49 |
| val_ood_cond | 0.7227 | 3.76 | 1.13 | 14.54 |
| val_ood_re | 0.5456 | 3.30 | 0.96 | 28.04 |
| val_tandem_transfer | 1.6250 | 6.13 | 2.26 | 38.50 |
| **mean (val/loss)** | **0.8732** | | | |

**mean3 surf_p (in+ood+re)/3 = 20.02** (baseline 19.76) — **worse**
**val/loss = 0.8732** (baseline 0.8635) — **worse**

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.05 | 0.35 | 18.73 |
| val_ood_cond | 0.70 | 0.27 | 12.38 |
| val_ood_re | 0.79 | 0.35 | 46.73 |
| val_tandem_transfer | 1.89 | 0.87 | 37.87 |

**Peak memory:** ~15.0 GB

### What happened

Noise annealing is still beneficial on Regime W. Removing it made things worse across most splits.

Per-split vs Regime W baseline (in=17.99, ood=13.50, re=27.79, tan=37.81):
- **in_dist**: 17.49 vs 17.99 — **better** (-0.50) ✓
- **ood_cond**: 14.54 vs 13.50 — **worse** (+1.04) ✗
- **ood_re**: 28.04 vs 27.79 — **worse** (+0.25) ✗
- **tandem**: 38.50 vs 37.81 — **worse** (+0.69) ✗

The in_dist split improved without noise (suggesting noise slightly hurts in-distribution fit), but this is outweighed by significant degradation in ood_cond and the other splits. The noise appears to function as domain-specific data augmentation — it prevents the model from over-fitting to the exact in-distribution training examples, which aids OOD generalization.

Note: both noise types were disabled (input feature noise on x[:, :, 2:25] and target label noise on y_norm). The effect could be from either or both.

### Suggested follow-ups

- Noise is confirmed beneficial — try reducing noise magnitude by 50% (current levels may be too aggressive for Regime W's larger capacity)
- Test disabling ONLY target noise (y_norm noise) vs ONLY input feature noise to isolate which type matters more
- The in_dist improvement (+0.50) without noise suggests input noise may be hurting in-dist fit; try keeping target noise only