### PR TITLE
Novel: Head-wise multi-scale slice resolution (16/48/80 slices per head)

### DIFF
--- a/train.py
+++ b/train.py
@@ -132,8 +132,12 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
-        self.in_project_slice = nn.Linear(dim_head, slice_num)
-        torch.nn.init.orthogonal_(self.in_project_slice.weight)
+        self.slice_nums = [16, slice_num, slice_num + 32]  # coarse, medium, fine
+        self.in_project_slices = nn.ModuleList([
+            nn.Linear(dim_head, sn) for sn in self.slice_nums
+        ])
+        for proj in self.in_project_slices:
+            torch.nn.init.orthogonal_(proj.weight)
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
@@ -162,27 +166,30 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         temp = self.temperature
         if tandem_mask is not None:
             temp = (temp + self.tandem_temp_offset * tandem_mask).clamp(min=1e-4)
-        slice_logits = self.in_project_slice(x_mid) / temp
-        if spatial_bias is not None:
-            slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
-        slice_weights = self.softmax(slice_logits)
-        slice_norm = slice_weights.sum(2)
-        slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
-        slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
-
-        q_slice_token = self.to_q(slice_token)
-        slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # shared K,V: (bsz, 1, slice_num, dim_head)
-        k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
-        v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
-        q_norm = F.normalize(q_slice_token, dim=-1)
-        k_norm = F.normalize(k_slice_token, dim=-1)
-        attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
-        attn_weights = F.softmax(attn_logits, dim=-1)
-        out_slice_token = torch.matmul(attn_weights, v_slice_token)
-        out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
-
-        out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
-        out_x = rearrange(out_x, "b h n d -> b n (h d)")
+        outs = []
+        for h in range(self.heads):
+            sn = self.slice_nums[h]
+            x_h = x_mid[:, h:h+1, :, :]  # [B, 1, N, D]
+            fx_h = fx_mid[:, h:h+1, :, :]
+            temp_h = temp[:, h:h+1, :, :]
+            slice_logits = self.in_project_slices[h](x_h) / temp_h  # [B, 1, N, sn]
+            if spatial_bias is not None:
+                sb_h = spatial_bias[:, :, :sn].unsqueeze(1)
+                slice_logits = slice_logits + 0.1 * sb_h
+            sw = F.softmax(slice_logits, dim=-1)
+            sn_norm = sw.sum(2)
+            st = torch.einsum("bhnc,bhng->bhgc", fx_h, sw) / (sn_norm + 1e-5)[:, :, :, None]
+            q = self.to_q(st)
+            kv = st.mean(dim=1, keepdim=True)
+            k = self.to_k(kv).expand(-1, 1, -1, -1)
+            v = self.to_v(kv).expand(-1, 1, -1, -1)
+            qn = F.normalize(q, dim=-1)
+            kn = F.normalize(k, dim=-1)
+            attn = F.softmax(torch.matmul(qn, kn.transpose(-2, -1)) * self.attn_scale[:, h:h+1, :, :], dim=-1)
+            out_st = torch.matmul(attn, v) + self.slice_residual_scale * st
+            out_h = torch.einsum("bhgc,bhng->bhnc", out_st, sw)
+            outs.append(out_h.squeeze(1))  # [B, N, D]
+        out_x = torch.cat(outs, dim=-1)  # [B, N, H*D]
         return self.to_out(out_x)
 
 
