### PR TITLE
LR 2e-3 recalibration for dist-to-surface architecture

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.5e-3
+    lr: float = 2e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The dist-to-surface feature changed the input dimension and spatial bias architecture. The current lr=2.5e-3 was optimized for the previous code. The new feature may benefit from a slightly lower LR (2e-3) that gives the optimizer more time to integrate the new input dimension without overshooting. LR recalibration after architecture changes was the 5th merge (lr=2.5e-3 after n_head=3).

## Instructions
Change learning rate:
```python
lr = 2e-3  # was 2.5e-3
```
One-line change. Run with `--wandb_group lr-2e-3-dist`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** [thponv4a](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/thponv4a)
**Best epoch:** 60/100
**Peak VRAM:** ~17.9 GB

### Validation Loss

| Split | This run (lr=2e-3) | Baseline (lr=2.5e-3) |
|-------|-------------------|---------------------|
| val/loss (combined) | **0.8658** | 0.8495 |
| val_in_dist | 0.5843 | — |
| val_tandem_transfer | 1.6286 | — |
| val_ood_cond | 0.6983 | — |
| val_ood_re | 0.5517 | — |

### Surface MAE

| Split | Ux | Uy | p | p (baseline) |
|-------|----|----|---|--------------|
| val_in_dist | 5.2461 | 1.7350 | 17.4806 | 17.84 |
| val_tandem_transfer | 5.5228 | 2.1889 | 38.5673 | 36.36 |
| val_ood_cond | 3.3147 | 1.1629 | 13.8666 | 13.66 |
| val_ood_re | 2.9196 | 0.9745 | 27.8722 | 27.77 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.0712 | 0.3640 | 19.3205 |
| val_tandem_transfer | 1.9040 | 0.8722 | 37.6352 |
| val_ood_cond | 0.7273 | 0.2765 | 12.2054 |
| val_ood_re | 0.8530 | 0.3673 | 47.0540 |

### What happened

No improvement — val/loss 0.8658 vs 0.8495 (+0.016, at the noise floor boundary). LR=2e-3 does not recalibrate positively for the dist-to-surface architecture. The surface pressure MAEs are mixed: in_dist improved slightly (17.48 vs 17.84), but tandem_transfer regressed noticeably (38.57 vs 36.36) and ood_cond/ood_re are essentially flat. The tandem regression suggests 2e-3 is too slow to converge within 30 minutes, particularly for the harder tandem samples.

The hypothesis that a lower LR would better integrate the new dist-to-surface dimension doesn't hold here. The original 2.5e-3 apparently already works fine, and reducing it to 2e-3 leads to underfitting within the 30-minute window.

### Suggested follow-ups

- **Try lr=3e-3 or keep 2.5e-3**: The baseline at 2.5e-3 is already optimal or close to it for this architecture. A higher LR might help converge the new dist feature faster.
- **Extended schedule**: If 2e-3 is theoretically better, it may just need more epochs. Not testable within the 30-min constraint, but worth noting.