### PR TITLE
n_head=3 baseline seed=42 (variance measurement on new code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,17 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int | None = None
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed is not None:
+    import random, numpy as np
+    torch.manual_seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
+    np.random.seed(cfg.seed)
+    random.seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Measure natural variance of the n_head=3 baseline. nezuko is running seed=7. Together these give us the noise floor for evaluating temp-clamp experiments.

## Instructions
1. No code changes to train.py
2. Pass --seed 42 on the command line
3. Run with --wandb_group nhead3-seed42

## Baseline (n_head=3, default seed): val_loss=0.8602

---
## Results

**W&B run:** hz3z96bm
**Epochs completed:** 59/100 (30-min timeout)
**Peak memory:** ~22 GB
**Seed:** 42

| Metric | Seed=42 (this run) | Default seed (baseline) | Δ |
|--------|---------------------|------------------------|---|
| val/loss | 0.8771 | 0.8602 | +2.0% |
| Surface MAE p (in_dist) | 18.19 | — | — |
| Surface MAE p (ood_cond) | 14.40 | — | — |
| Surface MAE p (ood_re) | 27.71 | — | — |
| Surface MAE p (tandem) | 38.48 | — | — |

Full Surface MAE (best epoch, seed=42):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 6.14 | 1.70 | 18.19 |
| ood_cond | 2.56 | 0.89 | 14.40 |
| ood_re | 2.12 | 0.72 | 27.71 |
| tandem | 5.98 | 2.19 | 38.48 |

**Note on implementation:** The `--seed` CLI argument did not exist in train.py, so I added a `seed: int | None = None` field to Config and minimal seeding code (torch.manual_seed, cuda.manual_seed_all, numpy.seed, random.seed). This is the only code change — no architecture or hyperparameter changes.

### What happened

The seed=42 run yields val_loss=0.8771, compared to the default-seed baseline of 0.8602. This is a ~2% variance between seeds for the n_head=3 configuration. Combined with nezuko's seed=7 run, this establishes the noise floor for evaluating temperature clamping experiments on this architecture.

Key implication: experiments that differ from the baseline by less than ~2% in val_loss may be within noise. This has implications for evaluating recent results — differences of 1-2% should be interpreted cautiously.

### Suggested follow-ups

- **Compile noise floor across all 3 seeds:** default, seed=42 (this), seed=7 (nezuko). If the range is ~2%, then we need improvements of ~3%+ to be confident they're signal not noise.
- **Consider ensemble of seeds for more reliable comparisons:** Two runs per variant would give more statistically reliable comparisons.