### PR TITLE
OOD-conditioned noise (retain noise for extreme AoA samples)

### DIFF
--- a/train.py
+++ b/train.py
@@ -675,7 +675,10 @@ for epoch in range(MAX_EPOCHS):
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+            aoa_magnitude = x[:, 0, 14].abs()
+            aoa_max = aoa_magnitude.max().clamp(min=1e-6)
+            ood_factor = (0.5 + 0.5 * (aoa_magnitude / aoa_max).clamp(0, 1)).view(-1, 1, 1)
+            y_norm = y_norm + ood_factor * noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
With n_head=3, training reaches ~59 epochs. The cosine schedule (T_max=62) means the LR hasn't fully decayed by epoch 59. T_max=55 (warmup=10 + 55 cosine = completes at epoch 65) fits the 59-epoch window better, letting the LR reach near-minimum during the EMA phase.

## Instructions
1. After computing the noise_progress (epoch-dependent noise scale), add per-sample conditioning:
   ```python
   aoa_magnitude = x[:, 0, 14].abs()  # AoA feature at index 14
   aoa_max = aoa_magnitude.max().clamp(min=1e-6)
   ood_factor = 0.5 + 0.5 * (aoa_magnitude / aoa_max).clamp(0, 1)  # 0.5-1.0 range
   # Multiply noise scale by ood_factor (per-sample, shape [B])
   # Apply this factor when adding noise to targets
   ```
2. This should multiply the existing noise scale per sample
3. Keep everything else identical
4. Run with `--wandb_group ood-noise`

0 new parameters. Targets ood_cond regression specifically.

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `30hwr6i8`
**Best epoch:** 59 / 100 (hit wall-clock limit, ~31s/epoch)
**Peak memory:** 14.9 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6097 | 6.88 | 2.03 | 18.53 | 1.09 | 0.36 | 19.75 |
| val_tandem_transfer | 1.6437 | 6.23 | 2.35 | 39.29 | 1.92 | 0.87 | 38.67 |
| val_ood_cond | 0.7008 | 4.12 | 1.32 | 13.97 | 0.72 | 0.27 | 12.03 |
| val_ood_re | 0.5384 | 3.81 | 1.12 | 27.69 | 0.82 | 0.36 | 46.65 |
| **mean3** | **0.988** | **5.74** | **1.90** | **23.93** | — | — | — |

Baseline: mean3=23.27 (in=17.11, ood=14.40, tan=38.30, re=27.84), val_loss=0.8600

**What happened:** Negative result overall. mean3 surface_p worsened from 23.27 → 23.93, despite a partial win on ood_cond (14.40 → 13.97, -0.43). In-dist regressed significantly (17.11 → 18.53, +1.42), and tandem got slightly worse (38.30 → 39.29). The ood_re split also marginally improved (27.84 → 27.69).

The hypothesis was directionally correct for ood_cond — conditioning noise on AoA magnitude does help OOD generalization. But the gain is small and the in_dist cost is too large. The issue is that the ood_factor adds noise to more samples than expected: within a batch, even the 'typical' samples may have moderate AoA, so their ood_factor is 0.6-0.8 rather than the minimum 0.5. The full 2× reduction of noise floor (0.5× for low-AoA) may not be enough to protect in_dist convergence.

Additionally, this branch appears to be based on a configuration different from the n_head=2 baseline (the baseline listed here shows in=17.11, which is better than the n_head=2 adaptive baseline of 17.5). The gains on ood_cond may simply reflect variance rather than the conditioning effect.

**Suggested follow-ups:**
- Try ood_factor range 0.1–1.0 (more aggressive reduction for typical samples) to better protect in_dist.
- Try applying the per-sample factor only to p_noise (not vel_noise) since surface pressure is the main OOD concern.
- Investigate whether the ood_cond improvement (+0.43) is consistent across seeds or just noise — run a seed ablation.