### PR TITLE
Slice-mem with faster EMA (0.95 instead of 0.99)

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.register_buffer('slice_prototypes', torch.zeros(heads, slice_num, dim_head))
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -169,6 +170,12 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        # Slice prototype memory: EMA update + blend
+        if self.training:
+            with torch.no_grad():
+                self.slice_prototypes.mul_(0.95).add_(slice_token.detach().mean(dim=0) * 0.05)
+        slice_token = 0.8 * slice_token + 0.2 * self.slice_prototypes.unsqueeze(0)
 
         q_slice_token = self.to_q(slice_token)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)


### PR DESCRIPTION
## Hypothesis
Slice-mem used EMA 0.99 (slow prototype update, ~100 step window). Faster EMA 0.95 (~20 step window) makes prototypes more responsive to recent batches. The more responsive prototypes might reduce the re/tandem regression.

## Instructions
1. Add slice_prototypes buffer + EMA(**0.95**) update + blend(0.8*token + 0.2*proto)
2. Only change: EMA decay from 0.99 to 0.95
3. Run with `--wandb_group slice-mem-ema-095`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** yanoklkw
**Epochs completed:** 57/100 (30-min timeout)
**Peak memory:** 14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8555 | 0.8687 | +1.5% worse |
| val_in_dist | mae_surf_p | 17.48 | 17.95 | +2.7% worse |
| val_ood_cond | mae_surf_p | 13.59 | 13.69 | +0.8% worse |
| val_tandem_transfer | mae_surf_p | 38.53 | 38.52 | ~0% (identical) |
| val_ood_re | mae_surf_p | 27.57 | 27.85 | +1.0% worse |
| **mean3** | mae_surf_p | **23.20** | **23.39** | **+0.8% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=6.24, Uy=1.82, p=17.95 | Vol: Ux=1.11, Uy=0.37, p=19.01
- **ood_cond:** Ux=4.24, Uy=1.29, p=13.69 | Vol: Ux=0.73, Uy=0.27, p=12.05
- **ood_re:** Ux=3.92, Uy=1.16, p=27.85 | Vol: Ux=0.84, Uy=0.36, p=46.99
- **tandem_transfer:** Ux=6.08, Uy=2.29, p=38.52 | Vol: Ux=1.94, Uy=0.88, p=38.06

### What happened

Slice-mem with EMA 0.95 performs very close to baseline — within the run-to-run noise range (~0.7% on mean3 per prior reproducibility experiments). All individual splits are within 1-3% of baseline, which is within expected variance. Notably, tandem transfer mae_surf_p is essentially identical to baseline (38.52 vs 38.53), showing no regression on the hardest split.

This is a much better result than recent experiments (which typically regressed 4-10%). The prototype memory appears neither strongly helpful nor harmful: at EMA 0.95, the prototype is updated fast enough that it mostly tracks the current batch distribution, and the 0.2 blend weight keeps the perturbation small enough to not disrupt learning.

Whether this is a marginal positive signal or a wash depends on whether the model was converging at epoch 57. The val losses are still declining, so the final checkpoint may be slightly better or worse than reported here.

### Suggested follow-ups

- **EMA 0.9 (10-step window)**: Try even faster prototype updates — at 0.95 the prototype is mostly current anyway, 0.9 would make it more distinct.
- **Blend weight tuning**: Try 0.9/0.1 (less prototype influence) to see if the prototype is helpful at all, or 0.7/0.3 (more influence).
- **Layer-selective application**: Apply prototype blending only in early transformer layers (where spatial structure is more relevant) rather than all layers.