### PR TITLE
Weight decay 1e-5 (minimal regularization at lr=2.6e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -412,7 +412,7 @@ MAX_EPOCHS = 100
 @dataclass
 class Config:
     lr: float = 2.6e-3
-    weight_decay: float = 0.0
+    weight_decay: float = 1e-5
     batch_size: int = 4
     surf_weight: float = 20.0
     manifest: str = "data/split_manifest.json"


### PR DESCRIPTION
## Hypothesis
Light weight decay prevents parameter drift at the new LR. 1e-5 is 10x less than the previously removed wd=1e-4.
## Instructions
Change `weight_decay: float = 0.0` to `weight_decay: float = 1e-5` on line 415. One-line change. Run with `--wandb_group wd-1e5-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `3brymevj`
**Best epoch:** 58/100 (wall-clock limit at 30 min)
**Peak memory:** ~17 GB

### Metrics (best epoch)

| Split | val/loss | Surf p | Surf Ux | Surf Uy | Vol p | Vol Ux | Vol Uy |
|-------|----------|--------|---------|---------|-------|--------|--------|
| val_in_dist | 0.623 | 18.46 | 5.53 | 1.53 | 19.90 | 1.13 | 0.37 |
| val_ood_cond | 0.726 | 14.33 | 3.35 | 1.02 | 12.49 | 0.72 | 0.28 |
| val_ood_re | 0.564 | 28.31 | 2.99 | 0.88 | 47.19 | 0.83 | 0.37 |
| val_tandem_transfer | 1.652 | 39.79 | 5.24 | 1.97 | 38.90 | 1.95 | 0.88 |
| **combined val/loss** | **0.8910** | | | | | | |

### vs Baseline

| Metric | Baseline | wd=1e-5 | Delta |
|--------|----------|---------|-------|
| val/loss | 0.8477 | 0.8910 | +0.043 ▲ |
| in/surf_p | 17.74 | 18.46 | +0.72 ▲ |
| ood_c/surf_p | 13.77 | 14.33 | +0.56 ▲ |
| ood_r/surf_p | 27.52 | 28.31 | +0.79 ▲ |
| tan/surf_p | 37.72 | 39.79 | +2.07 ▲ |

### What happened

Weight decay of 1e-5 hurts uniformly (+5.1% val/loss), with every split worse. Even a tiny weight decay interferes with the learned representations, confirming that wd=0 is optimal for this model configuration.

This is consistent with the prior result (wd=1e-4 was also worse than wd=0). The model appears to rely on large parameter norms for accurate routing and feature cross-multiplication — any L2 penalty pulls these toward zero and degrades performance.

### Suggested follow-ups

- Weight decay is clearly harmful here; don't revisit
- If regularization is needed, consider gradient clipping or noise injection (already present) rather than L2 penalty