### PR TITLE
Noise scale 1.2x (slightly more noise to help ood_cond)

### DIFF
--- a/train.py
+++ b/train.py
@@ -665,15 +665,15 @@ for epoch in range(MAX_EPOCHS):
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+            noise_scale = 0.06 * (1 - epoch / 60)  # 1.2x: was 0.05
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
             noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            vel_noise = 0.018 * (1 - noise_progress) + 0.0036 * noise_progress  # 1.2x: was 0.015/0.003
+            p_noise = 0.0096 * (1 - noise_progress) + 0.0012 * noise_progress  # 1.2x: was 0.008/0.001
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 


### PR DESCRIPTION
## Hypothesis
The per-head tandem temp caused ood_cond to regress from 13.49→14.40 (+6.7%). The ablation showed noise helps ood_cond: removing noise cost +1.04 on ood_cond. The per-head temp may have effectively reduced the noise benefit for ood_cond by changing the attention landscape. Increasing noise to 1.2x provides extra regularization that may specifically help ood_cond recover.

## Instructions
1. Find the noise scale (the initial noise level before annealing). Multiply by 1.2 (20% more noise).
2. Keep the annealing schedule unchanged (just start from a higher level)
3. Keep everything else identical
4. Run with `--wandb_group noise-12x`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `yk2a8a1x` (thorfinn/noise-12x, group: noise-12x)
**Peak memory:** 14.8 GB
**Training:** 59 epochs, 30.0 min

### Surface MAE (mae_surf_p, primary metric)

| Split | This run (1.2x noise) | Baseline (1.0x) | Delta |
|-------|-----------------------|-----------------|-------|
| val_in_dist | 17.3 | 17.1 | +0.2 |
| val_ood_cond | 14.4 | 14.4 | 0.0 |
| val_ood_re | 27.8 | 27.8 | 0.0 |
| val_tandem_transfer | 39.9 | 38.3 | +1.6 |
| **mean3 (in+ood+tan)/3** | **23.9** | **23.3** | **+0.6** |

### Full Surface MAE breakdown (best checkpoint, epoch 59)

| Split | Ux | Uy | p | val/loss |
|-------|-----|-----|-----|---------|
| val_in_dist | 4.3 | 1.6 | 17.3 | 0.5860 |
| val_ood_cond | 2.9 | 1.0 | 14.4 | 0.7246 |
| val_ood_re | 2.7 | 0.8 | 27.8 | 0.5404 |
| val_tandem_transfer | 4.9 | 2.2 | 39.9 | 1.6669 |

**val/loss (4-split avg):** 0.8795 (baseline 0.8600)

### What happened

The 1.2x noise increase doesn't help ood_cond (14.4 vs 14.4, essentially the same). val/loss regresses from 0.8600 → 0.8795 (-2.3%). Tandem notably worsens (+1.6). In_dist and ood_re are essentially unchanged.

The hypothesis that more noise would specifically recover ood_cond is not supported. The ood_cond regression appears to be a structural feature of the per-head tandem temperature mechanism, not a noise issue. Extra regularization via noise has no effect on the specific spatial regions where ood_cond struggles.

### Suggested follow-ups
- The noise level appears to be well-calibrated at 1.0x. Going higher only hurts tandem.
- The ood_cond regression from the per-head tandem temp may require architectural changes, not training adjustments.
- Consider reducing noise (0.8x) to see if the current noise level is slightly too high.