### PR TITLE
Cosine T_max=56 (precise schedule alignment for dist code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=56, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
The new code with dist_feat reaches ~58-59 epochs. With T_max=62, the LR has a dead zone near the end. T_max=56 means LR hits its minimum around epoch 66 (56 + 10 warmup), giving more productive epochs at the floor. Schedule alignment has historically been a consistent winner.

## Instructions
Change on the cosine scheduler line:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=56, eta_min=5e-5)
```
One-line change. Run with `--wandb_group tmax-56`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** 6q1g3uw7
**Epochs completed:** 58/100 (30-min timeout)
**Peak memory:** ~14.8GB (unchanged)
**Epoch time:** 30.0s (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8495 | 0.8720 | +2.6% worse |
| val_in_dist | mae_surf_p | 17.84 | 17.93 | +0.5% worse |
| val_ood_cond | mae_surf_p | 13.66 | 14.16 | +3.7% worse |
| val_ood_re | mae_surf_p | 27.77 | 27.74 | -0.1% |
| val_tandem_transfer | mae_surf_p | 36.36 | 38.89 | +7.0% worse |
| **mean3** | mae_surf_p | **22.62** | **23.66** | **+4.6% worse** |

Surface MAE (full breakdown, epoch 58):
- **in_dist:** Ux=5.71, Uy=2.13, p=17.93 | Vol: Ux=1.11, Uy=0.37, p=19.70
- **ood_cond:** Ux=3.30, Uy=1.27, p=14.16 | Vol: Ux=0.72, Uy=0.28, p=12.27
- **ood_re:** Ux=2.73, Uy=1.05, p=27.74 | Vol: Ux=0.83, Uy=0.37, p=46.78
- **tandem_transfer:** Ux=6.20, Uy=2.52, p=38.89 | Vol: Ux=1.94, Uy=0.88, p=38.20

### What happened

T_max=56 is worse than the T_max=62 baseline by 4.6% on mean3, with tandem_transfer suffering the most (+7.0%). The hypothesis was incorrect in a key way.

Both T_max=56 and T_max=62 have their cosine minimum AFTER epoch 58 (the 30-min cutoff): T_max=56 → epoch 66, T_max=62 → epoch 72. Neither has a 'dead zone' within the training window. The real difference is LR *shape* during the actual training epochs: T_max=56 is a shorter cycle, so the LR drops more aggressively. At epoch 58 (cosine step 48), T_max=56 gives roughly LR = eta_min + 5% * (lr_max - eta_min), while T_max=62 gives roughly LR = eta_min + 11% * (lr_max - eta_min). So T_max=56 effectively ends training with a colder LR, reducing the model's ability to make productive updates in the final ~10 epochs.

Tandem transfer is most sensitive to this change — tandem samples may require more gradient steps to converge, so a colder LR late in training disproportionately hurts tandem accuracy.

### Suggested follow-ups

- **T_max=48 or T_max=52**: If the hypothesis is schedule tightness, try an even shorter T_max so the LR reaches eta_min *within* the 58-epoch window, then potentially recovers (if using cosine with restarts) or stabilizes at eta_min.
- **Verify T_max=55 baseline**: The existing noam baseline likely uses T_max=55. What's the current baseline T_max? If T_max=62 was already introduced as an experiment, compare against T_max=55 to understand the direction of the tradeoff.
- **Warm restarts (SGDR)**: Replace CosineAnnealingLR with CosineAnnealingWarmRestarts, tuning restart period to the actual epoch budget.