### PR TITLE
AdaLN output head + warmup=5 (ood + tandem synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -230,8 +230,13 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.adaln = nn.Sequential(
+                nn.Linear(4, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, hidden_dim * 2),
+            )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
@@ -240,7 +245,10 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            adaln_params = self.adaln(condition)  # [B, hidden_dim*2]
+            gamma, beta = adaln_params.chunk(2, dim=-1)  # [B, hidden_dim]
+            fx = (1 + gamma.unsqueeze(1)) * self.ln_3(fx) + beta.unsqueeze(1)
+            return self.mlp2(fx)
         return fx
 
 
@@ -307,6 +315,11 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
+        # Zero-init adaln output layer so it starts as identity (no adaptation)
+        for block in self.blocks:
+            if hasattr(block, 'adaln'):
+                nn.init.zeros_(block.adaln[-1].weight)
+                nn.init.zeros_(block.adaln[-1].bias)
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
@@ -382,6 +395,9 @@ class Transolver(nn.Module):
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
+        # Condition vector for AdaLN: [Re, AoA, gap, stagger]
+        c = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)  # [B, 4]
+
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
@@ -393,7 +409,7 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=c)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
@@ -576,10 +592,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
AdaLN output head improved ood from 13.59→13.16 (-3.2%). warmup=5 improved tandem from 38.53→37.62 (-2.4%). These target different splits via different mechanisms. Combining them might improve the combined metric.

## Instructions
1. Add AdaLN on ln_3: condition=[Re,AoA,gap,stagger], MLP to (gamma,beta), zero-init
2. Change warmup from 10 to 5: total_iters=5, milestones=[5]
3. Run with `--wandb_group adaln-warmup5`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** iq1pj68n
**Epochs completed:** 58/100 (30-min timeout)
**Peak memory:** 14.8 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8753 | 0.8555 | +2.3% (worse) |
| Surface MAE p (in_dist) | 18.49 | 17.48 | +5.8% (worse) |
| Surface MAE p (ood_cond) | 13.52 | 13.59 | -0.5% (≈same) |
| Surface MAE p (ood_re) | 27.51 | 27.57 | -0.2% (≈same) |
| Surface MAE p (tandem) | 39.84 | 38.53 | +3.4% (worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 6.37 | 1.66 | 18.49 |
| ood_cond | 2.76 | 0.85 | 13.52 |
| ood_re | 2.47 | 0.71 | 27.51 |
| tandem | 6.07 | 2.09 | 39.84 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.12 | 0.37 | 20.06 |
| ood_cond | 0.71 | 0.26 | 11.44 |
| ood_re | 0.83 | 0.36 | 46.64 |
| tandem | 1.98 | 0.90 | 39.14 |

### What happened

Another multi-variable failure. val/loss worse +2.3%, in_dist regresses +5.8%, tandem regresses +3.4%. The AdaLN-alone ood_cond improvement (-3.2%) barely persists here (only -0.5%), and the warmup=5 tandem improvement (-2.4%) is completely reversed (+3.4%).

Expected from each component alone:
- AdaLN alone: ood_cond improved (-3.2%), tandem roughly neutral
- warmup=5 alone: tandem improved (-2.4%), ood roughly neutral

Combined: ood_cond = +0.5% (lost the improvement), tandem = +3.4% (reversed!)

The interaction pattern is getting clear: shorter warmup (5 epochs) destabilizes the AdaLN conditioning module, which needs more early training epochs to settle. The AdaLN module has conditional parameters that need to learn meaningful gamma/beta corrections — with only 5 warmup epochs, the model tries to adapt these parameters before the main representations are stable.

This is the 4th multi-variable experiment on this codebase (warmup5+T_max48, input-skip+warmup7, now adaln+warmup5) — all have failed. The evidence strongly suggests that parameter interactions in this training regime make near-misses non-additive.

### Suggested follow-ups

- **AdaLN alone on lr=2.5e-3:** Verify the AdaLN ood improvement holds on the current baseline (it was measured on a previous code version).
- **warmup=5 alone on lr=2.5e-3:** Same verification for warmup=5.
- **Stop combining near-misses.** Individual verifications first, combination attempts only if both individually hold.