### PR TITLE
Tandem-specific noise floor 0.02 (preserve OOD regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -667,9 +667,12 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+        if model.training:
+            noise_scale = 0.05 * max(0, 1 - epoch / 60)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.01)
+            tandem_floor = 0.02 * is_tandem_curr.float().unsqueeze(1).unsqueeze(2)
+            actual_noise = noise_scale + tandem_floor
+            x[:, :, 2:25] = x[:, :, 2:25] + actual_noise * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Noise annealing reduces input noise to ~0 by epoch 60. But tandem samples (hardest split, now 36.36) benefit most from noise regularization. Keep residual noise=0.02 specifically for tandem samples throughout training, maintaining regularization for the most complex geometry without contaminating in_dist signal.

## Instructions
In the input noise section (~line 670-672), modify:
```python
if model.training:
    noise_scale = 0.05 * max(0, 1 - epoch / 60)
    # Add tandem-specific floor
    is_tandem_curr = (x[:, 0, 21].abs() > 0.01)  # tandem gap feature
    tandem_floor = 0.02 * is_tandem_curr.float().unsqueeze(1).unsqueeze(2)
    actual_noise = noise_scale + tandem_floor
    x[:, :, 2:25] = x[:, :, 2:25] + actual_noise * torch.randn_like(x[:, :, 2:25])
```
Remove the `epoch < 60` guard so tandem noise persists. Run with `--wandb_group tandem-noise-floor`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** pmdldsod  
**Change:** Tandem-specific noise floor 0.02 persisting after epoch 60 (gap threshold 0.01)

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Δ |
|-------|----------|------------|---------------------|---|
| val_in_dist | 0.5988 | 18.3 | 17.84 | +0.46 |
| val_ood_cond | 0.7128 | 14.1 | 13.66 | +0.44 |
| val_ood_re | 0.5386 | 27.6 | 27.77 | **-0.17** |
| val_tandem_transfer | 1.6191 | 38.2 | 36.36 | **+1.84** |
| **combined** | **0.8673** | — | **0.8495** | **+0.0178** |

**Peak memory:** 18.1 GB  
**Epochs completed:** 60 in ~30 min (~30 s/epoch)  
**Throughput:** EMA activated at epoch 40 ✓ (20 EMA epochs)

### What happened

The tandem noise floor made tandem performance **worse**, not better (+1.84 on mae_surf_p). The hypothesis that persistent noise regularization would help tandem generalization did not hold. All splits except ood_re degraded.

The likely cause: persistent input noise at epoch 60+ means the model never sees clean tandem inputs during training. By the time EMA starts averaging (epoch 40+), the model has learned to expect noise in tandem geometry features — but at inference (val) the inputs are clean, creating a train/test mismatch. The baseline model learns clean representations of tandem geometry in later epochs; this version cannot.

There's also a potential threshold issue: `is_tandem_curr = (x[:, 0, 21].abs() > 0.01)` uses a very permissive threshold (0.01) compared to the per-sample std logic which uses 0.5 for the same feature. This may be classifying single-foil samples as tandem and adding noise where it shouldn't.

### Suggested follow-ups

- **Correct the tandem detection threshold:** Use 0.5 to match the rest of the code; 0.01 may be mis-classifying samples.
- **Noise floor only during annealing phase:** Instead of extending past epoch 60, add tandem floor only in epochs 30-60 (not 0-30 and not after 60) to preserve clean representations in late training.
- **Target output noise, not input noise:** Rather than adding noise to x (which is never clean at test time), add output noise to y for tandem samples — this doesn't create a train/test mismatch.