### PR TITLE
Skip gate dropout p=0.15 (stochastic ensemble at architectural bottleneck)

### DIFF
--- a/train.py
+++ b/train.py
@@ -395,6 +395,8 @@ class Transolver(nn.Module):
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
+        if self.training:
+            gate = F.dropout(gate, p=0.15, training=True)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}


### PR DESCRIPTION
## Hypothesis
The skip gate controls the bypass vs attention balance. Adding dropout (p=0.15) specifically on the skip gate creates a stochastic ensemble: sometimes the model relies on attention, sometimes on bypass. This forces BOTH pathways to be independently good — a targeted form of regularization at the most critical junction.

## Instructions
1. In the skip gate application, add dropout during training:
   ```python
   gate = self.skip_gate(...)
   if self.training:
       gate = F.dropout(gate, p=0.15, training=True)
   out = gate * skip_features + (1 - gate) * attention_features
   ```
2. This only adds ~1 line of code
3. Run with `--wandb_group skip-gate-dropout`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `dpdw9h7b` (`norman/skip-gate-dropout`)
**Best epoch:** 57
**Peak memory:** N/A (run killed by 30-min timeout at 32.2 min)

**Note on implementation:** The actual skip gate in this codebase adds `gate * out_skip(fx_pre)` to `fx` (not a strict `gate * skip + (1-gate) * attention` structure). I applied dropout to the gate value before the skip addition, consistent with the PR intent:
```python
gate = self.skip_gate(fx_pre)
if self.training:
    gate = F.dropout(gate, p=0.15, training=True)
fx = fx + gate * self.out_skip(fx_pre)
```

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 0.6145 | 18.62 |
| val_ood_cond | 0.7171 | 14.58 |
| val_ood_re | 0.5475 | 27.92 |
| val_tandem_transfer | 1.6317 | 38.73 |
| **Combined** | **0.8777** | — |

**vs baseline (0.8555):** +0.0222 (worse)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8555 | 0.8777 | **+0.0222** ✗ |
| in_dist surf_p | 17.48 | 18.62 | +1.14 ✗ |
| ood_cond surf_p | 13.59 | 14.58 | +0.99 ✗ |
| ood_re surf_p | 27.57 | 27.92 | +0.35 ✗ |
| tandem surf_p | 38.53 | 38.73 | +0.20 ✗ |

### What happened
Skip gate dropout hurt on all metrics. The combined val/loss went up by 0.022 and surface pressure MAE degraded on every split. The skip gate in this architecture is already carefully initialized (bias=-2.0, nearly closed at start), meaning it's already trained to represent a learned, stable bypass signal. Randomly zeroing 15% of gate values during training disrupts this learned balance without providing a useful regularization signal — the gate is already at a late-training optimum and doesn't benefit from being stochastically ablated.

### Suggested follow-ups
- The skip gate appears to be a precise learned mechanism, not a noisy pathway that benefits from dropout. Adding stochasticity here makes things worse.
- If further regularization is wanted, try dropout on the skip path's *features* (`out_skip` output) rather than the gate itself, though this is likely to also hurt.
- The skip gate value could be analyzed (mean gate activation across training) to understand how much it's contributing — this would help decide if the skip is even active enough to be worth regularizing.