### PR TITLE
Slice token memory + AdaLN output (in_dist/ood + ood/re synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.register_buffer('slice_prototypes', torch.zeros(heads, slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +170,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        # Slice prototype memory: blend current tokens with running prototypes
+        slice_token = 0.9 * slice_token + 0.1 * self.slice_prototypes.detach().unsqueeze(0)
+        # Store mean for EMA update outside compiled graph (updated in training loop)
+        self._slice_token_mean = slice_token.detach().float().mean(0)
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
@@ -230,8 +236,13 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.ada_ln3_proj = nn.Sequential(
+                nn.Linear(4, 32), nn.GELU(), nn.Linear(32, 2 * hidden_dim)
+            )
+            nn.init.zeros_(self.ada_ln3_proj[-1].weight)
+            nn.init.zeros_(self.ada_ln3_proj[-1].bias)
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, cond=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
@@ -240,7 +251,12 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            x_normed = self.ln_3(fx)
+            if cond is not None:
+                gamma_beta = self.ada_ln3_proj(cond)  # [B, 2*hidden_dim]
+                gamma, beta = gamma_beta.chunk(2, dim=-1)
+                x_normed = (1 + gamma.unsqueeze(1)) * x_normed + beta.unsqueeze(1)
+            return self.mlp2(x_normed)
         return fx
 
 
@@ -382,18 +398,21 @@ class Transolver(nn.Module):
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
+        # AdaLN condition: log_Re(13), AoA0(14), gap(22), stagger(23) — global per sample
+        cond = x[:, 0, [13, 14, 22, 23]]  # [B, 4]
+
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
@@ -693,6 +712,7 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        torch.compiler.cudagraph_mark_step_begin()
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
             pred = out["preds"]
@@ -783,6 +803,11 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        # EMA update for slice prototypes (after backward to avoid version mismatch)
+        with torch.no_grad():
+            attn = _base_model.blocks[0].attn
+            if hasattr(attn, '_slice_token_mean'):
+                attn.slice_prototypes.copy_(0.99 * attn.slice_prototypes + 0.01 * attn._slice_token_mean.to(attn.slice_prototypes.device))
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
@@ -864,6 +889,7 @@ for epoch in range(MAX_EPOCHS):
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
 
+                torch.compiler.cudagraph_mark_step_begin()
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = eval_model({"x": x})["preds"]
                 pred = pred.float()


### PR DESCRIPTION
## Hypothesis
Slice-token-memory improved in_dist (17.33) and ood (13.40). AdaLN output head improved ood (13.16). Together, they might double-down on ood improvement while slice-mem maintains in_dist.

## Instructions
1. Add slice_prototypes buffer + EMA update + blend (same as alphonse's)
2. Add AdaLN on ln_3: condition=[Re,AoA,gap,stagger]→MLP→(gamma,beta), adaptive output norm
3. Run with `--wandb_group slice-mem-adaln`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** psuvjsjf
**Runtime:** 32 min (30-min training + 2 min data load)

### Metrics vs baseline

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val/loss | combined | 0.8555 | 0.8664 | +0.0109 ↑ |
| in_dist | surf_p | 17.48 | 18.36 | +0.88 ↑ |
| ood_cond | surf_p | 13.59 | 13.28 | -0.31 ↓ |
| tandem | surf_p | 38.53 | 39.19 | +0.66 ↑ |
| ood_re | surf_p | — | 27.91 | — |
| **mean3** | **(in+ood+tan)/3** | **23.20** | **23.61** | **+0.41 ↑** |

Full surface MAE:

| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 6.61 | 2.17 | 18.36 |
| ood_cond | 4.03 | 1.25 | 13.28 |
| tandem | 6.38 | 2.45 | 39.19 |
| ood_re | 3.56 | 1.05 | 27.91 |

Peak memory: ~62 GB (same as baseline, additions are negligible: 36KB buffer + tiny MLP)

### What happened

The combination did **not** stack — results are worse than baseline on all but ood_cond. Neither the slice memory gain (in_dist improved to 17.33) nor the AdaLN gain (ood improved to 13.16) survived combination. The joint model degrades to 18.36/13.28/39.19.

Implementation note: this experiment required significant debugging — the EMA update on `slice_prototypes` using `copy_()` must happen *after* `loss.backward()`, not between forward and backward (causes version mismatch in AOT autograd). Moving it after backward fixed the issue.

A likely explanation: slice memory anchors the attention to trajectory-averaged prototypes while AdaLN shifts the output distribution; these signals may conflict, causing the model to find a compromise that satisfies neither.

### Suggested follow-ups
- Try slice memory alone (without AdaLN) to isolate its contribution cleanly
- If AdaLN on ln_3 (output) is the stronger component, try AdaLN on ln_1 (input) instead
- Investigate whether slice memory actually changes learned prototype content (log prototype cosine sim over training)