### PR TITLE
Temp clamp 0.22 at epoch 48 (fine-tuned midpoint between 0.2@45 and 0.25@50)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 48:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.22)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
temp-clamp-0.2@ep45 was amazing on n_head=4 but failed on n_head=3. temp-clamp-0.25@ep50 is baseline. The midpoint 0.22@ep48 is a gentler adjustment that may work better on the wider n_head=3 heads with per-head tandem temp.

## Instructions
1. Change temp clamp value from 0.25 to 0.22
2. Change start epoch from 50 to 48
3. Keep everything else identical
4. Run with `--wandb_group temp-clamp-022-ep48`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** 4s3jonld
**Epochs completed:** 60/100 (30-min timeout)
**Peak memory:** 14.8 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8703 | 0.8600 | +1.2% (worse) |
| Surface MAE p (in_dist) | 17.85 | 17.11 | +4.3% (worse) |
| Surface MAE p (ood_cond) | 13.81 | 14.40 | -4.1% (better) |
| Surface MAE p (ood_re) | 27.61 | 27.84 | -0.8% (better) |
| Surface MAE p (tandem) | 38.99 | 38.30 | +1.8% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 5.90 | 1.52 | 17.85 |
| ood_cond | 3.21 | 0.86 | 13.81 |
| ood_re | 2.79 | 0.74 | 27.61 |
| tandem | 5.84 | 2.00 | 38.99 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.09 | 0.36 | 19.31 |
| ood_cond | 0.70 | 0.27 | 11.78 |
| ood_re | 0.80 | 0.36 | 46.81 |
| tandem | 1.94 | 0.88 | 38.21 |

### What happened

Mixed results. The overall val/loss is slightly worse (+1.2%), and in_dist pressure regresses (+4.3%). However, ood_cond pressure drops from 14.40 to 13.81 (-4.1%) and ood_re pressure improves slightly from 27.84 to 27.61 (-0.8%). The ood_cond improvement is well outside the ~2% noise floor from PR #1333.

The pattern is interesting: this clamp (0.22@48) helps OOD generalization (ood_cond, ood_re) while hurting in-distribution accuracy (in_dist). A tighter clamp earlier forces sharper routing sooner, which may impose a more general structure but at the cost of fitting training distribution details.

Compared to the previous warmup8-perhead run (also on this codebase), this run is slightly better across the board, suggesting the temp clamp is the bigger lever here.

The composite val/loss (which weights all splits equally) doesn't capture the ood_cond improvement fully -- ood_cond is just 1 of 4 splits. If ood generalization is prioritized, this result is interesting.

### Suggested follow-ups

- **0.22@ep45:** Try clamping at ep45 instead of ep48 -- even earlier sharp routing to see if ood improvement grows.
- **0.20@ep48:** Try clamping tighter (0.20) at same epoch -- see if further tightening helps ood_cond more.
- **0.22@ep50 (same clamp, back to baseline epoch):** Isolate whether the value (0.22) or the epoch (48) is driving the ood_cond improvement.
- **Separate clamps per block:** The current code only clamps blocks[0]. If all blocks have temperature params, clamping all of them might have a stronger effect.