### PR TITLE
Progressive volume subsample to 2048 (from 1024, more spatial context)

### DIFF
--- a/train.py
+++ b/train.py
@@ -713,9 +713,9 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
 
         # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+        # Ramps from 10% → 100% of volume nodes over first 20 epochs (was 40)
+        if epoch < 20:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / 20)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)


### PR DESCRIPTION
## Hypothesis
The training code progressively subsamples volume nodes to 1024 by epoch 30. With the wider model (n_hidden=192) and finer slicing (48), the model may benefit from more volume context. Doubling to 2048 subsampled nodes provides richer spatial information for the attention mechanism to route, potentially improving both surface accuracy (through better volume-surface coupling) and OOD generalization.

## Instructions
1. Find where the progressive volume subsampling target is set (the final number of volume nodes kept during training, usually 1024)
2. Change from 1024 to 2048
3. Keep everything else identical
4. Run with `--wandb_group progressive-vol-subsample`

**Expected**: Slightly more memory (~16-17 GB) and slightly slower epochs. But 2x more volume context could help surface accuracy.

## Baseline: val_loss=0.8635, in=17.99, ood=13.50, re=27.79, tan=37.81

---
## Results

**W&B run**: `0io3bfsc` (gilbert/progressive-vol-2x)

**Implementation note**: The current code has no literal "1024 node" cap -- instead it ramps `vol_keep_ratio` from 5%->100% over the first N epochs (with ~80K volume nodes per sample, that is ~4K->80K nodes, not 1024). The closest interpretation of "double the target" is to reach full coverage 2x faster. I changed the ramp endpoint from epoch 40 to epoch 20, so the model sees full volume context sooner.

### Metrics

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol (avg) |
|---|---|---|---|---|
| val_in_dist | 5.12 | 1.57 | **18.30** | 6.88 |
| val_ood_cond | 2.97 | 1.11 | **14.13** | 4.41 |
| val_ood_re | 2.74 | 0.98 | **27.82** | 16.02 |
| val_tandem_transfer | 5.24 | 2.07 | **38.53** | 13.46 |

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 0.8707 | 0.8635 | +0.0072 (~1.4sigma) |
| mean3 (surf_p: in+ood+tan)/3 | 23.65 | 23.10 | +0.55 (~1.6sigma) |

Peak memory: not logged (system metrics unavailable), expected ~15-16 GB (same model size as baseline).

### What happened

Near-null result. All changes are within noise (sigma ~+/-0.005 on val/loss, +/-0.35 on mean3). The change slightly worsened performance on every split, but none of the differences are statistically meaningful.

The faster ramp did not help -- exposing the model to full volume context earlier may have disrupted the gradual curriculum that aided training stability. The original 40-epoch ramp likely let the model learn good surface features first before being overwhelmed with full volume context.

The underlying premise (more nodes = better attention routing) may be misspecified: the model is likely not bottlenecked by the number of volume nodes in the loss, but rather by the attention mechanism ability to generalize to unseen geometries.

### Suggested follow-ups

- Try the opposite direction: slower ramp (epoch 60 or 80) to see if more curriculum helps
- Investigate whether the volume loss itself is necessary at all (zero-weight ablation)
- The progressive subsampling may interact with the coarse loss weight (1.5x) -- could test reducing coarse loss during ramp phase