### PR TITLE
Combo: PCGrad tandem-only + error-based curriculum (in_dist + ood_re synergy)

### DIFF
--- a/train.py
+++ b/train.py
@@ -784,9 +784,9 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
-        # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
-        # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
+        # PCGrad: in-dist (Group A) vs tandem-only (Group B) gradient projection
+        # Group B = tandem only, Group A = rest (in-dist + OOD cond/Re)
+        is_ood_pcgrad = is_tandem_batch
         is_indist_pcgrad = ~is_ood_pcgrad
         use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
 
@@ -849,6 +849,41 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+
+    # Error-based curriculum: update sampler weights after epoch 25, every 5 epochs
+    if epoch >= 25 and (epoch - 25) % 5 == 0 and not cfg.debug:
+        model.eval()
+        sample_losses = torch.zeros(len(train_ds), device='cpu')
+        with torch.no_grad():
+            for idx in range(len(train_ds)):
+                s_x, s_y, s_is_surf = train_ds[idx]
+                s_x = s_x.unsqueeze(0).to(device)
+                s_y = s_y.unsqueeze(0).to(device)
+                s_mask = torch.ones(1, s_x.shape[1], dtype=torch.bool, device=device)
+                s_x_n = (s_x - stats["x_mean"]) / stats["x_std"]
+                curv = s_x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * s_is_surf.unsqueeze(0).to(device).float().unsqueeze(-1)
+                dist_s = s_x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
+                dist_f = torch.log1p(dist_s * 10.0)
+                s_x_n = torch.cat([s_x_n, curv, dist_f], dim=-1)
+                raw_xy = s_x_n[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                s_x_n = torch.cat([s_x_n, fourier_pe], dim=-1)
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred = model({"x": s_x_n})["preds"].float()
+                loss_i = (pred.squeeze(0) - s_y.to(device)).abs().mean()
+                sample_losses[idx] = loss_i.cpu()
+        # Boost: 1.5x for above-median loss samples
+        median_loss = sample_losses.median()
+        new_weights = torch.where(sample_losses > median_loss, sample_losses * 1.5, sample_losses)
+        new_weights = new_weights / new_weights.sum() * len(train_ds)
+        sampler.weights = new_weights.double()
+        model.train()
+
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)


