### PR TITLE
Novel: SAM-lite (Sharpness-Aware Minimization every 3rd step)

### DIFF
--- a/train.py
+++ b/train.py
@@ -832,6 +832,45 @@ for epoch in range(MAX_EPOCHS):
             loss.backward()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+
+        # SAM-lite: every 3rd step on non-PCGrad batches
+        sam_rho = 0.05
+        use_sam = (global_step % 3 == 0) and not use_pcgrad and epoch >= 10
+
+        if use_sam:
+            grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=float('inf'))
+            if grad_norm > 0:
+                with torch.no_grad():
+                    old_params = []
+                    for p in model.parameters():
+                        if p.grad is not None:
+                            old_params.append(p.data.clone())
+                            eps = sam_rho * p.grad / (grad_norm + 1e-12)
+                            p.data.add_(eps)
+                        else:
+                            old_params.append(None)
+
+                # Step 2: compute gradient at perturbed point
+                optimizer.zero_grad()
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    out2 = model({"x": x.detach()})
+                    pred2 = out2["preds"].float()
+                if model.training:
+                    pred2 = pred2 / sample_stds
+                abs_err2 = (pred2 - y_norm).abs()
+                vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+                surf_per2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+                surf_loss2 = (surf_per2 * tandem_boost).mean()
+                loss2 = vol_loss2 + surf_weight * surf_loss2
+                loss2.backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+
+                # Step 3: restore original params, then step with SAM gradient
+                with torch.no_grad():
+                    for p, old_p in zip(model.parameters(), old_params):
+                        if old_p is not None:
+                            p.data.copy_(old_p)
+
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:


### PR DESCRIPTION
## Hypothesis
85+ experiments stuck at the same basin suggests the optimization is trapped in a sharp minimum. SAM (Foret et al., 2021) explicitly seeks flatter minima by first ascending the loss landscape (finding the worst-case perturbation) then descending from there. SAM has shown strong gains for OOD generalization — exactly our problem (ood_cond, ood_re are the hardest splits).

**Why full SAM is too expensive:** SAM doubles backward passes. With PCGrad already doubling backward passes on some batches, this would be 4x cost — too slow for 30 minutes.

**SAM-lite solution:** Apply SAM only every 3rd gradient step, and only on non-PCGrad batches. This gives ~33% SAM coverage at ~33% extra cost — manageable within 30 minutes (lose ~5 epochs, from 59 to ~50).

**Why this might break the plateau:** Every experiment so far uses the same AdamW+Lookahead optimizer path. SAM fundamentally changes the optimization trajectory by actively seeking flatter regions. Even if we lose 5 epochs, the flatter minimum may generalize better across splits.

## Instructions
Make these changes to `train.py`:

1. **After line 834 (gradient clipping), before optimizer.step()**, wrap the gradient update:
   ```python
   # SAM-lite: every 3rd step on non-PCGrad batches
   sam_rho = 0.05  # perturbation radius
   use_sam = (global_step % 3 == 0) and not use_pcgrad and epoch >= 10
   
   if use_sam:
       # Step 1: compute epsilon = rho * grad / ||grad||
       grad_norm = torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=float('inf'))
       if grad_norm > 0:
           with torch.no_grad():
               old_params = []
               for p in model.parameters():
                   if p.grad is not None:
                       old_params.append(p.data.clone())
                       eps = sam_rho * p.grad / (grad_norm + 1e-12)
                       p.data.add_(eps)
                   else:
                       old_params.append(None)
           
           # Step 2: compute gradient at perturbed point
           optimizer.zero_grad()
           with torch.amp.autocast("cuda", dtype=torch.bfloat16):
               out2 = model({"x": x})
               pred2 = out2["preds"].float()
           if model.training:
               pred2 = pred2 / sample_stds
           abs_err2 = (pred2 - y_norm).abs()
           vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
           surf_per2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
           surf_loss2 = (surf_per2 * tandem_boost).mean()
           loss2 = vol_loss2 + surf_weight * surf_loss2
           loss2.backward()
           torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
           
           # Step 3: restore original params, then step with SAM gradient
           with torch.no_grad():
               for p, old_p in zip(model.parameters(), old_params):
                   if old_p is not None:
                       p.data.copy_(old_p)
   ```

2. Move the `optimizer.step()` call AFTER this block (it should use the SAM gradient when use_sam=True, normal gradient otherwise).

Run with `--wandb_group sam-lite`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B Run:** foxpb4nu
**Best epoch:** ~50 (run killed by wall-clock limit at epoch 51)

### Metrics vs Baseline

| Split | val_loss | surf_p |
|-------|----------|--------|
| val_in_dist | — | 20.33 |
| val_ood_cond | — | 15.87 |
| val_ood_re | — | 28.53 |
| val_tandem_transfer | — | 38.87 |
| **combined** | **0.9240** | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8477 | 0.9240 | +0.0763 ↑ worse |
| in surf_p | 17.74 | 20.33 | +2.59 ↑ worse |
| ood_c surf_p | 13.77 | 15.87 | +2.10 ↑ worse |
| ood_r surf_p | 27.52 | 28.53 | +1.01 ↑ worse |
| tan surf_p | 37.72 | 38.87 | +1.15 ↑ worse |

**Peak memory:** ~17.7 GB

### Implementation note

**Bug fix required:** The original instructions used `model({"x": x})` in the SAM forward pass, but `x` contains Fourier PE computed with the learnable `fourier_freqs_learned` parameter — so `x` has `requires_grad=True`. After `loss.backward()` frees the computation graph, the SAM forward pass would get `RuntimeError: Trying to backward through the graph a second time`. Fix: use `model({"x": x.detach()})` in the SAM pass.

### What happened

Negative result — primarily due to compute overhead exceeding the training budget. SAM-lite adds ~1/3 overhead every 3rd step, reducing the number of training epochs from ~61 to ~50 within the 30-minute window. The model doesn't fully converge in 50 epochs (still improving at termination), so the comparison is unfair: we're comparing a partially-trained SAM model against a fully-trained baseline.

At epoch 50, val/loss=0.924 is clearly worse than baseline (0.848). The model's convergence trajectory may be flatter (as intended), but 50 epochs isn't enough to demonstrate the benefit.

The core SAM hypothesis may be valid, but the implementation is constrained by the 30-minute budget. Even the "lite" version (every 3rd step) is too expensive given training speed.

### Suggested follow-ups

- Try SAM every 9th step (1/9 coverage, ~11% overhead) to stay within budget while getting some flatness benefit
- Alternatively, try a pure SAM approach with `rho=0.02` (smaller perturbation = faster convergence to flat minimum) and remove the every-3rd-step constraint
- The flatness hypothesis is worth testing with a longer training budget (60-min experiment)