### PR TITLE
PCGrad: OOD splits vs in-dist gradient projection

### DIFF
--- a/train.py
+++ b/train.py
@@ -530,7 +530,8 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
+torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
+model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -749,6 +750,7 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
+        _coarse_loss = None
         coarse_pool_size = 64
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
@@ -770,6 +772,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+            _coarse_loss = coarse_loss
             loss = loss + 1.0 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
@@ -779,8 +782,53 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        optimizer.zero_grad()
-        loss.backward()
+        # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
+        # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
+        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
+        is_indist_pcgrad = ~is_ood_pcgrad
+        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+
+        if use_pcgrad:
+            n_a = is_indist_pcgrad.float().sum().clamp(min=1)
+            n_b = is_ood_pcgrad.float().sum().clamp(min=1)
+            vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
+            vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
+            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
+            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
+            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
+            surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
+            coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+
+            optimizer.zero_grad()
+            loss_a.backward(retain_graph=True)
+            grads_a = [p.grad.clone() if p.grad is not None else None
+                       for p in model.parameters()]
+            optimizer.zero_grad()
+            loss_b.backward()
+
+            ga_flat = torch.cat([g.view(-1) for g in grads_a if g is not None])
+            gb_flat = torch.cat([p.grad.view(-1) for p in model.parameters() if p.grad is not None])
+            dot_ab = (ga_flat @ gb_flat).item()
+            gb_ns = float((gb_flat @ gb_flat).item()) + 1e-8
+            ga_ns = float((ga_flat @ ga_flat).item()) + 1e-8
+            for p, ga in zip(model.parameters(), grads_a):
+                gb = p.grad
+                if ga is None and gb is None:
+                    continue
+                if ga is None:
+                    pass  # keep gb
+                elif gb is None:
+                    p.grad = ga
+                elif dot_ab < 0:
+                    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
+                else:
+                    p.grad = (ga + gb) * 0.5
+        else:
+            optimizer.zero_grad()
+            loss.backward()
+
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         if epoch >= ema_start_epoch:


### PR DESCRIPTION
## Hypothesis
Stratify gradients by in-dist vs all-OOD (ood_cond+ood_re+tandem).

## Instructions
See the primary experiment in this direction for detailed implementation guidance.
Run with `--wandb_group pcgrad-ood-only`

## Baseline: val_loss=0.8555

---
## Results

**W&B run:** `78fy2yi7`

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 0.8555 | **0.8525** | −0.0030 (<1σ) |
| mae_surf_p in_dist | 17.48 | 17.03 | −0.45 |
| mae_surf_p ood_cond | 13.59 | 13.90 | +0.31 |
| mae_surf_p ood_re | 27.57 | 27.62 | +0.05 |
| mae_surf_p tandem | 38.53 | 38.14 | −0.39 |
| **mean3 mae_surf_p** | **23.27** | **23.02** | **−0.25 (~1.2σ)** |
| mae_vol_p in_dist | — | 18.12 | — |
| mae_vol_p ood_cond | — | 11.87 | — |
| mae_vol_p tandem | — | 37.91 | — |

**Peak VRAM:** ~same as baseline (PCGrad adds gradient buffers ≈ 2× grad memory, negligible vs activations)

**Implementation notes:**
- Changed `torch.compile(mode="reduce-overhead")` → `mode="default"` + `torch._functorch.config.donated_buffer=False` (required for `retain_graph=True`)
- Group A (in-dist): non-tandem AND normalized log(Re) ≤ 1σ AND |normalized AoA| ≤ 1σ
- Group B (all-OOD): tandem OR extreme-Re (>1σ) OR extreme-AoA (>1σ)
- Global cosine similarity projection: when dot(g_a, g_b) < 0, project each gradient to remove the conflicting component; average projected gradients

### What happened

Borderline null result. val/loss improved by −0.0030 (< 1σ, not significant). mean3 mae_surf_p improved by −0.25 (~1.2σ, below the 2σ threshold of 0.42).

The per-split pattern is interesting:
- **in_dist improved** (−0.45 on mae_surf_p): PCGrad protected the in-dist gradient from being dominated by OOD updates
- **tandem improved** (−0.39): tandem samples are a large fraction of group B, so their gradient is well-represented and not unduly suppressed
- **ood_cond worsened slightly** (+0.31): these samples moved from "group A" (where they had gradient alignment with in-dist) to "group B" (all-OOD), so their specific signal may have been diluted in the OOD mixture

The gradient conflict detection likely fires more often for this grouping than for the primary #1446 grouping (in-dist+ood_cond vs ood_re+tandem), since ood_cond gradients may actually be MORE aligned with in-dist than with tandem/ood_re gradients. By forcing ood_cond into the OOD group, we may be unnecessarily projecting away gradients that were helpful.

The ~2× slower per-step throughput from two backward passes means fewer epochs (~45 vs ~60), which likely offsets any gradient-quality gains.

### Suggested follow-ups

- Compare with primary PCGrad (#1446) grouping results — if #1446 shows similar pattern, it suggests the grouping boundary doesn't matter much and the mechanism itself is the issue
- Try PCGrad only after epoch 30 (once the model has learned the easy patterns), to avoid wasting the early optimization budget on gradient projections
- The ood_re group seems "neutral" (barely changed in both directions) — it may be worth a pure in-dist vs tandem-only grouping to simplify the signal