### PR TITLE
Detach volume gradients after epoch 45 (surface focus)

### DIFF
--- a/train.py
+++ b/train.py
@@ -727,7 +727,8 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        _abs_err_vol = abs_err.detach() if epoch >= 45 else abs_err
+        vol_loss = (_abs_err_vol * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
@@ -793,8 +794,8 @@ for epoch in range(MAX_EPOCHS):
             n_b = is_ood_pcgrad.float().sum().clamp(min=1)
             vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
             vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
-            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
-            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
+            vol_loss_a = (_abs_err_vol * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
+            vol_loss_b = (_abs_err_vol * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0


### PR DESCRIPTION
## Hypothesis
After epoch 45, volume predictions are well-converged (vol MAE is low and stable). The volume loss gradient still dominates shared parameters because volume nodes outnumber surface nodes ~50:1. Detaching volume gradients from the shared backbone after epoch 45 lets the final ~15 epochs focus purely on surface accuracy improvement. This is a stronger version of the vol_loss_scale=0.1 idea (PR #1082) because it completely removes volume gradient signal in late training.

## Instructions
1. In the loss computation section (around line 770), make vol_loss detached after epoch 45:
```python
# After computing abs_err and vol_mask_train:
if epoch >= 45:
    vol_loss = (abs_err.detach() * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
else:
    vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
```

2. This means `vol_loss` still gets logged but doesn't contribute gradients to the backbone in the final EMA phase.

3. Note: if PCGrad is active, the same detach should apply to `vol_loss_a` and `vol_loss_b` inside the PCGrad block (lines 796-797) when epoch >= 45.

4. Run with `--wandb_group detach-vol-late`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `e7hsyugg`
**Best epoch:** 58/100 (wall-clock limit at 30 min)
**Peak memory:** ~17 GB

### Metrics (best epoch)

| Split | val/loss | Surf p | Surf Ux | Surf Uy | Vol p | Vol Ux | Vol Uy |
|-------|----------|--------|---------|---------|-------|--------|--------|
| val_in_dist | 0.629 | 18.01 | 6.63 | 1.91 | 22.37 | 1.36 | 0.44 |
| val_ood_cond | 0.738 | 14.28 | 3.75 | 1.15 | 13.61 | 0.88 | 0.33 |
| val_ood_re | 0.573 | 28.02 | 3.52 | 0.97 | 48.21 | 0.97 | 0.41 |
| val_tandem_transfer | 1.667 | 38.60 | 6.31 | 2.33 | 39.81 | 2.20 | 1.00 |
| **combined val/loss** | **0.9015** | | | | | | |

### vs Baseline

| Metric | Baseline | Detach epoch≥45 | Delta |
|--------|----------|-----------------|-------|
| val/loss | 0.8525 | 0.9015 | +0.049 ▲ |
| in/surf_p | 17.03 | 18.01 | +0.98 ▲ |
| ood/surf_p | 13.90 | 14.28 | +0.38 ▲ |
| re/surf_p | 27.62 | 28.02 | +0.40 ▲ |
| tan/surf_p | 38.14 | 38.60 | +0.46 ▲ |

### What happened

Detaching volume gradients after epoch 45 moderately hurt performance (+5.7% on val/loss, consistent across all splits). The hypothesis was that volume gradients dominate shared parameters and removing them in late training would sharpen surface predictions — but the opposite occurred.

Likely reason: volume and surface representations are deeply shared, and volume gradients still provide useful curvature signal for the backbone even at epoch 45. Cutting them abruptly disrupts the trained parameter updates and prevents further refinement of shared representations. The EMA model (which starts at epoch 40) also mixes the pre-detach and post-detach weight trajectories, potentially creating instability.

Also worth noting: at epoch 45, vol_loss is ~0.17 (still not fully converged), so the premise that volume is "well-converged by epoch 45" may not hold.

### Suggested follow-ups

- Try detaching later (epoch 60+) when volume is more stably converged
- Instead of full detach, try scaling volume gradient contribution (e.g., 0.1× after epoch 45)
- A gentler approach: raise surf_weight further (e.g., from ~5-50 adaptive to a fixed 50) in late training rather than detaching volume