### PR TITLE
Slice-mem with gentler blend (0.1 instead of 0.2)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.register_buffer('slice_prototypes', torch.zeros(1, heads, slice_num, dim_head))
+        self.register_buffer('proto_initialized', torch.zeros(1, dtype=torch.bool))
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +171,15 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        if self.training:
+            batch_proto = slice_token.detach().mean(dim=0, keepdim=True)
+            if not self.proto_initialized.item():
+                self.slice_prototypes.copy_(batch_proto)
+                self.proto_initialized.fill_(True)
+            else:
+                self.slice_prototypes.copy_(0.99 * self.slice_prototypes + 0.01 * batch_proto)
+            slice_token = 0.9 * slice_token + 0.1 * self.slice_prototypes
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)


### PR DESCRIPTION
## Hypothesis
Slice-mem used 0.8*token + 0.2*proto. The 0.2 blend might be too strong, causing the re/tandem regression. Try 0.9*token + 0.1*proto for a gentler prototype influence.

## Instructions
1. Add slice_prototypes buffer + EMA(0.99) update + blend(0.9*token + 0.1*proto) — changed from 0.2 to 0.1
2. Run with `--wandb_group slice-mem-blend-01`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `sfte9vxt`
**Best epoch:** 54 / 100 (hit wall-clock limit, ~33s/epoch — 7 fewer than baseline's 61)
**Peak memory:** 14.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6319 | 6.80 | 2.00 | 19.11 | 1.14 | 0.38 | 20.39 |
| val_tandem_transfer | 1.7189 | 6.67 | 2.47 | 40.91 | 2.00 | 0.91 | 40.33 |
| val_ood_cond | 0.7222 | 4.02 | 1.45 | 14.47 | 0.76 | 0.28 | 12.37 |
| val_ood_re | 0.5752 | 3.55 | 1.25 | 28.48 | 0.86 | 0.37 | 47.44 |
| **mean3** | **1.025** | **5.83** | **1.97** | **24.83** | — | — | — |

Baseline: mean3=23.20 (in=17.48, ood=13.59, tan=38.53, re=27.57), val_loss=0.8555

**What happened:** Strongly negative result. mean3=24.83 vs 23.20 (+1.63), val/loss 0.8555 → 0.9121. All splits degraded significantly: in_dist (+1.63), tandem (+2.38), ood_cond (+0.88), ood_re (+0.91). The run also completed only 54 epochs (vs 61 baseline) — 11% slower per epoch due to the extra EMA computation.

The gentler 0.1 blend is still too strong. The prototype mechanism fundamentally interferes with the model's per-sample adaptation: the EMA prototypes average across all flow conditions (single, tandem, different AoA, different Re), forcing each sample's slice tokens toward a condition-agnostic mean. For this dataset where flow distribution varies widely, this averaging out of per-sample variation is harmful — the model's strength comes from its ability to route different flow regions to appropriate slices.

The slice-mem idea is counterproductive for this model at this scale — the slice attention already has enough capacity to learn good routing per sample; an external memory only adds noise.

**Suggested follow-ups:**
- Drop the slice-mem line of experiments — neither 0.2 nor 0.1 blend helps.
- The prototype could work if updated per-sample (not batch-averaged), but that would require tracking separate prototypes per flow condition, which is complex and not worth the cost.