### PR TITLE
Learned surface interpolation kernel (k=8 neighbor spatial smoother)

### DIFF
--- a/train.py
+++ b/train.py
@@ -405,6 +405,82 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
+class SurfaceRefiner(nn.Module):
+    """Learned k=8 nearest-neighbor surface interpolation kernel.
+
+    Input per (node, neighbor) pair: [dx, dy, dist, curvature_diff] → scalar weight.
+    Zero-init output layer → uniform (arithmetic-mean) weighting at init.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(4, 16),
+            nn.GELU(),
+            nn.Linear(16, 1),
+        )
+        nn.init.zeros_(self.mlp[-1].weight)
+        nn.init.zeros_(self.mlp[-1].bias)
+
+    def forward(self, edge_feats):
+        """edge_feats: [S, k, 4] → weights [S, k, 1] (after softmax)."""
+        return torch.softmax(self.mlp(edge_feats), dim=1)
+
+
+def apply_surf_refiner(refiner, pred, x_full, is_surface, mask, k=8):
+    """surf_pred_refined = surf_pred + 0.1 * weighted_neighbor_avg.
+
+    refiner   : SurfaceRefiner
+    pred      : [B, N, C] float predictions
+    x_full    : [B, N, D] fully-preprocessed input (curvature at index X_DIM)
+    is_surface: [B, N] bool
+    mask      : [B, N] bool
+    """
+    B, N, C = pred.shape
+    corrections = []
+
+    for b in range(B):
+        surf_valid = is_surface[b] & mask[b]
+        surf_idx = surf_valid.nonzero(as_tuple=False).view(-1)  # [S]
+        S = surf_idx.shape[0]
+
+        if S < 2:
+            corrections.append(pred.new_zeros(N, C))
+            continue
+
+        k_actual = min(k, S - 1)
+
+        with torch.no_grad():
+            surf_xy = x_full[b, surf_idx, :2].float()             # [S, 2]
+            surf_curv = x_full[b, surf_idx, X_DIM:X_DIM + 1].float()  # [S, 1]
+            dists = torch.cdist(surf_xy.unsqueeze(0), surf_xy.unsqueeze(0)).squeeze(0)  # [S, S]
+            dists_no_self = dists.clone()
+            dists_no_self.fill_diagonal_(1e9)
+            _, nn_idx = dists_no_self.topk(k_actual, dim=1, largest=False)  # [S, k]
+            nn_xy = surf_xy[nn_idx]                                # [S, k, 2]
+            nn_curv = surf_curv[nn_idx]                            # [S, k, 1]
+            dx = nn_xy[:, :, 0:1] - surf_xy[:, 0:1].unsqueeze(1)  # [S, k, 1]
+            dy = nn_xy[:, :, 1:2] - surf_xy[:, 1:2].unsqueeze(1)  # [S, k, 1]
+            nn_dist = torch.gather(dists, 1, nn_idx).unsqueeze(-1)  # [S, k, 1]
+            curv_diff = nn_curv - surf_curv.unsqueeze(1)           # [S, k, 1]
+            edge_feats = torch.cat([dx, dy, nn_dist, curv_diff], dim=-1)  # [S, k, 4]
+
+        weights = refiner(edge_feats)                              # [S, k, 1]
+        surf_pred_vals = pred[b, surf_idx]                         # [S, C]
+        nn_pred_vals = surf_pred_vals[nn_idx]                      # [S, k, C]
+        weighted_avg = (weights * nn_pred_vals).sum(dim=1)         # [S, C]
+
+        corr_b = torch.scatter_add(
+            pred.new_zeros(N, C), 0,
+            surf_idx.unsqueeze(-1).expand(-1, C),
+            weighted_avg,
+        )
+        corrections.append(corr_b)
+
+    correction = torch.stack(corrections, dim=0)  # [B, N, C]
+    return pred + 0.1 * correction
+
+
 MAX_TIMEOUT = 30.0  # minutes
 MAX_EPOCHS = 100
 
@@ -533,6 +609,8 @@ model = Transolver(**model_config).to(device)
 model = torch.compile(model, mode="reduce-overhead")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
+surf_refiner = SurfaceRefiner().to(device)
+
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
@@ -573,7 +651,8 @@ attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['W
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
+    {'params': other_params, 'lr': cfg.lr},
+    {'params': list(surf_refiner.parameters()), 'lr': cfg.lr},
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
@@ -701,6 +780,7 @@ for epoch in range(MAX_EPOCHS):
         pred = pred.float()
         re_pred = re_pred.float()
         aoa_pred = aoa_pred.float()
+        pred = apply_surf_refiner(surf_refiner, pred, x, is_surface, mask)
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -867,6 +947,7 @@ for epoch in range(MAX_EPOCHS):
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
+                pred = apply_surf_refiner(surf_refiner, pred, x, is_surface, mask)
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis
Surface predictions are noisy at the node level. A learned interpolation kernel smooths predictions using k=8 nearest surface neighbors, with weights from a tiny MLP conditioned on relative position. Physics-motivated spatial coherence.

## Instructions
1. Precompute k=8 nearest surface neighbor indices using torch.cdist on xy coords
2. Add SurfaceRefiner: MLP [4]->[16]->[1] (input: dx,dy,dist,curvature_diff; output: weight)
3. surf_pred_refined = surf_pred + 0.1 * weighted_neighbor_avg (zero-init output)
4. Run with `--wandb_group surf-interpolation`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** `3qyqbok1` | **Epochs:** 55 (30-min timeout) | **Peak memory:** 14.9 GB

### val/loss (4-split avg)
| Metric | This run | Baseline | delta |
|--------|----------|----------|-------|
| val/loss | **0.9268** | 0.8555 | +8.3% (worse) |

### Surface MAE at best checkpoint (epoch 55)
| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 5.41 | 2.00 | 21.13 |
| val_ood_cond | 3.08 | 1.33 | 15.65 |
| val_ood_re | 2.85 | 1.15 | 29.32 |
| val_tandem_transfer | 5.40 | 2.53 | 39.11 |

### Baseline reference (PR #1419 best)
| Split | surf p baseline |
|-------|----------------|
| val_in_dist | ~18.2 |
| val_ood_cond | ~14.4 |
| val_ood_re | ~28.1 |
| val_tandem_transfer | ~38.5 |

All splits worse: in_dist +16%, ood_cond +9%, ood_re +5%, tandem +2%.

### Volume MAE (val_in_dist, epoch 55)
Ux=1.12, Uy=0.37, p=19.79

### What happened

The surf_refiner hypothesis did not work -- all metrics are worse than baseline across every split.

**Root cause analysis:**

1. **Zero-init gives non-zero initial perturbation.** With output layer zero-initialized, softmax gives uniform weights (1/k), so the initial correction is `0.1 x mean(8 neighbors)`. This is NOT a zero correction -- it immediately adds spatial smoothing that fights against learning sharp surface features (stagnation points, trailing-edge separation, pressure peaks).

2. **Smoothing in normalized space is not physical.** The refiner operates on pred in the model's normalized output space. Spatial averaging there is meaningless -- each channel is re-scaled by per-sample std, so the magnitude of smoothing varies arbitrarily across samples.

3. **Cross-surface contamination.** torch.cdist nearest neighbors in XY can find nodes on the opposite side of the foil (inner vs. outer surface), which are Euclidean-close but surface-far. Averaging these creates anti-physical corrections.

4. **Competing gradients.** The loss gradient wants sharp heterogeneous predictions; the refiner's initialization pushes predictions toward the local average every step, slowing convergence.

The model was still improving at ep55 (every epoch new best), but the trajectory (0.9268) is clearly above baseline (0.8555) with no indication it would close the gap.

### Suggested follow-ups
- **Post-processing only:** Apply smoothing only at inference time to avoid competing gradients during training.
- **Arc-length neighbors:** Use surface arc-length distance instead of Euclidean to avoid inner/outer surface contamination.
- **Physical space smoothing:** Denormalize first, smooth in physical units, renormalize -- so the averaging is meaningful.
- **Smaller initial correction:** Use scale 0.01 instead of 0.1, or initialize output layer to large negative bias so softmax gives near-zero weights initially.
- **Geometry-aware neighborhood:** Filter neighbors to same boundary_id before cdist to keep only same-side surface nodes.