### PR TITLE
Coarse weight 1.5x (moderate increase, between 1x and 2x)

### DIFF
--- a/train.py
+++ b/train.py
@@ -770,7 +770,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 1.5 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
The no-coarse ablation showed coarse loss is ESSENTIAL (+40% regression when removed). Emma is testing 2x coarse weight. This tests 1.5x — a gentler increase that gives the coarse loss more influence without potentially over-weighting it. Since the ablation proved coarse is critical, increasing it moderately may help.

## Instructions
1. Find the coarse_weight or coarse loss scaling. Multiply the coefficient by 1.5.
2. Keep everything else identical
3. Run with `--wandb_group coarse-1.5x`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---
## Results

**W&B run:** `s1x94da2` (`gilbert/coarse-1.5x`, group: `coarse-1.5x`)

**Epochs completed:** 59 (hit 30-min timeout; ~30-31s/epoch)

**Peak memory:** 15.0 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | This run | Baseline (Regime W) | Δ | σ |
|-------|----------|---------------------|---|---|
| val_in_dist | 18.32 | 17.99 | +0.33 | ~1σ |
| val_ood_cond | 13.76 | 13.50 | +0.26 | ~0.7σ |
| val_ood_re | 28.13 | 27.79 | +0.34 | ~1σ |
| val_tandem_transfer | 38.72 | 37.81 | +0.91 | ~2.5σ |
| **mean3** | **23.6** | **23.1** | **+0.5** | ~1.4σ |

*σ calibrated from seed=42 test: ±0.35 on mean3_p, ±0.005 on val/loss*

### Val loss
- val/loss: **0.878** vs baseline 0.864 (Δ=**+0.014**, ~2.8σ)
- val_in_dist: 0.618, val_ood_cond: 0.701, val_ood_re: 0.557, val_tandem_transfer: 1.635

### Full Surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 5.01 | 1.74 | 18.32 |
| val_ood_cond | 2.86 | 1.07 | 13.76 |
| val_ood_re | 2.40 | 0.90 | 28.13 |
| val_tandem_transfer | 5.50 | 2.20 | 38.72 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.13 | 0.37 | 20.23 |
| val_ood_cond | 0.71 | 0.27 | 11.89 |
| val_ood_re | 0.82 | 0.36 | 47.00 |
| val_tandem_transfer | 1.91 | 0.87 | 37.63 |

---

### What happened

**Weak negative result.** Coarse weight 1.5x shows val/loss=0.878 vs baseline 0.864 (+0.014, ~2.8σ), suggesting a real though small regression. Most per-split metrics are within noise (±1σ), but val_tandem_transfer/mae_surf_p jumped +0.91 (~2.5σ) and val/loss has the largest deviation in this regime-W experiment series.

The hypothesis that increasing coarse weight would help (given the ablation showed coarse is critical) doesn't hold. "Critical for correctness" doesn't mean "more is better" — the current 1.0x weight may already be at or near the optimal for the coarse regularization effect. The 1.5x increase slightly over-regularizes at the coarse scale, hurting fine-grained surface detail (especially tandem geometry which is the most complex).

Context from the seed variance test (PR #1298): run-to-run σ ≈ 0.005 on val/loss and ≈ 0.35 on mean3_p. The val/loss regression here (+0.014) is ~2.8σ and likely a real (small) effect.

### Suggested follow-ups

- **Compare with Emma's 2x result**: If 1.5x is worse than baseline and 2x is also worse, this suggests coarse weight should not be increased at all. The existing 1.0x is the sweet spot.
- **Coarse weight 0.5x**: If 1.5x hurts, try reducing it to see if there's a "sweet spot" below 1.0x.
- **Coarse pool_size**: Rather than weight, try coarser pooling (128 instead of 64) for a different type of multi-scale regularization.