### PR TITLE
Asymmetric tandem temp init [-0.1, 0, 0.1] (force head diversity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,7 +128,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
-        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
+        init_vals = torch.tensor([-0.1, 0.0, 0.1]).view(1, heads, 1, 1)
+        self.tandem_temp_offset = nn.Parameter(init_vals)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
The per-head tandem_temp_offset initializes at [0, 0, 0]. With 3 heads all starting identically, they may converge to similar patterns. Asymmetric initialization [-0.1, 0.0, 0.1] forces immediate diversity: one head sharpens tandem attention, one stays neutral, one softens. This breaks the symmetry and may help each head specialize earlier.

## Instructions
1. Change `self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))` to:
   ```python
   init_vals = torch.tensor([-0.1, 0.0, 0.1]).view(1, heads, 1, 1)
   self.tandem_temp_offset = nn.Parameter(init_vals)
   ```
2. Keep everything else identical
3. Run with `--wandb_group tandem-temp-asym`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** at41umeg  
**Status:** Timed out at epoch 58/100 (30-min cap, runtime 29.3 min)

### Metrics at epoch 58 (EMA model, mid-run)

| Split | val/loss | surf Ux | surf Uy | surf p | vol MAE (Ux/Uy/p) |
|-------|----------|---------|---------|--------|---------|
| in_dist | 0.5996 | 4.74 | 1.35 | 18.50 | 1.14 / 0.37 / 19.73 |
| ood_cond | 0.7279 | 2.96 | 0.91 | 14.62 | 0.73 / 0.28 / 12.71 |
| ood_re | 0.5552 | 2.47 | 0.74 | 28.03 | 0.84 / 0.37 / 47.20 |
| tandem | 1.6526 | 5.39 | 1.95 | 39.18 | 1.94 / 0.88 / 38.17 |

**mean3 (surf p, in+ood+tan / 3): 24.10 vs baseline 23.27 — worse (+3.6%)**  
in=18.50 (+1.39), ood=14.62 (+0.22), re=28.03 (+0.19), tan=39.18 (+0.88)

**val/loss: 0.8838 vs baseline 0.8600 — worse mid-training; still improving (best = last)**

**Peak GPU memory:** 91.93 GB

### Comparison vs tandem-temp-init-01 (uniform +0.1 init, epoch 57)

| Metric | Baseline | init-01 (ep57) | asym (ep58) | Better |
|--------|----------|---------|------|--------|
| val/loss | 0.8600 | 0.8821 | 0.8838 | init-01 |
| ood_cond p | 14.40 | **14.15** | 14.62 | init-01 |
| ood_re p | 27.84 | **27.63** | 28.03 | init-01 |
| in_dist p | 17.11 | 18.26 | 18.50 | init-01 |
| tandem p | 38.30 | 39.18 | 39.18 | tied |

### What happened

The asymmetric init [-0.1, 0, 0.1] is **worse than the uniform +0.1 init** (PR #1343) on all metrics except tandem (tied). The hypothesis that forced diversity would help specialization doesn't hold at epoch 58.

Possible explanations:
- The head with init=-0.1 (sharper for tandem) is counter-productive — tandem flows with sharper attention may be harder to generalize
- Symmetry breaking creates optimization interference between heads early in training
- The uniform +0.1 was already providing the right signal (softer attention for tandem), and asymmetry dilutes it by including a -0.1 head

The ood_cond pressure (14.62) is slightly above baseline (14.40) and worse than init-01 (14.15), suggesting the -0.1 head is hurting OOD generalization.

**Verdict:** Negative vs. uniform init-01. The asymmetric approach does not improve on a simple warm start. init-01 appears to be the better approach.

### Suggested follow-ups

- **Confirm init-01 at full convergence**: PR #1343 showed the most promising pattern — run it to epoch 100
- **Try init=0.05**: smaller uniform warm start to minimize in_dist regression while keeping OOD benefit
- **Try only 2 heads with asymmetry** (e.g., [0.0, 0.1] or [0.05, 0.1]): avoid the -0.1 head entirely