### PR TITLE
Volume loss: 2x weight on pressure channel

### DIFF
--- a/train.py
+++ b/train.py
@@ -729,7 +729,8 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        vol_weights = torch.tensor([1.0, 1.0, 2.0], device=device)
+        vol_loss = (abs_err * vol_weights * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss


### PR DESCRIPTION
## Hypothesis
Surface pressure is the key metric. Volume pressure directly determines surface pressure via boundary layer. Upweighting pressure 2x in vol loss directs more learning capacity there.
## Instructions
In vol_loss computation, multiply pressure channel by 2: `vol_weights = torch.tensor([1.0, 1.0, 2.0], device=device); vol_loss = (abs_err * vol_weights * vol_mask_train.unsqueeze(-1)).sum() / ...`. Run with `--wandb_group vol-pres-2x`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `ut49wamw`
**Epochs:** 61 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.6055 | 5.51 | 1.68 | 18.00 | 1.10 | 0.36 | 18.33 |
| ood_cond | 0.7013 | 3.07 | 0.99 | 14.22 | 0.73 | 0.28 | 11.29 |
| ood_re | 0.5342 | 2.66 | 0.82 | 27.53 | 0.83 | 0.36 | 46.40 |
| tandem | 1.6189 | 6.06 | 2.15 | 38.77 | 1.93 | 0.88 | 37.33 |
| **combined** | **0.8650** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (18.00 + 14.22 + 38.77) / 3 = **23.66**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.8650 | +2.0% |
| surf_p in_dist | 17.74 | 18.00 | +1.5% |
| surf_p ood_cond | 13.77 | 14.22 | +3.3% |
| surf_p ood_re | 27.52 | 27.53 | flat |
| surf_p tandem | 37.72 | 38.77 | +2.8% |
| surf_p mean3 | 23.08 | 23.66 | +2.5% |

### What happened

Neutral-to-negative result. 2x pressure weighting in vol_loss slightly worsened all splits except ood_re (flat). The hypothesis that volume pressure guidance would improve surface pressure predictions did not materialize.

**Why it likely failed:**

The adaptive surface weight (`surf_weight = prev_vol_loss / prev_surf_loss`) automatically re-balances. With 2x vol pressure, `prev_vol_loss` increases, which pushes `surf_weight` higher. This inadvertently amplifies the surf loss signal relative to what was intended, potentially over-constraining the training dynamics and hurting generalization.

Additionally, the surface pressure metric is computed as MAE on surface nodes, not volume nodes. The link between volume pressure accuracy and surface pressure accuracy may be indirect enough that 2x volume weighting doesn't translate into surface improvement.

### Suggested follow-ups

- Upweight pressure in the *surface* loss directly (`surf_pres = abs_err[:, :, 2:3]` is already separated — weight it more)
- Try a per-channel weighting in `surf_loss` instead of `vol_loss` (e.g. surf_weights=[1, 1, 2])
- Decouple adaptive weight from the pressure-weighted vol_loss to avoid the amplification feedback
