### PR TITLE
Triple combo: PCGrad tandem-only + Lookahead alpha=0.6 + disable noise

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,7 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=10, alpha=0.6)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
@@ -667,18 +667,20 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+        # input noise disabled
+        # if model.training and epoch < 60:
+        #     noise_scale = 0.05 * (1 - epoch / 60)
+        #     x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+        # target noise disabled
+        # if model.training:
+        #     noise_progress = min(1.0, epoch / 60)
+        #     vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
+        #     p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+        #     noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
+        #     y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]
@@ -786,7 +788,7 @@ for epoch in range(MAX_EPOCHS):
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
-        is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
+        is_ood_pcgrad = is_tandem_batch
         is_indist_pcgrad = ~is_ood_pcgrad
         use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
 


### PR DESCRIPTION
## Hypothesis
This is the aggressive "kitchen sink" combination of all three per-split champions that individually showed improvements: PCGrad tandem-only (in_dist 17.27), Lookahead alpha=0.6 (ood_cond 13.37), and noise removal (val_loss 0.8573 near-miss). The logic: if two-way combos work (PRs #1566-#1568), the three-way should capture all benefits simultaneously. Risk: three changes may interact non-linearly. But if they are truly orthogonal (gradient surgery / optimizer dynamics / signal cleanliness), they should compound.

## Instructions
Make exactly three changes to `train.py`:

1. **Line 789:** Change PCGrad grouping to tandem-only:
   ```python
   is_ood_pcgrad = is_tandem_batch
   ```

2. **Line 579:** Change Lookahead alpha from 0.8 to 0.6:
   ```python
   optimizer = Lookahead(base_opt, k=10, alpha=0.6)
   ```

3. **Lines 670-672 AND 677-681:** Remove ALL noise (both input and target):
   ```python
   # Comment out lines 670-672 (input noise):
   # if model.training and epoch < 60:
   #     noise_scale = 0.05 * (1 - epoch / 60)
   #     x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
   
   # Comment out lines 677-681 (target noise):
   # if model.training:
   #     noise_progress = min(1.0, epoch / 60)
   #     vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
   #     p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
   #     noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
   #     y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
   ```

Run with `--wandb_group triple-combo-all3`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `39glz0j2` | **best_epoch:** 60

| Metric | Baseline | Triple combo | Δ |
|--------|----------|--------------|---|
| val/loss | 0.8477 | **0.8894** | +0.042 |
| in_dist surf p | 17.74 | 18.20 | +0.46 |
| ood_cond surf p | 13.77 | 14.60 | +0.83 |
| ood_re surf p | 27.52 | 28.31 | +0.79 |
| tandem surf p | 37.72 | 40.04 | +2.32 |
| mean3 | ~23.08 | 24.28 | +1.20 |

**Surface MAE detail (Ux / Uy / p):**
- in_dist: 6.25 / 1.81 / 18.20
- ood_cond: 3.39 / 1.12 / 14.60
- ood_re: 3.10 / 0.98 / 28.31
- tandem: 5.47 / 2.21 / 40.04

**Volume MAE (in_dist):** Ux=1.11, Uy=0.37, p=19.49

### What happened

The triple combination **clearly fails** — worse than baseline on all metrics (val/loss: +4.9%). This is a negative interaction result. The three individual improvements do not combine additively; they interfere with each other.

The most likely culprits:
- **Removing noise + Lookahead α=0.6**: Both changes reduce regularization. Noise provides training-time augmentation, and aggressive Lookahead updating reduces optimizer stochasticity. Combined, the model may overfit more aggressively early on, before the EMA kicks in at epoch 40.
- **PCGrad tandem-only + no noise**: Tandem samples have unusual geometry; noise helped expose the model to geometric variation. Without it, PCGrad tandem-only concentrates more on narrow tandem examples that differ from in-dist, potentially harming generalization.
- **Tandem degraded most (+2.32)**: Confirms tandem-focused PCGrad is being hurt by something in the combo — noise removal appears to hurt tandem generalization specifically.

### Suggested follow-ups
- Test PCGrad tandem-only + Lookahead 0.6 WITHOUT noise removal (noise removal may be hurting tandem)
- Test noise removal + PCGrad tandem-only WITHOUT Lookahead change
- The two-way pairwise combos (PRs #1566-1568) should provide clearer signal on which pairs are compatible