### PR TITLE
Warmup 12 epochs (longer warmup for dist_feat integration)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=12)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[12]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
12-epoch warmup (vs 10) gives the model 2 more epochs at reduced LR to integrate the dist_feat before full LR kicks in. Gentler transition may produce a more stable optimization trajectory.

## Instructions
Change warmup: `total_iters=12` and milestone: `milestones=[12]`. Run with `--wandb_group warmup-12`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---

## Results

**W&B run ID:** b7f3lb61  
**Best epoch:** 61 (wall-clock timeout at 30.1 min)  
**Peak memory:** ~14.8 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8625** | 0.8495 |
| val_in_dist | 0.6039 | — |
| val_tandem_transfer | 1.6380 | — |
| val_ood_cond | 0.6842 | — |
| val_ood_re | 0.5237 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 5.62 | 1.91 | 18.59 | 17.84 | +4.2% |
| val_tandem_transfer | 5.92 | 2.30 | 38.92 | 36.36 | +7.0% |
| val_ood_cond | 3.79 | 1.10 | 13.68 | 13.66 | +0.1% |
| val_ood_re | 3.43 | 1.00 | **27.47** | 27.77 | **-1.1%** |

**mean3 surf_p** = (18.59 + 13.68 + 38.92) / 3 = **23.73** (baseline: 22.62, delta: +4.9%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.08 | 0.36 | 19.77 |
| val_tandem_transfer | 1.91 | 0.87 | 37.79 |
| val_ood_cond | 0.71 | 0.27 | 11.84 |
| val_ood_re | 0.81 | 0.36 | 46.74 |

---

### What happened

**Negative result.** val/loss = 0.8625 vs baseline 0.8495 (+1.5% worse). mean3 surf_p = 23.73 vs baseline 22.62 (+4.9% worse).

Mixed signals: val_ood_cond is essentially unchanged (+0.1%), val_ood_re improved slightly (-1.1%). But val_in_dist (+4.2%) and val_tandem_transfer (+7.0%) are notably worse.

The 12-epoch warmup loses 2 epochs of full-LR training versus the baseline (epoch 13 vs 11 is the first epoch at full cosine LR). With only ~60 total epochs in 30 min, losing 2 epochs to warmup is a non-trivial cost. The benefit of "gentler integration" for dist_feat did not compensate.

Note: the val_tandem_transfer regression (+7%) seen here is consistent with the cosine-profile-loss v2 experiment — this split seems to be harder to improve and is sensitive to training perturbations on this baseline.

---

### Suggested follow-ups

- **Warmup 8 epochs**: Going the other direction (shorter warmup) might give more full-LR training time and recover tandem performance.
- **Higher start_factor**: Instead of changing warmup length, raise start_factor from 0.1 to 0.2 (faster LR ramp) to keep warmup at 10 epochs but with a gentler initial step.
- **Feature-specific LR**: Give dist_feat embedding a lower LR in the optimizer param groups rather than warming up the whole model.
