### PR TITLE
Temp-clamp 0.2@ep45 on per-head tandem temp (KEY COMBINATION TEST)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 45:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.20)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
temp-clamp-0.2@ep45 was incredible on n_head=4 (val_loss=0.8568) but failed on n_head=3-only (0.874). With per-head tandem temp NOW MERGED, the dynamics are different: the global clamp affects the BASE temperature while the per-head offset adjusts for tandem. These could be synergistic — the global clamp provides sharper routing for all flows while the per-head offset fine-tunes for tandem.

## Instructions
1. Change temp clamp value from 0.25 to 0.20
2. Change start epoch from 50 to 45
3. Keep per-head tandem_temp_offset (already in code)
4. Keep everything else identical
5. Run with `--wandb_group temp-clamp-02-ep45-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `jpvy4xko`
**Epochs:** 60 (30-min timeout)
**Peak VRAM:** 14.8 GB

| Metric | Baseline (perhead-tandem-temp) | This run | Δ |
|--------|-------------------------------|----------|---|
| val/loss | 0.8600 | 0.8607 | +0.0007 ≈ |
| surf_p in_dist | 17.11 | 17.30 | +0.19 ↑ worse |
| surf_p ood_cond | 14.40 | 14.13 | -0.27 ↓ better |
| surf_p ood_re | 27.84 | 27.73 | -0.11 ↓ better |
| surf_p tandem | 38.30 | 37.97 | -0.33 ↓ better |
| **mean3** | **23.27** | **23.13** | -0.14 ↓ better |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**What happened:** This is a slight improvement — mean3 dropped by 0.14, driven mainly by tandem and ood_cond recovery. The tighter clamp (0.20) and earlier onset (ep45) appear to promote sharper attention routing slightly sooner, which helps the model specialize better by end of training. The effect is modest but in the right direction on all but in_dist. Val/loss is essentially identical to baseline (0.0007 difference), so the improvement in mean3 comes from a better balance of splits.

The original temp-clamp-0.2@ep50 experiment failed on n_head=3 without per-head temp (val_loss=0.874), but now with the per-head tandem offset acting as a correction signal, the global clamp no longer destabilizes tandem learning — it complements it.

**Suggested follow-ups:**
1. Try even tighter clamp (0.15) to see if sharper routing continues to help, or if 0.20 is already near optimal.
2. Try ep40 onset — applying the clamp even earlier.
3. Try applying the clamp to all blocks (currently only blocks[0]) since deeper layers also have learnable temperatures.