### PR TITLE
PCGrad late-start: activate only after epoch 20

### DIFF
--- a/train.py
+++ b/train.py
@@ -786,7 +786,7 @@ for epoch in range(MAX_EPOCHS):
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
         is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+        use_pcgrad = (epoch >= 20) and is_indist_pcgrad.any() and is_ood_pcgrad.any()
 
         if use_pcgrad:
             n_a = is_indist_pcgrad.float().sum().clamp(min=1)


### PR DESCRIPTION
## Hypothesis
PCGrad currently runs from epoch 0, doubling backward-pass cost throughout training. But in early epochs, all domains benefit from the same gradients (learning basic flow physics). Gradient conflicts between in-dist and OOD domains only become meaningful once the model has developed domain-specific features (typically after ~20 epochs). Delaying PCGrad to epoch 20+ gives: (1) single backward pass for the first 20 epochs = faster wall-clock, (2) more stable early training, (3) PCGrad kicks in exactly when gradient conflicts emerge. This could recover 1-2 extra epochs from the throughput gain.

## Instructions
1. On line 789, add an epoch condition to PCGrad activation:
```python
# OLD:
use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
# NEW: only activate PCGrad after epoch 20
use_pcgrad = (epoch >= 20) and is_indist_pcgrad.any() and is_ood_pcgrad.any()
```

2. That's the only change. Everything else stays the same — same grouping, same projection logic.

3. Run with `--wandb_group pcgrad-late-start`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** 2zn74t52  
**Change:** `use_pcgrad = (epoch >= 20) and ...` (one line)

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Δ |
|-------|----------|------------|---------------------|---|
| val_in_dist | 0.5984 | 18.64 | 17.03 | +1.61 |
| val_ood_cond | 0.6844 | 13.59 | 13.90 | **-0.31** |
| val_ood_re | 0.5427 | 27.74 | 27.62 | +0.12 |
| val_tandem_transfer | 1.6381 | 38.70 | 38.14 | +0.56 |
| **combined** | **0.8659** | — | **0.8525** | **+0.0134** |

**Peak memory:** 16.7 GB  
**Best epoch:** 61 (30.3 min total)

### What happened

PCGrad late-start is slightly worse than baseline (val/loss 0.8659 vs 0.8525, +0.013). The hypothesis that skipping PCGrad for the first 20 epochs would give extra throughput did not translate into better convergence. A few possible reasons:

1. **Early PCGrad helps more than expected.** Even in epochs 1-20, there is meaningful gradient conflict between in-dist and OOD splits (the model starts developing domain sensitivity early due to the tandem/non-tandem split and different Re ranges). Skipping PCGrad in this window loses useful gradient coordination from the start.

2. **No measurable throughput gain.** The run completed 61 epochs in 30 min, essentially the same as a normal run (~57-61 epochs). The 20 epoch speedup from single backward pass is canceled out by Lookahead's step overhead, so the expected "1-2 extra epochs" did not materialize.

3. **val_ood_cond improved slightly** (13.59 vs 13.90), suggesting PCGrad late-start may help on strict OOD conditions, but this is overshadowed by degradation on val_in_dist (+1.61 on mae_surf_p) and val_tandem_transfer (+0.56).

### Suggested follow-ups

- **Later start (epoch 30 or 40):** The EMA model activates at epoch 40, and the model's representational structure is largely set by then. It's possible epoch 20 is still too early — try activating PCGrad only in the EMA phase.
- **PCGrad only in EMA phase:** Pair PCGrad activation with EMA start (epoch 40), since EMA smooths out the noisier per-batch gradient projections that PCGrad produces.
- **Ablate PCGrad entirely:** Given this result and the baseline, consider whether PCGrad is net-positive at all in this setting. The `exp-noam/ablate-pcgrad` branch may already be tracking this.