### PR TITLE
Hard-mining start epoch 25 on per-head tandem temp code

### DIFF
--- a/train.py
+++ b/train.py
@@ -733,8 +733,8 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
+        # Asymmetric hard-node mining for non-tandem samples after epoch 25 (vectorized)
+        if epoch >= 25:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))


### PR DESCRIPTION
## Hypothesis
hard-mine-ep20 (nezuko) was the closest miss on old code (val_loss=0.865, re=27.4). ep25 is a more conservative earlier start. On the per-head tandem temp code, the interaction between hard-mining and per-head temperatures might be different.

## Instructions
1. Change hard-mining start epoch from 30 to 25
2. Keep everything else identical
3. Run with `--wandb_group hard-mine-ep25-v2`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** 8gqlmfl7  
**Epochs completed:** 57/100 (30-minute timeout)  
**Peak memory:** 14.8 GB  

### Validation Loss
| Split | This run (ep56) | Baseline |
|---|---|---|
| val_loss (avg) | 0.8891 | 0.8600 |
| in_dist | 0.6178 | — |
| ood_cond | 0.7279 | — |
| ood_re | 0.5534 | — |
| tandem_transfer | 1.6572 | — |

*(epoch 57 log: in_dist=0.6094, ood_cond=0.7204, ood_re=0.5482, tandem=1.6515, val_loss≈0.8824)*

### Surface MAE (epoch 56)
| Split | Ux | Uy | p | Baseline p |
|---|---|---|---|---|
| in_dist | 5.53 | 1.77 | 18.68 | 17.11 |
| ood_cond | 2.85 | 1.11 | 14.36 | 14.40 |
| ood_re | 2.37 | 0.99 | 28.04 | 27.84 |
| tandem | 6.06 | 2.30 | 39.56 | 38.30 |

### Volume MAE (epoch 56)
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.11 | 0.37 | 20.09 |
| ood_cond | 0.72 | 0.28 | 12.10 |
| ood_re | 0.83 | 0.37 | 46.90 |
| tandem | 1.95 | 0.89 | 39.12 |

### What happened
Negative result. val_loss 0.8891 vs baseline 0.8600 — 3.4% worse. Surface MAE p at epoch 56 is consistently behind baseline: in_dist 18.68 vs 17.11, ood_re 28.04 vs 27.84, tandem 39.56 vs 38.30. Only ood_cond shows near-parity (14.36 vs 14.40).

Starting hard-mining 5 epochs earlier (ep25 vs ep30) did not help on the per-head tandem temp code. The earlier start forces the model to up-weight high-pressure-error nodes before convergence is sufficient, potentially destabilizing learning for the remaining splits. The baseline ep30 appears to be a better tradeoff.

Unlike the n_head=4 runs where ep20 was the closest miss, on this per-head temp code ep25 doesn't replicate that pattern. The interaction between per-head temperatures and hard-mining likely changes the optimization landscape.

### Suggested follow-ups
- Try hard-mine-ep30 as a direct baseline confirmation on this code branch
- Try hard-mine-ep35 to see if even later start helps on the per-head temp code
- Investigate whether the per-head tandem temperature already provides sufficient signal differentiation, making hard-mining redundant