### PR TITLE
Asymmetric surface reconstruction (top-K slice tokens for surface nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -144,7 +144,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
 
-    def forward(self, x, spatial_bias=None, tandem_mask=None):
+    def forward(self, x, spatial_bias=None, tandem_mask=None, surface_mask=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -181,7 +181,18 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
         out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
 
-        out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
+        # Asymmetric surface reconstruction: surface nodes only attend to top-16 slice tokens
+        if surface_mask is not None:
+            top_k_vals = slice_weights.topk(16, dim=-1).values  # [B, H, N, 16]
+            threshold = top_k_vals[..., -1:]  # [B, H, N, 1] - 16th largest value per node
+            keep_mask = slice_weights >= threshold  # [B, H, N, G]
+            surf = surface_mask[:, None, :, None]  # [B, 1, N, 1]
+            slice_weights_recon = torch.where(surf & ~keep_mask, torch.zeros_like(slice_weights), slice_weights)
+            slice_weights_recon = slice_weights_recon / (slice_weights_recon.sum(-1, keepdim=True) + 1e-8)
+        else:
+            slice_weights_recon = slice_weights
+
+        out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights_recon)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
         return self.to_out(out_x)
 
@@ -231,9 +242,9 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, surface_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask, surface_mask=surface_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -368,6 +379,7 @@ class Transolver(nn.Module):
             raise ValueError("Missing required input tensor: x")
         if condition is not None:
             raise ValueError("Transolver does not support conditioning inputs")
+        surface_mask = data.get("surface_mask", None) if isinstance(data, dict) else None
 
         if self.unified_pos:
             if pos is None:
@@ -387,13 +399,13 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, surface_mask=surface_mask)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, surface_mask=surface_mask)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
@@ -693,8 +705,9 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
+        surf_mask_input = (is_surface & mask) if epoch >= 20 else None
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "surface_mask": surf_mask_input})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -864,8 +877,9 @@ for epoch in range(MAX_EPOCHS):
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
 
+                val_surf_mask = (is_surface & mask) if epoch >= 20 else None
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    pred = eval_model({"x": x, "surface_mask": val_surf_mask})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
Surface nodes currently reconstruct from ALL 48 slice tokens. Many represent far-field physics irrelevant to surface. Restrict surface reconstruction to only the K=16 slice tokens with highest surface attention weights. Volume still uses all 48. This creates an asymmetric bottleneck that focuses surface predictions on boundary-layer physics.

## Instructions
1. After computing attention weights, for surface nodes only: mask out all but top-16 slice tokens (by weight magnitude)
2. Volume nodes: no change, use all 48 slice tokens
3. Apply masking only after epoch 20 (let attention patterns stabilize first)
4. Run with --wandb_group asym-surf-recon

## Baseline: val_loss=0.8555
- in_dist p: 17.48, ood_cond p: 13.59, ood_re p: 27.57, tandem p: 38.53, mean3=23.20

## Results

**W&B run**: ky8q7156  
**Best epoch**: 55 (30.4 min, wall-clock limit)  
**VRAM**: 15.8 GB (+0.8 GB vs baseline)  

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6113 | 5.88 | 1.90 | **18.62** | 1.13 | 0.37 | 19.41 |
| val_ood_cond | 0.7202 | 3.40 | 1.20 | **14.49** | 0.74 | 0.28 | 12.47 |
| val_ood_re | 0.5673 | 3.06 | 1.07 | 28.30 | 0.84 | 0.37 | 47.02 |
| val_tandem_transfer | 1.6755 | 6.13 | 2.38 | **39.51** | 1.97 | 0.90 | 39.05 |
| **combined** | **0.8935** | | | | | | |

**mean3 (in/ood/tan p)**: (18.62 + 14.49 + 39.51) / 3 = **24.21** vs baseline 23.20 → **+1.01, negative result**

### What happened

The asymmetric top-16 restriction degraded all four splits uniformly. The val/loss went from 0.8555 → 0.8935. Mean3 pressure degraded by 1.01. No split improved.

The hypothesis that surface nodes should only attend to their top-16 slice tokens didn't hold. Two main issues:

1. **Disruption at epoch 20**: The model spends epochs 1–19 learning attention patterns that use all 48 slice tokens. Suddenly restricting surface nodes to top-16 at epoch 20 creates a discontinuity — the slice tokens that were "discarded" may encode information the surface decoder relied on. A smooth curriculum would be better.

2. **Tandem geometry needs global context**: Surface nodes on tandem foils need information from both foils. Restricting to only 16 slice tokens concentrates reconstruction on local boundary-layer slices, potentially starving surface nodes of the far-field coupling information between the two foils that drives tandem pressure prediction.

3. **Topk threshold instability**: With softmax outputs and 48 tokens, the 16th-largest weight is often very small (near uniform distribution during early learning). The `slice_weights >= threshold` keeps ~16 but due to floating point, can include slightly more or fewer entries, creating noisy gradients.

### Suggested follow-ups

1. **Smooth curriculum**: Instead of a hard threshold at epoch 20, use a soft temperature to gradually sharpen the slice weight distribution for surface nodes (boost temperature for surface node slice logits, not cut off abruptly).
2. **Learned surface-relevance gate**: Train a small MLP that predicts a per-slice relevance score for surface nodes, used as a differentiable soft mask (rather than hard top-K).
3. **Top-K=24 or 32**: The K=16 (1/3 of tokens) may be too aggressive. Try K=24 (half), which still creates a bottleneck but discards fewer tokens.