### PR TITLE
Deeper output head (3-layer MLP with intermediate LayerNorm)

### DIFF
--- a/train.py
+++ b/train.py
@@ -228,6 +228,9 @@ class TransolverBlock(nn.Module):
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
+                nn.LayerNorm(hidden_dim),
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
 


### PR DESCRIPTION
## Hypothesis
The output head is a 2-layer MLP. With n_head=3 producing richer 64-dim-per-head features, a deeper output head can better translate these into accurate predictions. Adding an intermediate layer with LayerNorm stabilizes the output pathway.

## Instructions
1. In TransolverBlock.__init__, replace the output head (inside `if self.last_layer:` block):
   ```python
   if self.last_layer:
       self.ln_3 = nn.LayerNorm(hidden_dim)
       self.mlp2 = nn.Sequential(
           nn.Linear(hidden_dim, hidden_dim),
           nn.GELU(),
           nn.LayerNorm(hidden_dim),
           nn.Linear(hidden_dim, hidden_dim),
           nn.GELU(),
           nn.Linear(hidden_dim, out_dim),
       )
   ```
2. No other changes
3. Run with `--wandb_group deeper-output-head`

~37K extra params on a ~750K model. Negligible memory cost.

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run:** leuunks1  
**Epochs completed:** 40/100 (crashed — CUDA OOM)  
**Peak memory (CPU/RAM):** 16.4 GB (vs 15.0 GB baseline)  

### What happened
**Crashed with CUDA Out of Memory at epoch 40.** This is exactly the epoch when EMA starts (`ema_start_epoch=40`), which triggers a `deepcopy(model)` to create the EMA model. The deeper output head's extra layer increases CUDA Graph private pool memory. When the EMA copy is attempted on top of nearly-full GPU memory (91.5 GB / 94.97 GB used), it fails.

Error: `torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 352.00 MiB. GPU 0 has a total capacity of 94.97 GiB of which 59.88 MiB is free.`

### Pre-crash metrics (epoch 40, before EMA)
Validation loss was 1.286 at crash time — still far from convergence. Surface MAE p at epoch 40 was much worse than baseline (in_dist=34.34 vs 17.50 baseline), indicating the model had not yet converged. This is expected since training was only ~40% through.

| Split | val/loss | surf p | Baseline surf p |
|---|---|---|---|
| in_dist | 1.038 | 34.34 | 17.50 |
| ood_cond | 1.074 | 21.90 | 13.49 |
| ood_re | 0.853 | 34.33 | 27.50 |
| tandem | 2.181 | 52.98 | 38.93 |

### Analysis
The crash is OOM-induced, not a training failure per se. The deeper output head adds ~37K params but those extra parameters + activations in the CUDA graph private pool push memory over the edge at the exact moment EMA deep copy is attempted. The training trajectory up to epoch 40 showed the model converging slowly (high variance in val_loss between epochs), which is also concerning.

### Suggested follow-ups
- Reduce `ema_start_epoch` from 40 to something after CUDA graphs stabilize, or investigate if the OOM is specifically a CUDA graph interaction
- Try the deeper head with a smaller `n_hidden` (e.g., 176 instead of 192) to reduce memory footprint and make room for the EMA copy
- Consider whether the deeper head is really needed — the current 2-layer MLP head seems adequate given baseline performance