### PR TITLE
AdaLN on ALL norms (full condition-adaptive normalization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -223,6 +223,11 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        _cond_dim = 4
+        self.adaln_1 = nn.Sequential(nn.Linear(_cond_dim, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
+        self.adaln_2 = nn.Sequential(nn.Linear(_cond_dim, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
+        self.adaln_1_post = nn.Sequential(nn.Linear(_cond_dim, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
+        self.adaln_2_post = nn.Sequential(nn.Linear(_cond_dim, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -230,16 +235,34 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.adaln_3 = nn.Sequential(nn.Linear(_cond_dim, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, cond=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
-        fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
+        if cond is not None:
+            _d = fx.shape[-1]
+            _g, _b = self.adaln_1(cond).chunk(2, dim=-1)
+            _pre = F.layer_norm(fx, [_d]) * (1 + _g.unsqueeze(1)) + _b.unsqueeze(1)
+            _res = self.attn(_pre, spatial_bias=sb, tandem_mask=tandem_mask) + fx
+            _g, _b = self.adaln_1_post(cond).chunk(2, dim=-1)
+            fx = F.layer_norm(_res, [_d]) * (1 + _g.unsqueeze(1)) + _b.unsqueeze(1)
+            _g, _b = self.adaln_2(cond).chunk(2, dim=-1)
+            _pre = F.layer_norm(fx, [_d]) * (1 + _g.unsqueeze(1)) + _b.unsqueeze(1)
+            _res = self.mlp(_pre) + fx
+            _g, _b = self.adaln_2_post(cond).chunk(2, dim=-1)
+            fx = F.layer_norm(_res, [_d]) * (1 + _g.unsqueeze(1)) + _b.unsqueeze(1)
+        else:
+            fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+            fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
+            if cond is not None:
+                _g, _b = self.adaln_3(cond).chunk(2, dim=-1)
+                fx = F.layer_norm(fx, [fx.shape[-1]]) * (1 + _g.unsqueeze(1)) + _b.unsqueeze(1)
+                return self.mlp2(fx)
             return self.mlp2(self.ln_3(fx))
         return fx
 
@@ -307,6 +330,14 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
+        # Zero-init AdaLN output layers so blocks start as identity transforms
+        for _block in self.blocks:
+            for _adaln in [_block.adaln_1, _block.adaln_2, _block.adaln_1_post, _block.adaln_2_post]:
+                nn.init.zeros_(_adaln[-1].weight)
+                nn.init.zeros_(_adaln[-1].bias)
+            if _block.last_layer:
+                nn.init.zeros_(_block.adaln_3[-1].weight)
+                nn.init.zeros_(_block.adaln_3[-1].bias)
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
@@ -375,6 +406,8 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        # Extract condition before feature mixing: Re, AoA, gap, stagger
+        cond = x[:, 0, [13, 14, 21, 22]]  # [B, 4]
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -387,13 +420,13 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
tanjiro tests AdaLN on ln_1 only, thorfinn tests on output ln_3 only. This tests AdaLN on ALL LayerNorms (ln_1, ln_2, ln_1_post, ln_2_post, ln_3) — full condition-adaptive normalization. If the model benefits from regime-awareness, it should benefit at every normalization point.

## Instructions
1. Extract condition: c = [Re, AoA, gap, stagger] (4-5 dims from x[:, 0, :])
2. For each LayerNorm in TransolverBlock, add a small MLP that outputs (gamma, beta) conditioned on c
3. Replace each ln(fx) with: fx = F.layer_norm(fx, [hidden_dim]) * (1 + gamma) + beta
4. Share the condition extraction, but each norm gets its own small MLP (4→32→2*hidden_dim)
5. Run with `--wandb_group n-wider-64d-v15`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `0ue049d2`
**Epochs:** 54 (30-min timeout — fewer than usual ~60 due to added AdaLN computation)
**Peak VRAM:** 15.7 GB (vs 14.8 GB baseline)

| Metric | Baseline (lr=2.5e-3) | This run | Δ |
|--------|----------------------|----------|---|
| val/loss | 0.8555 | 0.8813 | +0.0258 ↑ worse |
| surf_p in_dist | 17.48 | 20.21 | +2.73 ↑ worse |
| surf_p ood_cond | 13.59 | 13.86 | +0.27 ↑ worse |
| surf_p ood_re | 27.57 | 27.65 | +0.08 ↑ ≈ same |
| surf_p tandem | 38.53 | 39.40 | +0.87 ↑ worse |
| **mean3** | **23.20** | **24.49** | +1.29 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**Surface MAE breakdown (best epoch 54):**
| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 6.88 | 1.70 | 20.21 |
| ood_cond | 4.12 | 1.20 | 13.86 |
| ood_re | 3.73 | 1.03 | 27.65 |
| tandem | 6.73 | 2.17 | 39.40 |

**What happened:** AdaLN on all norms made things worse across the board. Several factors likely contributed:

1. **Fewer epochs**: The extra computation from 5 AdaLN MLPs (one per norm, 4→32→2×192 each) reduced training throughput from ~60 to 54 epochs in 30 minutes, giving the model less time to converge.

2. **Over-conditioning**: Applying condition-dependent scale/shift to ALL five LayerNorms (including the post-norms after residuals) may be too much conditioning signal. The post-norms see residual sums that already contain the condition information implicitly; adding explicit conditioning may interfere rather than help.

3. **Condition signal quality**: The condition `x[:, 0, [13,14,21,22]]` (Re, AoA, gap, stagger) is extracted after normalization, so the features are jointly normalized across single-foil and tandem regimes. The model may not benefit from explicit conditioning when the feature space already encodes regime information.

4. **Zero-init worked, but scaling was wrong**: The AdaLN gamma/beta outputs start at zero (identity), but orthogonal-initialized first layers can produce large intermediate activations before settling. This could initially destabilize the post-norms' residual streams.

Comparing with the partial results from tanjiro (ln_1 only) and thorfinn (ln_3 only): if those also underperformed, full AdaLN is likely the wrong direction for this architecture.

**Suggested follow-ups:**
1. If tanjiro/thorfinn show ln_1-only or ln_3-only helps, consider combining just those two (not all five norms).
2. Try conditioning only the **pre-norms** (ln_1, ln_2) and skip the post-norms and output norm — the post-norms see mixed signals from the residual path.
3. Use a detached/separate condition encoding (not from the normalized x features) — for example, derive condition directly from the raw gap/stagger values before normalization.