### PR TITLE
Stochastic EMA ensemble: average fast + EMA predictions at inference

### DIFF
--- a/train.py
+++ b/train.py
@@ -861,6 +861,7 @@ for epoch in range(MAX_EPOCHS):
     eval_model = ema_model if ema_model is not None else model
     eval_model.eval()
     model.eval()
+    use_ensemble = (ema_model is not None) and (epoch >= 54)
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -917,7 +918,12 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    pred_ema = eval_model({"x": x})["preds"]
+                    if use_ensemble:
+                        pred_fast = model({"x": x})["preds"]
+                        pred = (pred_ema.float() + pred_fast.float()) * 0.5
+                    else:
+                        pred = pred_ema.float()
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2


### PR DESCRIPTION
## Hypothesis
The current model uses EMA for evaluation (eval_model = ema_model). The fast model (non-EMA) is discarded at inference. But the fast model and EMA model occupy different points in the loss landscape and make DIFFERENT errors. Averaging their predictions at inference is a FREE ensemble (zero extra training cost, ~2x inference cost but well within the 30-min budget since validation is much faster than training).

**Key insight from variance measurements:** Seed sweeps showed val_loss std of ~0.015 across seeds. This means different model instances make partially independent errors. The fast model is one such instance, and the EMA model is another (with correlated but not identical errors). Averaging them should reduce variance.

**Why this is different from previous ensemble attempts:**
- Snapshot ensemble (#994, #1447, #1452) required changing the training schedule
- Model soup (#1237, #1445, #1450) required training multiple models
- Multi-rate EMA (#1464) blended two EMA decays
- This proposal requires NO training changes — only a ~5-line change to the validation loop

## Instructions
1. **In the validation loop** (~line 861), instead of using only ema_model for evaluation, average predictions from BOTH models:
   ```python
   eval_model = ema_model if ema_model is not None else model
   eval_model.eval()
   model.eval()  # already there
   use_ensemble = (ema_model is not None)  # only ensemble if EMA exists
   ```

2. **In the val inner loop** (~line 919-921), get predictions from both models and average:
   ```python
   with torch.amp.autocast("cuda", dtype=torch.bfloat16):
       pred_ema = eval_model({"x": x})["preds"]
       if use_ensemble:
           pred_fast = model({"x": x})["preds"]
           pred = (pred_ema.float() + pred_fast.float()) * 0.5
       else:
           pred = pred_ema.float()
   pred = pred.float()
   ```

3. **That's it.** No training changes needed. The fast model is always available during validation.

4. Run with `--wandb_group stochastic-ema-ensemble`

Note: This will roughly double validation time (~30s extra per epoch for the fast model forward pass), but with ~60 epochs at ~30s each, this only adds ~30 minutes... wait, that would bust the 30-minute budget. 

**Revised approach:** Only ensemble on the FINAL checkpoint evaluation, or ensemble every 5th epoch. Better yet, since validation already runs every epoch, ensemble only when `epoch >= ema_start_epoch` (40+) to minimize overhead. With ~19 epochs after epoch 40, the extra forward pass adds ~19 * 5s = ~1.5 minutes. Worth it.

Actually simplest: just do the ensemble for ALL val epochs. The val loop processes all 4 splits in ~5s per split, so an extra forward pass adds ~5s per split * 4 splits = ~20s per epoch. Over 59 epochs, that's ~20 minutes... which IS too much.

**Final approach:** Ensemble ONLY on the last 5 epochs (epoch >= 54). This adds ~1.5 minutes total and captures the benefit where it matters most — the final checkpoint.

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `8pf0jx4c` | Best epoch: 58 | Peak memory: ~18 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6077 | 18.6 | +4.9% worse |
| val_ood_cond | 0.6871 | 13.8 | +0.2% worse |
| val_ood_re | 0.5460 | 27.9 | +1.3% worse |
| val_tandem_transfer | 1.6403 | 39.4 | +4.5% worse |
| **combined** | **0.8703** | — | **+2.7% worse** |

### What happened

Negative result. Averaging the fast model and EMA model slightly degrades quality across most splits (except ood_cond which is essentially flat). The combined val/loss is 2.7% worse than baseline.

The core issue: the fast model at epochs 54-58 is not at the same quality level as EMA. With Lookahead (k=10, alpha=0.8), the "fast weights" are essentially the short-term Lookahead buffer — noisy and not fully converged. EMA with decay=0.998 produces smooth, high-quality weights. Averaging a noisy fast model with a clean EMA dilutes quality rather than reducing prediction variance.

The hypothesis assumed the fast and EMA models make "different errors" that cancel. In practice, they make correlated errors (same architecture, same data), and the fast model makes strictly larger errors due to less smoothing.

### Suggested follow-ups

- This approach might work if using two EMA models with different decay rates (0.998 vs 0.995), which would give more meaningfully different checkpoint weights while both being high quality. This is the "dual EMA" idea.
- The key insight of "free inference-time ensemble" is valid — it just needs two quality checkpoints, not a quality+noisy checkpoint.