### PR TITLE
Noise scale 0.8x (gentler regularization at lr=2.6e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -668,15 +668,15 @@ for epoch in range(MAX_EPOCHS):
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+            noise_scale = 0.04 * (1 - epoch / 60)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
             noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            vel_noise = 0.012 * (1 - noise_progress) + 0.0024 * noise_progress
+            p_noise = 0.0064 * (1 - noise_progress) + 0.0008 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 


### PR DESCRIPTION
## Hypothesis
Lower LR relative to original 3e-3 may mean the model can't overcome noise perturbations as easily. Reducing noise by 20% gives cleaner gradients.
## Instructions
Multiply all noise scales by 0.8: line 671 `0.05→0.04`, line 678 `0.015→0.012`, `0.003→0.0024`, line 679 `0.008→0.0064`, `0.001→0.0008`. Run with `--wandb_group noise-08x-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** `00bk4370`

### Metrics vs Baseline

| Split | val_loss | mae_surf_p | Δ mae_surf_p | mae_surf_Ux | mae_surf_Uy |
|-------|----------|------------|--------------|-------------|-------------|
| val_in_dist | 0.6141 | 18.582 | +4.7% worse | 6.495 | 2.030 |
| val_ood_cond | 0.7176 | 14.609 | +6.1% worse | 4.061 | 1.391 |
| val_ood_re | 0.5632 | 28.189 | +2.4% worse | 3.583 | 1.176 |
| val_tandem_transfer | 1.6503 | 39.373 | +4.4% worse | 6.454 | 2.361 |
| **combined** | **0.8863** | — | +4.6% worse | — | — |

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.088 | 0.361 | 19.774 |
| val_ood_cond | 0.723 | 0.270 | 12.389 |
| val_ood_re | 0.834 | 0.367 | 47.057 |
| val_tandem_transfer | 1.907 | 0.856 | 38.948 |

Peak VRAM: not logged.

### What happened

Reducing noise by 20% made things worse across all splits — combined val/loss degraded from 0.8477 to 0.8863 (+4.6%). In-distribution surface pressure worsened by +4.7%, OOD-cond by +6.1%.

The hypothesis that lower LR requires less noise to maintain gradient quality was not supported. The noise appears to function as useful implicit regularization that prevents overfitting to the training set geometry, rather than being a source of gradient noise that hinders optimization.

The 0.998 convergence curve shows the same slow-then-fast pattern as the baseline but ends slightly higher. This suggests the model with less noise memorizes more precisely but generalizes less — consistent with reduced regularization.

### Suggested follow-ups

- **Increase noise instead**: try 1.2x noise (the opposite direction) — the current regime might benefit from more aggressive regularization at lr=2.6e-3.
- **Noise annealing end point**: instead of annealing to a fixed final value (0.003, 0.001), try annealing all the way to 0 after epoch 60 — remove noise entirely in late training when the model needs fine-tuning.
- **Decouple x-noise from y-noise**: try reducing x-noise (feature space) while keeping y-noise the same, or vice versa, to identify which type is actually beneficial.