### PR TITLE
EMA start epoch 35 on lr=2.5e-3 code (more EMA for gentler LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -535,7 +535,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 35
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
With lr=2.5e-3, the model converges more smoothly. Starting EMA 5 epochs earlier (ep35 vs ep40) gives 5 more epochs of EMA averaging. On lr=3e-3 code this hurt — but the gentler LR changes the dynamics.

## Instructions
1. Change ema_start_epoch from 40 to 35
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group ema-start-35-lr25`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** f5jo6uwu  
**Epochs completed:** 58/100 (30-min timeout)  
**Peak memory:** 14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8555 | 0.8644 | +1.0% worse |
| val_in_dist | mae_surf_p | 17.48 | 17.56 | +0.5% worse |
| val_ood_cond | mae_surf_p | 13.59 | 14.17 | +4.3% worse |
| val_tandem_transfer | mae_surf_p | 38.53 | 38.93 | +1.0% worse |
| val_ood_re | mae_surf_p | 27.57 | 27.93 | +1.3% worse |
| **mean3** | mae_surf_p | **23.20** | **23.55** | **+1.5% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=3.80, Uy=1.51, p=17.56 | Vol: Ux=1.09, Uy=0.36, p=18.90
- **ood_cond:** Ux=3.32, Uy=1.17, p=14.17 | Vol: Ux=0.72, Uy=0.27, p=11.93
- **ood_re:** Ux=2.79, Uy=0.99, p=27.93 | Vol: Ux=0.82, Uy=0.36, p=46.75
- **tandem_transfer:** Ux=4.70, Uy=2.09, p=38.93 | Vol: Ux=1.93, Uy=0.87, p=38.05

### What happened

The hypothesis did not clearly improve over baseline. All metrics are slightly worse, though the differences are modest (within ~1–4%) compared to the larger regressions seen on other experiments.

The hypothesis was that the gentler lr=2.5e-3 dynamics would make early EMA more beneficial. The outcome is essentially neutral — mean3 is 1.5% worse (23.55 vs 23.20), not meaningfully different. The ood_cond regression (+4.3%) is the largest single deterioration, which isn't explained by the EMA timing change alone.

This is a cleaner result than the perhead experiment where ema_start=35 caused larger regressions (mean3=24.10 vs 23.27). With lr=2.5e-3, the model is indeed in a less noisy state at epoch 35, but still not fully converged — the training curves at epoch 58 were still declining.

The baseline (ema_start=40) remains slightly preferred.

### Suggested follow-ups

- **EMA start 45**: Moving in the opposite direction — later EMA start — might give a cleaner snapshot of the converged model.
- **EMA decay 0.999**: Increasing decay gives more weight to recent (later-epoch) model states regardless of start epoch, avoiding contamination from early noisy epochs.