### PR TITLE
Input-skip with 0.2 scale (stronger raw physics shortcut)

### DIFF
--- a/train.py
+++ b/train.py
@@ -310,6 +310,9 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
@@ -375,6 +378,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_raw = x  # save before feature_cross for input skip
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +400,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.2 * self.input_skip(x_raw)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
alphonse's input-skip (0.1 scale, zero-init) got val_loss=0.8612 — closest architectural near-miss (+0.7%). in_dist=17.22 beat baseline! But val_loss was still above 0.8555. Testing with 0.2 scale (stronger shortcut) — the model may need MORE raw physics input to improve predictions.

## Instructions
1. Same as alphonse's input-skip: add self.input_skip = nn.Linear(fun_dim + space_dim, out_dim) with zero initialization
2. But use 0.2 scale instead of 0.1: `fx = fx + 0.2 * self.input_skip(x_raw)`
3. Run with `--wandb_group input-skip-scaled`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `8qpgtz9k` | **Epochs:** 59/100 (30-min timeout) | **Peak VRAM:** 14.8 GB

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | alphonse 0.1x | This run 0.2x | Δ vs baseline |
|-------|----------|---------------|----------------|---------------|
| val_in_dist | 17.48 | 17.22 | 17.20 | -0.28 ▼ better |
| val_ood_cond | 13.59 | — | 14.25 | +0.66 ▲ worse |
| val_ood_re | 27.57 | — | 27.65 | +0.08 ≈ tied |
| val_tandem | 38.53 | — | 38.93 | +0.40 ▲ slightly worse |
| **mean3** (in/ood_cond/tan) | **23.20** | — | **23.46** | **+0.26 ▲ slightly worse** |

**val/loss:** 0.8687 vs baseline 0.8555 → worse (+1.5%); alphonse's 0.1x got 0.8612 → scale 0.2x is worse than 0.1x

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 7.91 | 2.00 | 17.20 |
| val_ood_cond | 5.39 | 1.39 | 14.25 |
| val_ood_re | 5.11 | 1.25 | 27.65 |
| val_tandem | 6.22 | 2.29 | 38.93 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.07 | 0.36 | 18.92 |
| val_ood_cond | 0.73 | 0.27 | 12.66 |
| val_ood_re | 0.82 | 0.36 | 46.81 |
| val_tandem | 1.93 | 0.87 | 38.47 |

### What happened

Increasing the skip scale from 0.1 to 0.2 did not help — val/loss got worse (0.8687 vs alphonse's 0.8612), and mean3 is 23.46 vs baseline 23.20. The p MAE improvement in in_dist (-0.28) is the same order as alphonse's 0.1x result, suggesting this is already captured at 0.1 scale.

More concerning: Ux surface MAE is notably higher than usual (7.91 vs ~5-6 in other runs), particularly on ood_cond (5.39 vs ~3.0-3.5). This suggests that at 0.2 scale, the raw input shortcut is "leaking" direction-sensitive information (Ux depends on AoA direction) in a way that doesn't generalize well to OOD conditions. The 0.1 scale is already aggressive enough — 0.2 over-weights the direct path.

The optimal scale for the input skip is likely ≤0.1.

### Suggested follow-ups
- Try 0.05 scale — even more conservative shortcut might be the sweet spot
- alphonse's 0.1 scale is the best of the three (no skip, 0.1x, 0.2x) — consider making that the new baseline
- The consistent in_dist improvement from the input skip suggests it's finding something real; explore what the skip is learning