### PR TITLE
Tandem-conditioned spatial bias (routing aware of gap/stagger)

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(3, 64), nn.GELU(),
+            nn.Linear(5, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -377,7 +377,7 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25], x[:, :, 21:23]], dim=-1)  # x, y, curvature, gap, stagger
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]


### PR DESCRIPTION
## Hypothesis
The spatial_bias MLP maps (x,y,curvature) to slice routing logits. For tandem flows, the gap and stagger between foils fundamentally change flow topology. Adding these 2 features to spatial_bias lets routing adapt to tandem geometry, directly targeting the tandem regression.

## Instructions
1. In TransolverBlock.__init__, change spatial_bias input dim from 3 to 5:
   ```python
   self.spatial_bias = nn.Sequential(
       nn.Linear(5, 64), nn.GELU(),
       nn.Linear(64, 64), nn.GELU(),
       nn.Linear(64, slice_num),
   )
   ```
2. In Transolver.forward, change raw_xy to include gap and stagger:
   ```python
   raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25], x[:, :, 21:23]], dim=-1)
   ```
   (x, y, curvature, gap, stagger — gap=idx21, stagger=idx22)
3. Run with `--wandb_group tandem-spatial-bias`

For single-foil samples gap=stagger=0, so the MLP learns to ignore them.

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run:** 22uf1bzm  
**Epochs completed:** 57/100 (30-min timeout)  
**Peak memory:** 14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8602 | 0.8998 | +4.6% worse |
| val_in_dist | mae_surf_p | 17.50 | 18.69 | +6.8% worse |
| val_ood_cond | mae_surf_p | 13.49 | 14.62 | +8.4% worse |
| val_tandem_transfer | mae_surf_p | 38.93 | 40.28 | +3.5% worse |
| val_ood_re | mae_surf_p | 27.50 | 28.06 | +2.0% worse |
| **mean3** | mae_surf_p | **23.31** | **24.53** | **+5.2% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=6.13, Uy=1.94, p=18.69 | Vol: Ux=1.10, Uy=0.38, p=19.88
- **ood_cond:** Ux=3.20, Uy=1.06, p=14.62 | Vol: Ux=0.73, Uy=0.28, p=12.44
- **ood_re:** Ux=2.61, Uy=0.88, p=28.06 | Vol: Ux=0.85, Uy=0.37, p=47.13
- **tandem_transfer:** Ux=6.20, Uy=2.49, p=40.28 | Vol: Ux=1.95, Uy=0.89, p=39.11

### What happened

The hypothesis did not improve over baseline. All four splits degraded. The tandem transfer MAE-surf-p went from 38.93 → 40.28 (+3.5%) — the opposite of the intended effect.

Two likely reasons:

1. **Zero-feature contamination**: For single-foil samples (majority of training data), gap=stagger=0. The MLP receives constant zeros for two of its five inputs on most batches. This degrades the spatial routing signal — the model is being trained mostly on 3-effective-dimensions, but must also learn to handle 5 real dimensions for tandem samples. The gradient signal for the gap/stagger dimensions is sparse and dominated by the zero-fill regime.

2. **Convergence lag**: The model was still clearly improving at epoch 57 (val/loss still monotonically decreasing), and the 5D spatial bias MLP has more to learn than the 3D version. The 30-minute budget may be insufficient for this architecture change to converge to competitive performance.

### Suggested follow-ups

- **Binary tandem indicator**: Replace gap+stagger with a single binary feature (is_tandem=1 for tandem samples, 0 otherwise). Simpler, no zero-contamination issue, still informs routing.
- **Separate tandem spatial bias**: Keep the 3D MLP for all samples, add a small tandem-only additive correction (multiplied by is_tandem). Single-foil samples see no change; tandem routing gets an extra signal.
- **Longer runs**: If this branch is revisited, running 2× longer (60 min budget, 100+ epochs) might close the convergence gap.