### PR TITLE
Per-sample Fourier frequencies (hypernetwork on positional encoding)

### DIFF
--- a/train.py
+++ b/train.py
@@ -317,7 +317,9 @@ class Transolver(nn.Module):
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
-        self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.freq_net = nn.Sequential(nn.Linear(4, 16), nn.GELU(), nn.Linear(16, 4))
+        nn.init.zeros_(self.freq_net[-1].weight)
+        self.freq_net[-1].bias.data.copy_(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -660,8 +662,11 @@ for epoch in range(MAX_EPOCHS):
         xy_min = raw_xy.amin(dim=1, keepdim=True)
         xy_max = raw_xy.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-        freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+        c = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)  # [B, 4]: Re, AoA, gap, stagger
+        learned_freqs = _base_model.freq_net(c).abs()  # [B, 4]
+        freqs_fixed = _base_model.fourier_freqs_fixed.to(device)[None, :].expand(x.shape[0], -1)
+        freqs = torch.cat([freqs_fixed, learned_freqs], dim=-1)  # [B, 8]
+        xy_scaled = xy_norm.unsqueeze(-1) * freqs[:, None, None, :]  # [B, N, 2, 8]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
@@ -841,8 +846,11 @@ for epoch in range(MAX_EPOCHS):
                 xy_min = raw_xy.amin(dim=1, keepdim=True)
                 xy_max = raw_xy.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+                c = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)  # [B, 4]: Re, AoA, gap, stagger
+                learned_freqs = _base_model.freq_net(c).abs()  # [B, 4]
+                freqs_fixed = _base_model.fourier_freqs_fixed.to(device)[None, :].expand(x.shape[0], -1)
+                freqs = torch.cat([freqs_fixed, learned_freqs], dim=-1)  # [B, 8]
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs[:, None, None, :]  # [B, N, 2, 8]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
@@ -946,7 +954,8 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
-    learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
+    c_dummy = torch.zeros(1, 4, device=device)
+    learned_freqs = _base_model.freq_net(c_dummy).abs().detach().cpu()[0].tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f
     wandb.log(metrics)


### PR DESCRIPTION
## Hypothesis
The 4 learned Fourier frequencies are globally shared, but different flow regimes have different spatial scales (thin BL at high Re, thick at low Re). Predict frequencies per-sample from the condition vector [Re, AoA, gap, stagger] so the positional encoding adapts to the flow regime.

## Instructions
1. Replace `self.fourier_freqs_learned` (4 learnable params) with a small MLP:
   ```python
   self.freq_net = nn.Sequential(nn.Linear(4, 16), nn.GELU(), nn.Linear(16, 4))
   ```
2. Extract condition: `c = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)` (Re, AoA, gap, stagger)
3. In the PE computation: `learned_freqs = self.freq_net(c)` — shape [B, 4], then use these per-sample frequencies instead of the global ones
4. Initialize the MLP output to approximate the current learned frequencies
5. Run with `--wandb_group per-sample-fourier-freq`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** 68r8s08j
**Epochs completed:** 60/100 (30-min timeout)
**Peak memory:** 14.8 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8589 | 0.8555 | +0.4% (≈same) |
| Surface MAE p (in_dist) | 18.28 | 17.48 | +4.6% (worse) |
| Surface MAE p (ood_cond) | 13.87 | 13.59 | +2.1% (worse) |
| Surface MAE p (ood_re) | 27.75 | 27.57 | +0.7% (≈same) |
| Surface MAE p (tandem) | 37.84 | 38.53 | -1.8% (better) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 4.94 | 1.71 | 18.28 |
| ood_cond | 3.01 | 1.00 | 13.87 |
| ood_re | 2.58 | 0.88 | 27.75 |
| tandem | 4.91 | 1.98 | 37.84 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.11 | 0.36 | 19.13 |
| ood_cond | 0.72 | 0.27 | 11.92 |
| ood_re | 0.82 | 0.36 | 46.64 |
| tandem | 1.91 | 0.86 | 37.29 |

### What happened

Near-neutral result. Overall val/loss is +0.4% — well within the ~2% noise floor. The most notable finding is the tandem split: surface MAE p improves from 38.53 to 37.84 (-1.8%), which aligns with the hypothesis — tandem samples have varying gap and stagger values (the key conditioning features for freq_net), so per-sample PE could help differentiate configurations.

However, in_dist pressure regressed +4.6%, which is the worst trade-off. For single-foil in-distribution samples, the gap and stagger features are near-zero (uninformative), so the freq_net effectively just adds noise to the in-dist PE.

The hypothesis partially validated: per-sample frequencies do seem to help tandem but hurt in_dist where the condition signal is degenerate. The global learned frequencies may have been tuned toward single-foil cases (the majority of training data).

The `freq_net` is small (4→16→4) and adds negligible compute overhead.

### Suggested follow-ups

- **Condition on Re+AoA only (not gap/stagger):** The tandem-specific condition might be interfering with in_dist. Try `c = x[:, 0, 13:15]` (just Re, AoA) for a 2-input freq_net — this would adapt to flow regime without the tandem-specific signal.
- **Separate PE for tandem vs non-tandem:** Use `fourier_freqs_learned` for non-tandem, and a separate `fourier_freqs_tandem` (or freq_net conditioned on gap/stagger only) for tandem samples.
- **Initialize freq_net to output zeros (additive correction):** Instead of initializing to the baseline frequencies, train freq_net as a correction: `freqs = base_freqs + 0.1 * freq_net(c)`. This would constrain the per-sample deviation.