### PR TITLE
LR-diverse model soup 3x10min (average weights from lr=2e-3, 2.5e-3, 3e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -569,18 +569,8 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
-)
+SOUP_LRS = [2e-3, 2.5e-3, 3e-3] if getattr(cfg, 'wandb_group', None) == "lr-soup-3x10" else [cfg.lr]
+PHASE_TIMEOUT = MAX_TIMEOUT / len(SOUP_LRS) if len(SOUP_LRS) > 1 else MAX_TIMEOUT
 
 # --- wandb ---
 run = wandb.init(
@@ -616,367 +606,475 @@ model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
-best_val = float("inf")
-ema_val_loss = float("inf")
-ema_decay_val = 0.9
-best_metrics = {}
+soup_results = []
 global_step = 0
 train_start = time.time()
-prev_vol_loss = 1.0
-prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
-running_tandem_loss = 0.05
-running_nontandem_loss = 0.05
 
-for epoch in range(MAX_EPOCHS):
-    elapsed_min = (time.time() - train_start) / 60.0
-    if elapsed_min >= MAX_TIMEOUT:
-        print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {MAX_TIMEOUT} min). Stopping.")
-        break
+for _phase_idx, _phase_lr in enumerate(SOUP_LRS):
+    print(f"\n=== Phase {_phase_idx+1}/{len(SOUP_LRS)}: lr={_phase_lr:.4f} ===")
+    _phase_ckpt = model_dir / f"phase{_phase_idx}.pt"
+    model = torch.compile(Transolver(**model_config).to(device), mode="reduce-overhead")
+    _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
+    ema_model = None
+    attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+    other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+    base_opt = torch.optim.AdamW([
+        {'params': attn_params, 'lr': _phase_lr * 0.5},
+        {'params': other_params, 'lr': _phase_lr}
+    ], weight_decay=cfg.weight_decay)
+    optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+    scheduler = torch.optim.lr_scheduler.SequentialLR(
+        base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    )
+    best_val = float("inf")
+    ema_val_loss = float("inf")
+    ema_decay_val = 0.9
+    best_metrics = {}
+    phase_start = time.time()
+    prev_vol_loss = 1.0
+    prev_surf_loss = 0.2
+    running_tandem_loss = 0.05
+    running_nontandem_loss = 0.05
 
-    t0 = time.time()
+    for epoch in range(MAX_EPOCHS):
+        elapsed_min = (time.time() - phase_start) / 60.0
+        if elapsed_min >= PHASE_TIMEOUT:
+            print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {PHASE_TIMEOUT} min). Stopping.")
+            break
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+        t0 = time.time()
 
-    # --- Train ---
-    model.train()
-    epoch_vol = 0.0
-    epoch_surf = 0.0
-    n_batches = 0
+        # Adaptive surface weight: loss-ratio based, clamped [5, 50]
+        surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
-    pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
-        x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
-        is_surface = is_surface.to(device, non_blocking=True)
-        mask = mask.to(device, non_blocking=True)
+        # --- Train ---
+        model.train()
+        epoch_vol = 0.0
+        epoch_surf = 0.0
+        n_batches = 0
 
-        x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
-        # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
-        raw_xy = x[:, :, :2]
-        # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
-        xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-        freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
-        x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
-        Umag, q = _umag_q(y, mask)
-        y_phys = _phys_norm(y, Umag, q)
-        y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+        pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
+        for x, y, is_surface, mask in pbar:
+            x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+            is_surface = is_surface.to(device, non_blocking=True)
+            mask = mask.to(device, non_blocking=True)
 
