### PR TITLE
Input-skip + warmup=7 (combine two near-misses)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,9 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -396,6 +399,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
@@ -576,10 +580,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=7)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[7]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
input-skip got val_loss=0.8612 (in=17.22 beats baseline). warmup=7 got val_loss=0.8625 (ood=13.35 and re=27.37 beat baseline). These target DIFFERENT weaknesses — input-skip helps in_dist, warmup=7 helps ood. Combining them might compound.

## Instructions
1. Add input-skip: self.input_skip = nn.Linear(fun_dim + space_dim, out_dim) zero-init, scale 0.1
2. Change warmup from 10 to 7, milestones from [10] to [7]
3. Run with `--wandb_group input-skip-warmup7`

WARNING: Multi-variable experiments have historically failed (warmup5+T_max48 on Regime W failed). But these two changes target orthogonal weaknesses.

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** v07om3t5
**Epochs completed:** 59/100 (30-min timeout)
**Peak memory:** 14.8 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8740 | 0.8555 | +2.2% (worse) |
| Surface MAE p (in_dist) | 17.83 | 17.48 | +2.0% (worse) |
| Surface MAE p (ood_cond) | 13.94 | 13.59 | +2.6% (worse) |
| Surface MAE p (ood_re) | 27.89 | 27.57 | +1.2% (worse) |
| Surface MAE p (tandem) | 39.15 | 38.53 | +1.6% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 6.84 | 1.87 | 17.83 |
| ood_cond | 5.19 | 1.37 | 13.94 |
| ood_re | 4.86 | 1.22 | 27.89 |
| tandem | 5.66 | 2.24 | 39.15 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.08 | 0.36 | 19.20 |
| ood_cond | 0.75 | 0.27 | 12.16 |
| ood_re | 0.84 | 0.36 | 47.03 |
| tandem | 1.95 | 0.89 | 38.80 |

### What happened

Negative result — combination is worse than either component alone, and worse than baseline. This confirms the PR warning: "Multi-variable experiments have historically failed."

The individual results were:
- input-skip alone: val_loss=0.8612 (in=17.22, ood_cond not specified)
- warmup=7 alone: val_loss=0.8625 (ood=13.35)
- combined: val_loss=0.8740 (in=17.83, ood=13.94) — **worse than both**

Possible reasons:
1. **The "orthogonal weaknesses" framing was wrong.** input-skip adds a direct linear path from input to output, which changes the gradient flow through the entire network. warmup=7 also affects early gradient dynamics. Together, they interact in the warmup phase where the input_skip weight (zero-init) is competing with the main path for gradient signal at a time when the learning rate is ramping.
2. **Warmup=7 hurts when input_skip is present.** With a direct input-output connection (even at 0.1 scale after warm-up), the model may need MORE warmup, not less, to avoid the skip dominating early.
3. **Interference in in_dist.** The input-skip alone improved in_dist from 17.48 to 17.22. Combined with warmup=7, in_dist is now 17.83 — worse than baseline. This directly contradicts the orthogonality hypothesis.

The warning proved prescient: combining near-misses amplifies instabilities rather than gains.

### Suggested follow-ups

- **input-skip alone on lr=2.5e-3:** The original input-skip test was on a different code version. Re-verify it still helps on the current lr=2.5e-3 baseline before building on it.
- **input-skip with longer warmup (12 epochs):** If input-skip needs more stability to converge, combine it with a slightly longer warmup rather than shorter.
- **Accept that near-misses don't compound here.** Focus on single-variable experiments.