### PR TITLE
Laplacian smoothing on surface pressure predictions (post-hoc denoising)

### DIFF
--- a/train.py
+++ b/train.py
@@ -939,6 +939,18 @@ for epoch in range(MAX_EPOCHS):
                 # Denormalize: phys_stats → Cp space → original scale
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
                 pred_orig = _phys_denorm(pred_phys, Umag, q)
+                # Laplacian smoothing on surface pressure at inference
+                for b_idx in range(pred_orig.shape[0]):
+                    surf_nodes = surf_mask[b_idx]  # [N] bool
+                    if surf_nodes.sum() < 6:
+                        continue
+                    surf_pos = x[b_idx, surf_nodes, :2].float()  # [Ns, 2]
+                    surf_pred_p = pred_orig[b_idx, surf_nodes, 2]  # [Ns]
+                    dists = torch.cdist(surf_pos, surf_pos)  # [Ns, Ns]
+                    _, nn_idx = dists.topk(7, dim=1, largest=False)  # [Ns, 7] (incl self)
+                    nn_preds = surf_pred_p[nn_idx[:, 1:]]  # [Ns, 6] (exclude self)
+                    smoothed = 0.5 * surf_pred_p + 0.5 * nn_preds.mean(dim=1)
+                    pred_orig[b_idx, surf_nodes, 2] = smoothed
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()
                 finite = err.isfinite()


### PR DESCRIPTION
## Hypothesis
Surface pressure predictions are noisy at the node level because each node predicts independently via the output MLP. But physics demands spatial coherence: pressure cannot jump discontinuously between adjacent surface nodes (pressure is governed by an elliptic PDE). Applying a single step of Laplacian smoothing on surface pressure predictions — averaging each surface node's prediction with its k nearest surface neighbors — should reduce high-frequency noise without requiring any architecture change.

**Key insight from CFD:** Pressure on an airfoil surface is a smooth, continuous function of arc-length (except at the trailing edge). The model's node-wise predictions inevitably have high-frequency noise that a simple spatial average can remove.

**Why this is different from previous smoothing attempts:**
- #953 (k-NN smoothing) was tested on OLD code (val_loss=2.2) and used k=3 with fixed averaging
- #1192 (surface k-NN context) tried to ADD neighbor features as model input — very different from post-hoc smoothing
- #1434 (learned surface interpolation) added a learned kernel — too complex
- This proposal uses simple, unweighted averaging with k=6 neighbors, applied ONLY to pressure, ONLY at inference (no training change)

**Zero training cost:** This is a val-only modification. If it helps, it helps immediately with no risk to training dynamics.

## Instructions
1. **After computing `pred_orig` in the val loop** (~line 941), apply Laplacian smoothing to surface pressure:
   ```python
   # Laplacian smoothing on surface pressure at inference
   if True:  # always apply
       for b_idx in range(pred_orig.shape[0]):
           surf_nodes = surf_mask[b_idx]  # [N] bool
           if surf_nodes.sum() < 6:
               continue
           surf_pos = x[b_idx, surf_nodes, :2]  # [Ns, 2] surface node positions
           surf_pred_p = pred_orig[b_idx, surf_nodes, 2]  # [Ns] pressure predictions
           # k-NN: find 6 nearest neighbors per surface node
           dists = torch.cdist(surf_pos, surf_pos)  # [Ns, Ns]
           _, nn_idx = dists.topk(7, dim=1, largest=False)  # [Ns, 7] (includes self)
           # Average: self + 6 neighbors, weighted 0.5 self + 0.5 mean(neighbors)
           nn_preds = surf_pred_p[nn_idx[:, 1:]]  # [Ns, 6] (exclude self)
           smoothed = 0.5 * surf_pred_p + 0.5 * nn_preds.mean(dim=1)
           pred_orig[b_idx, surf_nodes, 2] = smoothed
   ```

2. **Do NOT modify training.** This is inference-only.

3. **Important: apply AFTER _phys_denorm** so the smoothing operates on original-scale pressure values where physical smoothness is meaningful.

4. Run with `--wandb_group surface-knn-smooth`

Note: The torch.cdist computation on ~300-600 surface nodes is fast (<1ms per sample). No concern about computational overhead.

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `inwc03qf`
**Best epoch:** 58/100 (wall-clock limit at 30 min)
**Peak memory:** ~17 GB

### Metrics (best epoch)

| Split | val/loss | Surf p (smoothed) | Surf Ux | Surf Uy | Vol p | Vol Ux | Vol Uy |
|-------|----------|-------------------|---------|---------|-------|--------|--------|
| val_in_dist | 0.601 | **56.20** | 6.30 | 2.01 | 19.47 | 1.10 | 0.37 |
| val_ood_cond | 0.706 | **47.81** | 3.40 | 1.35 | 12.24 | 0.72 | 0.27 |
| val_ood_re | 0.549 | **53.03** | 3.08 | 1.21 | 46.83 | 0.83 | 0.36 |
| val_tandem_transfer | 1.621 | **61.24** | 6.06 | 2.41 | 37.65 | 1.90 | 0.86 |
| **combined val/loss** | **0.8690** | | | | | | |

**Note:** val/loss is computed from normalized predictions (BEFORE smoothing). MAE is computed from smoothed denormalized predictions (AFTER smoothing). The val/loss improvement (+0.017) is noise/unrelated to smoothing. The MAE catastrophically worsened (3x worse on pressure).

### vs Baseline

| Metric | Baseline | Smoothed | Delta |
|--------|----------|---------|-------|
| val/loss | 0.8477 | 0.8690 | +0.021 ▲ (noise) |
| in/surf_p | 17.74 | 56.20 | **+38.46 ▲ CATASTROPHIC** |
| ood_c/surf_p | 13.77 | 47.81 | **+34.04 ▲ CATASTROPHIC** |
| ood_r/surf_p | 27.52 | 53.03 | **+25.51 ▲ CATASTROPHIC** |
| tan/surf_p | 37.72 | 61.24 | **+23.52 ▲ CATASTROPHIC** |

### What happened

The k-NN Euclidean smoothing catastrophically destroyed pressure predictions (3x worse MAE). Root cause: **Euclidean k-NN crosses the airfoil surface**.

For a thin airfoil, the pressure side and suction side nodes are geometrically close in 2D (small Euclidean distance) but physically on opposite sides of the lifting surface. Pressure on the suction side is much lower (negative Cp) than on the pressure side (positive Cp). The k-NN smoothing averages these opposing values, creating nonsensical intermediate pressures for all boundary nodes.

This explains the consistent ~3x degradation: essentially every surface node's 6 nearest neighbors include nodes from the opposite side of the airfoil.

The val/loss appearing slightly better (0.8690 vs 0.8477) is misleading: val_surf and val_vol losses are computed from normalized predictions BEFORE smoothing is applied. So the model itself hasn't changed — the smoothing only affects the MAE reported.

### Suggested follow-ups

- Euclidean k-NN is fundamentally wrong for thin airfoil smoothing; don't revisit
- If smoothing is desired, it must use arc-length distance along the surface (node connectivity from mesh), not Euclidean distance
- The data loader would need to provide edge/connectivity information for arc-length smoothing — this is a data change not currently available