### PR TITLE
Alternating volume/surface epochs (2:1 cadence, eliminate gradient conflict)

### DIFF
--- a/train.py
+++ b/train.py
@@ -635,8 +635,8 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # alt-vol-surf-epochs: fixed surf_weight based on epoch type (replaces adaptive)
+    surf_weight = 40.0 if epoch % 3 == 2 else 5.0
 
     # --- Train ---
     model.train()
@@ -650,6 +650,7 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
+        raw_dsdf_norm = x[:, :, 2:6].norm(dim=-1)  # alt-vol-surf-epochs: dsdf norm before normalization [B, N]
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -725,6 +726,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
         else:
             vol_mask_train = vol_mask
+        if epoch % 3 == 2:  # alt-vol-surf-epochs: surface epoch — near-surface volume only
+            vol_mask_train = (raw_dsdf_norm < 0.2) & vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)


### PR DESCRIPTION
## Hypothesis
Instead of balancing one combined loss, alternate: 2 volume epochs (all nodes, surf_weight=5) then 1 surface epoch (surface + near-surface only, surf_weight=40). Eliminates gradient conflict by separation.

## Instructions
1. if epoch % 3 == 2: use only surface nodes + volume nodes with dsdf_norm < 0.2; surf_weight=40
2. else: normal training with surf_weight=5
3. Run with `--wandb_group alt-vol-surf-epochs`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** btcitv8w  
**Best checkpoint:** epoch 60

| Split | val/loss | surf_p | surf_Ux | surf_Uy |
|-------|----------|--------|---------|---------|
| val_in_dist | 0.6019 | 17.88 | 7.60 | 2.07 |
| val_ood_cond | 0.7275 | 14.24 | 4.84 | 1.18 |
| val_ood_re | 0.5581 | 27.85 | 4.40 | 1.00 |
| val_tandem_transfer | 1.7121 | 40.72 | 7.41 | 2.61 |
| **combined val/loss** | **0.8999** | | | |

**vs Baseline (val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53):**

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8555 | 0.8999 | +0.0444 ❌ |
| surf_p in_dist | 17.48 | 17.88 | +0.40 ❌ |
| surf_p ood_cond | 13.59 | 14.24 | +0.65 ❌ |
| surf_p ood_re | 27.57 | 27.85 | +0.28 ❌ |
| surf_p tandem | 38.53 | 40.72 | +2.19 ❌ |
| mean3 surf_p | ~19.55 | 19.99 | +0.44 ❌ |

**What happened:** The alternating strategy made things worse across all splits, with tandem degrading most (+2.19). The Ux metrics also degraded sharply (in_dist Ux: 7.60 vs baseline ~4.95).

The hypothesis that gradient conflict is the main bottleneck appears incorrect. The 2:1 alternating ratio (66% volume-focused epochs at surf_weight=5) heavily under-weights surface accuracy during training. The adaptive surf_weight mechanism in the baseline (dynamically 5–50×) keeps better pressure on surface quality throughout.

Also, the dsdf_norm < 0.2 threshold may select very few or no near-surface volume nodes on the normalized data, making the surface epochs essentially identical to surface-only training — which is too sparse a signal per epoch for the optimizer.

**Memory:** No change.

**Suggested follow-ups:**
- If gradient conflict is a real concern, try a softer version: smooth interpolation of surf_weight between 5 and 40 using epoch-based scheduling rather than hard alternation
- Measure how many volume nodes actually pass the dsdf_norm < 0.2 threshold to validate the near-surface selection is working as intended
- Keep the adaptive surf_weight but cap it at a lower maximum (e.g. clamp [5, 20] vs [5, 50]) to reduce volume/surface weight swings