### PR TITLE
Lookahead alpha=0.6 (gentler slow-weight sync)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,7 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=10, alpha=0.6)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
alpha=0.8 means slow weights jump 80% toward fast. With PCGrad noise + lr=2.6e-3, gentler alpha=0.6 keeps slow weights more stable. Never tuned below 0.8.
## Instructions
Change `alpha=0.8` to `alpha=0.6` on line 579. One line. Run with `--wandb_group lookahead-alpha06`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run ID:** klkmbjkd  
**Best epoch:** 61 (wall-clock timeout at 30.1 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8755** | 0.8477 |
| val_in_dist | 0.6099 | — |
| val_tandem_transfer | 1.6519 | — |
| val_ood_cond | 0.6799 | — |
| val_ood_re | 0.5605 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 6.02 | 2.23 | 18.63 | 17.74 | +5.0% |
| val_tandem_transfer | 6.17 | 2.74 | 38.58 | 37.72 | +2.3% |
| val_ood_cond | 3.64 | 1.39 | **13.37** | 13.77 | **-2.9%** |
| val_ood_re | 3.43 | 1.25 | 28.20 | 27.52 | +2.5% |

**mean3 surf_p** = (18.63 + 13.37 + 38.58) / 3 = **23.53** (baseline: 23.01, delta: +2.3%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.12 | 0.37 | 20.39 |
| val_tandem_transfer | 1.94 | 0.87 | 38.23 |
| val_ood_cond | 0.73 | 0.28 | 12.13 |
| val_ood_re | 0.85 | 0.37 | 47.33 |

---

### What happened

**Negative result.** val/loss = 0.8755 vs baseline 0.8477 (+3.3% worse). mean3 surf_p = 23.53 vs 23.01 (+2.3% worse).

Most splits degraded: val_in_dist (+5.0%), val_ood_re (+2.5%), val_tandem_transfer (+2.3%). Only val_ood_cond improved (-2.9%), which is consistent with many recent experiments showing this split is most responsive to architectural changes.

The gentler alpha=0.6 means the slow weights advance only 60% toward the fast weights at each sync step (vs 80% at alpha=0.8). This makes the slow weights lag further behind the fast weights rather than stabilizing them — the net effect is that the slow weights are a more outdated snapshot of training, reducing the benefit of the Lookahead step. At alpha=0.8, the synchronization already provides good momentum; going to 0.6 loses useful gradient signal without providing meaningful additional stability.

*Visualization crash* (same as PR #1457): `mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x58)` in `feature_cross` during post-training visualization. Training metrics are unaffected.

---

### Suggested follow-ups

- **Try alpha=0.9**: Go the other direction — more aggressive sync. With lr=2.6e-3 and PCGrad, faster synchronization might help the slow weights track better and converge sooner within the 30-min budget.
- **Reduce k to 5**: Instead of changing alpha, double the sync frequency (k=5 steps). More frequent updates at alpha=0.8 could provide similar stability to alpha=0.6 with more responsiveness.
- **Lookahead ablation**: Remove Lookahead entirely (just use AdamW with PCGrad) for one run to measure its actual contribution. If the baseline already has Lookahead, we've never measured its true benefit vs. the added complexity.
