### PR TITLE
Temp-clamp 0.2@ep45 + seed=42 on n_head=3 (reproducibility check)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,17 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int | None = None
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed is not None:
+    torch.manual_seed(cfg.seed)
+    import random, numpy as np
+    random.seed(cfg.seed)
+    np.random.seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3
@@ -799,9 +807,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 45:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.20)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
fern is retesting temp-clamp-0.2@ep45 on n_head=3 with default seed. This runs the SAME experiment with seed=42 to verify reproducibility. If both runs beat baseline, the temp-clamp change is confirmed real (not seed noise).

## Instructions
1. Change temp clamp value from 0.25 to 0.20
2. Change start epoch from 50 to 45
3. Pass --seed 42 on the command line
4. Keep everything else identical (n_head=3, n_hidden=192, slice_num=48)
5. Run with `--wandb_group temp-clamp-02-ep45-seed42`

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---

## Results

**W&B run ID**: `js65w757`  
**Best epoch**: 59  
**Peak memory**: 14.8 GB  

### Metrics at best checkpoint

| Split | val/loss | Surface p |
|---|---|---|
| val_in_dist | 0.611 | **18.9** |
| val_ood_cond | 0.719 | **14.7** |
| val_ood_re | 0.546 | **27.9** |
| val_tandem_transfer | 1.644 | **38.7** |
| **combined val/loss** | **0.8802** | |

### vs. Baseline (n_head=3 baseline)

| Metric | Baseline | This run (seed=42) | Delta |
|---|---|---|---|
| val/loss | 0.8602 | 0.8802 | +0.020 ❌ |
| surf_p in_dist | 17.50 | 18.90 | +1.40 ❌ |
| surf_p ood_cond | 13.49 | 14.70 | +1.21 ❌ |
| surf_p ood_re | 27.50 | 27.90 | +0.40 ❌ |
| surf_p tandem | 38.93 | 38.70 | **-0.23** ✓ |

### What happened

**Reproducibility check fails.** This seed=42 run with temp-clamp 0.20@ep45 is **worse** than the n_head=3 baseline on all metrics except tandem (marginal improvement). The combined val/loss is 0.8802 vs 0.8602 baseline (+0.020).

This indicates the temperature clamp improvement seen in fern's default-seed run was likely **seed noise** rather than a real algorithmic improvement. When two runs of the same experiment — same code, different random seeds — produce opposite conclusions relative to baseline, that's strong evidence neither result reflects a systematic effect.

The temperature clamp hypothesis was: clamping attention temperature at a lower value (0.20) earlier (epoch 45 instead of 50) forces the model into a sharper attention regime sooner, potentially improving generalization. This seed=42 run doesn't support that hypothesis.

Run-to-run variance in these 30-minute experiments is significant: seeds produce different initialization of ~1.7M parameters, different data ordering, and different EMA model trajectories. The n_head=3 baseline itself likely carries ±0.015 uncertainty in val/loss.

### Suggested follow-ups

- **Average over multiple seeds**: run both baseline and temp-clamp 0.20@ep45 with 3+ seeds each to get a statistically meaningful comparison. A difference of 0.02 val/loss is within the noise for a single run.
- **Temperature dynamics are worth exploring**: the temperature parameter controls attention sharpness and is architecture-specific. A proper sweep over clamp values (0.15, 0.20, 0.25) with multiple seeds per setting would give a reliable signal.
- **n_head=3 seed stability**: the n_head=3 architecture itself may have higher variance than n_head=4 due to fewer independent attention heads. Baseline results for n_head=3 should be treated with more uncertainty.