### PR TITLE
Slice-mem with seed=42 (reproducibility of 0.8569 near-miss)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.register_buffer('slice_prototypes', torch.zeros(1, heads, slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +170,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        # Slice memory: EMA update + blend with prototypes
+        if self.training:
+            with torch.no_grad():
+                mean_st = slice_token.float().mean(dim=0, keepdim=True)
+                self.slice_prototypes.lerp_(mean_st, 0.01)
+        slice_token = 0.8 * slice_token + 0.2 * self.slice_prototypes.to(dtype=slice_token.dtype)
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
@@ -421,9 +429,15 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = 0
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed != 0:
+    import random
+    random.seed(cfg.seed)
+    torch.manual_seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3


### PR DESCRIPTION
## Hypothesis
Slice-mem got 0.8569 (3rd closest). Testing with seed=42 to verify the in_dist+ood improvement is reproducible.

## Instructions
1. Add slice_prototypes buffer + EMA(0.99) update + blend(0.8*token + 0.2*proto)
2. Pass --seed 42
3. Run with `--wandb_group slice-mem-seed42`

## Baseline: val_loss=0.8555

---
## Results

**W&B run**: `fcgbm9cl` (gilbert/slice-mem-seed42), 60 epochs

Implementation:
- Added `register_buffer("slice_prototypes", torch.zeros(1, heads, slice_num, dim_head))` in Physics_Attention_Structured_Mesh.__init__
- In forward, after slice_token normalization: EMA update with `self.slice_prototypes.lerp_(mean_st, 0.01)` (=EMA 0.99), then blend: `slice_token = 0.8*slice_token + 0.2*proto`
- EMA update is gated by `self.training` and runs under `torch.no_grad()`
- Added seed: int = 0 to Config, using torch.manual_seed(42)

### Metrics

| Split | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|---|---|---|---|
| val_in_dist | 4.50 | 1.50 | **18.24** |
| val_ood_cond | 2.76 | 0.99 | **13.59** |
| val_ood_re | -- | -- | **27.67** |
| val_tandem_transfer | 5.16 | 1.90 | **39.31** |

| Metric | seed=42 | seed=0 (original) | Baseline (no slice-mem) | 
|---|---|---|---|
| val/loss | 0.8697 | ~0.8569 | 0.8555 |
| mean3 | 23.71 | ~(unknown) | ~23.27 |

| Metric | This run vs baseline | Delta |
|---|---|---|
| val/loss | 0.8697 vs 0.8555 | +0.0142 (~4.3sigma) |
| mean3 | 23.71 vs ~23.27 | +0.44 (~2.1sigma) |

### What happened

Negative result with seed=42. The original seed=0 result (val_loss=0.8569) was itself slightly worse than baseline -- it was described as "3rd closest" but was still above the baseline of 0.8555. With seed=42, the result (0.8697) is clearly worse than baseline and much worse than the seed=0 result.

This confirms the original 0.8569 result was likely noise (within the ~0.0046 sigma, 0.8569 is only 0.0014 above baseline = 0.3sigma). The slice memory feature has high variance across seeds (0.8569 vs 0.8697, range=0.0128) and provides no consistent improvement.

The blending with prototypes that start at zero may hurt early in training (for the first ~100 batches where prototypes haven t accumulated meaningful information, the blend pulls slice_tokens toward zero, dampening them by 20%). Once prototypes accumulate, the effect would be a running average of recent slice tokens across samples -- which may or may not help.

### Suggested follow-ups

- Skip slice memory in this form; it adds complexity without reliable gain
- If pursuing, could initialize prototypes from first batch instead of zeros, or use a warmer blend (0.95*token + 0.05*proto)