### PR TITLE
Seed 1 at lr=2.6e-3 (basin exploration)

### DIFF
--- a/train.py
+++ b/train.py
@@ -529,6 +529,8 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
+torch.manual_seed(1)
+torch.cuda.manual_seed_all(1)
 model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode="default")


### PR DESCRIPTION
## Hypothesis
Seed 1 has never been tested on the current dist_feat + lr=2.6e-3 code.
## Instructions
Add `torch.manual_seed(1); torch.cuda.manual_seed_all(1)` before model creation. Run with `--wandb_group seed-1-lr26`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** `lp86tfp0`

| Metric | Baseline | Seed 1 | Δ |
|--------|----------|--------|---|
| val/loss | 0.8477 | **0.8713** | +0.0236 (~5.1σ, worse) |
| mae_surf_p in_dist | 17.74 | 18.02 | +0.28 |
| mae_surf_p ood_cond | 13.77 | 14.11 | +0.34 |
| mae_surf_p ood_re | 27.52 | 27.82 | +0.30 |
| mae_surf_p tandem | 37.72 | **39.25** | **+1.53** |
| **mean3 mae_surf_p** | **23.08** | **23.79** | **+0.71 (~3.4σ, worse)** |

**Memory:** 17.9 GB. **Epochs:** 58/100.

### What happened

Seed 1 is worse across all splits, with tandem showing the largest regression (+1.53). This continues the pattern established by seed 123 — neither alternative seed beats the default.

Seed variance summary across tested seeds on dist_feat + lr=2.6e-3:
| Seed | val/loss | tandem mae_surf_p | mean3 |
|------|----------|-------------------|-------|
| default | **0.8477** | **37.72** | **23.08** |
| 1 | 0.8713 | 39.25 | 23.79 |
| 123 | 0.8695 | 39.88 | 23.79 |

The default seed consistently wins on tandem, which drives the val/loss (tandem loss is weighted heavily). The in_dist and ood splits show smaller variance (~0.3 range) compared to tandem (~2 range). The default seed appears to be either lucky or at a genuinely better basin.

### Suggested follow-ups

- Seeds 0, 42, 7 could further characterize the distribution — are we seeing ~1.5+ unit variance on tandem consistently, or is the default seed specifically lucky?
- The tandem domain has the highest sensitivity to seed (~2 unit range vs ~0.3 for in_dist). This suggests the model is in a regime where tandem learning depends heavily on initialization order
- Multi-seed soup (averaging parameters of multiple seeds' best checkpoints) could reduce variance without needing to find a better seed