### PR TITLE
Smooth attention temp annealing (cosine 0.5->0.15)

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -847,9 +848,12 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 30:
+        progress = min(1.0, (epoch - 30) / 25.0)  # 0->1 over epochs 30-55
+        target_temp = 0.15 + 0.5 * (0.5 - 0.15) * (1 + math.cos(math.pi * progress))
+        # Cosine decay from 0.5 to 0.15
         with torch.no_grad():
-            _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=target_temp)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol


### PR DESCRIPTION
## Hypothesis
The current hard temperature clamp at epoch 50 (`temperature.clamp_(max=0.25)` on line 850-852) creates a discontinuity in the optimization landscape. A smooth cosine annealing from 0.5 to 0.15 over epochs 30-55 provides a gradual sharpening that completes before the end of training, giving the EMA a clean signal to average over. The hard clamp at epoch 50 coincides with the EMA phase (started epoch 40), creating instability during the averaging phase.

## Instructions
1. Replace the hard clamp block (lines 850-852):
```python
# OLD:
if epoch >= 50:
    with torch.no_grad():
        _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
```

With a smooth cosine annealing:
```python
import math
if epoch >= 30:
    progress = min(1.0, (epoch - 30) / 25.0)  # 0->1 over epochs 30-55
    target_temp = 0.15 + 0.5 * (0.5 - 0.15) * (1 + math.cos(math.pi * progress))
    # Cosine decay from 0.5 to 0.15
    with torch.no_grad():
        _base_model.blocks[0].attn.temperature.data.clamp_(max=target_temp)
```

2. Make sure `import math` is at the top of the file (it likely already is).

3. Run with `--wandb_group smooth-temp-anneal`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run**: ztdclyfo  
**Best epoch**: 61 (30.4 min, wall-clock limit)  
**VRAM**: 17.9 GB  

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5844 | 4.70 | 1.29 | **17.84** | 1.08 | 0.35 | 18.48 |
| val_ood_cond | 0.6931 | 2.92 | 1.01 | **13.88** | 0.73 | 0.27 | 12.08 |
| val_ood_re | 0.5417 | 2.43 | 0.84 | 27.55 | 0.84 | 0.36 | 46.86 |
| val_tandem_transfer | 1.6201 | 4.88 | 1.91 | **38.01** | 1.92 | 0.86 | 37.29 |
| **combined** | **0.8598** | | | | | | |

**mean3 (in/ood/tan p)**: (17.84 + 13.88 + 38.01) / 3 = **23.24** vs baseline 23.02 → **+0.22, marginal negative**

### What happened

The smooth cosine annealing produced a mixed result. Tandem (-0.13) and ood_re (-0.07) and ood_cond (-0.02) all improved slightly, but in_dist degraded notably (+0.81). The combined val/loss of 0.8598 vs 0.8525 is slightly worse overall.

The hypothesis that the hard clamp creates optimization instability during EMA (epochs 40+) has partial support: the OOD and tandem splits (which benefit most from generalization) show tiny improvements. However, the in-distribution degradation suggests the smooth annealing interferes with fitting the training distribution's pressure structures.

One issue: the annealing starts at epoch 30 and reaches 0.15 at epoch 55. But the EMA phase starts at epoch 40 — this means 10 epochs of aggressive sharpening happen while EMA is already running. The final temperature after epoch 55 is 0.15 (vs old hard clamp at 0.25), which may be too sharp — the model could be over-focusing on a narrow set of slices, hurting in-distribution generalization.

### Suggested follow-ups

1. **End at 0.20 instead of 0.15**: The old clamp was 0.25; dropping to 0.15 is a 40% sharper temperature. Try ending at 0.20 to see if the smooth transition has value without going too sharp.
2. **Start annealing at epoch 40**: Align the start with EMA (epoch 40) so the smooth sharpening and EMA averaging work together from the beginning.
3. **Apply to all blocks, not just blocks[0]**: The current implementation only adjusts the first block's temperature; a consistent effect across all layers might be cleaner.