### PR TITLE
Enable per-sample std normalization for tandem samples

### DIFF
--- a/train.py
+++ b/train.py
@@ -680,20 +680,16 @@ for epoch in range(MAX_EPOCHS):
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
-        # Per-sample std normalization: skip tandem samples (gap feature index 21)
+        # Per-sample std normalization: uniform clamps for all samples including tandem
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
         sample_stds = torch.ones(B, 1, 3, device=device)
         channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
-        tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
         if model.training:
             for b in range(B):
                 valid = mask[b]
-                if is_tandem[b]:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                else:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
@@ -901,19 +897,15 @@ for epoch in range(MAX_EPOCHS):
                 y_phys = _phys_norm(y, Umag, q)
                 y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
-                # Per-sample std normalization: skip tandem samples
+                # Per-sample std normalization: uniform clamps for all samples including tandem
                 raw_gap = x[:, 0, 21]
                 is_tandem = raw_gap.abs() > 0.5
                 B = y_norm.shape[0]
                 sample_stds = torch.ones(B, 1, 3, device=device)
                 channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
-                tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
                 for b in range(B):
                     valid = mask[b]
-                    if is_tandem[b]:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                    else:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
Per-sample std normalization currently SKIPS tandem samples (`is_tandem[b]` uses `tandem_clamps=[0.3, 0.3, 1.0]` instead of `channel_clamps=[0.1, 0.1, 0.5]`). The original rationale was to \"preserve dual-foil learning.\" But tandem is our WORST split (37.72 vs 17.74 for in_dist — 2.1x worse). The relaxed clamps mean tandem samples see less aggressive normalization, which may be creating a distribution mismatch between training and what the model learns.

**The counter-hypothesis:** Tandem samples have wider variance (two foils, more complex flow). But per-sample std normalization is designed to HANDLE this — it normalizes each sample to unit variance. By using higher clamps for tandem, we're actually PREVENTING the normalization from working as intended.

**Proposal:** Remove the tandem exception entirely. Use the same `channel_clamps=[0.1, 0.1, 0.5]` for ALL samples. This ensures every sample, regardless of complexity, is normalized to the same scale before the model sees it.

This is a ONE-LINE change with potentially high impact on tandem, which is the weakest split.

## Instructions
1. **Remove the tandem/non-tandem distinction in per-sample std normalization.** In the training loop (~line 690-697):
   ```python
   # BEFORE (current):
   tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
   if model.training:
       for b in range(B):
           valid = mask[b]
           if is_tandem[b]:
               sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
           else:
               sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
   
   # AFTER (proposed):
   if model.training:
       for b in range(B):
           valid = mask[b]
           sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
   ```

2. **Same change in val loop** (~line 910-916): remove the `if is_tandem[b]` branch, use `channel_clamps` for all.

3. Run with `--wandb_group tandem-unified-std`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `oexpjn1s`

### Metrics vs Baseline

| Split | val_loss | mae_surf_p | Δ mae_surf_p | mae_surf_Ux | mae_surf_Uy |
|-------|----------|------------|--------------|-------------|-------------|
| val_in_dist | 0.6737 | 18.119 | +2.1% worse | 6.577 | 1.837 |
| val_ood_cond | 0.8543 | 13.181 | -4.3% better | 3.572 | 1.171 |
| val_ood_re | 0.7188 | 27.560 | +0.1% neutral | 3.344 | 1.048 |
| val_tandem_transfer | 1.6118 | 37.933 | +0.6% neutral | 6.286 | 2.293 |
| **combined** | **0.9646** | — | +13.8% worse | — | — |

### Volume MAE

| Split | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|------------|------------|-----------|
| val_in_dist | 1.106 | 0.360 | 18.653 |
| val_ood_cond | 0.710 | 0.276 | 11.374 |
| val_ood_re | 0.816 | 0.363 | 46.550 |
| val_tandem_transfer | 1.904 | 0.857 | 37.061 |

Peak VRAM: not logged.

### What happened

Mixed result. Combined val/loss degraded significantly (+13.8%), but individual surface pressure metrics are nearly neutral: tandem surface_p is only +0.6% worse, and ood_cond actually improved (-4.3%). The big regression in combined val/loss is driven by the volume loss term for tandem and ood_re.

The per-sample normalization change appears to have made volume predictions worse while leaving surface predictions mostly intact. The likely cause: for tandem samples where the actual std falls between the two clamp ranges (channel_clamps vs tandem_clamps), removing the larger clamp forces more aggressive normalization. The model then needs to predict larger normalized targets, which requires more fitting capacity.

The larger val_loss for tandem (1.61) is dominated by the volume term — the model can predict surface nodes (contact with geometry) but struggles more with volume nodes under the tighter normalization.

The val/loss is still decreasing at the 30-min timeout (0.96), suggesting the model could potentially converge further with more epochs. But the convergence is clearly slower than baseline.

### Suggested follow-ups

- **Intermediate clamps**: try `[0.15, 0.15, 0.7]` for all samples — tighter than tandem_clamps but looser than channel_clamps.
- **Separate train vs val clamps**: keep tandem_clamps for val (to match the training distribution used by the baseline) but use channel_clamps only for training — this would test whether the train/val mismatch is what matters.
- **Root cause diagnosis**: check if tandem samples have actual std < 0.3 (Ux/Uy) or < 1.0 (p) — if not, the two clamps are equivalent and the regression comes from elsewhere.