-        # Per-sample std normalization: skip tandem samples (gap feature index 21)
-        raw_gap = x[:, 0, 21]
-        is_tandem = raw_gap.abs() > 0.5
-        B = y_norm.shape[0]
-        sample_stds = torch.ones(B, 1, 3, device=device)
-        channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
-        tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
-        if model.training:
-            for b in range(B):
-                valid = mask[b]
-                if is_tandem[b]:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                else:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
-            y_norm = y_norm / sample_stds
+            x = (x - stats["x_mean"]) / stats["x_std"]
+            # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+            curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+            x = torch.cat([x, curv], dim=-1)
+            # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
+            raw_xy = x[:, :, :2]
+            # Normalize xy to [0,1] per-sample for consistent Fourier encoding
+            xy_min = raw_xy.amin(dim=1, keepdim=True)
+            xy_max = raw_xy.amax(dim=1, keepdim=True)
+            xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+            freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+            xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+            fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+            x = torch.cat([x, fourier_pe], dim=-1)
+            if model.training and epoch < 60:
+                noise_scale = 0.05 * (1 - epoch / 60)
+                x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+            Umag, q = _umag_q(y, mask)
+            y_phys = _phys_norm(y, Umag, q)
+            y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+            if model.training:
+                noise_progress = min(1.0, epoch / 60)
+                vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
+                p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+                noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
+                y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
-        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
-            pred = out["preds"]
-            re_pred = out["re_pred"]
-            aoa_pred = out["aoa_pred"]
-        pred = pred.float()
-        re_pred = re_pred.float()
-        aoa_pred = aoa_pred.float()
-        if model.training:
-            pred = pred / sample_stds
-        sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
-        if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
-
-        # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
-            vol_indices = vol_mask.nonzero(as_tuple=False)
-            n_vol = vol_indices.shape[0]
-            n_keep = max(int(n_vol * vol_keep_ratio), 1)
-            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
-            vol_mask_train = torch.zeros_like(vol_mask)
-            if n_keep > 0:
-                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
-        else:
-            vol_mask_train = vol_mask
-
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-        tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
-        nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
-        running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
-        running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
-            surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
-            surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
-            thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
-            thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
-            hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
-            hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-        adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
-        tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
-        surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
-
-        # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
-        B, N, C = pred.shape
-        n_groups = N // coarse_pool_size
-        if n_groups > 1:
-            # Sort by x-coordinate for spatially coherent groups
-            raw_x_coord = x[:, :, 0]  # x-coordinate
-            sort_idx = raw_x_coord.argsort(dim=1)
-            pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
-            y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
-            mask_sorted = torch.gather(mask, 1, sort_idx)
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
-            y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
-
-            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
-
-            coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
-
-        log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
-        re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
-        aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
-        aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
-        loss = loss + 0.01 * aoa_loss
-
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(_base_model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
-
-        epoch_vol += vol_loss.item()
-        epoch_surf += surf_loss.item()
-        n_batches += 1
-        pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
-
-    scheduler.step()
-    if epoch >= 50:
-        with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
-    epoch_vol /= n_batches
-    epoch_surf /= n_batches
-    prev_vol_loss = epoch_vol
-    prev_surf_loss = epoch_surf
-
-    # --- Validate across all splits ---
-    eval_model = ema_model if ema_model is not None else model
-    eval_model.eval()
-    model.eval()
-    val_metrics_per_split: dict[str, dict] = {}
-    val_loss_sum = 0.0
-
-    for split_name, vloader in val_loaders.items():
-        val_vol = 0.0
-        val_surf = 0.0
-        mae_surf = torch.zeros(3, device=device)
-        mae_vol = torch.zeros(3, device=device)
-        n_surf = torch.zeros(3, device=device)
-        n_vol = torch.zeros(3, device=device)
-        n_vbatches = 0
-
-        with torch.no_grad():
-            for x, y, is_surface, mask in tqdm(
-                vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
-            ):
-                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
-                is_surface = is_surface.to(device, non_blocking=True)
-                mask = mask.to(device, non_blocking=True)
-
-                x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
-                # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
-                raw_xy = x[:, :, :2]
-                # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
-                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
-                x = torch.cat([x, fourier_pe], dim=-1)
-                Umag, q = _umag_q(y, mask)
-                y_phys = _phys_norm(y, Umag, q)
-                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-
-                # Per-sample std normalization: skip tandem samples
-                raw_gap = x[:, 0, 21]
-                is_tandem = raw_gap.abs() > 0.5
-                B = y_norm.shape[0]
-                sample_stds = torch.ones(B, 1, 3, device=device)
-                channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
-                tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+            # Per-sample std normalization: skip tandem samples (gap feature index 21)
+            raw_gap = x[:, 0, 21]
+            is_tandem = raw_gap.abs() > 0.5
+            B = y_norm.shape[0]
+            sample_stds = torch.ones(B, 1, 3, device=device)
+            channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
+            tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+            if model.training:
                 for b in range(B):
                     valid = mask[b]
                     if is_tandem[b]:
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
                     else:
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
-                y_norm_scaled = y_norm / sample_stds
+                y_norm = y_norm / sample_stds
 
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
-                pred = pred.float()
-                pred_loss = pred / sample_stds
-                sq_err = (pred_loss - y_norm_scaled) ** 2
-                abs_err = (pred_loss - y_norm_scaled).abs()
-                abs_err = abs_err.nan_to_num(0.0)
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                out = model({"x": x})
+                pred = out["preds"]
+                re_pred = out["re_pred"]
+                aoa_pred = out["aoa_pred"]
+            pred = pred.float()
+            re_pred = re_pred.float()
+            aoa_pred = aoa_pred.float()
+            if model.training:
+                pred = pred / sample_stds
+            sq_err = (pred - y_norm) ** 2
+            abs_err = (pred - y_norm).abs()
+            if epoch < 10:
+                is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+                sample_mask = (~is_tandem_curr).float()[:, None, None]
+                abs_err = abs_err * sample_mask
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
 
-                vol_mask = mask & ~is_surface
-                surf_mask = mask & is_surface
-                val_vol += min(
-                    (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
-                    1e6
-                )
-                val_surf += min(
-                    (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item(),
-                    1e6
-                )
-                n_vbatches += 1
+            # Progressive resolution: subsample volume nodes in loss early in training
+            # Ramps from 10% → 100% of volume nodes over first 40 epochs
+            if epoch < 40:
+                vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+                vol_indices = vol_mask.nonzero(as_tuple=False)
+                n_vol = vol_indices.shape[0]
+                n_keep = max(int(n_vol * vol_keep_ratio), 1)
+                perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
+                vol_mask_train = torch.zeros_like(vol_mask)
+                if n_keep > 0:
+                    vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
+            else:
+                vol_mask_train = vol_mask
 
-                # Denormalize: phys_stats → Cp space → original scale
-                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
-                pred_orig = _phys_denorm(pred_phys, Umag, q)
-                y_clamped = y.clamp(-1e6, 1e6)
-                err = (pred_orig - y_clamped).abs()
-                finite = err.isfinite()
-                err = err.where(finite, torch.zeros_like(err))
-                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
-                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
-                n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
-                n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+            vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+            is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
+            surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
+            nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
+            running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
+            running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
+            # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
+            if epoch >= 30:
+                surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+                surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
+                surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
+                thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
+                thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
+                hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
+                hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
+                surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
+            tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
+            surf_loss = (surf_per_sample * tandem_boost).mean()
+            loss = vol_loss + surf_weight * surf_loss
 
-        val_vol /= max(n_vbatches, 1)
-        val_surf /= max(n_vbatches, 1)
-        val_vol = float(torch.tensor(val_vol).nan_to_num(0.0).clamp(max=1e6))
-        val_surf = float(torch.tensor(val_surf).nan_to_num(0.0).clamp(max=1e6))
-        split_loss = val_vol + cfg.surf_weight * val_surf
-        mae_surf /= n_surf.clamp(min=1)
-        mae_vol /= n_vol.clamp(min=1)
+            # Multi-scale loss: coarse spatial pooling
+            coarse_pool_size = 64
+            B, N, C = pred.shape
+            n_groups = N // coarse_pool_size
+            if n_groups > 1:
+                # Sort by x-coordinate for spatially coherent groups
+                raw_x_coord = x[:, :, 0]  # x-coordinate
+                sort_idx = raw_x_coord.argsort(dim=1)
+                pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
+                y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
+                mask_sorted = torch.gather(mask, 1, sort_idx)
+                # Pool predictions and targets over groups of 64 nodes
+                pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
+                y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
+                mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
-        val_metrics_per_split[split_name] = {
-            f"{split_name}/vol_loss":    val_vol,
-            f"{split_name}/surf_loss":   val_surf,
-            f"{split_name}/loss":        split_loss,
-            f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
-            f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
-            f"{split_name}/mae_vol_p":   mae_vol[2].item(),
-            f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
-            f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
-            f"{split_name}/mae_surf_p":  mae_surf[2].item(),
-        }
-        val_loss_sum += split_loss
+                pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+                y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+                mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
-    # 4-split val/loss (all splits) — used for checkpoint selection
-    _checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names
-    _checkpoint_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _checkpoint_names
+                coarse_err = (pred_coarse - y_coarse).abs()
+                coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+                loss = loss + 1.0 * coarse_loss
+
+            log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
+            re_loss = F.mse_loss(re_pred, log_re_target)
+            loss = loss + 0.01 * re_loss
+            aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
+            aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
+            loss = loss + 0.01 * aoa_loss
+
+            optimizer.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            if epoch >= ema_start_epoch:
+                if ema_model is None:
+                    ema_model = deepcopy(_base_model)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
+                            ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+            global_step += 1
+            wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+
+            epoch_vol += vol_loss.item()
+            epoch_surf += surf_loss.item()
+            n_batches += 1
+            pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
+
+        scheduler.step()
+        if epoch >= 50:
+            with torch.no_grad():
+                _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+        epoch_vol /= n_batches
+        epoch_surf /= n_batches
+        prev_vol_loss = epoch_vol
+        prev_surf_loss = epoch_surf
+
+        # --- Validate across all splits ---
+        eval_model = ema_model if ema_model is not None else model
+        eval_model.eval()
+        model.eval()
+        val_metrics_per_split: dict[str, dict] = {}
+        val_loss_sum = 0.0
+
+        for split_name, vloader in val_loaders.items():
+            val_vol = 0.0
+            val_surf = 0.0
+            mae_surf = torch.zeros(3, device=device)
+            mae_vol = torch.zeros(3, device=device)
+            n_surf = torch.zeros(3, device=device)
+            n_vol = torch.zeros(3, device=device)
+            n_vbatches = 0
+
+            with torch.no_grad():
+                for x, y, is_surface, mask in tqdm(
+                    vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
+                ):
+                    x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                    is_surface = is_surface.to(device, non_blocking=True)
+                    mask = mask.to(device, non_blocking=True)
+
+                    x = (x - stats["x_mean"]) / stats["x_std"]
+                    # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+                    curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                    x = torch.cat([x, curv], dim=-1)
+                    # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
+                    raw_xy = x[:, :, :2]
+                    # Normalize xy to [0,1] per-sample for consistent Fourier encoding
+                    xy_min = raw_xy.amin(dim=1, keepdim=True)
+                    xy_max = raw_xy.amax(dim=1, keepdim=True)
+                    xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                    freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+                    xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+                    fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                    x = torch.cat([x, fourier_pe], dim=-1)
+                    Umag, q = _umag_q(y, mask)
+                    y_phys = _phys_norm(y, Umag, q)
+                    y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+
+                    # Per-sample std normalization: skip tandem samples
+                    raw_gap = x[:, 0, 21]
+                    is_tandem = raw_gap.abs() > 0.5
+                    B = y_norm.shape[0]
+                    sample_stds = torch.ones(B, 1, 3, device=device)
+                    channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
+                    tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+                    for b in range(B):
+                        valid = mask[b]
+                        if is_tandem[b]:
+                            sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
+                        else:
+                            sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                    y_norm_scaled = y_norm / sample_stds
+
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        pred = eval_model({"x": x})["preds"]
+                    pred = pred.float()
+                    pred_loss = pred / sample_stds
+                    sq_err = (pred_loss - y_norm_scaled) ** 2
+                    abs_err = (pred_loss - y_norm_scaled).abs()
+                    abs_err = abs_err.nan_to_num(0.0)
+
+                    vol_mask = mask & ~is_surface
+                    surf_mask = mask & is_surface
+                    val_vol += min(
+                        (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
+                        1e6
+                    )
+                    val_surf += min(
+                        (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item(),
+                        1e6
+                    )
+                    n_vbatches += 1
+
+                    # Denormalize: phys_stats → Cp space → original scale
+                    pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                    pred_orig = _phys_denorm(pred_phys, Umag, q)
+                    y_clamped = y.clamp(-1e6, 1e6)
+                    err = (pred_orig - y_clamped).abs()
+                    finite = err.isfinite()
+                    err = err.where(finite, torch.zeros_like(err))
+                    mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                    mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                    n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+                    n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+
+            val_vol /= max(n_vbatches, 1)
+            val_surf /= max(n_vbatches, 1)
+            val_vol = float(torch.tensor(val_vol).nan_to_num(0.0).clamp(max=1e6))
+            val_surf = float(torch.tensor(val_surf).nan_to_num(0.0).clamp(max=1e6))
+            split_loss = val_vol + cfg.surf_weight * val_surf
+            mae_surf /= n_surf.clamp(min=1)
+            mae_vol /= n_vol.clamp(min=1)
+
+            val_metrics_per_split[split_name] = {
+                f"{split_name}/vol_loss":    val_vol,
+                f"{split_name}/surf_loss":   val_surf,
+                f"{split_name}/loss":        split_loss,
+                f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
+                f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
+                f"{split_name}/mae_vol_p":   mae_vol[2].item(),
+                f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
+                f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
+                f"{split_name}/mae_surf_p":  mae_surf[2].item(),
+            }
+            val_loss_sum += split_loss
+
+        # 4-split val/loss (all splits) — used for checkpoint selection
+        _checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names
+        _checkpoint_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _checkpoint_names
+                              if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
+                                      torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
+        val_loss_3split = sum(_checkpoint_losses) / max(len(_checkpoint_losses), 1)
+        ema_val_loss = val_loss_3split if ema_val_loss == float("inf") else ema_decay_val * ema_val_loss + (1 - ema_decay_val) * val_loss_3split
+
+        # 4-split val/loss (all splits including ood_re)
+        _4split_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in VAL_SPLIT_NAMES
                           if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
                                   torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
-    val_loss_3split = sum(_checkpoint_losses) / max(len(_checkpoint_losses), 1)
-    ema_val_loss = val_loss_3split if ema_val_loss == float("inf") else ema_decay_val * ema_val_loss + (1 - ema_decay_val) * val_loss_3split
+        val_loss_4split = sum(_4split_losses) / max(len(_4split_losses), 1)
 
-    # 4-split val/loss (all splits including ood_re)
-    _4split_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in VAL_SPLIT_NAMES
-                      if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
-                              torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
-    val_loss_4split = sum(_4split_losses) / max(len(_4split_losses), 1)
+        dt = time.time() - t0
 
-    dt = time.time() - t0
-
-    # --- Log to wandb ---
-    metrics = {
-        "train/vol_loss": epoch_vol,
-        "train/surf_loss": epoch_surf,
-        "val/loss": val_loss_3split,
-        "val/loss_3split": val_loss_3split,
-        "val/loss_4split": val_loss_4split,
-        "lr": scheduler.get_last_lr()[0],
-        "epoch_time_s": dt,
-    }
-    for split_metrics in val_metrics_per_split.values():
-        metrics.update(split_metrics)
-    metrics["global_step"] = global_step
-    learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
-    for i, f in enumerate(learned_freqs):
-        metrics[f"fourier_freq_{i}"] = f
-    wandb.log(metrics)
-
-    if torch.cuda.is_available():
-        peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
-    else:
-        peak_mem_gb = 0.0
-
-    tag = ""
-    if ema_val_loss < best_val:
-        best_val = ema_val_loss
-        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split}
+        # --- Log to wandb ---
+        metrics = {
+            "train/vol_loss": epoch_vol,
+            "train/surf_loss": epoch_surf,
+            "val/loss": val_loss_3split,
+            "val/loss_3split": val_loss_3split,
+            "val/loss_4split": val_loss_4split,
+            "lr": scheduler.get_last_lr()[0],
+            "epoch_time_s": dt,
+        }
         for split_metrics in val_metrics_per_split.values():
-            for k, v in split_metrics.items():
-                best_metrics[f"best_{k}"] = v
-        save_model = ema_model if ema_model is not None else model
-        torch.save(save_model.state_dict(), model_path)
-        tag = f" * -> {model_path}"
+            metrics.update(split_metrics)
+        metrics["global_step"] = global_step
+        learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
+        for i, f in enumerate(learned_freqs):
+            metrics[f"fourier_freq_{i}"] = f
+        wandb.log(metrics)
 
-    split_summary = "  ".join(
-        f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
-        for name in VAL_SPLIT_NAMES
-    )
-    print(
-        f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
-        f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
-        f"val[{split_summary}]{tag}"
-    )
+        if torch.cuda.is_available():
+            peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
+        else:
+            peak_mem_gb = 0.0
 
+        tag = ""
+        if ema_val_loss < best_val:
+            best_val = ema_val_loss
+            best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split}
+            for split_metrics in val_metrics_per_split.values():
+                for k, v in split_metrics.items():
+                    best_metrics[f"best_{k}"] = v
+            save_model = ema_model if ema_model is not None else model
+            torch.save(save_model.state_dict(), _phase_ckpt)
+            tag = f" * -> {_phase_ckpt}"
+
+        split_summary = "  ".join(
+            f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
+            for name in VAL_SPLIT_NAMES
+        )
+        print(
+            f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
+            f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
+            f"val[{split_summary}]{tag}"
+        )
+
+    if best_metrics:
+        soup_results.append((best_val, _phase_ckpt, _phase_lr, best_metrics))
+    torch.cuda.empty_cache()
+
+
+def _eval_soup_state(sd):
+    """Evaluate a state dict on all val splits. Returns mean val/loss."""
+    _m = Transolver(**model_config).to(device)
+    _m.load_state_dict(sd)
+    _m.eval()
+    total = 0.0
+    n_splits = 0
+    with torch.no_grad():
+        for _sn, _vl in val_loaders.items():
+            vv, vs, nb = 0.0, 0.0, 0
+            for x, y, is_surface, mask in _vl:
+                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                is_surface = is_surface.to(device, non_blocking=True)
+                mask = mask.to(device, non_blocking=True)
+                x = (x - stats["x_mean"]) / stats["x_std"]
+                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv], dim=-1)
+                raw_xy = x[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm_e = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs_e = torch.cat([_m.fourier_freqs_fixed.to(device), _m.fourier_freqs_learned.abs()])
+                xy_sc = xy_norm_e.unsqueeze(-1) * freqs_e
+                fpe = torch.cat([xy_sc.sin().flatten(-2), xy_sc.cos().flatten(-2)], dim=-1)
+                x = torch.cat([x, fpe], dim=-1)
+                Umag, q = _umag_q(y, mask)
+                y_n = (_phys_norm(y, Umag, q) - phys_stats["y_mean"]) / phys_stats["y_std"]
+                raw_gap = x[:, 0, 21]
+                is_tan = raw_gap.abs() > 0.5
+                B = y_n.shape[0]
+                ss = torch.ones(B, 1, 3, device=device)
+                cc = torch.tensor([0.1, 0.1, 0.5], device=device)
+                tc = torch.tensor([0.3, 0.3, 1.0], device=device)
+                for b in range(B):
+                    vd = mask[b]
+                    ss[b, 0] = y_n[b, vd].std(dim=0).clamp(min=(tc if is_tan[b] else cc))
+                y_ns = y_n / ss
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pr = _m({"x": x})["preds"]
+                pr = pr.float() / ss
+                ae = (pr - y_ns).abs().nan_to_num(0.0)
+                vm = mask & ~is_surface
+                sm = mask & is_surface
+                vv += min((ae * vm.unsqueeze(-1)).sum().item() / vm.sum().clamp(min=1).item(), 1e6)
+                vs += min((ae[:, :, 2:3] * sm.unsqueeze(-1)).sum().item() / sm.sum().clamp(min=1).item(), 1e6)
+                nb += 1
+            sp = float(torch.tensor((vv + cfg.surf_weight * vs) / max(nb, 1)).nan_to_num(0.0).clamp(max=1e6))
+            total += sp
+            n_splits += 1
+    del _m
+    torch.cuda.empty_cache()
+    return total / max(n_splits, 1)
+
+
+if len(SOUP_LRS) > 1 and len(soup_results) >= 2:
+    import shutil
+    print("\n=== Greedy Model Soup ===")
+    soup_results.sort(key=lambda x: x[0])
+    soup_sd = torch.load(soup_results[0][1], map_location="cpu", weights_only=True)
+    soup_val = _eval_soup_state(soup_sd)
+    print(f"  Base lr={soup_results[0][2]:.4f}  val={soup_val:.4f}")
+    for _sv, _sp, _slr, _sm in soup_results[1:]:
+        cand = torch.load(_sp, map_location="cpu", weights_only=True)
+        avg = {k: (soup_sd[k].float() + cand[k].float()) / 2.0 for k in soup_sd}
+        avg_val = _eval_soup_state(avg)
+        print(f"  +lr={_slr:.4f}: avg_val={avg_val:.4f} (prev={soup_val:.4f})")
+        if avg_val < soup_val:
+            soup_sd = avg
+            soup_val = avg_val
+    torch.save(soup_sd, model_path)
+    wandb.log({"soup/val_loss": soup_val, "global_step": global_step})
+    wandb.summary.update({"soup_val_loss": soup_val})
+    print(f"  Final soup val/loss = {soup_val:.4f}")
+    best_metrics = soup_results[0][3]
+    best_metrics["soup_val_loss"] = soup_val
+elif soup_results:
+    best_metrics = soup_results[0][3]
+    if soup_results[0][1].exists():
+        import shutil
+        shutil.copy(str(soup_results[0][1]), str(model_path))
+else:
+    best_metrics = {}
 
 # --- Final summary ---
 total_time = (time.time() - train_start) / 60.0
@@ -984,7 +1082,8 @@ print("\n" + "=" * 70)
 print(f"TRAINING COMPLETE ({total_time:.1f} min)")
 print("=" * 70)
 if best_metrics:
-    print(f"Best model at epoch {best_metrics['epoch']}  (val/loss={best_metrics['val_loss']:.4f})")
+    _vl = best_metrics.get('soup_val_loss', best_metrics.get('val_loss', float('nan')))
+    print(f"Best model (val/loss={_vl:.4f})")
     for split_name in VAL_SPLIT_NAMES:
         k_p = f"best_{split_name}/mae_surf_p"
         k_l = f"best_{split_name}/loss"
@@ -996,31 +1095,33 @@ else:
 if best_metrics:
     wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})
 
