### PR TITLE
Grad clip 1.5 (preserve PCGrad direction, never >1.0)

### DIFF
--- a/train.py
+++ b/train.py
@@ -831,7 +831,7 @@ for epoch in range(MAX_EPOCHS):
             optimizer.zero_grad()
             loss.backward()
 
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.5)
         optimizer.step()
         if epoch >= ema_start_epoch:
             if ema_model is None:


### PR DESCRIPTION
## Hypothesis
PCGrad creates synthetic gradients that may exceed clip=1.0. Allowing 1.5 preserves more direction info.
## Instructions
Change `max_norm=1.0` to `max_norm=1.5` (line 834). Run with `--wandb_group clip-15`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** 3uv1kzoe  
**Best epoch:** 58

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5932 | 4.42 | 1.86 | **18.32** | 19.39 |
| ood_cond | 0.7037 | 2.61 | 1.06 | **13.96** | 11.91 |
| ood_re | 0.5326 | 2.27 | 0.95 | **27.57** | 46.61 |
| tandem | 1.5924 | 4.62 | 2.25 | **37.37** | 37.10 |
| **combined val/loss** | **0.8555** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8477 | 0.8555 | +0.9% (within noise) |
| in_dist surf_p | 17.74 | 18.32 | +3.3% |
| ood_cond surf_p | 13.77 | 13.96 | +1.4% |
| ood_re surf_p | 27.52 | 27.57 | +0.2% |
| tandem surf_p | 37.72 | 37.37 | **-0.9%** (marginal improvement) |

**Peak memory:** no OOM.

### What happened

**Neutral.** All deltas are within the ~3-7% seed noise floor established by PR #1513. No clear benefit from increasing the gradient clip to 1.5.

The hypothesis was that PCGrad's synthetic gradients exceed max_norm=1.0 and lose direction information. The results don't support this — the model performs essentially identically at clip=1.0 and clip=1.5. This suggests either (a) PCGrad gradients rarely hit the clip threshold at 1.0, making the change a no-op, or (b) the noise floor is too high to detect the difference.

The slight tandem improvement (37.37 vs 37.72) and ood_re near-tie are in the right direction but well within noise.

### Suggested follow-ups

- **Check if clipping is actually active:** Log the fraction of gradient batches where clipping fires (grad_norm > threshold) to verify the hypothesis is grounded. If <10% of steps are clipped, the change can't matter.
- **Try clip=2.0 or clip=0.5:** Wider spread may reveal whether this hyperparameter matters at all.
- **PCGrad gradient magnitude analysis:** If PCGrad rarely clips, the real opportunity may be in how gradients are projected, not clipped.