### PR TITLE
Snapshot ensemble: 3 cosine cycles, average predictions at troughs

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,11 +576,8 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
-)
+# snapshot-ensemble-3cycle: CAWR replaces warmup+cosine; troughs at epochs 18, 36, 54
+scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=18, T_mult=1, eta_min=5e-5)
 
 # --- wandb ---
 run = wandb.init(
@@ -626,6 +623,8 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+snapshot_models = []  # snapshot-ensemble-3cycle: model copies at LR troughs
+snapshot_epochs_set = {18, 36, 54}
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -802,6 +801,11 @@ for epoch in range(MAX_EPOCHS):
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+    # snapshot-ensemble-3cycle: save model copy at each LR trough
+    if (epoch + 1) in snapshot_epochs_set:
+        snap_src = ema_model if ema_model is not None else _base_model
+        snapshot_models.append({k: v.clone().cpu() for k, v in snap_src.state_dict().items()})
+        print(f"  [snapshot] Saved snapshot at epoch {epoch+1} ({len(snapshot_models)}/3)")
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
@@ -811,6 +815,16 @@ for epoch in range(MAX_EPOCHS):
     eval_model = ema_model if ema_model is not None else model
     eval_model.eval()
     model.eval()
+    # snapshot-ensemble-3cycle: load snapshots for ensemble eval if available
+    if len(snapshot_models) > 0:
+        _snap_evals = []
+        for snap_state in snapshot_models:
+            _sm = deepcopy(_base_model)
+            _sm.load_state_dict({k: v.to(device) for k, v in snap_state.items()})
+            _sm.eval()
+            _snap_evals.append(_sm)
+    else:
+        _snap_evals = None
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -865,7 +879,11 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    if _snap_evals is not None:  # snapshot-ensemble-3cycle: average predictions
+                        preds = [m({"x": x})["preds"] for m in _snap_evals]
+                        pred = torch.stack(preds).mean(dim=0)
+                    else:
+                        pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
Replace single cosine annealing with 3 mini-cosine cycles (~18 epochs each). Save snapshot at each trough. Average PREDICTIONS from all 3 snapshots. Different from SWA (which averages weights along one trajectory) — each snapshot is from a different loss basin after LR restart.

## Instructions
1. Replace CosineAnnealingLR with CosineAnnealingWarmRestarts(T_0=18, T_mult=1)
2. At epochs ~18, ~36, ~54: save model state_dict as snapshot
3. At evaluation, load all 3 snapshots, run forward pass with each, average the 3 predictions
4. Use the averaged predictions for val metrics
5. Run with `--wandb_group snapshot-ensemble-3cycle`

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** gg5qf5p5  
**Best checkpoint:** epoch 54

| Split | val/loss | surf_p | surf_Ux | surf_Uy |
|-------|----------|--------|---------|---------|
| val_in_dist | 0.9436 | 29.80 | 3.06 | 1.41 |
| val_ood_cond | 1.2016 | 23.59 | n/a | n/a |
| val_ood_re | 0.8810 | 34.27 | n/a | n/a |
| val_tandem_transfer | 2.3017 | 53.22 | n/a | n/a |
| **combined val/loss** | **1.3320** | | | |

**vs Baseline (val_loss=0.8555, in=17.48, ood=13.59, re=27.57, tan=38.53):**

All splits severely degraded. val/loss 1.3320 vs 0.8555 (+0.48 ❌). surf_p approximately 2× worse.

**What happened:** The snapshot ensemble idea is valid, but the implementation failed due to one critical issue: replacing the SequentialLR(warmup+cosine) with bare CAWR removed the LR warmup. Without warmup, the model starts at full LR (2.5e-3) in epoch 1, causing chaotic early training:
- Epochs 1-10: val/loss ranged 8–16, with surf_p > 200 
- Only recovered by epoch ~11 when LR had cosined down enough
- By the epoch-18 trough, the model was only at val/loss ~1.86 (vs baseline 0.85)

Once the epoch-18 snapshot was saved, subsequent evaluation used the ensemble average including this poor snapshot, which anchored performance near 1.86. The second snapshot (epoch 36) was slightly better (~1.50 for 2-snapshot ensemble), and the third (epoch 54) improved to 1.33 — but still nowhere near baseline.

The snapshot ensemble diversity mechanism appeared to work correctly — each trough improved the ensemble. But the snapshots themselves were from suboptimal training runs.

**Memory:** ~3× model memory for 3 loaded snapshots (~6MB total additional, negligible).

**Suggested follow-ups:**
- Retry with warmup preserved: SequentialLR(warmup=10 epochs, then CAWR) — adjust T_0 downward (e.g. T_0=14) so 3 troughs fit within 60 epochs: 10+14=24, 38, 52
- Or: keep standard warmup+cosine schedule but add snapshot saving at epochs 20, 40, 60 using the EXISTING schedule — avoids the CAWR instability entirely
- Test if a 2-snapshot ensemble (best 2 of 3 by val/loss) outperforms the fixed 3-snapshot approach