### PR TITLE
Tandem-conditioned spatial bias (sample-adaptive routing)

### DIFF
--- a/train.py
+++ b/train.py
@@ -217,6 +217,12 @@ class TransolverBlock(nn.Module):
         )
         nn.init.zeros_(self.spatial_bias[-1].weight)
         nn.init.zeros_(self.spatial_bias[-1].bias)
+        self.tandem_routing_offset = nn.Sequential(
+            nn.Linear(4, 32), nn.GELU(),
+            nn.Linear(32, slice_num),
+        )
+        nn.init.zeros_(self.tandem_routing_offset[-1].weight)
+        nn.init.zeros_(self.tandem_routing_offset[-1].bias)
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -233,6 +239,9 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+        if sb is not None and tandem_mask is not None:
+            tandem_correction = self.tandem_routing_offset(raw_xy)  # [B, N, slice_num]
+            sb = sb + tandem_correction * tandem_mask[..., 0]  # tandem_mask [B,1,1,1] → [B,1,1]
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis
The spatial_bias routes ALL samples identically. But tandem geometry creates fundamentally different flow patterns. The per-head tandem_temp already proves sample-conditioned attention works. Extend to routing: add a tandem_routing_offset MLP that corrects the spatial bias for tandem samples, zero-initialized so it starts as baseline.

## Instructions
1. In TransolverBlock.__init__, add:
```python
self.tandem_routing_offset = nn.Sequential(
    nn.Linear(4, 32), nn.GELU(),
    nn.Linear(32, slice_num),
)
nn.init.zeros_(self.tandem_routing_offset[-1].weight)
nn.init.zeros_(self.tandem_routing_offset[-1].bias)
```

2. Thread is_tandem_batch through block.forward. In the block's forward:
```python
sb = self.spatial_bias(raw_xy)
if tandem_mask is not None and hasattr(self, 'tandem_routing_offset'):
    tandem_correction = self.tandem_routing_offset(raw_xy)  # [B, N, slice_num]
    # tandem_mask: [B] boolean → [B, 1, 1] for broadcast
    sb = sb + tandem_correction * tandem_mask.float().unsqueeze(1).unsqueeze(1)
```

3. Pass `is_tandem_batch` from the training loop into the block forward calls.

Run with `--wandb_group tandem-routing`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `5v927vwn`

**Implementation note:** `tandem_mask` in block.forward is already a `[B,1,1,1]` float tensor (per the existing code). Used `tandem_mask[..., 0]` to get `[B,1,1]` for broadcasting with `tandem_correction [B,N,S]`.

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val/loss | 0.8495 | **0.8736** | +0.0241 (~5.2σ, significantly worse) |
| mae_surf_p in_dist | 17.84 | 18.52 | +0.68 |
| mae_surf_p ood_cond | 13.66 | 14.38 | +0.72 |
| mae_surf_p ood_re | 27.77 | 28.15 | +0.38 |
| mae_surf_p tandem | 36.36 | 38.66 | **+2.30** |
| **mean3 mae_surf_p** | **22.62** | **23.85** | **+1.23 (~5.9σ, significantly worse)** |

**Throughput note:** Each epoch took ~78 seconds (vs ~30s baseline). The PCGrad two-backward-pass overhead + mode=default compile means only ~23 epochs completed in 30 minutes. This severely limited convergence.

### What happened

Significantly worse on all metrics, particularly tandem (+2.30 on mae_surf_p) — the opposite of the intended effect.

Two main factors:

1. **Throughput collapse**: With PCGrad two-backward-pass (mode=default) + tandem_routing_offset, each epoch took ~78s vs the ~30s for simple training. Only ~23 epochs completed vs ~45-60 for the baseline. The model is severely undertrained.

2. **Architecture interaction**: The tandem_routing_offset adds per-sample routing corrections during backprop through PCGrad's `retain_graph=True`. This may have caused compilation issues or slow compilation re-records.

It's unclear whether the tandem routing concept itself is flawed, or whether it's primarily an efficiency problem. The zero-initialization means the model starts at the baseline, but 23 epochs may not be sufficient to learn useful tandem corrections.

### Suggested follow-ups

- Test tandem routing without PCGrad overhead: use `mode=reduce-overhead` with simple `loss.backward()` (no PCGrad), which would give ~60 epochs and a fairer comparison
- The zero-initialized offset may be learning in the wrong direction early in training — consider a warmup where it's frozen for the first 20 epochs
- The current spatial bias already gets 4D input including dist_feat, which is tandem-informative. It may already be learning separate routing implicitly