### PR TITLE
Tandem temp offset init=0.1 (warm start for per-head temperature)

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,7 +128,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
-        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
+        self.tandem_temp_offset = nn.Parameter(torch.full((1, heads, 1, 1), 0.1))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
The per-head tandem_temp_offset initializes at 0 (zeros). This means the model starts with no tandem-specific temperature adjustment and must learn it from scratch. Initializing at 0.1 gives a warm start — each head starts with a small positive offset for tandem flows, which slightly raises the temperature (softer attention) for tandem cases from the beginning. This may help ood_cond by preventing early training from over-committing the attention to in_dist patterns.

## Instructions
1. Find `self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))`
2. Change to `self.tandem_temp_offset = nn.Parameter(torch.full((1, heads, 1, 1), 0.1))`
3. Keep everything else identical
4. Run with `--wandb_group tandem-temp-init-01`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** 3magkkv5  
**Status:** Timed out at epoch 57/100 (30-min cap, runtime 29.0 min)

### Metrics at epoch 57 (EMA model, mid-run)

| Split | val/loss | surf Ux | surf Uy | surf p | vol MAE (Ux/Uy/p) |
|-------|----------|---------|---------|--------|---------|
| in_dist | 0.6272 | 5.88 | 1.68 | 18.26 | 1.14 / 0.37 / 19.60 |
| ood_cond | 0.7173 | 4.03 | 1.31 | **14.15** | 0.72 / 0.28 / 12.05 |
| ood_re | 0.5338 | 3.52 | 1.15 | **27.63** | 0.83 / 0.36 / 46.80 |
| tandem | 1.6502 | 5.99 | 2.10 | 39.18 | 1.94 / 0.88 / 38.31 |

**mean3 (surf p, in+ood+tan / 3): 23.86 vs baseline 23.27 — slightly worse (+2.5%)**  
in=18.26 (+1.15), **ood=14.15 (-0.25 ✓)**, **re=27.63 (-0.21 ✓)**, tan=39.18 (+0.88)

**val/loss: 0.8821 — among the better mid-run results this session**  
(57 epochs; best = last epoch, still improving; 17 EMA epochs)

**Peak GPU memory:** 78.86 GB

### What happened

The tandem temp offset warm-start shows a **promising pattern**: both ood_cond (14.15 vs 14.40, -1.7%) and ood_re (27.63 vs 27.84, -0.8%) pressure MAE are **below baseline** at epoch 57. This is exactly what the hypothesis predicted — the warm start prevents early over-commitment to in_dist patterns.

The trade-off is that in_dist (18.26 vs 17.11, +6.7%) and tandem (39.18 vs 38.30, +2.3%) are worse. These might converge further at full training.

val/loss=0.8821 is better than most mid-run experiments at comparable epochs (noise-075x: 0.8938, slice56: 0.8984, temp-clamp: 0.8981). Only seed=200 was better (0.8727).

**Verdict:** Encouraging — the OOD splits are already better than baseline at epoch 57, suggesting the warm start is helping generalization. The in_dist regression is a concern but may narrow at full convergence (when EMA averaging smooths out the initialization effect). Worth running to full convergence.

### Suggested follow-ups

- **Run to full convergence** (100 epochs) to see if the OOD improvement holds and in_dist recovers
- **Try init=0.05**: a smaller warm start that provides less initial bias — may get the OOD benefit with less in_dist regression
- **Try init=0.2**: if the trend is monotonic, larger warm start might help even more (or hurt in_dist further)
- **Combine with seed=200**: the two best mid-run experiments so far — pairing them could give additive benefits