### PR TITLE
Signed distance feature (preserve inside/outside info)

### DIFF
--- a/train.py
+++ b/train.py
@@ -654,8 +654,11 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-        dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        dsdf_channels = x[:, :, 2:10]  # [B, N, 8]
+        abs_dsdf = dsdf_channels.abs()
+        min_idx = abs_dsdf.min(dim=-1, keepdim=True).indices
+        signed_dist = torch.gather(dsdf_channels, -1, min_idx)  # [B, N, 1] — signed!
+        dist_feat = torch.sign(signed_dist) * torch.log1p(signed_dist.abs() * 10.0)
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
@@ -884,8 +887,11 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-                dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+                dsdf_channels = x[:, :, 2:10]  # [B, N, 8]
+                abs_dsdf = dsdf_channels.abs()
+                min_idx = abs_dsdf.min(dim=-1, keepdim=True).indices
+                signed_dist = torch.gather(dsdf_channels, -1, min_idx)  # [B, N, 1] — signed!
+                dist_feat = torch.sign(signed_dist) * torch.log1p(signed_dist.abs() * 10.0)
                 x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]


### PR DESCRIPTION
## Hypothesis
The current dist_feat uses `.abs()` on dsdf channels, discarding the SIGN that encodes whether a node is inside or outside a foil boundary. For tandem foils, knowing "between the two foils" vs "outside both" is critical for wake interference prediction. Preserving the sign should improve tandem further while potentially recovering in_dist (the sign provides cleaner geometry information).

## Instructions
Replace the dist_feat computation in BOTH train and val loops:
```python
# OLD:
dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
dist_feat = torch.log1p(dist_surf * 10.0)

# NEW: Signed distance — preserve inside/outside
dsdf_channels = x[:, :, 2:10]  # [B, N, 8]
abs_dsdf = dsdf_channels.abs()
min_idx = abs_dsdf.min(dim=-1, keepdim=True).indices
signed_dist = torch.gather(dsdf_channels, -1, min_idx)  # [B, N, 1] — signed!
dist_feat = torch.sign(signed_dist) * torch.log1p(signed_dist.abs() * 10.0)
```

Run with `--wandb_group signed-dist`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---

## Results

**W&B run:** merkq1en | **Epochs:** 62/100 (timeout) | **Peak memory:** ~17.8 GB

| Split | val_loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | Δ vs baseline |
|-------|----------|-------------|-------------|------------|---------------|
| val_in_dist | 0.5798 | 6.19 | 1.83 | **17.48** | **-0.36 (improved!)** |
| val_ood_cond | 0.7036 | 3.63 | 1.25 | 14.11 | +0.45 (worse) |
| val_ood_re | 0.5532 | 3.20 | 1.14 | 28.04 | +0.27 (slightly worse) |
| val_tandem_transfer | 1.5972 | 6.23 | 2.28 | 37.80 | +1.44 (worse) |
| **combined** | **0.8585** | — | — | — | +0.009 (worse) |

**mean3 mae_surf_p:** 23.13 vs baseline 22.62 — **slightly worse overall**

### What happened

Mixed results. The signed distance feature **did** improve in_dist (17.84 → 17.48, -2.0%), which partially confirms the hypothesis. However, tandem got worse (36.36 → 37.80, +4.0%), contradicting the main prediction that sign information would help wake interference prediction. ood_cond also regressed slightly.

The overall val_loss (0.8585 vs 0.8495) and mean3 (23.13 vs 22.62) are both worse than the unsigned baseline.

Possible explanations for the tandem regression:
- Signed distance is harder to learn from — negative values represent "inside" a foil boundary, which rarely occurs for domain nodes. The distribution of signed_dist is asymmetric and noisy.
- The min-index selection (`gather`) picks the nearest dsdf channel, but sign flipping between channels may add noise to the signal.
- The tandem improvement from dist_feat may come specifically from the **magnitude** (how far nodes are from any surface), not the sign.

### Suggested follow-ups

- Try using both signed and unsigned features: concatenate `[abs_dist_feat, signed_dist_feat]` (2-channel) to give the model both signals. This adds 1 more input dimension but may separate the useful information.
- Try using the raw signed distance values from multiple channels rather than the min-based single channel — the full dsdf tensor already contains this information implicitly.
- The in_dist improvement (+2%) is promising; investigate whether surface nodes specifically benefit from the sign information.