### PR TITLE
Dist_feat scale factor 20 (stronger distance signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -655,7 +655,7 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-        dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        dist_feat = torch.log1p(dist_surf * 20.0)  # log-scale for better gradient flow
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
@@ -885,7 +885,7 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-                dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+                dist_feat = torch.log1p(dist_surf * 20.0)  # log-scale for better gradient flow
                 x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
@@ -1066,7 +1066,7 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)
+                dist_feat = torch.log1p(dist_surf * 20.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()


### PR DESCRIPTION
## Hypothesis
The current dist_feat uses `torch.log1p(dist_surf * 10.0)`. The scale factor of 10.0 was chosen arbitrarily. Doubling it to 20.0 amplifies the distance signal, making the boundary-layer transition sharper. This could further improve tandem (where distinguishing the two near-surface regions is critical) while potentially recovering some in_dist by making the distance signal more decisive (less ambiguous intermediate values).

## Instructions
Change the dist_feat computation:
```python
# OLD: dist_feat = torch.log1p(dist_surf * 10.0)
# NEW: dist_feat = torch.log1p(dist_surf * 20.0)
```
One-line change, in both train and val loops. Run with `--wandb_group dist-scale-20`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36, mean3=22.62

---
## Results

**W&B run**: 8bh7n3so  
**Best epoch**: 60 (30.1 min, wall-clock limit)  
**VRAM**: 17.9 GB  

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5955 | 6.05 | 1.73 | **18.25** | 1.06 | 0.35 | 19.73 |
| val_ood_cond | 0.6879 | 3.65 | 1.20 | **13.56** | 0.72 | 0.27 | 11.88 |
| val_ood_re | 0.5301 | 3.14 | 1.00 | 27.52 | 0.81 | 0.36 | 46.84 |
| val_tandem_transfer | 1.6385 | 6.32 | 2.33 | **39.47** | 1.90 | 0.86 | 38.40 |
| **combined** | **0.8630** | | | | | | |

**mean3 (in/ood/tan p)**: (18.25 + 13.56 + 39.47) / 3 = **23.76** vs baseline 22.62 → **+1.14, negative result**

### What happened

Doubling the scale to 20.0 produced a clearly negative result. The most striking degradation is tandem pressure: **+3.11 (36.36 → 39.47)**. Single-foil splits were mixed: ood_cond and ood_re improved slightly (-0.10, -0.25) but in_dist degraded (+0.41).

Two likely causes for the tandem degradation:

1. **Tandem near-field geometry is more complex**: Tandem foils have two surfaces. The `dist_surf * 20.0` scale compresses the log1p range much more aggressively for intermediate distances. In a tandem configuration, nodes at intermediate distances may be in the "gap" between the two foils — a physically important region. Doubling the scale effectively saturates the feature representation there, making it harder to distinguish these intermediate positions.

2. **Scale-10 was already near-optimal**: log1p(x * 10) at the median near-surface distance already spans [0, ~2.4]. Doubling to 20 adds only ~0.7 more range at the upper end while cramping the near-surface gradient. The information-theoretic capacity gain is marginal but the saturation effect at intermediate distances is harmful.

### Suggested follow-ups

1. **Scale 5.0 (lower, not higher)**: Rather than amplifying, try reducing the scale to 5.0. This might provide a more linear (less compressed) distance signal, giving better gradient at larger distances where tandem inter-foil spacing matters.
2. **Separate scale for tandem vs non-tandem**: Use scale 10 for single-foil samples, scale 5 for tandem samples. The tandem near-surface region is denser and the inter-foil gap needs finer resolution.