### PR TITLE
Gradient accumulation 2x on lr=2.5e-3 (effective batch 8 with new LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -530,7 +530,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
+model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -643,6 +643,8 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
+    accum_steps = 2
+    optimizer.zero_grad()
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     for x, y, is_surface, mask in pbar:
@@ -779,10 +781,11 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
+        (loss / accum_steps).backward()
+        if (n_batches + 1) % accum_steps == 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            optimizer.zero_grad()
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)


### PR DESCRIPTION
## Hypothesis
Grad accum failed on lr=3e-3 code but the model is now different (n_head=3, per-head temp, lr=2.5e-3). With the gentler LR, effective batch=8 might now work -- smoother gradients + gentler LR could compound. Must use torch.compile mode=default instead of reduce-overhead.

## Instructions
1. Add accum_steps = 2
2. Change torch.compile mode to default
3. Divide loss by accum_steps, only step optimizer every 2 mini-batches
4. Keep lr=2.5e-3 (do NOT scale LR)
5. Run with `--wandb_group n-wider-64d-v14`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: `n5p4sp8p` (gilbert/n-wider-64d-v14), 61 epochs

Implementation:
- Changed `torch.compile(model, mode=reduce-overhead)` to `mode=default`
- Added `accum_steps = 2` and moved `optimizer.zero_grad()` before batch loop
- Scaled loss by 1/accum_steps before backward
- Called `optimizer.step() + optimizer.zero_grad()` every 2 batches (165 steps/epoch vs 331 in baseline)

### Metrics

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 4.37 | 1.68 | **18.28** |
| val_ood_cond | 3.06 | 1.13 | **14.75** |
| val_ood_re | -- | -- | **28.59** |
| val_tandem_transfer | 4.85 | 2.15 | **40.50** |

| Metric | This run | Baseline | Delta |
|---|---|---|---|
| val/loss | 0.9092 | 0.8555 | +0.0537 (~16sigma) |
| mean3 (in+ood+tan)/3 | 24.51 | ~23.27 | +1.24 |

### What happened

Clear negative result. Gradient accumulation 2x with lr=2.5e-3 significantly worsens performance. The degradation is far outside noise (~16sigma on val/loss).

Root cause: with effective batch=8 at lr=2.5e-3, the learning rate is 2x too high for the larger effective batch. The linear scaling rule suggests lr should scale with effective batch size (if doubling batch from 4 to 8, halve lr to 1.25e-3). The PR instructed to NOT scale LR, which effectively doubled the LR-to-batch ratio.

Additionally, gradient accumulation halves the number of optimizer steps per epoch (165 vs 331), which means the LR schedule cosine annealing completes at different relative times, further disrupting training dynamics.

The compile mode change (reduce-overhead -> default) likely also slowed down training slightly, but this is not the primary cause of degradation.

### Suggested follow-ups

- Retry gradient accumulation with lr scaled down: lr=1.25e-3 (linear scaling) or lr=1.8e-3 (sqrt scaling)
- Alternatively: gradient accumulation is not well-motivated here since memory is not a bottleneck (GPUs have 96GB). The model fits in ~15GB, leaving 80GB unused. Gradient accumulation only helps when you CANNOT fit a larger batch.