### PR TITLE
Reversal: Remove dist_feat + adjust fun_dim (test if dist hurts at lr=2.6e-3)

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(4, 64), nn.GELU(),
+            nn.Linear(3, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -377,7 +377,7 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
@@ -518,7 +518,7 @@ print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE
+    fun_dim=X_DIM - 2 + 1 + 32,  # +1 curv, +32 fourier PE (no dist_feat)
     out_dim=3,
     n_hidden=192,  # regime-w: full width with finer routing
     n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
@@ -654,9 +654,7 @@ for epoch in range(MAX_EPOCHS):
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-        dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-        dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
-        x = torch.cat([x, curv, dist_feat], dim=-1)
+        x = torch.cat([x, curv], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -884,9 +882,7 @@ for epoch in range(MAX_EPOCHS):
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
-                dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-                dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
-                x = torch.cat([x, curv, dist_feat], dim=-1)
+                x = torch.cat([x, curv], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -1065,9 +1061,7 @@ if best_metrics:
                 mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)
-                x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                x_n = torch.cat([x_n, curv], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
dist_feat (continuous distance-to-surface, PR #1473) was the second-to-last merge. It helped tandem (-4.7%) but hurt in_dist (+4.8%) on the code at the time. However, lr was then raised to 2.6e-3 (#1518) which changed the optimization dynamics. The dist_feat adds 1 extra input dimension and feeds into the spatial bias MLP — it changes the representation landscape. With 85+ experiments since then failing to beat baseline, it's worth testing whether the dist_feat is now net-harmful at the current lr.

**Evidence:** The input noise operates on features 2:25, which includes the dsdf-derived features that dist_feat depends on. If dist_feat is amplifying noise artifacts, removing it could immediately help.

## Instructions
Make these changes to `train.py`:

1. **Line 521:** Reduce fun_dim by 1 (remove dist_feat dimension):
   ```python
   # OLD:
   fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE
   # NEW:
   fun_dim=X_DIM - 2 + 1 + 32,  # +1 curv, +32 fourier PE (no dist_feat)
   ```

2. **Lines 657-658 (training):** Remove dist_feat computation and concatenation:
   ```python
   # OLD:
   dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
   dist_feat = torch.log1p(dist_surf * 10.0)
   x = torch.cat([x, curv, dist_feat], dim=-1)
   # NEW:
   x = torch.cat([x, curv], dim=-1)
   ```

3. **Lines 887-889 (validation):** Same removal:
   ```python
   # OLD:
   dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
   dist_feat = torch.log1p(dist_surf * 10.0)
   x = torch.cat([x, curv, dist_feat], dim=-1)
   # NEW:
   x = torch.cat([x, curv], dim=-1)
   ```

4. **Lines 1067-1070 (visualization):** Same removal:
   ```python
   # OLD:
   dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
   dist_feat = torch.log1p(dist_surf * 10.0)
   x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
   # NEW:
   x_n = torch.cat([x_n, curv], dim=-1)
   ```

5. **Line 380:** Update spatial bias raw_xy to use 3D (remove dist):
   ```python
   # OLD:
   raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
   # NEW:
   raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:25]], dim=-1)  # x, y, curvature
   ```

6. **Line 213:** Change spatial_bias input from 4 to 3:
   ```python
   nn.Linear(3, 64), nn.GELU(),  # was 4
   ```

Run with `--wandb_group revert-dist-feat`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `itr5ckqu`

| Metric | Baseline | No dist_feat | Δ |
|--------|----------|--------------|---|
| val/loss | 0.8477 | **0.8892** | +0.0415 (~9.0σ, significantly worse) |
| mae_surf_p in_dist | 17.74 | 18.96 | +1.22 |
| mae_surf_p ood_cond | 13.77 | 14.13 | +0.36 |
| mae_surf_p ood_re | 27.52 | 28.32 | +0.80 |
| mae_surf_p tandem | 37.72 | **39.83** | **+2.11** |
| **mean3 mae_surf_p** | **23.08** | **24.31** | **+1.23 (~5.9σ, significantly worse)** |

**Memory:** 18.4 GB. **Epochs:** 57/100.

### What happened

Removing dist_feat is significantly worse across all splits. The hypothesis was incorrect — dist_feat is actively helping at lr=2.6e-3, not hurting.

The dist_feat provides useful spatial information: it encodes the signed distance to the nearest airfoil surface node, allowing the model to distinguish near-surface and far-field regions. This is particularly valuable for:
1. **Tandem**: Two foils create complex near-surface interactions — knowing distance to any surface is critical
2. **In-dist**: Surface nodes need different representations from volume nodes, and dist_feat enables this
3. **Spatial bias**: The spatial_bias MLP uses dist as one of its 4 inputs; reducing to 3D inputs weakens this path

The concern about dist_feat amplifying noise artifacts appears unfounded. The dsdf-derived features (x[:,2:10]) are already in the model; dist_feat just adds a summary statistic (min abs value) with log scaling, which is inherently smooth and noise-resistant.

### Suggested follow-ups

- dist_feat is confirmed as useful — future experiments should keep it
- The spatial_bias with 4D input (x,y,curv,dist) is an important architectural feature
- If we want to improve dist handling, we could try log-scaling with a different constant (currently 10.0) or adding a learnable scalar