-    print("\nGenerating flow field plots...")
-    vis_model = ema_model if ema_model is not None else model
-    vis_model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
-    vis_model.eval()
-    plot_dir = Path("plots") / run.id
-    n = 1 if cfg.debug else 4
-    for split_name, split_ds in val_splits.items():
-        samples = []
-        for i in range(min(n, len(split_ds))):
-            x, y_true, is_surface = split_ds[i]
-            with torch.no_grad():
-                x_dev = x.unsqueeze(0).to(device)
-                y_dev = y_true.unsqueeze(0).to(device)
-                is_surf_dev = is_surface.unsqueeze(0).to(device)
-                mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
-                x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
-                curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                x_n = torch.cat([x_n, curv], dim=-1)
-                Umag, q = _umag_q(y_dev, mask)
-                pred = vis_model({"x": x_n})["preds"].float()
-                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
-                y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
-            samples.append((x[:, :2], y_true, y_pred, is_surface))
-        images = visualize(samples, out_dir=plot_dir / split_name)
-        if images:
-            wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})
+    if model_path.exists():
+        print("\nGenerating flow field plots...")
+        vis_model = Transolver(**model_config).to(device)
+        vis_model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
+        vis_model.eval()
+        plot_dir = Path("plots") / run.id
+        n = 1 if cfg.debug else 4
+        for split_name, split_ds in val_splits.items():
+            samples = []
+            for i in range(min(n, len(split_ds))):
+                x, y_true, is_surface = split_ds[i]
+                with torch.no_grad():
+                    x_dev = x.unsqueeze(0).to(device)
+                    y_dev = y_true.unsqueeze(0).to(device)
+                    is_surf_dev = is_surface.unsqueeze(0).to(device)
+                    mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
+                    x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
+                    curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
+                    x_n = torch.cat([x_n, curv], dim=-1)
+                    Umag, q = _umag_q(y_dev, mask)
+                    pred = vis_model({"x": x_n})["preds"].float()
+                    pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                    y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
+                samples.append((x[:, :2], y_true, y_pred, is_surface))
+            images = visualize(samples, out_dir=plot_dir / split_name)
+            if images:
+                wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})
 
 wandb.finish()
