### PR TITLE
Split output: shared trunk, separate pressure/velocity proj

### DIFF
--- a/train.py
+++ b/train.py
@@ -225,11 +225,9 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
-            )
+            self.mlp2_shared = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU())
+            self.mlp2_vel = nn.Linear(hidden_dim, 2)       # Ux, Uy
+            self.mlp2_pressure = nn.Linear(hidden_dim, 1)  # p
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -240,7 +238,10 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.mlp2_shared(self.ln_3(fx))
+            vel = self.mlp2_vel(h)
+            pres = self.mlp2_pressure(h)
+            return torch.cat([vel, pres], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The output MLP predicts [Ux, Uy, p] jointly through one Linear(192,192)->GELU->Linear(192,3). Pressure has 100x larger MAE and different spatial structure than velocity. Previous fully-separate-head attempts (#956, #1137, #1158, #1415) failed because they split too early, duplicating parameters. The minimal version: keep the shared trunk (Linear+GELU), split ONLY the final projection into Linear(192,2) for velocity and Linear(192,1) for pressure. This costs only 192 extra parameters but decouples the last gradient step.

## Instructions
In `TransolverBlock.__init__`, when `last_layer=True`:
```python
# Replace: self.mlp2 = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim))
# With:
self.mlp2_shared = nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU())
self.mlp2_vel = nn.Linear(hidden_dim, 2)    # Ux, Uy
self.mlp2_pressure = nn.Linear(hidden_dim, 1)  # p
```

In `TransolverBlock.forward()`, when `last_layer=True`:
```python
# Replace: return self.mlp2(self.ln_3(fx))
# With:
h = self.mlp2_shared(self.ln_3(fx))
vel = self.mlp2_vel(h)      # [B, N, 2]
pres = self.mlp2_pressure(h)  # [B, N, 1]
return torch.cat([vel, pres], dim=-1)  # [B, N, 3]
```

Run with `--wandb_group split-final-proj`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `g6az5rqc`
**Best epoch:** 57/100 (wall-clock limit at 30 min)
**Peak memory:** ~17 GB

### Metrics (best epoch)

| Split | val/loss | Surf p | Surf Ux | Surf Uy | Vol p | Vol Ux | Vol Uy |
|-------|----------|--------|---------|---------|-------|--------|--------|
| val_in_dist | 0.642 | 19.95 | 6.10 | 1.80 | 20.42 | 1.14 | 0.36 |
| val_ood_cond | 0.701 | 14.08 | 3.70 | 1.20 | 11.98 | 0.71 | 0.27 |
| val_ood_re | 0.554 | 28.11 | 3.04 | 1.04 | 46.83 | 0.83 | 0.36 |
| val_tandem_transfer | 1.660 | 39.59 | 5.75 | 2.08 | 39.09 | 1.95 | 0.88 |
| **combined val/loss** | **0.8893** | | | | | | |

### vs Baseline

| Metric | Baseline | Split proj | Delta |
|--------|----------|------------|-------|
| val/loss | 0.8525 | 0.8893 | +0.037 ▲ |
| in/surf_p | 17.03 | 19.95 | +2.92 ▲ |
| ood/surf_p | 13.90 | 14.08 | +0.18 ▲ |
| re/surf_p | 27.62 | 28.11 | +0.49 ▲ |
| tan/surf_p | 38.14 | 39.59 | +1.45 ▲ |

### What happened

Splitting only the final projection layer hurt across all splits (+4.3% on val/loss). The pressure accuracy degraded most on val_in_dist (+2.92 Pa) and val_tandem_transfer (+1.45 Pa), while val_ood_cond was nearly unchanged (+0.18 Pa).

I expected this change to be neutral-to-positive since it only adds 192 parameters and provides separate gradient paths for velocity vs pressure. The result suggests the original joint projection was learning a useful cross-field representation that the split disrupts. The shared trunk may not fully encode the cross-field correlation needed — velocity gradients apparently help pressure prediction even in the final layer.

This matches the pattern in prior split-head experiments (#956, #1137, #1158, #1415) — all failed. The final projection appears to play a role in cross-field coupling that benefits from joint training.

### Suggested follow-ups

- Try the inverse: a shared pressure-informed representation (predict p first, use as input to vel prediction)
- Could explore orthogonal gradient projection between vel/pressure gradients at the output layer specifically
- If cross-field coupling at the output is beneficial, a multi-task learning approach (uncertainty weighting per field) might be more principled