### PR TITLE
n_head=3 at n_hidden=192 (fewer but wider heads, 64-dim per head)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,15 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 0
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed != 0:
+    import random
+    random.seed(cfg.seed)
+    torch.manual_seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Run the exact current baseline config with seed=137 -- testing another promising seed from the variance data.

## Instructions
1. No code changes. Pass --seed 137.
2. Run with `--wandb_group n-wider-64d-v5`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: `80vqdggs` (gilbert/n-wider-64d-v5), 60 epochs

Implementation: Added `seed: int = 0` to Config, sets `random.seed` and `torch.manual_seed` when nonzero.

### Metrics

| Metric | seed=137 | seed=0 (baseline) | seed=42 |
|---|---|---|---|
| val/loss | 0.8646 | 0.8555 | 0.8601 |
| val_in_dist/mae_surf_p | 18.28 | ~17.48 | 17.40 |
| val_ood_cond/mae_surf_p | 13.70 | ~13.59 | 13.88 |
| val_ood_re/mae_surf_p | 27.66 | ~27.57 | 27.51 |
| val_tandem_transfer/mae_surf_p | 39.14 | ~38.53 | 38.54 |
| mean3 (in+ood+tan)/3 | 23.71 | ~23.27 | 23.27 |

### Full surface MAE (seed=137)

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 5.46 | 1.61 | **18.28** |
| val_ood_cond | 2.52 | 0.88 | **13.70** |
| val_ood_re | -- | -- | **27.66** |
| val_tandem_transfer | 5.35 | 2.10 | **39.14** |

### Updated noise floor (3 seeds: 0, 42, 137)

val/loss values: [0.8555, 0.8601, 0.8646]
mean=0.8601, std~=0.0046

mean3 values: [~23.27, 23.27, 23.71]
mean~=23.42, std~=0.21

Thresholds for ~2sigma significance:
- val/loss: changes > 0.009 are likely real
- mean3: changes > 0.42 are likely real

This is consistent with earlier estimates. Seed=137 is on the high end of the distribution (worst of 3 seeds). Seed=42 is in the middle. Seed=0 is the best.

### Suggested follow-ups

- With 3 seeds, the baseline distribution is well-characterized: sigma~=0.0046 on val/loss
- Future experiments should aim for val/loss improvements > 0.010 (>2sigma) to be confident they are real