### PR TITLE
lr=2.7e-3 (fine-tune between 2.5e-3 and 3e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.5e-3
+    lr: float = 2.7e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
lr=2.5e-3 beat baseline dramatically. lr=2.3e-3 was too slow. lr=2.7e-3 is the untested midpoint between 2.5e-3 and 3e-3.

## Instructions
1. Change lr from 2.5e-3 to 2.7e-3
2. Keep everything else identical
3. Run with `--wandb_group lr-27e3`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B Run ID:** `0p0kjzal`
**Epochs completed:** 61/100 (30.3 min wall-clock timeout)
**Peak memory:** 14.8 GB/GPU

### Validation Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 0.6102 | 5.21 | 1.79 | 18.39 | 1.13 | 0.37 | 19.50 |
| tandem_transfer | 1.6318 | 5.53 | 2.35 | 39.02 | 1.95 | 0.90 | 38.68 |
| ood_cond | 0.6855 | 3.02 | 1.00 | 13.76 | 0.70 | 0.27 | 11.70 |
| ood_re | 0.5347 | 2.50 | 0.84 | 27.68 | 0.81 | 0.36 | 46.55 |
| **overall val/loss** | **0.8656** | | | | | | |

### Comparison vs Baseline (lr=2.5e-3)

| Metric | Baseline | lr=2.7e-3 | Delta |
|--------|----------|-----------|-------|
| val/loss | 0.8555 | 0.8656 | +0.0101 ❌ |
| in mae_surf_p | 17.48 | 18.39 | +0.91 ❌ |
| ood mae_surf_p | 13.59 | 13.76 | +0.17 ❌ |
| re mae_surf_p | 27.57 | 27.68 | +0.11 ❌ |
| tan mae_surf_p | 38.53 | 39.02 | +0.49 ❌ |

### What happened

lr=2.7e-3 is worse than lr=2.5e-3 across all metrics. The degradation is consistent but modest — val/loss went from 0.8555 to 0.8656 (+1.2%), and in-distribution surface pressure error increased by ~0.9 Pa. This confirms lr=2.5e-3 is at or near the sweet spot; going higher hurts convergence. Combined with the earlier result that lr=2.3e-3 also underperformed, lr=2.5e-3 appears to be the optimal value in this range.

The run only reached epoch 61/100 in the 30-minute budget, same as the lr=2.3e-3 run. Training hadn't fully converged by timeout, but the trend shows the baseline (lr=2.5e-3) consistently ahead.

### Suggested follow-ups

- lr=2.5e-3 is confirmed best so far in the lr neighborhood. Next logical exploration: learning rate schedule tuning (warmup length, T_max, eta_min) rather than the peak lr value.
- The tandem split remains the hardest (mae_surf_p=39.02), much higher than in-dist (18.39) and ood (13.76). Worth exploring architecture changes that better handle tandem geometry.
- All runs timeout at ~61 epochs. A longer run (60+ min) on the best config might show further gains — though this violates the 30-min constraint, it may be worth flagging as an option.