### PR TITLE
Split spatial bias: separate dist pathway (decouple routing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -210,13 +210,19 @@ class TransolverBlock(nn.Module):
         )
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
-        self.spatial_bias = nn.Sequential(
-            nn.Linear(4, 64), nn.GELU(),
+        self.spatial_bias_pos = nn.Sequential(
+            nn.Linear(3, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
-        nn.init.zeros_(self.spatial_bias[-1].weight)
-        nn.init.zeros_(self.spatial_bias[-1].bias)
+        nn.init.zeros_(self.spatial_bias_pos[-1].weight)
+        nn.init.zeros_(self.spatial_bias_pos[-1].bias)
+        self.spatial_bias_dist = nn.Sequential(
+            nn.Linear(1, 32), nn.GELU(),
+            nn.Linear(32, slice_num),
+        )
+        nn.init.zeros_(self.spatial_bias_dist[-1].weight)
+        nn.init.zeros_(self.spatial_bias_dist[-1].bias)
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -232,7 +238,7 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
-        sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+        sb = (self.spatial_bias_pos(raw_xy[:, :, :3]) + 0.1 * self.spatial_bias_dist(raw_xy[:, :, 3:4])) if raw_xy is not None else None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis
The 4D spatial bias (x,y,curv,dist) may let dist_feat dominate or interfere with position-based routing, hurting in_dist. Split into two parallel pathways: 3D (x,y,curv) + 1D (dist) with learned combination, so distance adds routing signal for tandem without disrupting position routing for in_dist.

## Instructions
1. Replace the single spatial_bias with two parallel pathways:
```python
self.spatial_bias_pos = nn.Sequential(nn.Linear(3, 64), nn.GELU(), nn.Linear(64, 64), nn.GELU(), nn.Linear(64, slice_num))
self.spatial_bias_dist = nn.Sequential(nn.Linear(1, 32), nn.GELU(), nn.Linear(32, slice_num))
```
2. Zero-init the last layer of both.
3. In forward: `sb = self.spatial_bias_pos(raw_xy[:,:,:3]) + 0.1 * self.spatial_bias_dist(raw_xy[:,:,3:4])`
4. The 0.1 scale factor keeps dist contribution small initially.

Run with `--wandb_group split-spatial-bias`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `btpk587x`

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 0.8495 | **0.8705** | +0.0210 (~4.6σ, worse) |
| mae_surf_p in_dist | 17.84 | 17.90 | +0.06 |
| mae_surf_p ood_cond | 13.66 | 14.21 | +0.55 |
| mae_surf_p ood_re | 27.77 | 27.59 | −0.18 |
| mae_surf_p tandem | 36.36 | 39.42 | **+3.06** |
| **mean3 mae_surf_p** | **22.62** | **23.84** | **+1.22 (~5.8σ, worse)** |
| mae_vol_p in_dist | — | 19.50 | — |
| mae_vol_p ood_cond | — | 12.04 | — |
| mae_vol_p tandem | — | 38.27 | — |

**Peak VRAM:** ~same as baseline (split pathway adds ~1k parameters)

### What happened

Split spatial bias is significantly worse, primarily driven by a **+3.06 tandem regression** — the opposite of the intended effect.

The most likely explanation: the 4D unified pathway `spatial_bias(x,y,curv,dist)` had learned cross-feature interactions between the 4 inputs. The joint representation allows the network to use distance-position relationships like "this region is far from the leading edge AND near the trailing edge vortex" for tandem routing. Decoupling into separate 3D+1D pathways destroys these joint interactions.

The `0.1 * dist_pathway` scale factor (intended to "keep dist contribution small initially") may actually be too restrictive — if dist contributes 10× less than position, gradient flow through the dist pathway is weak and it doesn't learn useful routing. Zero-initialization of both last layers means both start from zero, but the position pathway has 3 input channels (better conditioning) vs the dist pathway's 1 channel.

The in_dist and ood_re splits are largely unaffected (within noise), confirming the damage is concentrated in tandem where dist_feat is most informative.

### Suggested follow-ups

- Try a unified 4D pathway but with a larger capacity: `nn.Linear(4, 128)` instead of `nn.Linear(4, 64)`
- Try removing the 0.1 dist scale and instead using equal-capacity pathways with full weight: `sb = spatial_bias_pos(...) + spatial_bias_dist(...)`
- Consider that the current unified 4D pathway already implicitly learns to weight dist separately via the learned weights — the split may not add value