### PR TITLE
lr=2.8e-3 on per-head tandem temp (between 2.5e-3 and 3e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 3e-3
+    lr: float = 2.8e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
norman/lr-25e3-perhead is showing cur_vl=0.8607 with ood=13.77 — tantalizingly close to baseline (0.8600) and with dramatically better ood_cond recovery. If lr=2.5e-3 is almost right, lr=2.8e-3 (between 2.5e-3 and the baseline 3e-3) might hit the sweet spot.

## Instructions
1. Change lr=3e-3 to lr=2.8e-3
2. Keep everything else identical
3. Run with `--wandb_group lr-28e3-perhead`

## Baseline: val_loss=0.8600, in=17.11, ood=14.40, re=27.84, tan=38.30

---
## Results

**W&B run:** 6vqyb5wq  
**Epochs completed:** 58/100 (30-minute timeout)  
**Peak memory:** 14.8 GB  

### Validation Loss
| Split | This run (ep58) | Baseline |
|---|---|---|
| val_loss (avg) | 0.8933 | 0.8600 |
| in_dist | 0.6133 | — |
| ood_cond | 0.7122 | — |
| ood_re | 0.5732 | — |
| tandem_transfer | 1.6743 | — |

### Surface MAE (epoch 58)
| Split | Ux | Uy | p | Baseline p |
|---|---|---|---|---|
| in_dist | 5.60 | 1.42 | 18.21 | 17.11 |
| ood_cond | 2.94 | 0.93 | 14.15 | 14.40 |
| ood_re | 2.40 | 0.79 | 28.60 | 27.84 |
| tandem | 5.36 | 1.85 | 40.06 | 38.30 |

### Volume MAE (epoch 58)
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.11 | 0.37 | 19.44 |
| ood_cond | 0.73 | 0.28 | 12.19 |
| ood_re | 0.84 | 0.37 | 47.30 |
| tandem | 1.97 | 0.90 | 39.33 |

### What happened
Negative result. val_loss 0.8933 vs baseline 0.8600 — 3.9% worse. lr=2.8e-3 is not the sweet spot.

The one bright spot is ood_cond surface pressure (14.15 vs 14.40 baseline) — a small improvement, consistent with the lr-25e-3 observation of better ood_cond recovery. But all other metrics are worse: in_dist mae_surf_p 18.21 vs 17.11, ood_re 28.60 vs 27.84, tandem 40.06 vs 38.30.

The model was still converging at epoch 58 (all epochs were new bests), so the 30-minute cutoff prevents seeing the final converged values. However, at the same stage (epoch 57-58), the baseline likely performs better.

The pattern across lr experiments suggests the original lr=3e-3 is already well-tuned for this architecture. Reducing it to 2.5e-3 or 2.8e-3 consistently hurts overall performance even if ood_cond benefits slightly.

### Suggested follow-ups
- lr=3e-3 appears optimal — focus on other knobs
- If ood_cond improvement from lower lr is real, try a differential LR (lower lr for some parameter groups while keeping 3e-3 for others)
- The consistent ood_cond surface p improvement at lower LRs may suggest that ood_cond benefits from more conservative updates