### PR TITLE
Curvature-weighted surface loss (focus on high-kappa nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -654,6 +654,7 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        curv_raw = curv[:, :, 0].detach()  # [B, N], 0 for non-surface; saved for loss weighting
         x = torch.cat([x, curv], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
@@ -729,7 +730,11 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Curvature-based surface weights: [1, 3] range for surface nodes, 1 for non-surface
+        curv_max = curv_raw.amax(dim=1, keepdim=True).clamp(min=1e-5)  # per-sample max
+        curv_weight = 1.0 + 2.0 * (curv_raw / curv_max)  # [B, N], range [1,3] for surface, 1 for non-surf
+        curv_surf_mean = (curv_weight * surf_mask.float()).sum(dim=1) / surf_mask.float().sum(dim=1).clamp(min=1)  # [B]
+        surf_per_sample = (abs_err[:, :, 2:3] * curv_weight.unsqueeze(-1) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / (surf_mask.float().sum(dim=1) * curv_surf_mean).clamp(min=1)
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -742,8 +747,11 @@ for epoch in range(MAX_EPOCHS):
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
-            hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            # Combined weight: hard-node × curvature, normalized to keep magnitude stable
+            hard_w = (hard_mask.float() * 0.5 + 1.0)  # [B, N], 1.5 hard / 1.0 else
+            combined_w = curv_weight * hard_w  # [B, N]
+            combined_w_mean = (combined_w * surf_mask.float()).sum(dim=1) / surf_mask.float().sum(dim=1).clamp(min=1)  # [B]
+            surf_per_sample = (surf_pres_flat * combined_w * surf_mask.float()).sum(dim=1) / (surf_mask.float().sum(dim=1) * combined_w_mean).clamp(min=1)
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis
Surface nodes at high-curvature regions (leading edges, trailing edges) are both harder to predict and more physically important — pressure gradients are steepest at these locations. Currently, all surface nodes contribute equally to the surface loss. Weighting surface loss by local curvature magnitude focuses the model's capacity on the regions where errors are largest and most consequential. This should disproportionately improve surface pressure predictions without affecting volume quality.

## Instructions
1. The curvature information is already available in the input features. Check which column index contains curvature (it's used for the spatial bias — likely column 24 or 25 in the 24-dim feature vector). Extract curvature per node.

2. Compute curvature-based weights for surface nodes:
```python
# After computing is_surface mask for the batch:
curvature = x[:, :, CURVATURE_COL].abs()  # [B, N] — verify CURVATURE_COL index
# Normalize curvature to [1, max_weight] range so all nodes contribute but high-curvature gets more
curv_surf = curvature * is_surface.float()  # zero for non-surface nodes
# Scale: min weight = 1.0, max weight = 3.0 for highest curvature
curv_max = curv_surf.max().clamp(min=1e-5)
curv_weight = 1.0 + 2.0 * (curv_surf / curv_max)  # [1, 3] range
curv_weight = curv_weight * is_surface.float() + (1 - is_surface.float())  # 1.0 for non-surface
```

3. Apply the curvature weight to the surface loss computation. Find where `surf_per_sample` is computed and multiply the per-node surface errors by the curvature weight before averaging:
```python
# In the surface loss computation, weight by curvature:
weighted_surf_err = surf_abs_err * curv_weight.unsqueeze(-1)  # [B, N, 3]
```

4. Keep the total surface loss magnitude roughly the same (normalize by the mean of curvature weights) to avoid LR interaction.

5. Run with `--wandb_group curvature-surf-weight`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `flaazuhc`

### Metrics vs Baseline

| Split | val_loss | mae_surf_p | Δ mae_surf_p | mae_surf_Ux | mae_surf_Uy |
|-------|----------|------------|--------------|-------------|-------------|
| val_in_dist | 0.6162 | 18.895 | +10.9% worse | 5.693 | 1.475 |
| val_ood_cond | 0.6970 | 13.622 | -2.0% better | 3.378 | 0.979 |
| val_ood_re | 0.5485 | 27.904 | +1.0% worse | 2.971 | 0.809 |
| val_tandem_transfer | 1.6717 | 39.648 | +4.0% worse | 6.235 | 2.122 |
| **combined** | **0.8833** | — | +3.6% worse | — | — |

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.120 | 0.373 | 19.887 |
| val_ood_cond | 0.734 | 0.277 | 12.279 |
| val_ood_re | 0.842 | 0.366 | 46.867 |
| val_tandem_transfer | 1.967 | 0.891 | 38.894 |

Peak VRAM: not logged.

### What happened

Curvature weighting did not improve results. Combined val/loss degraded from 0.8525 to 0.8833 (+3.6%), and in-distribution surface pressure MAE worsened by 11% (17.03 to 18.895). OOD-cond surface pressure was slightly better (-2%), but ood_re and tandem_transfer were worse.

Two likely causes:

1. **Slower convergence.** Curvature weights up-weight the hardest nodes, making optimization harder. The loss curve was still decreasing at the 30-minute cutoff (0.906 to 0.883 in the final minutes), suggesting the model hadn't fully converged yet. Given more time it might recover, but within the 30-min budget it trails baseline.

2. **Noisy curvature proxy + per-sample normalization.** The proxy (L2 norm of dsdf channels 2:6) is approximated before noise and Fourier PE. Per-sample max normalization means near-flat foils still get a [1,3] spread, which may be inappropriate.

3. **PCGrad interaction.** This branch also contains PCGrad domain-split loss from the advisor's base. Hard to isolate curvature-weighting effect from PCGrad effect.

### Suggested follow-ups

- **Milder weighting** [1, 1.5] instead of [1, 3]: less aggressive re-weighting might avoid destabilizing convergence while still biasing toward high-curvature regions.
- **Global normalization**: normalize curvature by training-set mean rather than per-sample max, so near-flat foils aren't over-spread.
- **Decouple from PCGrad**: test curvature weighting on a plain baseline to isolate its contribution.