### PR TITLE
4D anisotropic curvature in spatial bias (directional dsdf)

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(3, 64), nn.GELU(),
+            nn.Linear(6, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -377,7 +377,7 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 2:6]], dim=-1)  # x, y, 4 dsdf channels
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]


### PR DESCRIPTION
## Hypothesis
The spatial bias MLP currently takes (x, y, curvature_scalar) as 3D input, collapsing 4 directional dsdf channels into a single norm. This loses anisotropy information (e.g., leading vs trailing edge, suction vs pressure side). Providing the 4 raw dsdf channels gives the slice routing more nuanced geometry awareness, particularly helping surface nodes at high-curvature regions where pressure gradients are steepest.

## Instructions
1. Change the spatial_bias input dimension from 3 to 6. Find the spatial_bias definition:
```python
# OLD: self.spatial_bias = nn.Sequential(nn.Linear(3, 64), ...)
# NEW: 
self.spatial_bias = nn.Sequential(
    nn.Linear(6, 64), nn.GELU(),
    nn.Linear(64, 64), nn.GELU(),
    nn.Linear(64, slice_num),
)
```

2. In forward, change `raw_xy` construction to include the 4 dsdf channels (columns 2-5) instead of the scalar curvature (column 24 or 25):
```python
# OLD: raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
# NEW: raw_xy = torch.cat([x[:, :, :2], x[:, :, 2:6]], dim=-1)   # x, y, 4 dsdf channels
```
Note: verify the exact column indices for dsdf in the 24-dim feature vector (columns 2-5 are dsdf_x1, dsdf_y1, dsdf_x2, dsdf_y2). Check the data/README.md or feature construction code to confirm.

3. Keep the zero-init on the last layer of spatial_bias (existing code).

4. Run with `--wandb_group aniso-spatial-bias`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `i3l87v9m` | Best epoch: 57 | Peak memory: 18.1 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6119 | 18.9 | +10.9% worse |
| val_ood_cond | 0.7214 | 14.3 | +2.9% worse |
| val_ood_re | 0.5481 | 27.9 | +1.0% worse |
| val_tandem_transfer | 1.6431 | 38.9 | +2.0% worse |
| **combined** | **0.8811** | — | **+3.4% worse** |

### What happened

Negative result. Replacing the curvature scalar with the 4 raw dsdf channels made things uniformly slightly worse across all splits, with in-distribution suffering the most (+10.9% on mae_surf_p).

The likely reason: the curvature proxy (`norm(dsdf[2:6]) * is_surface`) was a compact and clean signal — it emphasized surface geometry where it matters (masked to surface nodes only) and collapsed directional redundancy. The raw dsdf channels give more information in principle, but in practice they introduce noise for volume nodes (where dsdf values are less meaningful as surface curvature proxies), and the directional decomposition may not be worth the added input dimensionality for what is ultimately a low-capacity routing function (3→6 input to a 64-dim hidden layer).

The magnitude of the degradation is small (combined val/loss 0.8811 vs 0.8525, ~3%) suggesting the spatial bias is not the bottleneck and the model is somewhat robust to its quality.

### Suggested follow-ups

- Try including only `dsdf[2:6]` for surface nodes (masked like the curvature scalar was): `x[:, :, 2:6] * is_surface.unsqueeze(-1)` — this would preserve the anisotropy signal while keeping the masking that made the scalar version clean. Input would be 6D as here.
- The tandem split (loss 1.6431) continues to dominate the combined metric; the spatial bias changes don't seem to help tandem much — consider geometry-specific routing ideas rather than signal refinement.