### PR TITLE
Feature dropout on preprocess output (implicit ensemble regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -318,6 +318,7 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.preprocess_dropout = nn.Dropout(p=0.03)
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -383,7 +384,8 @@ class Transolver(nn.Module):
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
         fx = self.preprocess(x)
-        fx_pre = fx  # save for skip
+        fx_pre = fx  # save for skip (BEFORE dropout, so skip has clean features)
+        fx = self.preprocess_dropout(fx)
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:


### PR DESCRIPTION
## Hypothesis
The GatedMLP2 preprocess maps 58-dim input to 192-dim hidden. With only 1,322 training samples and ~59 epochs, the preprocess embeddings may co-adapt: specific hidden dimensions may only fire for specific input patterns, creating brittle representations that don't generalize to OOD.

**Proposal:** Apply dropout (p=0.03) on the preprocess output BEFORE the placeholder scale+shift (line 387). This forces the downstream attention to work with randomly incomplete feature vectors, creating an implicit ensemble effect.

**Why p=0.03 and not higher:** 
- MLP dropout at p=0.05 was tested (PR #966) and was neutral
- DropPath at p=0.05 (#1476) regressed catastrophically
- Attention dropout at p=0.05 (#885) was neutral  
- The key difference: those applied dropout WITHIN the block. This applies it BETWEEN preprocessing and the Transolver block — a different location that affects how the attention sees its input, not how it computes internally.
- p=0.03 is very light — only 5-6 hidden dimensions out of 192 are zeroed per forward pass. This should be enough for regularization without degrading signal quality.

**Why this location specifically:** The preprocess-to-block boundary is the most critical information bottleneck in a 1-layer model. The preprocess must compress 58 input features into 192 hidden dimensions, and the single Transolver block must predict from those 192 dimensions. Dropout here forces the block to use DIVERSE feature combinations, improving robustness.

## Instructions
1. **Add a dropout layer** in `Transolver.__init__` (~line 316):
   ```python
   self.preprocess_dropout = nn.Dropout(p=0.03)
   ```

2. **Apply dropout** in `forward()` after preprocess but before placeholder (line 387):
   ```python
   fx = self.preprocess(x)
   fx_pre = fx  # save for skip (BEFORE dropout, so skip has clean features)
   fx = self.preprocess_dropout(fx)  # ADD THIS LINE
   fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
   ```

3. **Important: fx_pre should NOT have dropout** since it's used in the skip connection. The skip path should remain clean.

4. Run with `--wandb_group preprocess-dropout`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** aft25jav
**Total time:** 30.3 min, 56 epochs

### Metrics

| Split | val_loss | mae_surf_p |
|-------|----------|------------|
| val_in_dist | 0.6139 | 18.4 |
| val_ood_cond | 0.7354 | 14.6 |
| val_ood_re | 0.5527 | 27.9 |
| val_tandem_transfer | 1.6379 | 38.9 |
| **mean3 (in+ood+tan)** | **0.8850** | **23.97** |

Baseline: val_loss=0.8477, mean3_p=23.08

**Delta:** val_loss +0.0373 (+4.4%), mean3_p +0.89 (+3.9%)

**Peak VRAM:** ~18.5GB

### What happened

Dropout at the preprocess boundary hurts. All splits are worse than baseline, and the model completes slightly fewer epochs (56 vs ~58). Even p=0.03 is enough to degrade performance.

This is consistent with prior experiments: dropout has never helped this model architecture. The Transolver model with 1,322 training samples is likely not overfitting in a way dropout can fix — the model has sufficient regularization from weight decay, input noise augmentation, and the Lookahead optimizer's gradient smoothing. Adding dropout at the preprocess-to-block boundary creates information loss that the single attention block cannot compensate for, since it has limited capacity (1 layer).

The hypothesis that preprocess co-adaptation is the limiting factor is not supported. The model doesn't appear to be overfitting to specific hidden dimensions.

### Suggested follow-ups

1. Skip dropout experiments entirely: The consistent failure of dropout across multiple locations and scales suggests the architecture is not dropout-friendly. Prioritize other regularization strategies.
2. Try feature noise augmentation on preprocess output instead: Instead of dropout (zeroing), add small Gaussian noise to fx (scale 0.01-0.02). This maintains signal strength while introducing randomness.