### PR TITLE
Lookahead k=8 (more frequent slow-weight sync)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,7 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=8, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Higher LR means fast model diverges more between Lookahead syncs. k=8 (from k=10) provides 20% more frequent syncing.
## Instructions
Change `Lookahead(base_opt, k=10, alpha=0.8)` to `k=8`. One-line change. Run with `--wandb_group lookahead-k8-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run**: mp4khj8h  
**Best epoch**: 61  
**val/loss**: 0.8615 (baseline: 0.8477, Δ = +0.0138)

| Split | loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5813 | 4.3429 | 1.2281 | 18.2932 | 1.0665 | 0.3604 | 19.1366 |
| val_tandem_transfer | 1.6341 | 4.8777 | 1.8230 | 39.2478 | 1.9009 | 0.8615 | 38.2745 |
| val_ood_cond | 0.6906 | 2.9772 | 0.8449 | 13.7428 | 0.7128 | 0.2679 | 11.8565 |
| val_ood_re | 0.5400 | 2.5712 | 0.7036 | 27.7473 | 0.8335 | 0.3588 | 46.7310 |

**What happened**: k=8 is worse. val/loss increased by +0.0138 relative to the k=10 baseline. Surface pressure on in_dist (18.29 vs 17.74) and tandem_transfer (39.25 vs 37.72) both got worse. ood_cond (13.74 vs 13.77) and ood_re (27.75 vs 27.52) are essentially unchanged. More frequent slow-weight syncing doesn't help here — the hypothesis that the faster diverge from higher LR needs more frequent correction doesn't hold, or k=10 is already a good balance.

**Suggested follow-ups**:
- Try k=12 or k=6 to map out the shape of the k sensitivity curve more broadly
- The k=10 default was presumably tuned earlier; given that both k=8 is worse than k=10, sticking with k=10 seems correct