### PR TITLE
Temp clamp 0.2 at epoch 50 (sharper value, keep baseline epoch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -801,7 +801,7 @@ for epoch in range(MAX_EPOCHS):
     scheduler.step()
     if epoch >= 50:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.20)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
Isolate the effect of the clamp VALUE from the clamp EPOCH. fern tested 0.2@ep45 (changed both). This keeps the epoch at 50 (baseline) but changes only the value to 0.2 (from 0.25). If the improvement is primarily from the sharper value, this should also work. If it's from the earlier epoch, this will be neutral.

## Instructions
1. Change temp clamp value from 0.25 to 0.20
2. Keep start epoch at 50 (unchanged from baseline)
3. Keep everything else identical (n_head=3, n_hidden=192, slice_num=48)
4. Run with `--wandb_group temp-clamp-02-ep50`

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run:** `61rhp9ja` | **Epochs:** 57 | **Epoch time:** ~32s

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|-----------|-----------|----------|
| in_dist | 5.76 | 1.79 | 18.67 | 1.12 | 0.37 | 19.59 |
| ood_cond | 3.61 | 1.21 | 14.01 | 0.73 | 0.27 | 12.05 |
| ood_re | 3.08 | 1.03 | 27.89 | 0.82 | 0.36 | 46.84 |
| tandem | 6.01 | 2.24 | 39.37 | 1.94 | 0.88 | 38.40 |

**Summary vs baseline:**

| Metric | Baseline (0.25@ep50) | This run (0.20@ep50) | Delta |
|--------|---------------------|---------------------|-------|
| val/loss | 0.8602 | 0.8748 | +0.0146 (+1.7%) |
| in_p | 17.50 | 18.67 | +1.17 (+6.7%) |
| ood_p | 13.49 | 14.01 | +0.52 (+3.9%) |
| re_p | 27.50 | 27.89 | +0.39 (+1.4%) |
| tan_p | 38.93 | 39.37 | +0.44 (+1.1%) |
| mean3 | 23.31 | 24.02 | +0.71 (+3.0%) |

**Peak memory:** not logged (system metrics unavailable for this run)

### What happened

Clamp 0.20@ep50 is **worse than baseline (0.25@ep50)** across all splits. The sharper clamp hurts — mean3 regresses by 3.0% and val/loss by 1.7%. The in-distribution split shows the largest absolute regression (+1.17 pressure MAE).

The hypothesis is falsified: the improvement from fern's 0.2@ep45 (if any) was NOT primarily from the sharper clamp value. It was from the earlier epoch (ep45 vs ep50), or a combination of both. Clamping at 0.20 instead of 0.25 (while keeping the epoch the same) is strictly worse.

Mechanistically, the baseline temperature clamp at 0.25 may already be well-calibrated for the attention dynamics in this model. Forcing a sharper 0.20 cap too early constrains the routing too aggressively, preventing the model from learning good spatial decompositions in the later training phase.

Note: the run logs show state="failed" because the visualization code at the end of train.py does not apply Fourier positional encoding before calling the model (line 1018), causing a shape mismatch. This is a pre-existing bug in noam's train.py; training and all metrics were logged successfully before the crash.

### Suggested follow-ups

1. **Test ep45 vs ep50 at 0.25**: fern's 0.2@ep45 changed both parameters. If the epoch matters more than the value, test clamp=0.25@ep45 to isolate the epoch effect.
2. **Fix visualization Fourier encoding bug**: train.py line 1014-1018 needs to apply Fourier PE before calling vis_model — the missing augmentation causes a crash.
3. **Try even softer clamping**: if 0.25 is already well-tuned, maybe 0.30 or removing the clamp entirely in later epochs would help.