### PR TITLE
Input-skip with 0.05 scale (gentler physics shortcut)

### DIFF
--- a/train.py
+++ b/train.py
@@ -316,6 +316,9 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)  # input-skip-05: raw input shortcut
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
@@ -396,6 +399,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.05 * self.input_skip(x)  # input-skip-05: raw input shortcut at scale 0.05
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
input-skip at 0.1 scale got 0.8612. tanjiro is testing 0.2 (stronger). This tests 0.05 (gentler) — the optimal scale might be weaker than 0.1 to avoid interfering with the learned representation.

## Instructions
1. Same input-skip setup, but scale 0.05: fx = fx + 0.05 * self.input_skip(x_raw)
2. Run with `--wandb_group input-skip-05`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: ohrra4bl | **Epochs**: 59 | **val/loss**: 0.8731

| Split | Ux | Uy | p | vs baseline p |
|---|---|---|---|---|
| val_in_dist | 6.28 | 1.84 | 18.0 | +0.52 ↑ |
| val_ood_cond | 4.43 | 1.30 | 14.3 | +0.71 ↑ |
| val_ood_re | 4.03 | 1.12 | 27.8 | +0.23 ↑ |
| val_tandem | 5.66 | 2.25 | 39.0 | +0.47 ↑ |

**mean3 (in+ood+re)/3 surf_p**: 20.04 vs baseline 19.55 → **+0.49 worse**

**Peak memory**: ~30 GB (minimal change from extra linear layer)

### What happened

Negative across all splits. Input-skip at 0.05 scale gives val/loss=0.8731 vs baseline 0.8555 (+0.0176). Even at this smaller scale the raw-input shortcut path hurts performance on the current codebase.

The baseline context is important: the earlier 0.8612 result with scale=0.1 was on different code (older architecture). On the current lr=2.5e-3, n_head=3, per-head tandem temp code, the shortcut adds noise rather than useful signal. The raw input features (fun_dim+space_dim ≈ 57 dims) include geometry, flow conditions, and physics — providing a direct additive shortcut may interfere with the carefully trained physics normalization and feature weighting in the existing preprocess+skip_gate path.

### Suggested follow-ups

1. **Skip both scales are negative on this code**: if 0.1 and 0.05 both hurt, the input-skip mechanism doesn't help here
2. **Try a scalar-gated version**: instead of fixed 0.05, use a learned gate that starts at near-zero (like the existing skip_gate)
3. **The original 0.8612 result may not transfer**: architectures evolved significantly — worth checking if the current code still benefits from input shortcuts at all