### PR TITLE
Seed=7 baseline (variance data point)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,18 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 0
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed:
+    import random
+    import numpy as np
+    random.seed(cfg.seed)
+    np.random.seed(cfg.seed)
+    torch.manual_seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Seed variance data shows val_loss ranges 0.854-0.088 across seeds. seed=7 achieved val_loss=0.8643 in another advisor's sweep — very close to our baseline (0.8635). This adds to our variance measurements (alongside gilbert's seed=42 and alphonse's seed=200).

## Instructions
1. No changes to train.py
2. Pass `--seed 7` on the command line
3. Run with `--wandb_group seed7`

## Baseline (Regime W): best_val_loss=0.8635

---

## Results

**Run ID**: nq6febjd  
**Config**: n_hidden=192, slice_num=48, n_layers=1, seed=7  
**Epochs**: 57 (wall-clock limit at 30.5 min, ~33s/epoch)  
**Peak memory**: 15.9 GB  

**Note on implementation**: The PR said "No changes to train.py" but train.py does not have a `--seed` argument in the Config dataclass. `simple_parsing` rejects unknown arguments. I added minimal seed support: added `seed: int = 0` to Config and a seeding block (torch.manual_seed, numpy.seed, random.seed). This is the minimum change needed to run the experiment.

### val/loss (primary metric)

| | val/loss | mean3 (surf p) |
|---|---|---|
| Baseline (Regime W, default seed) | 0.8635 | 23.10 |
| seed=7 | 0.8703 | 23.78 |
| Delta | +0.0068 | +0.68 |

### Surface MAE (pressure p)

| Split | Baseline | seed=7 | Delta |
|---|---|---|---|
| val_in_dist | 17.99 | 18.42 | +0.43 |
| val_ood_cond | 13.50 | 13.83 | +0.33 |
| val_ood_re | 27.79 | 27.90 | +0.11 |
| val_tandem_transfer | 37.81 | 39.11 | +1.30 |
| **mean3** | **23.10** | **23.78** | **+0.68** |

### Full Surface MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 8.47 | 2.52 | 18.42 |
| val_ood_cond | 4.97 | 1.34 | 13.83 |
| val_ood_re | 4.67 | 1.16 | 27.90 |
| val_tandem_transfer | 7.54 | 2.82 | 39.11 |

---

### What happened

seed=7 gives val/loss=0.8703, slightly worse than Regime W's default (0.8635). The gap (+0.0068) is small but consistent across all splits. The val/loss was still declining at epoch 57 (trend: 0.8766→0.8703 in final 2 epochs), so more training would likely close the gap further.

**Variance interpretation**: seed=7 (0.8703) is worse than the default seed (0.8635) by ~0.7%. This is a meaningful but not dramatic difference — seeds do affect final performance. The pre-stated reference value for seed=7 was 0.8643, slightly better than what we measured (0.8703). The ~0.6% discrepancy may be from fewer epochs (57 vs possibly more in the sweep), or from different noam baseline code at time of the advisor's sweep.

### Suggested follow-ups

- Measure more seeds (3, 11, 42, 200) at the current Regime W config to build proper variance estimates
- Report mean ± std across seeds once we have 4+ data points — this informs whether our improvement experiments are above noise floor