### PR TITLE
LR 2.6e-3 (slightly higher LR for dist code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.5e-3
+    lr: float = 2.6e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
Slightly higher LR (2.6e-3 vs 2.5e-3) might escape a local minimum. The dist_feat adds a new input dimension that might benefit from more aggressive optimization.

## Instructions
Change lr: `lr = 2.6e-3`. One-line change. Run with `--wandb_group lr-26e-4`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run**: 2ktoqp97  
**Best epoch**: 62  
**val/loss**: 0.8477 (baseline: 0.8495, Δ = -0.0018)

| Split | loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5843 | 4.7339 | 1.4905 | 17.7384 | 1.0710 | 0.3525 | 18.8652 |
| val_tandem_transfer | 1.5856 | 5.0199 | 1.9354 | 37.7171 | 1.8937 | 0.8492 | 37.2874 |
| val_ood_cond | 0.6903 | 2.5248 | 1.0704 | 13.7685 | 0.6980 | 0.2632 | 11.7674 |
| val_ood_re | 0.5305 | 2.1910 | 0.9573 | 27.5153 | 0.8155 | 0.3556 | 46.7718 |

**Baseline (dist code)**:
| Split | Surf p |
|---|---|
| val_in_dist | 17.84 |
| val_ood_cond | 13.66 |
| val_ood_re | 27.77 |
| val_tandem_transfer | 36.36 |

**What happened**: Marginal improvement. val/loss dropped 0.0018 below baseline (0.8477 vs 0.8495). Surface pressure on in_dist (17.74 vs 17.84) and ood_cond (13.77 vs 13.66) are near-identical — within noise floor. tandem_transfer surf p (37.72 vs 36.36) is slightly worse. ood_re surf p (27.52 vs 27.77) slightly better. Overall the differences are at the noise level (~0.016 val/loss variance expected from seed), so 2.6e-3 is not clearly better than 2.5e-3.

**Suggested follow-ups**:
- Try lr=2.75e-3 or 3e-3 to see if there's a clear optimum above 2.5e-3, or if these small differences are just noise
- Run the same LR on a different random seed to check if 0.8477 is reproducible