### PR TITLE
Coarse weight 2x (increase coarse loss for stronger multi-scale signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -770,7 +770,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 2.0 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
While norman is ablating coarse loss (setting it to 0), this tests the opposite: doubling the coarse weight. The coarse loss provides a multi-scale training signal. With 48-slice routing, stronger coarse signal may help the attention learn better spatial decompositions earlier in training. If the ablation shows coarse loss helps, increasing it might help more.

## Instructions
1. Find the coarse_weight or coarse loss scaling (look for where coarse_loss is added to the total loss). Double the coefficient.
2. Keep everything else identical
3. Run with `--wandb_group coarse-2x`

## Baseline (Regime W): best_val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---

## Results

**W&B run:** lm4mh95w
**Epochs completed:** 59/100 (30-min timeout)
**Peak memory:** ~22 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8893 | 0.8635 | +3.0% (worse) |
| Surface MAE p (in_dist) | 18.27 | 17.99 | +1.6% (slightly worse) |
| Surface MAE p (ood_cond) | 14.41 | 13.50 | +6.7% (worse) |
| Surface MAE p (ood_re) | 28.09 | 27.79 | +1.1% (slightly worse) |
| Surface MAE p (tandem) | 39.78 | 37.81 | +5.2% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 3.68 | 1.57 | 18.27 |
| ood_cond | 2.97 | 1.00 | 14.41 |
| ood_re | 2.96 | 0.88 | 28.09 |
| tandem | 3.89 | 1.85 | 39.78 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.10 | 0.36 | 19.63 |
| ood_cond | 0.73 | 0.28 | 12.29 |
| ood_re | 0.83 | 0.36 | 47.04 |
| tandem | 1.95 | 0.89 | 38.97 |

### What happened

Doubling the coarse weight (1.0 → 2.0) made results worse across all splits, particularly tandem (+5.2%) and ood_cond (+6.7%). The stronger coarse loss forces the model to optimize for spatially-pooled coarse accuracy at the expense of fine-grained node-level accuracy.

At the current scale of improvement (competing with val_loss ~0.865), the coarse loss at 1.0 already provides a useful multi-scale signal. Doubling it over-weights coarse spatial accuracy and disrupts the fine-grained surface accuracy that the model has been carefully optimized for.

Combined with the "no coarse" ablation (if it shows coarse helps at 1.0), this suggests the current weight of 1.0 is close to optimal — the coarse signal is useful but must be kept subordinate to the main vol/surf loss.

### Suggested follow-ups

- **Try coarse weight 0.5:** If 1.0 is optimal-ish, maybe 0.5 is slightly better (less interference with fine-grained gradients).
- **Adaptive coarse weight:** Decay the coarse weight during training (strong early, reduced late) — could benefit from the multi-scale signal early but avoid interference during fine-tuning.
- **Wait for no-coarse ablation result:** Norman's ablation will directly quantify how much coarse loss contributes. If it shows coarse=0 is better, we should drop it entirely.