### PR TITLE
Warmup 8 epochs (faster ramp for dist_feat integration)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[8]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
With a new input feature (dist_feat), 10 warmup epochs may be too slow — the model needs higher LR sooner to learn to integrate the new feature. Reducing warmup to 8 frees 2 more high-LR epochs. Warmup=8 was historically a near-miss on older code.

## Instructions
Change warmup scheduler:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
```
And adjust milestones: `milestones=[8]` in the SequentialLR.

Run with `--wandb_group warmup-8`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** xvdy84tn
**Total time:** 30.4 min, 58 epochs

### Metrics

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.5876 | 17.7 |
| val_ood_cond | 0.6826 | 13.7 |
| val_ood_re | 0.5386 | 27.7 |
| val_tandem_transfer | 1.6336 | 38.9 |
| **mean3 (in+ood+tan)** | **0.8606** | **23.43** |

Baseline: val_loss=0.8495, mean3_p=22.62

**Delta:** val_loss +0.0111 (+1.3%), mean3_p +0.81 (+3.6%)

**Peak VRAM:** ~14.2GB

### What happened

No improvement. Warmup=8 is marginally worse than baseline (warmup=10) on all three key splits. In particular, tandem_transfer mae_surf_p is notably higher (38.9 vs 36.36, +7%), while in_dist and ood_cond are roughly the same.

Tandem samples require the model to attend to gap/stagger features and two-foil geometry, which seems to benefit from the slower, more gradual warmup at LR=10. Cutting 2 warmup epochs saves 2×32s≈64s but doesn't appear to translate to faster or better convergence — the model completes the same 58 epochs either way.

The hypothesis that dist_feat requires faster LR ramp doesn't hold: dist_feat is a log-scale continuous feature that's well-conditioned from the start, and the model is already regularized via Lookahead + AdamW weight decay.

### Suggested follow-ups

1. Longer warmup (12-15 epochs): If 10 is better than 8, the optimal may be even higher — especially given PCGrad + tandem complexity.
2. Warmup start_factor tuning: Start at 0.05 instead of 0.1 (slower ramp, more conservative early updates).