### PR TITLE
AdaLN on spatial bias MLP (condition-adaptive routing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -210,8 +210,9 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        # Input: (x, y, curvature) + (Re, AoA, gap, stagger) = 7 dims
         self.spatial_bias = nn.Sequential(
-            nn.Linear(3, 64), nn.GELU(),
+            nn.Linear(7, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -231,8 +232,15 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
-        sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+    def forward(self, fx, raw_xy=None, tandem_mask=None, cond=None):
+        if raw_xy is not None:
+            if cond is not None:
+                cond_exp = cond.unsqueeze(1).expand(-1, raw_xy.shape[1], -1)  # [B,N,4]
+                sb = self.spatial_bias(torch.cat([raw_xy, cond_exp], dim=-1))  # [B,N,7]
+            else:
+                sb = self.spatial_bias(torch.cat([raw_xy, torch.zeros(*raw_xy.shape[:2], 4, device=raw_xy.device, dtype=raw_xy.dtype)], dim=-1))
+        else:
+            sb = None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
@@ -375,6 +383,8 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        # Extract condition for spatial routing: Re, AoA, gap, stagger
+        cond = x[:, 0, [13, 14, 21, 22]]  # [B, 4]
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -387,13 +397,13 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
AdaLN on the output head (thorfinn) gave ood=13.16 (best ever). What about AdaLN on the spatial bias MLP — making the ROUTING itself condition-adaptive? The spatial bias maps (x,y,curvature) to slice assignment. Making this conditional on (Re,AoA) would let the routing adapt to flow regime, potentially helping OOD generalization at the source.

## Instructions
1. In the spatial_bias MLP, add condition vector as additional input:
   ```python
   # Change spatial_bias input from 3 (x,y,curvature) to 7 (x,y,curv,Re,AoA,gap,stagger)
   # The condition values are broadcast across all nodes (same per sample)
   ```
2. Or simpler: add an AdaLN layer inside the spatial_bias MLP
3. Run with `--wandb_group adaln-spatial-bias`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `lc0l7tjz`
**Epochs:** 56 (30-min timeout)
**Peak VRAM:** 15.7 GB

**Implementation:** Option 1 — concatenate condition [Re, AoA, gap, stagger] from `x[:, 0, [13,14,21,22]]` to the spatial_bias input, expanding spatial_bias from `Linear(3,64)` to `Linear(7,64)`. The 4-dim condition is broadcast across all N nodes before concatenation.

| Metric | Baseline (lr=2.5e-3) | This run | Δ |
|--------|----------------------|----------|---|
| val/loss | 0.8555 | 0.8912 | +0.0357 ↑ worse |
| surf_p in_dist | 17.48 | 17.95 | +0.47 ↑ worse |
| surf_p ood_cond | 13.59 | 14.60 | +1.01 ↑ worse |
| surf_p ood_re | 27.57 | 28.50 | +0.93 ↑ worse |
| surf_p tandem | 38.53 | 39.29 | +0.76 ↑ worse |
| **mean3** | **23.20** | **23.95** | +0.75 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**Surface MAE breakdown (best epoch 56):**
| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 6.03 | 1.84 | 17.95 |
| ood_cond | 3.41 | 1.18 | 14.60 |
| ood_re | 2.99 | 1.02 | 28.50 |
| tandem | 5.81 | 2.31 | 39.29 |

**What happened:** Condition-adaptive spatial routing hurt across all metrics. The hypothesis was that routing adapted to (Re, AoA) would improve OOD generalization, but the opposite happened.

Possible explanations:
1. **Wrong condition representation**: The condition features `x[:, 0, [13,14,21,22]]` come after per-channel normalization, which maps the condition values to a different scale for single-foil vs tandem cases. The model may be confused by this mixed representation when routing.

2. **The spatial_bias output starts at zero** (zero-init), so early in training the routing is purely geometric. Adding condition input means the first linear layer needs more capacity to ignore it initially — the orthogonal initialization of the 7-dim layer may spread weight too thinly across the spatial channels vs the 3-dim baseline.

3. **Routing and condition coupling**: The spatial bias is added to slice logits as `0.1 * spatial_bias`. When the MLP output depends on condition, it can inadvertently encode non-spatial information into the routing, disrupting the geometry-based token formation that Transolver relies on.

4. **More computation per step**: Like PR #1414, the expanded input adds computation, reducing training throughput (56 vs ~60 epochs in baseline).

**Suggested follow-ups:**
1. If thorfinn's ln_3 AdaLN worked well, investigate why the output norm is the right place for conditioning, not the routing.
2. Try concatenating only the regime-discriminative features (gap and stagger) to spatial_bias, not Re/AoA — the spatial routing may only need to know single-foil vs tandem.
3. Consider using the raw (unnormalized) gap/stagger features for conditioning rather than the jointly-normalized versions.