### PR TITLE
Per-head output projections (head-specialized decoding)

### DIFF
--- a/train.py
+++ b/train.py
@@ -225,11 +225,12 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            dim_head = hidden_dim // num_heads
+            self.head_mlps = nn.ModuleList([
+                nn.Sequential(nn.Linear(dim_head, dim_head), nn.GELU(), nn.Linear(dim_head, out_dim))
+                for _ in range(num_heads)
+            ])
+            self.head_weights = nn.Parameter(torch.ones(num_heads) / num_heads)
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -240,7 +241,12 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx = self.ln_3(fx)
+            B, N, _ = fx.shape
+            fx_heads = fx.view(B, N, self.attn.heads, self.attn.dim_head)
+            outputs = [self.head_mlps[h](fx_heads[:, :, h]) for h in range(self.attn.heads)]
+            w = F.softmax(self.head_weights, dim=0)
+            return sum(w[h] * outputs[h] for h in range(self.attn.heads))
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
All 3 heads' outputs are concatenated and passed through one shared output MLP. But each head specializes in different spatial regions. Per-head output projections allow head-specialized decoding: the wake head can learn a different mapping than the boundary-layer head.

## Instructions
1. In TransolverBlock, when self.last_layer, replace the single mlp2 with 3 parallel small MLPs:
   ```python
   self.head_mlps = nn.ModuleList([
       nn.Sequential(nn.Linear(dim_head, dim_head), nn.GELU(), nn.Linear(dim_head, out_dim))
       for _ in range(heads)
   ])
   self.head_weights = nn.Parameter(torch.ones(heads) / heads)
   ```
2. In forward, split fx into per-head chunks, pass each through its head MLP, and combine:
   ```python
   fx_heads = fx.view(B, N, heads, dim_head)
   outputs = [self.head_mlps[h](fx_heads[:, :, h]) for h in range(heads)]
   w = F.softmax(self.head_weights, dim=0)
   fx = sum(w[h] * outputs[h] for h in range(heads))
   ```
3. Run with `--wandb_group perhead-output-proj`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `ka2iqeid` | **Epochs:** 56 | **Epoch time:** ~32s

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|-----------|-----------|----------|
| in_dist | 6.57 | 2.27 | 18.40 | 1.09 | 0.36 | 19.33 |
| ood_cond | 3.81 | 1.43 | 14.59 | 0.72 | 0.27 | 11.90 |
| ood_re | 3.28 | 1.26 | 27.83 | 0.81 | 0.36 | 46.66 |
| tandem | 6.22 | 2.63 | 39.32 | 1.94 | 0.88 | 38.29 |

**Summary vs baseline:**

| Metric | Baseline | Per-head | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8555 | 0.8836 | +0.0281 (+3.3%) |
| in_p | 17.48 | 18.40 | +0.92 (+5.3%) |
| ood_p | 13.59 | 14.59 | +1.00 (+7.4%) |
| re_p | 27.57 | 27.83 | +0.26 (+0.9%) |
| tan_p | 38.53 | 39.32 | +0.79 (+2.1%) |
| mean3 | 23.20 | 24.10 | +0.90 (+3.9%) |

**Peak memory:** not logged (system metrics unavailable)

### What happened

Per-head output projections are **worse than baseline** across all splits. val/loss regresses by 3.3% and mean3 by 3.9%. The hypothesis does not hold.

The likely reason: the per-head decomposition drastically reduces output MLP capacity. The baseline shared MLP has ~192×192 + 192×3 ≈ 37k parameters for the hidden layer; the 3 parallel per-head MLPs have 3×(64×64 + 64×3) ≈ 13.5k total — about one-third the capacity. Each head only sees 64 features instead of the full 192, which limits what the output network can express. The softmax gating adds only 3 extra parameters and cannot compensate.

Additionally, at n_layers=1, the attention block already mixes all heads back into a single representation before this layer. The "head specialization" assumption may be too strong — heads in this model are not cleanly specialized to distinct regions.

Note: run shows state="failed" due to the pre-existing visualization bug in noam (Fourier PE missing in line 1018 of train.py). All training metrics were captured successfully.

### Suggested follow-ups

1. **Try with concatenation instead of weighted sum**: directly concatenate per-head outputs and project: Linear(heads*out_dim → out_dim). This preserves more information without capacity loss.
2. **Increase head MLP size**: use Linear(dim_head, hidden_dim) instead of Linear(dim_head, dim_head) to match baseline capacity while keeping per-head structure.
3. **Fix visualization bug**: train.py line 1014-1018 needs Fourier PE before calling vis_model.