### PR TITLE
Surf_weight clamp max=40 on per-head tandem temp code

### DIFF
--- a/train.py
+++ b/train.py
@@ -635,8 +635,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Adaptive surface weight: loss-ratio based, clamped [5, 40]
+    surf_weight = max(5.0, min(40.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
With per-head tandem temp changing attention routing, the adaptive surf_weight might reach different values. Reducing the ceiling from 50 to 40 provides a gentler constraint. This is less aggressive than the 30 ceiling (which hurt tandem) but more constrained than 50.

## Instructions
1. Change surf_weight ceiling from 50 to 40: `surf_weight = max(5.0, min(40.0, surf_weight))`
2. Keep everything else identical
3. Run with `--wandb_group surf-clamp-40-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `572e3z27` | **Epochs:** 60/100 (30-min timeout) | **Peak VRAM:** 14.8 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| val_in_dist | 17.11 | 17.69 | +0.58 ▲ slightly worse |
| val_ood_cond | 14.40 | 13.65 | -0.75 ▼ better |
| val_ood_re | 27.84 | 27.55 | -0.29 ▼ slightly better |
| val_tandem | 38.30 | 38.82 | +0.52 ▲ slightly worse |
| **mean3** (in/ood_cond/tan) | **23.27** | **23.39** | **+0.12 — essentially tied** |

**val/loss:** 0.8630 vs baseline 0.8600 → essentially tied (+0.35%)

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 5.01 | 1.53 | 17.69 |
| val_ood_cond | 3.04 | 0.95 | 13.65 |
| val_ood_re | 2.58 | 0.78 | 27.55 |
| val_tandem | 5.27 | 2.16 | 38.82 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.11 | 0.37 | 18.83 |
| val_ood_cond | 0.71 | 0.27 | 11.63 |
| val_ood_re | 0.82 | 0.36 | 46.60 |
| val_tandem | 1.95 | 0.88 | 38.05 |

### What happened

Lowering the surf_weight ceiling from 50 to 40 produced essentially no change (mean3 23.39 vs 23.27, val/loss 0.8630 vs 0.8600). The deltas are within run-to-run noise. This is a null result.

The most likely explanation: the adaptive surf_weight rarely (or never) exceeds 40 during training anyway, so the ceiling change has no practical effect. The weight is computed as `prev_vol_loss / max(prev_surf_loss, 1e-8)`, and once the model is well-trained, surf_loss is small enough that the ratio can be large — but in practice it seems to stay below 40 most of the time. The 50 ceiling was already non-binding.

The ood_cond improvement (-0.75) is interesting but inconsistent with in_dist regression (+0.58) and likely reflects stochastic variance rather than a real trend.

### Suggested follow-ups
- Check what values surf_weight actually reaches during training — if it never hits 40, then the [5,50] range is already fine and tuning the ceiling is not a productive direction
- If surf_weight does sometimes reach 50, try a harder constraint like [5,30] to see if reducing surface focus helps generalization
- More promising: focus on architecture changes that affect all splits uniformly rather than loss-weight tuning