### PR TITLE
Test-time prediction calibration (learned per-split affine correction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,16 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        # Lightweight output calibration: predict per-sample scale and shift for output
+        self.calibration = nn.Sequential(
+            nn.Linear(3, 16),  # input: [log_Re, AoA, is_tandem]
+            nn.GELU(),
+            nn.Linear(16, 6),  # output: [scale_Ux, scale_Uy, scale_p, shift_Ux, shift_Uy, shift_p]
+        )
+        nn.init.zeros_(self.calibration[-1].weight)
+        nn.init.zeros_(self.calibration[-1].bias)
+        # Initialize bias to [1,1,1, 0,0,0] so starts as identity
+        self.calibration[-1].bias.data[:3] = 1.0
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -396,8 +406,17 @@ class Transolver(nn.Module):
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        # Output calibration: per-sample scale + shift based on flow conditions
+        log_re = x[:, 0, 13:14]  # [B, 1]
+        aoa = x[:, 0, 14:15]  # [B, 1]
+        is_tandem_flag = (x[:, 0, 21].abs() > 0.5).float().unsqueeze(1)  # [B, 1]
+        cond = torch.cat([log_re, aoa, is_tandem_flag], dim=1)  # [B, 3]
+        cal = self.calibration(cond)  # [B, 6]
+        scale = cal[:, :3].unsqueeze(1)  # [B, 1, 3]
+        shift = cal[:, 3:].unsqueeze(1)  # [B, 1, 3]
+        fx = fx * scale + shift
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "cal": cal}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Hypothesis
The model is trained on a mix of single-foil, tandem, and cruise samples. At test time, the prediction distribution may be systematically biased for specific splits. A lightweight learned calibration — per-condition affine transform on the final prediction — can correct this without changing the model architecture or training dynamics.

**Key insight:** The model makes predictions in z-scored Cp space. If there's a systematic bias for certain conditions (e.g., tandem predictions are consistently 5% too high), a simple learned scale+shift on the output can correct it without changing the model's internal representations.

**Implementation:** Add a tiny MLP (condition -> scale, shift) that post-processes the model output based on the flow regime (Re, AoA, tandem flag). This is NOT a hypernetwork on the model weights — it's a simple post-hoc correction on the predictions.

**Why this is different from previous condition-adaptive work:** AdaLN (#1403, #1409) modulates intermediate representations, which is more invasive and showed mixed results. FiLM (#957, #1083) modulates hidden features. This operates ONLY on the final output, so it cannot break the learned representations — it can only correct systematic biases in the model's predictions.

## Instructions
1. **Add a calibration head** in `Transolver.__init__`:
   ```python
   # Lightweight output calibration: predict per-sample scale and shift for output
   self.calibration = nn.Sequential(
       nn.Linear(3, 16),  # input: [log_Re, AoA, is_tandem]
       nn.GELU(),
       nn.Linear(16, 6),  # output: [scale_Ux, scale_Uy, scale_p, shift_Ux, shift_Uy, shift_p]
   )
   nn.init.zeros_(self.calibration[-1].weight)
   nn.init.zeros_(self.calibration[-1].bias)
   # Initialize bias to [1,1,1, 0,0,0] so starts as identity
   self.calibration[-1].bias.data[:3] = 1.0
   ```

2. **In `forward()`**, after the final output, apply calibration:
   ```python
   # Extract condition features for calibration
   log_re = x[:, 0, 13:14]  # [B, 1]
   aoa = x[:, 0, 14:15]  # [B, 1] 
   is_tandem_flag = (x[:, 0, 21].abs() > 0.5).float().unsqueeze(1)  # [B, 1]
   cond = torch.cat([log_re, aoa, is_tandem_flag], dim=1)  # [B, 3]
   cal = self.calibration(cond)  # [B, 6]
   scale = cal[:, :3].unsqueeze(1)  # [B, 1, 3]
   shift = cal[:, 3:].unsqueeze(1)  # [B, 1, 3]
   fx = fx * scale + shift
   ```
   Place this AFTER the skip connection (line 398) but BEFORE the output dict return.

3. Return `calibration` output alongside other predictions for logging.

4. Run with `--wandb_group output-calibration`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `korem98k`
**Epochs:** 59 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.6015 | 4.17 | 1.31 | 18.24 | 1.12 | 0.37 | 19.14 |
| ood_cond | 0.6983 | 3.14 | 1.00 | 14.03 | 0.71 | 0.27 | 11.61 |
| ood_re | 0.5447 | 2.72 | 0.88 | 27.71 | 0.83 | 0.36 | 46.67 |
| tandem | 1.6925 | 5.00 | 1.89 | 40.80 | 1.97 | 0.90 | 39.88 |
| **combined** | **0.8842** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (18.24 + 14.03 + 40.80) / 3 = **24.36**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.8842 | +4.3% |
| surf_p in_dist | 17.74 | 18.24 | +2.8% |
| surf_p ood_cond | 13.77 | 14.03 | +1.9% |
| surf_p ood_re | 27.52 | 27.71 | +0.7% |
| surf_p tandem | 37.72 | 40.80 | +8.2% |
| surf_p mean3 | 23.08 | 24.36 | +5.5% |

### What happened

Negative result. The output calibration hurt performance across all splits, with tandem suffering most (+8.2%). The hypothesis that systematic per-condition bias could be corrected by a simple affine head did not hold.

**Likely causes:**

1. **Tandem detection is unreliable:** The feature at index 21 is `naca1[2]` (NACA second foil thickness divided by 24, i.e. `int(naca_str[2:]) / 24.0`). For NACA 0012, `naca1[2] = 12/24 = 0.5`, which fails the `> 0.5` threshold. Tandem samples with NACA 0012 second foils are therefore treated as non-tandem, giving the calibration network incorrect `is_tandem_flag=0` for those samples. The real tandem indicator is the gap feature at index 22. This likely explains why tandem got significantly worse — the calibration learned wrong corrections for a subset of tandem samples.

2. **Optimization interference:** The calibration introduces a jointly learned transformation on top of the model output. During training, `pred = calibrated_output / sample_stds`. The calibration scales get entangled with sample_stds in a way that encourages the main model to produce predictions that only work correctly after calibration — degrading uncalibrated representational quality.

3. **Tiny net, large interference:** 106 parameters (3→16→6) is small enough to learn fast, meaning early-epoch spurious patterns get locked in before the main model converges.

### Suggested follow-ups

- If re-testing calibration: use index 22 (gap) instead of index 21 (naca1[2]) as the tandem indicator, and use a threshold like 0.01
- Apply calibration at eval time only (post-hoc calibration on a held-out set), rather than integrating into the training loss — this avoids train/eval representation coupling
- Or explore per-split learned affine corrections as a post-processing step, keeping the model architecture unchanged
