### PR TITLE
Input-skip + T_max=55 (combine architectural + schedule near-misses)

### DIFF
--- a/train.py
+++ b/train.py
@@ -289,6 +289,9 @@ class Transolver(nn.Module):
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.feature_cross = nn.Linear(fun_dim + space_dim, fun_dim + space_dim, bias=False)
         nn.init.eye_(self.feature_cross.weight)  # start as identity
         self.blocks = nn.ModuleList(
@@ -375,6 +378,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_input = x  # save for input skip
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +400,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x_input)  # input skip
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
@@ -577,7 +582,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
input-skip improved in_dist. T_max=55 was close on old code. Combining them with lr=2.5e-3 might compound.

## Instructions
1. Add input-skip: self.input_skip = nn.Linear(fun_dim + space_dim, out_dim), zero-init, scale 0.1
2. Change T_max from 62 to 55
3. Run with `--wandb_group n-wider-64d-v4`

## Baseline: val_loss=0.8555

---

## Results

**W&B run:** `vtbzdjhd`
**Epochs:** ~62 (30-min timeout)
**Peak VRAM:** ~15 GB

*Implementation: Added `self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)` with zero weight/bias init to Transolver.__init__. In forward, saved `x_input = x` before feature_cross processing, then added `fx = fx + 0.1 * self.input_skip(x_input)` at the output. T_max changed from 62 to 55 in CosineAnnealingLR.*

*Note: W&B state shows "failed" due to pre-existing visualization crash after training. Metrics are valid.*

### Surface MAE (pressure) — primary metric

| Split | Baseline (lr=2.5e-3) | This run | Δ |
|-------|----------------------|---------|---|
| in_dist | 17.48 | **17.06** | -2.4% ✓ |
| ood_cond | 13.59 | 14.00 | +3.0% ✗ |
| ood_re | 27.57 | 28.06 | +1.8% ✗ |
| tandem | 38.53 | 38.23 | -0.8% ✓ |
| **mean3** | **23.20** | **23.10** | **-0.4% ✓** |

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|------|
| in_dist | 6.79 | 1.79 | 17.06 |
| ood_cond | 4.49 | 1.09 | 14.00 |
| ood_re | 4.22 | 0.95 | 28.06 |
| tandem | 5.88 | 2.23 | 38.23 |

### Losses

| Metric | Baseline | This run |
|--------|----------|---------|
| val/loss | 0.8555 | 0.8644 |

### What happened

**Modest improvement on mean3 (-0.4%) with mixed split performance.**

In_dist showed the strongest gain (-2.4%), consistent with the original input-skip motivation. Tandem also improved slightly. However, ood_cond and ood_re regressed (+3.0% and +1.8%). The net effect on mean3 is marginally positive.

Note: val/loss worsened (0.8555 → 0.8644) despite mean3 improvement, similar to the warmup=5 pattern. This suggests the adaptive surf_weight or volume components are affected.

The two changes (input-skip + T_max=55) were applied simultaneously, making it hard to disentangle their contributions. The in_dist improvement is likely from input-skip (direct path for geometry features), while T_max=55 may be the cause of ood regressions (faster LR decay means less exploration time).

Comparing recent experiments on the same lr=2.5e-3 baseline:
- warmup=5: mean3=22.96 (best so far, driven by tandem improvement)
- this run: mean3=23.10 (in_dist improvement)
- baseline: mean3=23.20
- warmup=7: mean3=23.59 (worst)

### Suggested follow-ups

1. **Input-skip alone (T_max=62)**: Isolate whether the in_dist gain comes from input-skip vs T_max. The OOD regressions may be from T_max=55.
2. **Input-skip + warmup=5**: Combine the best of both — warmup=5 helps tandem, input-skip helps in_dist. Could compound.
3. **T_max alone**: Test T_max=55 without input-skip to separate the effects.