### PR TITLE
Seed 7 at lr=2.6e-3 (never tested on current code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -529,6 +529,7 @@ model_config = dict(
     output_dims=[1, 1, 1],
 )
 
+torch.manual_seed(7); torch.cuda.manual_seed_all(7)
 model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode="default")


### PR DESCRIPTION
## Hypothesis
Seed 7 was one of the better seeds on older code. Never tested on current dist_feat + lr=2.6e-3 code.
## Instructions
Add `torch.manual_seed(7); torch.cuda.manual_seed_all(7)` before model creation. Run with `--wandb_group seed-7-lr26`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72

---

## Results

**W&B run:** jspvowwh  (runtime: 31.9 min, state: failed due to pre-existing vis crash)

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6105 | 8.19 | 2.58 | 18.48 | 1.12 | 0.37 | 20.21 |
| val_ood_cond | 0.7061 | 5.33 | 1.60 | 14.34 | 0.69 | 0.27 | 12.18 |
| val_ood_re | 0.5567 | 5.05 | 1.50 | 28.26 | 0.80 | 0.36 | 47.07 |
| val_tandem_transfer | 1.6285 | 7.70 | 2.86 | 37.91 | 1.91 | 0.86 | 37.34 |
| **val_loss (best)** | **0.8754** | | | | | | |

**mean3_p** = (18.48+14.34+37.91)/3 = **23.58**

**vs baseline:** val_loss +0.0277 (+3.3%), mean3_p +0.50 (+2.2%) — **worse**

### What happened

Seed 7 doesn't improve over the default seed on the current architecture (dist_feat + lr=2.6e-3). All splits are slightly worse than baseline. The val_loss=0.8754 is the best among recent experiments in this series, but still below baseline.

Interestingly, the Ux/Uy surface errors are notably higher (8.19/2.58 vs ~6.0/2.0 typical) suggesting seed 7 leads to different optimizer trajectory that hurts velocity prediction while keeping pressure competitive (18.48 vs 17.74). This seed-specific bias may have been beneficial on older architectures but doesn't transfer to the current one.

### Suggested follow-ups

- Seed ensemble: run 3 seeds (default, 7, 42) and average predictions at inference
- Or reduce LR slightly for seed 7 — the Ux instability could indicate a too-large step at this seed's initialization