### PR TITLE
LR-diverse soup 2x15min (lr=2e-3 and 3e-3, longer training)

### DIFF
--- a/train.py
+++ b/train.py
@@ -529,16 +529,18 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
-model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
-_base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
-
 from copy import deepcopy
-ema_model = None
-ema_start_epoch = 40
-ema_decay = 0.998
 
-n_params = sum(p.numel() for p in model.parameters())
+# ---------------------------------------------------------------------------
+# Model soup: train SOUP_N models with different LRs, average weights
+# ---------------------------------------------------------------------------
+SOUP_TIMEOUT_EACH = 15.0  # minutes per phase
+SOUP_LRS = [2e-3, 3e-3]
+
+# n_params (compute once from model_config before wandb.init)
+_tmp_model = Transolver(**model_config)
+n_params = sum(p.numel() for p in _tmp_model.parameters())
+del _tmp_model
 
 
 class Lookahead:
@@ -569,20 +571,7 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
-    {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
-)
-
-# --- wandb ---
+# --- wandb (shared across both soup phases) ---
 run = wandb.init(
     entity=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team"),
     project=os.environ.get("WANDB_PROJECT", "senpai-v1"),
@@ -609,211 +598,431 @@ for _sname in VAL_SPLIT_NAMES:
 wandb.define_metric("lr", step_metric="global_step")
 wandb.define_metric("epoch_time_s", step_metric="global_step")
 wandb.define_metric("val_predictions", step_metric="global_step")
+wandb.define_metric("soup/*", step_metric="global_step")
 
 model_dir = Path(f"models/model-{run.id}")
 model_dir.mkdir(parents=True)
-model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
-best_val = float("inf")
-ema_val_loss = float("inf")
-ema_decay_val = 0.9
-best_metrics = {}
 global_step = 0
-train_start = time.time()
-prev_vol_loss = 1.0
-prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
-running_tandem_loss = 0.05
-running_nontandem_loss = 0.05
+soup_ckpts = []
 
-for epoch in range(MAX_EPOCHS):
-    elapsed_min = (time.time() - train_start) / 60.0
-    if elapsed_min >= MAX_TIMEOUT:
-        print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {MAX_TIMEOUT} min). Stopping.")
-        break
+for _soup_phase, _phase_lr in enumerate(SOUP_LRS):
+    print(f"\n{'='*70}")
+    print(f"SOUP PHASE {_soup_phase + 1}/{len(SOUP_LRS)}  lr={_phase_lr}")
+    print(f"{'='*70}")
 
-    t0 = time.time()
+    model = Transolver(**model_config).to(device)
+    model = torch.compile(model, mode="reduce-overhead")
+    _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
-    # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    ema_model = None
+    ema_start_epoch = 40
+    ema_decay = 0.998
 
-    # --- Train ---
-    model.train()
-    epoch_vol = 0.0
-    epoch_surf = 0.0
-    n_batches = 0
+    attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+    other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+    base_opt = torch.optim.AdamW([
+        {'params': attn_params, 'lr': _phase_lr * 0.5},
+        {'params': other_params, 'lr': _phase_lr}
+    ], weight_decay=cfg.weight_decay)
+    optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+    scheduler = torch.optim.lr_scheduler.SequentialLR(
+        base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    )
 
-    pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
-        x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
-        is_surface = is_surface.to(device, non_blocking=True)
-        mask = mask.to(device, non_blocking=True)
+    model_path = model_dir / f"checkpoint_phase{_soup_phase}.pt"
+    best_val = float("inf")
+    ema_val_loss = float("inf")
+    ema_decay_val = 0.9
+    best_metrics = {}
+    train_start = time.time()
+    prev_vol_loss = 1.0
+    prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
+    running_tandem_loss = 0.05
+    running_nontandem_loss = 0.05
 
