### PR TITLE
LR 2.8e-3 (upper bracket for LR sweep)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 2.8e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
If 2.7e-3 improves, we need the upper bracket. If it doesn't, this confirms 2.6e-3 is near optimal.
## Instructions
Change `lr = 2.6e-3` to `lr = 2.8e-3`. One-line change. Run with `--wandb_group lr-28e3-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** `r1w1l1gx`

| Metric | Baseline | LR 2.8e-3 | Δ |
|--------|----------|-----------|---|
| val/loss | 0.8477 | **0.8689** | +0.0212 (~4.6σ, worse) |
| mae_surf_p in_dist | 17.74 | 18.12 | +0.38 |
| mae_surf_p ood_cond | 13.77 | 13.68 | −0.09 |
| mae_surf_p ood_re | 27.52 | 27.69 | +0.17 |
| mae_surf_p tandem | 37.72 | **39.63** | **+1.91** |
| **mean3 mae_surf_p** | **23.08** | **23.81** | **+0.73 (~3.5σ, worse)** |

**Memory:** 18.2 GB. **Epochs:** 58/100.

### What happened

LR 2.8e-3 is significantly worse than baseline 2.6e-3. All splits deteriorated, with tandem showing the largest regression (+1.91). This suggests the learning rate is already at or slightly above the optimum — the 2.5→2.6e-3 step helped but 2.8e-3 overshoots.

The gradient noise from PCGrad (two backward passes) may make the model more sensitive to LR: a slightly higher LR increases oscillations and the model fails to settle into a stable minimum for the tandem domain.

### Suggested follow-ups

- LR 2.7e-3 is the remaining middle point; if it was already tested and also worse, then 2.6e-3 appears to be the peak of the LR curve
- Consider cosine schedule T_max tuning — the scheduler's warm restart period determines effective LR dynamics more than the peak LR at late epochs
- Weight decay (currently 0.0) could help regularize against the high tandem variance seen across seeds and LR settings