### PR TITLE
Warmup 7 on lr=2.5e-3 (midpoint: better tandem than 10, better ood than 5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=7)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[7]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
warmup=5 gives the best tandem ever (37.62) but hurts ood. warmup=10 is baseline. warmup=7 is the untested midpoint that may capture some tandem benefit while preserving ood quality. With lr=2.5e-3, the gentler LR makes the warmup/ood tradeoff more favorable.

## Instructions
1. Change warmup total_iters from 10 to 7, milestones from [10] to [7]
2. Keep lr=2.5e-3 and everything else identical
3. Run with `--wandb_group lr-25e3-warmup7`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---

## Results

**W&B run:** `ywcoic84`
**Epochs:** ~62 (30-min timeout)
**Peak VRAM:** ~15 GB

*Note: W&B state shows "failed" due to pre-existing visualization crash after training. Metrics are valid.*

### Surface MAE (pressure) — three-way comparison

| Split | warmup=5 | warmup=7 (this) | warmup=10 (baseline) |
|-------|---------|-----------------|----------------------|
| in_dist | 17.48 | 17.82 | **17.48** |
| ood_cond | 13.79 | **13.35** | 13.59 |
| ood_re | 27.77 | **27.37** | 27.57 |
| tandem | **37.62** | 39.59 | 38.53 |
| **mean3** | **22.96 ✓** | 23.59 ✗ | 23.20 |
| val/loss | 0.8643 | 0.8625 | **0.8555** |

### What happened

**Not a midpoint — warmup=7 is the worst of the three on mean3 (23.59).**

The pattern is surprising: warmup=7 has the best ood_cond (13.35) and ood_re (27.37) of all three settings, but the worst tandem (39.59 — even worse than baseline). The in_dist also regressed vs. baseline (17.82 vs 17.48).

The tandem pattern is striking:
- warmup=5: tandem=37.62 (best)
- warmup=10: tandem=38.53 (middle)
- warmup=7: tandem=39.59 (worst)

This non-monotonic relationship suggests warmup isn't simply trading tandem vs ood. Different warmup lengths may produce different optimization trajectories that affect splits independently.

The warmup=7 result appears to be an unlucky combination — it recovers OOD quality but sacrifices both in_dist and tandem. The clear conclusion is: **warmup=5 is better than both 7 and 10 on mean3, but warmup=7 is worse than 10**.

### Suggested follow-ups

1. **warmup=5 is the winner** — the advisor should consider whether to merge it given the val/loss tradeoff (better mean3, worse val/loss).
2. **Further warmup tuning (3, 4) on the warmup=5 trajectory** may squeeze more out of tandem and mean3.
3. The OOD improvement in warmup=7 is notable — if the advisor wants better OOD at the cost of tandem, warmup=7 is the right choice. But for mean3 optimization, warmup=5 wins.