+


### PR DESCRIPTION
## Hypothesis
Train 3 models for 10 min each with different LRs (2e-3, 2.5e-3, 3e-3), then AVERAGE their final weights. LR-diverse trajectories explore different loss basins. Greedy soup: start with best single model, add others only if averaging improves val_loss. This is the Wortsman et al. (ICML 2022) model soups approach. 30-min budget perfectly splits into 3x10min.

## Instructions
1. Train model A with lr=2e-3 for 10 min, save weights
2. Train model B with lr=2.5e-3 for 10 min, save weights  
3. Train model C with lr=3e-3 for 10 min, save weights
4. Greedy soup: start with best single model. Average with 2nd best — keep if improves. Average with 3rd — keep if improves.
5. Evaluate the soup model on all 4 validation splits
6. Run with `--wandb_group lr-soup-3x10`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** tbdyhiup  
**Approach:** 3 phases × 10 min each (lr=2e-3, 2.5e-3, 3e-3), greedy soup

| Metric | Baseline | This run |
|--------|----------|----------|
| val/loss (4-split) | 0.8555 | **1.8111** |
| val_in_dist/mae_surf_p | — | 49.6 |
| val_tandem_transfer/mae_surf_p | — | 64.3 |
| val_ood_cond/mae_surf_p | — | 39.4 |
| val_ood_re/mae_surf_p | — | 45.4 |

