### PR TITLE
EMA start epoch 42 (slightly later for dist stabilization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 42
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
2 more epochs of unconstrained learning before EMA helps the model stabilize dist_feat representations.
## Instructions
Change `ema_start_epoch = 40` to `ema_start_epoch = 42`. One-line change. Run with `--wandb_group ema-ep42-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** eg09jvqh
**Total time:** 30.2 min, 58 epochs

### Metrics

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.5865 | 18.1 |
| val_ood_cond | 0.6998 | 13.7 |
| val_ood_re | 0.5406 | 27.8 |
| val_tandem_transfer | 1.6197 | 38.3 |
| **mean3 (in+ood+tan)** | **0.8617** | **23.37** |

Baseline: val_loss=0.8477, mean3_p=23.08

**Delta:** val_loss +0.0140 (+1.6%), mean3_p +0.29 (+1.3%)

**Peak VRAM:** ~18.5GB

### What happened

No improvement. ema_start_epoch=42 is marginally worse than 40. The differences are small (0.29 mean3_p), well within run-to-run noise. The model completes the same 58 epochs.

The hypothesis that dist_feat needs 2 more pre-EMA epochs to stabilize doesn't hold — the dist_feat is a simple log-scaled scalar that's conditioned well from the start. EMA starting 2 epochs later means 2 fewer EMA-smoothed model snapshots, which slightly reduces the averaging benefit over training.

ood_cond improved slightly (13.7 vs 13.77), but in_dist and tandem got slightly worse (18.1 vs 17.74, 38.3 vs 37.72). This is inconsistent with the hypothesis.

### Suggested follow-ups

1. ema_start_epoch=38: Try earlier EMA start to capture more of the training trajectory.
2. EMA decay tuning: More impactful than the start epoch — try 0.9985 or 0.999 (current is 0.998).