### PR TITLE
Conditional rank modulation (LoRA-at-inference for regime-specific decoding)

### DIFF
--- a/train.py
+++ b/train.py
@@ -231,7 +231,7 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, rank_ab=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
@@ -240,7 +240,12 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx_ln3 = self.ln_3(fx)
+            fx_out = self.mlp2(fx_ln3)
+            if rank_ab is not None:
+                A, B = rank_ab
+                fx_out = fx_out + fx_ln3 @ A @ B
+            return fx_out
         return fx
 
 
@@ -288,6 +293,7 @@ class Transolver(nn.Module):
             self.preprocess = GatedMLP2(fun_dim + space_dim, n_hidden * 2, n_hidden)
 
         self.n_hidden = n_hidden
+        self.out_dim = out_dim
         self.space_dim = space_dim
         self.feature_cross = nn.Linear(fun_dim + space_dim, fun_dim + space_dim, bias=False)
         nn.init.eye_(self.feature_cross.weight)  # start as identity
@@ -318,6 +324,12 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        # Regime-conditioned rank-4 modulation hypernetwork
+        self.regime_proj = nn.Sequential(
+            nn.Linear(2, 16), nn.GELU(), nn.Linear(16, n_hidden * 4 + 4 * out_dim)
+        )
+        nn.init.zeros_(self.regime_proj[-1].weight)
+        nn.init.zeros_(self.regime_proj[-1].bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -393,7 +405,13 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        # Regime-conditioned rank-4 modulation: condition on [log_Re, AoA]
+        log_re_aoa = x[:, 0, 13:15]  # [B, 2]
+        rank_out = self.regime_proj(log_re_aoa)  # [B, n_hidden*4 + 4*out_dim]
+        n_h = self.n_hidden
+        A = rank_out[:, :n_h * 4].reshape(-1, n_h, 4)   # [B, 192, 4]
+        B = rank_out[:, n_h * 4:].reshape(-1, 4, self.out_dim)  # [B, 4, 3]
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, rank_ab=(A, B))
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
A tiny hypernetwork generates per-sample rank-4 weight corrections for the output projection, conditioned on [log_Re, AoA]. This gives the model regime-specific decoding without architectural overhead. Never attempted in any form across 210+ experiments.

## Instructions
1. Add regime_proj MLP: nn.Sequential(nn.Linear(2, 16), nn.GELU(), nn.Linear(16, 192*4 + 4*3)), zero-init final layer
2. Extract [log_Re, AoA] from x[:, 0, 13:15]
3. Reshape output into A[192,4] and B[4,3]
4. In last block after ln_3: fx_out = mlp2(fx_ln) + (fx_ln @ A @ B)
5. Run with `--wandb_group cond-rank-mod`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `1jaac1n3` (`tanjiro/cond-rank-mod`)
**Epochs:** 57 (30-min timeout)
**Peak memory:** ~15.0 GB

### Validation losses (best epoch 57)

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6178 | 6.09 | 2.05 | **19.1** | 1.11 | 0.37 | 20.1 |
| val_ood_cond | 0.7145 | 3.24 | 1.25 | **14.6** | 0.73 | 0.27 | 12.2 |
| val_ood_re | 0.5542 | 2.84 | 1.09 | **28.0** | 0.83 | 0.37 | 47.0 |
| val_tandem | 1.6361 | 6.29 | 2.53 | **38.4** | 1.95 | 0.88 | 38.4 |
| **combined** | **0.8807** | | | | | | |

### vs. baseline (0.8555)

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8555 | 0.8807 | +0.0252 ↑ worse |
| in_dist mae_surf_p | ~18.0 | 19.1 | +1.1 ↑ worse |
| ood_cond mae_surf_p | ~14.0 | 14.6 | +0.6 ↑ worse |
| ood_re mae_surf_p | ~27.5 | 28.0 | +0.5 ↑ worse |
| tandem mae_surf_p | ~38.0 | 38.4 | +0.4 ↑ worse |

### What happened

Negative result across all metrics. The conditional rank modulation adds ~0.025 to val/loss compared to baseline.

The most likely reason is the **product-of-parameters gradient problem**: at zero init, both A and B are zero. During early training, the gradient w.r.t. A scales with B (which is zero) and vice versa. This means the rank path has vanishing gradients throughout early training, and by the time gradients are non-zero, the main `mlp2` path has already converged. The rank terms then mostly add noise rather than regime-specific corrections.

This is a known failure mode for low-rank factorized paths initialized to zero — the standard fix (initialize A with random, B with zeros) avoids the mutual gradient annihilation. With a hypernetwork, the issue is amplified because the hypernetwork itself is zero-initialized, so its output is always zero regardless of input, making the entire rank path dead for many early epochs.

Additionally, the conditioning features at `x[:, 0, 13:15]` are normalized flow condition features — it's unclear whether they truly encode log_Re and AoA cleanly after the feature_cross operation has run (we're using `x_raw` equivalent since no x_raw is saved here).

### Suggested follow-ups

- Fix the initialization: use random init for A-matrix weights in the hypernetwork, zero-init only for B. This avoids the mutual-zero gradient trap.
- Try the rank modulation without the hypernetwork: directly learn per-regime (single-sample) A and B as parameters, conditioned via a lookup into a small embedding table indexed by flow regime bucket.
- Consider conditioning earlier layers (attention slice projections) rather than the output head — regime-specific routing may be more impactful there.
