### PR TITLE
Warmup=5 + fast noise decay by ep30 (tandem + in_dist schedule synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,10 +576,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
 
 # --- wandb ---
@@ -664,14 +664,14 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+        if model.training and epoch < 30:
+            noise_scale = 0.05 * max(0, 1 - epoch / 30)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_progress = min(1.0, epoch / 60)
+            noise_progress = min(1.0, epoch / 30)
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)


### PR DESCRIPTION
## Hypothesis
warmup=5 helps tandem (-2.4%). Fast noise (complete by ep30) helps in_dist. Together: 25 productive epochs with noise (5-30), then 35 clean epochs for EMA refinement.

## Instructions
1. warmup total_iters=5, milestones=[5]
2. Noise decay to complete by epoch 30: noise_scale = 0.05 * max(0, 1 - epoch/30)
3. Run with `--wandb_group warmup5-fastnoise`

## Baseline: val_loss=0.8555

---
## Results

**W&B Run ID:** `5qfkzlsm`
**Epochs completed:** 62/100 (30.5 min wall-clock timeout)
**Peak memory:** 14.8 GB/GPU

### Validation Metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| in_dist | 0.6180 | 4.97 | 1.41 | 19.39 | 1.09 | 0.36 | 19.82 |
| tandem_transfer | 1.6609 | 5.76 | 2.15 | 39.67 | 1.96 | 0.89 | 38.77 |
| ood_cond | 0.6998 | 3.71 | 1.02 | 13.85 | 0.72 | 0.27 | 11.87 |
| ood_re | 0.5476 | 3.25 | 0.83 | 27.99 | 0.83 | 0.37 | 47.08 |
| **overall val/loss** | **0.8816** | | | | | | |

### Comparison vs Baseline

| Metric | Baseline | warmup5+fastnoise | Delta |
|--------|----------|-------------------|-------|
| val/loss | 0.8555 | 0.8816 | +0.0261 ❌ |
| in mae_surf_p | 17.48 | 19.39 | +1.91 ❌ |
| ood mae_surf_p | 13.59 | 13.85 | +0.26 ❌ |
| re mae_surf_p | 27.57 | 27.99 | +0.42 ❌ |
| tan mae_surf_p | 38.53 | 39.67 | +1.14 ❌ |

### What happened

This combination is noticeably worse than baseline across all splits, with val/loss up +0.03 and in-dist surface pressure degraded by ~1.9 Pa. The combination of short warmup and fast noise decay doesn't deliver the expected synergy.

The likely culprit is the fast noise decay. Cutting noise at epoch 30 means the model enters 30+ clean training epochs where the optimizer has learned to rely on the noise-regularized gradient landscape but now faces clean data. The EMA model doesn't start until epoch 40, so there are 10 "vulnerable" clean epochs before EMA kicks in. This may actually destabilize training.

The shorter warmup (5 vs 10) alone has little effect here — the dominant factor is the aggressive noise decay. Noise-free training from epoch 30 appears to hurt surface accuracy, particularly in-dist (+1.91 mae_surf_p).

### Suggested follow-ups

- Test warmup=5 alone (no fast noise decay) to isolate whether warmup change alone is beneficial.
- If fast noise decay is desired, try completing by epoch 40 or 45 instead of 30, to align with EMA startup at epoch 40.
- The input feature noise schedule and target noise schedule may need to be decoupled — target noise could decay faster than feature noise.