### PR TITLE
Aux weight 0.005 (halve Re/AoA loss contribution)

### DIFF
--- a/train.py
+++ b/train.py
@@ -779,10 +779,10 @@ for epoch in range(MAX_EPOCHS):
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
-        loss = loss + 0.01 * re_loss
+        loss = loss + 0.005 * re_loss
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
-        loss = loss + 0.01 * aoa_loss
+        loss = loss + 0.005 * aoa_loss
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
@@ -800,8 +800,8 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.0025 * re_loss + 0.0025 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.0025 * re_loss + 0.0025 * aoa_loss
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)


### PR DESCRIPTION
## Hypothesis
With dist_feat providing geometric awareness, the aux Re/AoA losses may be competing for gradient bandwidth. Halving frees capacity for the primary loss.
## Instructions
Change `0.01 * re_loss` to `0.005 * re_loss` and `0.01 * aoa_loss` to `0.005 * aoa_loss` everywhere in the loss computation. Also halve in PCGrad blocks. Run with `--wandb_group aux-005-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run ID:** ghh95y4f  
**Best epoch:** 61 (wall-clock timeout at 30.2 min)  
**Peak memory:** ~14.8 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8644** | 0.8477 |
| val_in_dist | 0.5883 | — |
| val_tandem_transfer | 1.6259 | — |
| val_ood_cond | 0.7056 | — |
| val_ood_re | 0.5377 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 5.91 | 2.12 | 17.97 | 17.74 | +1.3% |
| val_tandem_transfer | 5.74 | 2.45 | 38.68 | 37.72 | +2.5% |
| val_ood_cond | 3.04 | 1.26 | 13.84 | 13.77 | +0.5% |
| val_ood_re | 2.53 | 0.99 | 27.72 | 27.52 | +0.7% |

**mean3 surf_p** = (17.97 + 13.84 + 38.68) / 3 = **23.50** (baseline: 23.01, delta: +2.1%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.04 | 0.35 | 19.12 |
| val_tandem_transfer | 1.87 | 0.86 | 38.04 |
| val_ood_cond | 0.72 | 0.27 | 12.26 |
| val_ood_re | 0.82 | 0.36 | 46.87 |

---

### What happened

**Negative result.** val/loss = 0.8644 vs baseline 0.8477 (+2.0% worse). All splits degraded slightly.

The hypothesis that halving the aux loss weights would free gradient bandwidth for the primary loss did not pan out. Every metric is marginally worse (0.5-2.5%). The Re/AoA auxiliary supervision at 0.01 weight appears to be at a useful level — halving it reduces the regularizing effect these tasks provide.

Note: the PCGrad blocks were also halved (0.005 → 0.0025) per instructions. The PCGrad blocks already used 0.005 (half of the main path's 0.01), so effectively the PCGrad aux signal was already at a reduced level.

---

### Suggested follow-ups

- **Increase aux weights**: Try 0.02 to see if more auxiliary supervision helps. The current 0.01 might be under-weighted already.
- **Re-only or AoA-only ablation**: Determine which auxiliary task is more beneficial and focus on that one.
- **Aux weights decay**: Start at 0.01 and anneal to 0.001 over training, letting the model rely less on auxiliary supervision as it matures.
