### PR TITLE
Slice token memory (MoCo-style running prototypes for spatial routing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.register_buffer('slice_prototypes', torch.zeros(1, heads, slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +170,12 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        if self.training:
+            with torch.no_grad():
+                update = slice_token.detach().mean(dim=0, keepdim=True).clone()
+                self.slice_prototypes.copy_(0.99 * self.slice_prototypes + 0.01 * update)
+        slice_token = 0.8 * slice_token + 0.2 * self.slice_prototypes.detach()
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)


### PR DESCRIPTION
## Hypothesis
Slice tokens are recomputed from scratch each forward pass — no memory of what each slice should represent. Add a running EMA of slice tokens as persistent prototypes (like MoCo momentum encoder). Blend prototypes into slice tokens before Q/K/V, giving routing a strong spatial prior.

## Instructions
1. Register buffer: `self.register_buffer('slice_prototypes', torch.zeros(1, heads, slice_num, dim_head))`
2. After computing `slice_token` from weighted aggregation:
   ```python
   if self.training:
       self.slice_prototypes.data = 0.99 * self.slice_prototypes.data + 0.01 * slice_token.detach().mean(dim=0, keepdim=True)
   slice_token = 0.8 * slice_token + 0.2 * self.slice_prototypes.detach()
   ```
3. Run with `--wandb_group slice-token-memory`

9,216 params in the buffer (not learned, just EMA). Zero additional compute.

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `ww7p7btx` (alphonse/slice-token-memory)
**Epoch at timeout:** 60 (~20 EMA epochs; ema_start_epoch=40)
**Runtime:** 1908s (~32 min)

### Metrics vs baseline

| Metric | This run | Baseline | Δ |
|--------|----------|----------|---|
| val/loss | 0.8569 | 0.8555 | +0.0014 (+0.2%) |
| in_dist surf p | **17.33** | 17.48 | **-0.15** |
| ood_cond surf p | **13.40** | 13.59 | **-0.19** |
| ood_re surf p | 27.84 | 27.57 | +0.27 |
| tandem surf p | 38.91 | 38.53 | +0.38 |
| mean3 | 23.21 | 23.20 | +0.01 |

### Surface MAE (full)
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 5.10 | 1.83 | 17.33 |
| ood_cond | 2.86 | 1.00 | 13.40 |
| ood_re | 2.44 | 0.81 | 27.84 |
| tandem | 5.42 | 2.24 | 38.91 |

### Volume MAE (p)
in_dist=18.55, ood_cond=11.50, ood_re=46.64, tandem=38.27

**Peak GPU memory:** N/A (system metrics not logged)

### Implementation note
The instructed `.data =` assignment caused a CUDAGraph RuntimeError (`torch.compile(mode='reduce-overhead')` uses CUDAGraphs, which don't allow reassigning buffer data pointers to compiled output memory). Used `.copy_()` with `torch.no_grad()` and `.clone()` instead, which keeps the buffer's pre-allocated storage and copies values in. This is semantically equivalent for the EMA update and compatible with CUDAGraph replay.

### What happened

Essentially neutral with split results. Mean3 barely changes (23.21 vs 23.20, +0.01). The interesting signal is the split pattern: in_dist and ood_cond improved (-0.15, -0.19) while ood_re and tandem regressed (+0.27, +0.38). Val/loss is almost identical (+0.2%).

The in_dist/ood_cond improvement is consistent with the hypothesis: persistent prototypes provide better routing priors for the dominant distribution. However, tandem samples suffer — they likely have different spatial routing patterns (two airfoils vs one), and the single shared prototype buffer is dominated by non-tandem data (tandem is a minority), causing the tandem routing to be pulled toward single-airfoil prototypes.

The 0.2 prototype blend may be slightly too aggressive, especially for tandem samples which have different physics.

### Suggested follow-ups
- Add condition on is_tandem: separate prototype buffers for tandem/non-tandem samples, preventing cross-contamination
- Reduce prototype blend from 0.2 to 0.1 to be more conservative
- The in_dist/ood_cond improvement is the most consistent win so far; combining prototypes with tandem-specific logic could unlock broader gains