### PR TITLE
eta_min=1e-4 (warmer LR floor for EMA phase)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
eta_min=5e-5 may be too cold in late training. 1e-4 keeps productive gradient signal during EMA phase (epochs 40-59).
## Instructions
Change `eta_min=5e-5` to `eta_min=1e-4` on line 581. One-line change. Run with `--wandb_group etamin-1e4-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** `n1g27tcp` | Best epoch: 58 | Peak memory: ~18 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6033 | 18.0 | +1.5% worse |
| val_ood_cond | 0.6813 | 13.8 | +0.2% worse |
| val_ood_re | 0.5374 | 27.8 | +1.0% worse |
| val_tandem_transfer | 1.6151 | 38.7 | +2.6% worse |
| **combined** | **0.8593** | — | **+1.4% worse** |

### What happened

Marginal negative result — the differences are extremely small and well within seed variance (~3-7% noise identified from seed-2024 experiment). The combined val/loss degradation of +1.4% is below the seed noise floor. ood_cond is essentially identical (13.8 vs 13.77).

The warmer eta_min=1e-4 doesn't meaningfully change training dynamics at this scale. The model still converges around epoch 58. The LR during EMA phase (epochs 40+) with 1e-4 floor is higher by 2x, but the EMA averaging dominates eval quality by then, reducing sensitivity to the training LR floor.

### Suggested follow-ups

- The etamin change is essentially a null result — not worth pursuing further.
- Given that this and many other experiments show near-baseline performance (~0.85-0.87 range), the improvements may require architectural changes rather than hyperparameter tuning.