### PR TITLE
EMA start epoch 43 (later start, never tested)

### DIFF
--- a/train.py
+++ b/train.py
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 43
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
Between tested ep40 (current) and ep42 (worse). At ep43 the cosine LR is ~1.4e-3, deeper into decay.
## Instructions
Change `ema_start_epoch = 40` to `43` (line 539). Run with `--wandb_group ema-ep43`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B Run:** dt3ozrrh
**Best epoch:** 61 (run killed by timeout mid-epoch 62; model still improving at termination)

### Metrics vs Baseline

| Split | surf_p | surf_Ux | surf_Uy |
|-------|--------|---------|---------|
| val_in_dist | 17.90 | 5.87 | 1.95 |
| val_ood_cond | 14.12 | 3.03 | 1.16 |
| val_ood_re | 27.68 | 2.55 | 0.97 |
| val_tandem_transfer | 39.18 | 5.73 | 2.41 |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8477 | 0.8704 | +0.0227 ↑ worse |
| in surf_p | 17.74 | 17.90 | +0.16 ↑ worse |
| ood_c surf_p | 13.77 | 14.12 | +0.35 ↑ worse |
| ood_r surf_p | 27.52 | 27.68 | +0.16 ↑ worse |
| tan surf_p | 37.72 | 39.18 | +1.46 ↑ worse |
| mean3 surf_p | ~19.68 | 19.90 | +0.22 ↑ worse |

**Peak memory:** ~17.7 GB (no change from baseline)

### What happened

Negative result. Delaying EMA start from epoch 40 to 43 hurts performance across all splits, with tandem being most affected (+1.46 surf_p). 

The convergence curve shows the model was still improving at the last logged epoch (61), but at a slower rate than baseline. The last 5 epochs show monotonically decreasing val/loss (0.8831 → 0.8704), suggesting the model is on a reasonable trajectory — just shifted upward relative to baseline.

The likely explanation: EMA starting at epoch 40 catches the model right as it transitions from the rapid learning phase into fine-tuning (~LR ≈ 1.75e-3 at ep40 vs ~1.4e-3 at ep43). Earlier EMA averaging provides more smoothing over the high-LR portion of the trajectory, producing a better-regularized final model. Starting 3 epochs later misses this window.

Note: The run is in W&B 'running' state because the timeout killed the process mid-epoch 62 before it could send a final flush. All 61 validation epochs are logged correctly in history.

### Suggested follow-ups

- Try ep38 (earlier than current ep40) — if ep40 is better than ep43 because earlier is better, ep38 might improve further
- Try ep35 — even more EMA smoothing during the warm-up/high-LR phase
- The tandem split is most sensitive to this change; EMA timing may matter more for complex flow scenarios