### PR TITLE
Reversal: Disable per-head tandem temperature offset (test if it hurts now)

### DIFF
--- a/train.py
+++ b/train.py
@@ -128,7 +128,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
-        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
+        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1), requires_grad=False)
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)


### PR DESCRIPTION
## Hypothesis
Per-head tandem temp offset was merged in PR #1323 to fix a tandem regression caused by n_head=3. But since then, PCGrad (#1456), dist_feat (#1473), and lr=2.6e-3 (#1518) were added — all of which change the gradient landscape. The tandem_temp_offset adds 3 learnable parameters that specifically modify attention for tandem samples. With PCGrad now handling tandem-vs-rest gradient conflict, the tandem_temp_offset may be redundant or even harmful — it's an extra degree of freedom that could overfit.

**Nothing improves tandem beyond 37.72** — the baseline itself is the tandem champion. This suggests the tandem_temp_offset may have reached a local optimum that constrains other improvements. Removing it could free the optimization landscape.

## Instructions
Make these changes to `train.py`:

1. **Line 131:** Zero-out the tandem_temp_offset effect. Change:
   ```python
   # In Physics_Attention_Irregular_Mesh.__init__:
   self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
   ```
   to:
   ```python
   # Keep the parameter but make it non-learnable (frozen at zero):
   self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1), requires_grad=False)
   ```

2. This is the cleanest reversal: the parameter exists but is permanently zero, so it has no effect on the forward pass. No other changes needed.

Run with `--wandb_group revert-tandem-temp`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `ujrcm1k2`
**Epochs:** 61 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5922 | 5.32 | 1.84 | 17.71 | 1.09 | 0.36 | 19.45 |
| ood_cond | 0.6978 | 3.28 | 1.01 | 14.23 | 0.74 | 0.27 | 12.35 |
| ood_re | 0.5524 | 2.74 | 0.84 | 27.87 | 0.85 | 0.36 | 46.85 |
| tandem | 1.6181 | 5.92 | 2.19 | 37.96 | 1.89 | 0.86 | 37.43 |
| **combined** | **0.8652** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (17.71 + 14.23 + 37.96) / 3 = **23.30**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.8652 | +2.1% |
| surf_p in_dist | 17.74 | 17.71 | -0.2% |
| surf_p ood_cond | 13.77 | 14.23 | +3.3% |
| surf_p ood_re | 27.52 | 27.87 | +1.3% |
| surf_p tandem | 37.72 | 37.96 | +0.6% |
| surf_p mean3 | 23.08 | 23.30 | +1.0% |

### What happened

Neutral-to-negative result. Freezing `tandem_temp_offset` at zero slightly worsened most splits except in_dist (marginal -0.2% improvement). The hypothesis that the per-head tandem temperature offset was redundant with PCGrad is not supported — the offset still provides modest positive signal.

The in_dist split is essentially tied (17.71 vs 17.74). But ood_cond regressed (+3.3%) and tandem barely changed (+0.6%). The overall val/loss is worse by 2.1%.

The tandem_temp_offset is small (3 parameters across 3 heads) and appears to be doing useful work: it lets each head independently adjust its temperature for tandem vs non-tandem samples. PCGrad handles gradient conflict but doesn't specialize the attention temperature by condition — these are orthogonal mechanisms.

### Suggested follow-ups

- Keep tandem_temp_offset as-is
- If tandem is a target: try a per-head AoA offset (in addition to is_tandem) to handle multi-foil angle-of-attack variation
- Investigate why nothing has beaten tandem=37.72 — plot attention maps for tandem samples to understand if the model is attending to the wrong spatial regions
