### PR TITLE
Zone-aware spatial bias (add mesh zone ID to routing MLP)

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(4, 64), nn.GELU(),
+            nn.Linear(5, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -377,7 +377,9 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        saf_magnitude = x[:, :, 2:4].norm(dim=-1, keepdim=True)  # saf magnitude as zone proxy
+        zone_proxy = torch.log1p(saf_magnitude)  # higher near surface, lower in far-field
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], zone_proxy], dim=-1)  # x, y, curv, dist, zone
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]


### PR DESCRIPTION
## Hypothesis
The spatial bias MLP currently takes 4 inputs: (x, y, curvature, dist_to_surface). It ignores the MESH ZONE information. The overset mesh has 3 zones: zone 0 (coarse background), zone 1 (dense foil1 refinement), zone 2 (dense foil2 refinement). These zones have fundamentally different node densities and physics relevance. Adding zone ID to the spatial bias MLP lets the routing learn zone-appropriate slice assignments.

## Instructions
1. Compute an approximate zone feature from existing data:
   ```python
   saf_magnitude = x[:, :, 2:4].norm(dim=-1, keepdim=True)  # [B, N, 1]
   zone_proxy = torch.log1p(saf_magnitude)  # higher near surface
   ```

2. Expand the spatial bias MLP input from 4 to 5 dimensions:
   ```python
   self.spatial_bias = nn.Sequential(
       nn.Linear(5, 64), nn.GELU(),  # was 4, now 5
       ...
   )
   ```

3. Update `raw_xy` construction in `forward()`:
   ```python
   raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], zone_proxy], dim=-1)  # x, y, curv, dist, zone
   ```

4. Run with `--wandb_group zone-aware-attn`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run ID:** tceom49n  
**Best epoch:** 60 (wall-clock timeout at 30.2 min)  
**Peak memory:** ~14.8 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8556** | 0.8477 |
| val_in_dist | 0.5893 | — |
| val_tandem_transfer | 1.6110 | — |
| val_ood_cond | 0.6880 | — |
| val_ood_re | 0.5342 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 5.57 | 1.63 | 17.88 | 17.74 | +0.8% |
| val_tandem_transfer | 5.72 | 2.00 | 38.27 | 37.72 | +1.5% |
| val_ood_cond | 2.91 | 0.78 | **13.56** | 13.77 | **-1.5%** |
| val_ood_re | 2.61 | 0.72 | 27.60 | 27.52 | +0.3% |

**mean3 surf_p** = (17.88 + 13.56 + 38.27) / 3 = **23.24** (baseline: 23.01, delta: +1.0%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.06 | 0.35 | 18.70 |
| val_tandem_transfer | 1.87 | 0.85 | 37.76 |
| val_ood_cond | 0.69 | 0.27 | 11.97 |
| val_ood_re | 0.81 | 0.36 | 46.75 |

---

### What happened

**Borderline negative result.** val/loss = 0.8556 vs baseline 0.8477 (+0.93% worse). mean3 surf_p = 23.24 vs 23.01 (+1.0% worse).

However, the result is not uniform: **val_ood_cond improved by 1.5%** (13.56 vs 13.77), which is a meaningful signal. The val_ood_re is essentially flat (+0.3%). The degradation is mainly in val_in_dist (+0.8%) and val_tandem_transfer (+1.5%).

The saf_magnitude (x[:, :, 2:4].norm) encodes the proximity to the foil surface through the signed arc-length / dsdf features — nodes near the foil surface have larger saf values. This provides a continuous near-surface vs far-field signal that the routing can use to assign surface nodes to different slices.

The tandem regression is consistent across many recent experiments, suggesting it may be a general variance issue rather than being caused by specific changes. The ood_cond improvement reinforces the value of geometric context in the routing (consistent with the earlier cosine-profile-loss-v2 result also showing ood_cond as the most responsive split).

---

### Suggested follow-ups

- **True zone ID**: If the zone ID is available in the data, encode it as a learned embedding (3 zones × 4-dim embedding) and add it to the spatial bias. The continuous saf_magnitude proxy may be less informative than the discrete zone label.
- **Broader spatial bias**: Include the raw saf values (not just magnitude) as additional features, to distinguish foil1 vs foil2 proximity.
- **Separate routing per zone**: Rather than a single spatial bias MLP, use 3 separate MLPs (one per zone) to allow completely different routing policies per mesh region.
