### PR TITLE
AdamW beta2=0.99 (faster second moment, help dist_feat)

### DIFF
--- a/train.py
+++ b/train.py
@@ -575,7 +575,7 @@ other_params = [p for n, p in model.named_parameters() if not any(k in n for k i
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
+], weight_decay=cfg.weight_decay, betas=(0.9, 0.99))
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)


### PR DESCRIPTION
## Hypothesis
Default beta2=0.999 gives a slow-moving second moment estimate. With the dist_feat creating new gradient patterns, beta2=0.99 adapts faster to the new loss landscape. This was never tested on the current code.

## Instructions
Change beta2 in AdamW:
```python
base_opt = torch.optim.AdamW(param_groups, betas=(0.9, 0.99))
```
One-line change. Run with `--wandb_group beta2-099`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** 4vfwd4a7
**Epochs completed:** 59/100 (30-min timeout, +1 vs baseline from faster epochs: 29.5s vs ~30s)
**Peak memory:** ~14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8495 | 0.8763 | +3.2% worse |
| val_in_dist | mae_surf_p | 17.84 | 18.47 | +3.5% worse |
| val_ood_cond | mae_surf_p | 13.66 | 14.23 | +4.2% worse |
| val_ood_re | mae_surf_p | 27.77 | 27.99 | +0.8% worse |
| val_tandem_transfer | mae_surf_p | 36.36 | 38.99 | +7.2% worse |
| **mean3** | mae_surf_p | **22.62** | **23.90** | **+5.7% worse** |

Surface MAE (full breakdown, epoch 59):
- **in_dist:** Ux=6.25, Uy=2.14, p=18.47 | Vol: Ux=1.11, Uy=0.37, p=19.91
- **ood_cond:** Ux=3.40, Uy=1.29, p=14.23 | Vol: Ux=0.72, Uy=0.27, p=12.18
- **ood_re:** Ux=3.01, Uy=1.17, p=27.99 | Vol: Ux=0.83, Uy=0.37, p=47.03
- **tandem_transfer:** Ux=6.20, Uy=2.55, p=38.99 | Vol: Ux=1.94, Uy=0.89, p=38.77

### What happened

beta2=0.99 is worse across all splits, with tandem_transfer hurt most (+7.2%). The extra epoch (59 vs 58, from 29.5s vs 30s average) didn't compensate.

Faster second moment adaptation (beta2=0.99 vs 0.999) makes the effective per-parameter learning rate more volatile. The second moment estimate changes more rapidly, causing the optimizer to make larger or smaller updates based on recent gradient variance rather than the long-term average. In this setting — where the Lookahead optimizer (k=10) already creates a form of momentum smoothing — a more reactive base optimizer adds noise rather than signal.

The default beta2=0.999 provides a stable 1000-step horizon estimate of gradient variance, appropriate for a training run that lasts ~6,000 gradient steps (331 batches × 18 epochs worth of the relevant portion). With beta2=0.99, the effective horizon is only ~100 steps, making the adaptive scaling noisy.

Tandem transfer regresses most (+7.2%), likely because tandem samples appear in every batch but have distinct gradient scales. A noisy second moment estimate disproportionately affects parameters that handle tandem inputs.

### Suggested follow-ups

- **beta2=0.995**: A mild middle ground between 0.999 and 0.99.
- **Decouple beta2 per parameter group**: Use faster beta2 only for attention params (which adapt more slowly) and keep 0.999 for output params.
- **Adan or AdaFactor**: Alternative optimizers that may better handle the mixed in-dist/OOD gradient landscape.