### PR TITLE
Multi-scale attention (parallel 16-slice coarse + 48-slice fine)

### DIFF
--- a/train.py
+++ b/train.py
@@ -208,6 +208,13 @@ class TransolverBlock(nn.Module):
             dropout=dropout,
             slice_num=slice_num,
         )
+        self.coarse_attn = Physics_Attention_Irregular_Mesh(
+            hidden_dim,
+            heads=1,
+            dim_head=64,
+            slice_num=16,
+        )
+        self.coarse_scale = nn.Parameter(torch.tensor(0.1))
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
@@ -233,7 +240,10 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        x_norm = self.ln_1(fx)
+        fine_out = self.attn(x_norm, spatial_bias=sb, tandem_mask=tandem_mask)
+        coarse_out = self.coarse_attn(x_norm)
+        fx = self.ln_1_post(fine_out + self.coarse_scale * coarse_out + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))


### PR DESCRIPTION
## Hypothesis
Flow fields have multi-scale structure (large-scale pressure gradients + fine-scale boundary layers). Running attention at 16 coarse slices (1 head) in parallel with the 48 fine slices (3 heads) lets the model explicitly capture both scales.

## Instructions
1. Add a second attention: `self.coarse_attn = Physics_Attention_Irregular_Mesh(dim, heads=1, dim_head=64, slice_num=16)`
2. In forward: `coarse_out = self.coarse_attn(...)`, `fine_out = self.attn(...)`
3. Combine: `attn_out = fine_out + 0.1 * coarse_out` (learnable scale init=0.1)
4. Run with `--wandb_group multi-scale-attn`

Note: May slow epochs by ~10-15%.

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** mplxqka2
**Epochs completed:** 53/100 (30-min timeout, ~13% slower per epoch as predicted)
**Peak memory:** 15.6 GB (+0.8 GB over baseline)

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.9046 | 0.8555 | +5.7% (worse) |
| Surface MAE p (in_dist) | 19.08 | 17.48 | +9.2% (worse) |
| Surface MAE p (ood_cond) | 15.17 | 13.59 | +11.6% (worse) |
| Surface MAE p (ood_re) | 28.69 | 27.57 | +4.1% (worse) |
| Surface MAE p (tandem) | 38.50 | 38.53 | -0.1% (same) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 7.14 | 2.20 | 19.08 |
| ood_cond | 3.78 | 1.50 | 15.17 |
| ood_re | 3.27 | 1.35 | 28.69 |
| tandem | 6.35 | 2.47 | 38.50 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.16 | 0.39 | 20.43 |
| ood_cond | 0.76 | 0.29 | 12.87 |
| ood_re | 0.86 | 0.38 | 47.39 |
| tandem | 1.96 | 0.88 | 37.73 |

### What happened

Clear negative result across all splits. The coarse_attn adds ~13% per-epoch overhead (34s vs 30s), which means only 53 epochs in the 30-min budget vs the usual 59-61. The model regresses substantially, especially ood_cond pressure (+11.6%).

Several compounding factors:

1. **Fewer epochs hurt.** The model converges later with more parameters — 53 epochs is not enough to recover the parameter penalty from adding a full second attention module.
2. **coarse_scale doesn't converge fast enough.** The scale starts at 0.1 but the gradient signal to tune it requires many more epochs. The coarse attention is likely contributing noise rather than signal for most of the run.
3. **coarse_attn has its own temperature, slice_weight, etc.** These are initialized randomly and compete with the main attn's learned routing. The interaction may be destructive early in training.
4. **The 0.1 fixed-init scale may be too high.** Even at 0.1, the coarse attention contribution is non-trivial and could destabilize the routing.

### Suggested follow-ups

- **coarse_scale init=0.01 or 0.0:** Initialize the coarse contribution closer to zero so the main attn can converge before coarse_attn activates.
- **Larger-model context only:** The coarse attention makes more sense with bigger models (more capacity to spare). At this size, the extra params compete for optimization budget.
- **Shared weights between coarse and fine:** Rather than two independent attention modules, try sharing the projection weights and only varying slice_num. This halves the extra parameters.