### PR TITLE
Warmup 5 on lr=2.5e-3 code (more productive epochs with gentler LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
warmup=5 was a near-miss on multiple code versions. With lr=2.5e-3 (gentler), the risk of too-short warmup is reduced — the model doesn't spike as high. 5 extra productive epochs may help more than ever.

## Instructions
1. Change warmup total_iters from 10 to 5, milestones from [10] to [5]
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group warmup5-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---

## Results

**W&B run:** `lm7qz1io`
**Epochs:** ~65 (30-min timeout — 3 more than baseline due to faster warmup)
**Peak VRAM:** ~15 GB

*Note: W&B state shows "failed" due to pre-existing visualization crash after training. Metrics are valid.*

### Surface MAE (pressure) — primary metric

| Split | Baseline (warmup=10) | warmup=5 | Δ |
|-------|---------------------|---------|---|
| in_dist | 17.48 | 17.48 | 0.0% = |
| ood_cond | 13.59 | 13.79 | +1.5% ✗ |
| ood_re | 27.57 | 27.77 | +0.7% ✗ |
| tandem | 38.53 | 37.62 | **-2.4% ✓** |
| **mean3** | **23.20** | **22.96** | **-1.0% ✓** |

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|------|
| in_dist | 4.76 | 1.46 | 17.48 |
| ood_cond | 2.83 | 0.93 | 13.79 |
| ood_re | 2.32 | 0.77 | 27.77 |
| tandem | 5.20 | 2.00 | 37.62 |

### Losses

| Metric | Baseline (warmup=10) | warmup=5 |
|--------|---------------------|---------|
| val/loss | 0.8555 | 0.8643 |

### What happened

**Mixed: mean3 improved (-1.0%) but val/loss got slightly worse.**

The key driver is the **tandem improvement**: 38.53 → 37.62 (-2.4%). In_dist is exactly tied (17.48 = 17.48). Ood_cond and ood_re regressed slightly (+1.5%, +0.7%), within noise range.

Possible mechanism: the shorter warmup gives 3 additional full-LR epochs (65 vs ~62). More training time at full lr=2.5e-3 appears to help the tandem transfer case specifically, which may need more epochs to learn the cross-foil interactions.

The val/loss worsening (0.8555 → 0.8643) despite mean3 improvement suggests the adaptive surf_weight is interacting differently with the warmup schedule, or that volume MAE worsened slightly.

The in_dist tie (17.48 = 17.48) is notably tight — this may simply reflect the noise floor.

### Suggested follow-ups

1. **Confirm with a second seed**: The tandem improvement could be seed-dependent. Run seed=200 or seed=7 on warmup=5 to verify.
2. **Warmup=3**: Even shorter warmup may push even more epochs at full LR.
3. **Combined with temp clamp 0.2/ep45**: That change showed similar in_dist/ood improvements on n_head=4 code — combination might stack on lr=2.5e-3.