### PR TITLE
T_max=59 + eta_min=1e-4 (combined schedule optimization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=59, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
Combine the two most promising schedule changes: T_max=59 (schedule alignment) + eta_min=1e-4 (warmer floor).
## Instructions
Change line 581: `T_max=59, eta_min=1e-4` (two params on one line). Run with `--wandb_group schedule-combo-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `lpap5d2s`
**Epochs:** 61 (30 min, wall-clock limit)
**Peak memory:** 17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5967 | 4.71 | 1.77 | 18.16 | 1.08 | 0.36 | 19.04 |
| ood_cond | 0.7071 | 2.39 | 0.97 | 13.93 | 0.71 | 0.27 | 11.93 |
| ood_re | 0.5412 | 2.09 | 0.86 | 27.79 | 0.81 | 0.36 | 46.87 |
| tandem | 1.6030 | 4.94 | 2.12 | 37.82 | 1.88 | 0.85 | 36.94 |
| **combined** | **0.8620** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (18.16 + 13.93 + 37.82) / 3 = **23.30**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.8620 | +1.7% |
| surf_p in_dist | 17.74 | 18.16 | +2.4% |
| surf_p ood_cond | 13.77 | 13.93 | +1.2% |
| surf_p ood_re | 27.52 | 27.79 | +1.0% |
| surf_p tandem | 37.72 | 37.82 | +0.3% |
| surf_p mean3 | 23.08 | 23.30 | +1.0% |

### What happened

Neutral-to-negative result. The combined T_max=59 + eta_min=1e-4 did not improve over baseline — all splits are slightly worse. The lack of additive benefit suggests the two schedule changes may not compound cleanly. The warmer eta_min floor (1e-4 vs 5e-5) may slightly slow final-epoch refinement, while T_max=59 primarily benefits alignment in later cycles. With only 61 epochs the interaction may work against itself: the schedule aligns at epoch 59, but the higher floor keeps LR elevated longer, preventing the sharp descent that drives final convergence.

Both individual changes presumably showed modest gains; the combo cancels them out.

### Suggested follow-ups

- Test eta_min=1e-4 alone (without T_max change) to isolate whether the floor is beneficial or neutral
- Try T_max=59 alone to confirm it independently improved the baseline used here
- Consider a lower eta_min (2e-5) paired with T_max=59 — let the schedule align without a warm floor
