### PR TITLE
EMA start epoch 38 (5% more averaging at lr=2.6e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 38
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
EMA at ep35 failed, ep40 is current, ep42 failed. ep38 is untested — gives 20 vs 18 EMA updates (11% more).
## Instructions
Change `ema_start_epoch = 40` to `ema_start_epoch = 38`. One line. Run with `--wandb_group ema-ep38-dist`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run:** uyg17vkp

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6138 | 6.50 | 2.03 | 18.66 | 1.11 | 0.36 | 19.78 |
| val_ood_cond | 0.7126 | 3.90 | 1.24 | 14.36 | 0.73 | 0.27 | 12.18 |
| val_ood_re | 0.5573 | 3.64 | 1.11 | 28.12 | 0.84 | 0.37 | 47.12 |
| val_tandem_transfer | 1.6483 | 6.55 | 2.47 | 39.15 | 1.93 | 0.87 | 38.73 |
| **val_loss (best)** | **0.8830** | | | | | | |

**mean3_p** (in+ood_c+tan)/3 = (18.66+14.36+39.15)/3 = **24.06**

**vs baseline:** val_loss +0.0353 (+4.2%), mean3_p +0.98 (+4.2%) — **worse**

### What happened

EMA starting at epoch 38 instead of 40 is clearly worse across all splits. Starting 2 epochs earlier means the EMA absorbs model states from a higher-LR phase (cosine LR has dropped to ~2.0e-3 at ep38 vs ~1.8e-3 at ep40), so the averaged weights include noisier early-phase states. Combined with ep42 also being worse (+slight), the ep40 sweet spot seems well-calibrated.

The tandem transfer split is most affected (39.15 vs 37.72 baseline, +1.43), suggesting the early EMA is especially harmful for distribution generalization.

### Suggested follow-ups

- EMA decay itself: try 0.999 vs 0.998 (slower averaging captures less noise per step)
- EMA stop epoch: try stopping EMA updates earlier (e.g., keep ep40 start but stop at ep58 instead of last epoch) to freeze the averaged model before final noisy updates