### PR TITLE
Per-head skip gate (head-specific preprocessor-to-output bypass)

### DIFF
--- a/train.py
+++ b/train.py
@@ -310,8 +310,14 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
-        self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
-        nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
+        self.n_head = n_head
+        _dim_head_skip = n_hidden // n_head
+        self.skip_gate = nn.ModuleList([
+            nn.Sequential(nn.Linear(_dim_head_skip, 1), nn.Sigmoid())
+            for _ in range(n_head)
+        ])
+        for _g in self.skip_gate:
+            nn.init.constant_(_g[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
@@ -394,8 +400,11 @@ class Transolver(nn.Module):
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
-        gate = self.skip_gate(fx_pre)
-        fx = fx + gate * self.out_skip(fx_pre)
+        _B, _N, _ = fx_pre.shape
+        _skip_heads = fx_pre.reshape(_B, _N, self.n_head, -1)  # [B, N, n_head, dim_head]
+        _gates = torch.stack([self.skip_gate[h](_skip_heads[:, :, h]) for h in range(self.n_head)], dim=2)  # [B, N, n_head, 1]
+        _gated_skip = (_skip_heads * _gates).reshape(_B, _N, -1)  # [B, N, n_hidden]
+        fx = fx + self.out_skip(_gated_skip)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
The skip_gate (merged) provides a single gate for the preprocessor-to-output bypass. With n_head=3, each head specializes differently. Per-head skip gates let each head independently control how much raw preprocessed information to bypass — boundary-layer heads may want more bypass, wake heads less.

## Instructions
1. In the skip connection from preprocessor to output, replace the single skip_gate with per-head gates:
   - Split the hidden representation into 3 head chunks
   - Apply a separate sigmoid gate per head
   - This can be done by making skip_gate output shape [1, 1, n_head * dim_head] instead of [1, 1, hidden_dim], then reshaping
2. Or simpler: make skip_gate output n_head scalars and broadcast
3. Run with `--wandb_group perhead-skip-gate`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `c81l7x00`
**Epochs:** 59 (30-min timeout)
**Peak VRAM:** 15.4 GB (+0.7 GB vs baseline)

| Metric | Baseline (lr=2.5e-3) | This run | Δ |
|--------|----------------------|----------|---|
| val/loss | 0.8555 | 0.8696 | +0.0141 ↑ worse |
| surf_p in_dist | 17.48 | 17.78 | +0.30 ↑ worse |
| surf_p ood_cond | 13.59 | 14.49 | +0.90 ↑ worse |
| surf_p ood_re | 27.57 | 27.93 | +0.36 ↑ worse |
| surf_p tandem | 38.53 | 38.55 | +0.02 ≈ same |
| **mean3** | **23.20** | **23.61** | +0.41 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**Implementation:** Replaced single  with  per-head gates  (ModuleList). In forward: split  into head chunks , apply per-head sigmoid gate, reshape back to , then apply . All gates initialized with bias=-2.0 (starts nearly closed), same as the original.

**What happened:** The per-head skip gate is worse than baseline on all metrics (ood_cond +0.90 is the worst regression). This continues a pattern: per-head architectural changes on the lr=2.5e-3 base have consistently hurt (per-head spatial bias was also worse). The VRAM also increased by 0.7 GB (from shared KV/V patterns in the attention + extra gate params).

The skip connection's purpose is to let the model shortcut the full transformer processing for cases where the preprocessor output is already good. A shared gate is sufficient for this — per-head gating fragments the bypass into head-specialized chunks, which may interfere with the out_skip projection's ability to learn a good global bypass. The single gate's simplicity appears to be a feature, not a limitation.

**Suggested follow-ups:**
1. The lr=2.5e-3 base (without architectural changes) appears strongest for this branch. Consider training-dynamics improvements instead of architecture changes.
2. EMA decay tuning on the lr=2.5e-3 base may be worth trying.
3. Per-head changes that share architecture (like the tandem_temp_offset which was a bias, not a full layer) appear more likely to succeed than per-head replacement of shared components.