### PR TITLE
Temp clamp 0.15 at epoch 45 (even sharper attention on n_head=3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 45:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.15)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
temp-clamp-0.2@ep45 achieved val_loss=0.8568 on n_head=4 code. The trend shows sharper is better (0.3 hurt, 0.25 is baseline, 0.2 improved). This tests 0.15 — even sharper. With 3 wide heads (64-dim each), very sharp attention might help each head commit fully to its spatial specialization.

## Instructions
1. Change temp clamp value from 0.25 to 0.15
2. Change start epoch from 50 to 45
3. Keep everything else identical (n_head=3, n_hidden=192, slice_num=48)
4. Run with `--wandb_group temp-clamp-015-ep45`

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run:** 1auyydpo  
**Status:** Timed out at epoch 56/100 (30-min cap, runtime 28.5 min)

### Metrics at epoch 56 (EMA model, mid-run; temp clamp active since epoch 45 → 11 epochs of clamping)

| Split | val/loss | surf Ux | surf Uy | surf p | vol MAE (Ux/Uy/p) |
|-------|----------|---------|---------|--------|---------|
| in_dist | 0.6163 | 4.72 | 1.41 | 18.56 | 1.10 / 0.37 / 19.71 |
| ood_cond | 0.7350 | 3.32 | 1.00 | 14.74 | 0.73 / 0.28 / 12.54 |
| ood_re | 0.5693 | 2.76 | 0.77 | 28.41 | 0.82 / 0.36 / 47.27 |
| tandem | 1.6719 | 6.35 | 2.28 | 40.46 | 1.96 / 0.89 / 39.46 |

**mean3 (surf p, in+ood+tan / 3): 24.59 vs baseline 23.31 — worse (+5.5%)**  
in=18.56 (+1.06), ood=14.74 (+1.25), re=28.41 (+0.91), tan=40.46 (+1.53)

**val/loss: 0.8981 vs baseline 0.8602 — worse, but still improving (best = last epoch)**  
(16 EMA epochs since epoch 40; clamp active for only 11 epochs)

**Peak GPU memory:** 86.25 GB

### What happened

Run completed 56 epochs before timeout. The temperature clamp is only active from epoch 45, so only 11 epochs of clamped attention have occurred. With EMA starting at epoch 40 (16 EMA epochs), the averaged model hasn't had much clamped-regime training.

At epoch 56, results are slightly behind the n_head=3 baseline (which converged at epoch ~100). The trajectory is similar to other mid-run experiments. The val/loss is still improving, suggesting the model hasn't converged.

The clamping to 0.15 (vs 0.25 baseline) is quite aggressive — temperature is forced below its initial value (0.5) to 30% of that. Whether this helps at convergence (as 0.2 reportedly did) or hurts due to over-constraining is unknown from 11 epochs of clamped training.

**Verdict:** Inconclusive due to timeout. At epoch 56, performance is behind the n_head=3 baseline converged result, but this is expected mid-training. No signal that 0.15 is better or worse than 0.25/0.2 from this run.

### Suggested follow-ups

- **Run to full convergence** to see if the 0.2→0.15 trend continues — needs 60-min run
- **Check if temp actually reaches 0.15**: inspect the parameter value at epoch 45 before clamping to see if it was already below 0.15 (meaning the clamp had no effect)
- **Try temperature annealing from 0.25→0.15** over epochs 45-70 instead of hard clamping — smoother transition