### PR TITLE
Aux weight 0.015 (50% increase for stronger OOD regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -774,10 +774,10 @@ for epoch in range(MAX_EPOCHS):
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
+        loss = loss + 0.015 * re_loss
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
-        loss = loss + 0.01 * aoa_loss
+        loss = loss + 0.015 * aoa_loss
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
The aux heads (Re/AoA prediction) use weight=0.01. Ablation showed removing them hurts ood_cond (+1.27). The per-head tandem temp may have partially disrupted the aux gradient signal. A 50% increase to 0.015 provides stronger OOD regularization without the dramatic 2x increase that was previously tested.

## Instructions
1. Find the aux_weight values (currently 0.01 for Re and AoA heads)
2. Change both to 0.015
3. Keep everything else identical
4. Run with `--wandb_group aux-weight-015`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `mqr7yen0` (nezuko/aux-weight-015)
**Best epoch:** 59 / 59 (wall-clock limit)
**Peak memory:** 14.8 GB

### val/loss comparison

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8600 | **0.8792** | +0.0192 ↑ worse |

### Surface MAE by split

| Split | Ux | Uy | p | vs baseline (p) |
|-------|----|----|---|-----------------|
| val_in_dist | 4.88 | 1.79 | 18.27 | 17.11 → +1.16 ↑ |
| val_ood_cond | 2.60 | 1.02 | 14.27 | 14.40 → -0.13 ↓ |
| val_ood_re | 2.13 | 0.88 | 27.74 | 27.84 → -0.10 ↓ |
| val_tandem | 5.87 | 2.28 | 40.31 | 38.30 → +2.01 ↑ |

### Volume MAE by split

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.08 | 0.37 | 19.32 |
| val_ood_cond | 0.70 | 0.27 | 11.78 |
| val_ood_re | 0.82 | 0.36 | 46.69 |
| val_tandem | 1.94 | 0.89 | 39.47 |

---
### What happened

**Negative result.** Overall val/loss degraded from 0.8600 → 0.8792 (+2.2%). The hypothesis that a 50% increase in aux weight would provide stronger OOD regularization was not supported.

Breaking down by split:
- **ood_cond/ood_re:** Tiny improvements (-0.13, -0.10 surface pressure) — marginally consistent with the regularization hypothesis, but within noise
- **val_in_dist:** Worse by +1.16 surface pressure — stronger aux gradient is pulling the model away from in-distribution accuracy
- **val_tandem:** The biggest concern: +2.01 surface pressure degradation. The tandem-specific pathway (tandem_temp_offset) may be competing with the stronger Re/AoA signal, since tandem configurations differ significantly in Re/AoA distribution

The net effect is that the extra aux weight regularizes too aggressively for in-dist and tandem cases, and the ood improvements are negligibly small.

Note: post-training visualization crashed with a pre-existing shape mismatch bug (unrelated to this change).

### Suggested follow-ups

- The ood_cond/ood_re micro-improvements suggest the aux heads do help OOD, but at the cost of in-dist/tandem accuracy — possibly the aux loss weight needs to be made **split-aware** (e.g., apply stronger weight only on non-tandem OOD samples)
- Alternatively, try asymmetric aux weights: slightly raise the AoA aux weight alone (Re may already be well-predicted), as AoA variation drives ood_cond
- Consider whether the aux heads need their own learning rate to avoid interfering with the main backbone at higher weights