### PR TITLE
Warmup 8 on lr=2.5e-3 code (schedule tuning for gentler LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[8]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
With lr=2.5e-3 (17% lower than 3e-3), the warmup phase may be over-long. Reducing from 10 to 8 epochs gives 2 more epochs at full LR. warmup=8 was a near-miss on older code.

## Instructions
1. Change warmup total_iters from 10 to 8, milestones from [10] to [8]
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group warmup8-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** vob0l93k  
**Epochs completed:** 58/100 (30-min timeout)  
**Peak memory:** 14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8555 | 0.9024 | +5.5% worse |
| val_in_dist | mae_surf_p | 17.48 | 19.71 | +12.8% worse |
| val_ood_cond | mae_surf_p | 13.59 | 14.19 | +4.4% worse |
| val_tandem_transfer | mae_surf_p | 38.53 | 40.88 | +6.1% worse |
| val_ood_re | mae_surf_p | 27.57 | 27.97 | +1.4% worse |
| **mean3** | mae_surf_p | **23.20** | **24.93** | **+7.5% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=5.84, Uy=1.68, p=19.71 | Vol: Ux=1.12, Uy=0.37, p=20.20
- **ood_cond:** Ux=4.31, Uy=1.26, p=14.19 | Vol: Ux=0.74, Uy=0.28, p=12.52
- **ood_re:** Ux=4.01, Uy=1.14, p=27.97 | Vol: Ux=0.85, Uy=0.37, p=47.13
- **tandem_transfer:** Ux=6.35, Uy=2.22, p=40.88 | Vol: Ux=1.98, Uy=0.90, p=39.51

### What happened

The hypothesis did not improve over baseline. All splits degraded, most notably in_dist (+12.8%) and tandem (+6.1%).

Reducing warmup from 10 to 8 epochs appears to hurt: the 10-epoch warmup provides a gentler ramp that helps the model settle into a good initialization before the cosine schedule takes over. With only 8 epochs of warmup, the transition to full LR happens too abruptly — this seems to matter more at lr=2.5e-3 than expected. The previous "near-miss" result on older code may have been on a different architecture or noise schedule.

The training curves were still declining at epoch 58, confirming the 30-minute limit constrains comparison.

### Suggested follow-ups

- **Warmup=12**: If 10 is better than 8, trying 12 might improve further — trading more warmup for a smoother transition.
- **Start factor tuning**: Rather than varying the warmup length, trying start_factor=0.05 (stricter ramp) with warmup=10 may help.