### PR TITLE
Warmup start_factor=0.2 (faster initial LR ramp)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]


### PR DESCRIPTION
## Hypothesis
Initial LR doubles (5.2e-4 vs 2.6e-4) while keeping warmup length. Never changed start_factor before.
## Instructions
Change `start_factor=0.1` to `start_factor=0.2` (line 580). Run with `--wandb_group warmup-factor-02`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run**: g3hoijk2
**Best epoch**: 61
**val/loss**: 0.8469 (baseline: 0.8477, delta = -0.0008)

| Split | loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5751 | 6.3745 | 1.9756 | 17.6536 | 1.0675 | 0.3568 | 19.2879 |
| val_tandem_transfer | 1.6051 | 6.0210 | 2.2852 | 37.8599 | 1.8604 | 0.8411 | 37.2704 |
| val_ood_cond | 0.6801 | 3.3080 | 1.1096 | 13.6872 | 0.6986 | 0.2697 | 12.1111 |
| val_ood_re | 0.5274 | 2.8762 | 0.9158 | 27.4657 | 0.8080 | 0.3597 | 46.6570 |

**What happened**: Marginal improvement (-0.0008 vs baseline). In-dist surf_p slightly better (17.65 vs 17.74). OOD splits near-identical to baseline. Tandem slightly worse (37.86 vs 37.72). Overall the delta is well within the noise floor (~0.016) and this is not a meaningful improvement.

The higher start_factor means the model sees a higher LR in the first few epochs, which could marginally help find a better initial trajectory. But the effect is too small to distinguish from noise given the expected seed variance.

**Suggested follow-ups**:
- Try start_factor=0.3 or 0.5 to see if there is a clear optimum in the warmup start LR
- Given that both lr=2.6e-3 (Δ = -0.0018) and this warmup tweak (Δ = -0.0008) are marginal wins, their combination might compound — try combining both