### PR TITLE
Slice token memory + per-sample Fourier (in_dist/ood + tandem synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.register_buffer('slice_prototypes', torch.zeros(heads, slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +170,12 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        # EMA update of slice prototypes during training; blend current tokens with prototypes
+        if self.training:
+            with torch.no_grad():
+                self.slice_prototypes.lerp_(slice_token.detach().mean(0), 0.01)
+        slice_token = slice_token + 0.1 * self.slice_prototypes.unsqueeze(0)
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
@@ -318,6 +325,9 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.freq_net = nn.Sequential(nn.Linear(8, 16), nn.GELU(), nn.Linear(16, 4))
+        nn.init.zeros_(self.freq_net[-1].weight)
+        nn.init.zeros_(self.freq_net[-1].bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -660,9 +670,14 @@ for epoch in range(MAX_EPOCHS):
         xy_min = raw_xy.amin(dim=1, keepdim=True)
         xy_max = raw_xy.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-        freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+        B = x.shape[0]
+        cond = x[:, 0, 10:18]  # condition features (Re, AoA, and neighbors) [B, 8]
+        freq_offset = _base_model.freq_net(cond)  # [B, 4] per-sample frequency offsets
+        freqs_fixed = _base_model.fourier_freqs_fixed.to(device)  # [4]
+        freqs_learned = _base_model.fourier_freqs_learned.abs() + freq_offset  # [B, 4]
+        freqs = torch.cat([freqs_fixed.unsqueeze(0).expand(B, -1), freqs_learned], dim=-1)  # [B, 8]
+        xy_scaled = xy_norm.unsqueeze(-1) * freqs[:, None, None, :]  # [B, N, 2, 8]
+        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 32]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
             noise_scale = 0.05 * (1 - epoch / 60)
@@ -841,9 +856,14 @@ for epoch in range(MAX_EPOCHS):
                 xy_min = raw_xy.amin(dim=1, keepdim=True)
                 xy_max = raw_xy.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                B = x.shape[0]
+                cond = x[:, 0, 10:18]  # condition features [B, 8]
+                freq_offset = _base_model.freq_net(cond)  # [B, 4]
+                freqs_fixed = _base_model.fourier_freqs_fixed.to(device)  # [4]
+                freqs_learned = _base_model.fourier_freqs_learned.abs() + freq_offset  # [B, 4]
+                freqs = torch.cat([freqs_fixed.unsqueeze(0).expand(B, -1), freqs_learned], dim=-1)  # [B, 8]
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs[:, None, None, :]  # [B, N, 2, 8]
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 32]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
Slice-mem improved in_dist+ood but hurt tandem. Per-sample Fourier improved tandem (37.84). Combine: slice memory for in_dist/ood, Fourier for tandem.

## Instructions
1. Add slice_prototypes buffer + EMA update + blend
2. Add per-sample freq_net: condition→MLP→4 frequencies
3. Run with `--wandb_group slice-mem-fourier`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: `h42ypjpa`
**Epochs**: 56/100 (wall-clock limit, ~30 min)
**Peak memory**: 15.7 GB
**val/loss**: 0.8815 (baseline 0.8555, **+0.0260 worse**)

### Surface MAE

| Split | Ux | Uy | p | p vs baseline |
|-------|----|----|---|---------------|
| val_in_dist | 5.58 | 1.54 | 18.70 | ~17.48 → +1.22 ↑ |
| val_ood_cond | 3.15 | 1.04 | 14.55 | ~13.59 → +0.96 ↑ |
| val_ood_re | 2.76 | 0.88 | 28.01 | ~27.57 → +0.44 ↑ |
| val_tandem_transfer | 5.88 | 2.09 | 39.66 | ~38.53 → +1.13 ↑ |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.09 | 0.36 | 19.43 |
| val_ood_cond | 0.72 | 0.27 | 12.20 |
| val_ood_re | 0.83 | 0.36 | 46.88 |
| val_tandem_transfer | 1.92 | 0.88 | 38.41 |

### What happened

**Negative result.** All splits degraded vs baseline. The combination does not produce the expected synergy — in_dist (+1.22 p), tandem (+1.13 p), and ood (+0.96 p) all got worse.

**Implementation details:**
1. `slice_prototypes` buffer `[heads=3, slice_num=48, dim_head=64]` added to `Physics_Attention_Irregular_Mesh`. EMA update: `lerp_(slice_token.detach().mean(0), 0.01)` during training. Blend: `slice_token += 0.1 * prototypes`.
2. `freq_net = nn.Linear(8→16, GELU, 16→4)`, zero-init output. Input: `x[:, 0, 10:18]` (8 condition features around AoA/Re). Output: per-sample frequency offsets added to the 4 learned freqs. Fixed freqs remain global; only the 4 learned ones become per-sample.

The per-sample Fourier idea depends on the condition features `x[:, 0, 10:18]` being informative for frequency selection. These are post-normalization features, and it's unclear whether they encode enough condition information for meaningful per-sample tuning. The network may also need more epochs to learn the frequency-condition mapping.

The slice memory EMA starts near-zero (prototypes initialized to 0) and only meaningfully contributes after many epochs with 0.01 per-step update rate. At epoch 56 the prototypes have had time to accumulate, but the blend at 0.1× may be creating noise rather than useful signal.

### Suggested follow-ups

- Test slice memory and per-sample Fourier separately rather than combined — we can't determine which (if either) is contributing positively.
- For per-sample Fourier: try using more informative condition features (e.g., Re index, AoA index explicitly) rather than a 8-feature window.
- For slice memory: try a higher EMA blend (0.2) or lower update rate (0.001) to see if the effect changes.