### PR TITLE
Combo: Lookahead alpha=0.6 + zone-aware spatial bias (ood_cond synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(4, 64), nn.GELU(),
+            nn.Linear(5, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -377,7 +377,9 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        saf_magnitude = x[:, :, 2:4].norm(dim=-1, keepdim=True)
+        zone_proxy = torch.log1p(saf_magnitude)
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], zone_proxy], dim=-1)  # x, y, curv, dist, zone
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
@@ -576,7 +578,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=10, alpha=0.6)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
PCGrad grouping hasn't been retested since dist_feat+lr changes. Making OOD=tandem-only concentrates gradient surgery on the most conflicting split.
Two previously successful improvements:
1. Lookahead alpha=0.6 achieved best-ever ood_cond=13.37 (-2.9%)
2. Zone-aware spatial bias independently improved ood_cond to 13.56 (-1.5%) at val_loss=0.8556

If both ood_cond improvements compound, we expect ood_cond ~12.9-13.1.

## Instructions
1. Change Lookahead alpha from 0.8 to 0.6 (line 579)
2. Expand spatial_bias MLP input from 4 to 5 dims (line 213)
3. In Transolver.forward, add zone_proxy feature (line 380)
Run with `--wandb_group combo-la06-zone`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** rv09lcv9
**Epochs:** 58 (killed by 30-min timeout, normal)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 0.5990 | 6.493 | 1.952 | **18.07** | 1.128 | 0.370 | 19.74 |
| ood_cond | 0.7064 | 4.407 | 1.216 | **14.23** | 0.735 | 0.278 | 12.45 |
| ood_re | 0.5543 | 3.967 | 1.047 | **27.98** | 0.848 | 0.369 | 47.03 |
| tandem | 1.6617 | 6.357 | 2.591 | **39.67** | 2.001 | 0.889 | 39.30 |
| **combined** | **0.8803** | - | - | - | - | - | - |

**mean3 (in+ood_c+tan)/3 surf_p: 23.99** (baseline 23.08, +3.9% worse)

vs Baseline:
- val/loss: 0.8803 vs 0.8477 — 3.8% worse
- in_dist surf_p: 18.07 vs 17.74 — 1.9% worse
- ood_cond surf_p: 14.23 vs 13.77 — 3.3% worse (expected ~12.9-13.1)
- ood_re surf_p: 27.98 vs 27.52 — 1.7% worse
- tandem surf_p: 39.67 vs 37.72 — 5.2% worse

### What happened

**The combination did not compound.** The expected ood_cond improvement to ~12.9-13.1 did not materialize; instead we got 14.23, which is worse than both individual experiments (lookahead-alpha06 alone: 13.37, zone-aware alone: 13.56) and worse than baseline (13.77).

The combination is uniformly worse than baseline across all splits. This suggests negative interaction between the two modifications rather than additive improvement.

Likely causes:

1. **Lookahead alpha=0.6 changes the optimization trajectory**: With slower moving of slow weights, the zone-aware spatial bias MLP gets fewer effective gradient updates through the Lookahead steps. Zone learning may require more gradient momentum than alpha=0.6 provides.

2. **Zone feature interferes with existing spatial routing**: The `zone_proxy = log1p(||SAF||)` feature encodes proximity to the surface via the SAF (surface attachment force?) magnitude. This overlaps with the existing `dist_surf` feature (x[:, :, 24]) already present in raw_xy. Two correlated features may create degenerate routing in the attention bias, hurting rather than helping.

3. **Single-run variance**: Both individual experiments showed modest gains (~1-3%). At this scale, single-run variance makes compounding effects hard to confirm. A different random seed might show a different outcome.

### Suggested follow-ups

- Test lookahead alpha=0.6 on the current noam branch (which may have changed since the original experiment)
- Test zone-aware spatial bias without lookahead change to confirm it still helps
- If both individually show improvement on the same baseline, try the combo again — the negative interaction here may be run-specific
- Consider using only one of the two changes for the next iteration rather than combining before confirming each independently