### PR TITLE
Detach volume attention gradient after ep30 (surface-driven routing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -144,7 +144,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
-    def forward(self, x, spatial_bias=None, tandem_mask=None):
+    def forward(self, x, spatial_bias=None, tandem_mask=None, is_surface=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -166,6 +166,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if spatial_bias is not None:
             slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
         slice_weights = self.softmax(slice_logits)
+        if is_surface is not None:
+            # detach-vol-attn-grad: stop gradient for volume nodes' slice routing after ep30
+            surf_mask = is_surface[:, None, :, None]  # [B, 1, N, 1] → broadcasts to [B, H, N, slice_num]
+            slice_weights = torch.where(surf_mask, slice_weights, slice_weights.detach())
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -231,9 +235,9 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, is_surface=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask, is_surface=is_surface) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -368,6 +372,7 @@ class Transolver(nn.Module):
             raise ValueError("Missing required input tensor: x")
         if condition is not None:
             raise ValueError("Transolver does not support conditioning inputs")
+        is_surface = data.get("is_surface") if isinstance(data, dict) else None  # detach-vol-attn-grad
 
         if self.unified_pos:
             if pos is None:
@@ -387,13 +392,13 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, is_surface=is_surface)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, is_surface=is_surface)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
@@ -694,7 +699,11 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            # detach-vol-attn-grad: pass is_surface after ep30 to stop vol grad on slice routing
+            model_input = {"x": x}
+            if epoch >= 30:
+                model_input["is_surface"] = is_surface
+            out = model(model_input)
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]


### PR DESCRIPTION
## Hypothesis
~98% of nodes are volume, ~2% surface. Attention routing is overwhelmingly trained by volume gradients. After epoch 30, detach volume nodes' contribution to slice_weights gradient, so routing is trained by surface loss only. The MLP residual path still handles volume prediction.

## Instructions
1. Pass `is_surface` mask into Physics_Attention_Irregular_Mesh.forward
2. After computing `slice_weights` (the soft assignment), for volume nodes only: `slice_weights_vol = slice_weights.detach()` (stop gradient)
3. Reconstruct: `effective_weights = torch.where(is_surface, slice_weights, slice_weights_vol)`
4. Use `effective_weights` in the einsum for slice token computation
5. Only activate after epoch 30 (let routing converge normally first)
6. Run with `--wandb_group detach-vol-attn-grad`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** t39m0q3y  
**Best checkpoint:** epoch 58

| Split | val/loss | surf_p | surf_Ux | surf_Uy |
|-------|----------|--------|---------|---------|
| val_in_dist | 0.6104 | 18.44 | 4.95 | 1.43 |
| val_ood_cond | 0.6903 | 13.68 | 2.64 | 1.01 |
| val_ood_re | 0.5416 | 27.52 | 2.20 | 0.82 |
| val_tandem_transfer | 1.6373 | 38.61 | 5.33 | 2.00 |
| **combined val/loss** | **0.8699** | | | |

**vs Baseline (val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53):**

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8555 | 0.8699 | +0.0144 ❌ |
| surf_p in_dist | 17.48 | 18.44 | +0.96 ❌ |
| surf_p ood_cond | 13.59 | 13.68 | +0.09 ❌ |
| surf_p ood_re | 27.57 | 27.52 | −0.05 ≈ |
| surf_p tandem | 38.53 | 38.61 | +0.08 ≈ |
| mean3 surf_p | ~19.55 | 19.88 | +0.33 ❌ |

**What happened:** The hypothesis didn't work — detaching volume gradient from slice routing made things worse across the board. The in-dist surface pressure degraded most (+0.96). This suggests volume nodes aren't just noise for routing: they provide useful gradient signal that helps the attention slices generalize to surface nodes too. The MLP-only path for volume prediction (after detach) may not be sufficient to maintain joint optimization of the routing function. The conditional activation at epoch 30 didn't help — routing had already converged to a mixed-signal optimum that benefits surface accuracy.

**Memory:** No significant change (detach op has no memory overhead).

**Suggested follow-ups:**
- Try detaching only a fraction of volume nodes (e.g., randomly sample 50% to detach each step) — softer version of the idea
- Instead of detaching, try upweighting surface gradient for slice routing directly (surface loss × 5x on the routing logits only)
- Investigate whether volume nodes actually hurt or help by looking at which slices activate most on surface vs volume nodes