### PR TITLE
Learnable slice token init (DETR-style persistent slice identity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.slice_init = nn.Parameter(torch.randn(1, heads, slice_num, dim_head) * 0.02)
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +170,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+        slice_token = slice_token + self.slice_init
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)


### PR DESCRIPTION
## Hypothesis
Slice tokens are computed purely from weighted node aggregation. Adding a learnable per-slice embedding gives each slice a persistent identity (e.g., "I am the wake slice"). Like DETR's learnable object queries.

## Instructions
1. Add `self.slice_init = nn.Parameter(torch.randn(1, heads, slice_num, dim_head) * 0.02)` in Physics_Attention_Irregular_Mesh
2. After computing slice_token from weighted sum, add: `slice_token = slice_token + self.slice_init`
3. Run with `--wandb_group slice-token-init`

9,216 parameters (trivial), zero compute overhead.

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `tffmju2f` | **Epochs:** 59/100 (30-min timeout) | **Peak VRAM:** 14.8 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| val_in_dist | 17.48 | 18.60 | +1.12 ▲ worse |
| val_ood_cond | 13.59 | 13.94 | +0.35 ▲ worse |
| val_ood_re | 27.57 | 27.74 | +0.17 ▲ slightly worse |
| val_tandem | 38.53 | 38.69 | +0.16 ▲ slightly worse |
| **mean3** (in/ood_cond/tan) | **23.20** | **23.74** | **+0.54 ▲ worse** |

**val/loss:** 0.8740 vs baseline 0.8555 → worse (+2.1%)

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 5.84 | 1.69 | 18.60 |
| val_ood_cond | 3.48 | 1.04 | 13.94 |
| val_ood_re | 3.15 | 0.89 | 27.74 |
| val_tandem | 6.40 | 2.30 | 38.69 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.12 | 0.37 | 19.86 |
| val_ood_cond | 0.73 | 0.27 | 12.00 |
| val_ood_re | 0.83 | 0.36 | 46.76 |
| val_tandem | 1.96 | 0.88 | 38.37 |

### What happened

Adding learnable per-slice init embeddings hurt performance across all splits (mean3 +0.54, val/loss +2.1%). The DETR analogy doesn't hold here.

The key difference: DETR queries are the primary mechanism for object localization. Here, slice tokens are computed from input-conditioned weighted aggregation and are fully data-driven each forward pass. Adding a fixed bias doesn't give "persistent identity" — the weighted aggregation already captures which region this slice represents. Instead, the bias acts as input-independent noise that the model must learn to suppress, consuming optimization capacity.

With only 59 epochs, the extra ~9K parameters likely just introduce noise before the model can tune them away.

### Suggested follow-ups
- A learnable init might only help if the slice tokens were initialized from scratch (e.g., all-zeros) rather than from input aggregation — not applicable here
- Instead of biasing slice tokens, try biasing the Q projections (persistent query directions) or the output projections
- Focus on changes that alter information flow rather than adding offsets to already-meaningful representations