### PR TITLE
Warmup 8 epochs (shorter warmup at lr=2.6e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=8)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[8]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
dist_feat provides strong early signal; less warmup needed. 2 more full-LR epochs.
## Instructions
Change `total_iters=10` to `total_iters=8` and `milestones=[10]` to `milestones=[8]`. Run with `--wandb_group warmup-8-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run**: y711ci02
**Best epoch**: 58 (31.9 min, wall-clock limit)
**VRAM**: ~18 GB (same as baseline)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5774 | 4.63 | 1.72 | **18.07** | 1.06 | 0.36 | 18.85 |
| val_ood_cond | 0.7082 | 3.16 | 1.15 | **13.75** | 0.71 | 0.27 | 11.83 |
| val_ood_re | 0.5457 | 2.57 | 0.98 | **27.86** | 0.83 | 0.36 | 46.65 |
| val_tandem_transfer | 1.6335 | 5.40 | 2.35 | **38.91** | 1.93 | 0.87 | 38.14 |
| **combined** | **0.8662** | | | | | | |

**mean3 (in/ood/tan p)**: (18.07 + 13.75 + 38.91) / 3 = **23.58** vs baseline 23.08 → **+0.50, negative result**

### What happened

Shorter warmup (8 vs 10 epochs) slightly degrades all splits. The clearest cost is tandem: +1.19 (38.91 vs 37.72). ood_cond is essentially unchanged (-0.02). in_dist and ood_re each regressed modestly (+0.33, +0.34).

The hypothesis was that dist_feat provides enough early signal to justify a shorter ramp. This didn't pan out. The 10-epoch linear warmup appears well-calibrated for the full LR of 2.6e-3 — starting at full rate 2 epochs sooner introduces marginal instability that accumulates over the 60-epoch run. The tandem split, being further out-of-distribution, is most sensitive to early training dynamics.

One subtle factor: the cosine schedule (`T_max=62`) starts from epoch 8 instead of epoch 10, which shifts the decay curve. This means the learning rate at any given epoch > 8 is now slightly different from baseline, not just the warmup phase. These cascading schedule effects may contribute to the degradation beyond just "2 fewer warmup epochs."

### Suggested follow-ups

1. **T_max adjustment**: If shortening warmup is tried again, also reduce T_max proportionally (e.g., T_max=60 with warmup=8) to keep the total decay shape similar.
2. **Longer warmup (12)**: If shorter hurts, try slightly longer (12 epochs). More gradual warmup may stabilize early learning.