### PR TITLE
Gated attention output (sigmoid gate on attn before residual)

### DIFF
--- a/train.py
+++ b/train.py
@@ -223,6 +223,8 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        self.attn_gate = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.Sigmoid())
+        nn.init.constant_(self.attn_gate[0].bias, -1.0)  # starts near sigmoid(-1)≈0.27
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -233,7 +235,9 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        attn_out = self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask)
+        attn_out = self.attn_gate(attn_out) * attn_out  # gated-attn-output: per-node sigmoid gate
+        fx = self.ln_1_post(attn_out + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))


### PR DESCRIPTION
## Hypothesis
The skip_gate (preprocess→output) and SE block (channel gate after MLP) were both merged wins. The missing gate: attention output itself. Per-node gating lets the model control how much attention to apply — freestream nodes need minimal transformation, boundary-layer nodes need heavy transformation.

## Instructions
1. Add in TransolverBlock: `self.attn_gate = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.Sigmoid())`
2. Initialize the bias of the last linear to -1.0 (starts near 0.5, conservative)
3. Apply: `attn_out = self.attn_gate(attn_out) * attn_out` before the residual add
4. Run with `--wandb_group gated-attn-output`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run**: azqnnz0f | **Epochs**: 57 | **val/loss**: 0.8778

| Split | Ux | Uy | p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 6.05 | 1.94 | 18.9 | +1.42 ↑ |
| val_ood_cond | 3.18 | 1.22 | 13.8 | +0.21 ↑ |
| val_ood_re | 2.79 | 1.06 | 28.2 | +0.63 ↑ |
| val_tandem | 5.73 | 2.28 | 38.6 | +0.07 ↑ |

**mean3 (in+ood+re)/3 surf_p**: 20.31 vs baseline 19.55 → **+0.76 worse**

**Peak memory**: ~30 GB (minimal increase from extra linear layer)

### What happened

Negative across all splits. The sigmoid-gated attention output makes things worse by a significant margin (+0.76 mean3, +0.0223 val/loss). The gate appears to systematically suppress the attention output — initialized at sigmoid(-1.0)≈0.27, it multiplies the already-computed attention output by a 0.27 factor, which combined with the hidden_dim×hidden_dim linear transformation adds substantial parameters and compute without benefit.

Additionally, the training only ran 57 epochs (vs 58-60 for other experiments), suggesting the larger model slightly exceeds the per-epoch time budget.

The SE block (channel-wise gating after MLP pooled globally) works because it modulates channels based on global context. This per-node, per-channel gating on attention output is different: it's a full hidden_dim linear layer applied at every node, which is essentially a heavyweight transformation that duplicates the role of the existing to_out projection in the attention module.

### Suggested follow-ups

1. **Smaller gate**: try  (scalar per node) instead of  — much cheaper and less redundant with to_out
2. **Gate the MLP output instead**: apply the gate after the MLP (similar to SE but per-node rather than global)
3. **The SE block already covers channel gating**: the existing SE module already provides global channel gating — adding another local gate may create conflicting gradients