### PR TITLE
LR 2.4e-3 (fine-tune LR for dist-to-surface architecture)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.5e-3
+    lr: float = 2.4e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The dist_feat changed the loss landscape. A slightly lower LR (2.4e-3 vs 2.5e-3) might find a better optimum without overshooting. Previous LR recalibration (merge 5) showed sensitivity to this parameter.

## Instructions
Change lr: `lr = 2.4e-3`. One-line change. Run with `--wandb_group lr-24e-4`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B Run:** qbdmnaij
**Best epoch:** 61

### Metrics vs Baseline

| Split | val_loss | surf_p | surf_Ux | surf_Uy |
|-------|----------|--------|---------|---------|
| val_in_dist | 0.5832 | 17.31 | 4.34 | 1.43 |
| val_ood_cond | 0.6833 | 13.51 | 2.66 | 0.98 |
| val_ood_re | 0.5327 | 27.51 | 2.28 | 0.84 |
| val_tandem_transfer | 1.5959 | 37.29 | 4.88 | 1.95 |
| **combined** | **0.8488** | — | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8495 | 0.8488 | -0.0007 (noise) |
| in surf_p | 17.84 | 17.31 | -0.53 ↓ better |
| ood_c surf_p | 13.66 | 13.51 | -0.15 ↓ slightly better |
| ood_r surf_p | 27.77 | 27.51 | -0.26 ↓ slightly better |
| tan surf_p | 36.36 | 37.29 | +0.93 ↑ slightly worse |
| mean3 surf_p | 19.76 | 19.44 | -0.32 ↓ better |

**Peak memory:** ~17.9 GB (identical to baseline)

### What happened

Marginally positive result, though within noise range. The combined val/loss is nearly identical (-0.0007, well below the ~0.01 noise floor), but the non-tandem mean3 surf_p improves by 0.32 (noise floor ~0.5 for individual splits). Tandem performance is slightly worse (+0.93).

The pattern is consistent with a slightly more conservative optimizer: the in/ood splits benefit from smaller steps (less overshooting of sharp minima), while tandem — which is harder to learn — may need the larger LR to escape local optima during its limited share of training.

This is inconclusive within a single run given the noise floor. The direction is promising for non-tandem splits.

### Suggested follow-ups

- Run the same LR with a different seed to confirm whether the non-tandem improvement is signal or noise
- Try LR=2.3e-3 to see if the trend continues downward, or if 2.4e-3 is at/near the optimum
- The tandem degradation is worth investigating — tandem samples may benefit from a separate (higher) LR through a parameter group split