### PR TITLE
Temp clamp 0.2 at epoch 40 (even earlier sharp attention on n_head=3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 40:  # temp-clamp-02-ep40: earlier start (40 vs 50), tighter cap (0.20 vs 0.25)
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.20)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
fern's temp-clamp-0.2@ep45 achieved val_loss=0.8568 on OLD n_head=4 code — BETTER than both baselines! This tests an even earlier start (epoch 40 instead of 45) on the NEW n_head=3 code. Epoch 40 coincides with EMA start, meaning the EMA model only sees sharp-attention checkpoints. With wider 64-dim heads, sharper attention should produce even more decisive routing.

## Instructions
1. Find the temperature clamping code (where temp is clamped to 0.25 after epoch 50)
2. Change clamp value from 0.25 to 0.20
3. Change start epoch from 50 to 40
4. Keep everything else identical (n_head=3, n_hidden=192, slice_num=48)
5. Run with `--wandb_group temp-clamp-02-ep40`

**Note**: fern is retesting temp-clamp-0.2@ep45 on n_head=3. This tests ep40 as a complementary data point. Together they bracket the optimal start epoch.

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run**: rfhokk3d | **Epochs**: 59 | **val/loss**: 0.8752

| Split | Ux | Uy | p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 6.17 | 1.73 | 18.1 | +0.60 ↑ |
| val_ood_cond | 3.29 | 1.04 | 14.3 | +0.81 ↑ |
| val_ood_re | 2.80 | 0.87 | 27.9 | +0.40 ↑ |
| val_tandem | 6.22 | 2.17 | 39.2 | +0.27 ↑ |

**mean3 (in+ood+re)/3 surf_p**: 20.10 vs baseline 19.50 → **+0.60 worse**

**Peak memory**: ~30 GB (same as baseline, no architectural change)

### What happened

Negative across all splits. Clamping to 0.20 at epoch 40 is too aggressive — it constrains attention before the model has converged, and epoch 40 is exactly when EMA begins, meaning the EMA model inherits a temperature-constrained initial state before learning optimal routing. The ep40 start appears too early: the baseline (no clamping until epoch 50) outperforms this variant by ~0.015 val/loss and +0.60 mean3.

The original temp-clamp-0.2@ep45 improvement on n_head=4 may not transfer cleanly to n_head=3 with the same timing, or the benefit was specific to the wider-head architecture where sharper routing is more beneficial.

### Suggested follow-ups

1. **Wait for fern's ep45 result**: if ep45 also degrades, temp-clamping may simply not help on n_head=3 — the mechanism may have been specific to n_head=4
2. **Try 0.20 at epoch 50 (tighter cap, same epoch)**: isolate whether the issue is the epoch or the cap value
3. **Try 0.25 at epoch 45**: bracket with a softer cap at the intermediate epoch