### PR TITLE
Attention LR 0.3x on per-head tandem temp code (slower attention for wider heads)

### DIFF
--- a/train.py
+++ b/train.py
@@ -572,7 +572,7 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
+    {'params': attn_params, 'lr': cfg.lr * 0.3},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)


### PR DESCRIPTION
## Hypothesis
With n_head=3 (64-dim/head) and per-head tandem_temp_offset, the attention pathway has more influence. Slowing attention parameter learning (0.3x instead of 0.5x LR) may preserve ood generalization by preventing the attention from overfitting to in_dist patterns. Previously tested on old n_head=4 code with no clear result — the wider heads change the dynamics.

## Instructions
1. Change `cfg.lr * 0.5` to `cfg.lr * 0.3` for the attention parameter group
2. Keep everything else identical
3. Run with `--wandb_group attn-lr-03x-v2`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** myzqx63o  
**Epochs completed:** 57/100 (30-min timeout)  
**Peak memory:** 14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8600 | 0.8842 | +2.8% worse |
| val_in_dist | mae_surf_p | 17.11 | 19.24 | +12.5% worse |
| val_ood_cond | mae_surf_p | 14.40 | 14.31 | -0.6% better |
| val_tandem_transfer | mae_surf_p | 38.30 | 38.75 | +1.2% worse |
| val_ood_re | mae_surf_p | 27.84 | 28.04 | +0.7% worse |
| **mean3** | mae_surf_p | **23.27** | **24.10** | **+3.6% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=6.56, Uy=1.89, p=19.24 | Vol: Ux=1.11, Uy=0.37, p=20.17
- **ood_cond:** Ux=3.79, Uy=1.12, p=14.31 | Vol: Ux=0.73, Uy=0.28, p=12.27
- **ood_re:** Ux=3.46, Uy=0.96, p=28.04 | Vol: Ux=0.82, Uy=0.36, p=46.86
- **tandem_transfer:** Ux=6.34, Uy=2.40, p=38.75 | Vol: Ux=1.92, Uy=0.88, p=38.14

### What happened

The hypothesis did not improve over baseline. In_dist surface pressure degraded substantially (+12.5%), and tandem is essentially unchanged (+1.2%). The only partial win is ood_cond (-0.6%) — negligible.

The OOD preservation hypothesis didn't hold. Slowing the attention LR from 0.5x to 0.3x appears to hurt in-distribution performance without providing meaningful OOD protection. The attention pathway seems to need faster learning to accurately capture in-dist patterns within the 30-minute budget, and the 0.3x multiplier simply under-fits the attention parameters.

The fact that ood_cond is marginally better (and re/tandem essentially unchanged) weakly supports the overfitting hypothesis in principle, but the in_dist regression is too large to consider this a viable trade-off.

### Suggested follow-ups

- **0.4x multiplier**: A middle ground might retain in_dist performance while softening attention overfitting. The 0.5→0.3 jump may have been too large.
- **Warmup then slow**: Start with 0.5x LR for attention, then reduce to 0.3x after epoch 30 (once the attention has learned basic patterns). This avoids the under-fitting problem in early training.