### PR TITLE
Ablate PCGrad: restore reduce-overhead compile mode

### DIFF
--- a/train.py
+++ b/train.py
@@ -530,7 +530,8 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-model = torch.compile(model, mode="reduce-overhead")
+torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
+model = torch.compile(model, mode="default")  # reduce-overhead incompatible with retain_graph=True
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -749,6 +750,7 @@ for epoch in range(MAX_EPOCHS):
         loss = vol_loss + surf_weight * surf_loss
 
         # Multi-scale loss: coarse spatial pooling
+        _coarse_loss = None
         coarse_pool_size = 64
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
@@ -770,6 +772,7 @@ for epoch in range(MAX_EPOCHS):
 
             coarse_err = (pred_coarse - y_coarse).abs()
             coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+            _coarse_loss = coarse_loss
             loss = loss + 1.0 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
@@ -779,8 +782,52 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        optimizer.zero_grad()
-        loss.backward()
+        # PCGrad: tandem (Group B) vs non-tandem (Group A) gradient projection
+        is_ood_pcgrad = is_tandem_batch
+        is_indist_pcgrad = ~is_ood_pcgrad
+        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+
+        if use_pcgrad:
+            n_a = is_indist_pcgrad.float().sum().clamp(min=1)
+            n_b = is_ood_pcgrad.float().sum().clamp(min=1)
+            vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
+            vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
+            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
+            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
+            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
+            surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
+            coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+
+            optimizer.zero_grad()
+            loss_a.backward(retain_graph=True)
+            grads_a = [p.grad.clone() if p.grad is not None else None
+                       for p in model.parameters()]
+            optimizer.zero_grad()
+            loss_b.backward()
+
+            ga_flat = torch.cat([g.view(-1) for g in grads_a if g is not None])
+            gb_flat = torch.cat([p.grad.view(-1) for p in model.parameters() if p.grad is not None])
+            dot_ab = (ga_flat @ gb_flat).item()
+            gb_ns = float((gb_flat @ gb_flat).item()) + 1e-8
+            ga_ns = float((ga_flat @ ga_flat).item()) + 1e-8
+            for p, ga in zip(model.parameters(), grads_a):
+                gb = p.grad
+                if ga is None and gb is None:
+                    continue
+                if ga is None:
+                    pass  # keep gb
+                elif gb is None:
+                    p.grad = ga
+                elif dot_ab < 0:
+                    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
+                else:
+                    p.grad = (ga + gb) * 0.5
+        else:
+            optimizer.zero_grad()
+            loss.backward()
+
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         if epoch >= ema_start_epoch:


### PR DESCRIPTION
## Hypothesis
PCGrad required switching `torch.compile(mode="reduce-overhead")` to `mode="default"` and adding `donated_buffer=False` (lines 533-534). This compile mode change may have caused a regression independent of PCGrad gradient projection. Additionally, PCGrad halves effective throughput (two backward passes). Since PCGrad only improved val_loss by 0.003 (~0.35%), removing it and restoring the original compile mode may be net positive by recovering throughput (+2-3 more epochs) and CUDA graph optimizations.

## Instructions
...

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

### Run 1: Ablation — no PCGrad, `mode=reduce-overhead` restored
**W&B run:** `jv99mzve`

| Metric | PCGrad-OOD (#1456) | This ablation | Δ |
|--------|----------|----------|---|
| val/loss | 0.8525 | 0.8608 | +0.0083 (~1.8σ, worse) |
| mae_surf_p in_dist | 17.03 | 18.03 | +1.00 |
| mae_surf_p ood_cond | 13.90 | **13.30** | **−0.60** (best ever!) |
| mae_surf_p ood_re | 27.62 | 27.61 | −0.01 |
| mae_surf_p tandem | 38.14 | 38.78 | +0.64 |
| **mean3 mae_surf_p** | 23.02 | 23.37 | +0.35 (~1.7σ) |

### Run 2 (revised per advisor feedback): PCGrad tandem-only, `mode=default`
**W&B run:** `t3wldeqb`

As the advisor noted, restoring `reduce-overhead` is incompatible with `retain_graph=True` — even with `donated_buffer=False`, CUDAGraph recording fails ("input tensor deallocate during graph recording"). Switched to `mode="default"` as the fallback, with tandem-only PCGrad grouping (`is_ood_pcgrad = is_tandem_batch`).

| Metric | PCGrad-OOD (#1456) | Tandem-only PCGrad | Orig baseline |
|--------|----------|----------|---|
| val/loss | 0.8525 | 0.8636 | 0.8555 |
| mae_surf_p in_dist | 17.03 | 17.12 | 17.48 |
| mae_surf_p ood_cond | 13.90 | 13.76 | 13.59 |
| mae_surf_p ood_re | 27.62 | 27.68 | 27.57 |
| mae_surf_p tandem | 38.14 | 38.97 | 38.53 |
| **mean3 mae_surf_p** | **23.02** | 23.28 | 23.27 |

### What happened

The tandem-only grouping hypothesis was **not confirmed**. It performed worse than the PCGrad-OOD grouping on all metrics (val_loss +0.0111, mean3 +0.26 vs PCGrad-OOD). It is approximately equivalent to the original baseline (mean3 ≈ 23.28 vs 23.27).

Two possible explanations:

1. **The tandem gradient IS the dominant OOD signal**: with tandem-only grouping, only the tandem-vs-nontandem conflict is resolved, but ood_cond and ood_re still push the non-tandem gradient in potentially conflicting directions. The PCGrad-OOD grouping, by including ood_re in Group B, was resolving an additional conflict.

2. **Throughput penalty hurts**: with ~45 epochs instead of ~60 (2× backward passes), the model hasn't converged as much. Since tandem-only PCGrad fires on ~40% of batches (tandem fraction), the overhead is higher than it might seem.

The ablation's best-ever ood_cond=13.30 suggests the ood_cond samples benefit from having no PCGrad interference at all. But the overall val_loss is worse (0.8608 > 0.8525) because in_dist and tandem regress.

**Summary**: The PCGrad-OOD variant (#1456) with in-dist vs all-OOD grouping remains the best PCGrad configuration tested. Tandem-only grouping is not an improvement.

### Suggested follow-ups

- The ood_cond=13.30 in the no-PCGrad ablation is striking. The question is whether we can preserve that while also protecting in_dist. A potential approach: PCGrad between ood_re+tandem vs in_dist+ood_cond (the primary #1446 grouping), which treats ood_cond as aligned with in_dist rather than as OOD
- Apply PCGrad only in the later half of training (after epoch 40) to reduce throughput penalty during the critical early epochs