### PR TITLE
Asymmetric Cp clamps: tighter pressure, looser velocity denorm

### DIFF
--- a/train.py
+++ b/train.py
@@ -469,9 +469,9 @@ def _phys_norm(y, Umag, q):
 def _phys_denorm(y_p, Umag, q):
     """Reverse physics normalization: Ux/Umag→Ux, Uy/Umag→Uy, Cp→p."""
     y = y_p.clone()
-    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-10, 10) * Umag
-    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-10, 10) * Umag
-    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
+    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-5, 5) * Umag    # was [-10, 10]
+    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-5, 5) * Umag    # was [-10, 10]
+    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-8, 3) * q       # was [-20, 20]
     return y
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,


### PR DESCRIPTION
## Hypothesis
The `_phys_denorm` function uses symmetric clamps: Ux/Umag in [-10, 10] and Cp in [-20, 20]. These clamps were set conservatively when Cp normalization was first introduced (PR #400). But physical Cp values on airfoils are typically in [-4, 1.5] for attached flow and [-8, 2] for separated flow. The current [-20, 20] clamp allows the model to predict wildly non-physical Cp values (e.g., Cp=-15) that, when denormalized by q (which can be O(10^4) for high Re), produce enormous pressure errors.

**Key physics insight:** Cp cannot physically exceed 1.0 at stagnation (Bernoulli) and rarely goes below -10 even in strong suction peaks. The velocity ratio U/Umag similarly has known physical bounds: it's O(1) for attached flow and O(2-3) for accelerated flow near leading edges.

**Proposal:** Tighten the Cp clamp from [-20, 20] to [-8, 3] and velocity clamps from [-10, 10] to [-5, 5]. These are still generous enough to allow all physical values but will clip outlier predictions that currently create large MAE spikes.

This targets the TAIL of the error distribution — the hardest nodes where the model makes its worst predictions. By clamping these to physically reasonable bounds, the mean absolute error should decrease even if the median error is unchanged.

## Instructions
1. **Modify `_phys_denorm`** (~line 469-475):
   ```python
   def _phys_denorm(y_p, Umag, q):
       y = y_p.clone()
       y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-5, 5) * Umag    # was [-10, 10]
       y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-5, 5) * Umag    # was [-10, 10]
       y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-8, 3) * q       # was [-20, 20]
       return y
   ```

2. **That's it.** One-line change (well, 3 lines). Affects both training and validation.

3. Run with `--wandb_group asymmetric-clamp`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B Run:** yjk44war
**Best epoch:** 61

### Metrics vs Baseline

| Split | val_loss | surf_p |
|-------|----------|--------|
| val_in_dist | 0.5711 | 18.95 |
| val_ood_cond | 0.7044 | 14.13 |
| val_ood_re | 0.5278 | 27.52 |
| val_tandem_transfer | 1.6324 | 42.14 |
| **combined** | **0.8589** | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8477 | 0.8589 | +0.0112 ↑ worse |
| in surf_p | 17.74 | 18.95 | +1.21 ↑ worse |
| ood_c surf_p | 13.77 | 14.13 | +0.36 ↑ slightly worse |
| ood_r surf_p | 27.52 | 27.52 | 0.00 (same) |
| tan surf_p | 37.72 | 42.14 | +4.42 ↑ much worse |
| mean3 surf_p | 19.68 | 20.20 | +0.52 ↑ worse |

**Peak memory:** ~17.8 GB (negligible change)

### What happened

Negative result. The tighter clamps significantly hurt tandem (+4.42 surf_p, +11.7%) and in-dist (+1.21, +6.8%). OOD-cond is slightly worse; OOD-re is essentially unchanged.

The Cp clamp at -8 is too aggressive for tandem flow. In tandem foil configurations, inter-foil interference (wake impingement, slot flow effects) can produce strong suction peaks below -8 Cp, especially in close-gap or high-stagger configurations. The [-20, 20] clamp was conservative but permissive enough to handle these physically valid extreme values.

The velocity clamp at [-5, 5] also hurts in-dist. Near leading-edge stagnation points and in accelerating flow regions, U/Umag can exceed 5 even for single-foil cases.

The hypothesis was physically motivated, but physical Cp bounds for attached flow ([-4, 1.5]) don't apply to all cases — tandem foils experience more extreme aerodynamic effects than single isolated foils. The denorm clamps are not a bottleneck for the current error levels.

### Suggested follow-ups

- If clamp tightening is still desired, try a milder approach: Cp [-12, 5] and velocity [-8, 8], which would clip only truly non-physical values
- The real MAE spike fix may require better training supervision (e.g., harder negative sampling for high-error regions) rather than output clamping