### PR TITLE
Snapshot ensemble: 4 cycles of 13 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,8 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+T_SNAPSHOT = 13  # epochs per cosine cycle (4 cycles)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(base_opt, T_0=T_SNAPSHOT, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )
@@ -626,6 +627,10 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+# Snapshot ensemble: save EMA model at trough of each cosine cycle
+WARMUP_EPOCHS = 10
+snapshot_models = []
+snapshot_save_epochs = {WARMUP_EPOCHS + k * T_SNAPSHOT - 1 for k in range(1, 5)}  # 0-indexed: 22, 35, 48, 61
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -799,6 +804,14 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+
+    # Save snapshot at each cosine cycle trough
+    if epoch in snapshot_save_epochs:
+        snap = deepcopy(ema_model if ema_model is not None else _base_model)
+        snap.eval()
+        snapshot_models.append(snap)
+        print(f"Saved snapshot #{len(snapshot_models)} at epoch {epoch+1}")
+
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
@@ -864,9 +877,16 @@ for epoch in range(MAX_EPOCHS):
                         sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
 
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
-                pred = pred.float()
+                if snapshot_models:
+                    preds_list = []
+                    for snap_m in snapshot_models:
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            preds_list.append(snap_m({"x": x})["preds"].float())
+                    pred = torch.stack(preds_list).mean(dim=0)
+                else:
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        pred = eval_model({"x": x})["preds"]
+                    pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis
More snapshots (4) from shorter cycles.

## Instructions
See the primary experiment in this direction for detailed implementation guidance.
Run with `--wandb_group snapshot-4cycle`

## Baseline: val_loss=0.8555

---

## Results

**W&B run ID:** bu73e58h  
**Best epoch:** 55 (wall-clock timeout at 30.2 min)  
**Peak memory:** ~14.8 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|----------|
| Combined | **1.0238** | 0.8555 |
| val_in_dist | 0.7212 | — |
| val_tandem_transfer | 1.7736 | — |
| val_ood_cond | 0.9009 | — |
| val_ood_re | 0.6993 | — |

### Surface MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 9.06 | 2.69 | 22.13 |
| val_tandem_transfer | 8.03 | 3.01 | 41.23 |
| val_ood_cond | 5.58 | 1.80 | 18.20 |
| val_ood_re | 5.17 | 1.63 | 30.94 |

**mean3 surf_p** = (22.13 + 18.20 + 41.23) / 3 = **27.19**

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.36 | 0.44 | 23.69 |
| val_tandem_transfer | 2.16 | 0.96 | 41.06 |
| val_ood_cond | 0.90 | 0.35 | 15.89 |
| val_ood_re | 0.99 | 0.42 | 49.33 |

---

### What happened

**Negative result.** val/loss = 1.0238 vs baseline 0.8555 — 19.7% worse. The 4-cycle (T_0=13) snapshot ensemble hurt performance.

Three snapshots were saved during the run (0-indexed epochs 22, 35, 48 = display epochs 23, 36, 49). Epoch 62 was not reached before the 30-min timeout.

Likely causes of degradation:
1. **LR restart instability**: `CosineAnnealingWarmRestarts` spikes the LR back to its peak every 13 epochs (4x total). The baseline uses smooth cosine annealing (CosineAnnealingLR, T_max=62) with no restarts. Repeated LR spikes likely destabilize EMA weights and push models away from the optima the baseline finds with a gentle monotone LR decay.
2. **Short cycles -> shallow minima**: 13 epochs per cycle is short. Models saved at cycle troughs may not have converged enough to be high-quality individual predictors. Averaging mediocre ensemble members produces a mediocre ensemble.
3. **Val eval overhead**: Calling 3 snapshot models during every validation round adds ~3x overhead per val step, but this should not affect training quality.

The primary snapshot experiment likely showed similar issues — it would be worth checking if T_0=26 (2 cycles) performs better with longer cycles.

Also note: the visualization code crashed at end-of-run with a shape mismatch (84905x25 vs 57x57), likely from a leftover feature_cross layer. This does not affect training metrics.

---

### Suggested follow-ups

- **Longer cycles**: Try T_0=25-30 (2 cycles), so each cycle allows the LR to guide toward a real local minimum.
- **Post-convergence snapshots**: Keep the smooth cosine schedule and save snapshots at the end of training (e.g., last 3 checkpoints). Diversity from slight training variance rather than aggressive LR restarts.
- **Warm restarts with gradual damping**: Use T_mult > 1 (e.g., T_mult=2) so each successive cycle doubles in length, giving later snapshots more convergence time.
