### PR TITLE
n_layers=2 n_hidden=128 slice_num=48 (depth at iso-FLOPs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -520,9 +520,9 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE
     out_dim=3,
-    n_hidden=192,  # regime-w: full width with finer routing
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
-    n_head=3,
+    n_hidden=128,  # reduced from 192 to compensate for 2nd layer (iso-FLOPs)
+    n_layers=2,    # depth experiment: 2 layers at reduced width
+    n_head=4,      # 4 heads × 32 dim/head = 128
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],


### PR DESCRIPTION
## Hypothesis
The single-layer architecture is a fundamental capacity bottleneck that no training trick can overcome. Every previous depth attempt used the wrong trade-off: #1062 tried n_layers=2 at n_hidden=128 with slice_num=32 (old config); #1266/1269 tried n_layers=2 at n_hidden=160/192 (too slow, insufficient epochs). With the current finer routing (slice_num=48) and torch.compile, n_layers=2 at n_hidden=128 with mlp_ratio=2 gives roughly iso-FLOPs to the current 1-layer n_hidden=192 but adds a second round of slice attention for spatial decomposition refinement.

## Instructions
Change model_config parameters:
```python
n_hidden = 128  # down from 192 to compensate for 2nd layer
n_layers = 2    # up from 1
n_head = 4      # 4 heads × 32 dim/head = 128
slice_num = 48  # keep current fine routing
mlp_ratio = 2   # keep current
```

Keep all training parameters identical (lr=2.5e-3, PCGrad, etc). The key constraint is throughput — monitor epochs/30min. If you get fewer than 40 epochs, the EMA won't activate and the experiment is invalid.

Note: the per-head tandem_temp_offset is currently [1,3,1,1] for n_head=3. With n_head=4, adjust to [1,3,1,1] (unchanged, just has 4 heads now) or [1,2,1,1] if temp[1] range is too aggressive at 4 heads.

Run with `--wandb_group depth-iso-flops`.

## Baseline (post-dist-to-surface, #1473)
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.84 |
| val_ood_cond | — | 13.66 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 36.36 |
| **combined** | **0.8495** | **mean3=22.62** |

---

## Results (v2 — rebased onto noam with dist-to-surface)

**W&B run:** `ndb6dsnv`
**Model:** n_layers=2, n_hidden=128, n_head=4, slice_num=48, mlp_ratio=2
**Epochs:** 52 (avg ~34.7s/epoch; baseline ~60 epochs at ~29s/epoch)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | Δ surf_p vs baseline |
|---|---|---|---|---|---|
| val_in_dist | 0.6099 | 6.02 | 1.96 | 18.58 | +0.74 |
| val_ood_cond | 0.7572 | 4.07 | 1.20 | 15.30 | +1.64 |
| val_ood_re | 0.5769 | 3.71 | 1.02 | 28.84 | +1.22 |
| val_tandem_transfer | 1.6081 | 6.19 | 2.50 | 37.97 | +1.61 |
| **combined** | **0.8880** | — | — | **mean3=23.95** | **+1.33** |

Peak VRAM: ~15 GB

### What happened

The 2-layer architecture at iso-FLOPs is clearly worse than the new single-layer baseline across all splits. The tandem improvement that was visible in v1 (pre-dist-to-surface, tandem=37.37 vs old baseline 38.14) has vanished — the new dist-to-surface feature already provides the geometric information that depth was trying to recover, and the wider 1-layer model uses it more effectively.

Two compounding factors:
1. **Fewer training steps**: 52 epochs vs ~60 for the baseline (13% fewer due to per-epoch overhead). With 4 heads × dim_head=32, the attention has lower per-head capacity than the baseline's 3 heads × dim_head=64.
2. **The new feature made depth less useful**: dist-to-surface gives explicit distance information. The first attention layer can already decompose geometry well with this; the second layer adds computation without proportional gain.

The conclusion from both v1 and v2: at the current 30-minute training budget, the wider 1-layer architecture (n_hidden=192, dim_head=64) consistently outperforms the 2-layer iso-FLOPs design (n_hidden=128, dim_head=32).

### Suggested follow-ups

1. **Wider 2-layer with longer budget**: n_layers=2, n_hidden=160 at 40-minute budget. The tandem signal from v1 suggests depth has value, but needs more training time.
2. **Shared depth for tandem**: Apply a second attention layer only to tandem samples (conditional on is_tandem), preserving single-foil performance while adding capacity for complex geometry.
3. **Accept the baseline**: Single-layer n_hidden=192 remains the best architecture at 30-minute budget.