### PR TITLE
LR 2.65e-3 (upper micro-step)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 2.65e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
Test whether 2.65e-3 is better than 2.6e-3 — a finer grid between 2.6 and 2.7 (which was too high).
## Instructions
Change `lr = 2.6e-3` to `lr = 2.65e-3`. One line. Run with `--wandb_group lr-265e4`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B Run:** 0mj4a1zo
**Best epoch:** 61

### Metrics vs Baseline

| Split | val_loss | surf_p |
|-------|----------|--------|
| val_in_dist | 0.5918 | 17.90 |
| val_ood_cond | 0.6945 | 13.60 |
| val_ood_re | 0.5319 | 27.70 |
| val_tandem_transfer | 1.6579 | 39.60 |
| **combined** | **0.8690** | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8477 | 0.8690 | +0.0213 ↑ worse |
| in surf_p | 17.74 | 17.90 | +0.16 (noise) |
| ood_c surf_p | 13.77 | 13.60 | -0.17 (noise) |
| ood_r surf_p | 27.52 | 27.70 | +0.18 (noise) |
| tan surf_p | 37.72 | 39.60 | +1.88 ↑ worse |
| mean3 surf_p | 19.68 | 19.73 | +0.05 (noise) |

**Peak memory:** ~17.5 GB (identical)

### What happened

Negative result. LR=2.65e-3 is meaningfully worse than 2.6e-3 (+0.021 val/loss, beyond noise floor). The degradation is driven primarily by tandem (+1.88 surf_p); non-tandem metrics are essentially noise. This is the same pattern seen when trying even higher LRs.

The val/loss jump of +0.021 from a 2% increase in LR (2.6→2.65) suggests we are already near the right boundary — the model overshoots for tandem samples at this slightly elevated rate. This is consistent with prior experiments showing LR sensitivity: 2.5e-3 was slightly below optimum and 2.6e-3 appears to be at or near the peak.

### Suggested follow-ups

- 2.6e-3 appears to be the optimum for this architecture. No further micro-stepping seems warranted
- The tandem sensitivity to LR suggests tandem representations are learned last and most fragile — they may benefit from a dedicated lower LR or later start in training