### PR TITLE
Per-domain loss weights: tandem 2x, ood_cond 1.5x in PCGrad

### DIFF
--- a/train.py
+++ b/train.py
@@ -789,14 +789,23 @@ for epoch in range(MAX_EPOCHS):
         use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
 
         if use_pcgrad:
-            n_a = is_indist_pcgrad.float().sum().clamp(min=1)
-            n_b = is_ood_pcgrad.float().sum().clamp(min=1)
+            # Per-sample domain weighting within PCGrad groups
+            domain_w = torch.ones(x.shape[0], device=device)  # [B]
+            domain_w[is_tandem_batch] = 2.0
+            is_extreme_re = (x[:, 0, 13] > 1.0) & ~is_tandem_batch
+            domain_w[is_extreme_re] = 1.2
+            # Upweight ood_cond-like samples in Group A
+            is_ood_cond_a = (x[:, 0, 14].abs() > 1.0) & is_indist_pcgrad
+            domain_w_a = torch.ones(x.shape[0], device=device)
+            domain_w_a[is_ood_cond_a] = 1.5
             vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
             vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
             vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
-            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
-            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
-            surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
+            weighted_ood = is_ood_pcgrad.float() * domain_w
+            vol_loss_b = (abs_err * (vol_mask_b * domain_w.unsqueeze(1)).unsqueeze(-1)).sum() / (vol_mask_b * domain_w.unsqueeze(1)).sum().clamp(min=1)
+            weighted_indist = is_indist_pcgrad.float() * domain_w_a
+            surf_loss_a = (surf_per_sample * weighted_indist * tandem_boost).sum() / weighted_indist.sum().clamp(min=1)
+            surf_loss_b = (surf_per_sample * weighted_ood * tandem_boost).sum() / weighted_ood.sum().clamp(min=1)
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
             loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
             loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss


### PR DESCRIPTION
## Hypothesis
PCGrad projects conflicting gradients between Group A (in_dist) and Group B (OOD), but within each group loss is averaged uniformly. Group B contains tandem (mae_surf_p=38.14) and ood_re (27.62) — tandem with 3x worse error gets the same weight. Explicitly upweighting tandem by 2x and ood_cond by 1.5x within their respective groups steers more gradient toward the highest-error domains without changing the PCGrad conflict resolution.

## Instructions
In the PCGrad section (~line 790), after computing is_ood_pcgrad and is_indist_pcgrad, create per-sample domain weights:

```python
# Per-sample domain weighting within PCGrad groups
domain_w = torch.ones(x.shape[0], device=device)  # [B]
# Upweight tandem samples (worst split)
domain_w[is_tandem_batch] = 2.0
# Upweight extreme-Re OOD samples  
is_extreme_re = (x[:, 0, 13] > 1.0) & ~is_tandem_batch
domain_w[is_extreme_re] = 1.2
```

Then modify the Group B loss computation to use these weights:
```python
# OLD: surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
# NEW: apply domain weights
weighted_ood = is_ood_pcgrad.float() * domain_w
surf_loss_b = (surf_per_sample * weighted_ood * tandem_boost).sum() / weighted_ood.sum().clamp(min=1)
vol_loss_b = (abs_err * (vol_mask_b * domain_w.unsqueeze(1)).unsqueeze(-1)).sum() / (vol_mask_b * domain_w.unsqueeze(1)).sum().clamp(min=1)
```

Similarly, upweight ood_cond in Group A:
```python
# Detect ood_cond-like samples in Group A (extreme AoA)
is_ood_cond = (x[:, 0, 14].abs() > 1.0) & is_indist_pcgrad
domain_w_a = torch.ones(x.shape[0], device=device)
domain_w_a[is_ood_cond] = 1.5
weighted_indist = is_indist_pcgrad.float() * domain_w_a
surf_loss_a = (surf_per_sample * weighted_indist * tandem_boost).sum() / weighted_indist.sum().clamp(min=1)
```

Run with `--wandb_group domain-weighted-pcgrad`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `nypk31qj` | Best epoch: 57 | Peak memory: 18.5 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6038 | 18.1 | +6.3% worse |
| val_ood_cond | 0.7337 | 14.6 | +5.0% worse |
| val_ood_re | 0.5515 | 28.0 | +1.4% worse |
| val_tandem_transfer | 1.6676 | 39.6 | +3.8% worse |
| **combined** | **0.8891** | — | **+4.3% worse** |

### What happened

Negative result. All splits slightly worse across the board.

Two issues I noticed in implementation:

1. **Group A ood_cond weighting was a no-op**: `is_ood_pcgrad` already includes `(x[:, 0, 14].abs() > 1.0)`, so `is_ood_cond_a = (x[:, 0, 14].abs() > 1.0) & is_indist_pcgrad` is always empty. The extreme-AoA samples are in Group B by construction. The Group A `domain_w_a` changes had zero effect.

2. **Tandem 2x boost in Group B interacts badly with tandem_boost**: The adaptive `tandem_boost` (line ~748) already upweights tandem samples by up to ~3x based on the tandem/nontandem error ratio. Multiplying by another 2x via `domain_w` makes tandem samples dominate Group B loss by 6x — this likely made Group B gradient less informative about ood_re and pushed the PCGrad gradient projection further from Group A needs.

The net effect is that all splits got slightly worse, consistent with Group B loss becoming too tandem-focused and PCGrad conflicts increasing.

### Suggested follow-ups

- Remove the interaction with tandem_boost by only applying domain_w to the numerator, not multiplying with tandem_boost (or using domain_w as a replacement for tandem_boost rather than stacking on top).
- The Group A ood_cond upweighting needs a different detection strategy: perhaps samples where validation_split_id (if available in features) indicates ood_cond, or using a different feature column threshold that doesn't overlap with is_ood_pcgrad.
- Consider applying domain weights to the entire loss (not just PCGrad groups) as a simpler alternative.