### PR TITLE
n_head=3 n_hidden=192 baseline reproduction with seed=200

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,16 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 42
 
 
 cfg = sp.parse(Config)
+
+torch.manual_seed(cfg.seed)
+torch.cuda.manual_seed_all(cfg.seed)
+import random, numpy as np
+random.seed(cfg.seed)
+np.random.seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Measure variance on the LATEST code with seed=200 (which was the best seed on older n_head=4 code at 0.8603). This gives another variance data point.

## Instructions
1. No code changes. Pass --seed 200.
2. Run with `--wandb_group nhead3-wider-64d-v2`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** qf6e2r5r | **Epochs:** 58 (30-min timeout) | **Memory:** 14.8 GB

| Split | val_loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.6141 | 5.86 | 2.14 | 18.95 | 1.12 | 0.38 | 19.80 |
| ood_cond | 0.7091 | 3.35 | 1.32 | 14.07 | 0.73 | 0.28 | 12.12 |
| ood_re | 0.5485 | 2.90 | 1.12 | 27.75 | 0.84 | 0.37 | 46.87 |
| tandem | 1.6257 | 5.68 | 2.61 | 38.33 | 1.93 | 0.87 | 37.44 |
| **overall** | **0.8744** | | | | | | |

**Baseline (seed=42):** val_loss=0.8555, tandem surf p=38.53

**What happened:** seed=200 gives val_loss=0.8744, which is 2.2% *worse* than seed=42 (0.8555). This is a significant variance gap — the same architecture and hyperparameters yield quite different results depending on the random seed. Notably, the old n_head=4 code had seed=200 as its *best* seed at 0.8603, but on the current n_head=3 config it performs worse. This suggests seed interactions are architecture-specific. On the positive side, tandem surface p (38.33) is slightly better than the baseline's 38.53, though overall the run is worse.

**Added:** Wired `--seed` argument to Config dataclass and set torch/numpy/random seeds at startup so future seed experiments can be run without code changes.

**Suggested follow-ups:**
- Run seed=42 (default) again in this wandb_group to confirm the 0.8555 baseline is reproducible
- Try seed=100 or seed=0 to get a broader variance picture and establish confidence intervals