### PR TITLE
LR 2.7e-3 (continue LR sweep on dist code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 2.7e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
lr=2.6e-3 beat 2.5e-3. Continue the sweep upward — the dist_feat landscape may favor even higher LR.
## Instructions
Change `lr = 2.6e-3` to `lr = 2.7e-3`. One-line change. Run with `--wandb_group lr-27e3-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---

## Results

**W&B run:** xqk2exbx | **Epochs:** 62/100 (timeout) | **Peak memory:** ~17.8 GB

| Split | val_loss | mae_surf_p | Δ vs baseline |
|-------|----------|------------|---------------|
| val_in_dist | 0.5834 | **17.46** | **-0.28 (improved!)** |
| val_ood_cond | 0.7013 | 14.15 | +0.38 (worse) |
| val_ood_re | 0.5416 | 27.74 | +0.22 (slightly worse) |
| val_tandem_transfer | 1.6621 | 39.74 | **+2.02 (worse)** |
| **combined** | **0.8721** | — | +0.0244 (worse) |

**mean3 mae_surf_p:** 23.78 vs baseline 23.08 — **worse overall**

### What happened

lr=2.7e-3 is worse than 2.6e-3. The LR sweep has peaked at 2.6e-3. The tandem transfer performance collapsed notably (37.72 → 39.74, +5.4%). In_dist improved slightly (17.74 → 17.46), but the net effect is negative. The combined val_loss (0.8721) is meaningfully worse than the 2.6e-3 baseline (0.8477).

The LR sweep direction should stop here — higher LR overshoots for tandem/ood optimization.

### Suggested follow-ups

- 2.6e-3 appears to be the optimal LR for this configuration. Confirm by re-running 2.6e-3 with a different seed to verify it's a true improvement over 2.5e-3 and not just seed variance.
- Try a cosine warmup with lr=2.6e-3 to see if a better warmup schedule can improve convergence further.