### PR TITLE
Snapshot ensemble: 2 cycles of 27 epochs, average predictions

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,11 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
-)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=27, T_mult=1, eta_min=5e-5)
 
 # --- wandb ---
 run = wandb.init(
@@ -626,6 +622,7 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+snapshot_models = []  # list of eval-mode snapshot models (saved at each 27-epoch cycle end)
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -807,6 +804,14 @@ for epoch in range(MAX_EPOCHS):
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
 
+    # Save snapshot at end of each 27-epoch cycle (epochs 27, 54)
+    if (epoch + 1) % 27 == 0 and len(snapshot_models) < 2:
+        snap = deepcopy(_base_model)
+        snap.eval()
+        for p in snap.parameters():
+            p.requires_grad_(False)
+        snapshot_models.append(snap)
+
     # --- Validate across all splits ---
     eval_model = ema_model if ema_model is not None else model
     eval_model.eval()
@@ -865,7 +870,10 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    if len(snapshot_models) >= 2:
+                        pred = torch.stack([sm({"x": x})["preds"] for sm in snapshot_models], 0).mean(0)
+                    else:
+                        pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
Two longer cosine cycles instead of 3 shorter ones. Longer per-cycle gives better convergence.

## Instructions
See the primary experiment in this direction for detailed implementation guidance.
Run with `--wandb_group snapshot-2cycle`

## Baseline: val_loss=0.8555
---
## Results

**W&B run**: jtu2hljc | **Epochs**: 59 (30-min cap) | **Peak memory**: 14.8 GB

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.8406 | 3.27 | 1.53 | 26.50 | 1.45 | 0.55 | 29.13 |
| val_tandem_transfer | 2.1148 | 4.22 | 2.07 | 50.18 | 2.44 | 1.19 | 50.73 |
| val_ood_cond | 1.0542 | 2.45 | 1.18 | 21.34 | 0.95 | 0.39 | 18.39 |
| val_ood_re | 0.7759 | 2.21 | 1.01 | 32.54 | 1.01 | 0.45 | 51.12 |
| **combined** | **1.1964** | | | | | | |

**vs baseline (0.8555)**: val/loss +39.8% worse. All splits strongly degraded.

### What happened

This is **strongly negative** for two compounding reasons:

1. **Snapshot at epoch 27 is a poor ensemble member.** The epoch-27 snapshot is only halfway through training and is a much weaker model than the epoch-54 snapshot. Averaging their predictions dilutes the epoch-54 model significantly. For snapshot ensembling to work, all snapshots need to be near-comparable in quality — here they are not.

2. **Removing the warmup hurt training.** To implement CosineAnnealingWarmRestarts, I replaced the SequentialLR (warmup + cosine) with a plain WarmRestarts scheduler that starts at full LR immediately. Without the 10-epoch linear warmup, early training is less stable, and the training losses at epoch 59 are higher (vol=0.270, surf=0.068) compared to the alt-epochs run (vol=0.167, surf=0.028). The LR restarts at epoch 27 and 54 introduce additional disruption.

The 3-cycle version (PR #1447) would have the same problem if it removes warmup too. If that PR kept warmup, its snapshots may be at better quality since they're shorter cycles (18 epochs each).

### Suggested follow-ups

- This approach needs a warmup period before the first cycle: e.g., CosineAnnealingWarmRestarts starting from epoch 5 or using SequentialLR(warmup=5, cosine_warm_restarts)
- Snapshot ensembling only helps when all snapshots are strong — perhaps only snapshot from the last N cycles (N=1 or N=2 later cycles where the model has converged) would be better
- A simpler alternative: run two separate short experiments with different LRs, then average the trained models at test time (model soup)