### PR TITLE
Feature cross scale 0.05 (less interaction, never <0.1)

### DIFF
--- a/train.py
+++ b/train.py
@@ -376,7 +376,7 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         x_cross = x * self.feature_cross(x)
-        x = x + 0.1 * x_cross  # residual with small scale
+        x = x + 0.05 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting


### PR DESCRIPTION
## Hypothesis
Scale 0.2 was worse. Scale 0.05 reduces quadratic cross-terms to half current strength. Never tested lower.

## Instructions
Change `x = x + 0.1 * x_cross` to `0.05` (line 379). Run with `--wandb_group fcross-005`.

## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---

## Results

**W&B run:** zb8viple
**Epochs:** 58 (killed by 30-min timeout, normal)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 0.5978 | 7.021 | 2.067 | **18.08** | 1.087 | 0.367 | 19.25 |
| ood_cond | 0.7352 | 3.480 | 1.204 | **14.82** | 0.729 | 0.275 | 12.66 |
| ood_re | 0.5489 | 3.087 | 1.059 | **27.92** | 0.823 | 0.366 | 47.03 |
| tandem | 1.6145 | 6.464 | 2.466 | **38.15** | 1.924 | 0.868 | 38.16 |
| **combined** | **0.8741** | - | - | - | - | - | - |

**mean3 (in+ood_c+tan)/3 surf_p: 23.68** (baseline 23.08, +2.6% worse)

vs Baseline:
- val/loss: 0.8741 vs 0.8477 — 3.1% worse
- in_dist surf_p: 18.08 vs 17.74 — 1.9% worse
- ood_cond surf_p: 14.82 vs 13.77 — 7.6% worse (biggest regression)
- ood_re surf_p: 27.92 vs 27.52 — 1.5% worse
- tandem surf_p: 38.15 vs 37.72 — 1.1% worse

### What happened

**Slight regression.** Reducing the feature cross scale from 0.1 to 0.05 makes things uniformly slightly worse across all splits, with the largest regression on ood_cond (+7.6%). The current 0.1 scale appears to be at or near the optimal for this cross-feature interaction.

The quadratic cross-term `x * feature_cross(x)` at scale 0.1 provides a beneficial non-linear input mixing. Halving it to 0.05 reduces this mixing below the useful threshold — the model has less capacity to learn cross-channel correlations in the input features.

For reference: scale 0.2 was previously tested and was also worse. So both directions (0.05 and 0.2) around the current 0.1 are sub-optimal, suggesting 0.1 is in a local sweet spot.

### Suggested follow-ups

- The current 0.1 scale appears near-optimal; no need to explore this further unless other architecture changes alter the input feature correlations
- If exploring other scales, try 0.15 to confirm the 0.1 → 0.15 direction was also explored and is worse, completing the picture
- No further tuning of this hyperparameter seems warranted given two-sided tests both degraded