### PR TITLE
Learned boundary-type embedding (replace binary is_surface)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,7 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.boundary_embed = nn.Embedding(4, 4)  # 4 boundary types: volume, upper, lower, foil2
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -377,10 +378,10 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 27:29]], dim=-1)  # x, y, curvature, dist
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
-        is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
+        is_tandem = (x[:, 0, 24].abs() > 0.01).float()[:, None, None, None]
 
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
@@ -518,7 +519,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + 32 + 3,  # +1 curv, +1 dist_feat, +32 fourier PE, +3 boundary embed (4d replaces 1d)
     out_dim=3,
     n_hidden=192,  # regime-w: full width with finer routing
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -652,6 +653,19 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         x = (x - stats["x_mean"]) / stats["x_std"]
+        # Boundary type embedding: replace scalar is_surface (col 12) with 4-dim learned embedding
+        # Types: 0=volume, 1=surface_upper, 2=surface_lower, 3=surface_foil2 (tandem)
+        _B = x.shape[0]
+        saf_sign = (x[:, :, 2] > 0).long()  # saf[0]>0 → upper surface
+        is_tandem_b = x[:, 0, 21].abs() > 0.5  # naca1[2] as tandem proxy (index 21 pre-replacement)
+        boundary_type = torch.zeros(_B, x.shape[1], dtype=torch.long, device=device)
+        boundary_type[is_surface & (saf_sign == 1)] = 1  # upper surface
+        boundary_type[is_surface & (saf_sign == 0)] = 2  # lower surface
+        for _b in range(_B):
+            if is_tandem_b[_b]:
+                boundary_type[_b, is_surface[_b] & (x[_b, :, 0] > 0.5)] = 3  # foil2 (downstream)
+        btype_emb = _base_model.boundary_embed(boundary_type)  # [B, N, 4]
+        x = torch.cat([x[:, :, :12], btype_emb, x[:, :, 13:]], dim=-1)  # replace col 12 (1d→4d)
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
@@ -681,7 +695,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
-        raw_gap = x[:, 0, 21]
+        raw_gap = x[:, 0, 24]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
         sample_stds = torch.ones(B, 1, 3, device=device)
@@ -730,7 +744,7 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = vol_mask
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-        is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
+        is_tandem_batch = (x[:, 0, 24].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
@@ -777,16 +791,16 @@ for epoch in range(MAX_EPOCHS):
             _coarse_loss = coarse_loss
             loss = loss + 1.0 * coarse_loss
 
-        log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
+        log_re_target = x[:, 0, 16:17]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
-        aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
+        aoa_target = x[:, 0, 17:18]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
+        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 16] > 1.0) | (x[:, 0, 17].abs() > 1.0)
         is_indist_pcgrad = ~is_ood_pcgrad
         use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
 
@@ -882,6 +896,18 @@ for epoch in range(MAX_EPOCHS):
                 mask = mask.to(device, non_blocking=True)
 
                 x = (x - stats["x_mean"]) / stats["x_std"]
+                # Boundary type embedding: replace scalar is_surface (col 12) with 4-dim learned embedding
+                _Bv = x.shape[0]
+                saf_sign_v = (x[:, :, 2] > 0).long()
+                is_tandem_bv = x[:, 0, 21].abs() > 0.5
+                boundary_type_v = torch.zeros(_Bv, x.shape[1], dtype=torch.long, device=device)
+                boundary_type_v[is_surface & (saf_sign_v == 1)] = 1
+                boundary_type_v[is_surface & (saf_sign_v == 0)] = 2
+                for _bv in range(_Bv):
+                    if is_tandem_bv[_bv]:
+                        boundary_type_v[_bv, is_surface[_bv] & (x[_bv, :, 0] > 0.5)] = 3
+                btype_emb_v = _base_model.boundary_embed(boundary_type_v)
+                x = torch.cat([x[:, :, :12], btype_emb_v, x[:, :, 13:]], dim=-1)
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
@@ -902,7 +928,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 # Per-sample std normalization: skip tandem samples
-                raw_gap = x[:, 0, 21]
+                raw_gap = x[:, 0, 24]
                 is_tandem = raw_gap.abs() > 0.5
                 B = y_norm.shape[0]
                 sample_stds = torch.ones(B, 1, 3, device=device)


### PR DESCRIPTION
## Hypothesis
The model uses a binary `is_surface` flag (0 or 1) which discards rich boundary structure. The dataset has 8 boundary types (0=interior, 1=inlet, 2=outlet, 3=top wall, 4=bottom wall, 5=foil1 upper, 6=foil1 lower, 7=foil2). A learned 4-dim embedding per boundary type lets the model distinguish suction-side from pressure-side nodes, inlet from outlet, and foil1 from foil2 — all of which have fundamentally different pressure distributions.

The key insight: boundary ID 5 (foil1 upper) and 6 (foil1 lower) have very different pressure profiles (suction peak vs pressure side), but both get `is_surface=1`. Teaching the model this distinction should directly improve surface pressure predictions. This is a DATA REPRESENTATION change orthogonal to every previous experiment.

