### PR TITLE
Tandem curriculum: skip tandem for first 15 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -708,7 +708,7 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
+        if epoch < 15:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask


### PR DESCRIPTION
## Hypothesis
Extending the tandem-free warmup from 10 to 15 epochs gives 26% more single-foil-only training. The model builds stronger in_dist representations before encountering tandem complexity.
## Instructions
Change the tandem curriculum threshold from `epoch < 10` to `epoch < 15`. One line. Run with `--wandb_group tandem-curriculum-15`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** hk4t073c
**Runtime:** 1919s (30-min timeout)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.8913 | +5.1% worse |
| val_in_dist | 17.74 | ~24.1 (surf_p=18.65, Ux=4.47, Uy=1.48) | worse |
| val_ood_cond | 13.77 | ~18.5 (surf_p=14.47, Ux=3.06, Uy=0.97) | worse |
| val_ood_re | 27.52 | ~31.5 (surf_p=28.03, Ux=2.64, Uy=0.81) | worse |
| val_tandem | 37.72 | ~47.7 (surf_p=40.35, Ux=5.32, Uy=2.07) | worse |

Detailed metrics (Surface MAE):
- in_dist: surf_p=18.648, surf_Ux=4.473, surf_Uy=1.481, vol_Ux=1.103, vol_Uy=0.365, vol_p=19.506
- ood_cond: surf_p=14.473, surf_Ux=3.058, surf_Uy=0.967, vol_Ux=0.722, vol_Uy=0.278, vol_p=12.394
- ood_re: surf_p=28.033, surf_Ux=2.643, surf_Uy=0.807, vol_Ux=0.829, vol_Uy=0.365, vol_p=46.932
- tandem: surf_p=40.351, surf_Ux=5.322, surf_Uy=2.072, vol_Ux=1.946, vol_Uy=0.891, vol_p=39.239

**What happened:** Extending the tandem warmup from 10 to 15 epochs made things worse across all splits, including tandem itself (+26% worse on tandem vs baseline). The model doesn't converge as well when tandem samples are withheld even longer — likely because 30 minutes isn't enough time for the model to recover and learn tandem representations after the extended warmup period ends. With a longer run, the extra single-foil-only training might pay off, but within the 30-min budget the delayed tandem exposure simply means fewer epochs of joint training.

**Suggested follow-ups:**
- Try a shorter warmup (epoch < 5) to see if less warmup actually helps by giving more joint training time
- Alternatively, rather than a hard threshold, try a soft curriculum: gradually ramp up tandem sample weight over the first N epochs