### PR TITLE
Coarse pool size 48 (match slice_num granularity)

### DIFF
--- a/train.py
+++ b/train.py
@@ -753,7 +753,7 @@ for epoch in range(MAX_EPOCHS):
 
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None
-        coarse_pool_size = 64
+        coarse_pool_size = 48
         B, N, C = pred.shape
         n_groups = N // coarse_pool_size
         if n_groups > 1:


### PR DESCRIPTION
## Hypothesis
Matching coarse pool to slice_num=48 creates structural alignment between attention routing and coarse loss. Never tested.
## Instructions
Change `coarse_pool_size = 64` to `48` (line 756). Run with `--wandb_group coarse-48`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** whtl8r74  
**Epochs completed:** 59 (timeout at epoch 60)

### Metrics vs Baseline

| Metric | Baseline | coarse-48 | Delta |
|--------|----------|-----------|-------|
| val_loss | 0.8477 | **0.8706** | +2.7% worse |
| in_dist surf MAE | 17.74 | 21.90 | +23% worse |
| ood_cond surf MAE | 13.77 | 17.92 | +30% worse |
| ood_re surf MAE | 27.52 | 31.07 | +13% worse |
| tandem surf MAE | 37.72 | 44.04 | +17% worse |

Surface MAE by channel (best epoch):
- in_dist: Ux=3.54, Uy=0.90, p=17.46
- ood_cond: Ux=2.77, Uy=0.73, p=14.42
- ood_re: Ux=2.58, Uy=0.65, p=27.84
- tandem: Ux=3.67, Uy=1.40, p=38.97

**Epoch time:** ~30.7s vs baseline ~28s (+10% overhead)

### What happened

coarse_pool_size=48 is worse than 64 at comparable epochs. val_loss=0.8706 at epoch 59 vs baseline 0.8477. The val_loss was still trending down at cutoff (last 5 epochs: 0.8885 → 0.8835 → 0.8781 → 0.8754 → 0.8706, ~0.0045/epoch). Extrapolating 3 more epochs gives ~0.8571, still 1.1% below baseline.

The alignment hypothesis doesn't hold — matching coarse_pool_size to slice_num appears to hurt convergence slightly rather than help. One possible reason: N=10,000 nodes / 48 = ~208 groups. At 48, more groups means smaller pools, so each coarse aggregate covers fewer points. This increases variance in the coarse loss signal, making it a noisier regularizer. The original 64 groups (N/64 ≈ 156 points each) may simply be a better granularity for the coarse supervision.

### Suggested follow-ups

- Try coarse_pool_size=32 — if smaller is worse, that confirms 64 is near-optimal
- Try removing the coarse loss entirely for an epoch or two to test its contribution
- Try adaptive pool size based on actual N per sample rather than fixed