### PR TITLE
Attention LR ratio 0.4x (protect routing params at higher LR)

### DIFF
--- a/train.py
+++ b/train.py
@@ -573,7 +573,7 @@ class Lookahead:
 attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 base_opt = torch.optim.AdamW([
-    {'params': attn_params, 'lr': cfg.lr * 0.5},
+    {'params': attn_params, 'lr': cfg.lr * 0.4},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)


### PR DESCRIPTION
## Hypothesis
Spatial bias and tandem_temp params may be over-stepping at lr=2.6e-3. Reducing attention LR ratio from 0.5x to 0.4x protects routing.
## Instructions
Change `cfg.lr * 0.5` to `cfg.lr * 0.4` on line 576 (attn param group). One-line change. Run with `--wandb_group attn-lr-04x-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B Run:** ua2za5q5
**Best epoch:** 61

### Metrics vs Baseline

| Split | val_loss | surf_p |
|-------|----------|--------|
| val_in_dist | 0.5986 | 18.10 |
| val_ood_cond | 0.7036 | 14.12 |
| val_ood_re | 0.5428 | 27.82 |
| val_tandem_transfer | 1.6327 | 38.40 |
| **combined** | **0.8694** | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8477 | 0.8694 | +0.0217 ↑ worse |
| in surf_p | 17.74 | 18.10 | +0.36 ↑ worse |
| ood_c surf_p | 13.77 | 14.12 | +0.35 ↑ worse |
| ood_r surf_p | 27.52 | 27.82 | +0.30 ↑ worse |
| tan surf_p | 37.72 | 38.40 | +0.68 ↑ worse |
| mean3 surf_p | 19.68 | 20.01 | +0.33 ↑ worse |

**Peak memory:** ~17.9 GB (identical to baseline)

### What happened

Negative result. Reducing the attention LR ratio from 0.5x to 0.4x (effective attn LR: 1.3e-3 → 1.04e-3) degraded all splits by +0.02 val/loss, well beyond the noise floor. The degradation is uniform across all splits, suggesting the routing parameters need at least the 0.5x ratio to adapt adequately within 30 minutes.

The routing (spatial_bias, temperature, slice_weight) and attention parameters learn useful representations quickly. Slowing them down below 0.5x makes the model converge to a suboptimal routing configuration that the remaining training budget can't recover from.

### Suggested follow-ups

- The 0.5x ratio appears to be well-calibrated. If routing over-stepping is a real concern, try 0.45x as a minimal change
- Alternatively, try protecting routing with gradient clipping specifically for attention params rather than LR reduction