### PR TITLE
T_max=52 on lr=2.5e-3 code (schedule alignment for gentler LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=52, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
senku's T_max=52 on old code (lr=3e-3) showed cur_vl=0.866, promising but not beating old baseline. With the new lr=2.5e-3, the slower LR means the cosine decay reaches its floor later — T_max=52 may align better with the gentler convergence trajectory.

## Instructions
1. Change T_max=62 to T_max=52
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group tmax52-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `65xgb0z0`
**Best epoch:** 61 / 100 (hit wall-clock limit, ~30s/epoch)
**Peak memory:** 14.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5967 | 3.84 | 0.99 | 17.74 | 1.13 | 0.37 | 19.61 |
| val_tandem_transfer | 1.6465 | 4.93 | 1.82 | 39.30 | 1.98 | 0.89 | 38.64 |
| val_ood_cond | 0.6896 | 3.37 | 0.83 | 13.80 | 0.72 | 0.28 | 11.99 |
| val_ood_re | 0.5368 | 3.03 | 0.74 | 27.65 | 0.83 | 0.37 | 46.76 |
| **mean3** | **0.978** | **4.05** | **1.21** | **23.61** | — | — | — |

Baseline: mean3=23.20 (in=17.48, ood=13.59, tan=38.53, re=27.57), val_loss=0.8555

**What happened:** Negative result. mean3 surface_p worsened from 23.20 → 23.61, val/loss from 0.8555 → 0.8674. All splits regressed slightly: in_dist (+0.26), tandem (+0.77), ood_cond (+0.21), ood_re (+0.08).

The T_max=52 schedule is too aggressive for the lr=2.5e-3 configuration. With T_max=52 and warmup=10, the cosine phase completes at epoch 62 — meaning this run (which reached epoch 61) barely finished the cosine cycle. Paradoxically, T_max=62 (baseline) leaves the LR slightly above eta_min at epoch 61 (97% through the cycle), which appears to benefit late-stage refinement. The lr=2.5e-3 baseline already benefits from the slower convergence, and shortening T_max cuts off this late-stage benefit.

This mirrors the T_max=55 result on per-head tandem temp code — both show that faster decay hurts rather than helps.

**Suggested follow-ups:**
- Accept T_max=62 as optimal for this code variant with lr=2.5e-3.
- Focus on architectural changes rather than schedule tuning — schedule optimization appears saturated at T_max=62.