### PR TITLE
Asymmetric tandem temp [-0.1, 0, 0.1] on lr=2.5e-3 code

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,7 +128,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
-        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
+        init_vals = torch.tensor([-0.1, 0.0, 0.1]).view(1, heads, 1, 1)
+        self.tandem_temp_offset = nn.Parameter(init_vals)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
Asymmetric initialization forces head diversity from the start. On lr=3e-3 code it showed 0.884. With lr=2.5e-3, the gentler LR may allow the asymmetric heads to find better specialization paths.

## Instructions
1. Change tandem_temp_offset init from zeros to [-0.1, 0.0, 0.1]: `init_vals = torch.tensor([-0.1, 0.0, 0.1]).view(1, heads, 1, 1); self.tandem_temp_offset = nn.Parameter(init_vals)`
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group tandem-temp-asym-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** 58e75iic  
**Epochs completed:** 58/100 (30-minute timeout)  
**Peak memory:** 14.8 GB  

### Validation Loss
| Split | This run (ep57) | Baseline |
|---|---|---|
| val_loss (avg) | 0.8789 | 0.8555 |
| in_dist | 0.5989 | — |
| ood_cond | 0.7196 | — |
| ood_re | 0.5526 | — |
| tandem_transfer | 1.6445 | — |

*(epoch 58 log: in_dist=0.5945, ood_cond=0.7118, ood_re=0.5478, tandem=1.6394, val_loss≈0.8734)*

### Surface MAE (epoch 57)
| Split | Ux | Uy | p | Baseline p |
|---|---|---|---|---|
| in_dist | 6.48 | 2.00 | 18.32 | 17.48 |
| ood_cond | 3.85 | 1.40 | 14.26 | 13.59 |
| ood_re | 3.44 | 1.23 | 28.03 | 27.57 |
| tandem | 6.12 | 2.53 | 38.89 | 38.53 |

### Volume MAE (epoch 57)
| Split | Ux | Uy | p |
|---|---|---|---|
| in_dist | 1.13 | 0.36 | 19.66 |
| ood_cond | 0.73 | 0.27 | 12.06 |
| ood_re | 0.83 | 0.36 | 47.12 |
| tandem | 1.95 | 0.89 | 38.48 |

### What happened
Negative result. val_loss 0.8789 at epoch 57 vs baseline 0.8555 — 2.7% worse. Asymmetric tandem_temp_offset initialization [-0.1, 0.0, 0.1] did not improve over zero initialization on lr=2.5e-3.

All surface pressure metrics are worse than baseline: in_dist 18.32 vs 17.48, ood_cond 14.26 vs 13.59, ood_re 28.03 vs 27.57, tandem 38.89 vs 38.53. The tandem split is the closest (only 0.9% behind baseline), but this doesn't represent an improvement.

The asymmetric init forces the three heads to start with different effective temperatures for tandem samples (-0.1+base, 0+base, 0.1+base). This diversity doesn't appear to help convergence at lr=2.5e-3 — the model still needs to learn the right offsets from scratch, and starting asymmetrically may actually slow early convergence by introducing inconsistency.

Interestingly, the model is converging slower than the lr=3e-3 baseline at the same epoch count, yet better than the lr=2.8e-3 run at epoch 58. This suggests the asymmetric init slightly disrupts early convergence.

### Suggested follow-ups
- Try asymmetric init on lr=3e-3 (to isolate the LR effect vs init effect)
- Try smaller asymmetry [−0.05, 0, 0.05] — the ±0.1 range may be too large
- The near-parity on tandem surface p (38.89 vs 38.53) is notable; worth revisiting tandem-focused metrics specifically