### PR TITLE
Vectorize per-sample std normalization (+2-3 epochs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -684,17 +684,22 @@ for epoch in range(MAX_EPOCHS):
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
-        sample_stds = torch.ones(B, 1, 3, device=device)
         channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
         tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
         if model.training:
-            for b in range(B):
-                valid = mask[b]
-                if is_tandem[b]:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                else:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+            mask_f = mask.float().unsqueeze(-1)  # [B, N, 1]
+            n_valid = mask_f.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1, 1]
+            y_masked = y_norm * mask_f
+            y_mean = y_masked.sum(dim=1, keepdim=True) / n_valid
+            y_var = ((y_masked - y_mean * mask_f) ** 2 * mask_f).sum(dim=1, keepdim=True) / n_valid
+            sample_stds_raw = y_var.sqrt()  # [B, 1, 3]
+            clamp_vals = torch.where(is_tandem[:, None, None].expand_as(sample_stds_raw),
+                                     tandem_clamps[None, None, :].expand_as(sample_stds_raw),
+                                     channel_clamps[None, None, :].expand_as(sample_stds_raw))
+            sample_stds = torch.maximum(sample_stds_raw, clamp_vals)
             y_norm = y_norm / sample_stds
+        else:
+            sample_stds = torch.ones(B, 1, 3, device=device)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
@@ -905,15 +910,18 @@ for epoch in range(MAX_EPOCHS):
                 raw_gap = x[:, 0, 21]
                 is_tandem = raw_gap.abs() > 0.5
                 B = y_norm.shape[0]
-                sample_stds = torch.ones(B, 1, 3, device=device)
                 channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
                 tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
-                for b in range(B):
-                    valid = mask[b]
-                    if is_tandem[b]:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                    else:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                mask_f = mask.float().unsqueeze(-1)  # [B, N, 1]
+                n_valid = mask_f.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1, 1]
+                y_masked = y_norm * mask_f
+                y_mean = y_masked.sum(dim=1, keepdim=True) / n_valid
+                y_var = ((y_masked - y_mean * mask_f) ** 2 * mask_f).sum(dim=1, keepdim=True) / n_valid
+                sample_stds_raw = y_var.sqrt()  # [B, 1, 3]
+                clamp_vals = torch.where(is_tandem[:, None, None].expand_as(sample_stds_raw),
+                                         tandem_clamps[None, None, :].expand_as(sample_stds_raw),
+                                         channel_clamps[None, None, :].expand_as(sample_stds_raw))
+                sample_stds = torch.maximum(sample_stds_raw, clamp_vals)
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
The per-sample std normalization (lines ~691-697 train, ~911-916 val) uses a Python for-loop over the batch. Vectorizing it should save 5-10% epoch time, recovering 2-3 more epochs in 30 minutes. Every extra epoch at this stage of training (EMA phase) improves val_loss.

## Instructions
Replace the Python for-loop with vectorized operations:
```python
# OLD (Python loop):
for b in range(B):
    valid = mask[b]
    if is_tandem[b]:
        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
    else:
        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)

# NEW (vectorized):
mask_f = mask.float().unsqueeze(-1)  # [B, N, 1]
n_valid = mask_f.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1, 1]
y_masked = y_norm * mask_f
y_mean = y_masked.sum(dim=1, keepdim=True) / n_valid
y_var = ((y_masked - y_mean * mask_f) ** 2 * mask_f).sum(dim=1, keepdim=True) / n_valid
sample_stds_raw = y_var.sqrt()  # [B, 1, 3]
clamp_vals = torch.where(is_tandem[:, None, None].expand_as(sample_stds_raw),
                         tandem_clamps.expand_as(sample_stds_raw),
                         channel_clamps.expand_as(sample_stds_raw))
sample_stds = torch.maximum(sample_stds_raw, clamp_vals)
```

Do the same for the val loop. Run with `--wandb_group vectorize-psnorm-v2`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---

## Results

**W&B run:** `p4ljpftj` | **Epochs completed:** 59 (30-min timeout) | **Peak memory:** 17.9 GB

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.5923 | **17.83** |
| val_ood_cond | 0.7011 | **14.24** |
| val_ood_re | 0.5329 | **27.75** |
| val_tandem_transfer | 1.6484 | **38.82** |
| **combined** | **0.8687** | — |

**vs. baseline (dist-to-surface PR #1473):**
| Split | surf_p baseline | surf_p result | Δ |
|-------|----------------|----------------|---|
| val_in_dist | 17.84 | 17.83 | ≈0 |
| val_ood_cond | 13.66 | 14.24 | +4.2% worse |
| val_ood_re | 27.77 | 27.75 | ≈0 |
| val_tandem_transfer | 36.36 | 38.82 | **+6.8% worse** |
| combined val_loss | 0.8495 | 0.8687 | +2.3% worse |

**What happened:** Two issues undermined this experiment:

1. **No speedup.** The vectorized version completed 59 epochs vs 58 for the baseline — essentially identical. The for-loop was not the bottleneck. The dominant cost per epoch is the GPU forward/backward pass (~28-30s), and the Python loop over batch size B (typically 4-8 samples) is negligible by comparison.

2. **Numerical difference.** The vectorized formula uses population std (divides by n), while PyTorch's `.std()` uses Bessel's correction (divides by n-1). This gives slightly smaller `sample_stds` values, meaning the normalized targets are slightly larger. This changes the effective training distribution and likely explains the ood_cond and tandem regressions.

The tandem regression (+6.8%) is particularly concerning: the vectorized formula applies identical weighting to all nodes, but the original loop selected valid nodes per sample. For tandem samples with more nodes, the population vs sample std difference is negligible, but for non-tandem samples with fewer valid nodes the correction matters more.

**Suggested follow-ups:**
- If vectorization is still desired, fix the std formula: use `y_var * n_valid / (n_valid - 1).clamp(min=1)` to apply Bessel's correction before sqrt. This would match the original `.std()` behavior exactly.
- The speedup hypothesis can be tested differently: profile the training loop with `torch.profiler` to find the actual bottleneck.
- The per-sample normalization itself may be worth revisiting — it adds complexity and the vectorized formula bugs suggest fragility. Consider whether simpler global normalization could work instead.