### PR TITLE
Aux weight 2x (double aux loss — ablation showed it helps OOD)

### DIFF
--- a/train.py
+++ b/train.py
@@ -774,10 +774,10 @@ for epoch in range(MAX_EPOCHS):
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
+        loss = loss + 0.02 * re_loss
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
-        loss = loss + 0.01 * aoa_loss
+        loss = loss + 0.02 * aoa_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The no-aux ablation confirmed aux heads help ood generalization (+1.27 on ood_cond when removed). The current aux_weight is 0.01 for each head (Re, AoA). Doubling to 0.02 provides stronger auxiliary gradient signal, which may improve OOD generalization further.

## Instructions
1. Find the aux_weight values (currently 0.01 for Re and 0.01 for AoA predictions). Double both to 0.02.
2. Keep everything else identical
3. Run with `--wandb_group aux-weight-2x`

## Baseline: best_val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run:** `bpr7m7j5`
**Best epoch:** 59 / 100 (hit wall-clock limit, 31s/epoch; W&B synced through epoch 58)
**Peak memory:** 15.0 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6159 | 5.44 | 1.44 | 18.22 | 1.13 | 0.37 | 19.84 |
| val_tandem_transfer | 1.6140 | 5.47 | 1.87 | 37.91 | 1.92 | 0.87 | 37.44 |
| val_ood_cond | 0.7164 | 2.87 | 0.93 | 14.32 | 0.70 | 0.27 | 12.04 |
| val_ood_re | 0.5401 | 2.62 | 0.83 | 27.78 | 0.80 | 0.36 | 46.63 |
| **mean3** | **0.982** | **4.59** | **1.42** | **23.48** | — | — | — |

Baseline (Regime W): mean3=23.10 (in=17.99, ood=13.50, tan=37.81, re=27.79), val/loss=0.8635
(Note: epoch 59 was a new best in the log but W&B only synced through epoch 58; differences are small.)

**What happened:** Negative result. mean3 surface_p worsened from 23.10 → 23.48, val/loss from 0.8635 → 0.8716. However, the degradation is modest and unevenly distributed: tandem is nearly identical (37.91 vs 37.81), ood_re improved slightly (27.78 vs 27.79), while ood_cond worsened (14.32 vs 13.50) and in_dist worsened (18.22 vs 17.99).

Doubling aux_weight doesn't provide the hoped-for OOD improvement. The stronger auxiliary signal appears to slightly distract the main optimization rather than helping. The original 0.01 aux_weight was already close to optimal — the auxiliary objectives are small-magnitude signals (Re, AoA prediction) and the extra gradient is marginally too much. The ablation showing aux helps is about presence/absence, not magnitude.

**Suggested follow-ups:**
- Try aux_weight=0.005 (halving) to see if lighter auxiliary signal helps.
- Try aux_weight=0.02 only for re_loss (not AoA) to isolate which head is more useful.
- Accept 0.01 as near-optimal for aux weights and focus elsewhere.