### PR TITLE
Replace GELU with SiLU/Swish in all MLPs

### DIFF
--- a/train.py
+++ b/train.py
@@ -49,7 +49,7 @@ torch.set_float32_matmul_precision('high')
 # ---------------------------------------------------------------------------
 
 ACTIVATION = {
-    "gelu": nn.GELU,
+    "gelu": nn.SiLU,
     "tanh": nn.Tanh,
     "sigmoid": nn.Sigmoid,
     "relu": nn.ReLU,
@@ -211,8 +211,8 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(3, 64), nn.GELU(),
-            nn.Linear(64, 64), nn.GELU(),
+            nn.Linear(3, 64), nn.SiLU(),
+            nn.Linear(64, 64), nn.SiLU(),
             nn.Linear(64, slice_num),
         )
         nn.init.zeros_(self.spatial_bias[-1].weight)
@@ -227,7 +227,7 @@ class TransolverBlock(nn.Module):
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
-                nn.GELU(),
+                nn.SiLU(),
                 nn.Linear(hidden_dim, out_dim),
             )
 
@@ -314,8 +314,8 @@ class Transolver(nn.Module):
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
-        self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
-        self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.SiLU(), nn.Linear(32, 1))
+        self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.SiLU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 


### PR DESCRIPTION
## Hypothesis
All MLPs in the Transolver use GELU activation. SiLU (Swish, x * sigmoid(x)) has shown consistent small improvements over GELU in vision transformers and physics-informed networks because its smoother gradient provides better optimization landscape for continuous field prediction. This has never been tested in our programme. It's a zero-cost change (same FLOPs, same parameter count) that could provide a small uniform improvement across all splits.

## Instructions
A simple global replacement in train.py:

1. In all nn.Sequential blocks that use nn.GELU(), replace with nn.SiLU():
   - `self.mlp` in TransolverBlock (the main FFN)
   - `self.mlp2` in TransolverBlock (the output head, last layer only)
   - `self.preprocess` MLP
   - `self.spatial_bias` MLP
   - Any other MLPs with GELU

2. Search for all occurrences of `nn.GELU()` and replace with `nn.SiLU()`.

3. This is literally a find-and-replace. No other changes.

4. Run with `--wandb_group gelu-to-swish`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run**: abaomx7p  
**Best epoch**: 61 (30.4 min, wall-clock limit)  
**VRAM**: 17.5 GB  

Implementation: replaced all 5 literal `nn.GELU()` instances with `nn.SiLU()`, and updated the ACTIVATION dict (`"gelu": nn.SiLU`) so that MLP/GatedMLP2 classes using `act="gelu"` (preprocess, block FFNs) also use SiLU.

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6066 | 6.45 | 1.95 | **17.70** | 1.11 | 0.37 | 19.26 |
| val_ood_cond | 0.7317 | 3.83 | 1.19 | **14.56** | 0.73 | 0.28 | 12.36 |
| val_ood_re | 0.5564 | 3.59 | 1.02 | 28.10 | 0.84 | 0.36 | 47.05 |
| val_tandem_transfer | 1.6124 | 6.24 | 2.42 | **38.13** | 1.94 | 0.88 | 37.46 |
| **combined** | **0.8768** | | | | | | |

**mean3 (in/ood/tan p)**: (17.70 + 14.56 + 38.13) / 3 = **23.46** vs baseline 23.02 → **+0.44, negative result**

### What happened

Replacing GELU with SiLU uniformly degraded performance. In_dist (+0.67), ood_cond (+0.66), and ood_re (+0.48) all got worse. Only tandem was essentially unchanged (-0.01). Val/loss went from 0.8525 → 0.8768.

SiLU's smoother gradient didn't help here. A few possible reasons:

1. **Architecture is already well-tuned for GELU**: The orthogonal weight initialization, learning rate, and other hyperparameters were tuned with GELU. SiLU shifts the activation function distribution and may require retuning (especially learning rate) to benefit from it.
2. **GatedMLP2 already provides smooth gating**: The preprocess MLP uses `GatedMLP2` which already has sigmoid gating (`sigmoid(gate) * act(up)`). SiLU's advantage over GELU is largely in non-gated MLPs; gated architectures already provide smooth multiplicative control.
3. **30-minute training window is too short**: SiLU advantages in vision transformers are often observed after many epochs of training. In our constrained 30-minute window, the model may not have enough time to adapt to the different activation statistics.

### Suggested follow-ups

1. **SiLU only in un-gated MLPs**: Apply SiLU specifically to `spatial_bias`, `mlp2`, `re_head`, `aoa_head` while keeping GELU in the gated MLPs (preprocess, block FFN). This avoids disrupting the gated architecture.
2. **Learning rate tune for SiLU**: SiLU typically benefits from slightly lower learning rates. Try SiLU with lr=2.0e-3 instead of 2.5e-3.