-        x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
-        # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
-        raw_xy = x[:, :, :2]
-        # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
-        xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-        freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
-        x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
-        Umag, q = _umag_q(y, mask)
-        y_phys = _phys_norm(y, Umag, q)
-        y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+    for epoch in range(MAX_EPOCHS):
+        elapsed_min = (time.time() - train_start) / 60.0
+        if elapsed_min >= SOUP_TIMEOUT_EACH:
+            print(f"Phase {_soup_phase + 1} wall-clock limit ({elapsed_min:.1f} min >= {SOUP_TIMEOUT_EACH} min). Stopping.")
+            break
 
-        # Per-sample std normalization: skip tandem samples (gap feature index 21)
-        raw_gap = x[:, 0, 21]
-        is_tandem = raw_gap.abs() > 0.5
-        B = y_norm.shape[0]
-        sample_stds = torch.ones(B, 1, 3, device=device)
-        channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
-        tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
-        if model.training:
-            for b in range(B):
-                valid = mask[b]
-                if is_tandem[b]:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                else:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
-            y_norm = y_norm / sample_stds
+        t0 = time.time()
 
-        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
-            pred = out["preds"]
-            re_pred = out["re_pred"]
-            aoa_pred = out["aoa_pred"]
-        pred = pred.float()
-        re_pred = re_pred.float()
-        aoa_pred = aoa_pred.float()
-        if model.training:
-            pred = pred / sample_stds
-        sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
-        if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
-        vol_mask = mask & ~is_surface
-        surf_mask = mask & is_surface
+        # Adaptive surface weight: loss-ratio based, clamped [5, 50]
+        surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
-        # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
-            vol_indices = vol_mask.nonzero(as_tuple=False)
-            n_vol = vol_indices.shape[0]
-            n_keep = max(int(n_vol * vol_keep_ratio), 1)
-            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
-            vol_mask_train = torch.zeros_like(vol_mask)
-            if n_keep > 0:
-                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
-        else:
-            vol_mask_train = vol_mask
+        # --- Train ---
+        model.train()
+        epoch_vol = 0.0
+        epoch_surf = 0.0
+        n_batches = 0
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-        tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
-        nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
-        running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
-        running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
-            surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
-            surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
-            thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
-            thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
-            hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
-            hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-        adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
-        tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
-        surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+        pbar = tqdm(train_loader, desc=f"Ph{_soup_phase+1} Ep{epoch+1}/{MAX_EPOCHS} [train]", leave=False)
+        for x, y, is_surface, mask in pbar:
+            x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+            is_surface = is_surface.to(device, non_blocking=True)
+            mask = mask.to(device, non_blocking=True)
 
-        # Multi-scale loss: coarse spatial pooling
-        coarse_pool_size = 64
-        B, N, C = pred.shape
-        n_groups = N // coarse_pool_size
-        if n_groups > 1:
-            # Sort by x-coordinate for spatially coherent groups
-            raw_x_coord = x[:, :, 0]  # x-coordinate
-            sort_idx = raw_x_coord.argsort(dim=1)
-            pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
-            y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
-            mask_sorted = torch.gather(mask, 1, sort_idx)
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
-            y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
+            x = (x - stats["x_mean"]) / stats["x_std"]
+            # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+            curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+            x = torch.cat([x, curv], dim=-1)
+            # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
+            raw_xy = x[:, :, :2]
+            # Normalize xy to [0,1] per-sample for consistent Fourier encoding
+            xy_min = raw_xy.amin(dim=1, keepdim=True)
+            xy_max = raw_xy.amax(dim=1, keepdim=True)
+            xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+            freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+            xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+            fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+            x = torch.cat([x, fourier_pe], dim=-1)
+            if model.training and epoch < 60:
+                noise_scale = 0.05 * (1 - epoch / 60)
+                x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+            Umag, q = _umag_q(y, mask)
+            y_phys = _phys_norm(y, Umag, q)
+            y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+            if model.training:
+                noise_progress = min(1.0, epoch / 60)
+                vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
+                p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+                noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
+                y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
-            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
+            # Per-sample std normalization: skip tandem samples (gap feature index 21)
+            raw_gap = x[:, 0, 21]
+            is_tandem = raw_gap.abs() > 0.5
+            B = y_norm.shape[0]
+            sample_stds = torch.ones(B, 1, 3, device=device)
+            channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
+            tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+            if model.training:
+                for b in range(B):
+                    valid = mask[b]
+                    if is_tandem[b]:
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
+                    else:
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                y_norm = y_norm / sample_stds
 
