### PR TITLE
Learned gate on dist_feat (recover in_dist regression)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,7 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.dist_gate = nn.Parameter(torch.tensor(-2.0))  # sigmoid(-2.0) ≈ 0.12, starts nearly closed
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -656,6 +657,7 @@ for epoch in range(MAX_EPOCHS):
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        dist_feat = dist_feat * torch.sigmoid(model.dist_gate)
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
@@ -886,6 +888,7 @@ for epoch in range(MAX_EPOCHS):
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+                dist_feat = dist_feat * torch.sigmoid(model.dist_gate)
                 x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]


### PR DESCRIPTION
## Hypothesis
dist_feat helped tandem (-4.7%) but hurt in_dist (+4.8%). The dist signal may add noise for simple single-foil geometries. A learned gate starting near zero lets the model gradually incorporate distance info without disrupting in_dist performance.

## Instructions
1. In `Transolver.__init__`, add: `self.dist_gate = nn.Parameter(torch.tensor(-2.0))`
2. In the training loop, after computing dist_feat, apply: `dist_feat = dist_feat * torch.sigmoid(model.dist_gate)`
3. Apply the same gating in the validation loop.
4. No other changes. The gate starts at sigmoid(-2.0) ≈ 0.12, letting the optimizer learn how much dist info to use.

Run with `--wandb_group dist-gate`.

## Baseline
| Split | mae_surf_p | val_loss |
|-------|------------|----------|
| val_in_dist | 17.84 | — |
| val_ood_cond | 13.66 | — |
| val_ood_re | 27.77 | — |
| val_tandem_transfer | 36.36 | — |
| **combined** | — | **0.8495** |

---

## Results

**W&B run:** flr7v32w | **Epochs:** 60/100 (timeout) | **Peak memory:** ~17.8 GB

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ vs baseline |
|-------|----------|-------------|-------------|------------|---------------|
| val_in_dist | 0.5875 | 4.66 | 1.76 | 18.01 | +0.17 (worse) |
| val_ood_cond | 0.7047 | 3.12 | 1.11 | 14.11 | +0.45 (worse) |
| val_ood_re | 0.5380 | 2.74 | 0.99 | 27.60 | -0.17 (better) |
| val_tandem_transfer | 1.6138 | 4.69 | 2.16 | 38.41 | **+2.05 (worse)** |
| **combined** | **0.8610** | — | — | — | +0.0115 (worse) |

**mean3 mae_surf_p:** 23.51 vs baseline 22.62 — **worse across the board**

### What happened

The gate hurt performance rather than helping. Starting at sigmoid(-2.0) ≈ 0.12 means the model sees very little distance signal for the first many epochs, which slows convergence. The tandem transfer regression is the most notable: 36.36 → 38.41 (+5.6%), which is bad since tandem improvement was the main motivation for dist_feat in the first place.

The in_dist regression from the dist_feat baseline (17.84 → 18.01) is actually *larger* with the gate, not smaller. The gate doesn't protect in_dist performance — it just slows the model from utilizing any of the dist information.

**Root cause:** Within the 30-minute budget, the gate may not have converged to an optimal value. A gate initialized at 0.12 needs to climb to some higher value to be useful; this takes gradient steps, effectively wasting early training time. The baseline (gate=1.0 fixed) gives the full dist_feat signal immediately.

### Suggested follow-ups

- Try initializing the gate to `0.0` (sigmoid(0) = 0.5) or `2.0` (sigmoid(2) ≈ 0.88) so the model gets more signal earlier.
- Instead of gating dist_feat, try only applying dist_feat to surface nodes (in_dist nodes are mostly volume, so the distance is less informative there; tandem nodes benefit from knowing proximity to the second foil).
- The in_dist regression with dist_feat may be a red herring — the baseline used for comparison may be from a different run with a different random seed.