### PR TITLE
Hard-mining boost 1.8x (gentler increase on per-head tandem temp code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -741,7 +741,7 @@ for epoch in range(MAX_EPOCHS):
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
-            hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
+            hard_weights = (hard_mask.float() * 0.8 + 1.0).unsqueeze(-1)  # 1.8 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)


### PR DESCRIPTION
## Hypothesis
Hard-mining boost 2.0x was too aggressive (regressed tandem). 1.5x is current. 1.8x is a gentler increase that focuses more gradient on hard nodes without the tandem penalty. On the per-head tandem temp code, the tandem-specific temperatures may interact differently with the hard-mining boost.

## Instructions
1. Find the hard-mining boost factor (currently 1.5). Change to 1.8.
2. Keep everything else identical
3. Run with `--wandb_group hard-mine-18x`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---

## Results

**W&B run:** `zdb8b1j7`
**Epochs:** ~63 (30-min timeout)
**Peak VRAM:** ~15 GB

*Note: W&B state shows "failed" due to pre-existing visualization crash after training. Metrics are valid.*

### Surface MAE (pressure) — primary metric

| Split | Baseline (1.5x) | This run (1.8x) | Δ |
|-------|-----------------|-----------------|---|
| in_dist | 17.11 | 18.94 | +10.7% ✗ |
| ood_cond | 14.40 | 14.33 | -0.5% ✓ |
| ood_re | 27.84 | 27.64 | -0.7% ✓ |
| tandem | 38.30 | 39.84 | +4.0% ✗ |
| **mean3** | **23.27** | **24.37** | **+4.7% (worse)** |

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|------|
| in_dist | 7.14 | 2.37 | 18.94 |
| ood_cond | 4.46 | 1.60 | 14.33 |
| ood_re | 3.96 | 1.41 | 27.64 |
| tandem | 6.41 | 2.70 | 39.84 |

### Losses

| Metric | Baseline (1.5x) | This run (1.8x) |
|--------|-----------------|-----------------|
| val/loss | 0.8600 | 0.8813 |
| train/surf_weight (final) | — | 6.06 |

### What happened

**Did not work.** Increasing the hard-mining boost to 1.8x made things worse, consistent with the pattern that 2.0x was previously shown to be "too aggressive." In fact, even 1.8x appears to be too aggressive.

The most notable regression is **in_dist surf_p: 17.11 → 18.94 (+10.7%)**. This is a large degradation for a small parameter change. The in-distribution split has many medium-difficulty nodes that benefit from uniform weighting; heavily boosting the hardest nodes forces the model to specialize on extremes at the expense of typical cases.

Only ood_cond and ood_re showed tiny improvements (within noise), likely because these OOD conditions have more consistently hard nodes where the extra focus helps.

The pattern is clear: the 1.5x boost strikes the right balance. Going above 1.5x consistently hurts in_dist and tandem splits, which represent the bulk of the evaluation.

### Suggested follow-ups

1. **1.5x is the sweet spot** — further search in the 1.5-2.0x range is unlikely to yield gains. The boost hyperparameter appears saturated.
2. **Hard-mining start epoch**: Currently epoch 30. Starting earlier (epoch 20) or later (epoch 40) might be more impactful than changing the boost factor.
3. **Surface-only hard mining for tandem**: Apply hard mining to tandem samples too, but only on surface nodes (not excluded entirely as currently done). May help tandem without hurting in_dist.