### PR TITLE
Seed 42 at lr=2.6e-3 (explore optimization landscape)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,9 +21,12 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 """
 
 import os
+import random
 import time
 from collections.abc import Mapping
 from pathlib import Path
+
+import numpy as np
 
 import torch
 import torch.nn as nn
@@ -515,6 +518,11 @@ _pmean = (_phys_sum / _phys_n).float()
 _pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
 phys_stats = {"y_mean": _pmean, "y_std": _pstd}
 print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
+
+random.seed(42)
+np.random.seed(42)
+torch.manual_seed(42)
+torch.cuda.manual_seed_all(42)
 
 model_config = dict(
     space_dim=2,


### PR DESCRIPTION
## Hypothesis
Seed variance on dist code is wide. A different seed at the new LR might find a better basin.
## Instructions
Add before model creation: `import random; random.seed(42); np.random.seed(42); torch.manual_seed(42); torch.cuda.manual_seed_all(42)`. Run with `--wandb_group seed-42-lr26`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** krptssa5
**Epochs:** 59 (30-min timeout)

| Split | val/loss | Surf MAE (Ux/Uy/p) | Vol MAE |
|-------|----------|---------------------|---------|
| in_dist | 0.582 | 8.47 (5.81 / 1.81 / 17.78) | 6.80 |
| ood_cond | 0.728 | 6.55 (3.60 / 1.14 / 14.91) | 4.49 |
| ood_re | 0.552 | 10.80 (3.27 / 1.01 / 28.13) | 16.06 |
| tandem | 1.640 | 15.57 (5.60 / 2.34 / 38.78) | 13.67 |
| **overall** | **0.8755** | — | — |

**vs baseline:** val_loss=0.8755 vs 0.8477 (+3.3% worse), tan surf_p=38.78 vs 37.72 (+2.8% worse), ood_c surf_p=14.91 vs 13.77 (+8.3% worse)

**What happened:** Seed 42 found a worse basin than the default initialization. All splits regressed relative to baseline. The hypothesis was that a different seed might find a better optimum given wide seed variance, but in this case it did not — the default initialization appears to already be in a favorable region. 59 epochs completed (same as baseline), so no training speed difference.

**Suggested follow-ups:**
- Try seed 0 or seed 123 to see if variance is truly wide, or if the default is consistently better
- Since lr=2.6e-3 baseline (0.8477) already beats lr=2.5e-3 dist-to-surface (0.8495), investigate whether further LR tuning (2.7e-3, 2.8e-3) continues the trend