### PR TITLE
T_max=48 on per-head tandem temp code (aggressive schedule alignment)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=48, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
T_max=48 was the closest miss on n_head=4 code (val_loss=0.8671, best in_dist=17.89). On the per-head tandem temp code with n_head=3, the epoch budget is ~59 epochs. T_max=48 (warmup=10) means the cosine completes at epoch 58 — exactly aligning with the budget. This was the best schedule finding from our entire research.

## Instructions
1. Change T_max=62 to T_max=48
2. Keep everything else identical
3. Run with `--wandb_group tmax48-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** `czgr7ke6`
**Best epoch:** 61 / 100 (hit wall-clock limit, ~30s/epoch)
**Peak memory:** 14.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6196 | 8.01 | 2.32 | 18.30 | 1.15 | 0.39 | 20.02 |
| val_tandem_transfer | 1.6696 | 7.04 | 2.69 | 39.13 | 1.98 | 0.91 | 38.75 |
| val_ood_cond | 0.7065 | 4.40 | 1.50 | 14.17 | 0.74 | 0.28 | 12.56 |
| val_ood_re | 0.5507 | 4.11 | 1.34 | 27.91 | 0.84 | 0.37 | 47.19 |
| **mean3** | **0.998** | **6.48** | **2.17** | **23.87** | — | — | — |

Baseline: mean3=23.27 (in=17.11, ood=14.40, tan=38.30, re=27.84), val_loss=0.8600

**What happened:** Negative result. mean3 surface_p worsened from 23.27 → 23.87, val/loss from 0.8600 → 0.8866. In-dist degraded significantly (17.11 → 18.30), tandem worsened (38.30 → 39.13), ood_re nearly unchanged (27.84 → 27.91). Only ood_cond showed a marginal improvement (14.40 → 14.17, -0.23) which is within noise.

The T_max=48 strategy was developed for a different codebase variant (n_head=4, different architecture). The n_head=3 per-head tandem temp code differs in enough ways that the T_max=48 schedule is too aggressive here. With T_max=48, the cosine decay completes at epoch 58, leaving the final ~3 epochs running at eta_min=5e-5. However this run reached 61 epochs — meaning the schedule already cycled fully, providing extra warmup-and-decay. The resulting LR profile doesn't match the budget as well as intended.

More importantly, this run reached epoch 61 (vs 59 for the baseline), meaning the architecture with these settings runs slightly faster. The T_max=62 baseline with epoch budget of ~61 is a better match — epoch 61 is 98% through T_max=62, which is near-ideal.

**Suggested follow-ups:**
- Accept T_max=62 as the near-optimal schedule for this codebase variant.
- Since this branch reaches 61 epochs, try T_max=51 (10 warmup + 51 cosine = completes at epoch 61 exactly).