### PR TITLE
Combo: Disable noise + Lookahead alpha=0.6 (regularization trade + ood_cond gain)

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,7 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=10, alpha=0.6)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
@@ -667,18 +667,9 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
Disabling noise (#1560) achieved val_loss=0.8573 — the closest near-miss to baseline. It improved in_dist vol metrics and was only +0.010 from baseline. Lookahead alpha=0.6 (#1562) achieved best-ever ood_cond=13.37. The theory: noise removal frees the model from unnecessary regularization (we already have PCGrad + EMA + Lookahead), while gentler Lookahead compensates by providing more stable slow-weight convergence. The two changes operate on different axes: noise affects input/target signal quality, alpha affects optimizer dynamics.

## Instructions
Make these changes to `train.py`:

1. **Lines 670-672:** Remove input noise:
   ```python
   # COMMENT OUT or DELETE these 3 lines:
   # if model.training and epoch < 60:
   #     noise_scale = 0.05 * (1 - epoch / 60)
   #     x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
   ```

2. **Lines 677-681:** Remove target noise:
   ```python
   # COMMENT OUT or DELETE these 5 lines:
   # if model.training:
   #     noise_progress = min(1.0, epoch / 60)
   #     vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
   #     p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
   #     noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
   #     y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
   ```

3. **Line 579:** Change Lookahead alpha from 0.8 to 0.6:
   ```python
   optimizer = Lookahead(base_opt, k=10, alpha=0.6)
   ```

Run with `--wandb_group combo-nonoise-la06`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** afnzvb8m  (runtime: 31.7 min, state: failed due to pre-existing vis crash)

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6119 | 6.07 | 2.06 | 18.71 | 1.12 | 0.37 | 19.94 |
| val_ood_cond | 0.7225 | 4.01 | 1.48 | 14.47 | 0.74 | 0.28 | 12.28 |
| val_ood_re | 0.5645 | 3.82 | 1.35 | 28.20 | 0.84 | 0.37 | 47.00 |
| val_tandem_transfer | 1.6425 | 6.34 | 2.64 | 39.05 | 1.98 | 0.88 | 38.70 |
| **val_loss (best)** | **0.8853** | | | | | | |

**mean3_p** = (18.71+14.47+39.05)/3 = **24.08**

**vs baseline:** val_loss +0.0376 (+4.4%), mean3_p +1.00 (+4.3%) — **worse**

### What happened

The combination is worse than both individual changes. No-noise alone was 0.8573 and lookahead-0.6 alone reportedly hit ood_cond=13.37, but together they reach val_loss=0.8853 — worse than each component independently.

The likely mechanism: noise acts as implicit regularization that stabilizes lookahead's slow-weight averaging. Without noise, the fast weights explore a sharper loss landscape, and the lookahead slow weights (which average over k=10 fast steps with alpha=0.6 pull) may not converge to a good flat minimum. With noise, there's implicit smoothing that keeps fast-weight trajectories more predictable and benefits from the lookahead sync. When both noise and the noise-compensating alpha are removed, neither mechanism is present.

The ood_cond result (14.47) is notably worse than the standalone lookahead-0.6 result (13.37), confirming the interaction is negative.

### Suggested follow-ups

- Try the reverse combo: keep noise but use alpha=0.6 (i.e., just the lookahead change alone)
- Or try no-noise with alpha=0.8 (the original) to confirm no-noise alone still gives 0.8573