### PR TITLE
T_max=55 on per-head tandem temp code (LR schedule alignment)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
T_max=55 was tested on pre-merge n_head=3 code and showed cur_vl=0.894. The per-head tandem temp changes convergence dynamics. Retesting T_max=55 on the updated code with per-head tandem temp may work better now. The LR schedule completes closer to the 59-epoch budget.

## Instructions
1. Change T_max=62 to T_max=55
2. Keep everything else identical
3. Run with `--wandb_group tmax55-v2`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run**: `9xzza2c9` (gilbert/tmax55-v2), 59 epochs

Note: run marked "failed" in W&B due to a visualization error at the very end (shape mismatch in vis_model, unrelated to the T_max change). All 59 training epochs completed normally and metrics are valid.

### Metrics

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol (avg) |
|---|---|---|---|---|
| val_in_dist | 7.60 | 2.00 | **17.72** | 6.93 |
| val_ood_cond | 4.07 | 1.29 | **14.17** | 4.34 |
| val_ood_re | 3.58 | 1.17 | **27.53** | -- |
| val_tandem_transfer | 6.99 | 2.35 | **39.65** | 13.87 |

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 0.8720 | 0.8600 | +0.0120 (~2.4sigma) |
| mean3 (surf_p: in+ood+tan)/3 | 23.85 | 23.27 | +0.58 (~1.7sigma) |

Peak memory: not logged.

### What happened

Negative result. T_max=55 performs slightly worse than T_max=62 on this codebase. val/loss is +0.012 worse (~2.4sigma above noise floor), and mean3 is +0.58 worse (~1.7sigma). The tandem transfer set regressed the most (39.65 vs 38.30 baseline).

The LR schedule completing at epoch 55 vs 62 appears to be mildly harmful here -- the model benefits from continued cosine annealing through the full ~59-epoch training budget. With T_max=55, the LR has already reached eta_min=5e-5 by epoch 55, leaving the last 4 epochs at a flat low LR that may not help optimization.

The hypothesis that per-head tandem temperature changes convergence dynamics in a way that benefits from a shorter schedule was not confirmed.

### Suggested follow-ups

- T_max=65 or 70 might be worth testing (schedule slightly longer than the 59-epoch budget for smoother tail)
- The vis_model shape mismatch error (84905x25 vs 57x57) happens at inference time and is an existing bug in the visualization code, not training -- worth fixing separately