### PR TITLE
AdaLN: Condition-adaptive LayerNorm (replace fixed norm with Re/AoA-dependent)

### DIFF
--- a/train.py
+++ b/train.py
@@ -223,6 +223,9 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        self.adaln_mlp = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
+        nn.init.zeros_(self.adaln_mlp[-1].weight)
+        nn.init.zeros_(self.adaln_mlp[-1].bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -231,9 +234,14 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        if condition is not None:
+            gamma, beta = self.adaln_mlp(condition).chunk(2, dim=-1)
+            fx_ln1 = F.layer_norm(fx, [fx.shape[-1]]) * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
+        else:
+            fx_ln1 = self.ln_1(fx)
+        fx = self.ln_1_post(self.attn(fx_ln1, spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -382,18 +390,21 @@ class Transolver(nn.Module):
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
+        # Condition vector: Re, AoA, gap, stagger (indices 13:15, 21:23) — constant across nodes
+        adaln_cond = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)  # [B, 4]
+
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=adaln_cond)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=adaln_cond)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
Every LayerNorm uses fixed learned affine parameters. But the model processes flows at dramatically different Re, AoA, and geometries. AdaLN (from DiT) makes norm parameters conditional on the input — the internal representation rescales per-sample based on flow conditions. This is structurally different from FiLM (which was tried and failed) because it replaces the normalization itself rather than adding post-hoc modulation.

## Instructions
1. Extract condition vector: `c = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)` (Re, AoA, gap, stagger — 4-5 dims, constant across nodes in each sample)
2. Add small MLP: `self.adaln_mlp = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))` — outputs (gamma, beta) for the main LayerNorm (ln_1)
3. Replace `self.ln_1(fx)` with adaptive norm:
   ```python
   gamma, beta = self.adaln_mlp(condition).chunk(2, dim=-1)
   fx_norm = F.layer_norm(fx, [hidden_dim])
   fx_norm = fx_norm * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
   ```
4. Start with just ln_1 (pre-attention norm). If it helps, expand to other norms.
5. Run with `--wandb_group adaln-conditional`

## Baseline: val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53

---
## Results

**W&B run:** `aku3i552` | **Epochs:** 58/100 (30-min timeout) | **Peak VRAM:** 14.8 GB | **Extra params:** ~85K

### Surface MAE (mae_surf_p) — primary metric

| Split | Baseline | This run | Δ |
|-------|----------|----------|---|
| val_in_dist | 17.48 | 18.36 | +0.88 ▲ worse |
| val_ood_cond | 13.59 | 13.77 | +0.18 ▲ slightly worse |
| val_ood_re | 27.57 | 28.28 | +0.71 ▲ worse |
| val_tandem | 38.53 | 38.13 | -0.40 ▼ slightly better |
| **mean3** (in/ood_cond/tan) | **23.20** | **23.42** | **+0.22 ▲ slightly worse** |

**val/loss:** 0.8697 vs baseline 0.8555 → worse (+1.6%)

### Full surface MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 6.56 | 2.08 | 18.36 |
| val_ood_cond | 3.48 | 1.28 | 13.77 |
| val_ood_re | 2.86 | 1.10 | 28.28 |
| val_tandem | 6.02 | 2.34 | 38.13 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| val_in_dist | 1.12 | 0.37 | 19.31 |
| val_ood_cond | 0.74 | 0.28 | 12.07 |
| val_ood_re | 0.85 | 0.37 | 47.26 |
| val_tandem | 1.95 | 0.88 | 37.83 |

### What happened

AdaLN conditional normalization did not improve overall performance (mean3 +0.22, val/loss +1.6%). The tandem split improved slightly (-0.40 on p MAE), suggesting the conditioning on gap/stagger features is partially useful for tandem geometry. But in_dist and ood_re both regressed.

The most likely reason: AdaLN requires the gamma/beta MLP to learn meaningful per-sample normalization — this takes many epochs to converge. With 58 epochs and ~85K extra parameters per application (5 blocks), the model is still in early learning phases for the conditional components. At initialization, the MLP outputs zeros (via zero-init on last layer), so gamma=0 and beta=0, which reduces to standard LayerNorm. The model hasn't yet learned to use the conditioning.

Additionally, the features at indices 13:15 and 21:23 may not be clean representations of the conditioning variables — the x tensor has already been processed through feature_cross before conditioning is extracted (but actually we extract from `x` before the feature_cross in the correct code order).

### Suggested follow-ups
- AdaLN might need more epochs (100+) to show its benefit — the zero-init provides a safe starting point but slows down useful adaptation
- Try conditioning only on the last block (fewer parameters to learn)
- The tandem improvement is interesting — try conditioning only on gap/stagger (2D) for simpler conditioning
- Alternatively, try adaLN with a stronger init for gamma (e.g., 0.01 or 0.1 std) to help it activate sooner