### PR TITLE
Content-based routing: blend hidden features with spatial bias

### DIFF
--- a/train.py
+++ b/train.py
@@ -217,6 +217,13 @@ class TransolverBlock(nn.Module):
         )
         nn.init.zeros_(self.spatial_bias[-1].weight)
         nn.init.zeros_(self.spatial_bias[-1].bias)
+        self.content_bias = nn.Sequential(
+            nn.Linear(hidden_dim, 64), nn.GELU(),
+            nn.Linear(64, slice_num),
+        )
+        nn.init.zeros_(self.content_bias[-1].weight)
+        nn.init.zeros_(self.content_bias[-1].bias)
+        self.routing_blend = nn.Parameter(torch.tensor(0.0))  # sigmoid(0)=0.5
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -232,7 +239,13 @@ class TransolverBlock(nn.Module):
             )
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
-        sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+        if raw_xy is not None:
+            sb_spatial = self.spatial_bias(raw_xy)
+            sb_content = self.content_bias(self.ln_1(fx))
+            blend = torch.sigmoid(self.routing_blend)
+            sb = (1 - blend) * sb_spatial + blend * sb_content
+        else:
+            sb = None
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis
The spatial_bias routes nodes by (x,y,curv,dist) — spatial position. But physically similar nodes at different positions should share slices. Adding a content-based routing pathway (route by hidden features, not position) with a learnable blend lets the model choose optimal routing strategy.

## Instructions
1. In TransolverBlock.__init__, add:
```python
self.content_bias = nn.Sequential(
    nn.Linear(hidden_dim, 64), nn.GELU(),
    nn.Linear(64, slice_num),
)
nn.init.zeros_(self.content_bias[-1].weight)
nn.init.zeros_(self.content_bias[-1].bias)
self.routing_blend = nn.Parameter(torch.tensor(0.0))  # sigmoid(0)=0.5
```

2. In forward:
```python
sb_spatial = self.spatial_bias(raw_xy)
sb_content = self.content_bias(self.ln_1(fx))
blend = torch.sigmoid(self.routing_blend)
sb = (1 - blend) * sb_spatial + blend * sb_content
```

Run with `--wandb_group content-routing`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B Run:** 597tzgay
**Best epoch:** 58

### Metrics vs Baseline

| Split | val_loss | surf_p | surf_Ux | surf_Uy |
|-------|----------|--------|---------|---------|
| val_in_dist | 0.5901 | 17.6 | 6.52 | 2.10 |
| val_ood_cond | 0.6893 | 14.1 | 3.34 | 1.16 |
| val_ood_re | 0.5252 | 27.5 | 2.93 | 1.00 |
| val_tandem_transfer | 1.6305 | 38.4 | 6.07 | 2.54 |
| **combined** | **0.8588** | — | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8495 | 0.8588 | +0.0093 ↑ slightly worse |
| in surf_p | 17.84 | 17.60 | -0.24 (noise) |
| ood_c surf_p | 13.66 | 14.10 | +0.44 ↑ worse |
| ood_r surf_p | 27.77 | 27.50 | -0.27 (noise) |
| tan surf_p | 36.36 | 38.40 | +2.04 ↑ worse |
| mean3 surf_p | 19.76 | 19.73 | -0.03 (noise) |

**Peak memory:** 18.3 GB (vs ~17.9 GB baseline — +0.4 GB from content_bias params)

### What happened

Marginal negative result. The combined val/loss degrades slightly (+0.009), driven mainly by the tandem split (+2.04 surf_p). Non-tandem mean3 is essentially unchanged (-0.03, well within noise). The content routing adds complexity (~15K params, doubled ln_1 computation) without meaningful benefit.

The tandem degradation is a recurring pattern: content-based routing trained primarily on non-tandem data may route tandem samples differently from how spatial routing would, causing worse predictions for the tandem domain. The spatial bias is physically motivated (nearby nodes share physics), while content routing lacks this inductive bias.

At initialization, routing_blend=0 means sigmoid(0)=0.5 — equal blend. This means the model starts with a strong content-routing signal from epoch 1, which may be destabilizing before the content_bias network has learned meaningful representations. Zero-initialized output layers help, but the 50/50 initial blend is still significant.

### Suggested follow-ups

- Try initializing routing_blend to a large negative value (e.g., -3.0, sigmoid≈0.047) so the model starts mostly spatial and learns content routing gradually
- Alternatively, add the content bias only after epoch 20 (schedule the blend from 0→0.5 progressively)
- The core hypothesis (content routing) is worth testing more carefully — the architecture change may have good potential with a better initialization strategy