### PR TITLE
EMA start epoch 35 (earlier EMA for better averaging)

### DIFF
--- a/train.py
+++ b/train.py
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 35
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
EMA currently starts at epoch 40 (of ~59 total). Starting at epoch 35 gives 5 more epochs of weight averaging, which could capture a better trajectory through the loss landscape. The model at epoch 35 is already well-trained and the extra averaging may smooth out the dist_feat-related instability.

## Instructions
Change ema_start_epoch from 40 to 35:
```python
ema_start_epoch = 35
```
One-line change. Run with `--wandb_group ema-start-35`.

## Baseline
val_loss=0.8495 | in=17.84 | ood_c=13.66 | ood_r=27.77 | tan=36.36

---
## Results

**W&B run:** `8nsxkzom`
**Best epoch:** 57/100 (wall-clock limit at 30 min)
**Peak memory:** ~17 GB

### Metrics (best epoch)

| Split | val/loss | Surf p | Surf Ux | Surf Uy | Vol p | Vol Ux | Vol Uy |
|-------|----------|--------|---------|---------|-------|--------|--------|
| val_in_dist | 0.596 | 18.15 | 6.32 | 1.83 | 19.59 | 1.11 | 0.36 |
| val_ood_cond | 0.718 | 14.50 | 3.52 | 1.14 | 12.05 | 0.72 | 0.27 |
| val_ood_re | 0.559 | 28.16 | 3.18 | 1.00 | 47.04 | 0.84 | 0.36 |
| val_tandem_transfer | 1.637 | 39.04 | 6.33 | 2.51 | 37.86 | 1.94 | 0.87 |
| **combined val/loss** | **0.8776** | | | | | | |

### vs Baseline

| Metric | Baseline | EMA start=35 | Delta |
|--------|----------|--------------|-------|
| val/loss | 0.8495 | 0.8776 | +0.028 ▲ |
| in/surf_p | 17.84 | 18.15 | +0.31 ▲ |
| ood_c/surf_p | 13.66 | 14.50 | +0.84 ▲ |
| ood_r/surf_p | 27.77 | 28.16 | +0.39 ▲ |
| tan/surf_p | 36.36 | 39.04 | +2.68 ▲ |

### What happened

Earlier EMA start hurts uniformly (+3.3% on val/loss). Starting EMA at epoch 35 vs 40 makes the averaged model include weights from an earlier training phase, which may be less converged — diluting the quality of the final ensemble. The tandem regression is again the most pronounced (+2.68 Pa), consistent with the pattern seen in recent experiments.

The baseline EMA at epoch 40 appears well-placed — it captures the trajectory starting from a well-converged point. Starting 5 epochs earlier brings in noisier early-phase weights.

### Suggested follow-ups

- Try EMA start at epoch 45 (later than baseline) to see if later start helps
- Or try a different EMA decay (currently 0.999) — higher decay gives more weight to recent checkpoints
- The tandem degradation in multiple experiments suggests tandem transfer is near its optimum with the current architecture; look for tandem-specific improvements elsewhere