### PR TITLE
Noise 0.75x (reduce noise by 25%, gentler than half-noise)

### DIFF
--- a/train.py
+++ b/train.py
@@ -665,15 +665,15 @@ for epoch in range(MAX_EPOCHS):
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+            noise_scale = 0.0375 * (1 - epoch / 60)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
             noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            vel_noise = 0.01125 * (1 - noise_progress) + 0.00225 * noise_progress
+            p_noise = 0.006 * (1 - noise_progress) + 0.00075 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 


### PR DESCRIPTION
## Hypothesis
Norman is testing half noise (0.5x). This tests 0.75x — a gentler reduction. The no-noise ablation showed full removal improves in_dist by 0.50 but hurts ood by 1.04. A 25% reduction should give ~0.12 in_dist gain with only ~0.26 ood cost — potentially net positive.

## Instructions
1. Find the noise scale/amplitude in the training loop. Multiply by 0.75 (reduce by 25%).
2. Keep everything else identical
3. Run with `--wandb_group noise-075x`

## Baseline: val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run:** nj7rukt3  
**Status:** Timed out at epoch 56/100 (30-min cap, runtime 28.8 min)

### Changes made
Two noise sources both scaled by 0.75×:
1. Input noise: `0.05` → `0.0375` (×0.75)
2. Target noise: vel `0.015→0.003` range → `0.01125→0.00225`; pressure `0.008→0.001` range → `0.006→0.00075`

### Metrics at epoch 56 (EMA model, mid-run)

| Split | val/loss | surf Ux | surf Uy | surf p | vol MAE (Ux/Uy/p) |
|-------|----------|---------|---------|--------|---------|
| in_dist | 0.6069 | 8.41 | 2.10 | 18.65 | 1.09 / 0.36 / 19.51 |
| ood_cond | 0.7358 | 4.75 | 1.27 | 14.75 | 0.73 / 0.28 / 12.52 |
| ood_re | 0.5620 | 4.33 | 1.10 | 28.36 | 0.81 / 0.36 / 47.14 |
| tandem | 1.6706 | 7.26 | 2.61 | 40.03 | 1.93 / 0.90 / 39.16 |

**mean3 (surf p, in+ood+tan / 3): 24.48 vs baseline 23.10 — worse (+5.9%)**  
in=18.65 (+0.66), ood=14.75 (+1.25), re=28.36 (+0.57), tan=40.03 (+2.22)

**val/loss: 0.8938 — worse than comparable mid-run runs with default noise**  
(seed=200 same epoch: 0.8727; lookahead-k5 same epoch: 0.8889; all with default noise)

**Peak GPU memory:** 74.43 GB

### What happened

Noise-075x at epoch 56 is slightly worse than same-config default-noise runs at the same epoch. The expected pattern (removing noise helps in_dist, hurts ood) is not visible here — the in_dist pressure (18.65) is actually higher than the default-noise runs at similar epochs (~18.4–18.9), and ood_cond is also worse.

This is a **mild negative signal**: reducing noise by 25% appears to slightly hurt performance at epoch 56, contrary to the hypothesis. 

Possible explanations:
1. The noise is still acting as a useful regularizer at epoch 56 (early-to-mid training), so reducing it hurts rather than helps
2. The benefit of noise reduction may only appear late in training (epoch 80+) after the model has already learned the core patterns; we can't observe this due to the timeout
3. The effect is small enough to be within normal run-to-run variance

**Verdict:** Mild negative signal at epoch 56 (16 EMA epochs). Cannot confirm or deny the hypothesis at full convergence.

### Suggested follow-ups

- **Compare with half-noise (Norman's run)**: if 0.5x also shows no benefit at epoch 56, this strongly suggests noise reduction doesn't help early training
- **Noise annealing**: rather than a fixed 0.75x multiplier, try stopping noise earlier (epoch 40 vs 60) — keeps full noise during exploration, removes it during convergence
- **Run to completion**: if 0.75x noise finds a better minimum at epoch 100, the regularization tradeoff may be worth it