### PR TITLE
Temperature clamp 0.2 at epoch 45 (sharper attention earlier)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 45:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.20)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
The attention temperature is clamped to 0.25 starting at epoch 50 in the current code. Sharper attention (lower temperature = 0.2) forces more decisive spatial routing, and starting 5 epochs earlier (epoch 45) gives the model more time with committed routing before the EMA-dominated final phase. This is a fine-grained attention dynamics change never tested on Regime W.

## Instructions
1. Find the temperature clamping code (around where temperature is clamped to 0.25 after epoch 50)
2. Change the clamp value from 0.25 to 0.20
3. Change the start epoch from 50 to 45
4. Keep everything else identical
5. Run with `--wandb_group temp-clamp-02-ep45`

## Baseline (Regime W)
- best_val_loss: 0.8635
- Surface MAE p: in_dist=17.99, ood_cond=13.50, ood_re=27.79, tandem=37.81

---

## Results

### Round 1 — n_head=4 code (original run)

**W&B run:** `1190ur47`  **Epochs:** ~62 (30-min timeout)

| Split | Baseline (n_head=4) | Round 1 | Δ |
|-------|---------------------|---------|---|
| in_dist | 17.99 | 17.57 | -2.3% ✓ |
| ood_cond | 13.50 | 13.44 | -0.4% ✓ |
| ood_re | 27.79 | 27.50 | -1.0% ✓ |
| tandem | 37.81 | 38.56 | +2.0% ✗ |
| **mean3** | **23.10** | **23.19** | **+0.4% (wash)** |
| val/loss | 0.8635 | **0.8568** | **-0.8% ✓** |

---

### Round 2 — Rebased on n_head=3 (advisor requested)

**W&B run:** `2xuu1g53`  **Epochs:** ~63 (30-min timeout)  **Peak VRAM:** ~15 GB

n_head=3 baseline: val/loss=0.8602, mean3=23.31 (run: `j0ay8k68`)

| Split | n_head=3 baseline | Round 2 | Δ |
|-------|-------------------|---------|---|
| in_dist | 17.50 | 17.15 | -2.0% ✓ |
| ood_cond | 13.49 | 14.11 | +4.6% ✗ |
| ood_re | 27.50 | 27.78 | +1.0% ✗ |
| tandem | 38.93 | 39.60 | +1.7% ✗ |
| **mean3** | **23.31** | **23.62** | **+1.3% (worse)** |
| val/loss | 0.8602 | 0.8735 | +1.5% (worse) |

*Note: W&B state shows "failed" due to pre-existing visualization crash after training. Metrics are valid.*

### What happened

**The hypothesis did not hold on n_head=3.**

On n_head=4 (Round 1), the change was a wash with a useful val/loss gain — 3 splits improved slightly, tandem regressed slightly, net mean3 was near-flat. On n_head=3 (Round 2), the change made things worse: only in_dist improved, while ood_cond, ood_re, and tandem all regressed. val/loss went up significantly (0.8602 → 0.8735).

**Likely reason:** n_head=3 uses wider attention heads (64-dim per head vs 48-dim with n_head=4). Wider heads may already benefit from softer routing — forcing hard commitment (0.20 clamp) fights against what n_head=3 is good at. The temperature dynamics that work for n_head=4 do not transfer to n_head=3.

### Suggested follow-ups

1. **Looser clamp on n_head=3**: Try clamp=0.25 or 0.30 at epoch 45 — earlier commitment without the aggressive sharpening.
2. **Temperature anneal on n_head=3**: Instead of a hard clamp, gradually reduce temperature over epochs 40-60 to avoid the abrupt transition that seems to hurt n_head=3.
3. **Drop this change on n_head=3**: The temp clamp 0.2/ep45 appears specific to n_head=4 and should not be carried forward to the current n_head=3 baseline.