### PR TITLE
Half noise intensity (reduce noise scale by 50% for in_dist improvement)

### DIFF
--- a/train.py
+++ b/train.py
@@ -665,15 +665,15 @@ for epoch in range(MAX_EPOCHS):
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+            noise_scale = 0.025 * (1 - epoch / 60)  # half-noise: 0.05 → 0.025
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
             noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            vel_noise = 0.0075 * (1 - noise_progress) + 0.0015 * noise_progress  # half-noise: 0.015/0.003 → 0.0075/0.0015
+            p_noise = 0.004 * (1 - noise_progress) + 0.0005 * noise_progress   # half-noise: 0.008/0.001 → 0.004/0.0005
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 


### PR DESCRIPTION
## Hypothesis
The no-noise ablation (senku) revealed that noise removal improves in_dist dramatically (17.49 vs 17.99) but hurts ood (14.54 vs 13.50). Halving the noise intensity may capture most of the in_dist gain while preserving enough noise for ood regularization. This is the MOST ACTIONABLE finding from the ablation round.

## Instructions
1. Find the noise computation in the training loop (where Gaussian noise is added to input features, typically controlled by a noise_scale parameter that decays with epoch)
2. Multiply the noise scale/magnitude by 0.5 (halve it). This should be the initial noise level before the annealing schedule.
3. Keep the annealing schedule the same (just start from a lower level)
4. Keep everything else identical (n_hidden=192, slice_num=48, etc.)
5. Run with `--wandb_group half-noise`

**Key insight**: Full noise hurts in_dist by 0.50 MAE. Zero noise hurts ood by 1.04. Half noise should split the difference — perhaps gaining 0.25 on in_dist while only losing 0.50 on ood. Net effect depends on how the combined metric weighs these.

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

**W&B run ID**: `xwj37jph`  
**Best epoch**: 59  
**Peak memory**: 15.0 GB  

### Metrics at best checkpoint

| Split | val/loss | Surface p |
|---|---|---|
| val_in_dist | 0.606 | **18.1** |
| val_ood_cond | 0.718 | **14.3** |
| val_ood_re | 0.565 | **28.1** |
| val_tandem_transfer | 1.682 | **40.3** |
| **combined val/loss** | **0.8927** | |

### vs. Baseline (Regime W)

| Metric | Baseline | Half-noise | Delta |
|---|---|---|---|
| val/loss | 0.8635 | 0.8927 | +0.029 ❌ |
| surf_p in_dist | 17.99 | 18.10 | +0.11 ≈ |
| surf_p ood_cond | 13.50 | 14.30 | +0.80 ❌ |
| surf_p ood_re | 27.79 | 28.10 | +0.31 ❌ |
| surf_p tandem | 37.81 | 40.30 | +2.49 ❌ |

### What happened

Half-noise did **not** produce the expected split-the-difference result. Performance is uniformly worse than the full-noise baseline across all metrics. The in_dist improvement from no-noise (which motivated this experiment) did not materialize — halving the noise gives in_dist=18.1, essentially the same as baseline (17.99).

The tandem split suffered most (+2.49), which is particularly problematic since tandem is already the hardest track.

This suggests the current noise schedule is not over-regularizing in_dist — the in_dist gain from zero-noise (17.49 vs 17.99) appears to come from the test-time distribution being noiseless, giving the zero-noise model an unfair advantage on in_dist. When we reduce noise by only 50%, the training distribution still has more noise than test, but the model doesn't generalize as well to ood because it received less data augmentation. The full noise level strikes a better balance for overall generalization.

### Suggested follow-ups

- The noise schedule may be well-calibrated already. **Quarter noise (0.25x)** could be tried to see if there's a sweet spot between 0 and 0.5x.
- **Input noise only (no target noise)**: separate the two noise types. Target noise is the stronger regularizer; input noise primarily provides data augmentation. Halving only the target noise while keeping input noise might recover in_dist without hurting ood.
- The no-noise in_dist improvement (17.49) was tested with a different batch seed. It may reflect run-to-run variance rather than a real effect of noise removal.