### PR TITLE
lr=2.3e-3 on per-head tandem temp code (continue LR search)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.5e-3
+    lr: float = 2.3e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
lr=2.5e-3 beat baseline (0.8555 vs 0.8600) with dramatic ood recovery. Testing 2.3e-3 continues the downward LR search — does even gentler LR push further or did 2.5e-3 already find the sweet spot?

## Instructions
1. Change lr from 2.5e-3 (current) to 2.3e-3
2. Keep everything else identical
3. Run with `--wandb_group lr-23e3`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `xgrbesx1` (thorfinn/lr-23e3, group: lr-23e3)
**Peak memory:** 14.8 GB
**Training:** 61 epochs, 30.3 min

### Surface MAE (mae_surf_p, primary metric)

| Split | This run (lr=2.3e-3) | Baseline (lr=2.5e-3) | Delta |
|-------|----------------------|----------------------|-------|
| val_in_dist | 18.2 | 17.5 | +0.7 |
| val_ood_cond | 14.3 | 13.6 | +0.7 |
| val_ood_re | 28.1 | 27.6 | +0.5 |
| val_tandem_transfer | 38.8 | 38.5 | +0.3 |
| **mean3 (in+ood+tan)/3** | **23.8** | **23.2** | **+0.6** |

### Full Surface MAE breakdown (best checkpoint, epoch 61)

| Split | Ux | Uy | p | val/loss |
|-------|-----|-----|-----|---------|
| val_in_dist | 5.0 | 1.9 | 18.2 | 0.5974 |
| val_ood_cond | 3.2 | 1.3 | 14.3 | 0.7131 |
| val_ood_re | 2.9 | 1.2 | 28.1 | 0.5527 |
| val_tandem_transfer | 5.5 | 2.5 | 38.8 | 1.6316 |

**val/loss (4-split avg):** 0.8737 (baseline 0.8555)

### What happened

lr=2.3e-3 is worse than lr=2.5e-3 across all splits. val/loss regresses from 0.8555 → 0.8737 (+2.1%). The lower LR slows convergence — the model doesn't reach the same quality in the 30-min budget. 

The LR sweet spot appears to be lr=2.5e-3. Going lower to 2.3e-3 is suboptimal: the benefit of gentler gradient steps is outweighed by reduced convergence speed given the fixed 30-min budget.

### Suggested follow-ups
- lr=2.5e-3 appears to be the optimal LR for the current architecture. The LR sweep should stop here.
- If trying to further optimize LR, a longer training run (not possible with 30-min budget) might show lr=2.3e-3 eventually catching up.