### PR TITLE
Cosine warm restarts with 3 short cycles (SGDR T_0=17, T_mult=1)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,9 +578,12 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+# 3 equal cycles of 17 epochs, each restarting at progressively lower peak
+restart_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+    base_opt, T_0=17, T_mult=1, eta_min=5e-5
+)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, restart_scheduler], milestones=[10]
 )
 
 # --- wandb ---
@@ -849,6 +852,10 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    # Decay peak LR by 0.6x at each restart boundary (after warmup)
+    if epoch > 10 and (epoch - 10) % 17 == 0 and epoch > 11:
+        for pg in base_opt.param_groups:
+            pg['initial_lr'] = pg['initial_lr'] * 0.6
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)


### PR DESCRIPTION
## Hypothesis
The current single cosine annealing (T_max=62, eta_min=5e-5) reaches very low LR in the final epochs. Previous warm restart attempts (#976, #1077, #1251) failed because they used T_0=20 with T_mult=2 (so the second cycle starts at full LR and runs for 40 epochs — far too long and disruptive) or had 3 long cycles.

**Key difference in this proposal:** Use T_0=17, T_mult=1 (three EQUAL short cycles of 17 epochs each = 51 epochs total, leaving ~8 final epochs at minimum LR for EMA to converge). The peak LR for restarts is NOT the original 2.6e-3 but a DECAYED peak: 2.6e-3, 1.5e-3, 0.8e-3 for cycles 1, 2, 3. This is the SGDR-with-decay pattern (Loshchilov & Hutter 2017 + Smith 2017 decay).

**Why short equal cycles with decay:** Each restart explores a new region of the loss landscape, but with progressively smaller jumps. The first cycle builds the main representation, the second refines it, the third fine-tunes. EMA averaging over the second and third cycle troughs combines multiple local minima.

**Important:** Previous cycle experiments averaged WEIGHTS at troughs (snapshot ensemble). This experiment does NOT do weight averaging — it simply restarts LR and lets the standard EMA + Lookahead do the averaging naturally. The key mechanism is that the LR restarts push the model out of the current local minimum into a potentially better one nearby.

## Instructions
1. **Replace the LR scheduler** (lines 580-584) with CosineAnnealingWarmRestarts + decay:
   ```python
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
   # 3 equal cycles of 17 epochs, each restarting at progressively lower peak
   restart_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
       base_opt, T_0=17, T_mult=1, eta_min=5e-5
   )
   scheduler = torch.optim.lr_scheduler.SequentialLR(
       base_opt, schedulers=[warmup_scheduler, restart_scheduler], milestones=[10]
   )
   ```

2. **Add LR decay at restart boundaries.** After `scheduler.step()` (~line 851), check if we're at a restart and decay:
   ```python
   # Decay peak LR by 0.6x at each restart boundary (after warmup)
   if epoch > 10 and (epoch - 10) % 17 == 0 and epoch > 11:
       for pg in base_opt.param_groups:
           pg['initial_lr'] = pg['initial_lr'] * 0.6
   ```

3. Run with `--wandb_group cyclic-lr-3x`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `r5kfp235`

| Metric | Baseline | Cyclic LR 3x | Δ |
|--------|----------|--------------|---|
| val/loss | 0.8477 | **0.9101** | +0.0624 (~13.6σ, much worse) |
| mae_surf_p in_dist | 17.74 | 19.34 | +1.60 |
| mae_surf_p ood_cond | 13.77 | 14.79 | +1.02 |
| mae_surf_p ood_re | 27.52 | 28.72 | +1.20 |
| mae_surf_p tandem | 37.72 | 39.74 | +2.02 |
| **mean3 mae_surf_p** | **23.08** | **24.62** | **+1.54 (~7.3σ, much worse)** |

**Memory:** 18.4 GB. **Epochs:** 58/100.

### What happened

Significantly worse on all splits. The warm restart schedule disrupted convergence.

The problem: the first LR restart at epoch 27 (warmup ends at epoch 10, then 17 more epochs = epoch 27) resets LR to a high value just as the model is beginning to converge. With PCGrad's two-backward-pass overhead limiting us to ~58 epochs, each 17-epoch cycle is too short to converge — the model barely settles before the next restart undoes its progress.

At epoch 58, val_in_dist=0.63 (vs baseline ending ~0.60), showing that the cyclic schedule is still converging where the plain cosine was already settled. The decayed peak LR mechanism also didn't help — the `initial_lr` manipulation may not correctly interact with `CosineAnnealingWarmRestarts` (which tracks `base_lrs` internally, not `initial_lr`).

### Suggested follow-ups

- The `initial_lr` decay approach may not work correctly with PyTorch's `CosineAnnealingWarmRestarts` — it uses `base_lrs`, not `initial_lr`. Would need to modify `scheduler.base_lrs` directly
- Single long cosine schedule (current baseline) appears better for our ~58 epoch budget — there isn't enough training time for restarts to be beneficial
- If warm restarts are desired, they need longer cycles (T_0=40+) to give each cycle time to converge