-            coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            loss = loss + 1.0 * coarse_loss
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                out = model({"x": x})
+                pred = out["preds"]
+                re_pred = out["re_pred"]
+                aoa_pred = out["aoa_pred"]
+            pred = pred.float()
+            re_pred = re_pred.float()
+            aoa_pred = aoa_pred.float()
+            if model.training:
+                pred = pred / sample_stds
+            sq_err = (pred - y_norm) ** 2
+            abs_err = (pred - y_norm).abs()
+            if epoch < 10:
+                is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+                sample_mask = (~is_tandem_curr).float()[:, None, None]
+                abs_err = abs_err * sample_mask
+            vol_mask = mask & ~is_surface
+            surf_mask = mask & is_surface
 
-        log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
-        re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
-        aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
-        aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
-        loss = loss + 0.01 * aoa_loss
-
-        optimizer.zero_grad()
-        loss.backward()
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(_base_model)
+            # Progressive resolution: subsample volume nodes in loss early in training
+            # Ramps from 10% → 100% of volume nodes over first 40 epochs
+            if epoch < 40:
+                vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+                vol_indices = vol_mask.nonzero(as_tuple=False)
+                n_vol = vol_indices.shape[0]
+                n_keep = max(int(n_vol * vol_keep_ratio), 1)
+                perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
+                vol_mask_train = torch.zeros_like(vol_mask)
+                if n_keep > 0:
+                    vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
             else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
-        global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+                vol_mask_train = vol_mask
 
-        epoch_vol += vol_loss.item()
-        epoch_surf += surf_loss.item()
-        n_batches += 1
-        pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
+            vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+            is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
+            surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
+            nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
+            running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
+            running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
+            # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
+            if epoch >= 30:
+                surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+                surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
+                surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
+                thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
+                thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
+                hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
+                hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
+                surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
+            tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
+            surf_loss = (surf_per_sample * tandem_boost).mean()
+            loss = vol_loss + surf_weight * surf_loss
 
