### PR TITLE
Condition-adaptive output: tiny hypernetwork on (Re,AoA,tandem)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,12 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.cond_hyper = nn.Sequential(
+            nn.Linear(3, 16), nn.GELU(),
+            nn.Linear(16, 6),  # 3 scales + 3 shifts for [Ux, Uy, p]
+        )
+        nn.init.zeros_(self.cond_hyper[-1].weight)
+        nn.init.zeros_(self.cond_hyper[-1].bias)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -396,6 +402,15 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        cond_input = torch.stack([
+            x[:, 0, 13],  # log_Re
+            x[:, 0, 14],  # AoA
+            (x[:, 0, 21].abs() > 0.01).float(),  # is_tandem
+        ], dim=-1)  # [B, 3]
+        cond_params = self.cond_hyper(cond_input)  # [B, 6]
+        cond_scale = 1.0 + 0.1 * cond_params[:, :3].unsqueeze(1)  # [B, 1, 3]
+        cond_shift = 0.1 * cond_params[:, 3:].unsqueeze(1)  # [B, 1, 3]
+        fx = fx * cond_scale + cond_shift
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 


### PR DESCRIPTION
## Hypothesis
Previous AdaLN showed best-ever ood_cond (13.16) but regressed other splits — too aggressive. A tiny hypernetwork that generates per-channel scale+shift for the output, conditioned on (log_Re, AoA, is_tandem), provides condition-adaptive predictions with minimal parameters. Zero-initialized so it starts as identity.

## Instructions
1. In Transolver.__init__, add:
```python
self.cond_hyper = nn.Sequential(
    nn.Linear(3, 16), nn.GELU(),
    nn.Linear(16, 6),  # 3 scales + 3 shifts for [Ux, Uy, p]
)
nn.init.zeros_(self.cond_hyper[-1].weight)
nn.init.zeros_(self.cond_hyper[-1].bias)
```

2. In Transolver.forward, after the output (after the last block):
```python
cond_input = torch.stack([
    x[:, 0, 13],  # log_Re
    x[:, 0, 14],  # AoA
    (x[:, 0, 21].abs() > 0.01).float(),  # is_tandem
], dim=-1)  # [B, 3]
cond_params = self.cond_hyper(cond_input)  # [B, 6]
cond_scale = 1.0 + 0.1 * cond_params[:, :3].unsqueeze(1)  # [B, 1, 3]
cond_shift = 0.1 * cond_params[:, 3:].unsqueeze(1)  # [B, 1, 3]
fx = fx * cond_scale + cond_shift
```

Run with `--wandb_group cond-hyper-output`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** jo2pnh6h
**Epochs completed:** 57/100 (30-min timeout)
**Peak memory:** ~14.8GB (unchanged)
**Epoch time:** 30.7s (+0.7s vs baseline — minor overhead)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8495 | 0.8785 | +3.4% worse |
| val_in_dist | mae_surf_p | 17.84 | 18.41 | +3.2% worse |
| val_ood_cond | mae_surf_p | 13.66 | 14.16 | +3.7% worse |
| val_ood_re | mae_surf_p | 27.77 | 28.12 | +1.3% worse |
| val_tandem_transfer | mae_surf_p | 36.36 | 38.43 | +5.7% worse |
| **mean3** | mae_surf_p | **22.62** | **23.67** | **+4.6% worse** |

Surface MAE (full breakdown, epoch 57):
- **in_dist:** Ux=7.17, Uy=2.22, p=18.41 | Vol: Ux=1.10, Uy=0.37, p=19.54
- **ood_cond:** Ux=3.65, Uy=1.04, p=14.16 | Vol: Ux=0.72, Uy=0.27, p=12.13
- **ood_re:** Ux=3.44, Uy=0.93, p=28.12 | Vol: Ux=0.82, Uy=0.36, p=47.05
- **tandem_transfer:** Ux=6.73, Uy=2.51, p=38.43 | Vol: Ux=1.93, Uy=0.87, p=38.21

### What happened

The hypernetwork regresses across all splits, with mean3 +4.6% worse. The zero-initialization ensures it starts as identity, so the model begins training identically to baseline — but as the hypernetwork learns, it hurts.

The key issue is that the three conditioning features (log_Re, AoA, is_tandem) are already in the input x and fully accessible to the main trunk. The main model with PCGrad can already learn condition-specific representations. Adding a separate hypernetwork at the output creates a second gradient path to condition-adapt, which competes with the main trunk rather than complementing it. The main trunk may partially rely on the hypernetwork for conditioning during early learning, then get confused when the hypernetwork's corrections don't align with what the physics requires.

Additionally, the cond_scale/cond_shift operates in normalized output space, but after inference the predictions are multiplied by sample_stds (per-sample un-normalization). The hypernetwork's learned calibration doesn't automatically account for this transformation, creating scale mismatches.

Epoch count dropped by 1 (57 vs 58) due to slightly longer epoch time (+0.7s), a minor cost.

### Suggested follow-ups

- **Apply conditioning earlier**: Instead of at the output, apply condition-adaptive scale+shift at the hidden representation level (after preprocess) where it can shape the entire forward pass rather than just post-processing outputs.
- **Use conditioning only for tandem vs non-tandem**: The binary is_tandem flag is the most informative condition. A gate that applies learned corrections only for tandem samples (x[is_tandem] *= scale + shift) might be more targeted.
- **Condition on learned embeddings**: Instead of raw Re/AoA values, condition on the Re head's hidden representation (32-dim) which already encodes useful condition information.