### PR TITLE
Tandem temp offset init=-0.05 (sharper initial tandem attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,7 +128,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
-        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
+        self.tandem_temp_offset = nn.Parameter(torch.full((1, heads, 1, 1), -0.05))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
The tandem_temp_offset initializes at 0 (no effect). A negative init (-0.05) means each head starts with slightly SHARPER attention for tandem flows. Since wider heads (64-dim) benefit from sharper routing, starting sharper may help tandem without requiring the model to learn the negative offset from scratch.

## Instructions
1. Change tandem_temp_offset init from torch.zeros to torch.full with value -0.05:
   `self.tandem_temp_offset = nn.Parameter(torch.full((1, heads, 1, 1), -0.05))`
2. Keep everything else identical
3. Run with `--wandb_group n-wider-64d-v8`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `kmtn33ig`
**Best epoch:** 61 / 100 (hit wall-clock limit, ~30s/epoch)
**Peak memory:** 14.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6035 | 5.12 | 1.96 | 18.24 | 1.11 | 0.36 | 19.49 |
| val_tandem_transfer | 1.6486 | 5.65 | 2.37 | 39.02 | 1.94 | 0.88 | 38.39 |
| val_ood_cond | 0.6981 | 2.75 | 1.19 | 13.88 | 0.72 | 0.27 | 11.55 |
| val_ood_re | 0.5393 | 2.43 | 1.04 | 27.69 | 0.81 | 0.36 | 46.47 |
| **mean3** | **0.984** | **4.51** | **1.84** | **23.71** | — | — | — |

Baseline: mean3=23.20 (in=17.48, ood=13.59, tan=38.53, re=27.57), val_loss=0.8555

**What happened:** Negative result. mean3=23.71 vs 23.20 baseline, val/loss 0.8555 → 0.8724. All splits degraded: in_dist (+0.76), tandem (+0.49), ood_cond (+0.29), ood_re (+0.12).

Starting with tandem_temp_offset=-0.05 (sharper tandem attention) doesn't help. The hypothesis assumes sharper routing from epoch 0 is beneficial, but the model actually needs the flexibility to learn the optimal offset. Starting at -0.05 may constrain the early learning — the optimizer has to overcome a bias before exploring the right direction. The model performs better when tandem_temp_offset starts at 0 and learns the offset from data.

More practically: the temperature parameter itself (init 0.5) already provides control over sharpness; a -0.05 offset on temperature means tandem heads start at 0.45 vs 0.5 — a 10% sharpening. This is a small but meaningful constraint that appears to hurt rather than help.

**Suggested follow-ups:**
- Try a positive init (+0.05) to start with *softer* tandem attention, which may help the model distinguish tandem geometry more gradually.
- Accept tandem_temp_offset init=0 as the correct starting point.