@@ -213,7 +220,7 @@ class TransolverBlock(nn.Module):
         self.spatial_bias = nn.Sequential(
             nn.Linear(4, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
-            nn.Linear(64, slice_num),
+            nn.Linear(64, 80),  # max(slice_nums) for multi-scale heads
         )
         nn.init.zeros_(self.spatial_bias[-1].weight)
         nn.init.zeros_(self.spatial_bias[-1].bias)


### PR DESCRIPTION
## Hypothesis
The 3 attention heads all use the same 48-slice resolution. But flow fields have inherent multi-scale structure: large-scale freestream patterns, medium-scale wake/separation structures, and fine-scale boundary layer features. In multigrid methods from computational mathematics, different grid resolutions capture different scales simultaneously. Assigning different slice counts per head (head 0: 16 coarse slices, head 1: 48 medium, head 2: 80 fine) forces each head to specialize at a different spatial resolution.

**Why this differs from #1381 (multi-scale attention):** That PR created parallel 16-slice and 48-slice branches with separate parameters, doubling compute. This reuses the EXISTING 3-head structure but gives each head a different slice_num — no extra parameters, no extra compute (total slices: 16+48+80=144 vs current 3*48=144).

**Analogy:** Wavelet decomposition uses multi-resolution analysis. This is the attention equivalent — each head becomes a different wavelet scale.

## Instructions
The key change is in `Physics_Attention_Irregular_Mesh`. Currently, all heads share the same `in_project_slice` which maps to `slice_num`. We need per-head slice projections.

1. **In `Physics_Attention_Irregular_Mesh.__init__`** (lines 119-145), replace the single `in_project_slice` with per-head projections:
   ```python
   # OLD:
   self.in_project_slice = nn.Linear(dim_head, slice_num)
   torch.nn.init.orthogonal_(self.in_project_slice.weight)
   
   # NEW:
   self.slice_nums = [16, slice_num, slice_num + 32]  # coarse, medium, fine
   self.in_project_slices = nn.ModuleList([
       nn.Linear(dim_head, sn) for sn in self.slice_nums
   ])
   for proj in self.in_project_slices:
       torch.nn.init.orthogonal_(proj.weight)
   ```

2. **In `forward()`** (lines 147-186), process each head separately for the slice assignment part. This requires splitting x_mid and fx_mid per head and processing each with its own slice resolution.

3. **Spatial bias MLP** needs to output max(slice_nums)=80 channels. Change line 216:
   ```python
   nn.Linear(64, 80),  # was slice_num (48)
   ```

Run with `--wandb_group multiscale-heads`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** kzjdiix4  
**Best epoch:** 51 (epoch_time ≈ 34.9s/epoch, ~17% slower than baseline ~29s → fewer epochs in 30 min)

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.6398 | 6.73 | 1.77 | **19.22** | 20.21 |
| ood_cond | 0.7709 | 4.18 | 1.19 | **15.64** | 13.39 |
| ood_re | 0.5790 | 3.75 | 1.01 | **28.37** | 47.53 |
| tandem | 1.6783 | 6.18 | 2.25 | **39.35** | 38.82 |
| **combined val/loss** | **0.9170** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8477 | 0.9170 | +8.2% worse |
| in_dist surf_p | 17.74 | 19.22 | +8.3% |
| ood_cond surf_p | 13.77 | 15.64 | +13.6% |
| ood_re surf_p | 27.52 | 28.37 | +3.1% |
| tandem surf_p | 37.72 | 39.35 | +4.3% |

**Peak memory:** no OOM observed.

### What happened

**Negative across all splits.** The 16/48/80 multi-scale configuration performed worse than uniform 48.

Two likely causes:

1. **Slower training / fewer epochs.** The sequential Python loop over heads broke the batched GPU kernels. Epoch time went from ~29s to ~34.9s (~17% slower), giving only 51 epochs vs ~57-58 in the baseline — fewer gradient steps in the 30-min window.

2. **Lost cross-head K/V sharing.** The original forward() computes `kv = slice_token.mean(dim=1, keepdim=True)` across all 3 heads, enabling cross-resolution communication. In the per-head loop, each head computes its own K/V from its own slice tokens (mean of a single-head tensor is the tensor itself), removing this interaction.

Additionally, the coarse head (16 slices) may lack resolution for boundary-layer features, and 80 slices on the fine head may be underutilized at epoch 51.

### Suggested follow-ups

- **Restore cross-head K/V:** Even with variable slice counts, project each head's slice tokens to a shared K/V space before attention — preserves cross-resolution communication.
- **Batched with masking:** Pad all heads to 80 slices with a mask to avoid the Python loop; restores GPU efficiency.
- **Milder asymmetry:** Try [32, 48, 64] instead of [16, 48, 80]; less risk from the coarse head.
- **Just increase resolution uniformly:** Try all heads at 64 slices (total=192 vs 144) for a simpler baseline comparison.