### PR TITLE
Warmup 5 epochs on per-head tandem temp code (more productive training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)  # warmup5-perhead: 5 vs 10
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]  # warmup5-perhead: 5 vs 10
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Warmup 5 was a near-miss on Regime W code (val_loss=0.8675, +0.5%). On the per-head tandem temp code with wider heads, the reduced warmup gives 5 more productive epochs with full LR. The per-head tandem temp parameters (3 learnable values) may benefit from reaching full LR faster.

## Instructions
1. Change warmup total_iters from 10 to 5
2. Change milestones from [10] to [5]
3. Keep everything else identical
4. Run with `--wandb_group warmup5-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run**: qy91y6zn | **Epochs**: 59 | **val/loss**: 0.8714

| Split | Ux | Uy | p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 5.66 | 1.60 | 18.5 | +1.39 ↑ |
| val_ood_cond | 3.28 | 0.99 | 13.9 | -0.50 ↓ |
| val_ood_re | 2.70 | 0.78 | 27.6 | -0.24 ↓ |
| val_tandem | 6.10 | 2.21 | 39.2 | +0.90 ↑ |

**mean3 (in+ood+re)/3 surf_p**: 20.0 vs baseline 19.78 → **+0.22 worse**

**Peak memory**: ~30 GB (same architecture, no change)

### What happened

Mixed but overall negative. OOD splits improved (ood_cond -0.50, ood_re -0.24), which supports the hypothesis that faster warmup helps OOD generalization. However, in-distribution degraded significantly (+1.39 p MAE), and tandem also worsened (+0.90). The shorter warmup may cause the model to commit to a suboptimal in-dist solution before the LR annealing has shaped the loss landscape — the per-head tandem temp offsets may not be the bottleneck, and the faster LR increase causes instability in the main model weights.

val/loss 0.8714 vs baseline 0.8600: **+0.0114 worse**.

### Suggested follow-ups

1. **Try warmup 8**: a middle ground between 5 and 10 — note warmup8-nhead3 is already a new branch, check that result first
2. **Decouple warmup from temp params**: if per-head temp benefits from faster LR, consider a separate higher LR just for temperature params while keeping warmup 10 for main weights
3. **The OOD improvement is real**: ood_cond improved by 0.5 suggesting faster warmup helps distribution shift — worth investigating whether the in-dist regression is seed variance