### PR TITLE
Raw input-to-output skip (direct physics shortcut)

### DIFF
--- a/train.py
+++ b/train.py
@@ -310,6 +310,9 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
@@ -375,6 +378,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_raw = x  # save raw input before preprocessing
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +400,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x_raw)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
The model has preprocess→output skip but no raw input→output skip. Raw features contain explicit physics (Re, AoA, coordinates, NACA). A direct shortcut lets the model condition predictions on known physics without relying on learned abstractions.

## Instructions
1. Add in Transolver: `self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)` with zero initialization
2. In forward, save raw input, then add: `fx = fx + 0.1 * self.input_skip(x_raw)` where x_raw is the input before preprocessing
3. Zero-init ensures it starts as no-op
4. Run with `--wandb_group input-skip`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `l8vff733` (alphonse/input-skip)
**Epoch at timeout:** 59 (~19 EMA epochs; ema_start_epoch=40)
**Runtime:** 1911s (~32 min)

### Metrics vs baseline

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8612 | 0.8555 | +0.0057 (+0.7%) |
| in_dist surf p | 17.22 | 17.48 | **-0.26** |
| ood_cond surf p | 13.77 | 13.59 | +0.18 |
| ood_re surf p | 27.86 | 27.57 | +0.29 |
| tandem surf p | 38.43 | 38.53 | **-0.10** |
| mean3 | 23.14 | 23.20 | **-0.06** |

### Surface MAE (full)
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 7.80 | 2.27 | 17.22 |
| ood_cond | 5.95 | 1.66 | 13.77 |
| ood_re | 5.49 | 1.47 | 27.86 |
| tandem | 6.26 | 2.58 | 38.43 |

### Volume MAE (p)
in_dist=18.82, ood_cond=11.74, ood_re=46.70, tandem=37.50

**Peak GPU memory:** N/A (system metrics not logged)

### What happened

Mixed result. Mean3 is marginally better (23.14 vs 23.20, −0.06), driven by improved in_dist and tandem pressure. However val/loss is slightly worse (+0.7%), which likely reflects degraded velocity prediction — the Ux/Uy surface MAEs are significantly higher than expected from the baseline regime.

The raw input skip appears to be providing a useful residual path for pressure prediction (in_dist −0.26, tandem −0.10) but trades off velocity accuracy. This makes physical sense: raw features contain Re/AoA/NACA which are most directly informative for pressure distributions (which scale with dynamic pressure) but less helpful for local velocity perturbations which depend on fine-grained geometry.

The skip starts as a no-op (zero init) and is scaled by 0.1, but as it learns, it likely "steals" learning signal from the shared output space, biasing the model toward pressure shortcutting at the expense of velocity.

### Suggested follow-ups
- Use field-specific skips: separate Linear layers for velocity vs pressure outputs, allowing independent scaling
- Reduce scale to 0.01 to make the shortcut more conservative — may retain pressure benefit with less velocity harm
- Gate the input skip (like `out_skip`) so it learns when to activate rather than always contributing