### PR TITLE
Cosine T_max=55, eta_min=8e-5 (schedule alignment)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=8e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
With the current architecture, training reaches ~59-60 epochs in 30 minutes. The cosine schedule uses T_max=62 and eta_min=5e-5 (line 581), meaning the LR hasn't fully decayed when training stops. Setting T_max=55 lets the cosine reach its minimum around epoch 65 (55+10 warmup), better aligning with the ~60-epoch budget. A slightly warmer floor (8e-5 vs 5e-5) keeps the final epochs productive. Past T_max experiments (#1130: T_max=62, #1279: T_max=48, #1355: T_max=52) showed sensitivity to this parameter on older code.

## Instructions
1. Change T_max from 62 to 55 and eta_min from 5e-5 to 8e-5 on line 581:
```python
# OLD:
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
# NEW:
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=8e-5)
```

2. That's it — single line change.

3. Run with `--wandb_group tmax55-etamin8e5`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** jdx0qscx
**Total time:** 30.3 min, 58 epochs

### Metrics

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.6046 | 18.3 |
| val_ood_cond | 0.6973 | 13.6 |
| val_ood_re | 0.5492 | 27.8 |
| val_tandem_transfer | 1.6207 | 38.1 |
| **mean3 (in+ood+tan)** | **0.8680** | **23.33** |

Baseline: val_loss=0.8525, mean3_p=23.02

**Delta:** val_loss +0.0155 (+1.8%), mean3_p +0.31 (+1.3%)

**Peak VRAM:** ~18.5GB

### What happened

No meaningful improvement. The T_max=55 schedule is marginally worse on val_loss (+1.8%) and mean3_p (+1.3%). The individual splits show mixed results: ood_cond and tandem_transfer are very slightly better (-0.3, -0.04), while in_dist is slightly worse (+1.27). These differences are within noise range.

The hypothesis was that the cosine LR hadn't decayed fully before training stopped. In practice, the model ran 58 epochs — 3 after the cosine minimum at T_max=55 (10 warmup + 55 cosine = 65 epochs to decay). With T_max=55, the LR hits eta_min=8e-5 around epoch 65, but training stops at 58, meaning the schedule still hasn't reached its floor. So the alignment is similar to the baseline setup.

The slightly warmer floor (8e-5 vs 5e-5) likely negated any benefit from better alignment, as the final epochs ran at a higher LR than before.

### Suggested follow-ups

1. T_max=48 with eta_min=5e-5: The original T_max=48 experiment (#1279) was on older code. On current code, this would fully decay the LR by epoch 58, potentially giving more converged final epochs.
2. Eta_min tuning alone: Try eta_min=3e-5 with T_max=62 to ensure final LR is lower without changing the decay shape.