### PR TITLE
Separate pressure output head (decouple pressure from velocity prediction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -230,6 +230,11 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.pressure_head = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim // 2),
+                nn.GELU(),
+                nn.Linear(hidden_dim // 2, 1),
+            )
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -240,7 +245,10 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx_norm = self.ln_3(fx)
+            out = self.mlp2(fx_norm)
+            p_pred = self.pressure_head(fx_norm)
+            return torch.cat([out[:, :, :2], p_pred], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The single output head predicts [Ux, Uy, p] together. But pressure is the hardest channel (10x larger MAE than velocity) and has fundamentally different physics. A separate pressure head — small MLP from hidden to 1 — lets the model learn a pressure-specific decoder while the main head handles velocities.

## Instructions
1. Add `self.pressure_head = nn.Sequential(nn.Linear(hidden_dim, hidden_dim//2), nn.GELU(), nn.Linear(hidden_dim//2, 1))` 
2. The main mlp2 still outputs 3 channels but the pressure channel is REPLACED:
   ```python
   out = self.mlp2(self.ln_3(fx))  # [B, N, 3]
   p_pred = self.pressure_head(self.ln_3(fx))  # [B, N, 1]
   out = torch.cat([out[:,:,:2], p_pred], dim=-1)  # replace p channel
   ```
3. Run with `--wandb_group n-wider-64d-v16`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `0jhaztdl`
**Best epoch:** 58 / 100 (hit wall-clock limit, ~31s/epoch — 3 fewer than baseline's 61)
**Peak memory:** 14.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5890 | 4.49 | 1.59 | 17.93 | 1.10 | 0.36 | 19.30 |
| val_tandem_transfer | 1.6550 | 5.06 | 1.98 | 39.57 | 1.92 | 0.86 | 38.73 |
| val_ood_cond | 0.6938 | 3.12 | 1.01 | 13.86 | 0.72 | 0.27 | 12.03 |
| val_ood_re | 0.5406 | 2.86 | 0.86 | 27.77 | 0.83 | 0.36 | 46.62 |
| **mean3** | **0.979** | **4.22** | **1.53** | **23.79** | — | — | — |

Baseline: mean3=23.20 (in=17.48, ood=13.59, tan=38.53, re=27.57), val_loss=0.8555

**What happened:** Negative result. mean3=23.79 vs 23.20 baseline. val/loss 0.8555 → 0.8696. All splits degraded: in_dist (+0.45), tandem (+1.04), ood_cond (+0.27), ood_re (+0.20). Tandem pressure got notably worse (+1.04).

The separate pressure head adds ~18K parameters (192×96 + 96 + 96×1 + 1 = ~18.6K params) and one extra forward pass through a smaller MLP per node. This brings the total per-epoch compute up slightly (58 epochs vs 61), but the main problem is architectural: the pressure head is initialized from scratch and has less capacity (96 hidden units vs 192 in the main mlp2). The shared ln_3 representation has to simultaneously serve both heads, which may limit the gradient flow for pressure. Additionally, the main mlp2 still predicts a pressure channel (index 2) that's thrown away — wasted gradient signal.

The hypothesis that pressure needs a separate decoder is not supported by the data — the existing combined head is already well-calibrated.

**Suggested follow-ups:**
- Try where mlp2 predicts only 2 channels (Ux, Uy) and pressure_head provides the third — eliminating the wasted pressure gradient from mlp2.
- The hypothesis may be more effective at larger model scales where the single head is capacity-bottlenecked.