### PR TITLE
Baseline seed=42 on lr=2.5e-3 code (variance measurement)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,15 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 0
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed != 0:
+    import random
+    random.seed(cfg.seed)
+    torch.manual_seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Measure variance on the LATEST code (lr=2.5e-3 + per-head tandem temp + n_head=3). This gives the noise floor for evaluating future experiments.

## Instructions
1. No code changes. Pass --seed 42.
2. Run with `--wandb_group seed42-lr25`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: `cla4pnpk` (gilbert/seed42-lr25), 61 epochs

Implementation: Added `seed: int = 0` to Config dataclass. When seed != 0, sets `random.seed` and `torch.manual_seed` (CPU + CUDA default generator). Note: `torch.cuda.manual_seed_all` was NOT used -- a first attempt with that call caused CUDAGraph pool errors (run `3e6ciaov`, crashed in epoch 1). Using only `torch.manual_seed` avoids this.

### Metrics comparison

| Metric | seed=42 | seed=0 (baseline) | Diff |
|---|---|---|---|
| val/loss | 0.8601 | 0.8555 | +0.0046 |
| val_in_dist/mae_surf_p | 17.40 | ~17.11 | +0.29 |
| val_ood_cond/mae_surf_p | 13.88 | ~14.40 | -0.52 |
| val_ood_re/mae_surf_p | 27.51 | ~27.84 | -0.33 |
| val_tandem_transfer/mae_surf_p | 38.54 | ~38.30 | +0.24 |
| mean3 (in+ood+tan)/3 | 23.27 | ~23.27 | ~0.00 |

(baseline split-level metrics estimated from PR #1350 seed=0 run on similar code)

### Full surface MAE (seed=42)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol (avg) |
|---|---|---|---|---|
| val_in_dist | 4.71 | 1.58 | **17.40** | 6.58 |
| val_ood_cond | 2.93 | 1.06 | **13.88** | 4.13 |
| val_ood_re | -- | -- | **27.51** | -- |
| val_tandem_transfer | 5.26 | 2.01 | **38.54** | 13.65 |

### Noise floor estimate

With seed=0 vs seed=42:
- |Delta val/loss| = 0.0046, so sigma_val_loss ~= 0.0046/sqrt(2) ~= 0.0033
- |Delta mean3| ~= 0.00, so the mean3 metric is very stable

Conservative thresholds for statistical significance (~2sigma):
- val/loss: changes > 0.0066 are likely real
- mean3: changes > 0.3 are likely real (conservative estimate given near-zero in this run)

This is the lowest noise measured so far. The lr=2.5e-3 code appears more stable across seeds than the lr=3e-3 per-head code (previous calibration: sigma~0.0054 on val/loss).

### Suggested follow-ups

- With sigma~0.0033, even small improvements of ~0.01 on val/loss are clearly significant
- The CUDAGraph / `torch.cuda.manual_seed_all` conflict is worth noting for future seed experiments on torch.compile models: use only `torch.manual_seed`