### PR TITLE
AdaLN on output head (condition-adaptive output normalization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -224,14 +224,15 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
-            self.ln_3 = nn.LayerNorm(hidden_dim)
+            self.hidden_dim = hidden_dim
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.adaln_out = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
@@ -240,7 +241,9 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            gamma, beta = self.adaln_out(condition).chunk(2, dim=-1)  # each [B, hidden_dim]
+            fx = F.layer_norm(fx, [self.hidden_dim]) * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
+            return self.mlp2(fx)
         return fx
 
 
@@ -307,6 +310,11 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
+        # Zero-init adaln_out output layer so AdaLN starts as identity
+        for block in self.blocks:
+            if block.last_layer:
+                nn.init.zeros_(block.adaln_out[-1].weight)
+                nn.init.zeros_(block.adaln_out[-1].bias)
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
@@ -382,6 +390,9 @@ class Transolver(nn.Module):
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
+        # Extract global condition: [log_Re, AoA0, gap, stagger] from node 0 (same for all nodes)
+        c = x[:, 0, :][:, [13, 14, 22, 23]]  # [B, 4]
+
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
@@ -393,7 +404,7 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=c)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
Apply AdaLN to the output head's ln_3 specifically — the normalization right before the final prediction. This is the most impactful location because it directly conditions the prediction on flow regime.

## Instructions
1. Extract condition: c = [Re, AoA, gap, stagger] from x[:, 0, :]
2. Add MLP: adaln_out = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, 2*hidden_dim))
3. In the last block, replace ln_3(fx) with adaptive: gamma, beta = adaln_out(c).chunk(2); fx = F.layer_norm(fx, [hidden_dim]) * (1+gamma) + beta
4. Run with `--wandb_group n-wider-64d-v10`

## Baseline: val_loss=0.8555

---
## Results

**W&B Run ID:** `9zz33on2`
**Epochs completed:** 59/100 (30.3 min wall-clock timeout)
**Peak memory:** 14.8 GB/GPU

### Validation Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 0.6040 | 6.24 | 1.90 | 18.33 | 1.10 | 0.36 | 19.37 |
| tandem_transfer | 1.6458 | 6.23 | 2.32 | 39.12 | 1.94 | 0.89 | 37.98 |
| ood_cond | 0.6586 | 3.67 | 1.10 | 13.16 | 0.70 | 0.26 | 11.21 |
| ood_re | 0.5352 | 3.29 | 0.95 | 27.68 | 0.82 | 0.36 | 46.53 |
| **overall val/loss** | **0.8609** | | | | | | |

### Comparison vs Baseline

| Metric | Baseline | AdaLN-out | Delta |
|--------|----------|-----------|-------|
| val/loss | 0.8555 | 0.8609 | +0.0054 ❌ |
| in mae_surf_p | 17.48 | 18.33 | +0.85 ❌ |
| ood mae_surf_p | 13.59 | 13.16 | **-0.43** ✅ |
| re mae_surf_p | 27.57 | 27.68 | +0.11 ❌ |
| tan mae_surf_p | 38.53 | 39.12 | +0.59 ❌ |

### What happened

AdaLN on the output head produced a mixed result. The overall val/loss (0.8609 vs 0.8555) is slightly worse than baseline. Only ood_cond improved meaningfully (mae_surf_p: 13.16 vs 13.59, -0.43). In-dist and tandem both degraded slightly.

The delta of +0.0054 in val/loss is within the noise floor of ~0.016 observed across seed variations, so this is essentially a null result — AdaLN here didn't help or hurt noticeably. The run also converged 2 epochs fewer (59 vs 61), possibly because the adaln_out MLP adds a small computation overhead.

A possible issue: at inference the condition features (log_Re, AoA, gap, stagger) are normalized by x_std, which may differ slightly across batches due to the normalization procedure. The 4-dim condition is quite information-sparse compared to the hidden_dim=192 AdaLN modulation target, so the MLP may struggle to learn meaningful scaling.

### Suggested follow-ups

- Try AdaLN with a richer condition vector (e.g., all 24 original features of node 0, or use learned tokens). The 4-feature condition may be too limited.
- The ood_cond improvement suggests AdaLN helps for novel operating conditions. A deeper conditioning MLP or conditioning at multiple layers (not just the output head) might amplify this.
- Zero-init for adaln_out (used here) ensures stable start, but the MLP may need more epochs to learn useful modulations — worth checking if a longer run shows improvement.