### PR TITLE
Warmup 8 epochs on n_head=3 (schedule tuning for wider heads)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[8]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
warmup=8 was close to baseline on n_head=4 code (val_loss=0.8669, +0.4%). On n_head=3 with wider heads, the reduced warmup gives 2 more productive epochs with full LR. This might compound with the wider heads' better convergence behavior.

## Instructions
1. Change warmup total_iters from 10 to 8
2. Change milestones from [10] to [8]
3. Keep everything else identical (n_head=3, n_hidden=192, slice_num=48)
4. Run with `--wandb_group warmup8-nhead3`

## Baseline (n_head=3): val_loss=0.8602, in=17.50, ood=13.49, re=27.50, tan=38.93

---
## Results

**W&B run:** 6mgvghaj  
**Epochs completed:** 57/100 (30-minute timeout)  
**Peak memory:** 14.8 GB  

### Validation Loss
| Split | This run (ep56) | Baseline |
|---|---|---|
| val_loss (avg) | 0.8827 | 0.8602 |
| in_dist | 0.6066 | — |
| ood_cond | 0.7115 | — |
| ood_re | 0.5601 | — |
| tandem_transfer | 1.6526 | — |

*(epoch 57 log: in_dist=0.5944, ood_cond=0.7084, ood_re=0.5554, tandem=1.6565, val_loss≈0.8787)*

### Surface MAE (epoch 56)
| Split | Ux | Uy | p | Baseline p |
|---|---|---|---|---|
| in_dist | 5.91 | 1.67 | 18.12 | 17.50 |
| ood_cond | 3.23 | 1.06 | 14.18 | 13.49 |
| ood_re | 2.75 | 0.93 | 28.13 | 27.50 |
| tandem | 5.63 | 2.26 | 39.42 | 38.93 |

### Volume MAE (epoch 56)
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.10 | 0.37 | 19.09 |
| ood_cond | 0.72 | 0.28 | 12.36 |
| ood_re | 0.82 | 0.37 | 46.94 |
| tandem | 1.96 | 0.89 | 38.70 |

### What happened
Negative result. val_loss 0.8827 at epoch 56 vs baseline 0.8602 — consistently 2-3% worse across all splits. Surface MAE p is uniformly worse than baseline (in_dist: 18.12 vs 17.50, ood_cond: 14.18 vs 13.49, ood_re: 28.13 vs 27.50, tandem: 39.42 vs 38.93).

Warmup 8 on n_head=3 does not improve over warmup 10. Both runs were timed out at ~57 epochs, so the comparison is fair. The 2-epoch reduction in warmup doesn't give the model a meaningful benefit — any advantage of reaching full LR sooner appears to be offset by slightly worse initialization into the cosine schedule phase.

The result is weaker than on n_head=4 (where warmup=8 gave +0.4%), so the n_head=3 configuration does not benefit from the shorter warmup.

### Suggested follow-ups
- Try warmup=6 to see if even shorter warmup helps or hurts further
- Try warmup=12 (slightly longer than baseline) — perhaps n_head=3's wider heads need more careful warmup
- The pattern suggests warmup length is not a key lever for this architecture