### PR TITLE
Sinusoidal spatial PE added to Q/K in slice attention

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,8 +143,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.pos_to_qk = nn.Linear(4, self.dim_head, bias=False)
+        nn.init.normal_(self.pos_to_qk.weight, std=0.01)
 
-    def forward(self, x, spatial_bias=None, tandem_mask=None):
+    def forward(self, x, spatial_bias=None, tandem_mask=None, raw_xy=None):
         bsz, num_points, _ = x.shape
 
         fx_mid = (
@@ -170,9 +172,18 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
 
-        q_slice_token = self.to_q(slice_token)
+        # Sinusoidal PE from per-slice spatial centroids
+        if raw_xy is not None:
+            slice_centroid = torch.einsum("bhng,bnd->bhgd", slice_weights, raw_xy[:, :, :2])  # [B, H, G, 2]
+            slice_centroid = slice_centroid / (slice_norm.unsqueeze(-1) + 1e-5)
+            pos_enc = torch.cat([slice_centroid.sin(), slice_centroid.cos()], dim=-1)  # [B, H, G, 4]
+            pos_proj = self.pos_to_qk(pos_enc)  # [B, H, G, dim_head]
+        else:
+            pos_proj = None
+
+        q_slice_token = self.to_q(slice_token) + (pos_proj if pos_proj is not None else 0)
         slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
-        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
+        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1) + (pos_proj if pos_proj is not None else 0)
         v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
         q_norm = F.normalize(q_slice_token, dim=-1)
         k_norm = F.normalize(k_slice_token, dim=-1)
@@ -233,7 +244,8 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        xy2d = raw_xy[:, :, :2] if raw_xy is not None else None
+        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask, raw_xy=xy2d) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))


### PR DESCRIPTION
## Hypothesis
The slice-token attention (Q/K/V on aggregated slice tokens) has no positional information — it treats all 48 slices as unordered. Adding sinusoidal position encoding to Q and K based on the mean spatial position of nodes assigned to each slice gives the attention mechanism spatial awareness. Previous attempts at positional encoding (#1118, #1125) used arbitrary slice ordering; this approach uses the data-driven spatial centroid of each slice, which is physically meaningful.

## Instructions
1. In `PhysicsAttention`, after computing `slice_token` (around line 170), compute per-slice spatial centroids using the node positions and slice assignment weights:
```python
# raw_xy is the (x, y) spatial coordinates: shape [B, N, 2]
# slice_weights shape: [B, H, N, G] (from softmax of slice assignments)
# slice_norm shape: [B, H, G] (sum of weights per slice)
slice_centroid = torch.einsum("bhng,bn2->bhg2", slice_weights, raw_xy[:, :, :2])  # [B, H, G, 2]
slice_centroid = slice_centroid / (slice_norm.unsqueeze(-1) + 1e-5)
```

2. Apply sinusoidal encoding and add to Q/K:
```python
# Sinusoidal encoding of 2D centroids → 4D
pos_enc = torch.cat([slice_centroid.sin(), slice_centroid.cos()], dim=-1)  # [B, H, G, 4]
pos_proj = self.pos_to_qk(pos_enc)  # Linear(4, dim_head, bias=False)
```

3. Add the projection to Q and K before computing attention:
```python
q_slice_token = self.to_q(slice_token) + pos_proj
k_slice_token = self.to_k(slice_token) + pos_proj
```

4. Add `self.pos_to_qk = nn.Linear(4, dim_head, bias=False)` in `__init__`, initialized with small weights:
```python
self.pos_to_qk = nn.Linear(4, self.dim_head, bias=False)
nn.init.normal_(self.pos_to_qk.weight, std=0.01)
```

5. You'll need to pass `raw_xy` (the spatial coordinates) into the attention module. Thread it through the block's forward method.

6. Run with `--wandb_group slice-pos-enc`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** [aenvjbmg](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/aenvjbmg)
**Best epoch:** 57/100
**Peak VRAM:** ~18.7 GB

### Validation Loss

| Split | This run | Baseline |
|-------|----------|----------|
| val/loss (combined) | **0.8693** | 0.8525 |
| val_in_dist | 0.6174 | — |
| val_tandem_transfer | 1.6250 | — |
| val_ood_cond | 0.7082 | — |
| val_ood_re | 0.5265 | — |

### Surface MAE

| Split | Ux | Uy | p | p (baseline) |
|-------|----|----|---|--------------|
| val_in_dist | 4.8099 | 1.5474 | 19.0548 | 17.03 |
| val_tandem_transfer | 5.7583 | 2.1474 | 38.1294 | 38.14 |
| val_ood_cond | 3.2811 | 1.1373 | 13.9750 | 13.90 |
| val_ood_re | 2.7971 | 1.0060 | 27.3084 | 27.62 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.1608 | 0.3746 | 19.9453 |
| val_tandem_transfer | 1.9487 | 0.8756 | 37.6046 |
| val_ood_cond | 0.7184 | 0.2756 | 11.9881 |
| val_ood_re | 0.8211 | 0.3609 | 46.6084 |

### What happened

Essentially no change — combined val/loss 0.8693 vs 0.8525 baseline (+0.017, within the ~0.016 seed noise floor). The surface pressure MAEs are mixed: slightly worse on val_in_dist (19.05 vs 17.03), essentially identical on val_tandem_transfer (38.13 vs 38.14) and val_ood_cond (13.98 vs 13.90), and slightly better on val_ood_re (27.31 vs 27.62). None of these differences are clearly meaningful.

The sinusoidal centroid PE appears to have negligible effect. This is plausible because: (1) the existing spatial_bias MLP already encodes per-node positions into slice assignment logits, giving the model positional information at the grouping stage; (2) the centroids are data-driven and vary per example, potentially noisy signal; (3) the small-std initialization (0.01) keeps the contribution minimal throughout training.

Note: the einsum subscript in the PR instructions used a digit (`"bhng,bn2->bhg2"`) which is invalid in PyTorch — had to change to `"bhng,bnd->bhgd"`.

### Suggested follow-ups

- **Rotary PE (RoPE) on slice centroids**: Apply RoPE to Q and K using 2D centroid coordinates instead of additive PE. RoPE encodes relative positions more robustly.
- **Learn the centroid PE scale**: Make the std of `pos_to_qk` learnable or initialize it larger (e.g., std=0.1) to let the model discover if positional info is useful.
- **Centroid-based slice sorting**: Sort slices by x-coordinate centroid before attention (a deterministic ordering). This gives the attention a stable positional structure without any PE overhead.