### PR TITLE
Alternating epochs 3:1 cadence (more surface emphasis)

### DIFF
--- a/train.py
+++ b/train.py
@@ -637,6 +637,11 @@ for epoch in range(MAX_EPOCHS):
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Alternating 3:1 cadence: every 4th epoch uses surf_weight=40 (surface-focused)
+    if epoch % 4 == 3:
+        surf_weight = 40.0
+    else:
+        surf_weight = 5.0
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis
Variant of senku's 2:1: try 3:1 (3 volume, 1 surface). More surface epochs.

## Instructions
1. if epoch % 4 == 3: surface-only training with surf_weight=40
2. else: normal training with surf_weight=5
3. Run with `--wandb_group alt-epochs-3-1`

## Baseline: val_loss=0.8555
---
## Results

**W&B run**: 5vhhgmlk | **Epochs**: 59 (30-min cap) | **Peak memory**: 14.8 GB

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6142 | 6.51 | 2.19 | 18.59 | 1.17 | 0.39 | 20.25 |
| val_tandem_transfer | 1.6619 | 6.21 | 2.57 | 39.77 | 2.00 | 0.91 | 38.82 |
| val_ood_cond | 0.7382 | 3.16 | 1.11 | 14.66 | 0.75 | 0.29 | 12.78 |
| val_ood_re | 0.5698 | 2.75 | 0.93 | 28.20 | 0.84 | 0.37 | 47.58 |
| **combined** | **0.8960** | | | | | | |

**vs baseline (0.8555)**: val/loss +4.7% worse. All four splits degraded.

### What happened

The 3:1 alternating cadence (surf_weight=40 every 4th epoch, else 5) is clearly **negative** — it hurts across all splits compared to the baseline dynamic weighting. Forcing surf_weight=5 on 3 out of 4 epochs is more restrictive than the adaptive formula, which naturally balanced to higher weights (clamped to [5,50] based on loss ratio). In practice the dynamic weight was likely running well above 5 during most of training; hard-clamping it down to 5 on 75% of epochs starves surface learning. The cadence also introduces abrupt surf_weight jumps (5→40→5) that may destabilize the optimizer.

Senku's 2:1 variant (if it exists in W&B) would be worth comparing directly to see whether any cadence outperforms continuous dynamic weighting.

### Suggested follow-ups

- Compare to senku's 2:1 results: if that also failed, drop the alternating-epoch idea entirely
- Try a gentler modulation: rather than hard-setting surf_weight to 5/40, keep the dynamic formula but multiply by 0.5 on 3 out of 4 epochs (so the ratio-based logic still applies, just with reduced surface emphasis on most epochs)
- Alternatively, investigate whether there's a better baseline for the dynamic weight floor (currently 5); raising it to 10 consistently might help