### PR TITLE
Hard-mining start epoch 20 (from 30, earlier focus on difficult nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -733,8 +733,8 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
+        # Asymmetric hard-node mining for non-tandem samples after epoch 20 (vectorized)
+        if epoch >= 20:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))


### PR DESCRIPTION
## Hypothesis
Hard-mining currently starts at epoch 30. With the wider model (n_hidden=192) having more capacity to handle difficult nodes earlier, starting at epoch 20 gives 10 more epochs of focused training on hard surface nodes. This gives the EMA phase (epochs 40-58) better-differentiated weights to average.

## Instructions
1. Find where hard-mining starts (the epoch check, around line 737). Change the threshold from 30 to 20.
2. Keep everything else identical
3. Run with \`--wandb_group hard-mine-ep20\`

## Baseline (Regime W): best_val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---

## Results

**W&B run ID:** 1qezhp7u
**Run name:** nezuko/hard-mine-ep20
**Epochs completed:** 59 (hit 30-min wall-clock limit)
**Peak VRAM:** 15.0 GB
**Epoch time:** ~31s

### Metrics at best epoch (59)

| Split | val_loss | Surface Ux MAE | Surface Uy MAE | Surface p MAE | Volume MAE (Ux/Uy/p) |
|---|---|---|---|---|---|
| in_dist | 0.610 | 6.97 | 1.80 | **18.3** | 1.11 / 0.36 / 19.4 |
| ood_cond | 0.689 | 3.82 | 1.08 | **13.8** | 0.71 / 0.27 / 11.9 |
| ood_re | 0.529 | 3.44 | 0.89 | **27.4** | 0.82 / 0.36 / 46.6 |
| tandem | 1.632 | 6.83 | 2.44 | **38.9** | 1.93 / 0.88 / 38.4 |
| **best_val_loss** | **0.865** | | | | |

### vs. Baseline

| Metric | Baseline | This Run | Delta |
|---|---|---|---|
| best_val_loss | 0.8635 | 0.865 | +0.2% (essentially same) |
| Surface p in_dist | 17.99 | 18.3 | +1.6% (slightly worse) |
| Surface p ood_cond | 13.50 | 13.8 | +1.9% (slightly worse) |
| Surface p ood_re | 27.79 | **27.4** | **-1.3% (better)** |
| Surface p tandem | 37.81 | 38.9 | +3.0% (worse) |

### What happened

Mixed, marginal result. The overall loss is essentially at parity with baseline (0.865 vs 0.864). There's a small improvement on ood_re (-1.3% pressure MAE) but regressions on in_dist, ood_cond, and tandem. The net effect is noise-level variation.

The ood_re improvement might be real: starting hard-mining at epoch 20 exposes the model to difficult high-error surface nodes earlier, which may particularly help for the Reynolds-OOD split where difficult flow patterns are more extreme. But the tandem regression (+3%) suggests the earlier hard mining may destabilize learning on tandem samples, which are already harder.

The best_epoch was 59 (same as baseline), VRAM is identical (15.0 GB), and epoch time is unchanged — the change only affects when an existing code path activates.

### Suggested follow-ups

- **Hard-mining start epoch 15 or 25**: the sweet spot might not be 20. A sweep over {15, 20, 25} would clarify whether earlier is better or if 30 is already well-tuned.
- **Tandem-aware hard mining**: the current hard mining is skipped for tandem samples (`~is_tandem_batch`). The tandem regression here might be because better learning on non-tandem hard nodes comes at a small cost to tandem generalization. Consider whether tandem should also get hard mining.
- **Combine epoch 20 with a slower ramp**: instead of a hard cutoff, try a soft ramp-in of the hard mining weight starting at epoch 20 (0 → 1 over 10 epochs) to reduce disruption.