### PR TITLE
Mixup on z-scored inputs+targets (alpha=0.3, skip tandem)

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import numpy as np
 import os
 import time
 from collections.abc import Mapping
@@ -693,6 +694,21 @@ for epoch in range(MAX_EPOCHS):
                 else:
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
+
+        if model.training and epoch >= 5:
+            # Mixup: only mix non-tandem samples (tandem has different geometry)
+            non_tandem = ~is_tandem  # [B]
+            non_tandem_idx = non_tandem.nonzero(as_tuple=True)[0]
+            if len(non_tandem_idx) >= 2:
+                lam = np.random.beta(0.3, 0.3)
+                # Shuffle non-tandem indices
+                perm = non_tandem_idx[torch.randperm(len(non_tandem_idx), device=device)]
+                # Mix features and targets for non-tandem samples
+                x[non_tandem_idx] = lam * x[non_tandem_idx] + (1 - lam) * x[perm]
+                y_norm[non_tandem_idx] = lam * y_norm[non_tandem_idx] + (1 - lam) * y_norm[perm]
+                # For masks: use intersection (only nodes valid in both samples)
+                mask[non_tandem_idx] = mask[non_tandem_idx] & mask[perm]
+                is_surface[non_tandem_idx] = is_surface[non_tandem_idx] & is_surface[perm]
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})


### PR DESCRIPTION
## Hypothesis
With only 1,322 training samples, data efficiency is paramount. Mixup (Zhang et al., 2018) was tried once early (PR #987, val_loss=2.20) but on a completely different architecture (5-layer, 128-dim, no compile, no PCGrad). The current 1-layer model with PCGrad creates a fundamentally different landscape where mixup could help. Apply mixup AFTER physics normalization and z-scoring so interpolated targets remain physically meaningful. Skip tandem samples (different geometry makes linear interpolation unphysical). Alpha=0.3 for moderate interpolation.

## Instructions
1. After computing y_norm and before the forward pass, if in training and epoch >= 5:
```python
if model.training and epoch >= 5:
    # Only mix non-tandem samples within the batch
    non_tandem = ~is_tandem_batch  # [B]
    non_tandem_idx = non_tandem.nonzero(as_tuple=True)[0]
    if len(non_tandem_idx) >= 2:
        lam = np.random.beta(0.3, 0.3)
        # Shuffle non-tandem indices
        perm = non_tandem_idx[torch.randperm(len(non_tandem_idx), device=device)]
        # Mix features and targets for non-tandem samples
        x[non_tandem_idx] = lam * x[non_tandem_idx] + (1 - lam) * x[perm]
        y_norm[non_tandem_idx] = lam * y_norm[non_tandem_idx] + (1 - lam) * y_norm[perm]
        # For masks: use intersection (only nodes valid in both samples)
        mask[non_tandem_idx] = mask[non_tandem_idx] & mask[perm]
        is_surface[non_tandem_idx] = is_surface[non_tandem_idx] & is_surface[perm]
```

2. Make sure `import numpy as np` is at the top.

3. Note: the mask intersection is critical — only predict where both samples have valid nodes.

4. Run with `--wandb_group mixup-zscore`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** j7ki5che
**Epochs completed:** 58/100 (30-min timeout)
**Peak memory:** ~14.8GB (unchanged)
**Epoch time:** 30.1s (unchanged — no throughput cost/benefit)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8525 | 0.9313 | +9.2% worse |
| val_in_dist | mae_surf_p | 17.03 | 17.77 | +4.3% worse |
| val_ood_cond | mae_surf_p | 13.90 | 15.29 | +10.0% worse |
| val_ood_re | mae_surf_p | 27.62 | 28.48 | +3.1% worse |
| val_tandem_transfer | mae_surf_p | 38.14 | 40.22 | +5.5% worse |
| **mean3** | mae_surf_p | **23.02** | **24.43** | **+6.1% worse** |

Surface MAE (full breakdown, epoch 58):
- **in_dist:** Ux=6.12, Uy=1.74, p=17.77 | Vol: Ux=1.16, Uy=0.40, p=20.23
- **ood_cond:** Ux=2.74, Uy=1.09, p=15.29 | Vol: Ux=0.79, Uy=0.30, p=14.24
- **ood_re:** Ux=2.43, Uy=0.93, p=28.48 | Vol: Ux=0.86, Uy=0.38, p=47.98
- **tandem_transfer:** Ux=4.84, Uy=1.90, p=40.22 | Vol: Ux=2.13, Uy=1.01, p=43.25

### What happened

Mixup significantly worsens performance: val_loss +9.2%, mean3 +6.1%. Three compounding issues explain this:

1. **Mask intersection shrinks training signal**: Each non-tandem CFD sample has a different mesh. The intersection  is the set of nodes valid in both meshes. For variable-size meshes this can be significantly smaller than either individual mesh, reducing effective training signal per batch.

2. **Scale inconsistency from per-sample std norm**: The per-sample std normalization runs *before* mixup, so y_norm[i] = y_phys[i] / sample_stds[i] and y_norm[j] = y_phys[j] / sample_stds[j]. After mixing, the target for sample i is  — an interpolation of values normalized by *different* per-sample scales. The forward pass then divides pred[i] by sample_stds[i] only, creating a systematic loss scale mismatch for mixed samples.

3. **Geometric interpolation is non-physical**: Even for non-tandem airfoils, different shapes have distinct SDF values, curvature profiles, and node distributions. Linearly interpolating x (including dsdf channels, curvature) doesn't produce a valid intermediate airfoil geometry — the model is being asked to predict pressure fields for physically non-existent geometries.

Interestingly, velocity errors (Ux, Uy) are *lower* than baseline in some splits (e.g., ood_cond Ux=2.74 vs pcgrad-sparse 4.05). The augmentation may help low-frequency velocity patterns but hurt pressure, which is the most important metric.

### Suggested follow-ups

- **Mixup before per-sample std normalization**: Apply mixup to y_phys and x before the per-sample std step, then recompute sample_stds on the mixed batch. This avoids the scale inconsistency issue.
- **CutMix instead of standard mixup**: Select contiguous spatial regions from one sample and paste into another. Respects mesh geometry better than full-sample linear interpolation.
- **Condition-only mixup**: Mix only the flow condition features (Re, AoA channels) while keeping geometry fixed. This avoids the geometry mismatch problem entirely.