### PR TITLE
Progressive temperature annealing (linear decay 1.0→0.15, epochs 30-55)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,13 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 30:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            if epoch <= 55:
+                target_temp = 1.0 - (1.0 - 0.15) * (epoch - 30) / (55 - 30)
+            else:
+                target_temp = 0.15
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=target_temp)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
The current temperature clamping is a hard switch (clamp to 0.25 at epoch 50). A gradual linear decay from 1.0 to 0.15 over epochs 30-55 allows the attention to progressively sharpen, avoiding the discontinuity of the hard clamp. The lower final value (0.15 vs 0.25) gives even sharper routing in the final phase.

## Instructions
1. Instead of the hard temperature clamp at epoch 50, implement a linear decay:
   \`\`\`python
   if epoch >= 30 and epoch <= 55:
       target_temp = 1.0 - (1.0 - 0.15) * (epoch - 30) / (55 - 30)
       # Clamp temperature to target_temp
   elif epoch > 55:
       target_temp = 0.15
   \`\`\`
2. Apply this as a clamp (temperature can't go below target_temp)
3. Keep everything else identical
4. Run with \`--wandb_group temperature-anneal\`

## Baseline: val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run ID:** ss12r1ac
**Run name:** nezuko/temperature-anneal
**Epochs completed:** 60 (hit 30-min wall-clock limit)
**Peak VRAM:** 15.0 GB
**Epoch time:** ~31s

### Metrics at best epoch (60)

| Split | val_loss | Surface Ux MAE | Surface Uy MAE | Surface p MAE | Volume MAE (Ux/Uy/p) |
|---|---|---|---|---|---|
| in_dist | 0.607 | 5.98 | 1.85 | **18.4** | 1.14 / 0.37 / 20.0 |
| ood_cond | 0.706 | 3.36 | 1.14 | **14.2** | 0.71 / 0.27 / 12.1 |
| ood_re | 0.540 | 2.96 | 1.00 | **27.7** | 0.81 / 0.36 / 46.9 |
| tandem | 1.633 | 6.01 | 2.35 | **38.6** | 1.91 / 0.88 / 38.2 |
| **best_val_loss** | **0.872** | | | | |

### vs. Baseline

| Metric | Baseline | This Run | Delta |
|---|---|---|---|
| best_val_loss | 0.8635 | 0.872 | **+0.9% (worse)** |
| Surface p in_dist | 17.99 | 18.4 | +2.4% (worse) |
| Surface p ood_cond | 13.50 | 14.2 | **+5.5% (worse)** |
| Surface p ood_re | 27.79 | 27.7 | -0.4% (negligible) |
| Surface p tandem | 37.81 | 38.6 | +2.0% (worse) |

### What happened

No improvement. The progressive temperature annealing is worse than the baseline hard clamp across all splits, with the largest regression on ood_cond (+5.5%). The overall val_loss is 0.9% higher.

Two possible explanations:

1. **Starting annealing too early.** Beginning the decay at epoch 30 (20 epochs before the EMA phase at epoch 40) may force the attention to sharpen before it has found good spatial decomposition. The hard clamp starting at epoch 50 leaves the model free to explore broadly during training and only constrains it near the end.

2. **Target temperature 0.15 may be too sharp.** The baseline clamps at 0.25, which already provides clear routing. Sharpening to 0.15 may over-commit to specific spatial partitions that were poorly learned, especially for OOD conditions.

The epoch count (60) is the same as other runs on this branch, and VRAM is unchanged, so the overhead of this approach is zero.

### Suggested follow-ups

- **Start annealing later (epoch 40 → 55)**: align the ramp with the EMA phase so sharpening happens during the refinement window, not during early learning.
- **Higher target temperature (0.20)**: keep the gradual decay but stop at a less extreme value to avoid over-committing.
- **Remove temperature annealing entirely**: with the current model, the hard clamp at epoch 50 (max=0.25) may already be close to optimal — the extra complexity of gradual annealing doesn't help.