### PR TITLE
Warmup 8 epochs on per-head tandem temp code

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[8]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Warmup 8 was close on older code (val_loss=0.8669, +0.4%). On the per-head tandem temp code, the wider heads and per-head temperature params may benefit from reaching full LR slightly earlier. 2 fewer warmup epochs = 2 more epochs of productive training.

## Instructions
1. Change warmup total_iters from 10 to 8
2. Change milestones from [10] to [8]
3. Keep everything else identical
4. Run with `--wandb_group warmup8-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** 9re8nhro
**Epochs completed:** 59/100 (30-min timeout)
**Peak memory:** 14.8 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8716 | 0.8600 | +1.3% (worse) |
| Surface MAE p (in_dist) | 17.81 | 17.11 | +4.1% (worse) |
| Surface MAE p (ood_cond) | 14.01 | 14.40 | -2.7% (better) |
| Surface MAE p (ood_re) | 28.15 | 27.84 | +1.1% (slightly worse) |
| Surface MAE p (tandem) | 39.06 | 38.30 | +2.0% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 5.35 | 1.67 | 17.81 |
| ood_cond | 3.35 | 1.05 | 14.01 |
| ood_re | 2.77 | 0.88 | 28.15 |
| tandem | 5.53 | 2.20 | 39.06 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.07 | 0.35 | 18.63 |
| ood_cond | 0.72 | 0.27 | 11.98 |
| ood_re | 0.83 | 0.37 | 46.98 |
| tandem | 1.91 | 0.88 | 38.36 |

### What happened

Shorter warmup did not help on the per-head tandem temp code. Overall val/loss regressed +1.3%, in_dist pressure rose +4.1%, and tandem pressure +2.0%. The one bright spot is ood_cond pressure dropped from 14.40 to 14.01 (-2.7%), but that is within the ~2% noise range established by PR #1333.

This result mirrors the original warmup8 test (PR #1294 on Regime W): that also regressed, and the hypothesis posited that the per-head tandem structure might change things. It did not.

Possible reasons:
1. **10 warmup epochs is already near-optimal.** Cutting it by 20% just makes the early phase noisier without adding useful training time.
2. **Per-head temps are low-parameter.** Each block has 4 temperature scalars (one per head). Their optimization does not require a different warmup relative to the heavy attention weight matrices.
3. **The 2 "extra productive" epochs cost more than they gain.** The cosine LR is near its peak at epoch 8 -- jumping to full LR 2 epochs earlier adds instability not recovered by epoch 59.

### Suggested follow-ups

- **Warmup 12 epochs:** If 10 is better than 8, test the opposite direction.
- **Warmup with per-head temp frozen for first N epochs:** Try initializing temp params after warmup finishes rather than adjusting warmup length.
- **Lower start_factor (0.05 instead of 0.1):** Gentler warmup that ramps more slowly.