### PR TITLE
Temp clamp 0.22@ep48 on lr=2.5e-3 code (fine-tuned midpoint)

### DIFF
--- a/train.py
+++ b/train.py
@@ -799,9 +799,9 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 48:
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.22)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
temp-clamp-0.22@ep48 showed best_vl=0.870 on pre-merge code (lr=3e-3). Retesting with lr=2.5e-3 — the gentler LR may compound with the slightly sharper attention (0.22 vs baseline 0.25).

## Instructions
1. Change temp clamp from 0.25 to 0.22, start epoch from 50 to 48
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group temp-clamp-022-ep48-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** iuvx5j86
**Epochs completed:** 61/100 (30-min timeout)
**Peak memory:** 14.8 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8738 | 0.8555 | +2.1% (worse) |
| Surface MAE p (in_dist) | 17.85 | 17.48 | +2.1% (worse) |
| Surface MAE p (ood_cond) | 14.60 | 13.59 | +7.4% (worse) |
| Surface MAE p (ood_re) | 28.34 | 27.57 | +2.8% (worse) |
| Surface MAE p (tandem) | 38.23 | 38.53 | -0.8% (negligible) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 5.19 | 1.66 | 17.85 |
| ood_cond | 2.99 | 1.17 | 14.60 |
| ood_re | 2.47 | 1.04 | 28.34 |
| tandem | 5.56 | 2.12 | 38.23 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.07 | 0.36 | 18.80 |
| ood_cond | 0.71 | 0.27 | 12.10 |
| ood_re | 0.82 | 0.36 | 47.02 |
| tandem | 1.93 | 0.87 | 37.61 |

### What happened

Negative result. val/loss worse +2.1%, and ood_cond pressure regresses substantially (+7.4%) — the opposite of what was hoped. The hypothesis did not replicate.

The previous temp-clamp-022@ep48 test (PR #1358, lr=3e-3) showed ood_cond improving from 14.40 to 13.81 (-4.1%). On lr=2.5e-3 with a lower baseline (13.59), the same clamp pushes ood_cond to 14.60 (+7.4%). This reversal is notable:

1. **The lr=2.5e-3 baseline is already at a different optimum.** The lr=2.5e-3 code (val_loss=0.8555) reaches a better point with the default clamp (0.25@50). Changing the clamp disrupts that solution.
2. **The 0.22@ep48 improvement in PR #1358 may have been noise or code-specific.** With a better baseline model, the clamp tightening hurts rather than helps — there's less slack for the model to recover from the sharper routing constraint.
3. **Compounding does not apply.** The gentler LR does not compound with the sharper clamp — they interfere.

### Suggested follow-ups

- **Accept baseline clamp (0.25@50) as optimal for lr=2.5e-3.** The evidence suggests the default is fine on this code.
- **Test 0.28@52 on lr=2.5e-3:** If 0.25@50 is the sweet spot for this LR regime, test a slightly looser clamp applied later to confirm.
- **Return to 0.22@ep48 on lr=3e-3 and repeat:** The PR #1358 result was interesting but should be replicated before investing further in it.