### PR TITLE
dist_feat scale 5.0 (finer near-surface resolution)

### DIFF
--- a/train.py
+++ b/train.py
@@ -655,7 +655,7 @@ for epoch in range(MAX_EPOCHS):
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-        dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        dist_feat = torch.log1p(dist_surf * 5.0)  # log-scale for better gradient flow
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
@@ -885,7 +885,7 @@ for epoch in range(MAX_EPOCHS):
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 dist_surf = x[:, :, 2:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
-                dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+                dist_feat = torch.log1p(dist_surf * 5.0)  # log-scale for better gradient flow
                 x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
@@ -1066,7 +1066,7 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)
+                dist_feat = torch.log1p(dist_surf * 5.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()


### PR DESCRIPTION
## Hypothesis
Scale 20 was worse. Scale 5 gives finer near-surface gradation — never tested lower than 10.
## Instructions
Change `log1p(dist_surf * 10.0)` to `log1p(dist_surf * 5.0)` in BOTH train and val. Run with `--wandb_group dist-scale-5`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---
## Results

**W&B run**: fkz5mbwt
**Best epoch**: 58 (31.9 min, wall-clock limit)
**VRAM**: ~18 GB (same as baseline)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6209 | 5.10 | 1.70 | **19.01** | 1.10 | 0.37 | 19.55 |
| val_ood_cond | 0.6943 | 3.07 | 1.06 | **13.94** | 0.71 | 0.27 | 12.10 |
| val_ood_re | 0.5367 | 2.60 | 0.83 | **27.70** | 0.81 | 0.36 | 46.85 |
| val_tandem_transfer | 1.6009 | 5.06 | 2.10 | **38.07** | 1.88 | 0.86 | 37.80 |
| **combined** | **0.8632** | | | | | | |

**mean3 (in/ood/tan p)**: (19.01 + 13.94 + 38.07) / 3 = **23.67** vs baseline 23.08 → **+0.59, negative result**

### What happened

Scale 5.0 is worse than baseline, particularly on in_dist (+1.27). Both scale 5 and scale 20 are worse than scale 10, confirming that the current scale 10.0 is near-optimal for this feature.

The scale 5 vs scale 10 vs scale 20 comparison (across this and previous experiments):
- scale 5.0: mean3 = 23.67 (+0.59 vs baseline 23.08) — in_dist severely hurt (+1.27)
- scale 10.0 (baseline): mean3 = 23.08 (best)
- scale 20.0 (prior experiment): mean3 ≈ 23.76 (+1.14 vs that baseline) — tandem severely hurt (+2.62)

The degradation patterns are complementary: scale 5 hurts in_dist (loses near-surface sharpness for single foils) while scale 20 hurts tandem (oversaturates intermediate distances between tandem foils). Scale 10 balances both failure modes.

This is consistent with the log1p function's behavior: log1p(5x) provides roughly 1 additional nat of information per unit distance vs log1p(x), while log1p(20x) compresses the intermediate range. The existing scale 10 sits at a natural sweet spot where:
- Near-surface nodes (dist ≈ 0.05): log1p(0.5)=0.41 (scale 5) vs log1p(1.0)=0.69 (scale 10) — scale 10 gives better signal
- Inter-foil gap nodes (dist ≈ 0.1): log1p(0.5)=0.41 vs log1p(1.0)=0.69 — similar argument applies

### Suggested follow-ups

1. **Scale 7 or 8**: If the sweet spot is between 5 and 10, micro-stepping might find marginal improvement. But the evidence suggests 10 is near the optimum and further tuning has diminishing returns.
2. **Move on from dist_feat scale**: Scale 10 appears optimal. Future experiments should focus on other aspects of the model.