### PR TITLE
PCGrad tandem-only as OOD group (retune grouping)

### DIFF
--- a/train.py
+++ b/train.py
@@ -786,7 +786,7 @@ for epoch in range(MAX_EPOCHS):
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
+        is_ood_pcgrad = is_tandem_batch
         is_indist_pcgrad = ~is_ood_pcgrad
         use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
 


### PR DESCRIPTION
## Hypothesis
PCGrad grouping hasn't been retested since dist_feat+lr changes. Making OOD=tandem-only concentrates gradient surgery on the most conflicting split.

## Instructions
Line 789: change `is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)` to `is_ood_pcgrad = is_tandem_batch`. One line. Run with `--wandb_group pcgrad-tandem-only`.

## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---

## Results

**W&B run:** oa43oy1l
**Epochs:** 59 (killed by 30-min timeout, normal)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 0.5759 | 4.769 | 1.714 | **17.27** | 1.068 | 0.362 | 18.58 |
| ood_cond | 0.7203 | 2.785 | 1.025 | **14.39** | 0.734 | 0.277 | 12.42 |
| ood_re | 0.5513 | 2.280 | 0.845 | **27.88** | 0.846 | 0.368 | 47.13 |
| tandem | 1.6871 | 5.532 | 2.227 | **40.22** | 1.925 | 0.874 | 39.13 |
| **combined** | **0.8836** | - | - | - | - | - | - |

**mean3 (in+ood_c+tan)/3 surf_p: 23.96** (baseline 23.08, +3.8% worse)

vs Baseline:
- val/loss: 0.8836 vs 0.8477 — 4.2% worse
- in_dist surf_p: 17.27 vs 17.74 — **2.7% better**
- ood_cond surf_p: 14.39 vs 13.77 — 4.5% worse
- ood_re surf_p: 27.88 vs 27.52 — 1.3% worse
- tandem surf_p: 40.22 vs 37.72 — 6.6% worse

### What happened

**Modest regression.** Narrowing PCGrad's OOD group to tandem-only slightly improved in-distribution performance (+2.7% surf_p) but hurt tandem transfer the most (−6.6% surf_p), with small regressions on ood_cond and ood_re. Net result: mean3 increases from 23.08 to 23.96.

The original broader PCGrad grouping (tandem | extreme-Re | extreme-AoA) appears better calibrated for this dataset. Including high-Re and high-AoA samples in the OOD group provided useful gradient deconfliction that kept the tandem performance higher — suggesting the conflicts between in-dist and tandem share overlap with conflicts involving extreme conditioning cases.

The result suggests PCGrad is most useful when the OOD group captures the full range of conflicting gradients, not just the most obvious subgroup. Tandem cases alone may not provide enough gradient diversity to fully protect in-dist learning.

### Suggested follow-ups

- The in_dist improvement hints that tandem-only PCGrad does help protect the in-dist gradient. Could try the reverse grouping: PCGrad between tandem vs (extreme-Re | extreme-AoA), keeping in-dist unlabeled — focuses surgery on the OOD-vs-OOD conflict
- Alternatively, try three-way PCGrad: in-dist vs tandem vs extreme-Re+AoA groups, projecting each pair's conflicting gradients
- The vol_p for ood_re is very high (47.1) and anomalous — possibly related to the tandem-only grouping leaving extreme-Re samples in neither group cleanly