### PR TITLE
EMA decay 0.997 (faster averaging at lr=2.6e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -537,7 +537,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.997
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
Higher LR means faster weight changes — EMA decay=0.997 tracks the model better than 0.998.
## Instructions
Change `ema_decay = 0.998` to `ema_decay = 0.997`. One-line change. Run with `--wandb_group ema-997-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** yyjr5q9s
**Epochs completed:** 59/100 (30-min timeout, 29.5s/epoch)
**Peak memory:** ~14.8GB (unchanged)

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val_loss (combined) | — | 0.8477 | 0.8713 | +2.8% worse |
| val_in_dist | mae_surf_p | 17.74 | 18.27 | +3.0% worse |
| val_ood_cond | mae_surf_p | 13.77 | 14.26 | +3.6% worse |
| val_ood_re | mae_surf_p | 27.52 | 27.95 | +1.6% worse |
| val_tandem_transfer | mae_surf_p | 37.72 | 38.98 | +3.3% worse |
| **mean3** | mae_surf_p | **23.08** | **23.84** | **+3.3% worse** |

Surface MAE (full breakdown, epoch 59):
- **in_dist:** Ux=6.43, Uy=1.87, p=18.27 | Vol: Ux=1.09, Uy=0.36, p=19.74
- **ood_cond:** Ux=3.00, Uy=1.10, p=14.26 | Vol: Ux=0.72, Uy=0.28, p=12.37
- **ood_re:** Ux=2.73, Uy=0.96, p=27.95 | Vol: Ux=0.83, Uy=0.36, p=46.79
- **tandem_transfer:** Ux=6.51, Uy=2.32, p=38.98 | Vol: Ux=1.93, Uy=0.87, p=38.58

### What happened

EMA decay=0.997 regresses mean3 by 3.3%. Faster EMA tracking is not beneficial here.

With decay=0.997, the EMA weights at inference track the fast weights more closely but with less averaging. The EMA averages the last ~333 parameter snapshots (1/(1-0.997)) vs ~500 for decay=0.998. The value of EMA at inference is specifically to average out sharp local minima and capture a smoother parameter space — less averaging means more variance in the EMA checkpoint, which hurts generalization.

The baseline EMA at decay=0.998 finds the right balance: enough averaging to smooth out noise from Lookahead's periodic slow-weight updates, without being so conservative that it falls behind the learning curve. The LR=2.6e-3 (slightly higher than before) doesn't appear to require faster EMA tracking.

### Suggested follow-ups

- **EMA decay=0.9985**: Test the opposite direction — slightly more averaging than baseline. With lr=2.6e-3 and the model converging by epoch 40-45, a longer EMA horizon might capture a better average of the converged weights.
- **Checkpoint ensemble**: Instead of EMA, save 3-5 checkpoints near convergence and average their weights directly. Removes the decay hyperparameter entirely.