### PR TITLE
EMA decay 0.997 on lr=2.5e-3 code (faster averaging for gentler LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.997
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
With lr=2.5e-3, the LR is gentler and late-training updates are smoother. EMA decay 0.997 (faster than baseline 0.998) may better track the smoother trajectory. This was tested on lr=3e-3 code and didn't help — but lr=2.5e-3 changes the gradient dynamics.

## Instructions
1. Change EMA decay from 0.998 to 0.997
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group ema-decay-997-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `174zxftr` (alphonse/ema-decay-997-lr25)
**Epoch at timeout:** 61 (~21 EMA epochs; ema_start_epoch=40)
**Runtime:** 1924s (~32 min)

### Metrics vs baseline

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8736 | 0.8555 | +0.0181 (+2.1%) |
| in_dist surf p | 17.58 | 17.48 | +0.10 |
| ood_cond surf p | 14.15 | 13.59 | +0.56 |
| ood_re surf p | 28.26 | 27.57 | +0.69 |
| tandem surf p | 38.33 | 38.53 | **-0.20** |
| mean3 | 23.35 | 23.20 | +0.15 |

### Surface MAE (full)
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 4.84 | 1.54 | 17.58 |
| ood_cond | 2.76 | 1.00 | 14.15 |
| ood_re | 2.31 | 0.79 | 28.26 |
| tandem | 4.92 | 2.08 | 38.33 |

### Volume MAE (p)
in_dist=19.05, ood_cond=12.17, ood_re=47.09, tandem=37.73

**Peak GPU memory:** N/A (system metrics not logged)

### What happened

Negative result. EMA decay 0.997 on lr=2.5e-3 code is slightly worse than baseline (0.998) on all splits except tandem (−0.20, modest). The val/loss is 2.1% higher. The faster averaging doesn't appear to help in the lr=2.5e-3 regime — or at least doesn't hurt and the difference is close to noise level.

The key limitation remains: with ema_start_epoch=40 and the run timing out at epoch 61, we only get ~21 EMA epochs of averaging regardless of decay value. At 0.997 vs 0.998, the effective window is ~333 epochs vs ~500 epochs — both far more than the 21 epochs we actually run, so in practice both decays are in the "fast accumulation" phase and the difference is negligible.

The hypothesis that slower gradients warrant faster EMA isn't supported here.

### Suggested follow-ups
- Lower ema_start_epoch to 20–30 to get more EMA averaging within the 30-min window; that would actually test EMA decay differences
- The lr=2.5e-3 baseline itself (0.8555) shows the LR change is beneficial; focus on other knobs in that regime
- Try ema_decay=0.995 to see if there's a stronger trend, or accept 0.998 as fine and move on