### PR TITLE
GroupNorm(3) on output head (decouple p/vel normalization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -224,7 +224,7 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
-            self.ln_3 = nn.LayerNorm(hidden_dim)
+            self.ln_3 = nn.GroupNorm(3, hidden_dim)
             self.mlp2 = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
@@ -240,7 +240,8 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            fx_ln = self.ln_3(fx.transpose(1, 2)).transpose(1, 2)  # (B,C,N) for GroupNorm
+            return self.mlp2(fx_ln)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
The output ln_3 (LayerNorm) couples normalization statistics of pressure and velocity features. GroupNorm with 3 groups (matching 3 output fields, 64 dims each) decouples them, letting the network maintain separate statistics for different output channels.

## Instructions
In TransolverBlock.__init__, when last_layer=True:
```python
# Replace: self.ln_3 = nn.LayerNorm(hidden_dim)
# With: 
self.ln_3 = nn.GroupNorm(3, hidden_dim)
```
In forward, GroupNorm expects (B, C, L) but fx is (B, N, C). Reshape before/after:
```python
fx_ln = self.ln_3(fx.transpose(1, 2)).transpose(1, 2)  # (B,C,N) for GroupNorm
return self.mlp2(fx_ln)
```

Run with `--wandb_group groupnorm-output`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `22ihgzmk` | Best epoch: 51 | Peak memory: ~18 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6548 | 19.9 | +11.5% worse |
| val_ood_cond | 0.7540 | 14.9 | +9.1% worse |
| val_ood_re | 0.5894 | 28.8 | +3.7% worse |
| val_tandem_transfer | 1.6905 | 40.1 | +10.3% worse |
| **combined** | **0.9222** | — | **+8.6% worse** |

### What happened

Clearly negative. All splits significantly worse — this is the most degradation seen so far across experiments. Best epoch reached earlier (51 vs ~57), suggesting the model converged faster to a worse solution.

The core issue: LayerNorm normalizes each token's 192-dim feature vector (per-node, across channels), which is the natural operation for transformers where nodes are the sequence dimension. GroupNorm with 3 groups normalizes across 64 channels per group, treating the node dimension as the spatial/sequence axis — this introduces cross-node normalization which is not appropriate here (mesh nodes have variable quantities and aren't exchangeable like image pixels). The hidden representation doesn't have a natural 3-group structure at this layer; the groups only emerge after mlp2 projects to 3 output dimensions.

### Suggested follow-ups

- If the goal is to decouple output field statistics, consider post-prediction normalization: apply separate LayerNorms (or simply separate scale/bias) to the 3 output fields after mlp2 produces them — that would actually target Ux, Uy, p directly.
- The hypothesis is sound but the intervention point (before mlp2) is wrong. Replacing the last Linear in mlp2 with 3 separate Linears (one per field) while keeping LayerNorm would more cleanly test decoupled output statistics.