### PR TITLE
Gradient Vaccine: cosine-scaled gradient surgery (replace PCGrad)

### DIFF
--- a/train.py
+++ b/train.py
@@ -812,21 +812,27 @@ for epoch in range(MAX_EPOCHS):
 
             ga_flat = torch.cat([g.view(-1) for g in grads_a if g is not None])
             gb_flat = torch.cat([p.grad.view(-1) for p in model.parameters() if p.grad is not None])
-            dot_ab = (ga_flat @ gb_flat).item()
-            gb_ns = float((gb_flat @ gb_flat).item()) + 1e-8
-            ga_ns = float((ga_flat @ ga_flat).item()) + 1e-8
-            for p, ga in zip(model.parameters(), grads_a):
-                gb = p.grad
-                if ga is None and gb is None:
-                    continue
-                if ga is None:
-                    pass  # keep gb
-                elif gb is None:
-                    p.grad = ga
-                elif dot_ab < 0:
-                    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
-                else:
-                    p.grad = (ga + gb) * 0.5
+            cos_sim = F.cosine_similarity(ga_flat.unsqueeze(0), gb_flat.unsqueeze(0)).item()
+
+            if cos_sim < 0:
+                scale = 1.0 + cos_sim  # 0 to 1 for cos in [-1, 0)
+                for p, ga in zip(model.parameters(), grads_a):
+                    gb = p.grad
+                    if ga is None or gb is None:
+                        if ga is not None:
+                            p.grad = ga
+                        continue
+                    ga_n = ga / (ga.norm() + 1e-8)
+                    gb_n = gb / (gb.norm() + 1e-8)
+                    ga_proj = (ga * gb_n).sum() * gb_n
+                    gb_proj = (gb * ga_n).sum() * ga_n
+                    p.grad = ((ga - (1 - scale) * ga_proj) + (gb - (1 - scale) * gb_proj)) * 0.5
+            else:
+                for p, ga in zip(model.parameters(), grads_a):
+                    if ga is not None and p.grad is not None:
+                        p.grad = (ga + p.grad) * 0.5
+                    elif ga is not None:
+                        p.grad = ga
         else:
             optimizer.zero_grad()
             loss.backward()


### PR DESCRIPTION
## Hypothesis
PCGrad projects away the conflicting gradient component entirely when cos(θ)<0. Gradient Vaccine (Pu et al., 2020) is gentler: it scales the conflicting component by (1+cos(θ)), preserving more information. When cos=-0.1 (slight conflict), scale=0.9 (keep most). When cos=-1 (full opposition), scale=0 (same as PCGrad). This should handle the in_dist vs OOD gradient conflict better.

## Instructions
Replace the PCGrad projection block (lines ~811-827) with Gradient Vaccine:
```python
import torch.nn.functional as F

ga_flat = torch.cat([g.view(-1) for g in grads_a if g is not None])
gb_flat = torch.cat([p.grad.view(-1) for p in model.parameters() if p.grad is not None])
cos_sim = F.cosine_similarity(ga_flat.unsqueeze(0), gb_flat.unsqueeze(0)).item()

if cos_sim < 0:
    scale = 1.0 + cos_sim  # 0 to 1 for cos in [-1, 0)
    for p, ga in zip(model.parameters(), grads_a):
        gb = p.grad
        if ga is None or gb is None:
            if ga is not None: p.grad = ga
            continue
        ga_n = ga / (ga.norm() + 1e-8)
        gb_n = gb / (gb.norm() + 1e-8)
        ga_proj = (ga * gb_n).sum() * gb_n
        gb_proj = (gb * ga_n).sum() * ga_n
        p.grad = ((ga - (1-scale)*ga_proj) + (gb - (1-scale)*gb_proj)) * 0.5
else:
    for p, ga in zip(model.parameters(), grads_a):
        if ga is not None and p.grad is not None:
            p.grad = (ga + p.grad) * 0.5
        elif ga is not None:
            p.grad = ga
```

Run with `--wandb_group grad-vaccine`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `d3qns2bj` | Best epoch: 57 | Peak memory: ~18 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6071 | 18.1 | +1.5% worse |
| val_ood_cond | 0.7134 | 13.9 | +1.8% worse |
| val_ood_re | 0.5561 | 28.0 | +0.8% worse |
| val_tandem_transfer | 1.6544 | 38.9 | +7.0% worse |
| **combined** | **0.8827** | — | **+3.9% worse** |

### What happened

Mildly negative. The ood_cond and ood_re results are close to baseline, but tandem degraded by 7% and pulled up the combined val/loss. In-dist stayed nearly flat.

The gradient surgery is gentler overall, but doesn't improve on the baseline. The combined metric is driven heavily by tandem loss (val_tandem_transfer weight is largest), and tandem worsened. Gradient Vaccine's partial preservation of conflicting gradients may not be the right inductive bias when the in-dist and tandem domains are structurally different — the in-dist gradient component that gets partially preserved in Group B may be pulling tandem predictions toward in-dist behavior.

Compared to plain PCGrad, Gradient Vaccine doesn't offer a clear improvement on any split except possibly ood_cond which was already near baseline.

### Suggested follow-ups

- The fundamental challenge is that tandem geometry is qualitatively different from single-foil. Gradient surgery at the global gradient level (all parameters) may be too coarse — per-layer or per-parameter-group Gradient Vaccine might work better, allowing tandem-specific layers to update freely.
- Try disabling PCGrad entirely and relying on the tandem_boost mechanism alone — the PCGrad overhead may not be paying off given consistently negative results across alt-epochs, domain-weighted, and now gradient vaccine variants.