### PR TITLE
lr=2.5e-3 on per-head tandem temp code (gentler LR for wider heads)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 2.5e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The per-head tandem temp code with n_head=3 (64-dim/head) may benefit from a slightly lower LR. The wider heads + per-head temperature parameters create a more complex optimization landscape. lr=2.5e-3 (vs current 3e-3) is a 17% reduction — gentler than the 2e-3 that was tested on older code and found too slow. This splits the difference.

## Instructions
1. Change lr=3e-3 to lr=2.5e-3
2. Keep everything else identical
3. Run with `--wandb_group lr-25e3-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `9ms94ykg` (`norman/lr-25e3-perhead`)
**Best epoch:** 60
**Peak memory:** 14.8 GB

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 0.5737 | 17.48 |
| val_ood_cond | 0.6797 | 13.59 |
| val_ood_re | 0.5297 | 27.57 |
| val_tandem_transfer | 1.6387 | 38.53 |
| **Combined** | **0.8555** | — |

**vs baseline (0.8600):** −0.0045 ✓

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8600 | 0.8555 | **−0.0045** ✓ |
| in_dist surf_p | 17.11 | 17.48 | +0.37 (slightly worse) |
| ood_cond surf_p | 14.40 | 13.59 | **−0.81** ✓ |
| ood_re surf_p | 27.84 | 27.57 | **−0.27** ✓ |
| tandem surf_p | 38.30 | 38.53 | +0.23 (slightly worse) |

### What happened
The lower LR gave a small improvement in combined val/loss (−0.005). OOD splits improved noticeably — ood_cond dropped 0.81 surface pressure MAE and ood_re dropped 0.27. However, in_dist and tandem got marginally worse (+0.37 and +0.23 respectively), suggesting the slower learning rate helps generalization slightly at the cost of some in-distribution fitting.

The effect is modest but consistent with the hypothesis: the per-head temperature introduces more optimizer complexity, and a slightly lower LR appears to regularize it better on OOD splits. The trade-off looks net-positive given that surface accuracy on OOD conditions is important.

### Suggested follow-ups
- Try lr=2e-3 — may push OOD generalization further, though earlier experiments on older code found it too slow. Worth re-testing on current architecture.
- Try a warmup schedule (e.g., linear warmup to 3e-3 then cosine decay to 1e-3) to get fast early training with stable late-phase optimization.
- Investigate whether the in_dist regression is consistent across seeds or noise.