### PR TITLE
Gradient scaling 0.3x on dist_feat for first 30 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -656,6 +656,9 @@ for epoch in range(MAX_EPOCHS):
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        if epoch < 30:
+            dist_feat = dist_feat * 1.0 + (dist_feat.detach() - dist_feat) * 0.7
+            # Forward: unchanged. Backward: gradient * 0.3
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]


### PR DESCRIPTION
## Hypothesis
The dist_feat gradient may hijack optimization for in_dist samples. Scale the backward gradient through dist_feat by 0.3x for the first 30 epochs, letting the model use the feature at full magnitude in forward but limiting its influence on weight updates. After epoch 30, remove scaling.

## Instructions
After computing dist_feat, add gradient scaling:
```python
if model.training and epoch < 30:
    dist_feat = dist_feat * 1.0 + (dist_feat.detach() - dist_feat) * 0.7
    # Forward: unchanged. Backward: gradient * 0.3
```

Run with `--wandb_group dist-grad-scale`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B Run:** h2russd2
**Best epoch:** 60

### Metrics vs Baseline

| Split | val_loss | surf_p | surf_Ux | surf_Uy |
|-------|----------|--------|---------|---------|
| val_in_dist | 0.5819 | 17.79 | 5.03 | 1.29 |
| val_ood_cond | 0.7251 | 14.44 | 2.88 | 0.93 |
| val_ood_re | 0.5619 | 28.05 | 2.54 | 0.75 |
| val_tandem_transfer | 1.6338 | 38.69 | 5.34 | 1.86 |
| **combined** | **0.8757** | — | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8495 | 0.8757 | +0.0262 ↑ worse |
| in surf_p | 17.84 | 17.79 | -0.05 (noise) |
| ood_c surf_p | 13.66 | 14.44 | +0.78 ↑ worse |
| ood_r surf_p | 27.77 | 28.05 | +0.28 ↑ slightly worse |
| tan surf_p | 36.36 | 38.69 | +2.33 ↑ worse |
| mean3 surf_p | 19.76 | 20.09 | +0.33 ↑ worse |

**Peak memory:** ~same as baseline (no structural change)

### What happened

Negative result. The gradient scaling hurt overall performance, with the combined val/loss degrading by +0.026. The in-distribution split is essentially unchanged (-0.05 surf_p, within noise), while OOD and tandem splits are worse — particularly tandem (-2.33 surf_p).

The hypothesis that dist_feat was "hijacking" in_dist optimization doesn't hold up: restricting the gradient didn't help in-dist and actively hurt generalization. This suggests dist_feat is a genuinely useful learning signal across all regimes, and throttling it early prevents the model from building accurate representations of the surface-to-volume transition during the critical first 30 epochs.

The tandem degradation is notable: tandem foil aerodynamics is strongly influenced by inter-foil proximity effects, which are precisely what dist_feat encodes. Weakening this signal during early training likely causes the model to learn a suboptimal representation that isn't fully corrected later.

### Suggested follow-ups

- If gradient concerns about dist_feat persist, try **curriculum learning** — start with surface-heavy batches before introducing full-volume training — rather than gradient scaling on the feature itself
- Alternatively, try adding dist_feat as a **separate auxiliary loss target** to give it more direct supervision, rather than relying solely on gradient flow from the main loss