### PR TITLE
SE-block on attention output (channel attention after spatial attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -219,6 +219,12 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.spatial_bias[-1].bias)
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
+        self.attn_se = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim // 4),
+            nn.GELU(),
+            nn.Linear(hidden_dim // 4, hidden_dim),
+            nn.Sigmoid(),
+        )
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
@@ -233,7 +239,9 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        attn_out = self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask)
+        attn_out = attn_out * self.attn_se(attn_out.mean(dim=1, keepdim=True))
+        fx = self.ln_1_post(attn_out + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))


### PR DESCRIPTION
## Hypothesis
The model has an SE block after the MLP (merged early). Adding a SECOND SE block after the attention output (before the residual) lets the model recalibrate channel importance based on what the spatial attention has computed. The attention captures SPATIAL patterns; the SE block captures CHANNEL importance. Together they create a richer per-node representation.

## Instructions
1. In TransolverBlock, add an SE block after the attention output (after to_out, before residual add):
   ```python
   self.attn_se = nn.Sequential(
       nn.Linear(hidden_dim, hidden_dim // 4),
       nn.GELU(),
       nn.Linear(hidden_dim // 4, hidden_dim),
       nn.Sigmoid()
   )
   ```
2. Apply: `attn_out = attn_out * self.attn_se(attn_out.mean(dim=1, keepdim=True))` 
   (squeeze-excite: global pool -> project -> sigmoid gate)
3. Run with `--wandb_group se-block-attn`

Negligible compute. ~2x(192*48 + 48*192) = ~37K params.

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `95nvqx6j` (`norman/se-block-attn`)
**Best epoch:** 56
**Peak memory:** N/A (run killed by 30-min timeout at 32.1 min)
**Run state:** failed (training timeout + pre-existing visualization error)

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 0.6169 | 18.50 |
| val_ood_cond | 0.7102 | 13.82 |
| val_ood_re | 0.5479 | 27.86 |
| val_tandem_transfer | 1.6632 | 39.20 |
| **Combined** | **0.8845** | — |

**vs baseline (0.8555):** +0.0290 (worse)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8555 | 0.8845 | **+0.0290** ✗ |
| in_dist surf_p | 17.48 | 18.50 | +1.02 ✗ |
| ood_cond surf_p | 13.59 | 13.82 | +0.23 ✗ |
| ood_re surf_p | 27.57 | 27.86 | +0.29 ✗ |
| tandem surf_p | 38.53 | 39.20 | +0.67 ✗ |

### What happened
Adding an SE block after the attention output made every metric worse. The combined val/loss increased by 0.029 and surface pressure MAE degraded on all splits — notably in_dist surf_p jumped +1.02.

The existing SE block (after the MLP, with zero-init) serves as a calibrated channel-weighting that can be learned gradually. Adding a second SE block after the attention output adds another gating layer that likely competes with or undermines this — the model now has two separate channel-importance mechanisms operating at different points in the residual stream, which may create training instability.

Note: the run was killed by the 30-min timeout at 32.1 min. The best epoch was 56. The run state shows "failed" due to the timeout combined with the pre-existing visualization shape mismatch error that always fires at the very end of training.

### Suggested follow-ups
- The current single SE block (after MLP, zero-init) appears well-placed. Adding redundant gating at both attention and MLP stages seems to hurt.
- If channel recalibration is to be explored, try replacing the existing MLP SE block with an attention-stage SE block (not adding both) — though given the consistent degradation, this may also fail.
- Zero-initializing `attn_se` (like the existing `se_fc2`) might help this learn more gradually from identity, but it's not obvious that would flip the result given the magnitude of degradation.