### PR TITLE
Input-skip + lr=2.3e-3 (different LR for different architecture)

### DIFF
--- a/train.py
+++ b/train.py
@@ -312,6 +312,9 @@ class Transolver(nn.Module):
         nn.init.zeros_(self.out_skip.bias)
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
@@ -396,6 +399,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
@@ -411,7 +415,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.5e-3
+    lr: float = 2.3e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
Input-skip changes the gradient flow by adding a raw physics shortcut. The optimal LR for this modified architecture might be different from the no-skip model. lr=2.3e-3 was too slow for the vanilla model, but with input-skip providing additional gradient signal, the slower LR might work better.

## Instructions
1. Add input-skip: self.input_skip = nn.Linear(fun_dim + space_dim, out_dim), zero-init, scale 0.1
2. Change lr from 2.5e-3 to 2.3e-3
3. Run with `--wandb_group n-wider-64d-v7`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `pktkblpq`
**Epochs:** 59 (30-min timeout)
**Peak VRAM:** 14.8 GB

| Metric | Baseline (lr=2.5e-3) | This run | Δ |
|--------|----------------------|----------|---|
| val/loss | 0.8555 | 0.8758 | +0.0203 ↑ worse |
| surf_p in_dist | 17.48 | 17.57 | +0.09 ↑ worse |
| surf_p ood_cond | 13.59 | 14.05 | +0.46 ↑ worse |
| surf_p ood_re | 27.57 | 27.82 | +0.25 ↑ worse |
| surf_p tandem | 38.53 | 39.58 | +1.05 ↑ worse |
| **mean3** | **23.20** | **23.73** | +0.53 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**What happened:** Both changes hurt. The lower LR (2.3e-3) is the likely primary cause — it slows convergence such that by the 30-minute cutoff the model hasn't fully converged (still decreasing at epoch 59). The input_skip provides a direct raw-feature-to-output path, but with zero initialization it starts inactive and needs to learn. During the early epochs when the LR is relatively high (before cosine decay), the skip may contribute noisy signal.

The tandem regression is the biggest issue (+1.05). With the slower LR, the model adapts less well to the tandem distribution shift before the timeout.

Note: The input_skip concept itself isn't necessarily bad — it might help if paired with lr=2.5e-3 (or without the LR change), allowing faster convergence to use the shortcut effectively.

**Suggested follow-ups:**
1. Test input_skip alone with lr=2.5e-3 to isolate the skip contribution from the LR change.
2. Try a larger scale factor (0.2 instead of 0.1) for faster initial learning of the skip path.
3. The lr=2.5e-3 base remains the best — consider other modifications on top of it.