### PR TITLE
Input-skip + AdaLN combined (two novel directions together)

### DIFF
--- a/train.py
+++ b/train.py
@@ -223,6 +223,9 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        self.ada_ln_proj = nn.Linear(4, 2 * hidden_dim)
+        nn.init.zeros_(self.ada_ln_proj.weight)
+        nn.init.zeros_(self.ada_ln_proj.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -231,9 +234,14 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, cond=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        x_normed = self.ln_1(fx)
+        if cond is not None:
+            scale_shift = self.ada_ln_proj(cond)  # [B, 2*hidden_dim]
+            scale, shift = scale_shift.chunk(2, dim=-1)
+            x_normed = (1 + scale.unsqueeze(1)) * x_normed + shift.unsqueeze(1)
+        fx = self.ln_1_post(self.attn(x_normed, spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -310,6 +318,9 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
@@ -382,20 +393,24 @@ class Transolver(nn.Module):
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
+        # AdaLN condition: log_Re(13), AoA0(14), gap(22), stagger(23) — global per sample
+        cond = x[:, 0, [13, 14, 22, 23]]  # [B, 4]
+
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
Input-skip improved in_dist (0.8612, +0.7%). AdaLN targets ood_cond. Together they might address both weaknesses without the Pareto tradeoff.

## Instructions
1. Add input-skip: self.input_skip = nn.Linear(fun_dim + space_dim, out_dim), zero-init, scale 0.1
2. Add AdaLN on ln_1 with condition = [Re, AoA, gap, stagger]
3. Run with `--wandb_group n-wider-64d-v11`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `irh3nedf` | **Epochs:** 54 | **Epoch time:** ~32s

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|-----------|-----------|----------|
| in_dist | 7.75 | 2.53 | 18.28 | 1.12 | 0.37 | 20.06 |
| ood_cond | 5.32 | 1.60 | 14.98 | 0.74 | 0.28 | 12.50 |
| ood_re | 5.07 | 1.44 | 28.49 | 0.83 | 0.37 | 47.14 |
| tandem | 6.83 | 2.89 | 39.35 | 1.94 | 0.88 | 39.01 |

**Summary vs baseline:**

| Metric | Baseline | Input-skip+AdaLN | Delta |
|--------|----------|-----------------|-------|
| val/loss | 0.8555 | 0.8971 | +0.0416 (+4.9%) |
| in_p | 17.48 | 18.28 | +0.80 (+4.6%) |
| ood_p | 13.59 | 14.98 | +1.39 (+10.2%) |
| re_p | 27.57 | 28.49 | +0.92 (+3.3%) |
| tan_p | 38.53 | 39.35 | +0.82 (+2.1%) |
| mean3 | ~23.20 | 24.20 | +1.00 (+4.3%) |

**Peak memory:** not logged

### What happened

Input-skip + AdaLN combined is **clearly worse than baseline** across all splits — the worst result so far in this v-series (4.9% val/loss regression, 4.3% mean3 regression). The combination has failed.

Several failure modes are possible:

1. **AdaLN interferes with learned features**: The conditioning [Re, AoA, gap, stagger] are already encoded in x and used by the network. AdaLN on ln_1 adds another explicit conditioning path that may conflict with the implicit conditioning already learned.

2. **input_skip increases gradient noise early**: The input-skip adds a direct gradient path from raw features to output. This creates competing gradient signals with the main transformer path, potentially destabilizing training in the first 30-40 epochs before EMA kicks in.

3. **The two changes might fight each other**: If input_skip routes some spatial information directly, AdaLN may over-correct the same features in an inconsistent direction.

4. **Fewer effective epochs**: 54 epochs vs 56-57 baseline suggests slightly slower training convergence.

The hypothesis is falsified: combining two changes that individually showed marginal benefit does not compound those benefits.

Note: run state is "failed" due to pre-existing visualization bug in noam (line 1018, missing Fourier PE). Training metrics captured successfully.

### Suggested follow-ups

1. **Test each component in isolation on current noam**: If input-skip alone gives 0.8612 (as mentioned in hypothesis), that's still worse than 0.8555 baseline. Both may be net negatives on the current baseline.
2. **Lighter AdaLN**: Use only 2 conditions (gap, stagger) to avoid redundancy with already-encoded Re/AoA, or apply it on ln_2 instead of ln_1.
3. **Different input-skip formulation**: Instead of a direct raw-feature residual, try a gated or normalized version.