### PR TITLE
Combo: PCGrad tandem-only + Lookahead alpha=0.6 (in_dist + ood_cond synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,7 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=10, alpha=0.6)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
@@ -786,7 +786,7 @@ for epoch in range(MAX_EPOCHS):
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
+        is_ood_pcgrad = is_tandem_batch
         is_indist_pcgrad = ~is_ood_pcgrad
         use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
 


### PR DESCRIPTION
## Hypothesis
Two experiments each improved a different split: PCGrad tandem-only (#1557) improved in_dist surf_p from 17.74 to 17.27 (-2.7%), and Lookahead alpha=0.6 (#1562) improved ood_cond from 13.77 to 13.37 (-2.9%). These changes are orthogonal — PCGrad grouping affects gradient surgery while Lookahead alpha affects slow-weight synchronization. If the improvements compound, we could see simultaneous gains on both in_dist and ood_cond, which may push the combined val_loss below 0.8477.

**Key arithmetic:** If we get in_dist=17.27 and ood_cond=13.37 while holding ood_re and tandem at baseline, the mean3 surf_p drops from 23.08 to 22.79 (-1.3%).

## Instructions
Make exactly two changes to `train.py`:

1. **Line 789:** Change PCGrad grouping to tandem-only:
   ```python
   # OLD:
   is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
   # NEW:
   is_ood_pcgrad = is_tandem_batch
   ```

2. **Line 579:** Change Lookahead alpha from 0.8 to 0.6:
   ```python
   # OLD:
   optimizer = Lookahead(base_opt, k=10, alpha=0.8)
   # NEW:
   optimizer = Lookahead(base_opt, k=10, alpha=0.6)
   ```

Run with `--wandb_group combo-pcgrad-tandem-la06`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run**: 0cuqom2k
**Best epoch**: 58 (31.9 min, wall-clock limit)
**VRAM**: ~18 GB (same as baseline)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5895 | 4.60 | 1.83 | **17.88** | 1.08 | 0.36 | 19.01 |
| val_ood_cond | 0.7522 | 2.78 | 1.14 | **14.82** | 0.74 | 0.29 | 12.75 |
| val_ood_re | 0.5627 | 2.60 | 1.05 | **28.18** | 0.84 | 0.37 | 46.91 |
| val_tandem_transfer | 1.6492 | 4.97 | 2.15 | **40.34** | 1.96 | 0.89 | 39.21 |
| **combined** | **0.8884** | | | | | | |

**mean3 (in/ood/tan p)**: (17.88 + 14.82 + 40.34) / 3 = **24.35** vs baseline 23.08 → **+1.27, negative result**

### What happened

The combination is worse than either component alone AND worse than baseline. Notably:
- in_dist p: 17.88 vs 17.74 (+0.14) — barely changed, the expected in_dist gain from PCGrad tandem-only did not materialize
- ood_cond p: 14.82 vs 13.77 (+1.05) — the expected ood_cond gain from Lookahead alpha=0.6 reversed
- ood_re p: 28.18 vs 27.52 (+0.66) — degraded
- tandem p: 40.34 vs 37.72 (+2.62) — severe degradation

The hypothesis that improvements from independent experiments would compound was incorrect. The two changes interact negatively. Two mechanisms likely explain this:

1. **Lookahead alpha=0.6 destabilizes PCGrad**: PCGrad applies gradient projection to prevent one group's gradients from conflicting with the other. With Lookahead alpha=0.6, the slow weights lag further behind the fast weights (60% pull vs 80%). This means PCGrad is operating on a faster-changing effective parameter space, amplifying the instability of the gradient surgery. The result is that neither the tandem-specific PCGrad grouping nor the faster Lookahead synchronization works as intended.

2. **Tandem-only PCGrad becomes too aggressive**: When PCGrad's Group B only includes tandem samples (not extreme-Re/AoA), the gradient surgery may become sharper — there are fewer Group B samples, so each tandem sample's gradient gets more correction. Combined with alpha=0.6 Lookahead, the tandem-specific signal gets over-corrected, explaining the severe tandem degradation (+2.62).

### Suggested follow-ups

1. **PCGrad tandem-only without Lookahead change**: If #1557 showed in_dist improvements, test it with the original alpha=0.8 in isolation. The combo destroyed the ood_cond gain.
2. **Lookahead alpha=0.6 without PCGrad change**: Similarly, test alpha=0.6 with the original PCGrad grouping.