### PR TITLE
Per-head auxiliary loss (head-specific OOD gradient signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -314,8 +314,10 @@ class Transolver(nn.Module):
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
-        self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
-        self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.n_head = n_head
+        _dim_head = n_hidden // n_head
+        self.re_head = nn.ModuleList([nn.Linear(_dim_head, 1) for _ in range(n_head)])
+        self.aoa_head = nn.ModuleList([nn.Linear(_dim_head, 1) for _ in range(n_head)])
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
@@ -389,9 +391,10 @@ class Transolver(nn.Module):
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
 
-        # Auxiliary Re prediction from pre-output-head hidden representation
-        re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
-        aoa_pred = self.aoa_head(fx.mean(dim=1))
+        # Auxiliary Re/AoA prediction: per-head spatial mean for head-specific OOD gradient
+        _fx_mean = fx.mean(dim=1).reshape(fx.shape[0], self.n_head, -1)  # [B, n_head, dim_head]
+        re_pred = torch.stack([self.re_head[h](_fx_mean[:, h]) for h in range(self.n_head)], dim=1).mean(dim=1)
+        aoa_pred = torch.stack([self.aoa_head[h](_fx_mean[:, h]) for h in range(self.n_head)], dim=1).mean(dim=1)
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)


### PR DESCRIPTION
## Hypothesis
The aux heads (Re/AoA prediction) operate on `fx.mean(dim=1)` — averaging across spatial positions equally. With per-head tandem temp creating different attention patterns per head, some heads may drift from the OOD-regularizing gradient signal. Ensuring each head receives direct aux loss gradient should protect ood_cond generalization.

## Instructions
1. In `Transolver.forward`, where the auxiliary loss is computed (before the last block), the Re/AoA heads currently take `fx` after spatial mean. Instead, compute auxiliary predictions per-head:
   - Reshape `fx` from [B, N, 192] to [B, N, 3, 64]
   - Take spatial mean per head: [B, 3, 64]
   - Concatenate back to [B, 192] and pass through existing re_head/aoa_head
   - OR: simply pass each head's 64-dim mean through a small linear(64, 1) per head and average
2. The goal: every head gets direct gradient from the auxiliary task
3. Keep everything else identical
4. Run with `--wandb_group perhead-aux`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `mhps8po2`
**Epochs:** 59 (30-min timeout)
**Peak VRAM:** 14.8 GB

| Metric | Baseline (perhead-tandem-temp) | This run | Δ |
|--------|-------------------------------|----------|---|
| val/loss | 0.8600 | 0.8798 | +0.0198 ↑ worse |
| surf_p in_dist | 17.11 | 18.52 | +1.41 ↑ worse |
| surf_p ood_cond | 14.40 | 14.31 | -0.09 ↓ better |
| surf_p ood_re | 27.84 | 27.52 | -0.32 ↓ better |
| surf_p tandem | 38.30 | 39.78 | +1.48 ↑ worse |
| **mean3** | **23.27** | **24.20** | +0.93 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**What happened:** The per-head auxiliary prediction did not help. The primary cause is a ~30× capacity reduction: the original re_head/aoa_head were Linear(192→32→1) ~6K params each; the per-head version is 3× Linear(64→1) ~192 params each. The smaller heads likely have insufficient capacity to learn meaningful OOD regularization, weakening the aux loss signal. In_dist and tandem both regressed, while ood_cond and ood_re improved only marginally (<0.4). Net effect is worse overall.

The theoretical motivation (per-head gradients) is plausible, but dividing the channel dimension of `fx.mean` into head-sized chunks does not correspond to head-specific representations — at this stage `fx` is the combined output of all heads. The gradient routing benefit assumed is not actually achieved this way.

**Suggested follow-ups:**
1. Try per-head aux with equal capacity: Linear(64→32→1) per head to restore parameter count while keeping the per-head structure.
2. Route gradients before the final block's attention mixing (so head-specific features are truly separate) rather than after.
3. Alternatively, increase aux loss weight to compensate for the weakened heads — though this is not the right fix, it could serve as a control.