### PR TITLE
n_head=3 baseline with seed=7 (variance measurement on new code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -420,10 +420,13 @@ class Config:
     wandb_group: str | None = None
     wandb_name: str | None = None
     agent: str | None = None
+    seed: int = 42
     debug: bool = False
 
 
 cfg = sp.parse(Config)
+
+torch.manual_seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Measure the natural variance of the n_head=3 baseline. The seed sweeps on n_head=4 showed ±1-2% variance. Understanding variance on n_head=3 is critical for evaluating the temp-clamp experiments — we need to know if a 0.4% improvement is real or noise.

## Instructions
1. No changes to train.py
2. Pass --seed 7 on the command line
3. Run with --wandb_group nhead3-seed7

## Baseline (n_head=3, default seed): val_loss=0.8602

---
## Results

**W&B run:** `w16unssu`
**Epochs completed:** 59/100 (30-min wall-clock limit)
**Peak memory:** 14.8 GB

**Implementation note:** train.py had no `--seed` argument. Added `seed: int = 42` field to Config and `torch.manual_seed(cfg.seed)` immediately after parsing. This is the only change — no model or training algorithm modifications.

### Validation metrics (best checkpoint, epoch 59)

| Split | val_loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6343 | 7.41 | 2.17 | 19.2 | 1.11 | 0.36 | 19.5 |
| val_tandem_transfer | 1.6754 | 6.91 | 2.70 | 40.0 | 1.93 | 0.87 | 38.9 |
| val_ood_cond | 0.7132 | 4.27 | 1.34 | 14.1 | 0.72 | 0.27 | 11.9 |
| val_ood_re | 0.5372 | 3.95 | 1.15 | 27.7 | 0.81 | 0.36 | 46.7 |
| **Combined val/loss** | **0.8900** | | | | | | |

### Comparison to baseline

| | Baseline (default seed) | Seed 7 | Delta |
|---|---|---|---|
| val/loss | 0.8602 | 0.8900 | +0.0298 (+3.5%) |

**Variance finding:** seed 7 is 3.5% worse than the default-seed baseline. This is substantially larger than the ±1-2% seen with n_head=4 seed sweeps. This means differences of ~0.4% on n_head=3 runs are well within noise — they are not statistically meaningful without multiple seed repeats.

### What happened

The variance is large. With two data points (default seed: 0.8602, seed 7: 0.8900), we observe a spread of 0.0298 (~3.5%). This is more than the ±1-2% reported for n_head=4. A few possible reasons:
- n_head=3 may have fewer attention heads to average over, making each run more sensitive to weight initialization
- The default seed run had no explicit seeding, so we are comparing two arbitrary initializations rather than two known seeds — the true variance with controlled seeds may be different

Crucially: any temp-clamp experiment showing <1% improvement on n_head=3 cannot be declared significant from a single run.

### Suggested follow-ups

- Run 2-3 more seeds (e.g. seed=42, seed=13) to get a proper variance estimate with n_head=3
- When comparing temp-clamp variants, run each at 2 seeds before declaring a winner
- Consider whether the large variance is an argument for going back to n_head=4 where variance was better characterized