### PR TITLE
Hard-mining start epoch 25 (midpoint between 20 and 30)

### DIFF
--- a/train.py
+++ b/train.py
@@ -733,8 +733,8 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
+        # Asymmetric hard-node mining for non-tandem samples after epoch 25 (vectorized)
+        if epoch >= 25:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))


### PR DESCRIPTION
## Hypothesis
Hard-mine ep20 (nezuko) nearly tied baseline (0.865 vs 0.8635) and improved re_p to 27.4 (from 27.79). But tandem regressed. Epoch 25 is a gentler earlier start that might capture the re_p improvement without the tandem penalty.

## Instructions
1. Change the hard-mining start epoch from 30 to 25
2. Keep everything else identical
3. Run with `--wandb_group hard-mine-ep25`

## Baseline: val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**Run ID**: 63lp2b49  
**Config**: n_hidden=192, slice_num=48, n_layers=1, hard-mine start=epoch 25  
**Epochs**: 56 (wall-clock limit at 30.1 min, ~33s/epoch)  
**Peak memory**: 15.9 GB  

### Surface MAE (pressure p) — primary metric

| Split | Baseline (ep30) | ep25 | ep20 (nezuko) | Delta vs baseline |
|---|---|---|---|---|
| val_in_dist | 17.99 | 18.76 | — | +0.77 (worse) |
| val_ood_cond | 13.50 | 14.10 | — | +0.60 (worse) |
| val_ood_re | 27.79 | 28.01 | 27.40 | +0.22 (worse) |
| val_tandem_transfer | 37.81 | 40.67 | — | +2.86 (much worse) |
| **mean3** | **23.10** | **24.51** | — | **+1.41 (worse)** |

### val/loss
- ep25: **0.9001** vs Baseline: 0.8635 (worse by +0.0366)  
- ep20 (nezuko): 0.865 (nearly tied)

### Full Surface MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 5.12 | 1.37 | 18.76 |
| val_ood_cond | 2.70 | 0.82 | 14.10 |
| val_ood_re | 2.21 | 0.67 | 28.01 |
| val_tandem_transfer | 5.75 | 1.97 | 40.67 |

### Volume MAE

| Split | Ux | Uy | p |
|---|---|---|---|
| val_in_dist | 1.15 | 0.37 | 19.81 |
| val_ood_cond | 0.74 | 0.28 | 12.22 |
| val_ood_re | 0.83 | 0.37 | 46.71 |
| val_tandem_transfer | 1.96 | 0.89 | 39.46 |

---

### What happened

Hard-mine ep25 is clearly worse than baseline (ep30) and also worse than ep20. The hypothesis that ep25 would capture the re_p benefit of ep20 without the tandem penalty did not hold. Instead, ep25 shows:

- **re_p got worse, not better** (28.01 vs ep20's 27.40 vs ep30 baseline's 27.79)
- **tandem took a massive hit** (+2.86 vs baseline, worse than ep20's regression)
- **val/loss gap is large** (+0.0366 vs baseline)

The pattern suggests that starting hard mining earlier consistently hurts tandem transfer. The tandem regression at ep25 (+2.86) is larger than at ep20, contradicting the hypothesis that a gentler earlier start avoids the penalty.

Looking at the broader picture: hard mining at ep30 (baseline) is the sweet spot for this experiment. Moving earlier (ep25 or ep20) consistently degrades performance. The model likely needs ~30 epochs to build good general representations before hard mining can help without hurting transfer.

### Suggested follow-ups

- **Try ep35** — if ep30 is the best, perhaps the model benefits from even later hard mining; the idea of "nudging" after convergence rather than mid-training
- **Hard mining with decaying weight** — rather than full hard mining, a gradual increase in the hard-node fraction starting later might avoid the tandem regression
- **Tandem-aware hard mining** — the current hard mining excludes tandem samples (is_tandem_batch), but the asymmetry may not be enough; consider lowering hard-mining intensity or making the exclusion more aggressive