### PR TITLE
Novel: Gradient-stopped EMA teacher loss (consistency regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -715,6 +715,19 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
+        # EMA teacher consistency loss (after EMA is initialized)
+        ema_loss_val = 0.0
+        if ema_model is not None and epoch >= 45:
+            with torch.no_grad():
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    ema_pred = ema_model({"x": x})["preds"]
+                ema_pred = ema_pred.float()
+                if model.training:
+                    ema_pred = ema_pred / sample_stds
+            # L1 consistency loss on surface pressure only
+            ema_diff = (pred - ema_pred)[:, :, 2:3].abs()  # pressure channel
+            ema_loss_val = (ema_diff * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
         if epoch < 40:
@@ -783,6 +796,8 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+        if ema_loss_val > 0:
+            loss = loss + 0.5 * ema_loss_val  # 0.5 weight to not dominate
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest


### PR DESCRIPTION
## Hypothesis
The EMA model is currently used ONLY at inference. But in mean-teacher/self-distillation frameworks (Tarvainen & Valpola, 2017; Laine & Aila, 2017), the EMA model can serve as a teacher during training: penalizing disagreement between the student (fast model) and teacher (EMA model) forces the student to stay in a consistent region of weight space. This is a form of implicit regularization that discourages the student from overfitting to batch-level noise.

**Why this is especially relevant at a plateau:** The model has converged to a good solution, but per-batch gradient noise causes oscillation. The EMA teacher loss acts as a "gravity well" that dampens these oscillations without changing the optimizer.

**Why this differs from #963 (self-distillation):** That PR used MSE between student and EMA in feature space. This uses L1 on OUTPUT predictions (matching our loss metric) and is applied ONLY after epoch 45 (when EMA has been running for 5 epochs and is reliable).

## Instructions
Add this consistency loss to the training loop:

1. After `pred = pred.float()` (line 704) and the sample_stds scaling (line 708), add:
   ```python
   # EMA teacher consistency loss (after EMA is initialized)
   ema_loss_val = 0.0
   if ema_model is not None and epoch >= 45:
       with torch.no_grad():
           with torch.amp.autocast("cuda", dtype=torch.bfloat16):
               ema_pred = ema_model({"x": x})["preds"]
           ema_pred = ema_pred.float()
           if model.training:
               ema_pred = ema_pred / sample_stds
       # L1 consistency loss on surface pressure only
       ema_diff = (pred_for_loss - ema_pred)[:, :, 2:3].abs()  # pressure channel
       ema_loss_val = (ema_diff * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
   ```

   Where `pred_for_loss` is `pred / sample_stds` (needs to be saved before the abs_err computation).

2. Add the consistency loss to the total loss (before the PCGrad block, ~line 786):
   ```python
   if ema_loss_val > 0:
       loss = loss + 0.5 * ema_loss_val  # 0.5 weight to not dominate
   ```

3. **Important:** The `ema_model({"x": x})` call is inside `torch.no_grad()` so it adds zero gradient cost. The only backward-pass cost is through the student's prediction.

Run with `--wandb_group ema-teacher-loss`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** 0khki258 | **Epochs completed:** 56 (crashed epoch 57) | **Peak VRAM:** 45.6 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| val_in_dist | 0.6031 | 5.93 | 1.88 | 18.13 | 1.11 | 0.37 | 19.65 |
| val_ood_cond | 0.7249 | 3.20 | 1.16 | 14.55 | 0.73 | 0.28 | 12.31 |
| val_ood_re | 0.5497 | 2.78 | 0.95 | 27.90 | 0.83 | 0.36 | 46.86 |
| val_tandem_transfer | 1.6616 | 5.72 | 2.33 | 39.40 | 1.93 | 0.87 | 38.42 |
| **val/loss** | **0.8848** | | | | | | |

**vs baseline (0.8477):** +0.037 (substantially worse)

| Metric | EMA-teacher | Baseline | Delta |
|--------|-------------|----------|-------|
| mae_surf_p in_dist | 18.13 | 17.74 | +0.39 |
| mae_surf_p ood_cond | 14.55 | 13.77 | +0.78 |
| mae_surf_p ood_re | 27.90 | 27.52 | +0.38 |
| mae_surf_p tandem | 39.40 | 37.72 | +1.68 |

**What happened:** The EMA teacher consistency loss hurt performance in two ways:

1. **VRAM explosion and crash**: Peak VRAM jumped from ~17.5 GB to 45.6 GB, causing a crash during epoch 57. Running the EMA model (uncompiled deepcopy) in the batch loop doubles the memory footprint — even under `torch.no_grad()`, PyTorch keeps the full activation memory during the forward pass. The baseline achieves ~61 epochs in 30 min; this run only completed 56.

2. **Degraded metrics**: Even with 5 fewer epochs, the metrics are substantially worse across all splits (+0.037 val/loss). The 0.5-weighted consistency term disrupts the optimizer trajectory. The EMA model at epoch 45 is still learning and its predictions have non-trivial noise, so minimizing student-teacher disagreement can pull the student toward suboptimal directions.

**Suggested follow-ups:**
- If consistency regularization is worth revisiting, reduce the loss weight to 0.05–0.1 (not 0.5) to prevent it from dominating the gradient signal.
- To avoid VRAM overhead, the EMA teacher could be run only every N batches (e.g., every 10 batches) rather than every batch.
- An alternative: run the consistency loss only on val batches (test-time adaptation style) rather than during training.