### PR TITLE
Residual-weighted loss (reduce loss weight on easy-to-predict nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -705,6 +705,8 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
+        node_weight = (abs_err / abs_err.mean(dim=1, keepdim=True).clamp(min=1e-8)).clamp(0.5, 2.0)
+        abs_err = abs_err * node_weight
         if epoch < 10:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]


### PR DESCRIPTION
## Hypothesis
Instead of equal loss weighting on all nodes, weight each node's loss by how much better the model is vs a simple baseline prediction (e.g., channel mean). Nodes where the model already excels get less gradient; nodes where it struggles get more. This is a form of curriculum that automatically focuses on the hardest predictions.

## Instructions
1. After computing per-node abs_err, normalize by the per-sample mean error: `node_weight = (abs_err / abs_err.mean(dim=1, keepdim=True)).clamp(0.5, 2.0)`
2. Apply: `weighted_err = abs_err * node_weight`
3. Use weighted_err for loss computation instead of abs_err
4. The clamp prevents extreme weights
5. Run with `--wandb_group n-wider-64d-v17`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** 42dz0x7q
**Epochs completed:** 58/100 (30-min timeout)
**Peak memory:** 14.9GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8555 | 0.8893 | +4.0% worse |
| val_in_dist | mae_surf_p | 17.48 | 19.68 | +12.6% worse |
| val_ood_cond | mae_surf_p | 13.59 | 13.41 | -1.3% better |
| val_tandem_transfer | mae_surf_p | 38.53 | 39.70 | +3.0% worse |
| val_ood_re | mae_surf_p | 27.57 | 27.68 | +0.4% worse |
| **mean3** | mae_surf_p | **23.20** | **24.27** | **+4.6% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=9.25, Uy=2.74, p=19.68 | Vol: Ux=1.16, Uy=0.40, p=22.74
- **ood_cond:** Ux=9.50, Uy=2.43, p=13.41 | Vol: Ux=0.70, Uy=0.26, p=14.40
- **ood_re:** Ux=9.48, Uy=2.25, p=27.68 | Vol: Ux=0.82, Uy=0.36, p=48.93
- **tandem_transfer:** Ux=8.07, Uy=3.12, p=39.70 | Vol: Ux=2.00, Uy=0.91, p=40.99

### What happened

The residual-weighted loss did not improve over baseline. Surface pressure (mean3) regressed 4.6%, and Ux surface errors jumped from ~3-4 to 9+ across all splits — a consistent degradation.

The core issue: `abs_err.mean(dim=1, keepdim=True)` averages over ALL N mesh nodes (surface + volume together). Surface nodes are sparse (~2% of mesh) and have very different error scales than volume nodes. The resulting per-sample mean is dominated by volume statistics, so surface pressure node weights are determined by volume context rather than within-surface difficulty. This distorts the gradient signal for surface nodes.

Additionally, the weighting interacts with the existing surf_weight term. Applying error-proportional emphasis on top of surf_weight likely destabilized gradients for directions that were already well-optimized.

### Suggested follow-ups

- **Surface-only weighting**: Compute node_weight using only surface nodes (mean over surface mask), so the normalization reflects within-surface difficulty rather than cross-domain statistics.
- **Separate vol/surf weighting**: Apply independent node weights to vol_loss and surf_loss rather than a single weight over all nodes.
- **Softer clamp**: Use (0.8, 1.2) instead of (0.5, 2.0) to reduce gradient distortion.