### PR TITLE
Asymmetric channel gradient flow (pressure 2x, velocity 0.5x)

### DIFF
--- a/train.py
+++ b/train.py
@@ -116,6 +116,18 @@ class MLP(nn.Module):
         return x
 
 
+class GradientScale(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, scale):
+        ctx.save_for_backward(torch.tensor(scale))
+        return x
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        scale, = ctx.saved_tensors
+        return grad_output * scale.to(grad_output.device, grad_output.dtype), None
+
+
 class Physics_Attention_Irregular_Mesh(nn.Module):
     """Physics attention for irregular meshes in 1D/2D/3D space."""
 
@@ -240,7 +252,10 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            pred = self.mlp2(self.ln_3(fx))
+            pred_vel = GradientScale.apply(pred[:, :, :2], 0.5)
+            pred_p = GradientScale.apply(pred[:, :, 2:3], 2.0)
+            return torch.cat([pred_vel, pred_p], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Keep shared output MLP but scale gradients: pressure gets 2x gradient, velocity 0.5x. This gives pressure 4x effective influence WITHOUT separate heads. Zero forward-pass cost.

## Instructions
1. Define GradientScale(torch.autograd.Function) with backward: return grad * scale
2. After mlp2 output: pred[:,:,2:3] = GradientScale.apply(pred[:,:,2:3], 2.0); pred[:,:,:2] = GradientScale.apply(pred[:,:,:2], 0.5)
3. Run with `--wandb_group asym-grad-flow`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** si80tzbw
**Epochs completed:** 59/100 (30-min timeout)
**Peak memory:** 15.0 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.9457 | 0.8555 | +10.5% (much worse) |
| Surface MAE p (in_dist) | 19.23 | 17.48 | +10.0% (much worse) |
| Surface MAE p (ood_cond) | 14.80 | 13.59 | +8.9% (much worse) |
| Surface MAE p (ood_re) | 28.58 | 27.57 | +3.7% (worse) |
| Surface MAE p (tandem) | 41.82 | 38.53 | +8.5% (much worse) |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 7.72 | 2.29 | 19.23 |
| ood_cond | 5.16 | 1.50 | 14.80 |
| ood_re | 4.68 | 1.26 | 28.58 |
| tandem | 7.29 | 2.91 | 41.82 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.44 | 0.49 | 20.97 |
| ood_cond | 0.93 | 0.37 | 12.98 |
| ood_re | 1.00 | 0.43 | 47.41 |
| tandem | 2.37 | 1.07 | 41.16 |

### What happened

Strong negative result: +10.5% val/loss regression, all splits notably worse. The asymmetric gradient scaling severely destabilized the training dynamics.

The key issue: gradient scaling after the output head doesn't just affect the output head — it propagates backward through the ENTIRE network. Every parameter from `preprocess` through all `TransolverBlock`s receives distorted gradients where the pressure signal is 4x stronger than velocity. The model ends up implicitly training with a modified loss function where `pressure_loss * 4 = velocity_loss * 1` — a ratio of 4:1 when the current training uses `surf_weight=20` on the combined 3-channel loss.

Additionally, the velocity (Ux, Uy) channels get 0.5x gradient scaling. Since velocity is already well-constrained (lower MAE than pressure), reducing its gradient signal destabilizes the learned velocity representations.

The gradient manipulation approach is architecturally sound in principle, but the scale of the distortion (2x/0.5x = 4x ratio) was too aggressive. The existing `surf_weight=20` already provides a soft weighting — adding gradient scaling on top creates a compounded distortion.

### Suggested follow-ups

- **Much smaller scale: 1.2x pressure / 0.8x velocity:** The current ratio (4x) is way too aggressive. A subtle tilt might work without destabilizing.
- **Apply to loss directly instead of gradients:** Rather than gradient scaling, just weight the pressure channel differently in the loss computation: `loss = vel_loss + 2.0 * p_loss`. More transparent and controllable.
- **Accept that gradient manipulation is risky** at this scale. The training is already well-tuned and doesn't need explicit channel re-weighting.