### PR TITLE
Pressure-only input-skip + AdaLN output head (targeted in_dist + ood)

### DIFF
--- a/train.py
+++ b/train.py
@@ -230,8 +230,11 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.adaln_out_mlp = nn.Sequential(nn.Linear(4, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim))
+            nn.init.zeros_(self.adaln_out_mlp[-1].weight)
+            nn.init.zeros_(self.adaln_out_mlp[-1].bias)
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
@@ -240,7 +243,12 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            if condition is not None:
+                gamma, beta = self.adaln_out_mlp(condition).chunk(2, dim=-1)
+                fx_ln3 = F.layer_norm(fx, [fx.shape[-1]]) * (1 + gamma.unsqueeze(1)) + beta.unsqueeze(1)
+            else:
+                fx_ln3 = self.ln_3(fx)
+            return self.mlp2(fx_ln3)
         return fx
 
 
@@ -318,6 +326,9 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.input_skip_p = nn.Linear(fun_dim + space_dim, 1)
+        nn.init.zeros_(self.input_skip_p.weight)
+        nn.init.zeros_(self.input_skip_p.bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -375,6 +386,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_raw = x
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -393,9 +405,13 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        # AdaLN condition: [Re, AoA, gap, stagger] from raw input features
+        adaln_cond = torch.cat([x_raw[:, 0, 13:15], x_raw[:, 0, 21:23]], dim=-1)  # [B, 4]
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=adaln_cond)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        # Pressure-only input skip: direct linear path for pressure channel
+        fx[:, :, 2:3] = fx[:, :, 2:3] + 0.1 * self.input_skip_p(x_raw)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
Input-skip helped in_dist (17.22) but hurt velocity MAE. AdaLN on output head helped ood (13.16). This combines them surgically: skip ONLY predicts pressure (avoids velocity contamination) + AdaLN conditions the output on flow regime.

## Instructions
1. Add pressure-only skip: `self.input_skip_p = nn.Linear(fun_dim + space_dim, 1)`, zero-init
2. After output: `fx[:, :, 2:3] = fx[:, :, 2:3] + 0.1 * self.input_skip_p(x_raw)`
3. Add AdaLN on ln_3: condition=[Re,AoA,gap,stagger]→MLP→(gamma,beta), replace ln_3 with adaptive norm
4. Run with `--wandb_group p-skip-adaln`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `v8hnc7d9` (`tanjiro/p-skip-adaln`)
**Epochs:** 58 (30-min timeout)
**Peak memory:** ~15.1 GB

### Validation losses

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6004 | 6.72 | 2.03 | **18.04** | 1.09 | 0.36 | 19.35 |
| val_ood_cond | 0.6791 | 4.14 | 1.34 | **13.59** | 0.70 | 0.26 | 11.94 |
| val_ood_re | 0.5289 | 3.68 | 1.17 | **27.51** | 0.82 | 0.36 | 46.91 |
| val_tandem | 1.6186 | 6.80 | 2.75 | **38.03** | 1.91 | 0.86 | 37.65 |
| **combined** | **0.8568** | | | | | | |

### vs. baseline (0.8555)

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8555 | 0.8568 | +0.0013 ↑ worse |
| in_dist mae_surf_p | ~17.3 | 18.04 | +0.74 ↑ worse |
| ood_cond mae_surf_p | ~14.0 | 13.59 | -0.41 ↓ better |
| ood_re mae_surf_p | ~27.5 | 27.51 | ~0 neutral |
| tandem mae_surf_p | ~38.0 | 38.03 | ~0 neutral |

### What happened

Neutral/slightly negative result. The combination of pressure-only skip + AdaLN output conditioning did not improve over baseline. Notably:

- **in_dist pressure got worse** (18.04 vs ~17.3): the pressure skip adds a direct linear path from raw features, but the model already has an effective path through the learned network. Adding a second path at 0.1× scale appears to interfere rather than help.
- **ood_cond pressure slightly improved** (13.59 vs ~14.0): the AdaLN conditioning may be providing some benefit for out-of-distribution flow conditions, consistent with PR #1403 results.
- **velocity MAE unchanged**: the pressure-only skip correctly avoids the velocity contamination seen in the full input-skip (PR #1389).

The failure of the input skip in this variant (despite alphonse's scale=0.1 helping in isolation) suggests that the component interacts negatively with AdaLN — the AdaLN conditions the final layer differently than expected when the pressure output has a direct bypass. Zero-init ensures convergence parity at epoch 0, but the gradient signal may route through the bypass rather than refining the attention path.

### Suggested follow-ups

- Try AdaLN conditioning alone (without pressure skip) to isolate which component is responsible for the ood_cond improvement.
- Try conditioning the *intermediate* layers (e.g. layer 2 or 3) rather than just the final output head — AdaLN may be more effective earlier in the network where flow-regime decisions are made.
- If pressure skip is pursued separately, try an even smaller scale (0.05) or a gated skip that learns when to use the bypass.
