### PR TITLE
lr=3.5e-3 on per-head tandem temp code (slightly higher LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 3.5e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
lr=3e-3 is the long-standing default. With per-head tandem temp and n_head=3, the wider heads may benefit from slightly higher LR to explore the richer optimization landscape. 3.5e-3 is a modest 17% increase — never tested on any code version.

## Instructions
1. Change lr=3e-3 to lr=3.5e-3
2. Keep everything else identical
3. Run with `--wandb_group lr-35e3-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run**: `muxo40vd`
**Epochs**: 59/59 (wall-clock limit, 30.2 min)
**Peak memory**: 14.8 GB
**val/loss**: 0.8818 (baseline 0.8600, **+0.0218 worse**)

### Surface MAE

| Split | Ux | Uy | p | p vs baseline |
|-------|----|----|---|---------------|
| val_in_dist | 6.53 | 1.78 | 18.15 | 17.11 → +1.04 ↑ |
| val_ood_cond | 3.56 | 1.11 | 14.89 | 14.40 → +0.49 ↑ |
| val_ood_re | 3.05 | 0.92 | 27.93 | 27.84 → +0.09 ↑ |
| val_tandem | 6.06 | 2.24 | 38.48 | 38.30 → +0.18 ↑ |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.09 | 0.36 | 20.04 |
| val_ood_cond | 0.73 | 0.28 | 12.45 |
| val_ood_re | 0.82 | 0.36 | 46.92 |
| val_tandem | 1.93 | 0.88 | 38.57 |

### What happened

**Negative result.** All four splits degraded slightly. The 17% LR increase overshoots for this configuration. In-dist pressure MAE rose the most (+1.04), suggesting the optimizer is less stable at this LR. The tandem and OOD splits barely moved (+0.09–0.18), which is consistent with overshoot being a minor effect overall.

Note: Two failed runs preceded this result:
- `3rteqmbe`: OOM (CUDA out of memory) during val_ood_cond in epoch 1 — CUDAGraph private pools exhausted (51 distinct input sizes, 46.5 GB) during validation graph recording.
- `00rl7o7w`: Crashed with `RuntimeError: Expected curr_block->next == nullptr` when attempting `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` as a workaround (incompatible with CUDAGraph tree checkpoint state).
- Fix: `rm -rf /tmp/torchinductor_root` cleared the stale kernel cache from previous run `mqr7yen0`, and the third attempt `muxo40vd` ran cleanly.

### Suggested follow-ups

- Try lr=2.5e-3 (modest decrease) — if 3e-3 is already slightly too high for per-head tandem temp, a small reduction may help.
- Try a cosine LR schedule with warmup — rather than tweaking a fixed LR, a schedule might handle the LR sensitivity better.
- The OOM issue with 51 distinct input sizes is worth investigating — batching or padding to fixed sizes during training could reduce CUDAGraph pool pressure and improve run reliability.