### PR TITLE
Per-sample noise scale (condition-dependent noise level)

### DIFF
--- a/train.py
+++ b/train.py
@@ -666,7 +666,9 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
             noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+            aoa_mag = x[:, 0, 14].abs().detach()
+            noise_factor = 0.5 + 0.5 * (aoa_mag / aoa_mag.max()).clamp(0, 1)  # [B]
+            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * noise_factor[:, None, None] * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Noise helps ood but hurts in_dist. Instead of uniform noise, scale noise by AoA magnitude: extreme-AoA samples get full noise, typical samples get less. This was tried as OOD-conditioned noise on older code (0.873) but never on the lr=2.5e-3 code.

## Instructions
1. After computing noise level from epoch, multiply by per-sample factor based on AoA:
   aoa_mag = x[:, 0, 14].abs()
   noise_factor = 0.5 + 0.5 * (aoa_mag / aoa_mag.max()).clamp(0, 1)
2. Apply noise_factor to scale noise per sample
3. Run with `--wandb_group n-wider-64d-v12`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: `tj37k5dh`
**Epochs**: 56/100 (wall-clock limit, ~30 min)
**Peak memory**: 15.7 GB
**val/loss**: 0.8709 (baseline 0.8555, **+0.0154 worse**)

### Surface MAE

| Split | Ux | Uy | p | p vs baseline |
|-------|----|----|---|---------------|
| val_in_dist | 6.07 | 1.73 | 18.34 | ~17.48 → +0.86 ↑ |
| val_ood_cond | 3.49 | 1.25 | 14.68 | ~13.59 → +1.09 ↑ |
| val_ood_re | 3.03 | 1.09 | 27.88 | ~27.57 → +0.31 ↑ |
| val_tandem_transfer | 6.19 | 2.30 | 37.73 | ~38.53 → **-0.80 ↓** |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.12 | 0.36 | 19.08 |
| val_ood_cond | 0.73 | 0.27 | 12.31 |
| val_ood_re | 0.81 | 0.36 | 46.80 |
| val_tandem_transfer | 1.90 | 0.86 | 37.43 |

### What happened

**Mostly negative, with one bright spot.** All splits degraded vs baseline except tandem transfer, which improved noticeably (p: 38.53 → 37.73, -0.80). The overall val/loss is worse by +0.0154 due to in-dist and OOD degradation.

The tandem improvement makes intuitive sense: tandem geometries often have unusual AoA configurations (wake interaction creates high-effective-AoA conditions), so giving them more noise provides useful regularization for that split. But the in-dist and OOD splits, which have more typical AoA distributions, got more noise at the high end and less at the low end, which didn't help.

The `noise_factor` formula (`0.5 + 0.5 * (aoa_mag / aoa_mag.max())`) means the lowest-AoA sample in each batch gets 0.5x noise and the highest gets 1.0x. This creates within-batch non-uniformity where low-AoA samples are less regularized.

Note: First run `hahqga0y` crashed immediately with `RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation` — `aoa_mag = x[:, 0, 14].abs()` was derived from `x`, which was then modified in-place at `x[:, :, 2:25]` (feature 14 is in this range). Fixed by adding `.detach()` to `aoa_mag`. Second run `tj37k5dh` ran cleanly.

### Suggested follow-ups

- The tandem improvement (-0.80) is the most encouraging signal. Try applying the AoA noise scaling only to tandem samples, leaving non-tandem samples with uniform noise.
- The current noise_factor normalizes within the batch (dividing by `aoa_mag.max()` per batch). Consider normalizing across the dataset using a fixed reference AoA instead, to avoid batch-size artifacts.
- The `.detach()` fix is necessary and correct — `aoa_mag` should not be in the computation graph since it's used as a noise multiplier, not a differentiable parameter.