### PR TITLE
Contrastive v2 (temperature 0.05, weight 0.01)

### DIFF
--- a/train.py
+++ b/train.py
@@ -393,11 +393,12 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
+        fx_hidden = fx  # [B, N, n_hidden] — save for contrastive loss
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "fx_hidden": fx_hidden}
 
 
 # ---------------------------------------------------------------------------
@@ -698,6 +699,7 @@ for epoch in range(MAX_EPOCHS):
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
+            fx_hidden = out.get("fx_hidden")
         pred = pred.float()
         re_pred = re_pred.float()
         aoa_pred = aoa_pred.float()
@@ -778,6 +780,26 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+
+        # Contrastive loss: InfoNCE on surface embeddings (temperature=0.05, weight=0.01)
+        if fx_hidden is not None:
+            fx_h = fx_hidden.float()
+            surf_cnt = surf_mask.sum(dim=1, keepdim=True).float().clamp(min=1)
+            surf_embed = (fx_h * surf_mask.unsqueeze(-1).float()).sum(dim=1) / surf_cnt
+            surf_embed = F.normalize(surf_embed, dim=-1)
+            sim = surf_embed @ surf_embed.T / 0.05
+            src_labels = is_tandem.long()
+            B_ct = src_labels.shape[0]
+            eye_mask = torch.eye(B_ct, dtype=torch.bool, device=device)
+            pos_mask = (src_labels.unsqueeze(0) == src_labels.unsqueeze(1)) & ~eye_mask
+            has_pos = pos_mask.any(dim=1)
+            if has_pos.any():
+                sim_stable = sim - sim.amax(dim=1, keepdim=True).detach()
+                exp_sim = sim_stable.exp()
+                pos_sum = (exp_sim * pos_mask.float()).sum(dim=1).clamp(min=1e-8)
+                all_sum = (exp_sim * (~eye_mask).float()).sum(dim=1).clamp(min=1e-8)
+                ct_loss = -torch.log(pos_sum / all_sum)
+                loss = loss + 0.01 * ct_loss[has_pos].mean()
 
         optimizer.zero_grad()
         loss.backward()


### PR DESCRIPTION
## Hypothesis
Variant of thorfinn's contrastive: lower temperature (0.05, sharper) and higher weight (0.01). Stronger regularizer.

## Instructions
1. Same as thorfinn's but temperature=0.05 and loss weight=0.01
2. Run with `--wandb_group contrastive-v2`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** pan9jr9d
**Epochs completed:** 55/100 (30-min timeout)
**Peak memory:** 16.8GB (+2.0GB vs baseline — fx_hidden stays in compute graph)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8555 | 0.8982 | +5.0% worse |
| val_in_dist | mae_surf_p | 17.48 | 18.70 | +7.0% worse |
| val_ood_cond | mae_surf_p | 13.59 | 15.11 | +11.2% worse |
| val_tandem_transfer | mae_surf_p | 38.53 | 39.50 | +2.5% worse |
| val_ood_re | mae_surf_p | 27.57 | 28.30 | +2.6% worse |
| **mean3** | mae_surf_p | **23.20** | **24.44** | **+5.3% worse** |

Surface MAE (full breakdown, last epoch):
- **in_dist:** Ux=5.40, Uy=1.94, p=18.70 | Vol: Ux=1.12, Uy=0.37, p=19.64
- **ood_cond:** Ux=3.07, Uy=1.26, p=15.11 | Vol: Ux=0.74, Uy=0.28, p=12.63
- **ood_re:** Ux=2.54, Uy=1.02, p=28.30 | Vol: Ux=0.84, Uy=0.37, p=47.02
- **tandem_transfer:** Ux=5.66, Uy=2.50, p=39.50 | Vol: Ux=1.96, Uy=0.88, p=38.59

### What happened

The contrastive loss with temperature=0.05 and weight=0.01 degraded performance across all splits by 2.5-11.2%. The ood_cond split regressed the most (+11.2%), which is striking because ood_cond samples are all non-tandem — they should be in the same positive cluster as in_dist samples, yet they got worse.

Two factors likely caused the degradation:

1. **Temperature too sharp (0.05)**: At this temperature, the InfoNCE loss creates very strong gradients to push tandem and non-tandem clusters apart. However, many in_dist, ood_cond, and ood_re samples have very different physics (different Re, AoA) but are forced into a single "non-tandem" cluster. The model is pushed to make these dissimilar samples look similar in the embedding space, which may conflict with learning discriminative features.

2. **Memory overhead**: The retained fx_hidden tensor increased peak memory by 2GB (from 14.8 to 16.8GB), which also slowed training (55 epochs vs ~57 for baseline).

3. **Weight too high (0.01)**: At this weight, the contrastive loss is significant relative to the main prediction loss, potentially pulling the model away from the prediction objective.

### Suggested follow-ups

- **Finer-grained labels**: Instead of binary tandem/non-tandem, use source dataset labels if accessible, or cluster by physics range (Re bins, AoA bins) for more meaningful positive pairs.
- **Detach + smaller weight**: Try detaching fx_hidden from the compute graph (prevent backprop) and using a smaller weight (0.001) to avoid disrupting main loss gradients.
- **Temperature 0.1 baseline**: thorfinn's original temperature=0.1 likely yields softer supervision — try that first before going sharper.