### PR TITLE
Per-sample Fourier + input-skip (tandem + in_dist synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -317,7 +317,12 @@ class Transolver(nn.Module):
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
-        self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.freq_net = nn.Sequential(nn.Linear(4, 16), nn.GELU(), nn.Linear(16, 4))
+        nn.init.zeros_(self.freq_net[-1].weight)
+        self.freq_net[-1].bias.data = torch.tensor([1.0, 3.0, 6.0, 16.0])
+        self.input_skip = nn.Linear(fun_dim + space_dim, out_dim)
+        nn.init.zeros_(self.input_skip.weight)
+        nn.init.zeros_(self.input_skip.bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -375,6 +380,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x_raw = x  # save before feature_cross for input skip
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +402,7 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        fx = fx + 0.1 * self.input_skip(x_raw)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
@@ -654,15 +661,18 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
-        # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
+        # Fourier positional encoding: append sin/cos of (x,y) at 4 per-sample + 4 fixed frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
         xy_min = raw_xy.amin(dim=1, keepdim=True)
         xy_max = raw_xy.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-        freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+        c_freq = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)  # [B, 4]: Re, AoA, gap, stagger
+        learned_freqs = _base_model.freq_net(c_freq).abs()  # [B, 4]
+        fixed_freqs = model.fourier_freqs_fixed.to(device)  # [4]
+        freqs = torch.cat([fixed_freqs.unsqueeze(0).expand(x.shape[0], -1), learned_freqs], dim=-1)  # [B, 8]
+        xy_scaled = xy_norm.unsqueeze(-1) * freqs.unsqueeze(1).unsqueeze(1)  # [B, N, 2, 8]
+        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 32]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
             noise_scale = 0.05 * (1 - epoch / 60)
@@ -835,15 +845,18 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
-                # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
+                # Fourier positional encoding: append sin/cos of (x,y) at 4 per-sample + 4 fixed frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
                 xy_min = raw_xy.amin(dim=1, keepdim=True)
                 xy_max = raw_xy.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                c_freq = torch.cat([x[:, 0, 13:15], x[:, 0, 21:23]], dim=-1)  # [B, 4]: Re, AoA, gap, stagger
+                learned_freqs = _base_model.freq_net(c_freq).abs()  # [B, 4]
+                fixed_freqs = model.fourier_freqs_fixed.to(device)  # [4]
+                freqs = torch.cat([fixed_freqs.unsqueeze(0).expand(x.shape[0], -1), learned_freqs], dim=-1)  # [B, 8]
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs.unsqueeze(1).unsqueeze(1)  # [B, N, 2, 8]
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 32]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
@@ -946,9 +959,6 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
-    learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
-    for i, f in enumerate(learned_freqs):
-        metrics[f"fourier_freq_{i}"] = f
     wandb.log(metrics)
 
     if torch.cuda.is_available():


### PR DESCRIPTION
## Hypothesis
Per-sample Fourier improved tandem (37.84). Input-skip improved in_dist (17.22). These operate at opposite pipeline stages.

## Instructions
1. Per-sample Fourier freq_net on condition
2. Input-skip with zero-init scale 0.1
3. Run with `--wandb_group fourier-inputskip`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `l9rsgv0u` (`norman/fourier-inputskip`)
**Best epoch:** 56
**Peak memory:** 14.4 GB (from debug run)
**Runtime:** 31.7 min (killed by timeout)

**Implementation:**
- `freq_net = nn.Sequential(nn.Linear(4, 16), nn.GELU(), nn.Linear(16, 4))` in model, initialized to output [1.0, 3.0, 6.0, 16.0]
- Per-sample PE: `c = [Re, AoA, gap, stagger]` from x before Fourier append; applied in both train and val loops
- `input_skip = nn.Linear(57, 3)` zero-init, applied as `fx = fx + 0.1 * input_skip(x_raw)` at end of forward

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 0.6050 | 18.00 |
| val_ood_cond | 0.7216 | 14.44 |
| val_ood_re | 0.5639 | 28.20 |
| val_tandem_transfer | 1.6500 | 38.45 |
| **Combined** | **0.8851** | — |

**vs baseline (0.8555):** +0.0296 (worse)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8555 | 0.8851 | **+0.0296** ✗ |
| in_dist surf_p | 17.48 | 18.00 | +0.52 ✗ |
| ood_cond surf_p | 13.59 | 14.44 | +0.85 ✗ |
| ood_re surf_p | 27.57 | 28.20 | +0.63 ✗ |
| tandem surf_p | 38.53 | 38.45 | −0.08 ≈ |

### What happened
The combination was worse than baseline across all metrics, and notably worse than either individual experiment:
- Per-sample Fourier alone: val/loss=0.8589, tandem surf_p=37.84 (tandem improved, in_dist regressed)
- Input-skip alone: val/loss=0.8612, in_dist surf_p=17.22 (in_dist improved, other metrics slightly worse)
- Combined: val/loss=0.8851 — significantly worse than either alone

The "opposite pipeline stages" framing was appealing but the two changes don't combine additively. The per-sample Fourier introduces training instability (per-sample frequencies make the PE stochastic during training) while the input_skip adds another path that the model must learn to weight. Together they create a more complex optimization landscape that the model couldn't converge well in 30 minutes.

Additionally, in_dist improved from tandem-focused per-sample Fourier (which helps the model ignore gap/stagger features for single-foil) was not realized here — in_dist is still worse (+0.52 vs baseline).

### Suggested follow-ups
- Test input-skip alone more carefully (PR #1380 showed val/loss +0.7% but in_dist -0.26, which may be worth building on separately).
- Per-sample Fourier conditioned on only Re+AoA (not gap/stagger) to avoid tandem-specific noise bleeding into single-foil predictions.
- Try the two features separately on the current noam branch (lr=2.5e-3) rather than combining them.