### PR TITLE
Novel: Stagnation point anchoring loss (physics constraint at known-value nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -755,6 +755,20 @@ for epoch in range(MAX_EPOCHS):
         _coarse_loss = None
         coarse_pool_size = 64
         B, N, C = pred.shape
+
+        # Stagnation point anchoring loss
+        if epoch >= 10:
+            # Find approximate stagnation points: min velocity magnitude on surface
+            vel_mag = (pred[:, :, 0:2] ** 2).sum(dim=-1).sqrt()  # [B, N]
+            vel_surf = vel_mag.masked_fill(~surf_mask, float('inf'))
+            stag_idx = vel_surf.argmin(dim=1)  # [B] index of stagnation node per sample
+            # Get predicted pressure at stagnation in normalized space
+            stag_pred_p = pred[torch.arange(B, device=device), stag_idx, 2]  # [B]
+            # Target: stagnation Cp = 1.0, in z-scored space: (1.0 - y_mean_p) / y_std_p
+            stag_target = (1.0 - phys_stats["y_mean"][2]) / phys_stats["y_std"][2]
+            stag_loss = F.mse_loss(stag_pred_p, stag_target.expand_as(stag_pred_p))
+            loss = loss + 0.1 * stag_loss
+
         n_groups = N // coarse_pool_size
         if n_groups > 1:
             # Sort by x-coordinate for spatially coherent groups


### PR DESCRIPTION
## Hypothesis
In aerodynamics, the stagnation point on the leading edge of an airfoil has a KNOWN exact value: Cp = 1.0 (pressure coefficient at zero velocity). This is a physics invariant that holds for ALL samples regardless of Re, AoA, or tandem configuration. Currently, the model must learn this from data. Instead, we can add a cheap auxiliary loss that explicitly penalizes deviations from Cp=1 at the stagnation point.

**Why this is powerful:** The stagnation point is the "anchor" of the entire pressure distribution. Getting it right constrains the global pressure field. In CFD panel methods, the stagnation point is computed first, and the entire Cp distribution is built relative to it.

**Finding the stagnation point:** The leading-edge stagnation point is where velocity magnitude is minimum on the surface. In z-scored space, we can approximate it as the surface node with the smallest predicted velocity magnitude.

**This is different from #836:** That attempted a complex stagnation-specific loss on old code (val_loss ~2.2). This uses a simpler formulation on the much-better current model.

## Instructions
Add after the surf_loss computation (~line 751):

```python
# Stagnation point anchoring loss
if epoch >= 10:
    # Find approximate stagnation points: min velocity magnitude on surface
    vel_mag = (pred[:, :, 0:2] ** 2).sum(dim=-1).sqrt()  # [B, N]
    vel_surf = vel_mag.masked_fill(~surf_mask, float('inf'))
    stag_idx = vel_surf.argmin(dim=1)  # [B] index of stagnation node per sample
    # Get predicted pressure at stagnation in normalized space
    stag_pred_p = pred[torch.arange(B, device=device), stag_idx, 2]  # [B]
    # Target: stagnation Cp = 1.0, in z-scored space: (1.0 - y_mean_p) / y_std_p
    stag_target = (1.0 - phys_stats["y_mean"][2]) / phys_stats["y_std"][2]
    stag_loss = F.mse_loss(stag_pred_p, stag_target.expand_as(stag_pred_p))
    loss = loss + 0.1 * stag_loss
```

**Note:** The `stag_target` is computed from the Cp normalization. Since the model predicts in z-scored Cp space, Cp=1.0 maps to a specific z-score value. The 0.1 weight is conservative — the loss anchors but doesn't dominate.

Run with `--wandb_group stag-anchor`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** `xq8pvfn5`

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in-dist | 0.6312 | 3.13 | 1.21 | 19.98 | 1.13 | 0.37 | 20.07 |
| ood-cond | 0.7282 | 2.90 | 0.84 | 14.60 | — | — | — |
| ood-re | 0.5693 | 2.40 | 0.70 | 28.40 | — | — | — |
| tandem | 1.6462 | 3.94 | 1.65 | 39.08 | — | — | — |
| **combined** | **0.8937** | — | — | — | — | — | — |

**vs baseline:** val/loss 0.8937 vs 0.8477 (+0.046 worse)

Surface pressure (most important):
- in-dist: 19.98 vs 17.74 (+2.24 worse)
- ood-cond: 14.60 vs 13.77 (+0.83 worse)
- ood-re: 28.40 vs 27.52 (+0.88 worse)
- tandem: 39.08 vs 37.72 (+1.36 worse)

**Peak GPU memory:** not logged

**What happened:** Negative result. The stagnation anchoring loss hurt across all splits, with the most damage on in-dist surface pressure (+2.24 Pa).

Two likely explanations:

1. **Stagnation detection is noisy in z-scored prediction space.** We identify the stagnation node as the surface node with minimum predicted velocity magnitude in z-scored space. But early in training, predictions are noisy — the model may not have learned to put minimum velocity at the actual stagnation point. The "anchor" then penalizes random nodes, injecting misleading gradient signal.

2. **The Cp=1.0 target is approximate.** In discrete CFD meshes, the pressure coefficient at the closest mesh node to the stagnation point is close to 1.0 but not exactly 1.0 — it depends on mesh resolution and the distance to the true geometric stagnation point. The loss pushes the model toward a target that the training data itself doesn't achieve at that specific node.

The physics is correct in principle, but the noisy stagnation-point detection + the approximation error in the target conspire to add noise to the gradient rather than useful signal.

**Suggested follow-ups:**
- Try detecting stagnation from the target labels (y_norm) rather than predictions — that way the stagnation index is always accurate and the loss is purely about pressure accuracy
- Try a softer version: instead of argmin (hard single node), weight all surface nodes by exp(-vel_mag * temperature) to create a soft stagnation target
- Try activating the loss later (epoch >= 30) after predictions are more reliable