### PR TITLE
AdamW eps=1e-7 (untouched default, never tested)

### DIFF
--- a/train.py
+++ b/train.py
@@ -575,7 +575,7 @@ other_params = [p for n, p in model.named_parameters() if not any(k in n for k i
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
+], weight_decay=cfg.weight_decay, eps=1e-7)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)


### PR DESCRIPTION
## Hypothesis
AdamW epsilon has never been changed from default 1e-8 across 1200+ experiments. At 1e-7, updates on near-zero-gradient params are smoother.
## Instructions
Add `eps=1e-7` to AdamW constructor (line 575). Run with `--wandb_group adamw-eps-1e7`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `5taxv1fw` | **best_epoch:** 58

| Metric | Baseline | eps=1e-7 | Δ |
|--------|----------|----------|---|
| val/loss | 0.8477 | **0.8680** | +0.020 |
| in_dist surf p | 17.74 | **17.60** | -0.14 |
| ood_cond surf p | 13.77 | 13.84 | +0.07 |
| ood_re surf p | 27.52 | 28.07 | +0.55 |
| tandem surf p | 37.72 | 39.23 | +1.51 |
| mean3 | ~23.08 | 23.56 | +0.48 |

**Surface MAE detail (Ux / Uy / p):**
- in_dist: 4.24 / 1.07 / 17.60
- ood_cond: 2.59 / 0.77 / 13.84
- ood_re: 2.14 / 0.60 / 28.07
- tandem: 5.18 / 1.70 / 39.23

**Volume MAE (in_dist):** Ux=1.08, Uy=0.36, p=19.00

### What happened

Mixed results — in_dist surface pressure improved slightly (-0.14), but ood_re and tandem degraded enough to hurt overall val/loss (+2.4%). The eps change doesn't meaningfully help. The 10x larger epsilon reduces update precision on small-gradient parameters, which appears to hurt OOD generalization.

Notably, in_dist Ux (4.24 vs baseline ~5.5) and Uy (1.07 vs ~1.7) improved substantially, suggesting the smoother updates do help for in-distribution velocity prediction. But tandem transfer degraded by +1.51 on pressure, which dominates the combined loss metric.

### Suggested follow-ups
- The in_dist improvements suggest eps=1e-7 might be worth combining with a stronger tandem-focused technique (e.g., PCGrad tandem-only)
- Try eps=5e-8 (halfway between default and 1e-7) as a less aggressive change