### PR TITLE
Huber loss on surface pressure only (delta=0.5)

### DIFF
--- a/train.py
+++ b/train.py
@@ -708,6 +708,12 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
+        # Huber loss on surface pressure only (delta=0.5): L2 for small errors, L1 for large
+        huber_err = torch.where(
+            abs_err[:, :, 2:3] < 0.5,
+            0.5 * (pred - y_norm)[:, :, 2:3] ** 2,
+            0.5 * (abs_err[:, :, 2:3] - 0.25),
+        )
         if epoch < 10:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
@@ -731,7 +737,7 @@ for epoch in range(MAX_EPOCHS):
 
         vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_per_sample = (huber_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -745,7 +751,7 @@ for epoch in range(MAX_EPOCHS):
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            surf_per_sample = (huber_err * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis
At val_loss=0.8477, errors are small and Gaussian-like. Huber's L2 near zero gives smoother gradients than L1 for small errors, with L1 robustness for outliers. Never tested at this performance level.
## Instructions
Replace surface pressure abs_err with Huber: `huber_err = torch.where(abs_err[:,:,2:3] < 0.5, 0.5*(pred-y_norm)[:,:,2:3]**2, 0.5*(abs_err[:,:,2:3] - 0.25))`. Use in place of `abs_err[:,:,2:3]` for surface loss only. Volume stays L1. Run with `--wandb_group huber-surf-05`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** `kej7jpgh` | Best epoch: 58 | Peak memory: ~18 GB

| Split | val_loss | mae_surf_p | Δ surf_p vs baseline |
|-------|----------|------------|----------------------|
| val_in_dist | 0.6802 | 21.5 | +21.2% worse |
| val_ood_cond | 0.8024 | 16.6 | +20.5% worse |
| val_ood_re | 0.6194 | 29.7 | +7.9% worse |
| val_tandem_transfer | 1.6908 | 40.8 | +8.2% worse |
| **combined** | **0.9482** | — | **+11.9% worse** |

### What happened

Strongly negative. Huber loss degraded all splits significantly, with in-dist and ood_cond showing ~20% worse surface pressure MAE.

Three contributing factors:

1. **Training-validation mismatch**: The validation metric is L1-based (mae_surf_p), but training with Huber (effectively L2 for small errors) optimizes a different objective. Near-zero errors get very weak gradient signals from Huber, causing worse L1 performance at validation time.

2. **Adaptive surf_weight disruption**: The `prev_surf_loss` and `surf_weight` mechanism uses the training-time surface loss to compute the adaptive weight ratio. With Huber, `prev_surf_loss` values are substantially smaller (since Huber is ~0 for small errors, not the L1 value). This makes `surf_weight = vol_loss / surf_loss` grow larger, potentially overshooting and destabilizing the training balance between volume and surface.

3. **Hard-node mining interference**: The hard-node mining threshold is computed from L1 abs_err (identifying nodes above median error), but the actual loss uses Huber values. For the hardest nodes (large errors), Huber still gives ~L1 signal, so this is less of a problem — but for nodes with errors just above 0.5, the transition from L2 to L1 creates a kink that may confuse gradient flow.

### Suggested follow-ups

- If Huber is desired, it should be applied consistently to the validation metric too, or used with a larger delta that keeps more L1 behavior (delta=2.0 would mean L2 only for errors < 2.0, which at these error levels is essentially always L1).
- The simpler approach: don't change the loss function. The current L1 is well-calibrated to what we measure.