### PR TITLE
Inverse-frequency-weighted Fourier PE (amplify low-frequency spatial signal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -664,8 +664,14 @@ for epoch in range(MAX_EPOCHS):
         xy_max = raw_xy.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 8]
+        sin_pe = xy_scaled.sin()  # [B, N, 2, 8]
+        cos_pe = xy_scaled.cos()  # [B, N, 2, 8]
+        inv_freq_weight = 1.0 / freqs.clamp(min=0.1)
+        inv_freq_weight = inv_freq_weight / inv_freq_weight.mean()
+        sin_pe = sin_pe * inv_freq_weight
+        cos_pe = cos_pe * inv_freq_weight
+        fourier_pe = torch.cat([sin_pe.flatten(-2), cos_pe.flatten(-2)], dim=-1)  # [B, N, 32]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
             noise_scale = 0.05 * (1 - epoch / 60)
@@ -894,8 +900,14 @@ for epoch in range(MAX_EPOCHS):
                 xy_max = raw_xy.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 8]
+                sin_pe = xy_scaled.sin()
+                cos_pe = xy_scaled.cos()
+                inv_freq_weight = 1.0 / freqs.clamp(min=0.1)
+                inv_freq_weight = inv_freq_weight / inv_freq_weight.mean()
+                sin_pe = sin_pe * inv_freq_weight
+                cos_pe = cos_pe * inv_freq_weight
+                fourier_pe = torch.cat([sin_pe.flatten(-2), cos_pe.flatten(-2)], dim=-1)  # [B, N, 32]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
The Fourier PE currently uses 8 frequencies: fixed [0.5, 2.0, 8.0, 32.0] and learned [1.0, 3.0, 6.0, 16.0]. All frequencies contribute equally (sin/cos features are concatenated without weighting). But the spatial structure of aerodynamic flows has a natural frequency spectrum: low frequencies (large-scale pressure gradients, circulation) carry most of the energy, while high frequencies (boundary layer, wake) are local and harder to predict.

**Proposal:** Weight the Fourier PE features by inverse frequency, so low-frequency features have stronger signal:
- freq=0.5 gets weight ~2.0
- freq=32.0 gets weight ~0.03
This creates a multi-scale representation where the model can more easily learn the dominant low-frequency patterns while still having access to high-frequency detail.

**Why this is different from previous Fourier PE work:** Previous experiments (#1051, #1102, #1127, #1147, #1164) changed the number or values of frequencies. None weighted the features by frequency. This is a REPRESENTATION change that reshapes the feature space to match the physics spectrum.

## Instructions
1. **After computing `fourier_pe`** in the training loop (~line 668), apply inverse-frequency weighting:
   ```python
   # Fourier PE with inverse-frequency weighting
   freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
   xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 8]
   sin_pe = xy_scaled.sin()  # [B, N, 2, 8]
   cos_pe = xy_scaled.cos()  # [B, N, 2, 8]
   # Weight by 1/freq (lower frequencies get more weight)
   inv_freq_weight = 1.0 / freqs.clamp(min=0.1)  # [8], avoid div by 0
   inv_freq_weight = inv_freq_weight / inv_freq_weight.mean()  # normalize so mean weight = 1
   sin_pe = sin_pe * inv_freq_weight  # broadcast [B,N,2,8] * [8]
   cos_pe = cos_pe * inv_freq_weight
   fourier_pe = torch.cat([sin_pe.flatten(-2), cos_pe.flatten(-2)], dim=-1)  # [B, N, 32]
   ```

2. **Apply same change in val loop** (same Fourier PE computation, ~lines 890-898).

3. Run with `--wandb_group inv-freq-weight`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** o5m8hkaa  
**Change:** Fourier PE features scaled by 1/freq (normalized mean=1)

| Split | val_loss | mae_surf_p | Baseline mae_surf_p | Δ |
|-------|----------|------------|---------------------|---|
| val_in_dist | 0.5936 | 17.63 | 17.74 | **-0.11** |
| val_ood_cond | 0.7153 | 14.20 | 13.77 | +0.43 |
| val_ood_re | 0.5437 | 27.81 | 27.52 | +0.29 |
| val_tandem_transfer | 1.6348 | 38.44 | 37.72 | +0.72 |
| **combined** | **0.8668** | — | **0.8477** | **+0.0191** |

**Peak memory:** ~17.8 GB  
**Epochs completed:** ~61 in ~30 min

### What happened

Inverse-frequency weighting slightly improved in_dist (-0.11 mae_surf_p) but degraded OOD splits. Overall val/loss is worse than baseline (+0.019).

The weighting heavily suppresses high-frequency PE features (freq=32 gets weight ~0.03, vs mean=1.0). This means the model receives much weaker high-frequency spatial signal. For in_dist samples where large-scale flow patterns dominate, this might help. But OOD splits (ood_cond with extreme AoA/gap, ood_re with different Reynolds numbers, tandem with complex foil interactions) likely need high-frequency features to distinguish local boundary conditions — and suppressing these features hurts OOD generalization.

The hypothesis that "low frequencies carry most energy" is physically plausible for smooth in-distribution flows but doesn't hold uniformly across OOD conditions. The learned Fourier frequencies (currently around 1-16) have already been tuned to balance this spectrum; the additional manual reweighting distorts the already-optimized feature balance.

### Suggested follow-ups

- **Learned weighting:** Instead of fixed 1/freq weighting, add learnable scalar weights for each frequency band (initialized to 1.0) — let the model decide the right balance.
- **Only weight fixed frequencies:** The learned frequencies may already adapt their effective scale; apply inverse weighting only to the 4 fixed frequencies.