### PR TITLE
Per-head K,V projections (break multi-query bottleneck)

### DIFF
--- a/train.py
+++ b/train.py
@@ -171,9 +171,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
 
         q_slice_token = self.to_q(slice_token)
-        slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
-        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
-        v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
+        k_slice_token = self.to_k(slice_token)
+        v_slice_token = self.to_v(slice_token)
         q_norm = F.normalize(q_slice_token, dim=-1)
         k_norm = F.normalize(k_slice_token, dim=-1)
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale


### PR DESCRIPTION
## Hypothesis
Current multi-query attention computes K,V from `slice_token.mean(dim=1)` — averaging across heads before projecting. This forces all 3 heads to share the same key/value space. With wide 64-dim heads, each head should develop independent attention patterns. Removing the mean lets each head specialize: one for boundary-layer, one for wake, one for tandem interference.

## Instructions
1. In `Physics_Attention_Irregular_Mesh.forward`, replace:
   ```python
   slice_token_kv = slice_token.mean(dim=1, keepdim=True)
   k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
   v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
   ```
   with:
   ```python
   k_slice_token = self.to_k(slice_token)
   v_slice_token = self.to_v(slice_token)
   ```
2. No other changes
3. Run with `--wandb_group perhead-kv`

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run:** `wudjn4vp` | **Epochs:** 59/100 (30-min timeout) | **Peak VRAM:** 14.8 GB

| Split | Surface MAE Ux | Surface MAE Uy | Surface MAE p | Vol MAE Ux | Vol MAE Uy | Vol MAE p |
|---|---|---|---|---|---|---|
| val_in_dist | 5.22 | 1.52 | 18.60 | 1.12 | 0.36 | 20.12 |
| val_ood_cond | 3.37 | 1.00 | 15.03 | 0.72 | 0.28 | 12.71 |
| val_ood_re | 2.93 | 0.87 | 28.11 | 0.83 | 0.36 | 47.17 |
| val_tandem | 5.31 | 1.84 | 40.11 | 1.97 | 0.89 | 39.33 |

**val/loss:** 0.9031 | **mean3 (surf_p):** (18.60 + 15.03 + 40.11) / 3 = **24.58**

**Baseline:** val/loss=0.8602, mean3=23.31

### What happened

Per-head KV projections did **not** improve over multi-query. All 4 splits are worse than baseline:
- in_dist p: 18.60 vs 17.50 (+1.10)
- ood_cond p: 15.03 vs 13.49 (+1.54)
- ood_re p: 28.11 vs 27.50 (+0.61)
- tandem p: 40.11 vs 38.93 (+1.18)
- mean3: 24.58 vs 23.31 (+1.27, about 5.4% worse)
- val/loss: 0.9031 vs 0.8602 (+0.0429)

The hypothesis that each head should specialize is not validated here. The multi-query mean acts as a regularizer — sharing K,V forces a consensus representation that appears to generalize better. With 3 independent heads and only 48 slices, the per-head variant may be overfitting the attention patterns on the relatively small training set. It is also possible that the benefit of specialization requires more training epochs than available in 30 minutes.

Memory usage is unchanged at 14.8 GB — this change has zero memory overhead (same parameter count since `to_k`/`to_v` projections still map `dim_head → dim_head` per head).

### Suggested follow-ups

- **More epochs:** This run only completed 59/100 epochs. The per-head variant might converge more slowly and need a full run to compete. Not clear this is worth the cost without a stronger signal at 59 epochs.
- **Larger head dim:** The specialization argument gets stronger if dim_head is larger (e.g. n_head=2 with dim_head=96). Currently dim_head=64 which may be too small for per-head specialization to emerge robustly.
- **Partial sharing:** Try per-head V but shared K (or vice versa) to give each head different values while keeping a shared query/key similarity function.