### PR TITLE
Cosine sim loss on surface pressure profile (weight=0.05)

### DIFF
--- a/train.py
+++ b/train.py
@@ -784,6 +784,17 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
+        # Profile shape loss: cosine similarity on surface pressure
+        surf_mask_f = is_surface.float()  # [B, N]
+        pred_p = pred[:, :, 2] * surf_mask_f  # [B, N]
+        true_p = y_norm[:, :, 2] * surf_mask_f  # [B, N]
+        n_surf = surf_mask_f.sum(dim=1)  # [B]
+        valid = n_surf >= 2
+        if valid.any():
+            cos_sim = F.cosine_similarity(pred_p[valid], true_p[valid], dim=1)  # [B_valid]
+            profile_loss = (1 - cos_sim).mean()
+            loss = loss + 0.05 * profile_loss
+
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)


### PR DESCRIPTION
## Hypothesis
L1 loss on surface pressure treats each node independently, but pressure distributions have a characteristic SHAPE (suction peak, pressure recovery, trailing edge) that matters more than absolute values. Cosine similarity loss on the surface pressure profile captures shape information — two profiles with the same shape but constant offset score well. PR #760 tried weight=0.2 (improved ood_re/tandem but hurt val_loss). At weight=0.05, the shape-matching signal adds gradient without dominating.

## Instructions
After computing the surface loss and before adding to the total loss, add a profile-shape loss:

```python
import torch.nn.functional as F

# Per-sample cosine similarity on surface pressure
# pred shape: [B, N, 3], y_norm shape: [B, N, 3], is_surface: [B, N]
surf_mask_f = is_surface.float()  # [B, N]
pred_p = pred[:, :, 2] * surf_mask_f  # predicted pressure on surface [B, N]
true_p = y_norm[:, :, 2] * surf_mask_f  # target pressure on surface [B, N]

# Cosine similarity per sample (over the N dimension)
# Need at least 2 surface nodes per sample
n_surf = surf_mask_f.sum(dim=1)  # [B]
valid = n_surf >= 2
if valid.any():
    cos_sim = F.cosine_similarity(pred_p[valid], true_p[valid], dim=1)  # [B_valid]
    profile_loss = (1 - cos_sim).mean()
    loss = loss + 0.05 * profile_loss
```

Run with `--wandb_group cosine-profile-005`.

## Baseline (updated after PR #1473 merge)
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.84 |
| val_ood_cond | — | 13.66 |
| val_tandem_transfer | — | 36.36 |
| **combined** | **0.8495** | — |

---

## Results (v2 — rebased onto noam with dist-to-surface)

**W&B run ID:** sz4yvah5  
**Best epoch:** 60 (wall-clock timeout at 30.4 min)  
**Peak memory:** ~14.8 GB

### Validation losses

| Split | val/loss | new baseline |
|-------|----------|-------------|
| Combined | **0.8625** | 0.8495 |
| val_in_dist | 0.5833 | — |
| val_tandem_transfer | 1.6329 | — |
| val_ood_cond | 0.7003 | — |
| val_ood_re | 0.5335 | — |

### Surface MAE

| Split | Ux | Uy | p | new baseline p | delta |
|-------|----|----|---|----------------|-------|
| val_in_dist | 5.75 | 1.94 | **17.52** | 17.84 | **-1.8%** |
| val_tandem_transfer | 5.15 | 2.40 | 38.87 | 36.36 | +6.9% |
| val_ood_cond | 2.73 | 1.08 | 13.89 | 13.66 | +1.7% |
| val_ood_re | 2.54 | 0.97 | 27.63 | — | — |

**mean3 surf_p** = (17.52 + 13.89 + 38.87) / 3 = **23.43** (new baseline mean3 ≈ 22.62)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.08 | 0.35 | 19.15 |
| val_tandem_transfer | 1.91 | 0.87 | 38.65 |
| val_ood_cond | 0.71 | 0.27 | 11.73 |
| val_ood_re | 0.82 | 0.36 | 46.62 |

---

### What happened

**Negative result vs new baseline.** val/loss = 0.8625 vs 0.8495 (+1.5% worse). mean3 surf_p = 23.43 vs new baseline ~22.62 (+3.6% worse).

The v1 run (without dist-to-surface) showed ood_cond=13.48 (best in round). After rebasing onto the new noam with dist-to-surface, the advantage evaporated: ood_cond=13.89 vs new baseline 13.66 (now 1.7% worse). The biggest regression is val_tandem_transfer: 38.87 vs 36.36 (+6.9%).

The cosine profile loss does not improve the new baseline that includes dist-to-surface. The dist-to-surface feature likely already captures structural shape information, making the cosine shape loss redundant or even conflicting — the two signals may be pulling in inconsistent directions for tandem cases.

val_in_dist improved slightly (17.52 vs 17.84, -1.8%) which is a positive signal for single-foil cases.

---

### Suggested follow-ups

- **Surface-only cosine similarity**: The zero-padding approach computes similarity over mostly-zero vectors (volume nodes). Gather only surface node indices first, then compute cosine similarity over just those nodes — this gives a cleaner signal.
- **Cosine loss on Ux/Uy as well**: The velocity profiles also have characteristic shapes. Extending to all 3 channels might balance the loss better.
- **Lower weight (0.02)**: The in_dist improvement suggests the shape signal is useful at low weight. Try 0.02 to reduce the tandem regression.
