### PR TITLE
Tandem curriculum extend to epoch 15 (longer single-foil warmup)

### DIFF
--- a/train.py
+++ b/train.py
@@ -705,7 +705,7 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
+        if epoch < 15:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask


### PR DESCRIPTION
## Hypothesis
The tandem-free curriculum currently runs for 10 epochs. With wider n_head=3 heads and per-head tandem temp, attention patterns need more time to stabilize on single-foil physics before tandem complexity. Extending to 15 epochs may prevent the ood_cond regression by giving more robust single-foil foundations.

## Instructions
1. Find the tandem curriculum section (around `if epoch < 10:` where tandem samples are skipped)
2. Change `10` to `15`
3. Keep everything else identical
4. Run with `--wandb_group tandem-curriculum-15`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `podt40z6` | **Epochs:** 59/100 (30-min timeout) | **Peak VRAM:** 14.8 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| val_in_dist | 17.11 | 19.27 | +2.16 ▲ worse |
| val_ood_cond | 14.40 | 14.20 | -0.20 ▼ better |
| val_ood_re | 27.84 | 28.26 | +0.42 ▲ worse |
| val_tandem | 38.30 | 39.06 | +0.76 ▲ worse |
| **mean3** (in/ood_cond/tan) | **23.27** | **24.18** | **+0.91 ▲ worse** |

**val/loss:** 0.8895 vs baseline 0.8600 → worse (+3.4%)

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 5.86 | 1.71 | 19.27 |
| val_ood_cond | 3.45 | 0.93 | 14.20 |
| val_ood_re | 3.11 | 0.75 | 28.26 |
| val_tandem | 6.32 | 2.21 | 39.06 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.14 | 0.38 | 19.72 |
| val_ood_cond | 0.71 | 0.27 | 12.04 |
| val_ood_re | 0.82 | 0.36 | 47.11 |
| val_tandem | 1.92 | 0.87 | 38.27 |

### What happened

Extending the curriculum from 10→15 epochs hurt overall performance, especially in-distribution (+2.16 on mae_surf_p). The hypothesis was that attention patterns need more time to stabilize on single-foil physics before seeing tandem pairs — but in practice, the opposite appears to be true: the model benefits from seeing tandem pairs sooner.

With the 30-minute budget (~59 epochs total), the two runs compare as:
- **Baseline (epoch<10):** 49 epochs of tandem training (epochs 10–59)
- **This run (epoch<15):** 44 epochs of tandem training (epochs 15–59)

Losing ~10% of tandem exposure likely explains the in-distribution regression — the model learns cross-foil interaction patterns from tandem data even on in-distribution cases. The tiny ood_cond improvement (-0.20) is within noise.

The current 10-epoch warmup appears to be well-tuned or a sweet spot for this training budget. A shorter warmup (e.g. epoch<5) might be worth testing.

### Suggested follow-ups
- Try **epoch<5** (shorter warmup): if 10 is already helping, 5 might be neutral or positive
- Try **no curriculum** (epoch<0 equivalent): ablate whether the warmup helps at all
- If longer training is ever possible (>60 epochs), revisit epoch<15 — it may improve with more tandem exposure time