### PR TITLE
Attention temp clamp 0.3 at epoch 45 (gentler sharp attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 45:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.30)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
The current temp clamp is 0.25 at epoch 50. Fern is testing 0.2 at epoch 45 (sharper, earlier). This tests 0.3 at epoch 45 — gentler sharpening but earlier start. The goal is to find the right balance: earlier sharpening gives more epochs with committed routing while a higher temp (0.3 vs 0.2) avoids over-committing.

## Instructions
1. Find the temperature clamping code (where temp is clamped to 0.25 after epoch 50)
2. Change clamp value from 0.25 to 0.30
3. Change start epoch from 50 to 45
4. Keep everything else identical
5. Run with `--wandb_group temp-clamp-03-ep45`

## Baseline: val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run:** 30da35l3
**Epochs completed:** 59/100 (30-min timeout)
**Peak memory:** ~22 GB

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8808 | 0.8635 | +2.0% (worse) |
| Surface MAE p (in_dist) | 18.22 | 17.99 | +1.3% (slightly worse) |
| Surface MAE p (ood_cond) | 14.42 | 13.50 | +6.8% (worse) |
| Surface MAE p (ood_re) | 27.75 | 27.79 | -0.1% (≈same) |
| Surface MAE p (tandem) | 39.09 | 37.81 | +3.4% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 5.30 | 1.74 | 18.22 |
| ood_cond | 2.65 | 0.97 | 14.42 |
| ood_re | 2.07 | 0.82 | 27.75 |
| tandem | 5.83 | 2.21 | 39.09 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.10 | 0.37 | 19.22 |
| ood_cond | 0.72 | 0.28 | 12.54 |
| ood_re | 0.83 | 0.36 | 46.71 |
| tandem | 1.91 | 0.86 | 38.46 |

### What happened

Temperature clamp 0.3 at epoch 45 did not improve results — all metrics are worse than baseline except ood_re p which is essentially the same. The combination of earlier start (45 vs 50) with gentler clamping (0.3 vs 0.25) doesn't outperform the baseline.

The baseline setting of temp=0.25 at epoch 50 appears well-calibrated. Changing either parameter independently (or both together as here) seems to hurt more than it helps:
- Earlier clamping (ep45) may cut off useful routing exploration in epochs 45-50
- Gentler clamping (0.3) may not provide enough sharpening benefit to overcome the earlier start disadvantage

The ood_cond regression (+6.8%) is consistent across several failed experiments, suggesting that ood_cond accuracy is particularly sensitive to the attention routing dynamics.

### Suggested follow-ups

- **Compare with Fern's temp=0.2 at ep45:** If Fern's experiment (sharper, earlier) shows different results, we can better understand the temperature-epoch tradeoff.
- **Try keeping temp=0.25 but earlier (ep40 or ep45):** Isolate the epoch variable from the clamp value to understand which matters more.
- **Accept baseline temp settings:** Given that multiple temperature clamp variations have failed, the baseline 0.25@ep50 appears to be a good default for the current model. Suggests diminishing returns from this direction.