### PR TITLE
FiLM output modulation: Re/AoA scale+shift on ln_3

### DIFF
--- a/train.py
+++ b/train.py
@@ -230,8 +230,10 @@ class TransolverBlock(nn.Module):
                 nn.GELU(),
                 nn.Linear(hidden_dim, out_dim),
             )
+            self.film_scale = nn.Linear(2, hidden_dim, bias=False)
+            self.film_bias = nn.Linear(2, hidden_dim, bias=False)
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, cond=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
@@ -240,7 +242,11 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx_normed = self.ln_3(fx)
+            if cond is not None:
+                cond_expanded = cond.unsqueeze(1).expand(-1, fx_normed.shape[1], -1)  # [B, N, 2]
+                fx_normed = fx_normed * (1 + self.film_scale(cond_expanded)) + self.film_bias(cond_expanded)
+            return self.mlp2(fx_normed)
         return fx
 
 
@@ -307,6 +313,9 @@ class Transolver(nn.Module):
             ]
         )
         self.initialize_weights()
+        # Zero-init FiLM layers so they start as identity (no effect at t=0)
+        nn.init.zeros_(self.blocks[-1].film_scale.weight)
+        nn.init.zeros_(self.blocks[-1].film_bias.weight)
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
@@ -393,7 +402,8 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        cond = torch.cat([re_pred, aoa_pred], dim=-1)  # [B, 2]
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, cond=cond)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
AdaLN on the output head (PR #1409) achieved the best-ever ood_cond (13.16) but regressed in_dist and tandem because the full AdaLN MLP added too many parameters. A lighter FiLM approach uses the already-trained Re and AoA auxiliary predictions to modulate the output LayerNorm, adding minimal parameters. The key insight: the model already predicts Re and AoA via auxiliary losses, so those predictions contain condition information for free.

## Instructions
1. In `TransolverBlock.__init__`, when `last_layer=True`, add a lightweight FiLM projection:
```python
if last_layer:
    self.film_scale = nn.Linear(2, hidden_dim, bias=False)
    nn.init.zeros_(self.film_scale.weight)  # start as identity (no effect)
    self.film_bias = nn.Linear(2, hidden_dim, bias=False)
    nn.init.zeros_(self.film_bias.weight)
```

2. Pass `re_pred` and `aoa_pred` (the scalar auxiliary predictions, from the aux heads) into the last block's forward. In the main model `forward()`, after computing `re_pred` and `aoa_pred`, pass them to the last block:
```python
cond = torch.stack([re_pred, aoa_pred], dim=-1)  # [B, 2]
```

3. In the last block's forward, modulate after `ln_3`:
```python
fx_normed = self.ln_3(fx)
if hasattr(self, 'film_scale'):
    cond_expanded = cond.unsqueeze(1).expand(-1, fx_normed.shape[1], -1)  # [B, N, 2]
    fx_normed = fx_normed * (1 + self.film_scale(cond_expanded)) + self.film_bias(cond_expanded)
return self.mlp2(fx_normed)
```

4. Run with `--wandb_group film-output-light`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `b7gp604t` | **Epochs completed:** 56 (30-min timeout) | **Peak memory:** 19.3 GB

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol |
|-------|----------|-------------|-------------|------------|---------|
| val_in_dist | 0.5996 | 7.28 | 2.29 | **17.92** | — |
| val_ood_cond | 0.7149 | 4.57 | 1.45 | **14.47** | — |
| val_ood_re | 0.5621 | 4.26 | 1.34 | **28.14** | — |
| val_tandem_transfer | 1.6586 | 6.48 | 2.64 | **39.00** | — |
| **combined** | **0.8838** | — | — | — | — |

**vs. baseline:**
| Split | surf_p baseline | surf_p result | Δ |
|-------|----------------|----------------|---|
| val_in_dist | 17.03 | 17.92 | +5.2% worse |
| val_ood_cond | 13.90 | 14.47 | +4.1% worse |
| val_ood_re | 27.62 | 28.14 | +1.9% worse |
| val_tandem_transfer | 38.14 | 39.00 | +2.3% worse |
| combined val_loss | 0.8525 | 0.8838 | +3.7% worse |

**What happened:** The FiLM modulation did not improve over baseline — all metrics are 2–5% worse. The hypothesis was that re_pred and aoa_pred carry free condition information, but there's a circular dependency: these auxiliary predictions are derived from the same hidden state `fx` that's being modulated. The FiLM conditioning is essentially conditioning the output on a noisy, global summary of its own input representation, which provides no new signal. The model already has a global SE gate (squeeze-and-excite) over `fx` that does a similar thing, and the placeholder scale/shift provides unconditional output normalization — FiLM via auxiliary predictions appears redundant given these existing mechanisms. The parameter cost is minimal (2×192 = 384 weights), so it's not a capacity issue.

**Suggested follow-ups:**
- Try conditioning on the *ground-truth* Re/AoA at training time (and zero at test time → use predicted values). This tests whether the conditioning is useful in principle, separating the question of "does condition info help?" from "are aux predictions accurate enough to use?"
- Try FiLM on the spatial bias MLP (inside attention) rather than the output LayerNorm — the condition might be more useful earlier in the computation.
- If AdaLN (#1409) worked on ood_cond, try a hybrid: AdaLN only on the output head but with fewer layers (e.g., Linear(n_hidden, 2*hidden_dim) directly, skipping the intermediate 64-dim layer).