### PR TITLE
Coarse weight 0.5x (test if current coarse is over-weighted)

### DIFF
--- a/train.py
+++ b/train.py
@@ -770,7 +770,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 0.5 * coarse_loss  # coarse-05x: halved from 1.0
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
Removing coarse loss was catastrophic (+40%). But the current weight might be too high. Testing 0.5x to see if reducing (not removing) coarse loss is beneficial — if 0x is catastrophic and 1x is baseline, 0.5x tests the in-between.

## Instructions
1. Find the coarse_weight coefficient and multiply by 0.5
2. Keep everything else identical
3. Run with `--wandb_group coarse-05x`

## Baseline: best_val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run:** nbgdoncr | **Epochs:** 59 (best checkpoint) / 60 (timeout) | **Group:** coarse-05x

### Validation losses (best checkpoint, epoch 59)

| Split | loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|---|
| val_in_dist | 0.5974 | ~10.17* | ~2.79* | 18.1 |
| val_ood_cond | 0.6894 | ~6.98* | ~1.98* | 13.8 |
| val_ood_re | 0.5370 | ~6.64* | ~1.78* | 27.8 |
| val_tandem_transfer | 1.6536 | ~8.24* | ~3.09* | 39.2 |
| **mean (val/loss)** | **0.8694** | | | |

*Ux/Uy values are from last logged epoch (60), within margin of best checkpoint.

**mean3 surf_p (in+ood+re)/3 = 19.9** (baseline 19.76) — **marginally worse**
**val/loss = 0.8694** (baseline 0.8635) — **worse**

### Volume MAE (last epoch)

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|
| val_in_dist | 1.09 | 0.36 | 19.63 |
| val_ood_cond | 0.72 | 0.27 | 11.66 |
| val_ood_re | 0.82 | 0.36 | 46.64 |
| val_tandem_transfer | 1.94 | 0.87 | 38.28 |

**Peak memory:** ~15.0 GB

### What happened

Negative result. Reducing coarse weight to 0.5x did not improve over baseline.

Per-split vs Regime W baseline (in=17.99, ood=13.50, re=27.79, tan=37.81):
- **in_dist**: 18.1 vs 17.99 — slightly worse (+0.11)
- **ood_cond**: 13.8 vs 13.50 — slightly worse (+0.30)
- **ood_re**: 27.8 vs 27.79 — essentially the same (+0.01)
- **tandem**: 39.2 vs 37.81 — worse (+1.39)

The coarse loss at 1.0x appears to be well-calibrated — reducing it to 0.5x slightly degrades performance, especially on tandem. This is the third data point on the coarse loss sensitivity: 0x is catastrophic, 0.5x is slightly below baseline, 1x is baseline (best so far). The coarse weight of 1.0x seems to be approximately optimal.

### Suggested follow-ups

- Try 1.5x or 2x coarse weight — the data suggests 1.0x might not be the true optimum, just the best tested so far
- The consistent tandem regression (−1.4 here, −0.7 in no-noise) hints that the tandem split has different spatial structure than non-tandem; coarse pooling by x-coordinate might be less effective for tandem geometries
- Consider trying coarse pooling sorted by y-coordinate or radial distance instead