### PR TITLE
Multi-exit with deep supervision on preprocess features

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,9 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.early_exit = nn.Sequential(
+            nn.LayerNorm(n_hidden), nn.Linear(n_hidden, n_hidden), nn.GELU(), nn.Linear(n_hidden, out_dim),
+        )
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -383,6 +386,7 @@ class Transolver(nn.Module):
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
         fx = self.preprocess(x)
+        early_pred = self.early_exit(fx)  # [B, N, 3]
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
@@ -397,7 +401,7 @@ class Transolver(nn.Module):
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "early_preds": early_pred}
 
 
 # ---------------------------------------------------------------------------
@@ -701,11 +705,14 @@ for epoch in range(MAX_EPOCHS):
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
+            early_pred = out["early_preds"]
         pred = pred.float()
         re_pred = re_pred.float()
         aoa_pred = aoa_pred.float()
+        early_pred = early_pred.float()
         if model.training:
             pred = pred / sample_stds
+            early_pred = early_pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
@@ -783,6 +790,9 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+        early_err = (early_pred - y_norm).abs()
+        early_loss = (early_err * mask.unsqueeze(-1)).sum() / mask.sum().clamp(min=1)
+        loss = loss + 0.2 * early_loss
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest


### PR DESCRIPTION
## Hypothesis
Add an early prediction head after preprocessing (before attention) and supervise it. This forces preprocess features to be directly useful for prediction, not just for attention. The early exit provides a baseline that attention refines, improving feature quality.

## Instructions
1. In Transolver.__init__, add early exit head:
```python
self.early_exit = nn.Sequential(
    nn.LayerNorm(n_hidden), nn.Linear(n_hidden, n_hidden), nn.GELU(), nn.Linear(n_hidden, out_dim),
)
```

2. In Transolver.forward, after preprocessing but before attention blocks:
```python
fx = self.preprocess(x)
early_pred = self.early_exit(fx)  # [B, N, 3]
# ... rest of forward (attention, output) unchanged ...
```

3. Return early_pred: `return {"preds": fx, "early_preds": early_pred, ...}`

4. In the training loss, add auxiliary:
```python
early_pred = out["early_preds"].float()
if model.training:
    early_pred = early_pred / sample_stds
early_err = (early_pred - y_norm).abs()
early_loss = (early_err * mask.unsqueeze(-1)).sum() / mask.sum().clamp(min=1)
loss = loss + 0.2 * early_loss
```

Run with `--wandb_group multi-exit`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** e5j4guy0
**Total time:** 30.1 min, 54 epochs

### Metrics

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.6125 | 18.6 |
| val_ood_cond | 0.7128 | 14.1 |
| val_ood_re | 0.5474 | 28.0 |
| val_tandem_transfer | 1.6328 | 38.5 |
| **mean3 (in+ood+tan)** | **0.8764** | **23.73** |

Baseline: val_loss=0.8495, mean3_p=22.62

**Delta:** val_loss +0.0269 (+3.2%), mean3_p +1.11 (+4.9%)

**Peak VRAM:** ~12.7GB

### What happened

No improvement. Early exit supervision (weight=0.2) hurts rather than helps, and the model completes only 54 epochs vs ~58 in baseline (4 fewer epochs, ~2 minutes overhead from the deeper computation graph with retain_graph in PCGrad plus the early_exit module).

The early_loss is computed over all nodes (mask.unsqueeze(-1)), which means it creates a supervision signal on features that haven't seen any spatial attention yet. At this stage, the features are essentially per-node projections of the input (preprocess is a GatedMLP2). These feature vectors have no knowledge of neighboring nodes, so predicting flow fields from them is inherently harder than predicting from attention-processed features. The 0.2 weight forces the model to maintain a prediction-compatible representation in preprocess, constraining the intermediate features and potentially reducing the expressiveness available to attention.

The baseline already has strong supervision through the main loss, re_head, aoa_head, and coarse pooling loss — adding a fourth auxiliary doesn't provide new signal, just noise.

### Suggested follow-ups

1. Lower weight (0.05): Reduce early_loss weight to treat it as a very light regularizer rather than a primary supervision signal.
2. Surface-only early supervision: Compute early_loss only on surface nodes (surf_mask) rather than all nodes — the early representation may be more useful for surface structure.
3. Remove multi-exit and try feature reconstruction: Instead of predicting y from early features, regularize preprocess to preserve geometric features via reconstruction loss.