### PR TITLE
T_max=52 on per-head tandem temp code (midpoint schedule alignment)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=52, eta_min=5e-5)  # tmax52-perhead: 52 vs 62
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
T_max=48 and T_max=55 bracket the optimal schedule alignment. T_max=52 (warmup=10 + cosine=52 = 62, matching the ~59-epoch budget more closely) is the untested midpoint.

## Instructions
1. Change T_max=62 to T_max=52
2. Keep everything else identical
3. Run with `--wandb_group tmax52-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run**: fp6z77fm | **Epochs**: 60 (best=last, run terminated mid-epoch 61) | **val/loss**: 0.8651

| Split | Ux | Uy | p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 7.40 | 2.04 | 18.1 | +0.94 ↑ |
| val_ood_cond | 4.57 | 1.36 | 13.9 | -0.45 ↓ |
| val_ood_re | 4.31 | 1.27 | 27.4 | -0.42 ↓ |
| val_tandem | 6.79 | 2.45 | 38.4 | +0.11 ↑ |

**mean3 (in+ood+re)/3 surf_p**: 19.81 vs baseline 19.78 → **+0.03 essentially same**

**Peak memory**: ~30 GB (no architectural change)

### What happened

Mixed result, essentially neutral on mean3. T_max=52 shows the same OOD-vs-in-dist trade-off as the warmup5 experiment: OOD splits improve (ood_cond -0.45, ood_re -0.42) while in-distribution degrades (+0.94). The faster LR schedule reaches eta_min around epoch 62, which is similar to the actual run length — meaning the model gets less time at full LR. val/loss 0.8651 vs baseline 0.8600: **+0.0051 slightly worse**.

Note: the training aborted during epoch 61 validation (before completing the terminal summary), so the logged best is from epoch 60. The model was still improving at epoch 60 (it was the best epoch), suggesting it hadn't fully converged — slightly more epochs might have helped.

### Suggested follow-ups

1. **Check T_max=48 result**: if T_max=48 also shows this OOD/in-dist trade-off, the pattern is clear and T_max=62 is optimal for in-dist
2. **T_max=55 (already exists as tmax55-v2)**: check if this is the sweet spot between 52 and 62
3. **The OOD improvement pattern is consistent**: warmup5 and T_max=52 both help OOD. This suggests the current schedule slightly over-fits to in-distribution