### PR TITLE
Relative position bias between slice tokens in attention

### DIFF
--- a/train.py
+++ b/train.py
@@ -143,6 +143,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.rel_pos_bias = nn.Parameter(torch.zeros(heads, slice_num, slice_num))
+        with torch.no_grad():
+            for i in range(slice_num):
+                for j in range(slice_num):
+                    self.rel_pos_bias.data[:, i, j] = -0.1 * abs(i - j)
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape
@@ -177,6 +182,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         q_norm = F.normalize(q_slice_token, dim=-1)
         k_norm = F.normalize(k_slice_token, dim=-1)
         attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
+        attn_logits = attn_logits + self.rel_pos_bias.unsqueeze(0)  # [1, H, S, S]
         attn_weights = F.softmax(attn_logits, dim=-1)
         out_slice_token = torch.matmul(attn_weights, v_slice_token)
         out_slice_token = out_slice_token + self.slice_residual_scale * slice_token


### PR DESCRIPTION
## Hypothesis
The Q/K/V attention between slice tokens has no notion of spatial proximity. Nearby slices (along the flow) should interact more strongly. A learned relative position bias table (standard in Swin Transformer) encodes this inductive bias, initialized with distance decay.

## Instructions
1. In Physics_Attention_Irregular_Mesh.__init__:
```python
self.rel_pos_bias = nn.Parameter(torch.zeros(heads, slice_num, slice_num))
# Init with distance decay
with torch.no_grad():
    for i in range(slice_num):
        for j in range(slice_num):
            self.rel_pos_bias.data[:, i, j] = -0.1 * abs(i - j)
```

2. In forward, add to attention logits before softmax:
```python
attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
attn_logits = attn_logits + self.rel_pos_bias.unsqueeze(0)  # [1, H, S, S]
```

Run with `--wandb_group slice-rpb`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `69f25krl`
**Best epoch:** 58/100 (wall-clock limit at 30 min)
**Peak memory:** ~17 GB

### Metrics (best epoch)

| Split | val/loss | Surf p | Surf Ux | Surf Uy | Vol p | Vol Ux | Vol Uy |
|-------|----------|--------|---------|---------|-------|--------|--------|
| val_in_dist | 0.593 | 17.70 | 7.06 | 2.07 | 19.17 | 1.07 | 0.36 |
| val_ood_cond | 0.693 | 13.98 | 3.38 | 1.35 | 12.06 | 0.71 | 0.27 |
| val_ood_re | 0.561 | 28.37 | 3.02 | 1.17 | 47.09 | 0.81 | 0.36 |
| val_tandem_transfer | 1.644 | 38.97 | 6.73 | 2.64 | 38.01 | 1.89 | 0.86 |
| **combined val/loss** | **0.8728** | | | | | | |

### vs Baseline

| Metric | Baseline | Slice RPB | Delta |
|--------|----------|-----------|-------|
| val/loss | 0.8495 | 0.8728 | +0.023 ▲ |
| in/surf_p | 17.84 | 17.70 | -0.14 ▼ |
| ood_c/surf_p | 13.66 | 13.98 | +0.32 ▲ |
| ood_r/surf_p | 27.77 | 28.37 | +0.60 ▲ |
| tan/surf_p | 36.36 | 38.97 | +2.61 ▲ |

### What happened

Mixed results: val_in_dist pressure improved slightly (−0.14 Pa), but all other splits worsened, especially tandem (−2.61 Pa). Combined val/loss is +2.7% worse.

The "ordering" assumption behind relative position bias is problematic here. Slice tokens are learned routing constructs — they don't have a meaningful sequential spatial order (slices aren't sorted by x-coordinate or flow direction). Imposing a distance-decay prior based on index order imposes the wrong inductive bias: nearby indices may not represent nearby spatial regions.

This is consistent with the tandem regression: the two-foil geometry doesn't fit a monotone spatial ordering, so the bias actively hurts routing.

The val_in_dist improvement (+0.14 Pa) is encouraging but likely noise-level (within the ~0.017 variance from seed experiments).

### Suggested follow-ups

- If slice-to-slice attention needs a spatial bias, derive it from the slice centroids (learned during training) rather than index distance
- A content-based routing approach (slice tokens attend based on feature similarity, not index proximity) might be more appropriate
- The existing architecture already doesn't benefit from additional inter-slice constraints — the attention already allows any-to-any interaction