### PR TITLE
Weight decay 1e-5 (light regularization on dist code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -412,7 +412,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 2.5e-3
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
The current code uses no weight decay. With the new dist_feat adding parameters to learn, light weight decay (1e-5) could prevent overfitting without changing the architecture. This is the gentlest possible regularization change.

## Instructions
Change AdamW weight_decay from 0 to 1e-5:
```python
base_opt = torch.optim.AdamW(param_groups, weight_decay=1e-5)
```
One-line change. Run with `--wandb_group wd-1e5`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run**: yu2431uc
**Best epoch**: 58 (31.9 min, wall-clock limit)
**VRAM**: ~18 GB (same as baseline)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6019 | 6.92 | 2.10 | **18.35** | 1.09 | 0.36 | 19.28 |
| val_ood_cond | 0.7039 | 3.37 | 1.31 | **13.92** | 0.72 | 0.27 | 12.23 |
| val_ood_re | 0.5489 | 3.13 | 1.12 | **27.83** | 0.82 | 0.36 | 46.77 |
| val_tandem_transfer | 1.6201 | 6.50 | 2.41 | **38.20** | 1.88 | 0.85 | 37.51 |
| **combined** | **0.8687** | | | | | | |

**mean3 (in/ood/tan p)**: (18.35 + 13.92 + 38.20) / 3 = **23.49** vs baseline 22.62 → **+0.87, negative result**

### What happened

Weight decay 1e-5 uniformly degrades all splits. Every metric is worse than baseline:
- in_dist p: 18.35 vs 17.84 (+0.51)
- ood_cond p: 13.92 vs 13.66 (+0.26)
- ood_re p: 27.83 vs 27.77 (+0.06)
- tandem p: 38.20 vs 36.36 (+1.84)
- combined val/loss: 0.8687 vs 0.8495 (+0.019)

The hypothesis was incorrect. The model doesn't appear to be in an overfitting regime where regularization would help. With only 30 minutes of training and a large physics dataset, the model has more room to improve than room to overfit — weight decay penalizes the weights in a direction that reduces model expressiveness exactly when more capacity is needed. The tandem split suffers most (+1.84), consistent with the pattern that tandem transfer requires learning subtle inter-foil interactions that weight decay suppresses by biasing weights toward smaller magnitudes.

The original weight_decay=0 was the right choice for this training regime: physics surrogates on structured mesh data benefit from unconstrained weight scale, especially for the spatial and slice attention parameters that need to capture large-scale flow features.

### Suggested follow-ups

1. **Weight decay only on non-attention params**: Apply 1e-5 only to MLP layers, not to attention/slice parameters. Attention parameters may need freedom while MLPs could benefit from light regularization.
2. **Dropout instead of weight decay**: A tiny dropout (0.01) on intermediate MLP activations might regularize differently without penalizing weight scale. Less likely to hurt tandem.