### PR TITLE
PCGrad fix: regroup ood_cond with in_dist (restore 13.59)

### DIFF
--- a/train.py
+++ b/train.py
@@ -782,49 +782,56 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
-        # Group B = tandem + extreme-Re (>1σ) only; ood_cond stays in Group A with in_dist
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0)
-        is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+        # PCGrad 3-group: in_dist+ood_cond (A) vs tandem (B) vs extreme-Re (C)
+        is_grp_c = (~is_tandem_batch) & (x[:, 0, 13] > 1.0)  # Group C: ood_re
+        is_grp_b = is_tandem_batch                             # Group B: tandem
+        is_grp_a = ~is_grp_b & ~is_grp_c                      # Group A: in_dist + ood_cond
+        pcg_masks = [m for m in [is_grp_a, is_grp_b, is_grp_c] if m.any()]
+        n_pcg = len(pcg_masks)
 
-        if use_pcgrad:
-            n_a = is_indist_pcgrad.float().sum().clamp(min=1)
-            n_b = is_ood_pcgrad.float().sum().clamp(min=1)
-            vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
-            vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
-            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
-            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
-            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
-            surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
+        if n_pcg >= 2:
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            pcg_losses = []
+            for mask in pcg_masks:
+                n_g = mask.float().sum().clamp(min=1)
+                vol_mask_g = vol_mask_train & mask.unsqueeze(1)
+                vl_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
+                sl_g = (surf_per_sample * mask.float() * tandem_boost).sum() / n_g
+                pcg_losses.append(vl_g + surf_weight * sl_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss)
 
-            optimizer.zero_grad()
-            loss_a.backward(retain_graph=True)
-            grads_a = [p.grad.clone() if p.grad is not None else None
-                       for p in model.parameters()]
-            optimizer.zero_grad()
-            loss_b.backward()
+            # Backward for each group, collecting gradients
+            params = list(model.parameters())
+            grads_list = []
+            flats = []
+            for i, lg in enumerate(pcg_losses):
+                optimizer.zero_grad()
+                lg.backward(retain_graph=(i < n_pcg - 1))
+                gpp = [p.grad.clone() if p.grad is not None else None for p in params]
+                grads_list.append(gpp)
+                flats.append(torch.cat([g.view(-1) for g in gpp if g is not None]))
 
-            ga_flat = torch.cat([g.view(-1) for g in grads_a if g is not None])
-            gb_flat = torch.cat([p.grad.view(-1) for p in model.parameters() if p.grad is not None])
-            dot_ab = (ga_flat @ gb_flat).item()
-            gb_ns = float((gb_flat @ gb_flat).item()) + 1e-8
-            ga_ns = float((ga_flat @ ga_flat).item()) + 1e-8
-            for p, ga in zip(model.parameters(), grads_a):
-                gb = p.grad
-                if ga is None and gb is None:
-                    continue
-                if ga is None:
-                    pass  # keep gb
-                elif gb is None:
-                    p.grad = ga
-                elif dot_ab < 0:
-                    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
-                else:
-                    p.grad = (ga + gb) * 0.5
+            # Pairwise PCGrad: for each group, project out conflicting other-group components
+            norms_sq = [(f @ f).item() + 1e-8 for f in flats]
+            proj_grads = []
+            for i in range(n_pcg):
+                pg = [g.clone() if g is not None else None for g in grads_list[i]]
+                for j in range(n_pcg):
+                    if j == i:
+                        continue
+                    dot_ij = (flats[i] @ flats[j]).item()
+                    if dot_ij < 0:
+                        scale = dot_ij / norms_sq[j]
+                        for k in range(len(params)):
+                            if pg[k] is not None and grads_list[j][k] is not None:
+                                pg[k] = pg[k] - scale * grads_list[j][k]
+                proj_grads.append(pg)
+
+            # Average projected gradients across active groups
+            optimizer.zero_grad()
+            for pi, p in enumerate(params):
+                gs = [proj_grads[i][pi] for i in range(n_pcg) if proj_grads[i][pi] is not None]
+                if gs:
+                    p.grad = sum(gs) / len(gs)
         else:
             optimizer.zero_grad()
             loss.backward()


