### PR TITLE
Fisher-scaled weight perturbation (explore loss landscape topology)

### DIFF
--- a/train.py
+++ b/train.py
@@ -474,6 +474,33 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
+
+def _fisher_eval_loss(mdl, raw_batch, _stats, _phys_stats, _device):
+    """Evaluate simple L1 loss on a raw batch for Fisher perturbation accept/reject."""
+    fx, fy, fis, fm = raw_batch
+    fx_n = (fx - _stats["x_mean"]) / _stats["x_std"]
+    curv = fx_n[:, :, 2:6].norm(dim=-1, keepdim=True) * fis.float().unsqueeze(-1)
+    fx_n = torch.cat([fx_n, curv], dim=-1)
+    raw_xy = fx_n[:, :, :2]
+    xy_min = raw_xy.amin(dim=1, keepdim=True)
+    xy_max = raw_xy.amax(dim=1, keepdim=True)
+    xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+    freqs = torch.cat([mdl.fourier_freqs_fixed.to(_device), mdl.fourier_freqs_learned.abs()])
+    xy_sc = xy_norm.unsqueeze(-1) * freqs
+    fpe = torch.cat([xy_sc.sin().flatten(-2), xy_sc.cos().flatten(-2)], dim=-1)
+    fx_n = torch.cat([fx_n, fpe], dim=-1)
+    Umag_f, q_f = _umag_q(fy, fm)
+    y_phys_f = _phys_norm(fy, Umag_f, q_f)
+    y_norm_f = (y_phys_f - _phys_stats["y_mean"]) / _phys_stats["y_std"]
+    with torch.no_grad():
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            pred_f = mdl({"x": fx_n})["preds"]
+        pred_f = pred_f.float()
+        loss_f = (pred_f - y_norm_f).abs()
+        loss_f = (loss_f * fm.unsqueeze(-1)).sum() / fm.sum().clamp(min=1)
+    return loss_f.item()
+
+
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
@@ -626,6 +653,16 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+
+# === Fisher-scaled perturbation: precompute val batch for accept/reject ===
+_FISHER_SCALE = 0.001
+_fisher_raw_batch = None
+for _fxb, _fyb, _fisb, _fmb in val_loaders["val_in_dist"]:
+    _fisher_raw_batch = (
+        _fxb.to(device), _fyb.to(device), _fisb.to(device), _fmb.to(device)
+    )
+    break
+_fisher_prev_loss = float("inf")  # reference before perturbation
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -783,6 +820,37 @@ for epoch in range(MAX_EPOCHS):
         loss.backward()
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
+        # === Fisher-scaled perturbation (after Lookahead sync) ===
+        if optimizer.step_count % optimizer.k == 0 and _fisher_raw_batch is not None:
+            _base_model.eval()
+            # Compute reference loss before perturbation
+            _ref_loss = _fisher_eval_loss(_base_model, _fisher_raw_batch, stats, phys_stats, device)
+            # Save slow params, apply Fisher-scaled noise
+            _saved_slow = [
+                [s.data.clone() for s in sg]
+                for sg in optimizer.slow_params
+            ]
+            _accepted = True
+            with torch.no_grad():
+                for sg, pg in zip(optimizer.slow_params, optimizer.base_optimizer.param_groups):
+                    for s, p in zip(sg, pg['params']):
+                        _state = optimizer.base_optimizer.state.get(p, {})
+                        _v = _state.get('exp_avg_sq', None)
+                        if _v is not None:
+                            _noise_std = _FISHER_SCALE / (_v.sqrt() + 1e-8)
+                            s.data.add_(torch.randn_like(s.data) * _noise_std)
+                            p.data.copy_(s.data)
+            # Evaluate perturbed model
+            _new_loss = _fisher_eval_loss(_base_model, _fisher_raw_batch, stats, phys_stats, device)
+            if _new_loss > _ref_loss:
+                # Reject: restore slow and fast params
+                with torch.no_grad():
+                    for sg, pg, saved_g in zip(optimizer.slow_params, optimizer.base_optimizer.param_groups, _saved_slow):
+                        for s, p, sv in zip(sg, pg['params'], saved_g):
+                            s.data.copy_(sv)
+                            p.data.copy_(sv)
+                _accepted = False
+            _base_model.train()
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)


