### PR TITLE
Noise stop at epoch 40 (clean final 18 epochs for EMA averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -664,13 +664,13 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
+        if model.training and epoch < 60 and epoch < 40:
             noise_scale = 0.05 * (1 - epoch / 60)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
+        if model.training and epoch < 40:
             noise_progress = min(1.0, epoch / 60)
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress


### PR DESCRIPTION
## Hypothesis
The no-noise ablation showed noise removal improves in_dist by 0.50 (17.49 vs 17.99). Noise currently anneals to near-zero by ~epoch 60, but still adds variance. Stopping noise at epoch 40 (when EMA starts) gives 18 clean epochs for EMA to average over, combining the in_dist benefit of noise-free training with the ood benefit of noise during the learning phase (epochs 0-40).

## Instructions
1. Find the noise computation and add a hard cutoff at epoch 40: if epoch >= 40, set noise to 0 regardless of the annealing schedule
2. Keep the normal noise annealing for epochs 0-39
3. Keep everything else identical
4. Run with `--wandb_group noise-stop-ep40`

## Baseline: best_val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run:** `edward/noise-stop-ep40` (u6p96lxn), best epoch 58 (48 effective epochs past JIT warmup); W&B synced through epoch 57

**Peak memory:** 15.0 GB

| Split | mae_surf_p | vs baseline |
|-------|-----------|-------------|
| val_in_dist | 18.39 | +0.40 |
| val_ood_cond | 14.37 | +0.87 |
| val_tandem_transfer | 38.71 | +0.90 |
| val_ood_re | 28.26 | +0.47 |
| **mean3** | **23.82** | **+0.63 (+2.7%)** |

Surface MAE (Ux / Uy / p) by split (epoch 57, last W&B sync):
- val_in_dist: 5.32 / 1.79 / 18.39
- val_ood_cond: 3.23 / 1.16 / 14.37
- val_ood_re: 2.69 / 0.99 / 28.26
- val_tandem: 5.94 / 2.38 / 38.71

Volume MAE (Ux / Uy / p) by split:
- val_in_dist: 1.11 / 0.37 / 19.99
- val_ood_cond: 0.74 / 0.28 / 12.52
- val_ood_re: 0.85 / 0.37 / 47.27
- val_tandem: 1.94 / 0.88 / 38.08

val/loss (epoch 57): 0.8888; epoch 58 text log: val_in_dist=0.625, ood_cond=0.719, ood_re=0.561, tandem=1.644, est. combined ≈ 0.887

- **val/loss ≈ 0.887-0.889** vs baseline 0.8635 — **slight regression (+2.9%)**
- **mean3 = 23.82** vs baseline 23.19 — **slight regression (+2.7%)**

## What happened

Stopping noise at epoch 40 caused a small regression across all splits. The hypothesis was that clean epochs 40–57 would help EMA learn a tighter model, combining the benefits of noisy early training and clean late training. This did not work: the gradual noise annealing (epochs 40–60) appears to provide some ongoing regularization benefit that we lost by cutting it off early.

Notably, val_in_dist = 18.39 is WORSE than the full-noise baseline (17.99) and worse than what the no-noise ablation reportedly achieved (17.49). This is unexpected — the stopped-noise model performs worse on in_dist than both the full-noise and no-noise configs.

This suggests the noise annealing schedule in epochs 40–60 is part of a delicate training dynamic. Abruptly stopping it disrupts the learning trajectory rather than providing clean epochs.

## Suggested follow-ups

- Try noise-stop at epoch 50 (later cutoff, less disruption to the annealing schedule).
- The reported no-noise improvement (in=17.49) should be verified — it may reflect seed variance rather than a real signal.
- Consider a faster noise decay schedule (e.g., noise drops to 0 by epoch 40 instead of 60) rather than a hard stop.