### PR TITLE
lr=2.5e-3 on per-head tandem temp code (gentler LR for wider heads)

### DIFF
--- a/train.py
+++ b/train.py
@@ -421,9 +421,12 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 42
 
 
 cfg = sp.parse(Config)
+
+torch.manual_seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Run the exact current baseline config with seed=11 — another variance data point.

## Instructions
1. No code changes. Pass --seed 11.
2. Run with `--wandb_group n-wider-64d-v6`

## Baseline: val_loss=0.8555

---
## Results

**W&B Run ID:** `z01433h3`
**Epochs completed:** 61/100 (30.4 min wall-clock timeout)
**Peak memory:** 14.8 GB/GPU

**Note:** Added minimal `seed` parameter to Config dataclass (default=42) and `torch.manual_seed(cfg.seed)` call — the script had no existing seed support, so this one-line addition was required to pass `--seed 11`.

### Validation Metrics (seed=11)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 0.5973 | 5.02 | 1.82 | 17.79 | 1.06 | 0.35 | 19.34 |
| tandem_transfer | 1.6250 | 5.01 | 2.17 | 39.04 | 1.91 | 0.87 | 38.27 |
| ood_cond | 0.7172 | 2.79 | 1.17 | 14.41 | 0.71 | 0.27 | 12.07 |
| ood_re | 0.5453 | 2.46 | 1.00 | 27.93 | 0.81 | 0.36 | 46.75 |
| **overall val/loss** | **0.8712** | | | | | | |

### Comparison vs Baseline (seed=42)

| Metric | Baseline (seed=42) | seed=11 | Delta |
|--------|-------------------|---------|-------|
| val/loss | 0.8555 | 0.8712 | +0.0157 |
| in mae_surf_p | 17.48 | 17.79 | +0.31 |
| ood mae_surf_p | 13.59 | 14.41 | +0.82 |
| re mae_surf_p | 27.57 | 27.93 | +0.36 |
| tan mae_surf_p | 38.53 | 39.04 | +0.51 |

### What happened

seed=11 gives val/loss=0.8712 vs the seed=42 baseline of 0.8555 — a ~1.6% variance. This is useful calibration data: natural run-to-run variance is roughly ±0.016 in val/loss and ±0.3–0.8 in mae_surf_p across splits. Future experiments need to beat this noise floor to be considered meaningful improvements.

The seed=11 run is marginally worse across all splits, but this is within typical variance rather than a systematic failure. In-dist surface pressure (17.79 vs 17.48) is nearly identical; ood_cond is slightly noisier (+0.82 mae_surf_p).

### Suggested follow-ups

- Having two seed runs, establish the noise floor. A third seed (e.g. seed=0 or seed=100) would help confirm whether 0.8555 is actually better than average or just a lucky seed.
- With noise floor ~0.016 val/loss, experiments that improve by <0.01 are not reliably distinguishable. This suggests focusing on bigger structural changes rather than fine hyperparameter tuning.