### PR TITLE
Fast noise annealing (complete noise decay by epoch 30 instead of ~60)

### DIFF
--- a/train.py
+++ b/train.py
@@ -664,14 +664,14 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+        if model.training and epoch < 30:
+            noise_scale = 0.05 * max(0.0, 1 - epoch / 30)  # fast anneal: reaches 0 at epoch 30
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_progress = min(1.0, epoch / 60)
+            noise_progress = min(1.0, epoch / 30)  # fast anneal: reaches 1.0 at epoch 30
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)


### PR DESCRIPTION
## Hypothesis
The noise findings show: full noise (1.0x) helps ood but hurts in_dist. Half noise (0.5x) is worst of both worlds. What if the LEVEL is correct but the SCHEDULE is wrong? Currently noise anneals gradually to near-zero by epoch ~60. What if we anneal FASTER — completing the decay by epoch 30 instead of 60? This gives full noise benefit during the learning phase (epochs 0-30) and clean training during the refinement+EMA phase (epochs 30-58), avoiding the partial-noise trap that hurt half-noise.

## Instructions
1. Find the noise annealing schedule (the noise_scale computation that depends on epoch)
2. Make it decay faster — the noise should reach near-zero by epoch 30 instead of the current ~60
3. If the schedule is `noise_scale * (1 - epoch/max_epoch)`, change to `noise_scale * max(0, 1 - epoch/30)`
4. Keep the initial noise level the same (1.0x)
5. Keep everything else identical
6. Run with `--wandb_group noise-anneal-fast`

**Key insight**: This is NOT the same as noise-stop-ep40 (edward) which uses FULL noise then stops. This uses the FULL initial noise but decays it to zero by epoch 30, giving a smooth transition rather than a hard cutoff.

## Baseline: val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---

## Results

**W&B run ID**: `sllfwt6y`  
**Best epoch**: 60  
**Peak memory**: 15.0 GB  

### Metrics at best checkpoint

| Split | val/loss | Surface p |
|---|---|---|
| val_in_dist | 0.602 | **17.7** |
| val_ood_cond | 0.737 | **14.6** |
| val_ood_re | 0.568 | **28.2** |
| val_tandem_transfer | 1.645 | **39.0** |
| **combined val/loss** | **0.8878** | |

### vs. Baseline (Regime W)

| Metric | Baseline | Fast anneal | Delta |
|---|---|---|---|
| val/loss | 0.8635 | 0.8878 | +0.024 ❌ |
| surf_p in_dist | 17.99 | 17.70 | **-0.29** ✓ |
| surf_p ood_cond | 13.50 | 14.60 | +1.10 ❌ |
| surf_p ood_re | 27.79 | 28.20 | +0.41 ❌ |
| surf_p tandem | 37.81 | 39.00 | +1.19 ❌ |

### What happened

Mixed results. Fast annealing **did** improve in_dist surface pressure (-0.29), as expected from the hypothesis — clean training in the second half of the run reduces in_dist overfitting to noise. However, ood_cond and tandem got worse by a larger margin (+1.10 and +1.19 respectively), and the combined val/loss went up by 0.024.

The noise level after epoch 30 in the fast-anneal model is `0.003 * vel_noise` and `0.001 * p_noise` — much smaller than the original. This means the model trains on essentially noise-free targets for its last 30 epochs. While this helps in_dist accuracy, the OOD splits depend more on the noise regularization to avoid memorizing training distribution specifics, and the reduced noise in the second half hurts them.

The trade-off is unfavorable: gaining 0.29 on in_dist at the cost of 1.10 on ood_cond and 1.19 on tandem. The in_dist split is weighted equally to the others, so the net combined loss worsens.

The data strongly suggests that **the noise schedule should complete annealing later (or not at all), not sooner**. The regularization effect of noise is most valuable precisely during the EMA refinement phase (epochs 40+) when the model is fitting fine details.

### Suggested follow-ups

- **Reversed insight**: try extending the noise to MORE epochs or keeping a residual noise floor. The ablations consistently show that more noise helps OOD (which dominates the combined loss) while hurting in_dist.
- **Split noise by type**: keep target noise (strong regularizer) for longer but reduce input noise (primarily augmentation) faster. This could selectively retain OOD regularization while improving in_dist accuracy.
- **Target only the tandem noise**: tandem is hurt most by noise reduction. The tandem-specific adaptive boost already accounts for tandem difficulty; leaving noise at full for tandem samples while annealing faster for non-tandem could help.