### PR TITLE
Continuous curvature for all nodes (remove is_surface mask)

### DIFF
--- a/train.py
+++ b/train.py
@@ -652,8 +652,8 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
-        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+        # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for all nodes
+        curv = x[:, :, 2:6].norm(dim=-1, keepdim=True)
         dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         x = torch.cat([x, curv, dist_feat], dim=-1)
@@ -882,8 +882,8 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
-                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
-                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for all nodes
+                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True)
                 dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 x = torch.cat([x, curv, dist_feat], dim=-1)
@@ -1064,7 +1064,7 @@ if best_metrics:
                 is_surf_dev = is_surface.unsqueeze(0).to(device)
                 mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
-                curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
+                curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True)
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)


### PR DESCRIPTION
## Hypothesis
Curvature is currently zero for volume nodes (masked by is_surface). With dist_feat now providing surface proximity, making curvature continuous for ALL nodes (removing the is_surface mask) provides complementary geometry info: dist_feat tells \"how far from surface\" and curvature tells \"how curved is the nearest surface.\" The combination is synergistic — PR #919 tested continuous curvature alone and was neutral, but that was before dist_feat existed.

## Instructions
In both train and val loops, change the curvature computation:
```python
# OLD: curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
# NEW: curv = x[:, :, 2:6].norm(dim=-1, keepdim=True)
```
Remove the `* is_surface.float().unsqueeze(-1)` masking. One-line change per loop.

Run with `--wandb_group continuous-curv-v2`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `6dyize2s`

### Metrics vs Baseline

| Split | val_loss | mae_surf_p | Δ mae_surf_p | mae_surf_Ux | mae_surf_Uy |
|-------|----------|------------|--------------|-------------|-------------|
| val_in_dist | 0.5833 | 17.840 | 0.0% (identical) | 5.748 | 1.730 |
| val_ood_cond | 0.6885 | 13.454 | -1.5% better | 3.598 | 1.129 |
| val_ood_re | 0.5523 | 27.897 | +0.5% neutral | 3.145 | 0.929 |
| val_tandem_transfer | 1.5993 | 37.425 | +2.9% worse | 5.913 | 2.325 |
| **combined** | **0.8558** | — | +0.7% (neutral) | — | — |

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.067 | 0.354 | 19.038 |
| val_ood_cond | 0.714 | 0.274 | 11.865 |
| val_ood_re | 0.821 | 0.364 | 46.930 |
| val_tandem_transfer | 1.892 | 0.861 | 36.975 |

Peak VRAM: not logged.

### What happened

Essentially neutral. Combined val/loss is 0.8558 vs baseline 0.8495 (+0.7%), which is within noise. In-distribution surface pressure is identical to the baseline (17.840 vs 17.84). OOD-cond improved slightly (-1.5%), ood_re is flat (+0.5%), and tandem_transfer regressed slightly (+2.9%).

The hypothesis that removing the is_surface mask would be synergistic with dist_feat was not confirmed. The result is indistinguishable from the masked version.

One explanation: for volume nodes, the dsdf channels (indices 2:6) represent signed distance function gradients relative to the nearest surface. While these values are non-zero for volume nodes, the model may already learn to ignore the curvature feature for volume nodes through the learned weights — effectively recovering the masking behavior implicitly. The curvature signal may be informative only at the surface, and volume nodes already have dist_feat to indicate their distance.

Another explanation: the change is genuinely neutral, meaning the is_surface masking neither helps nor hurts — the model is indifferent to whether volume curvature is zero or the actual gradient norm.

### Suggested follow-ups

- **Normalize curvature by distance**: instead of raw gradient norm, use `curv / (dist_feat + epsilon)` to create a "curvature density" feature that accounts for both surface proximity and local geometry.
- **Learnable masking**: use a soft gate `sigma(w * dist_feat)` to let the model learn how much to use curvature as a function of distance from surface.
- **Check if curvature adds anything**: run a control without the curvature feature entirely to see if it matters at all, or if dist_feat already captures the relevant information.