### PR TITLE
EMA decay=0.999 on Regime W (between 0.998 and 0.9995)

### DIFF
--- a/train.py
+++ b/train.py
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.999
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
EMA decay=0.998 is the current value. decay=0.9995 was just tested and hurt (+2.6%). The midpoint decay=0.999 (half-life ~1000 steps, ~5 epochs) provides slightly more conservative averaging than 0.998 without the over-smoothing of 0.9995. This is a fine-grained search in the EMA decay hyperparameter.

## Instructions
1. Change EMA decay from 0.998 to 0.999:
   ```python
   ema_decay = 0.999
   ```
2. Keep EMA start at epoch 40, everything else identical
3. Run with `--wandb_group ema-decay-999`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** `jyi3l6sa`
**Best epoch:** 59 / 100 (hit wall-clock limit, 31s/epoch)
**Peak memory:** 15.0 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5975 | 6.04 | 1.71 | 18.19 | 1.11 | 0.36 | 19.52 |
| val_tandem_transfer | 1.6216 | 5.26 | 2.02 | 38.83 | 1.90 | 0.87 | 38.32 |
| val_ood_cond | 0.7006 | 3.18 | 1.03 | 14.08 | 0.71 | 0.27 | 12.11 |
| val_ood_re | 0.5558 | 2.81 | 0.87 | 28.09 | 0.82 | 0.36 | 46.81 |
| **mean3** | **0.973** | **4.83** | **1.58** | **23.70** | — | — | — |

Baseline (Regime W): mean3=23.10 (in=17.99, ood=13.50, tan=37.81, re=27.79), val/loss=0.8635

**What happened:** Negative result. mean3 surface_p worsened from 23.10 → 23.70. All splits slightly worse: in_dist (17.99 → 18.19), ood_cond (13.50 → 14.08), tandem (37.81 → 38.83), ood_re (27.79 → 28.09). val/loss worsened from 0.8635 → 0.8689.

The slower decay (0.999 vs 0.998) doesn't help. Together with the 0.9995 result being worse (+2.6%), the pattern suggests that 0.998 is already at or near the optimal EMA decay for this model: slower decay (more averaging) consistently hurts. The model's late-training updates contain useful information that the EMA should track, so over-smoothing removes signal rather than noise.

**Suggested follow-ups:**
- Try decay=0.997 or 0.996 (faster averaging) to see if the opposite direction helps.
- Accept that EMA decay=0.998 is near-optimal and focus on other aspects.
- Check if the EMA start epoch matters more than the decay rate — a very early start might be allowing the EMA to track the model through an unstable early phase.