### PR TITLE
EMA-smoothed spatial bias output (stable routing transitions)

### DIFF
--- a/train.py
+++ b/train.py
@@ -223,6 +223,7 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        self.register_buffer('sb_ema', None)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             self.mlp2 = nn.Sequential(
@@ -232,7 +233,19 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
-        sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+        if raw_xy is not None:
+            sb = self.spatial_bias(raw_xy)  # [B, N, slice_num]
+            if self.training:
+                # Scalar EMA: mean over B and N to handle variable mesh sizes
+                sb_mean = sb.detach().mean(dim=(0, 1), keepdim=True)  # [1, 1, slice_num]
+                if self.sb_ema is None:
+                    self.sb_ema = sb_mean
+                else:
+                    self.sb_ema = 0.9 * self.sb_ema + 0.1 * sb_mean
+                # Straight-through regularization toward running mean
+                sb = sb + 0.3 * (self.sb_ema.expand_as(sb) - sb).detach()
+        else:
+            sb = None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis
The spatial bias routing with the new 4D input (x,y,curv,dist) may change too rapidly during training, destabilizing in_dist. Adding EMA smoothing on the spatial bias output regularizes routing transitions: the slice assignments change smoothly rather than jumping between configurations.

## Instructions
In TransolverBlock.__init__, add: `self.register_buffer('sb_ema', None)`

In forward, after computing sb:
```python
sb = self.spatial_bias(raw_xy)
if self.training:
    if self.sb_ema is None:
        self.sb_ema = sb.detach().mean(dim=0, keepdim=True)  # [1, N_approx, slice_num]
    else:
        self.sb_ema = 0.9 * self.sb_ema + 0.1 * sb.detach().mean(dim=0, keepdim=True)
    # Regularize toward running mean (straight-through estimator)
    sb = sb + 0.3 * (self.sb_ema.expand_as(sb) - sb).detach()
```

Note: sb_ema shape may need handling for variable N. If N varies, use a scalar running-mean approach instead (mean over both B and N dimensions).

Run with `--wandb_group smooth-routing`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `k7ncbafx`
**Best epoch:** 58/100 (wall-clock limit at 30 min)
**Peak memory:** ~17 GB

### Metrics (best epoch)

| Split | val/loss | Surf p | Surf Ux | Surf Uy | Vol p | Vol Ux | Vol Uy |
|-------|----------|--------|---------|---------|-------|--------|--------|
| val_in_dist | 0.603 | 18.19 | 5.87 | 1.85 | 19.22 | 1.11 | 0.36 |
| val_ood_cond | 0.702 | 13.93 | 3.26 | 1.10 | 11.82 | 0.71 | 0.27 |
| val_ood_re | 0.557 | 28.07 | 2.95 | 0.97 | 46.82 | 0.83 | 0.36 |
| val_tandem_transfer | 1.645 | 39.48 | 5.92 | 2.40 | 38.67 | 1.95 | 0.88 |
| **combined val/loss** | **0.8769** | | | | | | |

### vs Baseline

| Metric | Baseline | Smooth routing | Delta |
|--------|----------|----------------|-------|
| val/loss | 0.8495 | 0.8769 | +0.027 ▲ |
| in/surf_p | 17.84 | 18.19 | +0.35 ▲ |
| ood_c/surf_p | 13.66 | 13.93 | +0.27 ▲ |
| ood_r/surf_p | 27.77 | 28.07 | +0.30 ▲ |
| tan/surf_p | 36.36 | 39.48 | +3.12 ▲ |

### What happened

EMA smoothing of spatial bias output hurt uniformly, with a notable regression on tandem (+3.12 Pa). All non-tandem splits degraded mildly (+0.27–0.35 Pa) and combined val/loss worsened +3.2%.

The scalar EMA (mean over B and N) loses spatial structure — the running mean becomes a single bias value per slice token, effectively adding a learned constant offset that doesn't respect spatial position. This probably hurts by biasing all nodes toward the same slice regardless of position.

The tandem regression is particularly striking: tandem samples have larger inter-foil flow regions where spatial routing matters most. Flattening the spatial structure specifically hurts tandem geometry.

More fundamentally, the original spatial bias already changes continuously via gradient descent — there's no evidence of instability in the routing. Adding EMA smoothing constrains what should be free parameters.

### Suggested follow-ups

- The spatial bias routing appears stable — don't try to constrain it further
- If routing instability is observed (sudden loss spikes in the training curve), a soft constraint (e.g., L2 penalty on per-step change) would be more principled
- Full spatial EMA (same N across a dataset) would need caching, which adds complexity not worth exploring