### PR TITLE
Temp-clamp 0.2@ep45 on lr=2.5e-3 code (retest KEY combination)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 45:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.20)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
temp-clamp-0.2@ep45 was incredible on n_head=4 (0.8568) and showed 0.8607 on n_head=3+per-head-temp (lr=3e-3). With lr=2.5e-3 now merged, the gentler LR may allow the sharper temp clamp to work even better — the two changes target complementary aspects of the attention mechanism.

## Instructions
1. Change temp clamp from 0.25 to 0.20
2. Change start epoch from 50 to 45
3. Keep lr=2.5e-3 and everything else identical
4. Run with `--wandb_group temp-clamp-02-ep45-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `bqnxftmq`
**Epochs:** 60 (30-min timeout)
**Peak VRAM:** 14.8 GB

| Metric | Baseline (lr=2.5e-3) | This run | Δ |
|--------|----------------------|----------|---|
| val/loss | 0.8555 | 0.8652 | +0.0097 ↑ worse |
| surf_p in_dist | 17.48 | 18.47 | +0.99 ↑ worse |
| surf_p ood_cond | 13.59 | 14.44 | +0.85 ↑ worse |
| surf_p ood_re | 27.57 | 27.79 | +0.22 ↑ worse |
| surf_p tandem | 38.53 | 37.87 | -0.66 ↓ better |
| **mean3** | **23.20** | **23.59** | +0.39 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**What happened:** The temp clamp hurt on the lr=2.5e-3 base, the opposite of what was hypothesized. Only tandem improved (-0.66) while all other splits got worse. This contrasts with the perhead-tandem-temp run where temp clamp gave a modest improvement (mean3 23.27 → 23.13).

A plausible explanation: lr=2.5e-3 already slows attention parameter updates more gently. The temperature parameter is also updated at this reduced rate. Adding a hard clamp of 0.20 at epoch 45 may be forcing temperatures down prematurely when the lr=2.5e-3 learning dynamic would have converged to a similar or better configuration naturally. Essentially, the clamp and the lower LR are both reducing attention aggressiveness — combining them may be over-regularizing the attention temperatures.

The fact that tandem improved while in_dist/ood regressed is also consistent with the temp clamp from the perhead-tandem-temp experiments: it primarily benefits tandem at some cost to other splits. With lr=2.5e-3, this tradeoff appears less favorable overall.

**Suggested follow-ups:**
1. The lr=2.5e-3 base without temp clamp (val_loss=0.8555, mean3=23.20) appears stronger — focus on improving that rather than combining with temp clamp.
2. Check whether the temp clamp at 0.25 (weaker constraint) on lr=2.5e-3 base is better than 0.20.
3. Test the perhead-tandem-temp improvement independently to understand if it's a stable win vs the lr=2.5e-3 direction.