### PR TITLE
Temp init=0.1 warm to learned by epoch 15 (sharp early)

### DIFF
--- a/train.py
+++ b/train.py
@@ -533,6 +533,9 @@ model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
+# Start with sharp temperature (0.1), will warm to 0.5 over epochs 0-14
+with torch.no_grad():
+    _base_model.blocks[0].attn.temperature.data.fill_(0.1)
 
 from copy import deepcopy
 ema_model = None
@@ -847,6 +850,11 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    if epoch < 15:
+        # Warm temperature from 0.1 to 0.5 over epochs 0-14 (sharp→moderate)
+        target_temp = 0.1 + (0.5 - 0.1) * (epoch / 14.0)
+        with torch.no_grad():
+            _base_model.blocks[0].attn.temperature.data.clamp_(min=0.1, max=target_temp)
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)


### PR DESCRIPTION
## Hypothesis
The attention temperature starts at 0.5 (moderate sharpness) and is clamped to 0.25 after epoch 50. Early in training, when the model is learning basic spatial decomposition, a SHARPER temperature could help by forcing more decisive routing from the start — creating cleaner cluster boundaries earlier. PR #468 showed temperature init=0.25 was a merged winner. But we've never tried starting VERY sharp (0.1) and warming up. This is analogous to inverse temperature annealing: start with sharp decisions (commit to spatial decomposition early), gradually allow exploration, then sharpen again.

## Instructions
1. After model creation but before torch.compile, set initial temperature to 0.1:
```python
with torch.no_grad():
    _base_model.blocks[0].attn.temperature.data.fill_(0.1)
```

2. In the training loop, after the optimizer step, add warmup for epochs 0-14:
```python
if epoch < 15:
    target_temp = 0.1 + (0.5 - 0.1) * (epoch / 14.0)  # 0.1 → 0.5 over 15 epochs
    with torch.no_grad():
        _base_model.blocks[0].attn.temperature.data.clamp_(min=0.1, max=target_temp)
```

3. The existing epoch >= 50 clamp to 0.25 stays as-is. The full schedule becomes:
   - Epochs 0-14: warm from 0.1 to 0.5 (sharp→moderate)
   - Epochs 15-49: learned (free parameter)
   - Epochs 50+: clamped to max 0.25 (sharpen again)

4. Run with `--wandb_group temp-warmup-cold`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** `rh90fvmv`

### Metrics vs Baseline

| Split | val_loss | mae_surf_p | Δ mae_surf_p | mae_surf_Ux | mae_surf_Uy |
|-------|----------|------------|--------------|-------------|-------------|
| val_in_dist | 0.6231 | 18.417 | +8.1% worse | 7.745 | 2.127 |
| val_ood_cond | 0.7378 | 14.752 | +6.1% worse | 4.015 | 1.250 |
| val_ood_re | 0.5658 | 28.112 | +1.8% worse | 3.686 | 1.123 |
| val_tandem_transfer | 1.6850 | 39.097 | +2.5% worse | 6.779 | 2.576 |
| **combined** | **0.9029** | — | +5.9% worse | — | — |

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.160 | 0.385 | 19.930 |
| val_ood_cond | 0.813 | 0.289 | 12.792 |
| val_ood_re | 0.904 | 0.377 | 47.431 |
| val_tandem_transfer | 1.985 | 0.897 | 39.473 |

Peak VRAM: not logged.

### What happened

Sharp temperature init (0.1) with warmup did not help — val/loss degraded from 0.8525 to 0.9029 (+5.9%), and all surface pressure metrics worsened across every split.

The loss curve reached 0.9029 at the 30-minute cutoff and was still declining, suggesting slower convergence rather than a convergence to a worse minimum. The baseline with default temp=0.5 reaches 0.8525 in the same time budget.

The likely reason: temperature=0.1 creates very sharp (near-argmax) slice routing from step 1. While this forces decisive assignments, it also means the gradient signal for adjusting routing is extremely small early on — sharp softmax has near-zero gradient for non-winning slices. The model spends the first ~15 epochs locked into suboptimal routing decisions before the warmup allows exploration. This is the opposite of the intended benefit.

The merged winner (PR #468, temp init=0.25) is a milder reduction from the default 0.5 — decisive but not frozen. Going to 0.1 crosses a threshold where the model can't escape bad initial routing.

### Suggested follow-ups

- **Try temp init=0.2 or 0.3** (intermediate between 0.25 winner and 0.1 failure): may capture the "sharper early" benefit without killing early gradients.
- **Longer warmup**: if temp=0.1 init is desired, extending warmup to 30 epochs (instead of 15) might give the model enough time to recover before the free-parameter phase.
- **Per-head scheduling**: instead of all-heads-same, try warming the temperature per block or per head separately to allow different routing heads to specialize at different rates.