### PR TITLE
Boundary-layer weighted volume loss (physics-informed)

### DIFF
--- a/train.py
+++ b/train.py
@@ -729,7 +729,11 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_weight = 1.0 / (1.0 + dist_feat.squeeze(-1))  # closer=higher weight
+        vol_weight = vol_weight * vol_mask_train.float()
+        # Normalize to preserve total loss magnitude
+        vol_weight = vol_weight / vol_weight.sum().clamp(min=1) * vol_mask_train.sum().clamp(min=1)
+        vol_loss = (abs_err * vol_weight.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
@@ -795,8 +799,12 @@ for epoch in range(MAX_EPOCHS):
             n_b = is_ood_pcgrad.float().sum().clamp(min=1)
             vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
             vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
-            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
-            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
+            vol_weight_a = 1.0 / (1.0 + dist_feat.squeeze(-1)) * vol_mask_a.float()
+            vol_weight_a = vol_weight_a / vol_weight_a.sum().clamp(min=1) * vol_mask_a.sum().clamp(min=1)
+            vol_loss_a = (abs_err * vol_weight_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
+            vol_weight_b = 1.0 / (1.0 + dist_feat.squeeze(-1)) * vol_mask_b.float()
+            vol_weight_b = vol_weight_b / vol_weight_b.sum().clamp(min=1) * vol_mask_b.sum().clamp(min=1)
+            vol_loss_b = (abs_err * vol_weight_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0


### PR DESCRIPTION
## Hypothesis
Volume nodes near the surface (boundary layer) matter most for surface pressure prediction. With dist_feat now available, weight volume loss by proximity: closer nodes get higher weight. This focuses volume learning on the boundary layer without losing far-field signal.

## Instructions
After computing vol_mask_train, add proximity-based weighting:
```python
vol_weight = 1.0 / (1.0 + dist_feat.squeeze(-1))  # closer=higher weight
vol_weight = vol_weight * vol_mask_train.float()
# Normalize to preserve total loss magnitude
vol_weight = vol_weight / vol_weight.sum().clamp(min=1) * vol_mask_train.sum().clamp(min=1)
vol_loss = (abs_err * vol_weight.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
```
Apply same in PCGrad vol_loss_a and vol_loss_b. Run with `--wandb_group bl-weighted-vol`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---

## Results

**W&B run:** `8ao8mb4z` | **Epochs completed:** 59 (30-min timeout) | **Peak memory:** 18.1 GB

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol |
|-------|----------|-------------|-------------|------------|---------|
| val_in_dist | 0.5998 | 4.09 | 1.35 | **18.02** | — |
| val_ood_cond | 0.7089 | 2.95 | 0.99 | **14.06** | — |
| val_ood_re | 0.5441 | 2.60 | 0.82 | **27.97** | — |
| val_tandem_transfer | 1.6499 | 4.93 | 1.93 | **39.28** | — |
| **combined** | **0.8756** | — | — | — | — |

**vs. baseline (dist-to-surface PR #1473):**
| Split | surf_p baseline | surf_p result | Δ |
|-------|----------------|----------------|---|
| val_in_dist | 17.84 | 18.02 | +1.0% worse |
| val_ood_cond | 13.66 | 14.06 | +2.9% worse |
| val_ood_re | 27.77 | 27.97 | +0.7% worse |
| val_tandem_transfer | 36.36 | 39.28 | **+8.1% worse** |
| combined val_loss | 0.8495 | 0.8756 | +3.1% worse |

**What happened:** The boundary-layer weighting hurt overall performance, with a particularly notable tandem regression (+8.1%). All splits are worse than the dist-to-surface baseline. The hypothesis was that near-surface volume nodes matter most for surface pressure — but in practice, downweighting far-field nodes appears to harm the model's ability to capture global pressure gradients that cascade to surface predictions. For tandem foils specifically, the wake interaction between the two foils involves far-field flow structures that the model can no longer learn as effectively. The normalization preserves total loss magnitude but changes the gradient distribution: the optimizer now sees far-field errors as less important, even though they carry global pressure information. The combined val/loss reports the same validation metric regardless of training weighting, so the real test (unweighted validation) penalizes the degraded far-field accuracy.

**Suggested follow-ups:**
- If boundary-layer weighting is desired, try a milder version: weight range [0.5, 2.0] instead of [1/(1+dist), 1.0]. Less aggressive reweighting may focus learning without discarding far-field signal.
- Rather than reweighting the volume loss, try adding a separate auxiliary boundary-layer loss at higher weight, keeping the main vol_loss uniform. This would add signal without removing any.
- The dist_feat feature may be most valuable in the *input* (as in PR #1473) rather than in loss reweighting. Consider reverting this and focusing on other uses of proximity information.