### PR TITLE
Seed 2024 (characterize variance on dist-to-surface code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,7 +21,9 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 """
 
 import os
+import random
 import time
+import numpy as np
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -529,6 +531,10 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
+random.seed(2024)
+np.random.seed(2024)
+torch.manual_seed(2024)
+torch.cuda.manual_seed_all(2024)
 model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode="default")


### PR DESCRIPTION
## Hypothesis
The current baseline (val_loss=0.8495) was trained with the default seed. With 40+ experiments failing to improve, we need to understand the seed variance on the new dist-to-surface code. A lucky seed might find a better minimum for both in_dist and tandem simultaneously.

## Instructions
Add a single line before model creation:
```python
torch.manual_seed(2024)
```
Also seed numpy and random for full reproducibility:
```python
import random
random.seed(2024)
np.random.seed(2024)
torch.manual_seed(2024)
torch.cuda.manual_seed_all(2024)
```
No other changes. Run with `--wandb_group seed-2024`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `z5fkdwor` | Best epoch: 58 | Peak memory: ~18 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6116 | 18.6 | +4.3% worse |
| val_ood_cond | 0.7271 | 14.6 | +6.9% worse |
| val_ood_re | 0.5441 | 27.9 | +0.5% worse |
| val_tandem_transfer | 1.6322 | 39.1 | +7.5% worse |
| **combined** | **0.8787** | — | **+3.4% worse** |

### What happened

Negative result. Seed 2024 is worse than the default seed across all splits, with tandem and ood_cond particularly affected. This is a useful variance characterization:

- The default-seed baseline (val_loss=0.8495) appears to be a relatively good draw
- Seed 2024 gives val_loss=0.8787 — a gap of ~0.03 in combined val_loss
- ood_re is essentially unchanged (27.9 vs 27.77), suggesting that split is seed-insensitive
- Tandem and ood_cond show ~7% seed sensitivity — these are the harder, higher-variance domains

This means experiments showing improvements below ~3-4% in combined val/loss may be within the seed noise floor. True improvements need to be more decisive.

### Suggested follow-ups

- Run a few more seeds (e.g., seed=42, seed=7, seed=123) to bracket the variance range — the advisor mentioned these are already running in parallel.
- The combined val_loss variance across seeds appears to be roughly [0.84, 0.88]. Experiments that land at 0.84 or below would be unambiguously positive.
- Consider whether the baseline itself should be re-run with multiple seeds to get a more robust performance estimate before comparing future experiments.