### PR TITLE
n_hidden=176 (capacity midpoint between Regime H and Regime W)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
     out_dim=3,
-    n_hidden=192,  # regime-w: full width with finer routing
+    n_hidden=176,  # nhidden176: midpoint between regime-h (160) and regime-w (192)
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=4,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition


### PR DESCRIPTION
## Hypothesis
Regime H (n_hidden=160) had the best in_dist (16.84) but weaker ood/tandem. Regime W (n_hidden=192) improved ood/tandem but regressed in_dist to 17.99. The midpoint n_hidden=176 (~660K params) may find the sweet spot: enough capacity for ood/tandem improvements while retaining more of Regime H's in_dist advantage. With slice_num=48 and n_head=4, each head gets 44-dim (between 40 and 48).

## Instructions
1. Change `n_hidden=192` to `n_hidden=176` in the model config
2. Keep slice_num=48, everything else identical
3. Run with `--wandb_group nhidden176`

**Expected**: ~14 GB memory, ~29s/epoch, ~62 epochs. Faster than Regime W (31s) but slower than Regime H (28s). The Goldilocks experiment.

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run:** `7vuvz1j3` (thorfinn/nhidden176, group: nhidden176)
**Peak memory:** 14.0 GB
**Training:** 60 epochs, 30.1 min

### Surface MAE (mae_surf_p, primary metric)

| Split | This run | Baseline (W, 192) | Delta |
|-------|----------|-------------------|-------|
| val_in_dist | 18.1 | 18.0 | +0.1 |
| val_ood_cond | 13.7 | 13.5 | +0.2 |
| val_ood_re | 27.8 | 27.8 | 0.0 |
| val_tandem_transfer | 39.7 | 37.8 | +1.9 |
| **mean3 (in+ood+tan)/3** | **23.8** | **23.1** | **+0.7** |

### Full Surface MAE breakdown (best checkpoint, epoch 60)

| Split | Ux | Uy | p | val/loss |
|-------|-----|-----|-----|---------|
| val_in_dist | 6.0 | 1.9 | 18.1 | 0.6048 |
| val_ood_cond | 3.6 | 1.1 | 13.7 | 0.6940 |
| val_ood_re | 3.2 | 1.0 | 27.8 | 0.5416 |
| val_tandem_transfer | 5.9 | 2.3 | 39.7 | 1.6482 |

**val/loss (4-split avg):** 0.8722 (baseline 0.8635)

### What happened

n_hidden=176 is consistently slightly worse than n_hidden=192 across all splits — the capacity midpoint doesn't find a Goldilocks zone, it just interpolates the performance. val/loss is 0.8722 vs 0.8635, and mean3 is 23.8 vs 23.1. Memory drops from 15.0 GB to 14.0 GB, saving 1 GB and allowing one extra epoch (60 vs 59), but that modest speedup doesn't compensate for the 1% capacity reduction.

The key signal: tandem regression (+1.9) is notably smaller than with 2.0x hard-mining (+2.7), but still loses vs Regime W. It appears that for this architecture, more hidden capacity is strictly better up to 192 — the performance didn't peak at 176.

### Suggested follow-ups
- Try n_hidden=208 or 224 to check if Regime W (192) is actually at the optimum or whether more capacity still helps.
- The consistent tandem regression (vs Regime W) with any variant suggests a different source of tandem error unrelated to hidden dim — worth investigating surface node coverage for foil-2.