### PR TITLE
PCGrad on domain-stratified gradients (resolve in-dist vs OOD conflict)

### DIFF
--- a/train.py
+++ b/train.py
@@ -41,6 +41,7 @@ from data.utils import visualize
 from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
 
 torch.set_float32_matmul_precision('high')
+torch._functorch.config.donated_buffer = False  # needed for retain_graph=True in PCGrad
 
 
 # ---------------------------------------------------------------------------
@@ -530,7 +531,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
+model = torch.compile(model, mode="default")  # "reduce-overhead" conflicts with retain_graph=True
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -749,6 +750,7 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
+        coarse_loss = torch.tensor(0.0, device=device)
         coarse_pool_size = 64
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
@@ -779,8 +781,42 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        optimizer.zero_grad()
-        loss.backward()
+        # PCGrad: group A = non-tandem + non-extreme-Re, group B = tandem + extreme-Re
+        # "extreme-Re": normalized Re feature |x[:,0,13]| > 1.5 (>1.5 std from training mean)
+        pcg_b = is_tandem_batch | (x[:, 0, 13].abs() > 1.5)
+        pcg_a = ~pcg_b
+        if pcg_a.any() and pcg_b.any():
+            # Per-sample main loss for group splitting
+            vol_per_s = (abs_err * vol_mask_train.unsqueeze(-1)).sum(dim=(1, 2)) / vol_mask_train.float().sum(dim=1).clamp(min=1)
+            main_per_s = vol_per_s + surf_weight * (surf_per_sample * tandem_boost)
+            aux = coarse_loss + 0.01 * re_loss + 0.01 * aoa_loss
+            loss_a = main_per_s[pcg_a].mean() + aux
+            loss_b = main_per_s[pcg_b].mean() + aux
+            # Backward group A, store gradients
+            optimizer.zero_grad()
+            loss_a.backward(retain_graph=True)
+            grad_a = [p.grad.clone() if p.grad is not None else torch.zeros_like(p)
+                      for p in model.parameters()]
+            # Backward group B, store gradients
+            optimizer.zero_grad()
+            loss_b.backward()
+            grad_b = [p.grad.clone() if p.grad is not None else torch.zeros_like(p)
+                      for p in model.parameters()]
+            # PCGrad projection: for each param, remove conflicting components then average
+            optimizer.zero_grad()
+            for p, ga, gb in zip(model.parameters(), grad_a, grad_b):
+                dot = (ga * gb).sum()
+                if dot < 0:
+                    gb_sq = (gb * gb).sum().clamp(min=1e-12)
+                    ga = ga - dot / gb_sq * gb
+                dot2 = (ga * gb).sum()
+                if dot2 < 0:
+                    ga_sq = (ga * ga).sum().clamp(min=1e-12)
+                    gb = gb - dot2 / ga_sq * ga
+                p.grad = (ga + gb) / 2.0
+        else:
+            optimizer.zero_grad()
+            loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         if epoch >= ema_start_epoch:


### PR DESCRIPTION
## Hypothesis
The Pareto frontier arises because samples from different flow regimes push shared parameters in opposing directions. PCGrad (Yu et al., NeurIPS 2020) projects conflicting gradients to remove the opposing component. Stratify by: (1) in-dist+ood_cond samples, (2) ood_re+tandem samples. When their gradients conflict (negative cosine similarity), project each to remove the conflicting component.

## Instructions
1. In each training step, split the batch into group A (non-tandem, non-extreme-Re) and group B (tandem + extreme-Re)
2. Compute gradients separately for each group
3. Check cosine similarity between grad_A and grad_B
4. If negative: project grad_A to remove component along grad_B, and vice versa
5. Average the projected gradients and step
6. Run with `--wandb_group pcgrad-domain`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** iy1wqudk  
**Epochs completed:** 60/100 (30-min timeout)  
**Peak memory:** 17.9 GB

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8684 | 0.8555 | +1.5% (slightly worse) |
| Surface MAE p (in_dist) | 17.54 | 17.48 | +0.3% |
| Surface MAE p (ood_cond) | 13.70 | 13.59 | +0.8% |
| Surface MAE p (ood_re) | 27.94 | 27.57 | +1.3% |
| Surface MAE p (tandem) | 39.49 | 38.53 | +2.5% |

Full Surface MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 7.01 | 2.05 | 17.54 |
| ood_cond | 3.55 | 1.30 | 13.70 |
| ood_re | 3.15 | 1.17 | 27.94 |
| tandem | 6.23 | 2.55 | 39.49 |

Volume MAE (best epoch):
| Split | Ux | Uy | p |
|-------|-----|-----|-----|
| in_dist | 1.11 | 0.36 | 18.86 |
| ood_cond | 0.71 | 0.27 | 12.02 |
| ood_re | 0.82 | 0.36 | 46.97 |
| tandem | 1.95 | 0.88 | 38.63 |

### What happened

Near-neutral to slightly negative result: +1.5% val/loss regression, all splits roughly at baseline or slightly worse.

**Implementation notes**: The standard `retain_graph=True` for double-backward conflicted with `torch.compile(mode="reduce-overhead")` — CUDA graphs don't support retained graph state. Fix was to switch to `mode="default"` (no CUDA graphs). Despite two backward passes per PCGrad step, epoch time stayed at ~28-30s (60 epochs in 30 min), similar to baseline, because PCGrad only triggers when both groups A and B are present in the batch, and Python/CUDA overhead for the projection loop over parameters is small.

**Why PCGrad didn't help**: Three possible explanations:
1. The gradient conflict between in-dist and OOD regimes may not be the primary bottleneck. If the gradients are mostly aligned (positive cos-sim), PCGrad is a no-op — and the training already handles this via adaptive surface weights and tandem boosting.
2. The group definition is imprecise: "extreme-Re" (|normalized_Re| > 1.5) is a crude proxy, and training data doesn't actually contain ood_re-style samples (Re=4.445M is fully OOD). So group B is mostly just tandem samples, not a meaningful Re-based split.
3. The compile mode change (reduce-overhead → default) may have introduced a small regression unrelated to PCGrad itself.

The negative result is informative: the model's performance gap across val splits appears to reflect data difficulty (tandem geometry is harder, ood_re is harder) rather than gradient interference that PCGrad could fix.

### Suggested follow-ups

- **Log gradient cosine similarity during training**: Before assuming conflict exists, measure it. If cos-sim between tandem/non-tandem gradients is typically positive, PCGrad is unnecessary.
- **Tandem-only PCGrad**: Split only by tandem vs non-tandem (drop the imprecise "extreme-Re" criterion). This gives a cleaner group definition.
- **Accept the Pareto frontier**: The performance gap may just reflect that tandem and ood_re are inherently harder for this model architecture, not that gradients are conflicting. Addressing it may require better tandem-specific features or a deeper model.
- **Restore mode="reduce-overhead"**: For all future experiments, the mode change may be causing a baseline regression unrelated to the hypothesis being tested.