### PR TITLE
Masked autoencoding on volume nodes (force spatial reasoning in attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -310,6 +310,7 @@ class Transolver(nn.Module):
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
+        self.mask_token = nn.Parameter(torch.zeros(fun_dim + space_dim))
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
@@ -693,6 +694,15 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        mask_idx = None
+        if model.training:
+            vol_mask_bool = mask & ~is_surface
+            rand_mask = torch.rand(B, x.shape[1], device=device) < 0.15
+            mask_idx = rand_mask & vol_mask_bool
+            if mask_idx.any():
+                mask_token_expanded = _base_model.mask_token.view(1, 1, -1).expand(B, x.shape[1], -1)
+                x = torch.where(mask_idx.unsqueeze(-1), mask_token_expanded, x)
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
             pred = out["preds"]
@@ -747,6 +757,9 @@ for epoch in range(MAX_EPOCHS):
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
+        if mask_idx is not None and mask_idx.any():
+            mask_recon_loss = (pred[mask_idx] - y_norm[mask_idx]).abs().mean() * 0.05
+            loss = loss + mask_recon_loss
 
         # Multi-scale loss: coarse spatial pooling
         coarse_pool_size = 64


### PR DESCRIPTION
## Hypothesis
Randomly mask 15% of volume node inputs with a learnable [MASK] token. Add auxiliary reconstruction loss on masked nodes (weight 0.05). Forces attention to propagate spatial information rather than per-node pattern matching. Surface nodes NEVER masked.

## Instructions
1. Add learnable mask_token: nn.Parameter(torch.zeros(fun_dim + space_dim))
2. During training: mask_idx = (torch.rand(B,N) < 0.15) & vol_mask; x[mask_idx] = mask_token
3. Add mask_recon_loss = (pred[mask_idx] - y_norm[mask_idx]).abs().mean() * 0.05
4. No masking at eval
5. Run with `--wandb_group masked-autoenc`

## Baseline: val_loss=0.8555
- in_dist p: 17.48, ood_cond p: 13.59, ood_re p: 27.57, tandem p: 38.53, mean3=23.20

## Results

**W&B run**: sp1hf4g8  
**Best epoch**: 60 (30.5 min, wall-clock limit)  
**VRAM**: 15.1 GB  

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5996 | 7.76 | 2.27 | **17.11** | 1.26 | 0.41 | 21.04 |
| val_ood_cond | 0.7336 | 4.99 | 1.59 | **13.98** | 0.85 | 0.31 | 13.33 |
| val_ood_re | 0.5650 | 4.79 | 1.42 | 27.88 | 0.94 | 0.39 | 47.75 |
| val_tandem_transfer | 1.6960 | 6.92 | 2.69 | **40.74** | 2.11 | 0.96 | 41.58 |
| **combined** | **0.8985** | | | | | | |

**mean3 (in/ood/tan p)**: (17.11 + 13.98 + 40.74) / 3 = **23.94** vs baseline 23.20 → **+0.74, negative result**

### What happened

Masked autoencoding hurt performance. val/loss degraded from 0.8555 → 0.8985, and mean3 worsened by 0.74. Tandem transfer pressure went from 38.53 → 40.74 (worst affected). In-dist and ood_cond were roughly flat.

The hypothesis was that masking volume nodes would force attention to propagate spatial context, improving pressure prediction. Instead, three things likely went wrong:

1. **Corrupted signal at 15% rate**: Masking 15% of volume features with a learned zero-init token significantly degrades the information passed into the network. The model spends capacity handling masked inputs instead of learning physical flow patterns.
2. **Competing objectives**: The 0.05-weighted reconstruction loss competes with the primary vol/surf losses. At this scale, it introduces gradient noise without adding a meaningful learning signal.
3. **Tandem sensitivity**: Tandem samples rely on inter-foil spatial propagation — exactly the regime where masking volume nodes is most disruptive, as it destroys the spatial context connecting the two foils.

### Suggested follow-ups

1. **Lower mask rate (5%)**: 15% may be too aggressive; 5% with same reconstruction loss weight might regularize without disrupting signal.
2. **Masking without reconstruction loss**: Use masking as pure input noise regularization (no aux loss). The context-forcing effect may work better if the model just learns to ignore masked nodes.
3. **Mask in hidden space instead of input space**: Masking after the preprocess layer avoids corrupting raw geometric features; the model would still need to use context but the pathological zero-token effect is avoided.