-    scheduler.step()
-    if epoch >= 50:
-        with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
-    epoch_vol /= n_batches
-    epoch_surf /= n_batches
-    prev_vol_loss = epoch_vol
-    prev_surf_loss = epoch_surf
+            # Multi-scale loss: coarse spatial pooling
+            coarse_pool_size = 64
+            B, N, C = pred.shape
+            n_groups = N // coarse_pool_size
+            if n_groups > 1:
+                # Sort by x-coordinate for spatially coherent groups
+                raw_x_coord = x[:, :, 0]  # x-coordinate
+                sort_idx = raw_x_coord.argsort(dim=1)
+                pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
+                y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
+                mask_sorted = torch.gather(mask, 1, sort_idx)
+                # Pool predictions and targets over groups of 64 nodes
+                pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
+                y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
+                mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
-    # --- Validate across all splits ---
-    eval_model = ema_model if ema_model is not None else model
-    eval_model.eval()
-    model.eval()
-    val_metrics_per_split: dict[str, dict] = {}
-    val_loss_sum = 0.0
+                pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+                y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+                mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
+                coarse_err = (pred_coarse - y_coarse).abs()
+                coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+                loss = loss + 1.0 * coarse_loss
+
+            log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
+            re_loss = F.mse_loss(re_pred, log_re_target)
+            loss = loss + 0.01 * re_loss
+            aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
+            aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
+            loss = loss + 0.01 * aoa_loss
+
+            optimizer.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+            if epoch >= ema_start_epoch:
+                if ema_model is None:
+                    ema_model = deepcopy(_base_model)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
+                            ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+            global_step += 1
+            wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+
+            epoch_vol += vol_loss.item()
+            epoch_surf += surf_loss.item()
+            n_batches += 1
+            pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
+
+        scheduler.step()
+        if epoch >= 50:
+            with torch.no_grad():
+                _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+        epoch_vol /= n_batches
+        epoch_surf /= n_batches
+        prev_vol_loss = epoch_vol
+        prev_surf_loss = epoch_surf
+
+        # --- Validate across all splits ---
+        eval_model = ema_model if ema_model is not None else model
+        eval_model.eval()
+        model.eval()
+        val_metrics_per_split: dict[str, dict] = {}
+        val_loss_sum = 0.0
+
+        for split_name, vloader in val_loaders.items():
+            val_vol = 0.0
+            val_surf = 0.0
+            mae_surf = torch.zeros(3, device=device)
+            mae_vol = torch.zeros(3, device=device)
+            n_surf = torch.zeros(3, device=device)
+            n_vol = torch.zeros(3, device=device)
+            n_vbatches = 0
+
+            with torch.no_grad():
+                for x, y, is_surface, mask in tqdm(
+                    vloader, desc=f"Ph{_soup_phase+1} Ep{epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
+                ):
+                    x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                    is_surface = is_surface.to(device, non_blocking=True)
+                    mask = mask.to(device, non_blocking=True)
+
+                    x = (x - stats["x_mean"]) / stats["x_std"]
+                    # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
+                    curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                    x = torch.cat([x, curv], dim=-1)
+                    # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
+                    raw_xy = x[:, :, :2]
+                    # Normalize xy to [0,1] per-sample for consistent Fourier encoding
+                    xy_min = raw_xy.amin(dim=1, keepdim=True)
+                    xy_max = raw_xy.amax(dim=1, keepdim=True)
+                    xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                    freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+                    xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+                    fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                    x = torch.cat([x, fourier_pe], dim=-1)
+                    Umag, q = _umag_q(y, mask)
+                    y_phys = _phys_norm(y, Umag, q)
+                    y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+
+                    # Per-sample std normalization: skip tandem samples
+                    raw_gap = x[:, 0, 21]
+                    is_tandem = raw_gap.abs() > 0.5
+                    B = y_norm.shape[0]
+                    sample_stds = torch.ones(B, 1, 3, device=device)
+                    channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
+                    tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+                    for b in range(B):
+                        valid = mask[b]
+                        if is_tandem[b]:
+                            sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
+                        else:
+                            sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                    y_norm_scaled = y_norm / sample_stds
+
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        pred = eval_model({"x": x})["preds"]
+                    pred = pred.float()
+                    pred_loss = pred / sample_stds
+                    sq_err = (pred_loss - y_norm_scaled) ** 2
+                    abs_err = (pred_loss - y_norm_scaled).abs()
+                    abs_err = abs_err.nan_to_num(0.0)
+
+                    vol_mask = mask & ~is_surface
+                    surf_mask = mask & is_surface
+                    val_vol += min(
+                        (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(),
+                        1e6
+                    )
+                    val_surf += min(
+                        (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item(),
+                        1e6
+                    )
+                    n_vbatches += 1
+
+                    # Denormalize: phys_stats → Cp space → original scale
+                    pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                    pred_orig = _phys_denorm(pred_phys, Umag, q)
+                    y_clamped = y.clamp(-1e6, 1e6)
+                    err = (pred_orig - y_clamped).abs()
+                    finite = err.isfinite()
+                    err = err.where(finite, torch.zeros_like(err))
+                    mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                    mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                    n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+                    n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+
+            val_vol /= max(n_vbatches, 1)
+            val_surf /= max(n_vbatches, 1)
+            val_vol = float(torch.tensor(val_vol).nan_to_num(0.0).clamp(max=1e6))
+            val_surf = float(torch.tensor(val_surf).nan_to_num(0.0).clamp(max=1e6))
+            split_loss = val_vol + cfg.surf_weight * val_surf
+            mae_surf /= n_surf.clamp(min=1)
+            mae_vol /= n_vol.clamp(min=1)
+
+            val_metrics_per_split[split_name] = {
+                f"{split_name}/vol_loss":    val_vol,
+                f"{split_name}/surf_loss":   val_surf,
+                f"{split_name}/loss":        split_loss,
+                f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
+                f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
+                f"{split_name}/mae_vol_p":   mae_vol[2].item(),
+                f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
+                f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
+                f"{split_name}/mae_surf_p":  mae_surf[2].item(),
+            }
+            val_loss_sum += split_loss
+
+        # 4-split val/loss (all splits) — used for checkpoint selection
+        _checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names
+        _checkpoint_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _checkpoint_names
+                              if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
+                                      torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
+        val_loss_3split = sum(_checkpoint_losses) / max(len(_checkpoint_losses), 1)
+        ema_val_loss = val_loss_3split if ema_val_loss == float("inf") else ema_decay_val * ema_val_loss + (1 - ema_decay_val) * val_loss_3split
+
+        # 4-split val/loss (all splits including ood_re)
+        _4split_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in VAL_SPLIT_NAMES
+                          if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
+                                  torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
+        val_loss_4split = sum(_4split_losses) / max(len(_4split_losses), 1)
+
+        dt = time.time() - t0
+
+        # --- Log to wandb ---
+        metrics = {
+            "train/vol_loss": epoch_vol,
+            "train/surf_loss": epoch_surf,
+            "val/loss": val_loss_3split,
+            "val/loss_3split": val_loss_3split,
+            "val/loss_4split": val_loss_4split,
+            "lr": scheduler.get_last_lr()[0],
+            "epoch_time_s": dt,
+        }
+        for split_metrics in val_metrics_per_split.values():
+            metrics.update(split_metrics)
+        metrics["global_step"] = global_step
+        learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
+        for i, f in enumerate(learned_freqs):
+            metrics[f"fourier_freq_{i}"] = f
+        wandb.log(metrics)
+
+        if torch.cuda.is_available():
+            peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
+        else:
+            peak_mem_gb = 0.0
+
+        tag = ""
+        if ema_val_loss < best_val:
+            best_val = ema_val_loss
+            best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split}
+            for split_metrics in val_metrics_per_split.values():
+                for k, v in split_metrics.items():
+                    best_metrics[f"best_{k}"] = v
+            save_model = ema_model if ema_model is not None else _base_model
+            torch.save(save_model.state_dict(), model_path)
+            tag = f" * -> {model_path}"
+
+        split_summary = "  ".join(
+            f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
+            for name in VAL_SPLIT_NAMES
+        )
+        print(
+            f"Ph{_soup_phase+1} Ep{epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
+            f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
+            f"val[{split_summary}]{tag}"
+        )
+
+    # --- Per-phase summary ---
+    phase_time = (time.time() - train_start) / 60.0
+    print(f"\nPhase {_soup_phase + 1} complete ({phase_time:.1f} min)")
+    if best_metrics:
+        print(f"  Best epoch {best_metrics['epoch']}, val/loss={best_metrics['val_loss']:.4f}")
+        for split_name in VAL_SPLIT_NAMES:
+            k_p = f"best_{split_name}/mae_surf_p"
+            k_l = f"best_{split_name}/loss"
+            if k_p in best_metrics:
+                print(f"  {split_name:30s}  loss={best_metrics[k_l]:.4f}  mae_surf_p={best_metrics[k_p]:.1f}")
+        wandb.summary.update({f"phase{_soup_phase+1}_best_" + k: v for k, v in best_metrics.items()})
+    if model_path.exists():
+        soup_ckpts.append(model_path)
+
+
+# --- Soup: average checkpoints and evaluate ---
+print(f"\n{'='*70}")
+print(f"SOUP: averaging {len(soup_ckpts)} checkpoints")
+print(f"{'='*70}")
+
+if len(soup_ckpts) >= 2:
+    sdicts = [torch.load(p, map_location=device, weights_only=True) for p in soup_ckpts]
+    soup_state = {k: sum(sd[k].float() for sd in sdicts) / len(sdicts) for k in sdicts[0]}
+    soup_model = Transolver(**model_config).to(device)
+    soup_model.load_state_dict(soup_state)
+    soup_model.eval()
+
+    soup_val_metrics: dict[str, dict] = {}
     for split_name, vloader in val_loaders.items():
         val_vol = 0.0
         val_surf = 0.0
@@ -824,32 +1033,26 @@ for epoch in range(MAX_EPOCHS):
         n_vbatches = 0
 
         with torch.no_grad():
-            for x, y, is_surface, mask in tqdm(
-                vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
-            ):
+            for x, y, is_surface, mask in tqdm(vloader, desc=f"Soup eval [{split_name}]", leave=False):
                 x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
                 is_surface = is_surface.to(device, non_blocking=True)
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 x = torch.cat([x, curv], dim=-1)
-                # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
-                # Normalize xy to [0,1] per-sample for consistent Fourier encoding
                 xy_min = raw_xy.amin(dim=1, keepdim=True)
                 xy_max = raw_xy.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                freqs = torch.cat([soup_model.fourier_freqs_fixed.to(device), soup_model.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
-                # Per-sample std normalization: skip tandem samples
                 raw_gap = x[:, 0, 21]
                 is_tandem = raw_gap.abs() > 0.5
                 B = y_norm.shape[0]
@@ -865,12 +1068,10 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    pred = soup_model({"x": x})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
-                sq_err = (pred_loss - y_norm_scaled) ** 2
-                abs_err = (pred_loss - y_norm_scaled).abs()
-                abs_err = abs_err.nan_to_num(0.0)
+                abs_err = (pred_loss - y_norm_scaled).abs().nan_to_num(0.0)
 
                 vol_mask = mask & ~is_surface
                 surf_mask = mask & is_surface
@@ -884,7 +1085,6 @@ for epoch in range(MAX_EPOCHS):
                 )
                 n_vbatches += 1
 
-                # Denormalize: phys_stats → Cp space → original scale
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
                 pred_orig = _phys_denorm(pred_phys, Umag, q)
                 y_clamped = y.clamp(-1e6, 1e6)
@@ -904,123 +1104,33 @@ for epoch in range(MAX_EPOCHS):
         mae_surf /= n_surf.clamp(min=1)
         mae_vol /= n_vol.clamp(min=1)
 
-        val_metrics_per_split[split_name] = {
-            f"{split_name}/vol_loss":    val_vol,
-            f"{split_name}/surf_loss":   val_surf,
-            f"{split_name}/loss":        split_loss,
-            f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
-            f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
-            f"{split_name}/mae_vol_p":   mae_vol[2].item(),
-            f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
-            f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
-            f"{split_name}/mae_surf_p":  mae_surf[2].item(),
+        soup_val_metrics[split_name] = {
+            f"soup/{split_name}/vol_loss":    val_vol,
+            f"soup/{split_name}/surf_loss":   val_surf,
+            f"soup/{split_name}/loss":        split_loss,
+            f"soup/{split_name}/mae_surf_Ux": mae_surf[0].item(),
+            f"soup/{split_name}/mae_surf_Uy": mae_surf[1].item(),
+            f"soup/{split_name}/mae_surf_p":  mae_surf[2].item(),
+            f"soup/{split_name}/mae_vol_Ux":  mae_vol[0].item(),
+            f"soup/{split_name}/mae_vol_Uy":  mae_vol[1].item(),
+            f"soup/{split_name}/mae_vol_p":   mae_vol[2].item(),
         }
-        val_loss_sum += split_loss
+        print(f"  Soup {split_name}: loss={split_loss:.4f}  mae_surf_p={mae_surf[2].item():.1f}")
 
-    # 4-split val/loss (all splits) — used for checkpoint selection
-    _checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names
-    _checkpoint_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _checkpoint_names
-                          if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
-                                  torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
-    val_loss_3split = sum(_checkpoint_losses) / max(len(_checkpoint_losses), 1)
-    ema_val_loss = val_loss_3split if ema_val_loss == float("inf") else ema_decay_val * ema_val_loss + (1 - ema_decay_val) * val_loss_3split
+    _soup_losses = [soup_val_metrics[n][f"soup/{n}/loss"] for n in VAL_SPLIT_NAMES
+                    if not torch.tensor(soup_val_metrics[n][f"soup/{n}/loss"]).isnan()]
+    soup_val_loss = sum(_soup_losses) / max(len(_soup_losses), 1)
+    soup_log = {"soup/val_loss": soup_val_loss, "global_step": global_step}
+    for split_metrics in soup_val_metrics.values():
+        soup_log.update(split_metrics)
+    wandb.log(soup_log)
+    wandb.summary.update({"soup/val_loss": soup_val_loss})
 
-    # 4-split val/loss (all splits including ood_re)
-    _4split_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in VAL_SPLIT_NAMES
-                      if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
-                              torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
-    val_loss_4split = sum(_4split_losses) / max(len(_4split_losses), 1)
-
-    dt = time.time() - t0
-
-    # --- Log to wandb ---
-    metrics = {
-        "train/vol_loss": epoch_vol,
-        "train/surf_loss": epoch_surf,
-        "val/loss": val_loss_3split,
-        "val/loss_3split": val_loss_3split,
-        "val/loss_4split": val_loss_4split,
-        "lr": scheduler.get_last_lr()[0],
-        "epoch_time_s": dt,
-    }
-    for split_metrics in val_metrics_per_split.values():
-        metrics.update(split_metrics)
-    metrics["global_step"] = global_step
-    learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
-    for i, f in enumerate(learned_freqs):
-        metrics[f"fourier_freq_{i}"] = f
-    wandb.log(metrics)
-
-    if torch.cuda.is_available():
-        peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
-    else:
-        peak_mem_gb = 0.0
-
-    tag = ""
-    if ema_val_loss < best_val:
-        best_val = ema_val_loss
-        best_metrics = {"epoch": epoch + 1, "val_loss": val_loss_3split}
-        for split_metrics in val_metrics_per_split.values():
-            for k, v in split_metrics.items():
-                best_metrics[f"best_{k}"] = v
-        save_model = ema_model if ema_model is not None else model
-        torch.save(save_model.state_dict(), model_path)
-        tag = f" * -> {model_path}"
-
-    split_summary = "  ".join(
-        f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
-        for name in VAL_SPLIT_NAMES
-    )
-    print(
-        f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
-        f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
-        f"val[{split_summary}]{tag}"
-    )
-
-
-# --- Final summary ---
-total_time = (time.time() - train_start) / 60.0
-print("\n" + "=" * 70)
-print(f"TRAINING COMPLETE ({total_time:.1f} min)")
-print("=" * 70)
-if best_metrics:
-    print(f"Best model at epoch {best_metrics['epoch']}  (val/loss={best_metrics['val_loss']:.4f})")
-    for split_name in VAL_SPLIT_NAMES:
-        k_p = f"best_{split_name}/mae_surf_p"
-        k_l = f"best_{split_name}/loss"
-        if k_p in best_metrics:
-            print(f"  {split_name:30s}  loss={best_metrics[k_l]:.4f}  mae_surf_p={best_metrics[k_p]:.1f}")
+    soup_path = model_dir / "checkpoint_soup.pt"
+    torch.save(soup_state, soup_path)
+    print(f"\nSoup model saved: {soup_path}")
+    print(f"Soup val/loss = {soup_val_loss:.4f}")
 else:
-    print("No completed epochs (timeout too short?).")
-
-if best_metrics:
-    wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})
-
-    print("\nGenerating flow field plots...")
-    vis_model = ema_model if ema_model is not None else model
-    vis_model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
-    vis_model.eval()
-    plot_dir = Path("plots") / run.id
-    n = 1 if cfg.debug else 4
-    for split_name, split_ds in val_splits.items():
-        samples = []
-        for i in range(min(n, len(split_ds))):
-            x, y_true, is_surface = split_ds[i]
-            with torch.no_grad():
-                x_dev = x.unsqueeze(0).to(device)
-                y_dev = y_true.unsqueeze(0).to(device)
-                is_surf_dev = is_surface.unsqueeze(0).to(device)
-                mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
-                x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
-                curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                x_n = torch.cat([x_n, curv], dim=-1)
-                Umag, q = _umag_q(y_dev, mask)
-                pred = vis_model({"x": x_n})["preds"].float()
-                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
-                y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
-            samples.append((x[:, :2], y_true, y_pred, is_surface))
-        images = visualize(samples, out_dir=plot_dir / split_name)
-        if images:
-            wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})
+    print("Not enough checkpoints for soup (need >= 2).")
 
 wandb.finish()


