### PR TITLE
Surf_weight floor=10 (raise minimum from 5 for stronger early surface signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -636,7 +636,7 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    surf_weight = max(10.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
The adaptive surf_weight clamp floor is 5. In early training, surf_weight stays near this minimum, meaning volume loss dominates. Raising to 10 gives the surface loss more influence from the start, helping the model attend to airfoil surface patterns earlier. This was suggested by kohaku's surf-clamp-30 results which showed surf_weight tuning has meaningful effects (in_dist improved to 17.61 when the ceiling was lowered).

## Instructions
1. Change the surf_weight floor from 5 to 10:
   ```python
   surf_weight = max(10.0, min(50.0, surf_weight))  # was max(5.0, ...)
   ```
2. Keep everything else identical
3. Run with `--wandb_group surf-floor-10`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** xgx7mlt6  
**Epochs completed:** 57/100 (30-minute timeout)  
**Peak memory:** 15.0 GB  

### Validation Loss
| Split | This run | Baseline |
|---|---|---|
| val_loss (avg) | 0.8819 | 0.8635 |
| in_dist | 0.6160 | — |
| ood_cond | 0.7273 | — |
| ood_re | 0.5624 | — |
| tandem_transfer | 1.6217 | — |

### Surface MAE
| Split | Ux | Uy | p | Baseline p |
|---|---|---|---|---|
| in_dist | 9.40 | 2.42 | 18.38 | 17.99 |
| ood_cond | 6.46 | 1.81 | 14.45 | 13.50 |
| ood_re | 6.06 | 1.59 | 27.79 | 27.79 |
| tandem | 7.77 | 2.90 | 37.76 | 37.81 |

### Volume MAE
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.18 | 0.39 | 20.68 |
| ood_cond | 0.79 | 0.30 | 13.18 |
| ood_re | 0.88 | 0.38 | 47.25 |
| tandem | 2.03 | 0.91 | 38.46 |

### What happened
The run was cut short by the 30-minute timeout at epoch 57. At that point, val_loss was 0.8819 vs the baseline 0.8635 — slightly worse. Surface MAE p was also slightly behind baseline on in_dist (18.38 vs 17.99) and ood_cond (14.45 vs 13.50), matching on ood_re (27.79), and marginally better on tandem (37.76 vs 37.81).

The model was still converging steadily at epoch 57 (every epoch was setting a new best), suggesting the floor=10 change didn't break training but did slow it down compared to the baseline. The higher floor likely forces more surface loss attention early, competing with volume loss and slowing the initial descent. Without more training time, it's unclear whether it would have converged to a better or worse final point.

The surf_weight stayed locked at the floor=10 throughout training (surf_weight: 10 in final summary), indicating the dynamic formula never pushed above 10. This means the floor is the binding constraint — the ratio vol_loss/surf_loss stayed below 10 the entire run.

### Suggested follow-ups
- Try floor=7 (halfway between 5 and 10) to see if a smaller nudge helps without slowing convergence
- Try floor=10 with a longer budget (e.g., T_max=80) to see if it catches up and eventually beats baseline
- Investigate why surf_weight never exceeded the floor — the dynamic ratio being <10 throughout suggests surf_loss grows proportionally with vol_loss, which may indicate the model is learning both jointly rather than one lagging behind