### PR TITLE
Baseline with seed=200 on lr=2.5e-3 (variance measurement)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,18 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int | None = None
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed is not None:
+    import random
+    random.seed(cfg.seed)
+    import numpy as np
+    np.random.seed(cfg.seed)
+    torch.manual_seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Variance measurement. seed=200 was the best seed on older code (0.8603).

## Instructions
1. No code changes. Pass --seed 200.
2. Run with `--wandb_group nhead3-lr25-seed200`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `uz7qjh4x` (`norman/nhead3-lr25-seed200`)
**Best epoch:** 57
**Peak memory:** N/A (run killed by 30-min timeout at 31.8 min)
**Note:** Added `seed: int | None = None` to Config + seeding code (required infrastructure to accept --seed flag; no model changes).

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 0.6097 | 18.75 |
| val_ood_cond | 0.6974 | 13.91 |
| val_ood_re | 0.5515 | 27.87 |
| val_tandem_transfer | 1.6298 | 38.37 |
| **Combined** | **0.8721** | — |

**vs baseline (0.8555):** +0.0166 (worse)

| Metric | Baseline (random seed) | seed=200 | Delta |
|---|---|---|---|
| val/loss | 0.8555 | 0.8721 | **+0.0166** ✗ |
| in_dist surf_p | 17.48 | 18.75 | +1.27 ✗ |
| ood_cond surf_p | 13.59 | 13.91 | +0.32 ✗ |
| ood_re surf_p | 27.57 | 27.87 | +0.30 ✗ |
| tandem surf_p | 38.53 | 38.37 | −0.16 ✓ |

### What happened
seed=200 gives val/loss=0.8721, worse than the baseline's 0.8555. This is a variance measurement showing the model has meaningful seed sensitivity: a 0.017 spread between the baseline (random seed) and seed=200. This means small improvements (e.g., the lr=2.5e-3 improvement of 0.005) could be within seed noise.

seed=200 was the best seed on older code (0.8603), but on the current architecture (n_head=3, lr=2.5e-3) it underperforms. This suggests seed rankings may not transfer across architectural changes.

### Suggested follow-ups
- Try seed=42 and another seed (e.g., seed=7) to build a proper variance picture — 3 seeds would let us compute mean ± std and see if the baseline's 0.8555 is within normal variance.
- If variance is ~0.01-0.02, small improvements need to be interpreted with caution.