### PR TITLE
Cond rank modulation v2 (rank-8, include gap/stagger)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,16 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        # Rank-8 conditioned output modulation: A[n_hidden,8] fixed, B[8,out_dim] conditioned
+        _rank = 8
+        self.rank_A = nn.Parameter(torch.empty(n_hidden, _rank))
+        nn.init.normal_(self.rank_A, std=0.01)
+        self.cond_B_mlp = nn.Sequential(
+            nn.Linear(4, 32), nn.GELU(),
+            nn.Linear(32, _rank * out_dim),
+        )
+        nn.init.zeros_(self.cond_B_mlp[-1].weight)
+        nn.init.zeros_(self.cond_B_mlp[-1].bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -375,6 +385,8 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        # Extract condition: Re, AoA, gap, stagger
+        cond = x[:, 0, [13, 14, 21, 22]]  # [B, 4]
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
@@ -396,6 +408,10 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        # Rank-8 modulation: fx_pre [B,N,192] @ rank_A [192,8] @ B_cond [B,8,3] → [B,N,3]
+        B_mat = self.cond_B_mlp(cond).reshape(cond.shape[0], 8, -1)  # [B, 8, out_dim]
+        rank_mod = torch.bmm(fx_pre @ self.rank_A, B_mat)  # [B, N, out_dim]
+        fx = fx + rank_mod
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
Variant of tanjiro's rank-4 modulation: use rank-8 and include gap/stagger in condition (4-dim instead of 2-dim). More expressive regime-specific decoding.

## Instructions
1. Same as tanjiro's but: condition = [log_Re, AoA, gap, stagger] (4-dim)
2. Rank-8 instead of rank-4: A[192,8], B[8,3]
3. Run with `--wandb_group cond-rank-mod-v2`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** `za5yj30l`
**Epochs:** 54 (30-min timeout)
**Peak VRAM:** 16.4 GB (vs 14.8 GB baseline — +1.6 GB)

**Implementation:** Fixed A[192,8] (learned parameter, normal init std=0.01), B conditioned on [Re,AoA,gap,stagger]: `cond_B_mlp` 4→32→24, zero-init output layer. Modulation: `fx_pre @ rank_A @ B_mat` added to output after skip connection.

| Metric | Baseline (lr=2.5e-3) | This run | Δ |
|--------|----------------------|----------|---|
| val/loss | 0.8555 | 0.8832 | +0.0277 ↑ worse |
| surf_p in_dist | 17.48 | 18.37 | +0.89 ↑ worse |
| surf_p ood_cond | 13.59 | 14.43 | +0.84 ↑ worse |
| surf_p ood_re | 27.57 | 27.89 | +0.32 ↑ worse |
| surf_p tandem | 38.53 | 38.48 | -0.05 ↓ ≈same |
| **mean3** | **23.20** | **23.76** | +0.56 ↑ worse |

(mean3 = avg of in_dist + ood_cond + tandem surf_p)

**Surface MAE breakdown (best epoch 54):**
| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 5.21 | 1.74 | 18.37 |
| ood_cond | 3.04 | 1.08 | 14.43 |
| ood_re | 2.76 | 0.92 | 27.89 |
| tandem | 6.05 | 2.33 | 38.48 |

**What happened:** Rank-8 modulation with 4-dim condition made things slightly worse than baseline on all metrics except tandem (essentially tied). A few issues:

1. **Slower training**: 54 epochs vs ~60 for baseline — the `fx_pre @ rank_A @ B_mat` computation added overhead. This matters at the 30-minute cutoff.

2. **rank_A not converging**: With B_mat starting at zero (zero-init), the gradient through `rank_A` is also zero initially. rank_A uses normal(0.01) init and accumulates gradients only as B_mat learns. This late start for rank_A may prevent it from finding useful directions in the 30-minute window.

3. **fx_pre vs post-block hidden**: The modulation is applied to `fx_pre` (pre-block hidden state). This is the preprocess output before any attention. Using a richer post-attention representation might have been more effective.

4. **VRAM cost**: +1.6 GB vs baseline — computing `torch.bmm(fx_pre @ rank_A, B_mat)` for [B,N,192] inputs is expensive.

Note: if tanjiro's rank-4 result was better with just 2-dim condition (Re, AoA), the 4-dim version adding gap/stagger might be adding noise rather than signal — the condition MLP has more inputs but the same capacity.

**Suggested follow-ups:**
1. If tanjiro's rank-4 worked, investigate whether rank-4 with 4-dim condition beats rank-8 (simpler is better principle).
2. Try applying the modulation to the post-attention hidden state (after blocks[-1] input, before mlp2) rather than fx_pre.
3. Initialize rank_A with non-zero values (e.g., SVD of baseline out_skip weights) to give it a useful starting point.