### PR TITLE
Input-skip with seed=42 (reproducibility of best near-miss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,9 +22,11 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 
 import os
 import time
+import random
 from collections.abc import Mapping
 from pathlib import Path
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -310,6 +312,9 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
@@ -375,6 +380,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_raw = x  # save raw input before preprocessing
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +402,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x_raw)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
@@ -421,9 +428,16 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 0
 
 
 cfg = sp.parse(Config)
+
+torch.manual_seed(cfg.seed)
+np.random.seed(cfg.seed)
+random.seed(cfg.seed)
+if torch.cuda.is_available():
+    torch.cuda.manual_seed_all(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
alphonse's input-skip got 0.8612 — closest near-miss. Testing with seed=42 to verify reproducibility.

## Instructions
1. Add self.input_skip = nn.Linear(fun_dim + space_dim, out_dim) with zero initialization
2. In forward: fx = fx + 0.1 * self.input_skip(x_raw)
3. Pass --seed 42
4. Run with `--wandb_group input-skip-seed42`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `6d6gs8k9` (alphonse/input-skip-seed42)
**Epoch at timeout:** 60 (~20 EMA epochs; ema_start_epoch=40)
**Runtime:** 1915s (~32 min)

### Metrics vs baseline

| Metric | seed=42 | seed=0 (PR #1380) | Baseline | Δ vs baseline (seed=42) |
|--------|---------|----------|----------|---|
| val/loss | **0.8565** | 0.8612 | 0.8555 | +0.0010 (+0.1%) |
| in_dist surf p | **17.37** | 17.22 | 17.48 | **-0.11** |
| ood_cond surf p | 14.25 | 13.77 | 13.59 | +0.66 |
| ood_re surf p | **27.55** | 27.86 | 27.57 | **-0.02** |
| tandem surf p | **37.84** | 38.43 | 38.53 | **-0.69** |
| mean3 | **23.15** | 23.14 | 23.20 | **-0.05** |

### Surface MAE (full, seed=42)
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 6.34 | 1.58 | 17.37 |
| ood_cond | 4.31 | 0.91 | 14.25 |
| ood_re | 3.97 | 0.79 | 27.55 |
| tandem | 5.83 | 2.00 | 37.84 |

### Volume MAE (p)
in_dist=18.85, ood_cond=11.92, ood_re=46.43, tandem=37.93

**Peak GPU memory:** N/A (system metrics not logged)

### What happened

Positive result on tandem; mixed elsewhere. Seed=42 gives val/loss=0.8565 (essentially tied with baseline 0.8555), with notable tandem pressure improvement (−0.69) and slight in_dist improvement (−0.11). ood_re is essentially unchanged (−0.02). ood_cond is worse in both seeds (+0.66 for seed=42, +0.18 for seed=0).

Cross-seed comparison shows moderate variance: tandem p varies by 0.59 between seeds (37.84 vs 38.43), and ood_cond by 0.48 (14.25 vs 13.77). This suggests the improvement signal is real but noisy — tandem improvement is the most consistent finding across both seeds.

The Ux/Uy values in seed=42 are much more reasonable (6.34/1.58 in_dist) than seed=0 (7.80/2.27), suggesting seed=0 may have had an unlucky initialization that biased toward pressure at the expense of velocities.

**Reproducibility verdict:** Partially reproducible. The tandem transfer benefit (−0.69 seed=42, −0.10 seed=0) and in_dist improvement are consistent across seeds. The ood_cond degradation is also consistent. Net: input-skip helps tandem but hurts ood_cond.

### Suggested follow-ups
- Try pressure-only skip: separate the out_dim=3 to apply input_skip only to the p channel, avoiding Ux/Uy interference
- The consistent ood_cond degradation may indicate the raw features (Re/AoA uniform per batch) provide a useful cue for in-distribution but a misleading one for OOD conditions