### PR TITLE
Batch size 3 (more gradient steps per epoch)

### DIFF
--- a/train.py
+++ b/train.py
@@ -413,7 +413,7 @@ MAX_EPOCHS = 100
 class Config:
     lr: float = 2.5e-3
     weight_decay: float = 0.0
-    batch_size: int = 4
+    batch_size: int = 3
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"
     stats_file: str = "data/split_stats.json"


### PR DESCRIPTION
## Hypothesis
Batch size 3 gives ~440 gradient steps per epoch (vs ~330 at batch 4). More steps = finer optimization, potentially finding a better minimum. The smaller batch also increases gradient noise, which can help escape sharp minima. This has been tested on older code but never on the dist-to-surface architecture.

## Instructions
Change batch_size from 4 to 3. Find the dataloader creation and change `batch_size=3`. Run with `--wandb_group batch3`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** wxr0ebez
**Total time:** 30.2 min, 59 epochs

### Metrics

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.5862 | 17.9 |
| val_ood_cond | 0.7258 | 14.5 |
| val_ood_re | 0.5437 | 28.0 |
| val_tandem_transfer | 1.5854 | 37.5 |
| **mean3 (in+ood+tan)** | **0.8603** | **23.30** |

Baseline: val_loss=0.8495, mean3_p=22.62

**Delta:** val_loss +0.0108 (+1.3%), mean3_p +0.68 (+3.0%)

**Peak VRAM:** ~10.8GB (-3.4GB vs baseline ~14.2GB)

### What happened

Slightly worse than baseline overall. Batch=3 gives 59 epochs (one more than batch=4's 58), and VRAM drops significantly (10.8GB vs ~14.2GB at batch=4), but the metrics are slightly worse across all splits. The tandem_transfer mae_surf_p (37.5) is somewhat better than what other experiments have been seeing (~38-39), but ood_cond is notably worse (14.5 vs 13.66).

The hypothesis that smaller batch = better generalization through noise didn't pan out here. With Lookahead (k=10, alpha=0.8) and AdamW, the optimization is already somewhat noise-averaged — the slow-weight update in Lookahead effectively smooths gradients over 10 steps. Adding more gradient noise from smaller batches on top of this likely doesn't help, and may increase training variance.

The additional ~33% gradient steps per epoch don't translate to faster convergence within the 30-minute budget, since the total compute time is similar (batch=3 with more steps ≈ batch=4 with fewer steps per epoch).

### Suggested follow-ups

1. Batch size 2: Even more gradient noise — but risk of very unstable early training.
2. Accumulated gradient with effective batch=6: Keep batch=3 but accumulate 2 steps before optimizer.step(), giving the noise benefit without the epoch overhead.