### PR TITLE
Slice token memory + warmup=5 (fix re/tandem regression from slice-mem)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.register_buffer('slice_prototypes', torch.zeros(1, heads, slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +170,12 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        if self.training:
+            with torch.no_grad():
+                update = slice_token.detach().mean(dim=0, keepdim=True).clone()
+                self.slice_prototypes.copy_(0.99 * self.slice_prototypes + 0.01 * update)
+        slice_token = 0.8 * slice_token + 0.2 * self.slice_prototypes.detach()
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
@@ -576,10 +583,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=5)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[5]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Slice-token-memory got 0.8569 — 3rd closest! It improved in_dist (17.33) and ood (13.40) but re/tandem regressed. warmup=5 specifically helps tandem (37.62, -2.4%). Combining them: slice memory handles in_dist+ood, warmup=5 handles tandem. Orthogonal targets.

## Instructions
1. Add slice_prototypes buffer: `self.register_buffer('slice_prototypes', torch.zeros(1, heads, slice_num, dim_head))`
2. After computing slice_token: update prototypes with EMA (0.99), blend (0.8*token + 0.2*prototype.detach())
3. Change warmup from 10 to 5: total_iters=5, milestones=[5]
4. Run with `--wandb_group slice-mem-warmup5`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `p83275hv` (alphonse/slice-mem-warmup5)
**Epoch at timeout:** 60 (~20 EMA epochs; ema_start_epoch=40)
**Runtime:** 1901s (~32 min)

### Metrics vs baseline

| Metric | This run | slice-mem alone | Baseline | Δ vs baseline |
|--------|----------|-----------------|----------|---|
| val/loss | 0.8728 | 0.8569 | 0.8555 | +0.0173 (+2.0%) |
| in_dist surf p | 17.52 | **17.33** | 17.48 | +0.04 |
| ood_cond surf p | 14.32 | **13.40** | 13.59 | +0.73 |
| ood_re surf p | 27.94 | 27.84 | 27.57 | +0.37 |
| tandem surf p | 38.92 | 38.91 | 38.53 | +0.39 |
| mean3 | 23.59 | 23.21 | 23.20 | +0.39 |

### Surface MAE (full)
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 4.84 | 1.41 | 17.52 |
| ood_cond | 2.87 | 0.88 | 14.32 |
| ood_re | 2.57 | 0.76 | 27.94 |
| tandem | 5.52 | 2.03 | 38.92 |

### Volume MAE (p)
in_dist=19.17, ood_cond=12.24, ood_re=46.83, tandem=38.61

**Peak GPU memory:** N/A

### What happened

Negative. All four splits are worse than baseline, and the combination is significantly worse than slice-mem alone (mean3: 23.59 vs 23.21). The hypothesis that the two improvements would be orthogonal was wrong — they interact negatively.

The likely cause: warmup=5 causes the LR to reach its full value by epoch 5, while the prototypes are still accumulating from noisy early representations. During the first 5 epochs, the model parameters are changing rapidly under a high LR, and the slice token representations are unstable. The EMA then captures these noisy early prototypes (with 0.99 decay, they persist for ~100 epochs). This corrupts the routing prior for the rest of training.

In contrast, warmup=10 gives the model more time to stabilize before the prototypes accumulate meaningful patterns.

### Suggested follow-ups
- Delay prototype accumulation: only start updating prototypes after warmup (e.g., `if self.training and epoch >= warmup_epochs:`)
- Or just keep slice-mem with warmup=10 (the original PR #1407 result was already close to baseline on mean3)
- The components are not orthogonal — test in isolation rather than combining