### PR TITLE
Slice-mem + input-skip (combine two closest near-misses)

### DIFF
--- a/train.py
+++ b/train.py
@@ -174,7 +174,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         # EMA prototype update (training only) + blend
         if self.training:
             proto_update = slice_token.detach().mean(dim=0)  # [heads, slice_num, dim_head]
-            self.slice_prototypes = 0.99 * self.slice_prototypes + 0.01 * proto_update
+            self.slice_prototypes.mul_(0.99).add_(proto_update, alpha=0.01)
         slice_token = 0.8 * slice_token + 0.2 * self.slice_prototypes.unsqueeze(0)
 
         q_slice_token = self.to_q(slice_token)


### PR DESCRIPTION
## Hypothesis
Slice-mem improved in_dist+ood (0.8569). Input-skip improved in_dist (0.8612). These address the same direction (better in_dist) plus different secondary targets. The combination might further improve in_dist while slice-mem maintains ood.

## Instructions
1. Add slice_prototypes buffer + EMA(0.99) update + blend(0.8*token + 0.2*proto)
2. Add input-skip: nn.Linear(fun_dim+space_dim, out_dim), zero-init, scale 0.1
3. Run with \`--wandb_group slice-mem-inputskip\`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** \`iqeo1jln\`  
**Best epoch:** 59  
**val/loss:** 0.8662 (baseline: 0.8555) ❌ worse  
**mean3 (surf_p avg):** 23.30 (baseline: 23.20) ❌ worse  
**Peak memory:** ~14.8 GB  

### Metrics by split

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5903 | 7.82 | 2.15 | 17.53 | 1.08 | 0.36 | 19.16 |
| val_ood_cond | 0.6927 | 6.06 | 1.44 | 13.70 | 0.72 | 0.27 | 11.99 |
| val_tandem_transfer | 1.6321 | 6.50 | 2.46 | 38.66 | 1.92 | 0.88 | 38.19 |
| val_ood_re | 0.5498 | 5.83 | 1.27 | 27.89 | 0.83 | 0.36 | 47.07 |

### What happened

The combination of slice-mem and input-skip did not improve on the baseline — val/loss went from 0.8555 to 0.8662, and mean3 from 23.20 to 23.30. This is mildly worse across the board.

There was one implementation issue: the EMA update \`self.slice_prototypes = 0.99 * ... + 0.01 * ...\` caused a CUDA graph conflict (overwrites buffer storage pointer). Fixed with in-place \`self.slice_prototypes.mul_(0.99).add_(proto_update, alpha=0.01)\`. The run completed cleanly after that fix.

The hypothesis that combining two near-misses would stack was not borne out. Possible reasons:
- Both features add small regularization/stabilization effects that partially overlap or cancel when combined
- The slice-mem EMA blending (0.2 weight on prototypes) reduces token diversity in a way that conflicts with the input-skip's direct low-level bypass
- The two improvements were each individually marginal, and combining two sub-threshold changes doesn't reliably improve over the baseline

The visualization crash at the end (shape mismatch 84905×25 vs 57×57) is a pre-existing issue unrelated to this PR — training metrics are valid.

### Suggested follow-ups
- Try slice-mem alone on the latest noam baseline (it was previously tested on an older baseline — the improvement may look different now)
- Try lower EMA blend ratio (e.g. 0.1 instead of 0.2) to reduce the dampening effect on token diversity
- Input-skip was separately close to baseline; try combining it with asymmetric hard-mining or deeper spatial bias MLP