### PR TITLE
Novel: Stochastic weight perturbation at Lookahead sync (escape local minima)

### DIFF
--- a/train.py
+++ b/train.py
@@ -557,9 +557,14 @@ class Lookahead:
         self.base_optimizer.step()
         self.step_count += 1
         if self.step_count % self.k == 0:
+            current_lr = self.base_optimizer.param_groups[0]['lr']
             for slow, group in zip(self.slow_params, self.base_optimizer.param_groups):
                 for s, p in zip(slow, group['params']):
                     s.data.add_(self.alpha * (p.data - s.data))
+                    # Stochastic perturbation scaled by LR (decays naturally)
+                    if s.dim() >= 2:  # only perturb weight matrices, not biases
+                        noise = torch.randn_like(s.data) * current_lr * 0.1
+                        s.data.add_(noise)
                     p.data.copy_(s.data)
 
     def zero_grad(self):


### PR DESCRIPTION
## Hypothesis
85+ experiments have failed to beat the baseline. This plateau behavior is consistent with being stuck in a sharp local minimum — the loss landscape has a basin that all optimization trajectories converge to regardless of hyperparameter changes. Sharp minima generalize poorly; flatter minima generalize better (Hochreiter & Schmidhuber, 1997; Keskar et al., 2017).

**The idea from simulated annealing:** Add controlled noise to the weights at each Lookahead synchronization step. The Lookahead sync happens every k=10 gradient steps — this is the natural moment to perturb because the slow weights are about to be updated anyway. A small Gaussian perturbation to the slow weights before the sync step effectively explores neighboring basins.

**Why this is different from Fisher perturbation (#1448, #1453):** Those were complex (computing Fisher information matrix). This is dead simple: add `noise * lr_scale` to slow weights at sync. The lr_scale decays with the learning rate so perturbations shrink as training converges. Total cost: 0.

## Instructions
Modify the `Lookahead.step()` method (lines 556-563) to add weight perturbation:

```python
def step(self):
    self.base_optimizer.step()
    self.step_count += 1
    if self.step_count % self.k == 0:
        # Get current LR for scaling perturbation
        current_lr = self.base_optimizer.param_groups[0]['lr']
        for slow, group in zip(self.slow_params, self.base_optimizer.param_groups):
            for s, p in zip(slow, group['params']):
                s.data.add_(self.alpha * (p.data - s.data))
                # Stochastic perturbation scaled by LR (decays naturally)
                if s.dim() >= 2:  # only perturb weight matrices, not biases
                    noise = torch.randn_like(s.data) * current_lr * 0.1
                    s.data.add_(noise)
                p.data.copy_(s.data)
```

The key design choices:
- Scale noise by `current_lr * 0.1` — so at lr=2.6e-3 this is ~2.6e-4, and it decays with cosine annealing
- Only perturb weight matrices (dim >= 2), not biases or scalars
- Applied AFTER the Lookahead update but BEFORE copying to fast weights

Run with `--wandb_group swp-lookahead`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run ID:** 8clbmlyi  
**Best epoch:** 61 (wall-clock timeout at 31.8 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8883** | 0.8477 |
| val_in_dist | 0.6232 | — |
| val_tandem_transfer | 1.6638 | — |
| val_ood_cond | 0.7053 | — |
| val_ood_re | 0.5609 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 4.97 | 1.56 | 18.65 | 17.74 | +5.1% |
| val_tandem_transfer | 5.25 | 2.12 | 39.64 | 37.72 | +5.1% |
| val_ood_cond | 2.98 | 0.90 | 14.12 | 13.77 | +2.5% |
| val_ood_re | 2.47 | 0.73 | 28.25 | 27.52 | +2.6% |

**mean3 surf_p** = (18.65 + 14.12 + 39.64) / 3 = **24.14** (baseline: 23.01, delta: +4.9%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.11 | 0.36 | 19.56 |
| val_tandem_transfer | 1.93 | 0.87 | 38.51 |
| val_ood_cond | 0.72 | 0.28 | 12.02 |
| val_ood_re | 0.82 | 0.36 | 47.09 |

---

### What happened

**Negative result.** val/loss = 0.8883 vs baseline 0.8477 (+4.8% worse). mean3 surf_p = 24.14 vs 23.01 (+4.9% worse). All splits degraded uniformly.

The stochastic perturbation at sync steps injected too much noise and destabilized training. At lr=2.6e-3, the noise scale is `2.6e-3 * 0.1 = 2.6e-4`. Typical weight matrix values are ~0.01–0.1, so this is ~0.25–2.6% of typical weight magnitude. With sync every 10 steps (~6 syncs per epoch × 61 epochs = ~366 perturbation events), the cumulative disruption is substantial — it prevents the model from settling into any basin, sharp or flat.

The analogy to simulated annealing breaks down because: (1) annealing perturbs activations/inputs, not weights; (2) the noise here is applied globally to all weight matrices at once, which is more disruptive than gradient-based noise; (3) the Lookahead slow weights are already serving as a low-pass filter — adding noise on top of this filtered signal defeats the purpose.

The result also suggests the baseline is not stuck in a pathologically sharp minimum — uniform degradation across all splits indicates the perturbation is simply harmful noise rather than helping the optimizer escape.

*Visualization crash* (same as PRs #1457, #1562): `mat1 and mat2 shapes cannot be multiplied` in `feature_cross` during post-training visualization. Training metrics are unaffected.

---

### Suggested follow-ups

- **Smaller noise scale**: Try `current_lr * 0.01` (10x smaller, ~2.6e-5). This would make the perturbation truly tiny (0.02–0.2% of weight magnitude) and may provide just enough exploration without destabilizing convergence.
- **Perturbation only before cosine decay**: Apply perturbation only during the warmup phase (epochs 1–10) when LR is already changing rapidly. This avoids disturbing the late-training fine-tuning.
- **Sharpness-aware minimization (SAM)**: Instead of random perturbation, SAM computes the gradient at the worst-case perturbation point. This is more principled but requires two forward-backward passes per step.