### PR DESCRIPTION
## Hypothesis
Train 2 models 15 min each (lr=2e-3 and lr=3e-3), average weights. Longer per-model training than 3x10.

## Instructions
See the primary experiment in this direction for detailed implementation guidance.
Run with `--wandb_group lr-soup-2x15`

## Baseline: val_loss=0.8555

---

## Results

**W&B run:** `7z6y94bx`
**Runtime:** ~31 min (2 × 15 min phases + soup eval)

### Per-phase results (31 epochs each)

| Phase | lr | val/loss | in_dist surf_p | ood_cond surf_p | tandem surf_p | mean3 surf_p |
|---|---|---|---|---|---|---|
| Phase 1 | 2e-3 | 1.501 | 49.6 | 26.2 | 53.6 | 43.1 |
| Phase 2 | 3e-3 | 1.503 | 44.0 | 28.9 | 56.4 | 43.1 |
| **Baseline** | **2.5e-3** | **0.856** | — | — | — | **23.20** |

### Soup results

| Split | val/loss | surf_p MAE |
|---|---|---|
| val_in_dist | 10.19 | 362.9 |
| val_ood_cond | 10.21 | 212.6 |
| val_tandem_transfer | 13.98 | 358.1 |
| val_ood_re | 8.42 | 194.8 |
| **Soup mean** | **10.70** | **~282** |

