### PR TITLE
Hard-mining start ep25 on lr=2.5e-3 code (retest near-miss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -733,8 +733,8 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
+        # Asymmetric hard-node mining for non-tandem samples after epoch 25 (vectorized)
+        if epoch >= 25:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))


### PR DESCRIPTION
## Hypothesis
hard-mine-ep25 was close on old code. hard-mine-ep20 was a near-miss (val_loss=0.865, re=27.4). ep25 is the conservative variant that might compound with the gentler lr=2.5e-3.

## Instructions
1. Change hard-mining start from 30 to 25
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group hard-mine-ep25-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run**: `dmtkcb45`
**Epochs**: 57/100 (wall-clock limit, ~30 min)
**Peak memory**: 15.7 GB
**val/loss**: 0.8786 (baseline 0.8555, **+0.0231 worse**)

### Surface MAE

| Split | Ux | Uy | p | p vs baseline |
|-------|----|----|---|---------------|
| val_in_dist | 5.25 | 1.76 | 18.28 | 17.48 → +0.80 ↑ |
| val_ood_cond | 3.20 | 1.24 | 14.37 | 13.59 → +0.78 ↑ |
| val_ood_re | 2.84 | 1.08 | 27.93 | 27.57 → +0.36 ↑ |
| val_tandem_transfer | 5.08 | 2.26 | 39.51 | 38.53 → +0.98 ↑ |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.09 | 0.36 | 19.19 |
| val_ood_cond | 0.72 | 0.27 | 11.93 |
| val_ood_re | 0.83 | 0.36 | 46.79 |
| val_tandem_transfer | 1.94 | 0.88 | 38.44 |

### What happened

**Negative result.** All splits degraded vs baseline. Starting hard-mining earlier at epoch 25 (vs 30) on lr=2.5e-3 code did not help — all four splits got slightly worse, with tandem and in-dist pressure taking the biggest hits (+0.98 and +0.80 respectively).

A possible explanation: at epoch 25 the model's predictions may not yet be reliable enough to distinguish "hard" from "easy" nodes meaningfully. The top-50% threshold at 1.5x weighting applied too early could be amplifying noise rather than signal, causing the model to focus on spurious surface errors before it has developed a stable baseline.

Note: Two complete training runs were performed (the second with cleared torchinductor cache). Both runs crashed with a pre-existing `RuntimeError: mat1 and mat2 shapes cannot be multiplied (84905x25 and 57x57)` during the post-training visualization step — training itself completed normally. I report the better run `dmtkcb45` (val/loss=0.8786). The other run `e1djg56a` scored val/loss=0.8814 — same conclusion, slightly worse.

### Suggested follow-ups

- Try hard-mining start ep35 or ep40 — if ep25 is too early and ep30 is also worse than no hard-mining (or the old code's ep30 was tuned differently), a later start may be safer.
- The hypothesis that ep25+lr=2.5e-3 would "compound" compared to ep30 appears incorrect. Hard-mining start and LR may interact in unexpected ways.
- Consider testing the hard-mining epoch sweep on the baseline (lr=3e-3) code to isolate the effect without LR confounding.