### PR DESCRIPTION
## Hypothesis
After every Lookahead sync, add Gaussian noise scaled by inverse Fisher information (from AdamW second moment). Accept perturbation only if val_loss doesn't increase on a mini-batch. Structured noise in weight space to escape sharp minima.

## Instructions
1. After each Lookahead sync: perturb slow weights with N(0, scale/sqrt(v+eps)) where v is AdamW second moment
2. Evaluate on a small held-out batch (first batch of val_in_dist)
3. Accept perturbation if val_loss <= previous; reject otherwise
4. scale = 0.001 (small perturbation)
5. Run with --wandb_group fisher-perturb

## Baseline: val_loss=0.8555
---
## Results

**W&B run:** `mtu0dtlh` | **Epochs:** 56 (30-min timeout) | **Peak memory:** 14.9 GB

### val/loss (4-split avg)
| Metric | This run | Baseline | delta |
|--------|----------|----------|-------|
| val/loss | **0.8903** | 0.8555 | +4.1% (worse) |

### Surface MAE at best checkpoint (epoch 56)
| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 6.33 | 2.04 | 18.56 |
| val_ood_cond | 3.26 | 1.17 | 15.29 |
| val_ood_re | 2.76 | 1.01 | 28.41 |
| val_tandem_transfer | 6.20 | 2.58 | **38.01** |

### Baseline reference
| Split | surf p baseline | This run | delta |
|-------|-----------------|----------|-------|
| val_in_dist | ~18.22 | 18.56 | +1.9% |
| val_ood_cond | ~14.37 | 15.29 | +6.4% |
| val_ood_re | ~28.06 | 28.41 | +1.2% |
| val_tandem_transfer | ~38.53 | **38.01** | **-1.4%** (better) |

### Volume MAE (val_in_dist, epoch 56)
Ux=1.15, Uy=0.37, p=19.51

### What happened

Mixed result. Overall val/loss (0.8903) is worse than baseline (0.8555), but the tandem split shows a slight improvement in surface pressure (38.01 vs 38.53). The model was still improving monotonically at epoch 56 (every epoch showed a new best), suggesting it might close the gap with more training time.

**Implementation notes:**
- Fisher perturbation applied every 10 gradient steps (k=10 Lookahead sync)
- Before each perturbation: evaluate base model on first val_in_dist batch -> ref_loss
- Perturb: slow_params += N(0, scale/sqrt(v+eps)) where v is AdamW exp_avg_sq, scale=0.001
- Copy perturbed slow params to fast params
- Re-evaluate -> new_loss; reject (restore) if new_loss > ref_loss
- Added 2 forward passes per sync = ~0.6% overhead; epochs stay at ~32s (negligible)

**Why only marginal improvement:**

1. **Perturbation accepted too often or has no effect early in training.** During warmup (epochs 1-10), v is small (AdamW hasn't accumulated much), making noise_std = scale/sqrt(eps) = 10x scale, which could be large. But since the loss is large then, it gets rejected most of the time.

2. **Accept/reject on training distribution.** The val batch used for accept/reject is from val_in_dist, which shares the same distribution as training. The perturbation may accept moves that help in-dist slightly but don't generalize to tandem/OOD splits. A mixed val batch (including tandem) might work better.

3. **Scale may be too small.** With scale=0.001 and typical v~0.01, noise_std~0.01, while model parameters are O(0.1). Only 10% of parameter magnitude. This perturbation is genuinely tiny and may not meaningfully explore the loss landscape.

4. **Sync frequency.** With k=10, syncs happen ~33 times per epoch. Each sync adds a perturbation attempt. The cumulative effect over 56 epochs is modest.

**Positive signal:** Tandem surf p slightly better (38.01 vs 38.53) despite overall worse val/loss. This is consistent with the accept/reject on val_in_dist potentially biasing towards in-dist generalization at the expense of OOD/tandem.

### Suggested follow-ups
- **Larger scale:** Try scale=0.01 or 0.1; current 0.001 may be too small to meaningfully explore.
- **Mixed eval batch:** Use a batch that includes tandem samples for accept/reject, so the perturbation serves tandem generalization too.
- **Log acceptance rate:** Track how often perturbations are accepted to understand actual effect.
- **Apply only after warmup:** Skip Fisher perturbation until epoch 20+ when the model is in a more stable region.
- **Perturb only output layers:** Fisher perturbation on all params may be too scattered; focusing on the output head might improve surface predictions specifically.