### PR TITLE
dp/ds weighted surface loss (physics-informed hard mining)

### DIFF
--- a/train.py
+++ b/train.py
@@ -715,6 +715,16 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
+        # dp/ds proxy weight: finite-difference pressure gradient along mesh ordering
+        surf_p = y_norm[:, :, 2:3] * is_surface.float().unsqueeze(-1)  # [B, N, 1]
+        dp = torch.zeros_like(surf_p)
+        dp[:, 1:] = (surf_p[:, 1:] - surf_p[:, :-1]).abs()
+        dp[:, 0] = dp[:, 1]
+        dp_max = dp.amax(dim=1, keepdim=True).clamp(min=1e-6)
+        dp_weight = (dp / dp_max).clamp(0, 1) * 2.0 + 1.0  # [1, 3] for surface nodes
+        dp_weight = dp_weight.detach() * is_surface.float().unsqueeze(-1)
+        dp_weight = dp_weight + (1.0 - is_surface.float().unsqueeze(-1))  # 1.0 for non-surface
+
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
         if epoch < 40:
@@ -731,7 +741,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1) * dp_weight).sum(dim=(1, 2)) / (surf_mask.float().unsqueeze(-1) * dp_weight).sum(dim=(1, 2)).clamp(min=1)
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -745,7 +755,7 @@ for epoch in range(MAX_EPOCHS):
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            surf_per_sample = (surf_pres * hard_weights * dp_weight * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / (surf_mask.float().unsqueeze(-1) * hard_weights * dp_weight).sum(dim=(1, 2)).clamp(min=1)
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis
Weight surface loss by the magnitude of the pressure gradient along the surface (dp/ds). This focuses on leading edges, suction peaks, and trailing edges — the physically most important regions. Unlike error-based hard mining (reactive), dp/ds weighting is predictive and physics-informed.

## Instructions
After computing y_norm and surface masks, compute dp/ds proxy:
```python
surf_p = y_norm[:, :, 2:3] * is_surface.float().unsqueeze(-1)  # [B, N, 1]
# Finite difference for surface pressure gradient
dp = torch.zeros_like(surf_p)
dp[:, 1:] = (surf_p[:, 1:] - surf_p[:, :-1]).abs()
dp[:, 0] = dp[:, 1]
# Normalize to [1, 3] range per sample
dp_max = dp.amax(dim=1, keepdim=True).clamp(min=1e-6)
dp_weight = (dp / dp_max).clamp(0, 1) * 2.0 + 1.0  # [1, 3]
dp_weight = dp_weight.detach() * is_surface.float().unsqueeze(-1)
# For non-surface nodes, weight=1
dp_weight = dp_weight + (1 - is_surface.float().unsqueeze(-1))
```

Apply to surface loss: multiply abs_err by dp_weight before averaging. Normalize by the sum of dp_weight to preserve loss magnitude.

Run with `--wandb_group dpds-loss`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** [7msatav3](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/7msatav3)
**Best epoch:** 61/100
**Peak VRAM:** ~17.4 GB

### Validation Loss

| Split | This run | Baseline |
|-------|----------|----------|
| val/loss (combined) | **0.8677** | 0.8495 |
| val_in_dist | 0.5930 | — |
| val_tandem_transfer | 1.6357 | — |
| val_ood_cond | 0.6936 | — |
| val_ood_re | 0.5483 | — |

### Surface MAE

| Split | Ux | Uy | p | p (baseline) |
|-------|----|----|---|--------------|
| val_in_dist | 6.5702 | 2.0848 | 17.9390 | 17.84 |
| val_tandem_transfer | 6.2109 | 2.3855 | 38.7842 | 36.36 |
| val_ood_cond | 3.0477 | 1.1217 | 13.9611 | 13.66 |
| val_ood_re | 2.6135 | 0.9222 | 27.9076 | 27.77 |

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.0680 | 0.3599 | 19.1884 |
| val_tandem_transfer | 1.9115 | 0.8653 | 38.3119 |
| val_ood_cond | 0.7217 | 0.2743 | 12.1387 |
| val_ood_re | 0.8327 | 0.3690 | 47.0463 |

### What happened

No improvement — val/loss 0.8677 vs 0.8495 (+0.018). Surface pressure MAE is slightly worse or flat across all splits. Velocity MAE (Ux) regressed noticeably on val_in_dist (6.57 vs baseline) and tandem (6.21 vs baseline).

The core issue: the finite-difference `dp[:, 1:] = (surf_p[:, 1:] - surf_p[:, :-1]).abs()` computes differences between consecutive mesh nodes in BATCH INDEX order, not arc-length order. Mesh node ordering is arbitrary (mesh ID), so consecutive indices are geometrically unrelated. The resulting "dp/ds" is essentially random noise, not the actual surface pressure gradient. The weighting therefore emphasizes random nodes rather than physically meaningful leading edges or suction peaks.

### Suggested follow-ups

- **Sort by arc-length first**: To compute a meaningful dp/ds, sort surface nodes by angle from airfoil centroid (or by x+y coordinates) before taking finite differences.
- **Use DSDF channels as dp/ds proxy**: The dsdf features (channels 4-11) encode signed distance field gradient magnitudes, which could serve as a better geometry-based proxy for regions of high pressure gradient.
- **Simpler approach**: Directly weight by the y-coordinate of the node relative to the chord (lower y ≈ suction peak) rather than finite-differencing the target.