### PR TITLE
Asymmetric gradient: pressure 3x (stronger pressure emphasis)

### DIFF
--- a/train.py
+++ b/train.py
@@ -60,6 +60,18 @@ ACTIVATION = {
 }
 
 
+class GradientScale(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, scale):
+        ctx.save_for_backward(torch.tensor(scale))
+        return x
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (scale,) = ctx.saved_tensors
+        return grad_output * scale.item(), None
+
+
 class GatedMLP(nn.Module):
     def __init__(self, n_input, n_hidden, n_output, act='gelu'):
         super().__init__()
@@ -396,6 +408,11 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        # Asymmetric gradient scaling: pressure 3x, velocity 0.5x
+        fx = torch.cat([
+            GradientScale.apply(fx[:, :, :2], 0.5),
+            GradientScale.apply(fx[:, :, 2:3], 3.0),
+        ], dim=-1)
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis  
Variant of emma's 2x: try 3x pressure gradient scale. More aggressive pressure emphasis.

## Instructions
1. Same GradientScale approach but pressure scale=3.0, velocity scale=0.5
2. Run with \`--wandb_group asym-grad-p3x\`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** \`9p14xx6z\`  
**Best epoch:** 59  
**val/loss:** 0.9491 (baseline: 0.8555) ❌ worse  
**mean3 (surf_p avg):** 24.27 (baseline: 23.20) ❌ worse  
**Peak memory:** ~14.8 GB  

### Metrics by split

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6551 | 9.60 | 2.70 | 18.33 | 1.52 | 0.52 | 20.28 |
| val_ood_cond | 0.8016 | 6.81 | 1.91 | 15.03 | 1.01 | 0.40 | 13.29 |
| val_tandem_transfer | 1.7276 | 8.34 | 3.01 | 39.45 | 2.52 | 1.12 | 39.68 |
| val_ood_re | 0.6120 | 6.51 | 1.70 | 28.40 | 1.06 | 0.45 | 47.41 |

### What happened

Pressure 3x gradient scaling made things worse across the board. val/loss went from 0.8555 to 0.9491 (+10.9%), and pressure MAE degraded in all splits. The more aggressive emphasis appears to destabilize training rather than help — surface errors went up for both velocity and pressure.

The gradient scaling mechanism itself is zero forward-pass cost and clean to implement, but 3x seems too aggressive. With pressure gradients 6x larger than velocity gradients (3.0 vs 0.5), the model likely over-rotates toward pressure at the cost of overall convergence quality. The volume losses also increased notably (in_dist vol: 0.1796 vs expected ~0.13 at baseline).

This suggests the effective loss signal imbalance at 3x/0.5x (6:1 ratio) hurts joint optimization. Even though pressure accuracy is our primary metric, the model needs the velocity gradients to learn good representations.

The visualization crash is a pre-existing issue — training metrics are valid.

### Suggested follow-ups
- Try emma's 2x approach to establish whether 2x is beneficial before escalating to 3x
- Try an intermediate scale (1.5x pressure / 0.75x velocity) with a smaller effective ratio (2:1)
- Consider applying gradient scaling only to surface nodes, not volume nodes — the pressure volume loss degradation suggests the emphasis may be harming the 3D field representation