### PR TITLE
Coarse pooling group size 128 (capture larger flow patterns)

### DIFF
--- a/train.py
+++ b/train.py
@@ -753,7 +753,7 @@ for epoch in range(MAX_EPOCHS):
 
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None
-        coarse_pool_size = 64
+        coarse_pool_size = 128
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:


### PR DESCRIPTION
## Hypothesis
Coarse pooling groups of 64 nodes. Doubling to 128 captures larger-scale patterns (wake regions, stagnation). Never tested.
## Instructions
Change `coarse_pool_size = 64` to `coarse_pool_size = 128`. One line. Run with `--wandb_group coarse-128`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `4m2c2uk5`

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in-dist | 0.5927 | 9.67 | 2.58 | 17.76 | 1.13 | 0.37 | 19.01 |
| ood-cond | 0.7368 | 6.95 | 1.92 | 14.70 | 0.75 | 0.29 | 12.46 |
| ood-re | 0.5664 | 6.52 | 1.71 | 28.03 | 0.87 | 0.38 | 47.01 |
| tandem | 1.6641 | 8.48 | 2.89 | 39.73 | 1.98 | 0.89 | 39.07 |
| **combined** | **0.8900** | — | — | — | — | — | — |

**vs baseline:** val/loss 0.8900 vs 0.8477 (+0.042 worse)

Surface pressure (most important):
- in-dist: 17.76 vs 17.74 (neutral, +0.02)
- ood-cond: 14.70 vs 13.77 (+0.93 worse)
- ood-re: 28.03 vs 27.52 (+0.51 worse)
- tandem: 39.73 vs 37.72 (+2.01 worse)

**Peak GPU memory:** not logged

**What happened:** Negative result. Larger coarse pool groups (128 vs 64) hurt across all splits. The coarse pooling loss provides a regularization signal by encouraging the model to get spatially-averaged predictions right — but groups of 128 average over too large a region, losing the spatial resolution needed to distinguish localized flow features like leading-edge stagnation or trailing-edge separation. At 64 nodes the groups are large enough to catch large-scale coherence while still preserving enough locality. The tandem transfer hurt most (+2.01 Pa surf_p), likely because tandem flows have strong inter-airfoil interaction gradients that require finer spatial discrimination.

**Suggested follow-ups:**
- Try coarse_pool_size=32 to see if smaller (finer) groups help, or if 64 is already at the sweet spot
- Try adaptive pool size: use 32 for tandem samples and 64 for single-foil (tandem flows have sharper spatial gradients)