### PR TITLE
EMA decay 0.999 (smoother weight averaging in final phase)

### DIFF
--- a/train.py
+++ b/train.py
@@ -537,7 +537,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.999
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
The current EMA decay=0.998 averages ~500 gradient steps. With the dist-to-surface feature creating noisier updates (the model must learn to integrate a new input), a smoother EMA (0.999, ~1000 steps) may produce better final weights. The val_loss at the end of training is determined by EMA quality more than raw model quality.

## Instructions
Change EMA decay from 0.998 to 0.999:
```python
# Find the EMA update line (around line 838):
# OLD: ema_decay = 0.998
# NEW: ema_decay = 0.999
```

One-line change. Run with `--wandb_group ema-decay-0999`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run**: fysez5ke
**Best epoch**: 58 (31.9 min, wall-clock limit)
**VRAM**: ~18 GB (same as baseline)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6174 | 4.75 | 1.66 | **19.03** | 1.13 | 0.37 | 19.79 |
| val_ood_cond | 0.7183 | 3.38 | 1.11 | **14.23** | 0.73 | 0.28 | 12.20 |
| val_ood_re | 0.5520 | 2.96 | 0.93 | **27.86** | 0.85 | 0.37 | 46.87 |
| val_tandem_transfer | 1.6302 | 5.77 | 2.19 | **38.16** | 1.93 | 0.87 | 37.76 |
| **combined** | **0.8795** | | | | | | |

**mean3 (in/ood/tan p)**: (19.03 + 14.23 + 38.16) / 3 = **23.81** vs baseline 22.62 → **+1.19, negative result**

### What happened

EMA decay 0.999 uniformly degrades all splits. Every metric is worse than baseline:
- in_dist p: 19.03 vs 17.84 (+1.19)
- ood_cond p: 14.23 vs 13.66 (+0.57)
- ood_re p: 27.86 vs 27.77 (+0.09)
- tandem p: 38.16 vs 36.36 (+1.80)
- combined val/loss: 0.8795 vs 0.8495 (+0.03)

The hypothesis was incorrect. A slower EMA (0.999) hurts rather than helps. The key reason: at 0.999 decay with ~330 steps/epoch, each epoch contributes only `1 - 0.999^330 ≈ 28%` to the EMA. At 0.998, each epoch contributes `1 - 0.998^330 ≈ 48%`. The faster-updating EMA (0.998) tracks model improvements more closely — when the model makes a meaningful jump in a few epochs, the EMA captures it quickly. With 0.999, the EMA is persistently stale relative to the current model, missing recent gains especially in the final training phase.

The tandem degradation (+1.80) is largest, consistent with the pattern seen in other experiments where slower/smoother operations hurt tandem more than single-foil splits. Tandem transfer likely requires the EMA to capture sharper, epoch-level gains.

### Suggested follow-ups

1. **Decay 0.997 (faster)**: If 0.998 → 0.999 (slower) hurts, maybe 0.998 → 0.997 (faster) could help. Each epoch would contribute `1 - 0.997^330 ≈ 63%`, making EMA much more responsive. Risk: too noisy.
2. **Adaptive decay schedule**: Start with 0.99 for fast tracking in early epochs (40-50), then ramp up to 0.998 as learning stabilizes. Balances tracking speed and smoothing.