### PR TITLE
Gradient accumulation 2x (effective batch 8)

### DIFF
--- a/train.py
+++ b/train.py
@@ -530,7 +530,6 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
@@ -644,9 +643,12 @@ for epoch in range(MAX_EPOCHS):
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
+    accum_steps = 2
+    n_batches_total = len(train_loader)
+    optimizer.zero_grad()
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
-    for x, y, is_surface, mask in pbar:
+    for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -782,62 +784,18 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
-        # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
-        is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
-
-        if use_pcgrad:
-            n_a = is_indist_pcgrad.float().sum().clamp(min=1)
-            n_b = is_ood_pcgrad.float().sum().clamp(min=1)
-            vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
-            vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
-            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
-            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
-            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
-            surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
-            coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-
+        (loss / accum_steps).backward()
+        if (batch_idx + 1) % accum_steps == 0 or (batch_idx + 1) == n_batches_total:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
             optimizer.zero_grad()
-            loss_a.backward(retain_graph=True)
-            grads_a = [p.grad.clone() if p.grad is not None else None
-                       for p in model.parameters()]
-            optimizer.zero_grad()
-            loss_b.backward()
-
-            ga_flat = torch.cat([g.view(-1) for g in grads_a if g is not None])
-            gb_flat = torch.cat([p.grad.view(-1) for p in model.parameters() if p.grad is not None])
-            dot_ab = (ga_flat @ gb_flat).item()
-            gb_ns = float((gb_flat @ gb_flat).item()) + 1e-8
-            ga_ns = float((ga_flat @ ga_flat).item()) + 1e-8
-            for p, ga in zip(model.parameters(), grads_a):
-                gb = p.grad
-                if ga is None and gb is None:
-                    continue
-                if ga is None:
-                    pass  # keep gb
-                elif gb is None:
-                    p.grad = ga
-                elif dot_ab < 0:
-                    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
+            if epoch >= ema_start_epoch:
+                if ema_model is None:
+                    ema_model = deepcopy(_base_model)
                 else:
-                    p.grad = (ga + gb) * 0.5
-        else:
-            optimizer.zero_grad()
-            loss.backward()
-
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        optimizer.step()
-        if epoch >= ema_start_epoch:
-            if ema_model is None:
-                ema_model = deepcopy(_base_model)
-            else:
-                with torch.no_grad():
-                    for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
+                            ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 


### PR DESCRIPTION
## Hypothesis
Previous gradient accumulation attempts (#1229, #1238, #1413) failed or were neutral on older code. The wider model (n_hidden=192, 3 heads) has more parameters and benefits more from smoother gradient estimates. With PCGrad present, grad accum is tricky — so simplify: remove PCGrad for this experiment, use grad accum 2x for effective batch size 8, and keep LR at 2.5e-3 (do NOT scale LR). The smoother gradients should particularly help OOD splits where gradient noise hurts most.

## Instructions
1. Remove all PCGrad code (lines 785-831) and restore simple backward:
```python
optimizer.zero_grad()
loss.backward()
```

2. Also restore `torch.compile(model, mode="reduce-overhead")` and remove `donated_buffer=False` (since PCGrad is gone).

3. Add gradient accumulation with accum_steps=2. Wrap the training loop:
```python
accum_steps = 2
# Before the batch loop in each epoch:
optimizer.zero_grad()
```

4. Inside the batch loop, scale the loss and only step every accum_steps:
```python
(loss / accum_steps).backward()
if (batch_idx + 1) % accum_steps == 0 or (batch_idx + 1) == n_batches:
    torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
    optimizer.step()
    optimizer.zero_grad()
```

5. Make sure EMA update happens after each optimizer.step(), not after each batch.

6. Run with `--wandb_group grad-accum-2x`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run ID:** j5qx7ytk  
**Best epoch:** 61 (wall-clock timeout at 30.2 min)  
**Peak memory:** ~14.8 GB

**Implementation note:** `mode="reduce-overhead"` (CUDA Graphs) is incompatible with gradient accumulation — each forward within an accumulation window overwrites the output buffers used by the previous forward, breaking the backward pass. `torch.compiler.cudagraph_mark_step_begin()` was tried but did not fix this for our model. Fell back to `mode="default"` which works correctly.

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.9038** | 0.8525 |
| val_in_dist | 0.6047 | — |
| val_tandem_transfer | 1.6799 | — |
| val_ood_cond | 0.7598 | — |
| val_ood_re | 0.5707 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p |
|-------|----|----|---|------------|
| val_in_dist | 3.68 | 1.81 | 18.67 | 17.03 |
| val_tandem_transfer | 4.43 | 2.24 | 39.48 | 38.14 |
| val_ood_cond | 3.04 | 1.18 | 14.89 | 13.90 |
| val_ood_re | 2.81 | 1.04 | 28.20 | 27.62 |

**mean3 surf_p** = (18.67 + 14.89 + 39.48) / 3 = **24.35** (baseline: 23.02)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.16 | 0.38 | 20.27 |
| val_tandem_transfer | 2.02 | 0.91 | 39.44 |
| val_ood_cond | 0.78 | 0.29 | 12.86 |
| val_ood_re | 0.89 | 0.37 | 47.20 |

---

### What happened

**Negative result.** val/loss = 0.9038 vs baseline 0.8525 — 6.0% worse. Every surface MAE metric is slightly worse.

Two likely explanations:

1. **Removing PCGrad hurt OOD splits**: PCGrad specifically manages in-dist vs OOD gradient conflicts. Removing it to enable clean grad accum removed that OOD benefit. OOD metrics confirm: val_ood_cond +7%, val_ood_re +2%, val_tandem_transfer +3.5%.

2. **Forced compile mode downgrade**: `mode="reduce-overhead"` (CUDA Graphs) is incompatible with gradient accumulation — buffers are overwritten between accumulation steps before backward runs. Falling back to `mode="default"` means less aggressive optimization, likely costing convergence speed within the 30-min budget.

The smoother gradient estimate from accum_steps=2 was not enough to compensate for losing PCGrad.

---

### Suggested follow-ups

- **PCGrad + grad accum together**: Accumulate group A and group B gradients separately across steps, then project once per optimizer step. Avoids the retain_graph issue.
- **Grad accum without removing PCGrad**: Keep PCGrad, use retain_graph=True only for the A backward, accumulate both groups across steps before projecting.
- **Larger accum_steps with LR scaling**: If grad accum is pursued, try accum_steps=4 with linear LR scaling (×2) to match larger effective batch theory more precisely.
