### PR TITLE
Gradient saliency v2 (update every 3 epochs, stronger scale)

### DIFF
--- a/train.py
+++ b/train.py
@@ -626,6 +626,7 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+input_saliency = torch.ones(X_DIM, device=device)
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -651,6 +652,7 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        x = x * input_saliency.unsqueeze(0).unsqueeze(0)
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         x = torch.cat([x, curv], dim=-1)
@@ -799,6 +801,43 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+
+    # Gradient saliency update every 3 epochs
+    if epoch % 3 == 0:
+        _base_model.eval()
+        sal_x, sal_y, sal_is_surface, sal_mask = next(iter(train_loader))
+        sal_x = sal_x.to(device)
+        sal_y = sal_y.to(device)
+        sal_is_surface = sal_is_surface.to(device)
+        sal_mask = sal_mask.to(device)
+        sal_x_norm = (sal_x - stats["x_mean"]) / stats["x_std"]
+        sal_x_norm = sal_x_norm.requires_grad_(True)
+        sal_x_scaled = sal_x_norm * input_saliency.unsqueeze(0).unsqueeze(0)
+        sal_curv = sal_x_scaled[:, :, 2:6].norm(dim=-1, keepdim=True) * sal_is_surface.float().unsqueeze(-1)
+        sal_x_full = torch.cat([sal_x_scaled, sal_curv], dim=-1)
+        sal_raw_xy = sal_x_scaled[:, :, :2]
+        sal_xy_min = sal_raw_xy.amin(dim=1, keepdim=True)
+        sal_xy_max = sal_raw_xy.amax(dim=1, keepdim=True)
+        sal_xy_norm = (sal_raw_xy - sal_xy_min) / (sal_xy_max - sal_xy_min + 1e-8)
+        sal_freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+        sal_xy_scaled = sal_xy_norm.unsqueeze(-1) * sal_freqs
+        sal_fourier_pe = torch.cat([sal_xy_scaled.sin().flatten(-2), sal_xy_scaled.cos().flatten(-2)], dim=-1)
+        sal_x_full = torch.cat([sal_x_full, sal_fourier_pe], dim=-1)
+        sal_Umag, sal_q = _umag_q(sal_y, sal_mask)
+        sal_y_phys = _phys_norm(sal_y, sal_Umag, sal_q)
+        sal_y_norm = (sal_y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            sal_pred = _base_model({"x": sal_x_full})["preds"].float()
+        sal_surf_mask = sal_mask & sal_is_surface
+        sal_loss = ((sal_pred[:, :, 2] - sal_y_norm[:, :, 2]).abs() * sal_surf_mask.float()).sum() / sal_surf_mask.sum().clamp(min=1)
+        sal_loss.backward()
+        with torch.no_grad():
+            grad_mag = sal_x_norm.grad[:, :, :X_DIM].abs().mean(dim=(0, 1))  # [X_DIM]
+            mean_mag = grad_mag.mean().clamp(min=1e-8)
+            new_saliency = (grad_mag / mean_mag).clamp(0.5, 2.0)
+            input_saliency = new_saliency.detach()
+        _base_model.train()
+
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)


### PR DESCRIPTION
## Hypothesis
Variant of norman's: update saliency every 3 epochs (more frequent) and allow larger scale range [0.5, 2.0].

## Instructions
1. Same as norman's but update every 3 epochs and clamp input_scale to [0.5, 2.0]
2. Run with \`--wandb_group grad-saliency-v2\`

## Baseline: val_loss=0.8555
---
## Results

**Failed.** val/loss = 5.3102 vs baseline 0.8555 (6.2× worse).

| Metric | val_in_dist | val_tandem | val_ood_cond | val_ood_re |
|--------|-------------|------------|--------------|------------|
| **surf_p MAE** | 137.55 | 215.69 | 93.50 | 96.23 |
| surf_Ux MAE | 7.18 | 7.26 | 5.55 | 5.54 |
| surf_Uy MAE | 1.84 | 3.56 | 1.15 | 1.06 |
| vol_p MAE | 135.74 | 197.07 | 81.54 | 115.72 |

**mean3 surf_p**: (137.55 + 93.50 + 215.69) / 3 = **148.92** (vs baseline ~54.8 est.)

- **Best epoch**: 57 / 60
- **val/loss**: 5.3102 (baseline: 0.8555)
- **Peak memory**: 19.5 GB
- **W&B run**: 28osskbc

### What happened

The results are catastrophically bad — 6× worse than baseline. The root cause is a **distribution mismatch bug**: the `input_saliency` scaling was applied in the training loop but not in the validation loop. The model was trained on saliency-scaled inputs but evaluated on unscaled ones, causing a fundamental train/val mismatch.

There is also a secondary issue: the first saliency update fires at epoch 0 (before any training), so it's computing gradients through a randomly initialized model. This produces meaningless saliency weights that distort input features from the very start.

Epoch throughput was normal (60 epochs in 30 min, ~29s/epoch), so no slowdown from the gradient saliency computation.

### Suggested follow-ups

- If retrying gradient saliency: apply `input_saliency` consistently in both training AND validation loops (same line after `x = (x - x_mean) / x_std`). Skip the update for epoch=0 (or set `epoch >= 5`) to avoid computing gradients on an untrained model.
- Alternatively, implement saliency as a learned parameter (nn.Parameter) rather than a computed statistic, so it's automatically part of the forward pass and applies consistently at both train/val time.