### PR TITLE
Input-skip with learnable scale (let optimizer find optimal scale)

### DIFF
--- a/train.py
+++ b/train.py
@@ -310,6 +310,10 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
+        self.input_skip_scale = nn.Parameter(torch.tensor(0.1))
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
@@ -375,6 +379,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_raw = x  # save raw input before feature_cross for input_skip
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +401,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + self.input_skip_scale * self.input_skip(x_raw)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
Input-skip at scale 0.1 got 0.8612. We're testing 0.05 (senku) and 0.2 (tanjiro). But maybe the optimal scale isn't any of these — let the model LEARN it. Use a single learnable scalar initialized to 0.1.

## Instructions
1. Add self.input_skip = nn.Linear(fun_dim + space_dim, out_dim), zero-init
2. Add self.input_skip_scale = nn.Parameter(torch.tensor(0.1))
3. In forward: fx = fx + self.input_skip_scale * self.input_skip(x_raw)
4. Run with `--wandb_group n-wider-64d-v9`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** ge4gnucp  
**Epochs completed:** 57/100 (30-min timeout)  
**Peak memory:** 14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8555 | 0.8795 | +2.8% worse |
| val_in_dist | mae_surf_p | 17.48 | 18.33 | +4.9% worse |
| val_ood_cond | mae_surf_p | 13.59 | 14.42 | +6.1% worse |
| val_tandem_transfer | mae_surf_p | 38.53 | 39.83 | +3.4% worse |
| val_ood_re | mae_surf_p | 27.57 | 27.89 | +1.2% worse |
| **mean3** | mae_surf_p | **23.20** | **24.19** | **+4.3% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=8.32, Uy=2.36, p=18.33 | Vol: Ux=1.12, Uy=0.37, p=19.60
- **ood_cond:** Ux=6.04, Uy=1.62, p=14.42 | Vol: Ux=0.71, Uy=0.27, p=12.52
- **ood_re:** Ux=5.71, Uy=1.48, p=27.89 | Vol: Ux=0.82, Uy=0.36, p=46.92
- **tandem_transfer:** Ux=7.45, Uy=2.70, p=39.83 | Vol: Ux=1.94, Uy=0.88, p=39.42

### What happened

The learnable scale input-skip did not improve over baseline, and performed worse than the fixed-scale version (val_loss=0.8612 for scale=0.1 fixed, vs 0.8795 here). All splits regressed, with Ux surface MAE notably large (in_dist: 8.32 vs ~3.8 in the baseline reproduction).

The large Ux regression suggests the learnable scale may have grown during training and added too much raw-input signal at the Ux output. The input skip creates a direct shortcut from raw features to output, which bypasses the attention mechanism entirely. With a fixed scale of 0.1, this was a mild regularization; with a learnable scale, the optimizer can freely increase it, potentially creating a shortcut that the attention doesn't need to overcome.

Also, the fixed-scale version (0.8612) was itself worse than the baseline (0.8555), suggesting the input skip path may not be beneficial at all in this architecture where the model already has  from .

### Suggested follow-ups

- **Remove input_skip entirely**: Given that both fixed-scale and learnable-scale versions underperform the baseline, this architectural addition appears to hurt. The existing  from  may already serve the same purpose.
- **Constrained scale**: If exploring further, clamp the learnable scale to [0, 0.2] or use sigmoid gating to prevent unbounded growth.