### PR TITLE
PCGrad: upweight ood_cond 2x in Group A loss

### DIFF
--- a/train.py
+++ b/train.py
@@ -789,14 +789,24 @@ for epoch in range(MAX_EPOCHS):
         use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
 
         if use_pcgrad:
-            n_a = is_indist_pcgrad.float().sum().clamp(min=1)
+            # Identify ood_cond-like samples (extreme AoA) within Group A
+            is_ood_cond_in_A = (x[:, 0, 14].abs() > 1.0) & is_indist_pcgrad  # extreme AoA but in Group A
+
+            # Create per-sample weights for Group A
+            w_a = torch.ones(x.shape[0], device=device)
+            w_a[is_ood_cond_in_A] = 2.0  # 2x weight for ood_cond samples
+
             n_b = is_ood_pcgrad.float().sum().clamp(min=1)
-            vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
             vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
-            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
             vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
-            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
+
+            # Weighted Group A loss
+            weighted_indist = is_indist_pcgrad.float() * w_a
+            n_a_weighted = weighted_indist.sum().clamp(min=1)
+            surf_loss_a = (surf_per_sample * weighted_indist * tandem_boost).sum() / n_a_weighted
+            vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
+            vol_loss_a = (abs_err * (vol_mask_a.float() * w_a.unsqueeze(1)).unsqueeze(-1)).sum() / (vol_mask_a.float() * w_a.unsqueeze(1)).sum().clamp(min=1)
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
             loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
             loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss


### PR DESCRIPTION
## Hypothesis
PCGrad groups ood_cond with in_dist in Group A. But ood_cond samples are a small minority in Group A (most batches are dominated by in_dist samples). As a result, ood_cond's gradient signal is diluted. Explicitly upweighting ood_cond samples by 2x within Group A gives more gradient signal to the second-best split (13.90) without changing the PCGrad inter-group dynamics. This is complementary to the current PCGrad architecture — it addresses intra-group imbalance rather than inter-group conflicts.

Key finding from round 7: removing PCGrad entirely gives ood_cond=13.30 (best ever). This means the current PCGrad is suppressing ood_cond signal. Upweighting ood_cond within its group should partially recover this.

## Instructions
In the PCGrad section (~line 790), after computing `is_indist_pcgrad`:

```python
# Identify ood_cond-like samples (extreme AoA) within Group A
is_ood_cond_in_A = (x[:, 0, 14].abs() > 1.0) & is_indist_pcgrad  # extreme AoA but in Group A

# Create per-sample weights for Group A
w_a = torch.ones(x.shape[0], device=device)
w_a[is_ood_cond_in_A] = 2.0  # 2x weight for ood_cond samples

# Modify Group A loss computation:
weighted_indist = is_indist_pcgrad.float() * w_a
n_a_weighted = weighted_indist.sum().clamp(min=1)
surf_loss_a = (surf_per_sample * weighted_indist * tandem_boost).sum() / n_a_weighted
vol_mask_a_w = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
vol_loss_a = (abs_err * (vol_mask_a_w.float() * w_a.unsqueeze(1)).unsqueeze(-1)).sum() / (vol_mask_a_w.float() * w_a.unsqueeze(1)).sum().clamp(min=1)
```

Leave Group B loss computation unchanged.

Run with `--wandb_group pcgrad-reweight-ood-cond`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** [nnyp9pps](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/nnyp9pps)
**Best epoch:** 61/100
**Peak VRAM:** ~17.2 GB

### Validation Loss

| Split | This run | Baseline |
|-------|----------|----------|
| val/loss (combined) | **0.8597** | 0.8525 |
| val_in_dist | 0.5985 | — |
| val_tandem_transfer | 1.6359 | — |
| val_ood_cond | 0.6772 | — |
| val_ood_re | 0.5271 | — |

### Surface MAE

| Split | Ux | Uy | p | p (baseline) |
|-------|----|----|---|--------------|
| val_in_dist | 5.3476 | 2.1053 | 17.9245 | 17.03 |
| val_tandem_transfer | 5.1456 | 2.5297 | 39.0482 | 38.14 |
| val_ood_cond | 3.5491 | 1.4667 | 13.5613 | 13.90 |
| val_ood_re | 3.1579 | 1.3125 | 27.4856 | 27.62 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.0819 | 0.3597 | 18.8758 |
| val_tandem_transfer | 1.9035 | 0.8557 | 38.0728 |
| val_ood_cond | 0.6972 | 0.2604 | 11.2704 |
| val_ood_re | 0.7980 | 0.3510 | 46.5387 |

### What happened

No change — this is a no-op. The condition `is_ood_cond_in_A = (x[:, 0, 14].abs() > 1.0) & is_indist_pcgrad` is always empty. The existing `is_ood_pcgrad` definition already includes `x[:, 0, 14].abs() > 1.0`, so any sample with extreme AoA is ALREADY in Group B, not Group A. The intersection with `is_indist_pcgrad` (which is `~is_ood_pcgrad`) is always empty by construction. `w_a` was always all-ones and no upweighting occurred.

The combined val/loss 0.8597 vs baseline 0.8525 (+0.007) is within noise floor (~0.016). The surface pressure MAEs are mixed — ood_cond slightly improved (13.56 vs 13.90) and ood_re slightly improved (27.49 vs 27.62), but in_dist slightly regressed (17.92 vs 17.03). These small differences are consistent with random seed variation.

### Suggested follow-ups

- **Lower the threshold**: Use `(x[:, 0, 14].abs() > 0.5)` to capture moderate-AoA samples that ARE in Group A, rather than 1.0 which is already the Group B boundary.
- **Use a separate feature**: Identify ood_cond samples by Reynolds number percentile or a split-level tag rather than AoA threshold, since "ood_cond" is a validation split concept, not a simple AoA threshold.
- **Eliminate PCGrad entirely**: The ablation finding that removing PCGrad gives ood_cond=13.30 (best ever) suggests PCGrad is net-negative for ood_cond. Simply removing it may be the right move.