### PR DESCRIPTION
## Hypothesis
The current PCGrad (PR #1456) groups ood_cond as OOD because it uses AoA > 1σ as a criterion (line 787: `x[:, 0, 14].abs() > 1.0`). But ood_cond samples have gradients more aligned with in_dist than with tandem/ood_re — the regression from 13.59 to 13.90 confirms this. Removing the AoA criterion from OOD grouping keeps ood_cond samples in Group A (in_dist), restoring the pre-PCGrad ood_cond performance while preserving PCGrad's benefits for tandem and ood_re.

## Instructions
On line 787, change the PCGrad grouping criterion:

```python
# OLD (current):
is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
# NEW (fix): only tandem and extreme-Re are OOD group, NOT extreme-AoA
is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0)
```

This removes `(x[:, 0, 14].abs() > 1.0)` so ood_cond samples stay with in_dist in Group A.

Run with `--wandb_group pcgrad-fix-grouping`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 (**regressed from 13.59**) |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

### Iteration 1: 2-group fix (remove AoA from OOD)
**W&B run:** ub2qtcau | **Epochs:** 61/100 (timeout) | **Peak memory:** ~17.6 GB

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|----------|-------------|-------------|------------|
| val_in_dist | 0.5855 | 5.45 | 1.65 | 17.81 |
| val_ood_cond | 0.6754 | 3.34 | 1.11 | **13.54** |
| val_ood_re | 0.5308 | 3.03 | 0.99 | 27.35 |
| val_tandem_transfer | 1.6487 | 5.46 | 2.11 | 39.18 |
| **combined** | **0.8601** | — | — | — |

**mean3 mae_surf_p:** 23.51 | ood_cond recovered 13.90 → 13.54 ✓ but in_dist regressed

### Iteration 2: 3-group PCGrad (A=in_dist+ood_cond, B=tandem, C=ood_re)
**W&B run:** e7y3kx23 | **Epochs:** 51/100 (timeout) | **Peak memory:** ~17.6 GB

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p |
|-------|----------|-------------|-------------|------------|
| val_in_dist | 0.6189 | 6.88 | 1.49 | 18.80 |
| val_ood_cond | 0.7728 | 4.37 | 1.06 | 15.73 |
| val_ood_re | 0.5744 | 4.03 | 0.89 | 28.30 |
| val_tandem_transfer | 1.6756 | 6.29 | 2.09 | 39.23 |
| **combined** | **0.9104** | — | — | — |

**mean3 mae_surf_p:** 24.59 | **Worse than both 2-group and noam baseline**

### What happened

**3-group approach didn't work.** Three backward passes per step makes each epoch ~19% slower (~37s vs ~31s), limiting training to only 51 epochs vs 61 for 2-group. The ood_re group is a small fraction of most batches, so its gradient estimates are noisy. The extra pairwise projections appear to over-constrain the gradient updates, hurting convergence.

The fundamental problem with the PCGrad family here: the 3 backward passes + pairwise projection computation add significant overhead without a clear benefit within the 30-minute training budget.

### Summary comparison
| Config | val/loss | mean3 | ood_cond surf_p |
|--------|----------|-------|-----------------|
| noam baseline | 0.8555 | ~23.20 | ~13.59 |
| 2-group (baseline for this PR) | 0.8525 | 23.02 | 13.90 |
| 2-group fix (iter 1) | 0.8601 | 23.51 | 13.54 |
| **3-group (iter 2)** | **0.9104** | **24.59** | **15.73** |

PCGrad does not appear to be beneficial for this model/dataset combination.

### Suggested follow-ups

- PCGrad is probably not the right lever here. The adaptive_boost mechanism already handles tandem/in_dist imbalance. May be worth confirming this with an ablation.
- If gradient conflict is genuinely the bottleneck, a much lighter approach would be to just scale the learning rate differently per group (via the tandem_boost), which is simpler and doesn't require extra backward passes.
- Explore other directions entirely: architecture changes, better positional encoding, or augmentation.