**Why this hasn't been tried before:** Previous "boundary embedding" attempts (#1140, #1170) tried adding a learnable embedding on TOP of is_surface. This approach REPLACES is_surface with a richer learned embedding that captures the actual boundary physics, and uses the `dsdf` sign pattern to infer boundary type without modifying the read-only data pipeline.

## Instructions
1. **Reconstruct boundary type from existing features.** The `dsdf` channels (indices 2-9 in normalized x) encode signed distances to foil surfaces. Surface nodes on different foil sides have characteristic `dsdf` patterns. Create a pseudo-boundary-type integer:
   ```python
   # After x normalization, before curv/dist computation (~line 654-659)
   is_surf = is_surface.float()  # [B, N]
   # Use saf[0] sign (arc-length, index 2) to distinguish upper vs lower surface
   saf_sign = (x[:, :, 2] > 0).long()  # 1=upper, 0=lower
   # Use gap feature to detect tandem
   is_tandem_sample = (x[:, 0, 21].abs() > 0.5).unsqueeze(1).expand_as(is_surf).long()
   # Pseudo boundary type: 0=volume, 1=surf_upper, 2=surf_lower, 3=surf_foil2
   boundary_type = torch.zeros_like(is_surface, dtype=torch.long)
   boundary_type[is_surface & (saf_sign == 1)] = 1  # upper surface
   boundary_type[is_surface & (saf_sign == 0)] = 2  # lower surface  
   # For tandem samples, reclassify based on position (foil2 is further downstream)
   # This is approximate but captures the key distinction
   ```

2. **Add a `nn.Embedding(4, 4)` in `Transolver.__init__`:**
   ```python
   self.boundary_embed = nn.Embedding(4, 4)  # volume, upper, lower, foil2
   ```

3. **In `forward()`, replace the single is_surface column with the 4-dim embedding:**
   ```python
   btype_emb = self.boundary_embed(boundary_type)  # [B, N, 4]
   # Replace is_surface column (index 10) with embedding
   x = torch.cat([x[:, :, :10], btype_emb, x[:, :, 11:]], dim=-1)
   ```

4. **Update `fun_dim` in model_config** to account for +3 extra dimensions (replacing 1 col with 4):
   ```python
   fun_dim=X_DIM - 2 + 2 + 32 + 3,
   ```

5. **Apply same boundary_type computation in val loop** (same logic, lines ~884-889).

6. Run with `--wandb_group boundary-type-embed`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run**: eiyu4idm
**Best epoch**: 54 (32.1 min, wall-clock limit)
**VRAM**: ~18 GB (same as baseline)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6110 | 8.38 | 2.27 | **18.59** | 1.12 | 0.37 | 19.94 |
| val_ood_cond | 0.7239 | 5.13 | 1.50 | **14.35** | 0.72 | 0.27 | 12.27 |
| val_ood_re | 0.5578 | 4.72 | 1.36 | **28.09** | 0.84 | 0.37 | 47.02 |
| val_tandem_transfer | 1.6569 | 7.15 | 2.66 | **39.02** | 1.92 | 0.87 | 38.61 |
| **combined** | **0.8874** | | | | | | |

**mean3 (in/ood/tan p)**: (18.59 + 14.35 + 39.02) / 3 = **23.99** vs baseline 23.08 → **+0.91, negative result**

### What happened

Replacing the binary is_surface scalar with a 4-dim boundary type embedding uniformly degraded all splits. Every metric is worse than baseline:
- in_dist p: 18.59 vs 17.74 (+0.85)
- ood_cond p: 14.35 vs 13.77 (+0.58)
- ood_re p: 28.09 vs 27.52 (+0.57)
- tandem p: 39.02 vs 37.72 (+1.30)
- combined val/loss: 0.8874 vs 0.8477 (+0.040)

The hypothesis that richer boundary type information would improve surface predictions was incorrect within this 30-minute training budget. Three likely causes:

1. **Larger input dim → slower convergence**: Adding 3 extra dims expands `fun_dim+space_dim` from 58 to 61, making the `preprocess` GatedMLP2 and `feature_cross` matrices larger (61×61 vs 58×58). With the same number of epochs (~54 best), the model had less time to learn the optimal boundary embeddings. The embedding table started random and needed time to specialize.

2. **Approximate foil2 classification**: The heuristic `x[:, :, 0] > 0.5` for classifying foil2 surface nodes in tandem is imprecise. Misclassified nodes (foil1 nodes labeled as foil2 or vice versa) corrupt the boundary type signal for tandem samples, hurting tandem performance (+1.30).

3. **is_surface already sufficient**: The binary is_surface flag combined with the existing dsdf channels already gives the model enough information to learn surface-specific representations. The boundary type embedding adds redundant signal (the model can infer upper/lower from dsdf sign patterns) while adding complexity.

### Suggested follow-ups

1. **Extend training budget**: This approach might work with more epochs. The boundary embedding may need 30+ epochs just to converge (beyond the ~40 EMA start), and we only had ~54 epochs total.
2. **Use actual boundary_id**: If the boundary ID feature were added directly to the input without reconstruction (requiring prepare_multi.py modification), the signal would be cleaner. The reconstruction from saf/dsdf is approximate.
3. **Just upper/lower (2 types)**: Simplify to 2-type embedding (upper/lower surface, ignoring foil2 distinction) with a 2-dim embedding, reducing the approximation error.