### PR TITLE
PCGrad: tandem vs non-tandem gradient projection

### DIFF
--- a/train.py
+++ b/train.py
@@ -786,7 +786,7 @@ for epoch in range(MAX_EPOCHS):
 
         if pcgrad_active:
             def _fwd_group_loss(idx):
-                x_g = x[idx]
+                x_g = x[idx].detach()  # detach: x shares grad path via fourier_freqs_learned
                 out_g = _base_model({"x": x_g})
                 pred_g = out_g["preds"].float() / sample_stds[idx]
                 ae_g = (pred_g - y_norm[idx]).abs()


### PR DESCRIPTION
## Hypothesis
Split gradients by tandem vs non-tandem samples only. Simpler 2-group version of PCGrad.

## Instructions
See the primary experiment in this direction for detailed implementation guidance.
Run with \`--wandb_group pcgrad-tandem-only\`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** t3wgs7vj  
**Best epoch:** 60 (wall-clock limit)  
**Peak memory:** 35.4 GB

### Key metrics

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|----------|-------------|-------------|------------|
| val_in_dist | 0.5968 | 3.05 | 1.00 | 18.38 |
| val_tandem_transfer | 1.6246 | 3.18 | 1.22 | 38.41 |
| val_ood_cond | 0.7022 | 2.86 | 0.71 | 13.86 |
| val_ood_re | 0.5348 | 2.76 | 0.64 | 27.65 |

**val/loss:** 0.8646 (baseline: 0.8555) → **+0.0091 worse**  
**mean3 (surf_p):** (18.38 + 13.86 + 38.41) / 3 = **23.55** (baseline: 23.20) → **+0.35 worse**

### What happened

PCGrad did not improve over baseline. val/loss and mean3 are both slightly worse.

The implementation required two non-trivial bug fixes before it could run:

1. **CUDAGraph reuse**: Using compiled \`model\` for sub-batch forward passes caused "backward through graph a second time" errors because \`torch.compile(mode='reduce-overhead')\` captures CUDAGraphs per input shape, and same-shaped sub-batches replayed the same graph. Fixed by using \`_base_model\` (uncompiled) for PCGrad forward passes.

2. **Shared gradient path through \`x\`**: \`x\` is built from \`model.fourier_freqs_learned.abs()\` in the training loop, so \`x.requires_grad=True\`. Both group slices (\`x[nontandem_idx]\` and \`x[tandem_idx]\`) share the same gradient path through \`x → freqs → fourier_freqs_learned\`. The first backward freed those saved tensors, causing the second backward to fail. Fixed by calling \`.detach()\` on \`x_g\` inside \`_fwd_group_loss\`, breaking the shared path.

With both fixes applied, training ran to 60 epochs without errors.

**Why it didn't help:** PCGrad triples the backward cost (3 backward passes per batch when both groups are present) with no gain. The existing adaptive_boost mechanism already handles tandem/nontandem imbalance by dynamically upweighting tandem samples based on running error ratio. Adding gradient projection on top may create conflicting signals or over-correct. The tandem split (mae_surf_p=38.41) did not improve.

**Note:** W&B run shows "failed" due to pre-existing visualization crash after training — training metrics are valid.

### Suggested follow-ups

- Could try PCGrad without adaptive_boost to test if they conflict with each other.
- Simpler alternative: fixed higher weight for tandem loss (e.g. 2x boost) — avoids the triple backward cost and may achieve a similar effect.
- If PCGrad is worth further exploration, limit projection to epochs where tandem/nontandem gap is largest (after epoch 30), reducing overhead.