### PR TITLE
Coarse weight 1.2x on lr=2.5e-3 code (slight increase never tested)

### DIFF
--- a/train.py
+++ b/train.py
@@ -770,7 +770,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            loss = loss + 1.2 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
Coarse weight was tested at 0.5x, 1.5x, and 2x on older code — all worse. But 1.2x (a very slight 20% increase) was never tested on ANY code. With lr=2.5e-3, the gentler LR may make the coarse signal slightly more important for guiding early learning.

## Instructions
1. Find the coarse weight and multiply by 1.2
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group coarse-12x-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `myrisjdu` (`norman/coarse-12x-lr25`)
**Best epoch:** 56
**Peak memory:** N/A (run killed by 30-min timeout at 31.9 min)

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 0.6044 | 17.93 |
| val_ood_cond | 0.7138 | 14.23 |
| val_ood_re | 0.5642 | 28.31 |
| val_tandem_transfer | 1.6730 | 39.86 |
| **Combined** | **0.8888** | — |

**vs baseline (0.8555):** +0.0333 (worse)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8555 | 0.8888 | **+0.0333** ✗ |
| in_dist surf_p | 17.48 | 17.93 | +0.45 ✗ |
| ood_cond surf_p | 13.59 | 14.23 | +0.64 ✗ |
| ood_re surf_p | 27.57 | 28.31 | +0.74 ✗ |
| tandem surf_p | 38.53 | 39.86 | +1.33 ✗ |

### What happened
Coarse weight 1.2x made every metric worse by a meaningful margin. The combined val/loss increased by 0.033 and all surface pressure MAEs increased. The run was killed by the 30-minute timeout (31.9 min), but the best epoch (56) had been logged before the cutoff — the training had converged to a clearly worse solution.

This is consistent with the previous history: coarse weight 0.5x, 1.5x, and 2.0x were all worse on older code. The 1.0x weight appears to be the optimum. Even the small 1.2x increase hurts. The coarse loss is already well-calibrated — it seems any deviation from 1.0x degrades performance.

### Suggested follow-ups
- The coarse weight appears to be a sharp optimum at 1.0x. Probably not worth testing other small deviations (0.8x, 0.9x).
- Consider whether the coarse pool size (currently 64 nodes) could be varied — that's a different dimension not yet explored.
- lr=2.5e-3 appears to be a solid baseline; future experiments can build on it.