### PR TITLE
Cosine T_max=59 (align schedule to actual epoch count)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=59, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
T_max=62 but training completes ~59 epochs. T_max=59 ensures LR completes its decay, giving cleaner late-training signal.
## Instructions
Change `T_max=62` to `T_max=59` on line 581. One-line change. Run with `--wandb_group tmax-59-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** 46zfjztn  
**Change:** CosineAnnealingLR T_max: 62 → 59

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Δ |
|-------|----------|------------|---------------------|---|
| val_in_dist | 0.5929 | 18.16 | 17.74 | +0.42 |
| val_ood_cond | 0.7073 | 14.30 | 13.77 | +0.53 |
| val_ood_re | 0.5333 | 27.53 | 27.52 | +0.01 |
| val_tandem_transfer | 1.6453 | 38.70 | 37.72 | +0.98 |
| **combined** | **0.8697** | — | **0.8477** | **+0.0220** |

**Peak memory:** ~17.8 GB  
**Epochs completed:** 61 in ~30 min (~30 s/epoch)

### What happened

T_max=59 is worse than T_max=62. All splits degraded, especially ood_cond (+0.53) and tandem (+0.98).

The hypothesis was backwards: a smaller T_max means the cosine LR decays *faster*, reaching eta_min sooner (at step 59 instead of 62 from warmup end). With ~61 total epochs, the cosine scheduler runs for 51 steps — at T_max=59, that's 51/59=86% through the cycle; at T_max=62, it's 51/62=82% through. The result is a slightly *lower* LR in epochs 40-61 with T_max=59, which reduces the model's ability to refine in the EMA-active phase (epochs 40+).

Conclusion: the T_max=62 setting is deliberately *slightly too long* for the actual training duration, keeping the late-epoch LR marginally higher and allowing more effective weight updates during the EMA smoothing phase. This is actually the desired behavior.

### Suggested follow-ups

- **T_max=65 (even longer):** Test whether keeping LR even higher in late epochs helps further.
- **eta_min tuning:** The current eta_min=5e-5 may be too conservative. Try eta_min=1e-4 to keep LR from decaying so far.