### PR TITLE
EMA start epoch 35 (5 epochs earlier for more averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -535,7 +535,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 35
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
EMA start at 30 was tested and hurt (averaging over noisy mid-training). Start at 40 is current. Start at 35 is the midpoint — 5 more EMA epochs than baseline without going as early as the failed ep30 test. This gives 23 EMA epochs instead of 18.

## Instructions
1. Change ema_start_epoch from 40 to 35
2. Keep EMA decay=0.998, everything else identical
3. Run with `--wandb_group ema-start-35`

## Baseline: best_val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run:** yfbi4ksb  
**Epochs completed:** 57/100 (30-minute timeout)  
**Peak memory:** 15.0 GB  

### Validation Loss
| Split | This run (ep56) | Baseline |
|---|---|---|
| val_loss (avg) | 0.8905 | 0.8635 |
| in_dist | 0.6002 | — |
| ood_cond | 0.7373 | — |
| ood_re | 0.5418 | — |
| tandem_transfer | 1.6827 | — |

*(epoch 57 log: in_dist=0.5961, ood_cond=0.7299, ood_re=0.5362, tandem=1.6769, val_loss≈0.8848 — marginally better but W&B summary captures ep56)*

### Surface MAE (epoch 56)
| Split | Ux | Uy | p | Baseline p |
|---|---|---|---|---|
| in_dist | 7.23 | 2.20 | 18.06 | 17.99 |
| ood_cond | 3.83 | 1.50 | 14.66 | 13.50 |
| ood_re | 3.54 | 1.40 | 27.66 | 27.79 |
| tandem | 6.63 | 2.49 | 40.62 | 37.81 |

### Volume MAE (epoch 56)
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.10 | 0.36 | 19.59 |
| ood_cond | 0.73 | 0.28 | 12.38 |
| ood_re | 0.84 | 0.36 | 46.85 |
| tandem | 1.96 | 0.90 | 39.57 |

### What happened
Negative result. Starting EMA at epoch 35 (vs 40) made things worse, not better. Val_loss of 0.8905 at epoch 56 is higher than the baseline 0.8635. The critical failure is tandem_transfer surface pressure: 40.62 vs 37.81 baseline — a 7.4% regression on the most important OOD metric.

The ood_cond surface pressure also regressed (14.66 vs 13.50). Only ood_re improved slightly (27.66 vs 27.79). The extra 5 EMA epochs from an earlier start seem to have hurt generalization to the tandem geometry, likely because the EMA model is averaging over epochs where the tandem-specific features haven't converged yet.

This aligns with the prior ep30 result that also hurt — earlier EMA start appears to consistently degrade tandem transfer. The EMA benefit seems to require sufficient pre-training before averaging begins.

### Suggested follow-ups
- Try ema_start_epoch=45 (5 later than baseline) to test whether starting even later helps
- Try ema_start_epoch=50 (much later, when the model should be fully converged)
- The consistent pattern (ep30 hurt, ep35 hurt) suggests starting EMA later is the right direction, not earlier