### PR TITLE
Surf_weight clamp max=40 on lr=2.5e-3 code

### DIFF
--- a/train.py
+++ b/train.py
@@ -635,8 +635,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Adaptive surface weight: loss-ratio based, clamped [5, 40]
+    surf_weight = max(5.0, min(40.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
surf-clamp-40 showed val_loss=0.863 on pre-merge code (lr=3e-3) — near-miss. With lr=2.5e-3 now merged, the gentler LR may compound with the reduced surf_weight ceiling.

## Instructions
1. Change surf_weight ceiling from 50 to 40: `surf_weight = max(5.0, min(40.0, surf_weight))`
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group surf-clamp-40-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `gc905b17` | **Epochs:** 60/100 (30-min timeout) | **Peak VRAM:** 14.8 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| val_in_dist | 17.48 | 17.46 | -0.02 — tied |
| val_ood_cond | 13.59 | 13.46 | -0.13 ▼ slightly better |
| val_ood_re | 27.57 | 27.78 | +0.21 ▲ slightly worse |
| val_tandem | 38.53 | 39.30 | +0.77 ▲ worse |
| **mean3** (in/ood_cond/tan) | **23.20** | **23.41** | **+0.21 ▲ slightly worse** |

**val/loss:** 0.8646 vs baseline 0.8555 → worse (+1.1%)

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 6.80 | 2.04 | 17.46 |
| val_ood_cond | 3.35 | 1.16 | 13.46 |
| val_ood_re | 2.91 | 1.00 | 27.78 |
| val_tandem | 6.53 | 2.36 | 39.30 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.09 | 0.36 | 18.97 |
| val_ood_cond | 0.72 | 0.27 | 11.56 |
| val_ood_re | 0.83 | 0.36 | 46.80 |
| val_tandem | 1.96 | 0.88 | 38.49 |

### What happened

Null result confirmed on the lr=2.5e-3 baseline. Reducing the surf_weight ceiling from 50 to 40 produced no meaningful improvement — mean3 is 23.41 vs 23.20 (worse by 0.21), and val/loss regressed (+1.1%). This follows the same pattern as the lr=3e-3 test (PR #1352).

The hypothesis that lr=2.5e-3 would compound favorably with the tighter ceiling does not hold. The surf_weight adaptive mechanism likely stays below 40 throughout training regardless of LR, making the ceiling irrelevant.

Two consecutive null results strongly suggest the surf_weight ceiling is not a useful knob. The ratio-based adaptive formula settles well below 40 by the time the model is trained, so neither 40 nor 50 is ever binding.

### Suggested follow-ups
- Stop exploring surf_weight ceiling tuning — two runs confirm it's not impactful
- The baseline lr=2.5e-3 (val_loss=0.8555) is better than lr=3e-3 (val_loss=0.8600); continue exploring other axes on this baseline
- Consider changes that directly affect the tandem split (tandem/mae_surf_p is the highest at ~38-39)