### PR TITLE
Gradient-based input saliency reweighting (learned feature selection)

### DIFF
--- a/train.py
+++ b/train.py
@@ -289,6 +289,7 @@ class Transolver(nn.Module):
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim
+        self.input_scale = nn.Parameter(torch.ones(fun_dim + space_dim))
         self.feature_cross = nn.Linear(fun_dim + space_dim, fun_dim + space_dim, bias=False)
         nn.init.eye_(self.feature_cross.weight)  # start as identity
         self.blocks = nn.ModuleList(
@@ -375,6 +376,7 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        x = x * self.input_scale  # saliency-guided feature scaling
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -806,6 +808,41 @@ for epoch in range(MAX_EPOCHS):
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
+
+    # --- Saliency-guided input scale update (every 5 epochs) ---
+    if epoch % 5 == 0:
+        model.eval()
+        sal_x, sal_y, sal_is_surface, sal_mask = next(iter(train_loader))
+        sal_x = sal_x.to(device)
+        sal_y = sal_y.to(device)
+        sal_is_surface = sal_is_surface.to(device)
+        sal_mask = sal_mask.to(device)
+        sal_x = (sal_x - stats["x_mean"]) / stats["x_std"]
+        sal_curv = sal_x[:, :, 2:6].norm(dim=-1, keepdim=True) * sal_is_surface.float().unsqueeze(-1)
+        sal_x = torch.cat([sal_x, sal_curv], dim=-1)
+        sal_raw_xy = sal_x[:, :, :2]
+        sal_xy_min = sal_raw_xy.amin(dim=1, keepdim=True)
+        sal_xy_max = sal_raw_xy.amax(dim=1, keepdim=True)
+        sal_xy_norm = (sal_raw_xy - sal_xy_min) / (sal_xy_max - sal_xy_min + 1e-8)
+        sal_freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+        sal_xy_scaled = sal_xy_norm.unsqueeze(-1) * sal_freqs
+        sal_fourier_pe = torch.cat([sal_xy_scaled.sin().flatten(-2), sal_xy_scaled.cos().flatten(-2)], dim=-1)
+        sal_x = torch.cat([sal_x, sal_fourier_pe], dim=-1).requires_grad_(True)
+        sal_Umag, sal_q = _umag_q(sal_y, sal_mask)
+        sal_y_phys = _phys_norm(sal_y, sal_Umag, sal_q)
+        sal_y_norm = (sal_y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+        with torch.enable_grad():
+            sal_out = _base_model({"x": sal_x})
+            sal_pred = sal_out["preds"]
+            sal_surf_mask = sal_is_surface.bool()
+            sal_surf_err = (sal_pred - sal_y_norm).abs()
+            sal_surf_loss = (sal_surf_err * sal_surf_mask.unsqueeze(-1)).sum() / sal_surf_mask.sum().clamp(min=1)
+            sal_grad = torch.autograd.grad(sal_surf_loss, sal_x)[0]  # [B, N, D]
+        saliency = sal_grad.abs().mean(dim=(0, 1))  # [D]
+        saliency = F.normalize(saliency, dim=0)
+        with torch.no_grad():
+            _base_model.input_scale.data.mul_(0.9).add_(0.1 * saliency)
+        model.train()
 
     # --- Validate across all splits ---
     eval_model = ema_model if ema_model is not None else model


### PR DESCRIPTION
## Hypothesis
Every 5 epochs, compute input saliency (gradient of surface loss w.r.t. input features). Rescale inputs by saliency to concentrate the preprocess MLP's capacity on what matters for surface pressure.

## Instructions
1. Add input_scale = nn.Parameter(torch.ones(fun_dim + space_dim))
2. Every 5 epochs: compute grad = autograd.grad(surf_loss, x_input) on a mini-batch
3. Update input_scale via EMA: input_scale = 0.9 * input_scale + 0.1 * abs(grad).mean(dim=(0,1)).normalize()
4. Apply: x = x * input_scale before preprocess
5. Run with `--wandb_group grad-saliency`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** `xphzphoi` (`norman/grad-saliency`)
**Best epoch:** 56
**Peak memory:** ~24.7 GB (saliency computation requires storing activations for backprop)
**Runtime:** 31.8 min (killed by timeout)

**Implementation note:** `input_scale` applied before `feature_cross` in the forward pass. Saliency computed via `torch.autograd.grad(surf_loss, x_input)` using `_base_model` (uncompiled) to avoid torch.compile/autograd interactions. Run state shows "failed" due to pre-existing visualization shape error (not training error).

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 0.6083 | 18.83 |
| val_ood_cond | 0.7186 | 14.33 |
| val_ood_re | 0.5489 | 27.81 |
| val_tandem_transfer | 1.6114 | 38.02 |
| **Combined** | **0.8718** | — |

**vs baseline (0.8555):** +0.0163 (worse)

| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8555 | 0.8718 | **+0.0163** ✗ |
| in_dist surf_p | 17.48 | 18.83 | +1.35 ✗ |
| ood_cond surf_p | 13.59 | 14.33 | +0.74 ✗ |
| ood_re surf_p | 27.57 | 27.81 | +0.24 ✗ |
| tandem surf_p | 38.53 | 38.02 | **−0.51** ✓ |

### What happened
Gradient-based saliency reweighting made most metrics worse, with only tandem improving slightly (−0.51). The combined val/loss increased by 0.016.

Several issues likely contributed:
1. **Scale interference with feature_cross**: Applying `input_scale` before `feature_cross` changes the effective feature magnitudes that `feature_cross` sees. Since `feature_cross` is initialized as identity (but learned), the `input_scale` effectively re-weighting inputs may destabilize the learned cross-feature interactions.
2. **Gradient-saliency is noisy on 1 batch**: The saliency gradient from a single mini-batch (batch_size=4) over N~85k nodes per sample is a very noisy estimate of true feature importance. The EMA helps but the noise-to-signal ratio is high.
3. **Saliency favors pressure input features which may already be downweighted**: The optimizer may have already implicitly learned to weight features appropriately. Overriding this with explicit saliency rescaling creates conflicting gradient signals.
4. **Memory overhead**: Saliency computation adds ~10 GB of memory (storing activations for backward), which may reduce effective batch throughput.

### Suggested follow-ups
- Try `input_scale` as a non-learnable buffer (only EMA-updated, not trained by optimizer) to remove the conflicting gradient signals.
- Apply `input_scale` AFTER `feature_cross` (closer to `preprocess`) to avoid interfering with cross-feature interactions.
- Use a larger saliency batch (e.g., 32 samples from train_loader) to reduce gradient noise.
- The tandem improvement (−0.51) might indicate the saliency is learning something useful for tandem configurations — worth exploring whether a tandem-specific feature weighting could help.