### PR DESCRIPTION
## Hypothesis
PCGrad tandem-only (#1557) improved in_dist from 17.74 to 17.27. Error-based curriculum (#1549) improved ood_re from 27.52 to 27.38 (best ever for ood_re). The curriculum caused catastrophic in_dist regression because it oversampled tandem — but with PCGrad tandem-only, the tandem gradient is surgically separated. This means the curriculum's oversampling of hard (tandem) samples won't corrupt the in_dist gradient, so both improvements should coexist.

**Critical fix from #1549:** The Re check `x_i[0, 13] > 1.0` activates for ALL samples (log(Re) is always >1). Use the NORMALIZED feature: after z-scoring, check `abs(x_i[0, 13]) > 1.0` which selects genuinely extreme Re samples.

## Instructions
Make these changes to `train.py`:

1. **Line 789:** Change PCGrad grouping to tandem-only:
   ```python
   is_ood_pcgrad = is_tandem_batch
   ```

2. **After epoch 25, boost sampling weights for high-loss samples.** Add after line 848 (end of training batch loop), inside the epoch loop:
   ```python
   # Error-based curriculum: update sampler weights after epoch 25
   if epoch >= 25 and not cfg.debug:
       model.eval()
       sample_losses = torch.zeros(len(train_ds), device='cpu')
       with torch.no_grad():
           for idx in range(len(train_ds)):
               s_x, s_y, s_is_surf = train_ds[idx]
               s_x = s_x.unsqueeze(0).to(device)
               s_y = s_y.unsqueeze(0).to(device)
               s_mask = torch.ones(1, s_x.shape[1], dtype=torch.bool, device=device)
               s_x_n = (s_x - stats["x_mean"]) / stats["x_std"]
               curv = s_x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * s_is_surf.unsqueeze(0).to(device).float().unsqueeze(-1)
               dist_s = s_x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
               dist_f = torch.log1p(dist_s * 10.0)
               s_x_n = torch.cat([s_x_n, curv, dist_f], dim=-1)
               raw_xy = s_x_n[:, :, :2]
               xy_min = raw_xy.amin(dim=1, keepdim=True)
               xy_max = raw_xy.amax(dim=1, keepdim=True)
               xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
               freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
               xy_scaled = xy_norm.unsqueeze(-1) * freqs
               fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
               s_x_n = torch.cat([s_x_n, fourier_pe], dim=-1)
               with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                   pred = model({"x": s_x_n})["preds"].float()
               loss_i = (pred.squeeze(0) - s_y.to(device)).abs().mean()
               sample_losses[idx] = loss_i.cpu()
           # Boost: 1.5x for above-median loss samples
           median_loss = sample_losses.median()
           new_weights = torch.where(sample_losses > median_loss, sample_losses * 1.5, sample_losses)
           new_weights = new_weights / new_weights.sum() * len(train_ds)
           sampler.weights = new_weights.double()
       model.train()
   ```

   **IMPORTANT:** This is expensive (~2 min). Only do it every 5 epochs: change `if epoch >= 25` to `if epoch >= 25 and (epoch - 25) % 5 == 0`

Run with `--wandb_group combo-pcgrad-tandem-curriculum`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** nm2c26rd
**Runtime:** 1921s (~32 min, hit timeout + visualization crash)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.9768 | +15.2% worse |
| val_in_dist surf_p | 17.74 | 18.37 | +3.5% worse |
| val_ood_cond surf_p | 13.77 | 17.88 | +29.8% worse |
| val_ood_re surf_p | 27.52 | 29.67 | +7.8% worse |
| val_tandem surf_p | 37.72 | 39.11 | +3.7% worse |

Detailed metrics (Surface MAE):
- in_dist: loss=0.6463, surf_p=18.369, surf_Ux=3.999, surf_Uy=1.409, vol_Ux=1.078, vol_Uy=0.355, vol_p=19.571
- ood_cond: loss=0.9133, surf_p=17.883, surf_Ux=3.531, surf_Uy=1.263, vol_Ux=0.843, vol_Uy=0.331, vol_p=14.927
- ood_re: loss=0.6733, surf_p=29.667, surf_Ux=3.150, surf_Uy=1.068, vol_Ux=0.935, vol_Uy=0.403, vol_p=48.644
- tandem: loss=1.6741, surf_p=39.111, surf_Ux=4.755, surf_Uy=1.914, vol_Ux=1.916, vol_Uy=0.865, vol_p=37.899

**What happened:** The combination failed. ood_cond degraded catastrophically (+29.8%) even though PCGrad tandem-only was supposed to isolate tandem gradients. Two problems: (1) PCGrad tandem-only groups ood_cond and ood_re into Group A (non-tandem), but when these OOD samples appear in batches, their gradients compete with tandem gradients as before — the projection only helps when a batch has BOTH tandem and non-tandem samples; (2) the error-based curriculum every 5 epochs takes ~2 min per invocation, stealing ~10 min from the 30-min budget (~33% overhead). This leaves far fewer epochs for training and likely explains why the val/loss=0.9767 is even worse than the individual components.

Note: the run technically crashed at the very end during visualization (a pre-existing bug in the baseline code — fourier_pe is missing in the visualization inference path at line 1107). All val metrics are valid as they were logged before the crash.

**Suggested follow-ups:**
- Skip the error-based curriculum — the ~2 min/invocation overhead is too expensive within a 30-min budget; consider a much lighter weight scheme (e.g., just track per-sample running loss with exponential average, no full re-evaluation)
- PCGrad tandem-only alone (without curriculum) already showed benefit (#1557) — don't combine with expensive operations