### PR TITLE
Seed 7 (characterize variance on dist-to-surface code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,10 +21,12 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 """
 
 import os
+import random
 import time
 from collections.abc import Mapping
 from pathlib import Path
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -515,6 +517,11 @@ _pmean = (_phys_sum / _phys_n).float()
 _pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
 phys_stats = {"y_mean": _pmean, "y_std": _pstd}
 print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
+
+random.seed(7)
+np.random.seed(7)
+torch.manual_seed(7)
+torch.cuda.manual_seed_all(7)
 
 model_config = dict(
     space_dim=2,


### PR DESCRIPTION
## Hypothesis
The current baseline (val_loss=0.8495) was trained with the default seed. With 40+ experiments failing to improve, we need to understand the seed variance on the new dist-to-surface code. A lucky seed might find a better minimum for both in_dist and tandem simultaneously.

## Instructions
Add a single line before model creation:
```python
torch.manual_seed(7)
```
Also seed numpy and random for full reproducibility:
```python
import random
random.seed(7)
np.random.seed(7)
torch.manual_seed(7)
torch.cuda.manual_seed_all(7)
```
No other changes. Run with `--wandb_group seed-7`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** 22kvy5kd  
**Change:** Seeds set to 7 (random, numpy, torch, cuda)

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Δ |
|-------|----------|------------|---------------------|---|
| val_in_dist | 0.6022 | 18.01 | 17.84 | +0.17 |
| val_ood_cond | 0.6790 | 13.70 | 13.66 | +0.04 |
| val_ood_re | 0.5447 | 27.97 | 27.77 | +0.20 |
| val_tandem_transfer | 1.5968 | 37.51 | 36.36 | +1.15 |
| **combined** | **0.8557** | — | **0.8495** | **+0.0062** |

**Peak memory:** 17.9 GB  
**Epochs completed:** 61 in ~30 min (~30 s/epoch)

### What happened

Seed 7 does not beat the baseline. All metrics are slightly worse, with the biggest degradation on tandem (+1.15 mae_surf_p). The combined val/loss of 0.8557 vs 0.8495 suggests seed variance is real but modest — on the order of 0.5-1.5 mae_surf_p per split.

Key observation: tandem variance appears higher than other splits (1.15 degradation from a single seed change, compared to <0.2 on other splits). This makes tandem improvement the hardest target — not only is it the most OOD, but it's also the most sensitive to random initialization.

The baseline seed is not exceptionally lucky; seed 7 is consistently slightly worse across all splits. This suggests the 0.8495 baseline is a reasonable representative and not an outlier.

### Suggested follow-ups

- **Seed sweep (3 seeds):** Run seed 42, seed 123, seed 2024 to get a proper variance estimate. This would tell us the true improvement threshold needed to claim a genuine gain.
- **Best-of-3 checkpoint:** If seed variance is ~0.01 val/loss, then beating baseline by less than 0.01 may be noise. Knowing the variance helps set a meaningful improvement bar.