### PR TITLE
LR 2.55e-3 (micro-step between 2.5 and 2.6)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 2.55e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
2.5e-3 and 2.6e-3 both worked. The optimal LR may be between them.
## Instructions
Change `lr = 2.6e-3` to `lr = 2.55e-3`. One line. Run with `--wandb_group lr-255e4`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run**: 3t9jgdbz
**Best epoch**: 58 (31.9 min, wall-clock limit)
**VRAM**: ~18 GB (same as baseline)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5981 | 6.02 | 1.99 | **18.26** | 1.11 | 0.37 | 20.16 |
| val_ood_cond | 0.7060 | 3.31 | 1.30 | **14.35** | 0.72 | 0.27 | 12.28 |
| val_ood_re | 0.5477 | 2.92 | 1.13 | **27.79** | 0.82 | 0.36 | 46.95 |
| val_tandem_transfer | 1.6208 | 5.70 | 2.53 | **38.11** | 1.94 | 0.86 | 37.34 |
| **combined** | **0.8681** | | | | | | |

**mean3 (in/ood/tan p)**: (18.26 + 14.35 + 38.11) / 3 = **23.57** vs baseline 23.08 → **+0.49, negative result**

### What happened

LR 2.55e-3 is uniformly slightly worse than the 2.6e-3 baseline. All splits degraded:
- in_dist p: 18.26 vs 17.74 (+0.52)
- ood_cond p: 14.35 vs 13.77 (+0.58)
- ood_re p: 27.79 vs 27.52 (+0.27)
- tandem p: 38.11 vs 37.72 (+0.39)

The hypothesis that 2.55e-3 might be optimal between 2.5e-3 and 2.6e-3 was incorrect. The slightly lower peak LR results in marginally slower convergence, and over the fixed 30-minute training budget this translates to slightly lower performance at best_epoch (~58 in both cases). The difference is small (+0.49 mean3) but consistent across all splits, suggesting that 2.6e-3 is the better choice.

The LR sensitivity in this range is very low — the difference between 2.55e-3 and 2.6e-3 is only ~2%. This experiment suggests we're already near a local optimum at 2.6e-3 and pushing lower doesn't help.

### Suggested follow-ups

1. **LR 2.65e-3**: Try going slightly higher instead of lower. If the boundary is above 2.6e-3, a small increase might help.
2. **LR sweep with longer training**: The optimal LR may shift with training duration. With 60+ epochs, a higher LR might converge faster and achieve better performance.