### PR TITLE
Dual-phase: 20min no dist_feat, 10min fine-tune with dist_feat

### DIFF
--- a/train.py
+++ b/train.py
@@ -627,12 +627,20 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+PHASE1_MINUTES = 20.0
+phase = 1
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
     if elapsed_min >= MAX_TIMEOUT:
         print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {MAX_TIMEOUT} min). Stopping.")
         break
+
+    if phase == 1 and elapsed_min >= PHASE1_MINUTES:
+        phase = 2
+        for pg in base_opt.param_groups:
+            pg['lr'] = pg['lr'] * 0.3
+        print(f"PHASE 2: dist_feat active, LR reduced, epoch {epoch+1}")
 
     t0 = time.time()
 
@@ -656,6 +664,8 @@ for epoch in range(MAX_EPOCHS):
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        if phase == 1:
+            dist_feat = torch.zeros_like(dist_feat)
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
@@ -886,6 +896,8 @@ for epoch in range(MAX_EPOCHS):
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+                if phase == 1:
+                    dist_feat = torch.zeros_like(dist_feat)
                 x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]


### PR DESCRIPTION
## Hypothesis
dist_feat helps tandem but hurts in_dist. If the model first builds a strong in_dist representation WITHOUT dist_feat (20 min), then fine-tunes WITH dist_feat at lower LR (10 min), it may preserve in_dist while gaining tandem benefits. This directly addresses the dist_feat Pareto trade-off.

## Instructions
1. Add phase tracking:
```python
PHASE1_MINUTES = 20.0
phase = 1
```

2. At the start of each epoch, check phase transition:
```python
if phase == 1 and elapsed_minutes >= PHASE1_MINUTES:
    phase = 2
    for pg in base_opt.param_groups:
        pg['lr'] = pg['lr'] * 0.3
    print(f"PHASE 2: dist_feat active, LR reduced, epoch {epoch+1}")
```

3. In feature construction, zero out dist_feat during phase 1:
```python
if phase == 1:
    dist_feat = torch.zeros_like(dist_feat)
```

4. In raw_xy for spatial_bias, zero the dist channel during phase 1:
```python
if phase == 1:
    raw_xy[:, :, 3:] = 0  # zero the dist channel
```

Run with `--wandb_group dual-phase-dist`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** o1kuo341  
**Change:** Phase 1 (0–20 min): dist_feat=0; Phase 2 (20–30 min): dist_feat active, LR×0.3

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Δ |
|-------|----------|------------|---------------------|---|
| val_in_dist | 0.5925 | 17.49 | 17.84 | **-0.35** |
| val_ood_cond | 0.7019 | 14.09 | 13.66 | +0.43 |
| val_ood_re | 0.5527 | 28.03 | 27.77 | +0.26 |
| val_tandem_transfer | 1.6274 | 38.46 | 36.36 | **+2.10** |
| **combined** | **0.8686** | — | **0.8495** | **+0.0191** |

**Peak memory:** 17.8 GB  
**Epochs completed:** 61 in ~30 min (~30 s/epoch)  
**Phase 2 activation:** ~epoch 40–41

### What happened

The dual-phase approach made in_dist surface accuracy slightly better (-0.35 on mae_surf_p) but significantly worsened tandem performance (+2.10). Overall val/loss degraded vs. baseline.

Phase 1 (no dist_feat, ~40 epochs): The model learned representations without the distance-to-surface cue, which appears to benefit in_dist generalization. This matches the hypothesis that dist_feat has a negative in_dist trade-off.

Phase 2 (dist_feat active, ~20 epochs, LR×0.3): Introducing dist_feat with a large LR reduction did not allow the model to effectively leverage the distance information. The EMA model (active since epoch 40) was heavily weighted toward phase 1 weights (no dist_feat), so the 20 fine-tuning epochs were insufficiently impactful. Tandem performance got worse — likely because the abrupt dist_feat introduction in phase 2 creates a distribution shift without enough capacity or time to adapt.

The fundamental issue: the dist_feat benefit for tandem appears to require learning from scratch with the feature present. Introducing it at 20 min as a switch leaves the model trying to adapt a well-established no-dist representation to a new cue in only 10 min at low LR.

### Suggested follow-ups

- **Shorter phase 1 (10 min):** Try 10 min no-dist / 20 min with-dist — more time for dist_feat adaptation, less "unlearning" needed.
- **Gradual dist_feat annealing:** Instead of a hard switch, linearly increase dist_feat weight from 0 to 1 over epochs 0–40, so the model gradually incorporates it.
- **No dist_feat at all:** Given that dist_feat consistently degrades tandem and doesn't help in the dual-phase setting either, consider removing it entirely and accepting the in_dist/tandem tradeoff.