### PR TITLE
Novel: Gradient centralization (zero-mean gradients for weight matrices)

### DIFF
--- a/train.py
+++ b/train.py
@@ -831,6 +831,11 @@ for epoch in range(MAX_EPOCHS):
             optimizer.zero_grad()
             loss.backward()
 
+        # Gradient centralization: zero-mean gradients for weight matrices
+        for p in model.parameters():
+            if p.grad is not None and p.grad.dim() >= 2:
+                p.grad.data.sub_(p.grad.data.mean(dim=tuple(range(1, p.grad.dim())), keepdim=True))
+
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
         if epoch >= ema_start_epoch:


### PR DESCRIPTION
## Hypothesis
Gradient Centralization (Yong et al., 2020) is a simple technique that subtracts the mean from each gradient matrix before the optimizer step. This constrains weight updates to the hyperplane of zero-mean perturbations, which has been shown to: (a) improve generalization, (b) regularize training, and (c) accelerate convergence. It has never been tested in our programme.

**Why GC might break this specific plateau:** GC acts as an implicit constraint that prevents weight matrices from drifting in the "mean direction" — the direction that uniformly scales all outputs. This is exactly the kind of drift that could cause a flat loss landscape (the model finds many equivalent solutions that differ only in mean scaling). By removing this degree of freedom, the optimizer is forced to find solutions that differ in more meaningful ways.

**The key property:** GC is orthogonal to ALL other changes we've tried. It modifies neither the model architecture nor the loss function — it operates purely on the gradient. It adds zero computational cost (a single mean subtraction per parameter per step). And it has never been explored in any of our 1198 experiments.

## Instructions
Add gradient centralization after the backward pass and before gradient clipping. After line 833 (end of else block) and before line 834 (clip_grad_norm_):

```python
# Gradient centralization: zero-mean gradients for weight matrices
for p in model.parameters():
    if p.grad is not None and p.grad.dim() >= 2:
        p.grad.data.sub_(p.grad.data.mean(dim=tuple(range(1, p.grad.dim())), keepdim=True))
```

That's it. Three lines. The `dim() >= 2` check ensures we only centralize weight matrices (not biases, scalars, or 1D parameters like LayerNorm). The mean is subtracted along all dimensions except the first (output dimension), which preserves the output-dimension structure.

Run with `--wandb_group grad-central`

## Baseline
val_loss=0.8477 | in_dist=17.74 | ood_cond=13.77 | ood_re=27.52 | tandem=37.72

---

## Results

**W&B run:** hfz8wfdb  
**Epochs completed:** 58 (timeout at epoch 60)

### Metrics vs Baseline

| Metric | Baseline | GC Result | Delta |
|--------|----------|-----------|-------|
| val_loss | 0.8477 | **0.9014** | +6.3% worse |
| in_dist surf MAE | 17.74 | 24.38 | +37% worse |
| ood_cond surf MAE | 13.77 | 18.79 | +36% worse |
| ood_re surf MAE | 27.52 | 31.42 | +14% worse |
| tandem surf MAE | 37.72 | 47.24 | +25% worse |

Surface MAE by channel (best epoch):
- in_dist: Ux=4.21, Uy=1.24, p=18.93
- ood_cond: Ux=3.13, Uy=0.94, p=14.72
- ood_re: Ux=2.56, Uy=0.78, p=28.07
- tandem: Ux=5.18, Uy=1.99, p=40.07

**Epoch time:** ~30.6s vs baseline ~28s (+9% overhead)  
**Peak GPU memory:** N/A (process finished before check)

### What happened

GC significantly hurt performance — val_loss is 6.3% worse than baseline at comparable epochs. All four splits are worse, with in_dist and ood_cond surf MAE up ~36-37%. 

The val_loss was still trending down at the cutoff (last 5 epochs: 0.9179 → 0.9137 → 0.9121 → 0.9069 → 0.9014), but the improvement rate (~0.004/epoch) was too slow to reach baseline (0.8477) within the remaining budget. At that rate it would need ~13 more epochs to reach baseline territory — possible but not certain given LR decay.

Contrary to the PR hypothesis, GC did not break any plateau. The run was slower to converge from the start (baseline was likely at ~0.86 at epoch 58 vs our 0.90).

**Why GC might hurt this architecture:** Transolver uses physics-attention (Fourier-based slice mechanism) where gradient direction encodes meaningful geometry-physics relationships. By zeroing out the mean gradient direction, GC removes what may be the dominant mode of the update — the "scale the whole slice" signal. This could force the optimizer to take detours in weight space, explaining the 9% overhead per epoch and slower convergence. The claim of "zero computational cost" holds theoretically (one mean subtract) but the iteration over all parameters is measurable.

### Suggested follow-ups

- Try GC only on attention layers (not all Linear layers) — the attention slices are most geometry-sensitive; restricting GC to the MLP layers might avoid disrupting the attention mechanism
- Try GC with a smaller LR to counteract the implicit regularization (GC + LR ~2.0e-3 instead of 2.6e-3)
- More epochs: if budget allows, letting this run to 80+ epochs would confirm whether GC converges to parity or stays worse