### PR TITLE
Per-head spatial bias MLP (architectural: each head routes nodes differently)

### DIFF
--- a/train.py
+++ b/train.py
@@ -164,7 +164,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             temp = (temp + self.tandem_temp_offset * tandem_mask).clamp(min=1e-4)
         slice_logits = self.in_project_slice(x_mid) / temp
         if spatial_bias is not None:
-            slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
+            slice_logits = slice_logits + 0.1 * spatial_bias
         slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
@@ -210,10 +210,11 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.num_heads = num_heads
         self.spatial_bias = nn.Sequential(
             nn.Linear(3, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
-            nn.Linear(64, slice_num),
+            nn.Linear(64, slice_num * num_heads),
         )
         nn.init.zeros_(self.spatial_bias[-1].weight)
         nn.init.zeros_(self.spatial_bias[-1].bias)
@@ -232,7 +233,11 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
-        sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+        if raw_xy is not None:
+            B, N = raw_xy.shape[:2]
+            sb = self.spatial_bias(raw_xy).reshape(B, N, self.num_heads, -1).permute(0, 2, 1, 3)
+        else:
+            sb = None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis
The spatial_bias MLP maps (x, y, curvature) to slice routing logits — shared across all 3 heads. With n_head=3 (64-dim/head), each head should specialize differently. Per-head spatial bias means each head routes nodes to different spatial groups, enabling true per-head specialization of the flow field. This is an ARCHITECTURAL change — the only kind that has reliably broken plateaus.

## Instructions
1. In TransolverBlock.__init__, change the spatial_bias from a single MLP to per-head:
   - Instead of one MLP outputting slice_num logits, create 3 separate MLPs (or one MLP outputting n_head * slice_num logits, then reshape)
   - Each head gets its own routing: spatial_bias output shape changes from [B, N, slice_num] to [B, N, n_head, slice_num]
2. In the forward pass, use each head's routing independently instead of sharing the same routing across all heads
3. This adds ~3x the spatial_bias parameters but is still tiny compared to the total model
4. Run with `--wandb_group perhead-spatial-bias-lr25`

**Key insight**: Per-head tandem temp worked by giving each head independent temperature. Per-head spatial bias extends this: each head gets independent ROUTING. One head might focus on boundary layer, another on wake, another on far-field.

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `07909fze`
**Epochs:** 59 (30-min timeout)
**Peak VRAM:** 15.0 GB (+0.3 GB vs baseline)

| Metric | Baseline (lr=2.5e-3) | This run | Δ |
|--------|----------------------|----------|---|
| val/loss | 0.8555 | 0.8676 | +0.0121 ↑ worse |
| surf_p in_dist | 17.48 | 18.28 | +0.80 ↑ worse |
| surf_p ood_cond | 13.59 | 13.89 | +0.30 ↑ slightly worse |
| surf_p ood_re | 27.57 | 27.96 | +0.39 ↑ worse |
| surf_p tandem | 38.53 | 38.43 | -0.10 ↓ negligible |
| **mean3** | **23.20** | **23.53** | +0.33 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**Implementation:** One MLP outputting  logits, reshaped to , permuted to , and added directly to per-head slice_logits (no broadcast needed). The last layer weight/bias initialization to zero is preserved.

**What happened:** Per-head spatial bias did not help — it's modestly worse on all metrics except tandem (which is unchanged). The intuition was compelling (independent routing per head = specialization), but the data suggests the original shared bias already works well. Sharing the routing signal may actually be beneficial as a form of coordination between heads, ensuring they all see the same geometric structure and can focus their capacity on learning different functional aspects of the solution. With per-head routing, the heads may over-specialize and lose this coordination signal.

An alternative explanation: the change adds 3× the spatial_bias parameters but the additional capacity doesn't help because the routing problem is already well-solved by the shared MLP — adding per-head capacity just makes optimization harder without adding useful inductive bias.

**Suggested follow-ups:**
1. Contrastive approach: keep shared bias but add a small per-head *correction* (e.g., per-head bias is 1.0 * shared + 0.1 * head_specific) to preserve coordination.
2. Focus optimization on aspects that show consistent gains — the lr=2.5e-3 base appears strong; try auxiliary loss weight variations or EMA decay on top of it.