### PR TITLE
mlp_ratio=3 on Regime W (wider FFN at slice_num=48, never tested)

### DIFF
--- a/train.py
+++ b/train.py
@@ -524,7 +524,7 @@ model_config = dict(
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
-    mlp_ratio=2,
+    mlp_ratio=3,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
mlp_ratio=3 (FFN hidden=576) was tested on OLD code (slice_num=32) and showed val_loss=0.885 — not far from old baseline. On the Regime W architecture (slice_num=48, n_hidden=192), the wider FFN has never been tested. With 48-slice routing, each spatial group gets more expressive nonlinear capacity from a wider FFN. This is an ARCHITECTURAL change (the only kind that has reliably beaten baselines in this research).

## Instructions
1. Change `mlp_ratio=2` to `mlp_ratio=3` in the model config
2. Keep n_hidden=192, slice_num=48, everything else identical
3. Run with `--wandb_group mlp-ratio-3`

**Expected**: ~17-18 GB memory, ~33s/epoch, ~55 epochs. The wider FFN adds capacity specifically in the feed-forward pathway where per-node predictions are refined.

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run ID**: `1bp2wczs`
**Epochs completed**: 56 / 100 (30.0 min timeout)
**Peak memory**: 15.7 GB

### Metrics at best checkpoint (epoch 56)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | Δ surf_p vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 0.6201 | 6.95 | 2.21 | 18.94 | +0.95 |
| val_ood_cond | 0.7317 | 3.60 | 1.17 | 14.63 | +1.13 |
| val_ood_re | 0.5515 | 3.27 | 1.04 | 27.99 | +0.20 |
| val_tandem_transfer | 1.6282 | 6.43 | 2.65 | 38.31 | +0.50 |

**Best val/loss**: 0.8829 (baseline: 0.8635 → **worse by 0.019**)
**mean3 surf_p (in, ood_cond, tandem)**: (18.94 + 14.63 + 38.31) / 3 = **23.96** (baseline: 23.10 → **worse by 0.86**)

### What happened

mlp_ratio=3 is slightly worse than the baseline mlp_ratio=2 across all splits. The model was still improving at epoch 56 (checkpoint updated every epoch through the cutoff), so the comparison is not fully converged — but the gap is consistent and appears real.

Two effects combine here:

1. **Fewer epochs from slower training.** mlp_ratio=3 takes 32s/epoch vs ~30s for baseline, costing ~2 fewer training epochs in 30 minutes. The model is slightly behind on the convergence curve at cutoff.

2. **The wider FFN doesn't help.** Even accounting for the 2-epoch deficit, the per-epoch validation losses at equivalent epochs (around epoch 50-54) are comparable to baseline but not better. The Transolver architecture appears bottlenecked in the slice-attention pathway rather than the per-node MLP. Adding FFN capacity doesn't resolve the spatial routing limitation.

This mirrors the earlier mlp_ratio=3 finding on old code (val_loss=0.885) — wider FFN was never a strong win even when directly tested. The current result confirms that pattern holds on Regime W.

### Suggested follow-ups

- **More attention heads (n_head=6 or 8)**: The slice-attention bottleneck suggests more expressive routing would help more than wider MLPs. More heads increase capacity exactly where it seems most needed.
- **More slices (slice_num=56 or 64)**: More spatial groups = finer-grained routing, which is the main signal this architecture depends on.
- **mlp_ratio=4**: The old code test with mlp_ratio=4 wasn't reported — might be worth trying at the absolute edge of memory budget to see if there's a threshold effect.