### PR TITLE
Revert PCGrad + restore reduce-overhead compile (throughput recovery)

### DIFF
--- a/train.py
+++ b/train.py
@@ -530,8 +530,7 @@ model_config = dict(
 )
 
 model = Transolver(**model_config).to(device)
-torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
-model = torch.compile(model, mode="default")
+model = torch.compile(model, mode="reduce-overhead")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -784,52 +783,8 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
-        # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
-        is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
-
-        if use_pcgrad:
-            n_a = is_indist_pcgrad.float().sum().clamp(min=1)
-            n_b = is_ood_pcgrad.float().sum().clamp(min=1)
-            vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
-            vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
-            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
-            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
-            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
-            surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
-            coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-
-            optimizer.zero_grad()
-            loss_a.backward(retain_graph=True)
-            grads_a = [p.grad.clone() if p.grad is not None else None
-                       for p in model.parameters()]
-            optimizer.zero_grad()
-            loss_b.backward()
-
-            ga_flat = torch.cat([g.view(-1) for g in grads_a if g is not None])
-            gb_flat = torch.cat([p.grad.view(-1) for p in model.parameters() if p.grad is not None])
-            dot_ab = (ga_flat @ gb_flat).item()
-            gb_ns = float((gb_flat @ gb_flat).item()) + 1e-8
-            ga_ns = float((ga_flat @ ga_flat).item()) + 1e-8
-            for p, ga in zip(model.parameters(), grads_a):
-                gb = p.grad
-                if ga is None and gb is None:
-                    continue
-                if ga is None:
-                    pass  # keep gb
-                elif gb is None:
-                    p.grad = ga
-                elif dot_ab < 0:
-                    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
-                else:
-                    p.grad = (ga + gb) * 0.5
-        else:
-            optimizer.zero_grad()
-            loss.backward()
+        optimizer.zero_grad()
+        loss.backward()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()


### PR DESCRIPTION
## Hypothesis
PCGrad was merged as the 7th improvement (PR #1456, val_loss 0.8600->0.8555). But PCGrad has a significant hidden cost: it requires TWO backward passes per batch AND forces `torch.compile(mode="default")` instead of `mode="reduce-overhead"`. The compile mode downgrade alone was measured at ~5-8% throughput loss (PR #1460 tested ablating PCGrad and restoring reduce-overhead — the result was 0.8525, BETTER than the PCGrad baseline of 0.8555 on that code).

**The critical observation:** After PCGrad was merged, three more improvements were merged on top of it (dist-to-surface, lr=2.6e-3, continuous curvature). These subsequent changes may have made PCGrad redundant or even harmful — the dist-to-surface feature provides the geometric awareness that PCGrad's gradient projection was trying to achieve.

**Cost-benefit:** PCGrad gives ~2x backward pass cost per batch. That's ~2-3 fewer epochs in 30 minutes. If removing PCGrad recovers those epochs AND restores `reduce-overhead` compile, the throughput gain may outweigh the gradient surgery benefit.

**What's different from #1460:** That experiment tested ablating PCGrad on OLDER code (before dist-to-surface, before lr=2.6e-3). This tests it on the CURRENT code with all 8 merged improvements active.

## Instructions
1. **Remove all PCGrad code** from the training loop (lines ~787-829). Replace the entire `if use_pcgrad:` block with just the simple gradient path:
   ```python
   # Remove the PCGrad block entirely. Keep only:
   optimizer.zero_grad()
   loss.backward()
   ```
   Also remove the PCGrad-related variable computations (is_ood_pcgrad, is_indist_pcgrad, etc., ~lines 788-804).

2. **Restore reduce-overhead compile mode** (line 534):
   ```python
   # Change from:
   model = torch.compile(model, mode="default")
   # To:
   model = torch.compile(model, mode="reduce-overhead")
   ```

3. **Remove the `retain_graph` config line** (line 533):
   ```python
   # Remove: torch._functorch.config.donated_buffer = False
   ```

4. Run with `--wandb_group revert-pcgrad`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `wk5pm1vx` | **best_epoch:** 56

| Metric | Baseline (w/ PCGrad) | This run (no PCGrad) | Δ |
|--------|---------------------|----------------------|---|
| val/loss | 0.8477 | **0.8793** | +0.032 |
| in_dist surf p | 17.74 | 18.01 | +0.27 |
| ood_cond surf p | 13.77 | 14.41 | +0.64 |
| ood_re surf p | 27.52 | 28.27 | +0.75 |
| tandem surf p | 37.72 | 38.74 | +1.02 |
| mean3 | ~23.08 | 23.72 | +0.64 |

**Surface MAE detail (Ux / Uy / p):**
- in_dist: 5.37 / 1.74 / 18.01
- ood_cond: 3.17 / 1.19 / 14.41
- ood_re: 2.63 / 0.98 / 28.27
- tandem: 5.37 / 2.18 / 38.74

**Volume MAE (in_dist):** Ux=1.11, Uy=0.36, p=19.54

**Peak GPU memory:** ~96GB (similar to baseline, no OOM)

### What happened

Removing PCGrad made things **clearly worse** across all metrics — val/loss rose from 0.8477 to 0.8793 (+3.7%). Every single surface pressure metric degraded. Despite restoring `reduce-overhead` compile mode, we only got 56 epochs — similar to PCGrad runs. The hypothesis that dist-to-surface made PCGrad redundant was **not confirmed**.

PCGrad is still providing genuine gradient surgery benefit in the current code. The geometric awareness from dist-to-surface features did not substitute for the conflict resolution that PCGrad provides between in-dist and OOD batches. The double backward pass cost is real, but so is the quality benefit.

### Suggested follow-ups
- Try a cheaper conflict-resolution alternative: gradient normalization (loss scaling so each group has equal gradient magnitude) without the double backward
- Test PCGrad only when gradient conflict is above a threshold (lazy PCGrad) — skip projection when dot product is already positive
- Investigate why reduce-overhead + no PCGrad gave 56 epochs vs the expected 65+; may indicate the compile mode switch alone isn't recovering the throughput we expected