Peak VRAM: ~15.7 GB

### What happened

The soup failed catastrophically. Individual phases are also much worse than the baseline because **31 epochs is only ~half the training budget** — the baseline runs ~60 epochs in 30 minutes.

Two compounding problems:
1. **Underfitting**: Each 15-min phase only reaches epoch 31 (~half-trained). The individual val/loss of 1.50 vs baseline 0.86 shows neither model has converged.
2. **Incompatible weight spaces**: Weight averaging of two unconverged models produces a model ~7x worse than either individual model (soup val/loss = 10.70 vs individual ~1.50). This is the classic failure mode of model soups with insufficiently trained models — the two models are in separate loss basins, and averaging their weights lands in a valley wall between them.

The 3x10 soup (10 min x 3 = 30 min total) would have the same or worse problem. The 2x15 variant gave longer per-model training but still did not reach the convergence threshold for weight averaging to work.

### Suggested follow-ups

1. **Late-epoch checkpoint soup**: Save checkpoints at epochs 50, 55, 60 of a SINGLE 30-min training run and average those. Each checkpoint is near-converged, same loss basin — weight averaging is more likely to work. Zero additional compute cost.
2. **LR-cycled soup**: Run a single 30-min training with cosine annealing that restarts multiple times; take checkpoint at each cycle nadir for averaging.
3. **Accept the baseline**: The 2x15 and 3x10 soup experiments consistently show that weight averaging with halved training budgets does not work. The baseline single-model 30-min training is better.