### PR TITLE
Warmup 7 + seed=42 (reproducibility check on near-miss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,13 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 0
 
 
 cfg = sp.parse(Config)
+
+torch.manual_seed(cfg.seed)
+torch.cuda.manual_seed_all(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3
@@ -576,10 +580,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=7)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[7]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
warmup=7 got val_loss=0.8625 — only +0.8% from baseline. With ood=13.35 and re=27.37 both beating baseline! Testing with seed=42 to check if the near-miss is seed-dependent or consistent.

## Instructions
1. Change warmup total_iters from 10 to 7, milestones from [10] to [7]
2. Pass --seed 42
3. Run with `--wandb_group warmup7-seed42`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `20wlc8px`
**Best epoch:** 61 / 100 (hit wall-clock limit, ~30s/epoch)
**Peak memory:** 14.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5931 | 6.65 | 2.06 | 17.99 | 1.09 | 0.37 | 19.24 |
| val_tandem_transfer | 1.6380 | 6.35 | 2.32 | 38.47 | 1.92 | 0.87 | 38.09 |
| val_ood_cond | 0.6921 | 3.63 | 1.17 | 13.85 | 0.72 | 0.27 | 11.70 |
| val_ood_re | 0.5306 | 3.12 | 0.95 | 27.61 | 0.82 | 0.36 | 46.69 |
| **mean3** | **0.974** | **5.55** | **1.85** | **23.44** | — | — | — |

Baseline: mean3=23.20 (in=17.48, ood=13.59, tan=38.53, re=27.57), val_loss=0.8555
Original warmup=7 (default seed): val_loss=0.8625, ood=13.35, re=27.37

**What happened:** Seed-dependent near-miss is confirmed. With seed=42, warmup=7 gives mean3=23.44 vs 23.20 baseline — worse across in_dist (+0.51), ood_cond (+0.26), and ood_re (+0.04), with only a marginal tandem improvement (-0.06).

The original warmup=7 run benefited from the default random seed in a way that doesn't generalize. With seed=42, both ood_cond (13.35 → 13.85) and ood_re (27.37 → 27.61) lost their gains relative to the original warmup=7 run. The default seed's warmup=7 advantage was real but seed-dependent — not a robust architectural improvement.

**Suggested follow-ups:**
- The warmup=7 result is too noisy to build on; accept warmup=10 as the robust default.
- If warmup tuning is worth pursuing, test 3+ seeds to get a reliable estimate — single-seed comparisons are unreliable for small Δ<1%.