### PR TITLE
Seed 137 at lr=2.6e-3 (basin exploration)

### DIFF
--- a/train.py
+++ b/train.py
@@ -516,6 +516,9 @@ _pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min
 phys_stats = {"y_mean": _pmean, "y_std": _pstd}
 print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
+torch.manual_seed(137)
+torch.cuda.manual_seed_all(137)
+
 model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE


### PR DESCRIPTION
## Hypothesis
Seed 137 has never been tested on the current dist_feat + lr=2.6e-3 code.
## Instructions
Add `torch.manual_seed(137); torch.cuda.manual_seed_all(137)` before model creation. Run with `--wandb_group seed-137-lr26`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** w59tvloh | **Epochs:** 61 | **Peak VRAM:** 17.5 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| val_in_dist | 0.5964 | 4.71 | 1.81 | 18.61 | 1.09 | 0.36 | 19.84 |
| val_ood_cond | 0.6856 | 2.79 | 1.08 | 13.86 | 0.70 | 0.27 | 11.86 |
| val_ood_re | 0.5292 | 2.44 | 0.88 | 27.41 | 0.82 | 0.36 | 46.56 |
| val_tandem_transfer | 1.6276 | 5.46 | 2.20 | 39.07 | 1.90 | 0.87 | 38.82 |
| **val/loss** | **0.8597** | | | | | | |

**vs baseline (0.8477):** +0.012 (worse)

| Metric | Seed 137 | Baseline | Delta |
|--------|----------|----------|-------|
| mae_surf_p in_dist | 18.61 | 17.74 | +0.87 |
| mae_surf_p ood_cond | 13.86 | 13.77 | +0.09 |
| mae_surf_p ood_re | 27.41 | 27.52 | -0.11 |
| mae_surf_p tandem | 39.07 | 37.72 | +1.35 |

**What happened:** Seed 137 is worse than the default seed across the board. val/loss is 0.8597 vs 0.8477 baseline (+1.4%). Tandem surface pressure is particularly degraded (+1.35 mae_surf_p). Only ood_re shows a marginal improvement (-0.11), which is likely noise. This matches the pattern seen with seed 7, which was also worse than default (0.8557 vs 0.8495). Neither alternative seed finds a better basin than default initialization at this lr=2.6e-3 regime.

**Suggested follow-ups:**
- The default seed appears to be at a good basin for this architecture/lr combination. Random seed exploration is yielding diminishing returns.
- If basin exploration is the goal, consider a larger LR range (e.g., 2.8e-3 or 3.0e-3) rather than different seeds.
- Alternatively, focus on architectural changes (e.g., slice_num tuning, n_head changes) that could improve performance more systematically.