### PR TITLE
MLP ratio 3 (wider FFN: 192→576→192)

### DIFF
--- a/train.py
+++ b/train.py
@@ -524,7 +524,7 @@ model_config = dict(
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
     n_head=3,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
-    mlp_ratio=2,
+    mlp_ratio=3,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
 )


### PR DESCRIPTION
## Hypothesis
The current mlp_ratio=2 gives FFN width of 384 (192*2). Wider FFN with mlp_ratio=3 (576) increases the model's capacity to learn complex nonlinear mappings in a single layer. Standard transformer practice uses mlp_ratio=4, but our 30-min budget constrains throughput. mlp_ratio=3 is the sweet spot — more capacity than 2 but not as slow as 4. Previous width experiments focused on n_hidden (the attention dimension); the FFN width has been fixed at ratio=2 since early in the programme and never tested at 3 on the current code.

## Instructions
Change mlp_ratio from 2 to 3:

```python
# In model_config:
mlp_ratio = 3  # was 2
```

This changes:
- FFN in TransolverBlock: Linear(192, 576) -> GELU -> Linear(576, 192)
- The output MLP also uses mlp_ratio, so check if it's affected

Monitor throughput carefully — if this drops below 40 epochs in 30 min, the EMA won't activate and the experiment is invalid.

Run with `--wandb_group mlp-ratio-3`.

## Baseline
| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | — | 17.03 |
| val_ood_cond | — | 13.90 |
| val_ood_re | — | 27.62 |
| val_tandem_transfer | — | 38.14 |
| **combined** | **0.8525** | — |

---

## Results

**W&B run:** 52lmugaj  
**Change:** `mlp_ratio=3` (was 2) in model_config

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Δ |
|-------|----------|------------|---------------------|---|
| val_in_dist | 0.5917 | 18.29 | 17.03 | +1.26 |
| val_ood_cond | 0.7271 | 14.46 | 13.90 | +0.56 |
| val_ood_re | 0.5619 | 28.15 | 27.62 | +0.53 |
| val_tandem_transfer | 1.6065 | 38.18 | 38.14 | +0.04 |
| **combined** | **0.8718** | — | **0.8525** | **+0.0193** |

**Peak memory:** 18.5 GB (vs ~16.7 GB baseline, +1.8 GB)  
**Epochs completed:** 58 in 30.2 min (~31 s/epoch, vs ~29 s/epoch baseline)  
**Throughput impact:** EMA activated at epoch 40 ✓ (18 EMA epochs)

### What happened

mlp_ratio=3 is marginally worse than mlp_ratio=2 on all splits. The wider FFN costs 1.8 GB more memory and runs ~2 seconds/epoch slower, resulting in 58 vs ~61 epochs in the same 30-min budget. The loss reduction curve is similar but 2-3 epochs behind the baseline at equivalent wall-clock time.

This suggests that for this architecture (1-layer, n_hidden=192), **the bottleneck is not FFN capacity but rather the number of training epochs**. The attention mechanism with slice_num=48 and 3 heads is the primary capacity constraint, not the FFN dimension. A wider FFN doesn't compensate for fewer training iterations within the 30-min budget.

The throughput warning in the PR was valid but not the binding constraint — EMA still activated at epoch 40, but the model had fewer epochs to benefit from EMA smoothing (18 vs ~21).

### Suggested follow-ups

- **mlp_ratio=4 with fewer slices:** If the FFN is the bottleneck, pair mlp_ratio=4 with slice_num=32 or 36 to keep epoch time similar to baseline.
- **Deeper model (n_layers=2) at n_hidden=128:** Instead of wider FFN, try deeper with narrower hidden dim to keep parameter count similar — may help with hierarchical feature learning.
- **FFN only in last layer:** Use mlp_ratio=4 in the final TransolverBlock only and mlp_ratio=2 elsewhere — asymmetric FFN sizing at minimal throughput cost.