### PR TITLE
EMA decay 0.9985 (sweet spot, never tested)

### DIFF
--- a/train.py
+++ b/train.py
@@ -537,7 +537,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 from copy import deepcopy
 ema_model = None
 ema_start_epoch = 40
-ema_decay = 0.998
+ema_decay = 0.9985
 
 n_params = sum(p.numel() for p in model.parameters())
 


### PR DESCRIPTION
## Hypothesis
Midpoint between tested 0.998 (current) and 0.999 (worse). ~667 steps of averaging vs 500 (current).
## Instructions
Change `ema_decay = 0.998` to `0.9985` (line 540). Run with `--wandb_group ema-09985`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `bra7z9i7` | **Epochs:** 58 | **Best epoch:** 58

| Split | surf_Ux | surf_Uy | surf_p | vol_MAE |
|---|---|---|---|---|
| in_dist | 5.18 | 1.70 | **18.13** | 6.94 |
| ood_cond | 3.42 | 1.19 | **14.27** | 4.58 |
| ood_re | 2.86 | 1.01 | **27.79** | 16.09 |
| tandem | 5.47 | 2.24 | **38.37** | 13.46 |

**val/loss: 0.8755** (baseline: 0.8477, delta=+0.0278, ~6sigma worse)

**surf_p mean3** (in/ood_c/tan): 23.59 vs baseline 23.08 (delta=+0.51, all splits worse)

### What happened

EMA decay 0.9985 is consistently worse than baseline 0.998 across all four splits, by a statistically significant margin (~6sigma on val/loss). Every split degraded slightly: in_dist +0.39, ood_cond +0.50, ood_re +0.27, tandem +0.65. The hypothesis that the midpoint 0.9985 would find a sweet spot does not hold -- the current 0.998 is already better.

The interpretation: slower EMA averaging (~667 effective steps vs ~500) slightly over-smooths the weights for this training length. With only ~58 epochs, the model has not converged deeply enough for a 0.9985 window to add value. Alternatively, 0.998 may simply be a genuine local sweet spot.

### Suggested follow-ups

- Try lower EMA values (0.997, 0.995) -- if the optimum is below 0.998, that direction remains unexplored
- Try varying EMA start epoch (currently epoch 40) -- later start with 0.9985 might avoid early noise
- Since EMA has a relatively small effect here, focus might yield more elsewhere