### PR TITLE
Vectorize per-sample std loop (pure throughput, zero model change)

### DIFF
--- a/train.py
+++ b/train.py
@@ -684,17 +684,25 @@ for epoch in range(MAX_EPOCHS):
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
-        sample_stds = torch.ones(B, 1, 3, device=device)
         channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
         tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
         if model.training:
-            for b in range(B):
-                valid = mask[b]
-                if is_tandem[b]:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                else:
-                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+            mask_f = mask.float().unsqueeze(-1)  # [B, N, 1]
+            n_valid = mask_f.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1, 1]
+            y_mean = (y_norm * mask_f).sum(dim=1, keepdim=True) / n_valid  # [B, 1, 3]
+            y_centered = (y_norm - y_mean) * mask_f  # [B, N, 3]
+            n_bessel = (n_valid - 1).clamp(min=1)  # Bessel correction (matches .std())
+            y_var = (y_centered ** 2).sum(dim=1, keepdim=True) / n_bessel  # [B, 1, 3]
+            sample_stds_raw = y_var.sqrt()  # [B, 1, 3]
+            clamp_vals = torch.where(
+                is_tandem[:, None, None].expand_as(sample_stds_raw),
+                tandem_clamps[None, None, :].expand_as(sample_stds_raw),
+                channel_clamps[None, None, :].expand_as(sample_stds_raw),
+            )
+            sample_stds = torch.maximum(sample_stds_raw, clamp_vals)
             y_norm = y_norm / sample_stds
+        else:
+            sample_stds = torch.ones(B, 1, 3, device=device)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
@@ -905,15 +913,21 @@ for epoch in range(MAX_EPOCHS):
                 raw_gap = x[:, 0, 21]
                 is_tandem = raw_gap.abs() > 0.5
                 B = y_norm.shape[0]
-                sample_stds = torch.ones(B, 1, 3, device=device)
                 channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
                 tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
-                for b in range(B):
-                    valid = mask[b]
-                    if is_tandem[b]:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
-                    else:
-                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+                mask_f = mask.float().unsqueeze(-1)  # [B, N, 1]
+                n_valid = mask_f.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1, 1]
+                y_mean = (y_norm * mask_f).sum(dim=1, keepdim=True) / n_valid  # [B, 1, 3]
+                y_centered = (y_norm - y_mean) * mask_f  # [B, N, 3]
+                n_bessel = (n_valid - 1).clamp(min=1)  # Bessel correction (matches .std())
+                y_var = (y_centered ** 2).sum(dim=1, keepdim=True) / n_bessel  # [B, 1, 3]
+                sample_stds_raw = y_var.sqrt()  # [B, 1, 3]
+                clamp_vals = torch.where(
+                    is_tandem[:, None, None].expand_as(sample_stds_raw),
+                    tandem_clamps[None, None, :].expand_as(sample_stds_raw),
+                    channel_clamps[None, None, :].expand_as(sample_stds_raw),
+                )
+                sample_stds = torch.maximum(sample_stds_raw, clamp_vals)
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
Python for-loop for per-sample std (~lines 691-697) wastes time. Vectorize with masked tensor ops for 1-2 extra epochs.
## Instructions
Replace the for-loop with vectorized masked std computation. Must produce IDENTICAL numerical output. Apply to both train (691-697) and val (911-916) loops. Run with `--wandb_group vectorize-std`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** dseo3qo4
**Epochs:** 59 (30-min timeout)
**Epoch time:** ~30s/epoch (vs ~28s baseline — marginally slower)

| Split | val/loss | Surf MAE (Ux/Uy/p) | Vol MAE (Ux/Uy/p) |
|-------|----------|---------------------|---------------------|
| in_dist | 0.580 | 4.98 / 1.56 / 17.26 | 1.07 / 0.35 / 18.16 |
| ood_cond | 0.697 | 3.45 / 1.01 / 13.74 | 0.70 / 0.26 / 11.81 |
| ood_re | 0.545 | 3.02 / 0.89 / 27.56 | 0.81 / 0.36 / 46.59 |
| tandem | 1.594 | 5.27 / 2.03 / 37.57 | 1.87 / 0.85 / 36.59 |
| **overall** | **0.8456** | — | — |

**vs baseline:** val_loss=0.8456 vs 0.8477 (-0.25%), tan surf_p=37.57 vs 37.72 (-0.4%), ood_c surf_p=13.74 vs 13.77 (-0.2%) — essentially identical to baseline.

**What happened:** The vectorized implementation is numerically faithful (Bessel correction ÷(n-1) matches PyTorch's `.std()`). Results match baseline within run-to-run variance. However, no speedup was achieved: epoch time is ~30s vs ~28s in the baseline (marginally slower). The for-loop was fast enough on GPU (batch_size=4, ~1000-3000 nodes/sample), and the vectorized ops add overhead from additional tensor allocations. No extra epochs were gained.

The change is neutral-to-positive for code quality: removes the Python for-loop and handles mixed tandem/non-tandem per-sample correctly in a single vectorized pass.

**Suggested follow-ups:**
- Per-epoch time is dominated by PCGrad and model forward/backward, not the std normalization; speedups need to target those bottlenecks
- At larger batch sizes the vectorized version should be meaningfully faster