### PR TITLE
Continuous distance-to-surface feature for all nodes

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(3, 64), nn.GELU(),
+            nn.Linear(4, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -377,7 +377,7 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
@@ -518,7 +518,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE
     out_dim=3,
     n_hidden=192,  # regime-w: full width with finer routing
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -654,7 +654,9 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        x = torch.cat([x, curv], dim=-1)
+        dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
+        dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -882,7 +884,9 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                x = torch.cat([x, curv], dim=-1)
+                dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
+                dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+                x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -1061,7 +1065,9 @@ if best_metrics:
                 mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                x_n = torch.cat([x_n, curv], dim=-1)
+                dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
+                dist_feat = torch.log1p(dist_surf * 10.0)
+                x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
The model's only surface/volume distinction is a binary is_surface flag. Volume nodes in the boundary layer (near the surface) are physically critical for determining surface pressure, but the model has no clean signal for which volume nodes are near the surface. The dsdf channels encode signed distance implicitly. Using the minimum absolute dsdf across all channels as a continuous distance-to-surface feature gives the spatial bias MLP a clean proximity signal for all nodes, enabling physically coherent slice clustering.

## Instructions
1. In the training loop, after computing `curv` (the curvature feature), add a distance-to-surface feature:
```python
# Minimum absolute dsdf across all 8 channels = proxy for distance to nearest surface
dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
```

2. Concatenate to the input features (alongside curv):
```python
x = torch.cat([x, curv, dist_feat], dim=-1)
```

3. Update `fun_dim` in model_config to account for the extra feature (+1).

4. Add dist_feat to the spatial_bias input. Change:
```python
# OLD: raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature (3D)
# NEW: raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25], dist_feat], dim=-1)  # x, y, curvature, dist (4D)
```
And update spatial_bias input dim from 3 to 4.

5. Run with `--wandb_group dist-to-surface`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `rnn009xv` | **Epochs completed:** 58 (30-min timeout) | **Peak memory:** 17.5 GB

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol |
|-------|----------|-------------|-------------|------------|---------|
| val_in_dist | 0.5994 | 6.87 | 2.27 | **17.84** | — |
| val_ood_cond | 0.6816 | 3.46 | 1.33 | **13.66** | — |
| val_ood_re | 0.5405 | 3.14 | 1.21 | **27.77** | — |
| val_tandem_transfer | 1.5766 | 6.34 | 2.65 | **36.36** | — |
| **combined** | **0.8495** | — | — | — | — |

**vs. baseline:**
| Split | surf_p baseline | surf_p result | Δ |
|-------|----------------|----------------|---|
| val_in_dist | 17.03 | 17.84 | +4.8% worse |
| val_ood_cond | 13.90 | 13.66 | **-1.7% better** |
| val_ood_re | 27.62 | 27.77 | +0.5% (marginal) |
| val_tandem_transfer | 38.14 | 36.36 | **-4.7% better** |
| combined val_loss | 0.8525 | 0.8495 | **-0.4% better** |

**What happened:** Positive result overall. The distance-to-surface feature provides a marginal combined loss improvement (-0.4%) but a meaningful tandem transfer improvement (-4.7%, from 38.14→36.36 surf_p). The ood_cond split also improved slightly (-1.7%). The in_dist regression (+4.8%) is the downside — the added feature slightly hurts performance on seen distributions, possibly because the dist_feat introduces a new input dimension that the model needs to learn to use, spending some capacity on it at the cost of in_dist specialization. The tandem win makes physical sense: tandem foils have two distinct near-surface regions that are harder to distinguish without proximity information. The spatial bias MLP, now receiving log-distance as input, can form proximity-aware slice clusters, which appears to help the model route near-boundary volume nodes differently from free-stream nodes.

**Suggested follow-ups:**
- Try giving the model stronger guidance: multiply dist_feat by the is_surface flag so surface nodes explicitly get dist=0 while volume nodes retain their proximity value. This removes ambiguity at the boundary.
- Try combining curv and dist into a single richer spatial feature: surface nodes get (curvature, 0), near-boundary volume nodes get (0, dist). This disentangles the two signals.
- The tandem improvement is the largest gain — worth investigating if the spatial bias is the bottleneck. Try adding dist_feat also to the attention temperature or as a per-node feature in the SE gate.
- Consider whether the log-scaling factor of 10.0 is optimal; a sweep over {1, 10, 100} could tune this.