### PR TITLE
Cosine eta_min=3e-5 (colder floor, never tested)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=3e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
Between 5e-5 (current) and 1e-5. Colder floor = less late-training perturbation to EMA weights.
## Instructions
Change `eta_min=5e-5` to `eta_min=3e-5` (line 581). Run with `--wandb_group etamin-3e5`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** 5ssbbzxg | **Epochs:** 61 | **Peak VRAM:** ~17.5 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| val_in_dist | 0.5858 | 4.43 | 1.22 | 17.80 | 1.08 | 0.36 | 18.91 |
| val_ood_cond | 0.6849 | 2.62 | 0.83 | 13.80 | 0.70 | 0.27 | 11.70 |
| val_ood_re | 0.5357 | 2.16 | 0.73 | 27.61 | 0.81 | 0.36 | 46.88 |
| val_tandem_transfer | 1.6365 | 4.80 | 1.71 | 38.75 | 1.92 | 0.87 | 38.23 |
| **val/loss** | **0.8607** | | | | | | |

**vs baseline (0.8477):** +0.013 (slightly worse)

| Metric | eta_min=3e-5 | Baseline | Delta |
|--------|--------------|----------|-------|
| mae_surf_p in_dist | 17.80 | 17.74 | +0.06 |
| mae_surf_p ood_cond | 13.80 | 13.77 | +0.03 |
| mae_surf_p ood_re | 27.61 | 27.52 | +0.09 |
| mae_surf_p tandem | 38.75 | 37.72 | +1.03 |

**What happened:** eta_min=3e-5 is slightly worse than 5e-5 across all splits. In-dist and ood_cond are essentially identical to baseline (within noise), but tandem transfer is noticeably worse (+1.03 mae_surf_p). The lower LR floor means the model makes more conservative updates in the final 20+ epochs. This may slightly hurt tandem generalization, which requires the model to keep adapting to the less-represented tandem distribution. The result is not conclusive — the deltas on in-dist/ood are within noise — but there's no benefit to lowering the floor further.

**Suggested follow-ups:**
- The current eta_min=5e-5 appears to be at or near optimal for this regime. Going lower (3e-5) doesn't help; going higher (tried T_max=59 in a prior PR) also didn't help.
- If LR schedule tuning is worth pursuing, consider a warmup period extension (more than 10 epochs) rather than adjusting eta_min.