### PR TITLE
Input-skip + EMA decay 0.997 (combine architectural + training near-misses)

### DIFF
--- a/train.py
+++ b/train.py
@@ -316,6 +316,9 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
@@ -375,6 +378,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_orig = x  # save original input for input-skip
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +400,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x_orig)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
@@ -536,7 +541,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.997
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
input-skip improved in_dist (17.22 vs 17.48). EMA 0.997 was tested alone and failed. But the combination might work — input-skip changes the gradient flow, and the faster EMA may better track the changed optimization dynamics.

## Instructions
1. Add input-skip: self.input_skip = nn.Linear(fun_dim + space_dim, out_dim), zero-init, scale 0.1
2. Change ema_decay from 0.998 to 0.997
3. Run with `--wandb_group n-wider-64d-v3`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: `w9wnvcd0`
**Epochs**: 55/100 (wall-clock limit, ~30 min)
**Peak memory**: 15.8 GB
**val/loss**: 0.8936 (baseline 0.8555, **+0.0381 worse**)

### Surface MAE

| Split | Ux | Uy | p | p vs baseline |
|-------|----|----|---|---------------|
| val_in_dist | 8.37 | 2.18 | 19.23 | ~17.48 → +1.75 ↑ |
| val_ood_cond | 5.98 | 1.58 | 14.68 | ~13.59 → +1.09 ↑ |
| val_ood_re | 5.81 | 1.46 | 27.94 | ~27.57 → +0.37 ↑ |
| val_tandem_transfer | 7.06 | 2.58 | 39.24 | ~38.53 → +0.71 ↑ |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.15 | 0.38 | 20.49 |
| val_ood_cond | 0.74 | 0.28 | 12.88 |
| val_ood_re | 0.84 | 0.37 | 47.14 |
| val_tandem_transfer | 1.95 | 0.89 | 38.57 |

### What happened

**Negative result.** All splits degraded significantly vs baseline. The combination does not work — val/loss is 0.0381 worse and Ux surface MAE is particularly bad (8.37 vs ~5 in other experiments), suggesting the input-skip is interfering with training rather than helping.

The input-skip (`nn.Linear(57→3)`, zero-init, scale 0.1) is zero at init and should be a no-op initially. However, it opens a gradient pathway directly from the raw input features to the output. This may be creating conflicting gradient signals: the skip wants to find a linear mapping from raw CFD features to flow fields (essentially a linear regression baseline), while the main network is trying to learn nonlinear representations. The competing gradients may destabilize learning, particularly for velocity fields (Ux, Uy), which are more sensitive to nonlinear feature interactions.

The EMA 0.997 alone was already known to fail. Adding the input-skip didn't rescue it.

### Suggested follow-ups

- Test input-skip alone (without the EMA change) at baseline ema_decay=0.998 to isolate whether the skip itself is the issue.
- If input-skip does add value in isolation, try a smaller scale (0.05 or 0.01) to reduce gradient interference.
- Consider adding the input-skip AFTER the preprocess stage (i.e., a skip from preprocessed hidden features, not raw inputs), which would avoid the linear-vs-nonlinear gradient conflict.