### PR TITLE
Seed 0 at lr=2.6e-3 (basin exploration)

### DIFF
--- a/train.py
+++ b/train.py
@@ -529,6 +529,8 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
+torch.manual_seed(0)
+torch.cuda.manual_seed_all(0)
 model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode="default")


### PR DESCRIPTION
## Hypothesis
Seed 0 has never been tested on the current dist_feat + lr=2.6e-3 code.
## Instructions
Add `torch.manual_seed(0); torch.cuda.manual_seed_all(0)` before model creation. Run with `--wandb_group seed-0-lr26`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `r3d92a6k` | **best_epoch:** 57

| Metric | Baseline (default seed) | Seed 0 | Δ |
|--------|------------------------|--------|---|
| val/loss | 0.8477 | **0.8756** | +0.028 |
| in_dist surf p | 17.74 | 18.03 | +0.29 |
| ood_cond surf p | 13.77 | 13.95 | +0.18 |
| ood_re surf p | 27.52 | 27.88 | +0.36 |
| tandem surf p | 37.72 | 39.58 | +1.86 |
| mean3 | ~23.08 | 23.85 | +0.77 |

**Surface MAE detail (Ux / Uy / p):**
- in_dist: 6.65 / 1.99 / 18.03
- ood_cond: 4.12 / 1.30 / 13.95
- ood_re: 3.77 / 1.16 / 27.88
- tandem: 6.13 / 2.52 / 39.58

**Volume MAE (in_dist):** Ux=1.09, Uy=0.37, p=19.25

### What happened

Seed 0 is **clearly worse** than the default seed on all metrics. val/loss degraded from 0.8477 to 0.8756 (+3.3%). Tandem is most hurt (+1.86 in surface pressure). This is a similar pattern to seed 42 (PR #1510, val/loss=0.8634) — both explicit seeds are worse than the default. The default random state appears to provide a favorable initialization for this model and dataset.

The Ux/Uy metrics also degraded noticeably (in_dist Ux: 6.65 vs baseline ~5.5), suggesting the initialization quality matters broadly, not just for pressure.

### Suggested follow-ups
- Seed 1 is being tested on another branch — if it also underperforms, this confirms the default seed is unusually good
- Multi-seed averaging (model soup): train 3 seeds, average weights — should reduce variance even if mean is slightly worse
- Profile whether the default pytorch seed is reproducible or whether this is luck; if luck, warmup-then-freeze initialization could help