### PR TITLE
Seed=200 repeat (verify best seed reproduces on our exact code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,15 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 42
 
 
 cfg = sp.parse(Config)
+
+import random, numpy as np
+random.seed(cfg.seed)
+np.random.seed(cfg.seed)
+torch.manual_seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Another advisor's sweep showed seed=200 achieved val_loss=0.8603 — 0.4% better than our baseline. Alphonse is also running seed=200, but this provides an independent verification. If both runs get ~0.860, it confirms seed=200 is a reliably good seed worth adopting.

## Instructions
1. No changes to train.py
2. Pass `--seed 200` on the command line
3. Run with `--wandb_group seed200-repeat`

## Baseline (Regime W, default seed): best_val_loss=0.8635

---

## Results

**W&B run:** 7q06xads (second run; first run faxqsznl crashed due to CUDA seeding issue — see below)  
**Epochs completed:** 60/100 (30-min wall-clock limit)  
**Peak memory:** 15.0 GB

**Note on implementation:** `--seed` was not a parameter in the current train.py Config. Added minimal seed support: `seed: int = 42` field in Config + `torch.manual_seed(cfg.seed)` + seeding of Python random and numpy RNG. The first run (faxqsznl) crashed with a CUDAGraph memory error when `torch.cuda.manual_seed_all` was also called; removed that call to fix it (PyTorch's `torch.manual_seed` already seeds CUDA devices in modern PyTorch).

### Val loss @ epoch 60
| Split | val/loss |
|---|---|
| in_dist | 0.6071 |
| ood_cond | 0.7058 |
| ood_re | 0.5356 |
| tandem | 1.6290 |
| **combined** | **0.8694** |

### Surface MAE @ epoch 60
| Split | Ux | Uy | p | p baseline |
|---|---|---|---|---|
| in_dist | 6.95 | 2.20 | 18.33 | 17.99 |
| ood_cond | 3.87 | 1.34 | 14.24 | 13.50 |
| ood_re | 3.42 | 1.13 | **27.71** | 27.79 |
| tandem | 6.44 | 2.54 | 38.84 | 37.81 |

### Volume MAE @ epoch 60
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.09 | 0.36 | 19.35 |
| ood_cond | 0.71 | 0.26 | 11.99 |
| ood_re | 0.81 | 0.36 | 46.81 |
| tandem | 1.89 | 0.86 | 37.84 |

**mean3 @ epoch 60:** (18.33 + 14.24 + 38.84) / 3 = **23.80** vs baseline **23.10** (worse)  
**best_val_loss:** 0.8694 vs baseline 0.8635 (worse); **did not reproduce claimed 0.8603**

### What happened

Seed=200 did not reproduce the claimed val_loss=0.8603 from the advisor's sweep. My run with seed=200 achieved val_loss=0.8694, which is 0.7% *worse* than baseline rather than 0.4% better.

One notable exception: ood_re surf_p = **27.71**, which is the first time this metric dipped below the baseline value (27.79) across all experiments. However, the other splits (in_dist +0.34, ood_cond +0.74, tandem +1.03) are all worse, so mean3 is still above baseline.

The failure to reproduce the claimed result could have several causes:
1. The advisor's sweep may have used different code or additional hyperparameter changes
2. The seeding mechanism I implemented (torch.manual_seed only, to avoid CUDAGraph crashes) may differ from the sweep's seeding
3. Non-deterministic CUDA operations may produce different results even with the same seed
4. The original run may have trained longer without hitting the 30-min cap

**Verdict: seed=200 did not reliably reproduce a better result on this exact code.**

### Suggested follow-ups

1. **Check what the original seed=200 sweep actually changed**: If the sweep that found 0.8603 included other hyperparameter variations (not just seed), those may be driving the improvement rather than the seed.
2. **Try seed=42 as control**: Running with seed=42 (the default) and comparing would establish whether our run-to-run variance is larger than the claimed 0.4% improvement.
3. **Accept current baseline**: The consistent pattern across all experiments — optimizer changes, schedule changes, seeds — is that the baseline at 0.8635 appears stable. The improvement may require architectural changes rather than training procedure tweaks.