**Individual phase val/loss (approx., from greedy soup eval):**
- Phase 1 (lr=2e-3): ~1.81 (not best)
- Phase 2 (lr=2.5e-3): 1.8111 (best)
- Phase 3 (lr=3e-3): ~1.81 (not best)

**Greedy soup:** Both candidates (lr=2e-3 and lr=3e-3) made things catastrophically worse when averaged with the base model (avg_val ~11.5). Soup degenerated — no merging occurred.

**Peak memory:** ~47 GB

### What happened

The experiment failed to improve over the baseline. Two root causes:

1. **Undertrained models:** Each phase only ran ~20 epochs (10 min × ~30 sec/epoch), vs ~57 epochs for a full 30-min run. The EMA model (which provides best checkpoints) only activates at epoch 40, so all 3 saved checkpoints came from the raw (non-EMA) compiled model. These models are far from convergence.

2. **Catastrophic averaging of undertrained models:** Wortsman et al. (2022) showed model soup works when averaging fine-tuned models that start from the same pre-trained checkpoint and have all converged to similar loss basins. Here, each model started from a different random initialization and only partially converged. Averaging their weights produced models with val/loss ~11.5 (6× worse than the individual phase models), suggesting they landed in incompatible loss basins.

3. **Wrong reference point:** The 30-min budget producing 3×10-min models is not equivalent to 1×30-min. Each 10-min model is dramatically worse than a full 30-min run, so the soup ceiling is ~1.8 instead of starting from 0.86.

### Suggested follow-ups

- **Pre-trained soup:** Start all 3 models from a saved checkpoint of a 20-epoch run, then fine-tune with different LRs for the remaining epochs. This is closer to Wortsman et al.'s setup (models share an initialization).
- **Single-run LR schedule with cycling:** Instead of parallel training, try a cosine-restart LR schedule where each restart uses a different peak LR — same wall time, no weight averaging needed.
- **Different hyperparameter axes for soup:** Soup might work better averaging models trained with different data augmentation strengths or dropout rates (keeping LR fixed), since those are less likely to produce incompatible loss basins.