### PR TITLE
Zone-aware input: dsdf proximity as 8-dim learned embedding

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,8 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.zone_embed = nn.Sequential(nn.Linear(1, 8), nn.GELU())
+        nn.init.zeros_(self.zone_embed[0].bias)  # start near zero effect
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -374,6 +376,11 @@ class Transolver(nn.Module):
                 raise ValueError("Missing required input tensor: pos")
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
+
+        # Zone proxy: proximity to nearest refinement boundary (≈1 near foils, ≈0 far)
+        zone_proxy = 1.0 / (1.0 + x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values * 5.0)
+        zone_feat = self.zone_embed(zone_proxy)  # [B, N, 8]
+        x = torch.cat([x, zone_feat], dim=-1)
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
@@ -518,7 +525,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 1 + 32,  # 8 freqs * 2 coords * 2 (sin+cos) = 32
+    fun_dim=X_DIM - 2 + 1 + 32 + 8,  # 8 freqs * 2 coords * 2 (sin+cos) = 32, +8 zone embed
     out_dim=3,
     n_hidden=192,  # regime-w: full width with finer routing
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min


### PR DESCRIPTION
## Hypothesis
The dataset uses overset meshes with 3 zones (background, foil1 refinement, foil2 refinement). Zone membership encodes which nodes are in the dense refinement region around foils. This info is NOT in the current input features. Since prepare_multi.py is read-only, approximate zone proximity from dsdf: the minimum absolute dsdf across channels gives a continuous distance-to-nearest-refinement-boundary that effectively encodes zone membership.

## Instructions
1. Create a continuous zone proxy feature:
```python
# Minimum absolute dsdf = proximity to nearest surface/boundary
zone_proxy = 1.0 / (1.0 + x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values * 5.0)
# zone_proxy ≈ 1.0 near foils (refinement zones), ≈ 0.0 far away
```

2. Add a learnable zone embedding in the model:
```python
# In Transolver.__init__:
self.zone_embed = nn.Sequential(
    nn.Linear(1, 8),
    nn.GELU(),
)
nn.init.zeros_(self.zone_embed[0].bias)  # start near zero effect
```

3. In the forward pass, compute zone features and concatenate:
```python
zone_feat = self.zone_embed(zone_proxy)  # [B, N, 8]
x = torch.cat([x, zone_feat], dim=-1)
```

4. Update `fun_dim` in model_config to +8 for the zone embedding.

5. Run with `--wandb_group zone-embed`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** qw8q84iu
**Total time:** 30.0 min, 56 epochs

### Metrics

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.6060 | 18.2 |
| val_ood_cond | 0.7252 | 14.5 |
| val_ood_re | 0.5510 | 28.0 |
| val_tandem_transfer | 1.6303 | 38.5 |
| **mean3 (in+ood+tan)** | **0.8781** | **23.73** |

Baseline: val_loss=0.8525, mean3_p=23.02

**Delta:** val_loss +0.0256 (+3.0%), mean3_p +0.71 (+3.1%)

**Peak VRAM:** ~18.9GB (+0.4GB vs baseline)

### What happened

No improvement. The zone-proxy embedding adds a small overhead and does not help — val_loss is 3% worse and mean3_p is 3.1% higher. The model runs 56 epochs vs baseline's ~58 epochs, which partly explains the gap (slightly fewer training steps).

The zone proxy feature (1.0 / (1 + min_dsdf_abs * 5.0)) is actually redundant information: the dsdf channels themselves already encode proximity to surfaces, and the curvature proxy already identifies surface vs. volume nodes. The model may have learned to extract zone proximity from existing features already. Adding a learned 8-dim expansion of this redundant signal just adds capacity without providing new information, resulting in slightly slower convergence.

Also, the zone_embed happens inside the model's forward pass, before the feature_cross layer. This means the zone features get processed through feature_cross (Linear(65,65)), preprocess (GatedMLP2), and the attention blocks — which is the same pipeline as all other features. There's no specialized treatment for this feature.

### Suggested follow-ups

1. Raw dsdf min as a scalar feature (no embedding): Add zone_proxy as a simple 1-dim scalar appended to the input features, increasing fun_dim by 1. This would test whether the spatial information adds value without the parameter overhead of an 8-dim embedding.
2. Input-side rather than model-side: Compute zone_proxy in the training loop and append to x before it enters the model, keeping fun_dim changes minimal.
3. Is the information already there? Check if the model's attention patterns already respect zone structure by visualizing attention weights.