### PR TITLE
EMA start epoch 35 on per-head tandem temp code

### DIFF
--- a/train.py
+++ b/train.py
@@ -535,7 +535,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 35
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
The per-head tandem_temp_offset adds 3 learnable parameters that evolve during training. Starting EMA 5 epochs earlier (ep35 vs ep40) gives EMA more time to average over the per-head temp trajectory, potentially stabilizing the learned temperatures.

## Instructions
1. Change ema_start_epoch from 40 to 35
2. Keep everything else identical
3. Run with `--wandb_group ema-start-35-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** yq3p44m1  
**Epochs completed:** 58/100 (30-min timeout)  
**Peak memory:** 14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8600 | 0.8932 | +3.9% worse |
| val_in_dist | mae_surf_p | 17.11 | 18.00 | +5.2% worse |
| val_ood_cond | mae_surf_p | 14.40 | 14.63 | +1.6% worse |
| val_tandem_transfer | mae_surf_p | 38.30 | 39.67 | +3.6% worse |
| val_ood_re | mae_surf_p | 27.84 | 27.97 | +0.5% worse |
| **mean3** | mae_surf_p | **23.27** | **24.10** | **+3.6% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=6.79, Uy=1.88, p=18.00 | Vol: Ux=1.10, Uy=0.37, p=18.91
- **ood_cond:** Ux=3.60, Uy=1.09, p=14.63 | Vol: Ux=0.73, Uy=0.28, p=12.53
- **ood_re:** Ux=3.22, Uy=0.97, p=27.97 | Vol: Ux=0.83, Uy=0.36, p=47.03
- **tandem_transfer:** Ux=6.45, Uy=2.28, p=39.67 | Vol: Ux=1.94, Uy=0.88, p=38.74

### What happened

The hypothesis did not improve over baseline. All four splits are worse. Moving EMA start from epoch 40 to epoch 35 hurt performance, with tandem_transfer seeing the largest regression (+3.6%).

The most likely explanation is that the model is still actively learning at epoch 35 — this is in the middle of the noise annealing phase (which runs epochs 0–60). EMA averaging during high-learning-rate, high-noise epochs captures noisy intermediate model states, and the 5 extra epochs of noisy EMA averaging are counter-productive. The temperature parameters (including tandem_temp_offset) haven't stabilized yet at epoch 35; the EMA snapshot is contaminated by early-phase noise.

The val losses in the log were still monotonically decreasing at epoch 58, confirming the model hadn't converged.

### Suggested follow-ups

- **Later EMA start (ep45 or ep50)**: If the issue is that ep40 is too early, starting even later might help — though there's a trade-off with giving EMA fewer epochs to average over.
- **EMA decay tuning**: Rather than shifting the start epoch, increasing the EMA decay (0.998 → 0.999) would put more weight on later, more converged snapshots regardless of start epoch.