### PR TITLE
MLP DropPath p=0.05 (implicit ensemble regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -219,6 +219,7 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.spatial_bias[-1].bias)
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
+        self.mlp_drop_prob = 0.05  # stochastic MLP drop (training only)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
@@ -234,7 +235,10 @@ class TransolverBlock(nn.Module):
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
-        fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
+        mlp_out = self.mlp(self.ln_2(fx))
+        if self.training and torch.rand(1).item() < self.mlp_drop_prob:
+            mlp_out = torch.zeros_like(mlp_out)
+        fx = self.ln_2_post(mlp_out + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))


### PR DESCRIPTION
## Hypothesis
MLP-only DropPath at p=0.1 was a massive early win (PR #801, val_loss 2.29→1.57, -31%). It was later removed when the architecture changed significantly. PR #1151 tried stochastic depth p=0.1 but on the entire block (attention AND MLP). The key insight from #801: dropping ONLY the MLP branch (keeping attention active) forces the attention to learn independently, creating an implicit ensemble at test time. With the current much-stronger architecture, p=0.1 might be too aggressive. Try p=0.05 — lighter touch that still provides implicit ensemble benefit.

## Instructions
In `TransolverBlock.forward()`, add stochastic drop to the MLP residual only:

```python
# In TransolverBlock.__init__:
self.mlp_drop_prob = 0.05  # only during training

# In forward(), find the MLP residual computation (around the ln_2/mlp/ln_2_post sequence):
mlp_out = self.mlp(self.ln_2(fx))

# Add DropPath:
if self.training and torch.rand(1).item() < self.mlp_drop_prob:
    mlp_out = torch.zeros_like(mlp_out)  # drop the entire MLP branch

fx = self.ln_2_post(mlp_out + fx)  # residual connection still passes fx through
```

This is zero-cost at inference (no random in eval mode). The residual ensures fx still flows even when MLP is dropped.

Run with `--wandb_group mlp-droppath-005`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B Run:** vdy3rnya
**Best epoch:** 58

### Metrics vs Baseline

| Split | val_loss | surf_p | surf_Ux | surf_Uy | vol_p |
|-------|----------|--------|---------|---------|-------|
| val_in_dist | 0.5983 | 18.12 | 3.82 | 1.29 | 19.44 |
| val_ood_cond | 0.7344 | 14.88 | 3.53 | 1.01 | 12.25 |
| val_ood_re | 0.5558 | 28.13 | 3.38 | 0.86 | 47.06 |
| val_tandem_transfer | 1.6432 | 39.43 | 3.82 | 1.78 | 38.61 |
| **combined** | **0.8829** | — | — | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8525 | 0.8829 | +0.0304 ↑ worse |
| in surf_p | 17.03 | 18.12 | +1.09 ↑ worse |
| ood surf_p | 13.90 | 14.88 | +0.98 ↑ worse |
| re surf_p | 27.62 | 28.13 | +0.51 ↑ worse |
| tandem surf_p | 38.14 | 39.43 | +1.29 ↑ worse |
| mean3 surf_p | 19.52 | 20.38 | +0.86 ↑ worse |

**Peak memory:** ~same as baseline (no model size change, p.s. params added negligible)

### What happened

Negative result — MLP DropPath at p=0.05 hurt across all splits, ~+0.03 val/loss above baseline. The degradation is consistent and exceeds seed variance (~0.01), so this is a real effect.

The implicit ensemble benefit expected at test time didn't materialize. The likely reason: with only **one** TransolverBlock, the MLP is the sole feature transformation path. Dropping it 5% of the time introduces meaningful noise without a deep network to compensate. In a deeper model (e.g., the 4-layer architecture from PR #801 era), each layer still receives regularized representations from adjacent layers; here there's no such redundancy.

Additionally, the current architecture already has SE (squeeze-excitation) gating and temperature-clamped attention as regularization. Adding stochastic MLP drop may be over-regularizing a model that's already well-constrained.

### Suggested follow-ups

- Try p=0.02 or p=0.01 (lighter touch) if the implicit ensemble hypothesis is still worth pursuing
- Alternatively, try attention DropPath rather than MLP DropPath — in a single-layer model, dropping attention occasionally might force the MLP to learn residual corrections
- The PR #801 context (deeper architecture) suggests this technique works best with 3+ layers; revisiting with depth increases would be more appropriate