### PR TITLE
PCGrad only every 3rd step (sparse activation)

### DIFF
--- a/train.py
+++ b/train.py
@@ -786,7 +786,7 @@ for epoch in range(MAX_EPOCHS):
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
         is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any() and (global_step % 3 == 0)
 
         if use_pcgrad:
             n_a = is_indist_pcgrad.float().sum().clamp(min=1)


### PR DESCRIPTION
## Hypothesis
The current PCGrad always computes two backward passes when both groups exist in a batch, halving effective throughput. Since gradient conflicts are intermittent, activating PCGrad only every 3rd optimization step recovers ~2/3 of throughput while retaining most gradient conflict resolution. This should yield 2-3 more epochs within the 30-min budget.

## Instructions
1. Add a step counter before the training loop (near line 700):
```python
global_step = 0
```

2. On line 789, change the PCGrad activation condition:
```python
# OLD:
use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
# NEW: only activate every 3rd step
use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any() and (global_step % 3 == 0)
```

3. After the optimizer step (after line 833), increment the counter:
```python
global_step += 1
```

4. Run with `--wandb_group pcgrad-sparse`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** hj9dvq00
**Epochs completed:** 58/100 (30-min timeout)
**Peak memory:** ~14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8525 | 0.8785 | +3.1% worse |
| val_in_dist | mae_surf_p | 17.03 | 18.64 | +9.5% worse |
| val_ood_cond | mae_surf_p | 13.90 | 13.90 | 0.0% |
| val_ood_re | mae_surf_p | 27.62 | 28.07 | +1.6% worse |
| val_tandem_transfer | mae_surf_p | 38.14 | 39.33 | +3.1% worse |
| **mean3** | mae_surf_p | **23.02** | **23.96** | **+4.1% worse** |

Surface MAE (full breakdown, epoch 58):
- **in_dist:** Ux=7.13, Uy=2.20, p=18.64 | Vol: Ux=1.09, Uy=0.36, p=19.42
- **ood_cond:** Ux=4.05, Uy=1.41, p=13.90 | Vol: Ux=0.71, Uy=0.27, p=11.94
- **ood_re:** Ux=3.52, Uy=1.20, p=28.07 | Vol: Ux=0.82, Uy=0.36, p=46.99
- **tandem_transfer:** Ux=6.40, Uy=2.55, p=39.33 | Vol: Ux=1.94, Uy=0.88, p=38.67

### What happened

Sparse PCGrad (1-in-3 steps) is worse than full PCGrad across all key splits, with mean3 regressing 4.1%. The throughput hypothesis did not pan out: epoch time remained ~30s (identical to baseline PCGrad), so no additional epochs were gained within the 30-minute budget. This suggests PCGrad's second backward pass was not the dominant cost per epoch — other compute (forward pass, validation, logging) dominates.

More importantly, the quality regression shows that gradient conflicts are not intermittent — they occur frequently enough that resolving them only 1/3 of the time is insufficient. In-dist mae_surf_p regressed 9.5%, the largest individual degradation. With 2/3 of steps receiving unresolved gradient conflicts between in-dist and OOD groups, the model can't maintain clean separation, and in-distribution quality suffers most.

The baseline PCGrad (every step) appears to be genuinely earning its compute cost. The second backward pass provides conflict resolution that outweighs its overhead.

### Suggested follow-ups

- **Verify PCGrad overhead**: Profile epoch wall-clock time with PCGrad fully disabled vs fully enabled to quantify the actual slowdown. If it's small (< 5%), sparse activation provides no throughput benefit and the idea is moot.
- **Smarter sparsity**: Instead of every-3rd-step, activate PCGrad only when conflict is detected (e.g., cosine similarity < 0 between gradients of groups A and B). This avoids the skip-on-schedule problem.
- **PCGrad on surface loss only**: Limit PCGrad to surface-related parameters to reduce backward-pass overhead while preserving the most important conflict resolution.