### PR TITLE
Multi-rate EMA: blend decay=0.995 and 0.999 at inference

### DIFF
--- a/train.py
+++ b/train.py
@@ -538,6 +538,11 @@ from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
 ema_decay = 0.998
+# dual-ema: two EMA models at different decay rates
+ema_model_fast = None  # decay=0.995, captures recent updates
+ema_model_slow = None  # decay=0.999, long-term smoothing
+ema_decay_fast = 0.995
+ema_decay_slow = 0.999
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -834,10 +839,16 @@ for epoch in range(MAX_EPOCHS):
         if epoch >= ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
+                ema_model_fast = deepcopy(_base_model)  # dual-ema: initialize fast EMA
+                ema_model_slow = deepcopy(_base_model)  # dual-ema: initialize slow EMA
             else:
                 with torch.no_grad():
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
                         ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+                    for ep, mp in zip(ema_model_fast.parameters(), _base_model.parameters()):  # dual-ema
+                        ep.data.mul_(ema_decay_fast).add_(mp.data, alpha=1 - ema_decay_fast)
+                    for ep, mp in zip(ema_model_slow.parameters(), _base_model.parameters()):  # dual-ema
+                        ep.data.mul_(ema_decay_slow).add_(mp.data, alpha=1 - ema_decay_slow)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -913,7 +924,10 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    if ema_model_fast is not None:  # dual-ema: average fast+slow EMA predictions
+                        pred = 0.5 * ema_model_fast({"x": x})["preds"] + 0.5 * ema_model_slow({"x": x})["preds"]
+                    else:
+                        pred = eval_model({"x": x})["preds"]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
The current single EMA (decay=0.998 from epoch 40) represents one temporal averaging window. Using two EMA models with different decays (0.995 for recent sharp updates, 0.999 for long-term smooth averaging) and averaging their predictions at inference creates a free ensemble that captures both fast adaptation and stability. This is essentially a zero-cost model soup with no additional training overhead.

## Instructions
1. Create two EMA models instead of one. After the existing EMA initialization (near line 539):
```python
ema_model_fast = None  # decay=0.995, captures recent updates
ema_model_slow = None  # decay=0.999, long-term smoothing
ema_decay_fast = 0.995
ema_decay_slow = 0.999
```

2. In the EMA update section (after line 834), update both simultaneously:
```python
if epoch >= ema_start_epoch:
    if ema_model_fast is None:
        ema_model_fast = copy.deepcopy(_base_model)
        ema_model_slow = copy.deepcopy(_base_model)
    else:
        for ema_p, model_p in zip(ema_model_fast.parameters(), _base_model.parameters()):
            ema_p.data.mul_(ema_decay_fast).add_(model_p.data, alpha=1 - ema_decay_fast)
        for ema_p, model_p in zip(ema_model_slow.parameters(), _base_model.parameters()):
            ema_p.data.mul_(ema_decay_slow).add_(model_p.data, alpha=1 - ema_decay_slow)
```

3. At evaluation, average predictions from both EMA models:
```python
if ema_model_fast is not None:
    pred_fast = ema_model_fast(batch_input)["preds"]
    pred_slow = ema_model_slow(batch_input)["preds"]
    pred = 0.5 * pred_fast + 0.5 * pred_slow
```

4. Note: this doubles memory for the EMA copies (~2x EMA storage), but EMA updates are cheap. Peak VRAM should stay well under 96GB.

5. Run with `--wandb_group dual-ema`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** sz4jf97v  
**Best checkpoint:** epoch 57

| Split | val/loss | surf_p | surf_Ux | surf_Uy |
|-------|----------|--------|---------|---------|
| val_in_dist | 0.6059 | 17.90 | 6.00 | 1.81 |
| val_ood_cond | 0.7042 | 14.02 | n/a | n/a |
| val_ood_re | 0.5358 | 27.68 | n/a | n/a |
| val_tandem_transfer | 1.6489 | 38.95 | n/a | n/a |
| **combined val/loss** | **0.8737** | | | |

**vs Baseline (val_loss=0.8525, in=17.03, ood=13.90, re=27.62, tan=38.14):**

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8525 | 0.8737 | +0.0212 ❌ |
| surf_p in_dist | 17.03 | 17.90 | +0.87 ❌ |
| surf_p ood_cond | 13.90 | 14.02 | +0.12 ❌ |
| surf_p ood_re | 27.62 | 27.68 | +0.06 ≈ |
| surf_p tandem | 38.14 | 38.95 | +0.81 ❌ |
| mean3 surf_p | ~19.52 | 19.87 | +0.35 ❌ |

**What happened:** The dual EMA blend made things slightly worse overall. In-dist and tandem degraded most (~0.8), while ood_re was essentially flat.

The likely explanation: the fast EMA (decay=0.995) has a lookahead window of only ~20 gradient steps, which is noisier than the existing decay=0.998 (~500 steps). When blended 50/50 with the slow EMA, the fast model's noise degrades the ensemble rather than adding useful diversity. For EMA ensembles to work, the two models need to provide complementary signal — but a fast vs slow EMA on the same training trajectory differ mainly in recency, not in fundamental diversity.

Also, the existing single EMA at decay=0.998 is already well-calibrated for this training setup. The dual EMA adds complexity without adding orthogonal signal.

**Memory:** ~2× EMA storage overhead, negligible in practice (~4MB extra for model copies).

**Suggested follow-ups:**
- Try asymmetric weighting: 0.3 × fast + 0.7 × slow (favor the stabler slow EMA)
- Test if the fast EMA alone (0.995) outperforms the slow EMA (0.999) or the current (0.998) — this would tell us which direction to adjust the single EMA decay
- Try a much more diverse ensemble: train two separate runs from different random seeds and average their predictions