### PR TITLE
Per-head tandem temperature offset (fix tandem regression)

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,7 +128,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
-        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, 1, 1, 1))
+        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
n_head=3 improved 3/4 splits but tandem regressed (+3.0%). The tandem_temp_offset is currently shape [1,1,1,1] — a single scalar shared across all heads. Making it per-head [1,3,1,1] lets each 64-dim head independently tune its attention sharpness for tandem flows: one head might sharpen (better wake), another might soften (broader interference). Only 3 new parameters.

## Instructions
1. In `Physics_Attention_Irregular_Mesh.__init__`, change:
   ```python
   self.tandem_temp_offset = nn.Parameter(torch.zeros(1, 1, 1, 1))
   ```
   to:
   ```python
   self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
   ```
2. No other changes — the forward pass already broadcasts correctly
3. Run with `--wandb_group perhead-tandem-temp`

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run ID**: `gmmvbn8s`
**Epochs completed**: 60 / 100 (30.4 min timeout)
**Peak memory**: 14.8 GB

### Metrics at best checkpoint (epoch 60)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | Δ vs n_head=3 |
|---|---|---|---|---|---|
| val_in_dist | 0.5737 | 6.19 | 1.99 | 17.11 | -0.39 ✓ |
| val_ood_cond | 0.7154 | 3.16 | 1.09 | 14.40 | +0.91 ✗ |
| val_ood_re | 0.5396 | 2.68 | 0.92 | 27.84 | +0.34 ✗ |
| val_tandem_transfer | 1.6113 | 6.50 | 2.50 | 38.30 | -0.63 ✓ |

**Best val/loss**: 0.8600 (n_head=3 baseline: 0.8602 → **no change**)
**mean3 surf_p (in, ood_cond, tandem)**: (17.11 + 14.40 + 38.30) / 3 = **23.27** (n_head=3: 23.31 → **no meaningful change**)

vs Regime W baseline (n_head=4): val/loss=0.8635, mean3=23.10 → still worse on mean3

### What happened

The per-head tandem temperature offset is essentially neutral. The gains and losses across splits are within run-to-run noise (+0.63 on tandem but -0.39 on in_dist; +0.91 on ood_cond). The net val/loss difference from n_head=3 is 0.0002 — indistinguishable from noise in a single run.

The tandem regression from n_head=3 (38.93 vs 37.81 baseline) improved slightly to 38.30, but it didn't fully recover to the n_head=4 tandem performance (37.81). Meanwhile ood_cond degraded slightly (14.40 vs 13.49 in n_head=3 baseline). These are the kinds of fluctuations expected across random seeds or minor hyperparameter changes.

The per-head temperature offset is a good low-cost idea, but tandem temperature adjustment doesn't appear to be the bottleneck for tandem performance. The tandem regression in n_head=3 likely reflects a capacity trade-off in the wider-head attention patterns, not a temperature calibration issue.

### Suggested follow-ups

- **Re-run n_head=3 with different seed**: The tandem regression may be noise. A second run would clarify whether the tandem issue is structural or stochastic.
- **Combine with Regime W n_head=4**: The per-head tandem_temp_offset could be tested on n_head=4 to see if it helps the baseline configuration.
- **Tandem-specific routing bias**: Instead of adjusting temperature, try adding a per-head learned bias to the tandem slice routing path to compensate for inter-foil flow patterns.