### PR TITLE
Gradient clip 0.5 (gentler clipping for dist code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -831,7 +831,7 @@ for epoch in range(MAX_EPOCHS):
             optimizer.zero_grad()
             loss.backward()
 
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:


### PR DESCRIPTION
## Hypothesis
The current gradient clip is max_norm=1.0. With PCGrad and dist_feat, gradient norms may spike. Reducing to 0.5 provides gentler training dynamics that could help the model settle into a better minimum.

## Instructions
Change gradient clip:
```python
torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=0.5)
```
One-line change. Run with `--wandb_group clip-05`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---

## Results

**W&B run:** `xcsxodc6` | **Epochs completed:** 59 (30-min timeout) | **Peak memory:** 17.7 GB

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.5943 | **17.85** |
| val_ood_cond | 0.7197 | **13.94** |
| val_ood_re | 0.5540 | **27.87** |
| val_tandem_transfer | 1.6230 | **38.56** |
| **combined** | **0.8727** | — |

**vs. baseline (dist-to-surface PR #1473):**
| Split | surf_p baseline | surf_p result | Δ |
|-------|----------------|----------------|---|
| val_in_dist | 17.84 | 17.85 | ≈0 |
| val_ood_cond | 13.66 | 13.94 | +2.1% worse |
| val_ood_re | 27.77 | 27.87 | +0.4% worse |
| val_tandem_transfer | 36.36 | 38.56 | **+6.0% worse** |
| combined val_loss | 0.8495 | 0.8727 | +2.7% worse |

**What happened:** Tighter gradient clipping (0.5 vs 1.0) hurt performance, especially on tandem transfer (+6.0%). The model reached 59 epochs (same as baseline 58), so the slowdown is not due to fewer iterations — the tighter clip is directly restricting the learning signal. Halving the gradient norm limit effectively halves the maximum step size at each clipping event, slowing convergence toward the optimum within the 30-minute budget. Tandem transfer is most affected, likely because tandem foil interactions require large coordinated gradient updates across many attention heads to model wake effects, and clipping to 0.5 bottlenecks this. The gradient norm hypothesis (that PCGrad + dist_feat causes spikes) appears to be incorrect — the current training with max_norm=1.0 already handles it well, and tightening the clip only adds unnecessary constraint.

**Suggested follow-ups:**
- Rather than tightening the clip, try monitoring the actual gradient norms during training (log `torch.nn.utils.clip_grad_norm_` return value to W&B) to see if 1.0 is actually being triggered often. If clips are rare, the hypothesis was wrong; if they're frequent, a tighter clip might make sense.
- If gradients are spiking specifically after Lookahead slow-weight updates, consider clipping per-group (attention vs MLP) rather than globally.