### PR TITLE
Tandem sample loss boost 1.5x (increase tandem gradient signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -746,7 +746,9 @@ for epoch in range(MAX_EPOCHS):
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        vol_per_sample = (abs_err * vol_mask_train.unsqueeze(-1)).sum(dim=(1, 2)) / (3.0 * vol_mask_train.sum(dim=1).clamp(min=1).float())
+        tandem_weight_15 = torch.where(is_tandem_batch, 1.5, 1.0).to(device)
+        loss = ((vol_per_sample + surf_weight * surf_per_sample * tandem_boost) * tandem_weight_15).mean()
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
Tandem (38.53) is consistently the weakest split. The per-head tandem temp helped (38.93→38.30→38.53 through merges) but tandem still lags. Directly boosting the loss contribution from tandem samples by 1.5x gives the optimizer more incentive to reduce tandem error.

## Instructions
1. In the training loop, identify tandem samples (using the is_tandem flag)
2. Multiply the loss for tandem samples by 1.5: `if is_tandem: loss = loss * 1.5`
3. Keep everything else identical
4. Run with `--wandb_group tandem-boost-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `f0tocckz`
**Best epoch:** 61 / 100 (hit wall-clock limit, ~30s/epoch)
**Peak memory:** 14.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6230 | 7.62 | 2.13 | 18.47 | 1.25 | 0.42 | 21.51 |
| val_tandem_transfer | 1.6796 | 6.96 | 2.47 | 39.12 | 2.17 | 0.99 | 40.67 |
| val_ood_cond | 0.7545 | 4.45 | 1.29 | 14.49 | 0.89 | 0.34 | 14.70 |
| val_ood_re | 0.5811 | 4.11 | 1.09 | 28.14 | 0.98 | 0.41 | 48.79 |
| **mean3** | **1.019** | **6.34** | **1.96** | **24.03** | — | — | — |

Baseline: mean3=23.20 (in=17.48, ood=13.59, tan=38.53, re=27.57), val_loss=0.8555

**What happened:** Negative result. mean3 surface_p worsened from 23.20 → 24.03, val/loss from 0.8555 → 0.9095. All splits degraded: in_dist (+0.99), tandem (+0.59), ood_cond (+0.90), ood_re (+0.57). Notably, even tandem got worse despite the 1.5× boost targeting it.

The 1.5× tandem loss multiplier overwhelms the optimizer's signal balance. Tandem samples already receive an adaptive boost through the existing `tandem_boost` mechanism (max 4× on surf loss) and the per-head tandem temperature. Adding a 1.5× multiplier on the *total* per-sample loss (including vol) creates over-emphasis on tandem samples, degrading the vol predictions for tandem samples (vol_p went from ~38 to 40.7) and forcing the model away from in-dist/ood_cond accuracy without actually improving tandem surface pressure.

**Implementation note:** The 1.5× was applied as a per-sample multiplier on the combined (vol + surf_weight × surf) loss, preserving the existing adaptive surf boost. This is the faithful interpretation of the pseudocode.

**Suggested follow-ups:**
- Try 1.1× or 1.2× multiplier instead of 1.5× — the existing adaptive boost already over-corrects for tandem.
- Remove the existing adaptive tandem boost first before adding a fixed multiplier (they compound).
- Accept that tandem transfer is fundamentally a different distribution (geometry varies) — loss weighting alone may not help.