### PR TITLE
Hard-mining epoch 25 (5 earlier on current code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -736,8 +736,8 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
+        # Asymmetric hard-node mining for non-tandem samples after epoch 25 (vectorized)
+        if epoch >= 25:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))


### PR DESCRIPTION
## Hypothesis
Currently starts at epoch 30. Starting 5 earlier gives more epochs of focused surface-hard-node loss. Never tested on current code.
## Instructions
Change `epoch >= 30` to `epoch >= 25` (line 740). Run with `--wandb_group hardmine-ep25`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run ID:** dns6h84d  
**Best epoch:** 61 (wall-clock timeout at ~30.0 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8505** | 0.8477 |
| val_in_dist | 0.5922 | — |
| val_tandem_transfer | 1.6052 | — |
| val_ood_cond | 0.6617 | — |
| val_ood_re | 0.5429 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 6.06 | 1.77 | 18.28 | 17.74 | +3.0% |
| val_tandem_transfer | 5.52 | 2.10 | 38.21 | 37.72 | +1.3% |
| val_ood_cond | 3.94 | 1.15 | **13.28** | 13.77 | **-3.6%** |
| val_ood_re | 3.67 | 0.97 | 27.92 | 27.52 | +1.5% |

**mean3 surf_p** = (18.28 + 13.28 + 38.21) / 3 = **23.26** (baseline: 23.01, delta: +1.1%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.09 | 0.36 | 19.93 |
| val_tandem_transfer | 1.88 | 0.85 | 37.75 |
| val_ood_cond | 0.70 | 0.26 | 11.42 |
| val_ood_re | 0.81 | 0.36 | 46.94 |

---

### What happened

**Borderline negative result.** val/loss = 0.8505 vs baseline 0.8477 (+0.3% — essentially flat). mean3 surf_p = 23.26 vs 23.01 (+1.1% worse).

Mixed signals: val_ood_cond improved meaningfully (-3.6%, 13.28 vs 13.77), which is the largest ood_cond improvement of recent experiments. However, val_in_dist (+3.0%) and val_tandem_transfer (+1.3%) are slightly worse. val_ood_re is nearly flat (+1.5%).

The earlier hard-node mining start (epoch 25 vs 30) gives 5 more epochs of boosted surface pressure losses. This helps the model focus on harder nodes during a window when the weights are still rapidly evolving, which may explain the ood_cond boost. The slight val_in_dist regression likely reflects that early hard-node mining directs capacity toward difficult nodes at the cost of easy cases that are already well-solved.

The net picture is neutral: the ood_cond gain (+3.6%) is encouraging but doesn't offset losses elsewhere in the aggregate metrics. This is consistent with the hard-node mining mechanism being beneficial for OOD conditions but slightly hurting in-distribution accuracy.

*Visualization crash* (same as previous PRs): `mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x58)` in `feature_cross`. Training metrics are unaffected.

---

### Suggested follow-ups

- **Even earlier start (epoch 20)**: If the ood_cond improvement tracks with earlier mining, going to epoch 20 might push it further. Diminishing returns expected at some point.
- **Earlier start + higher cap**: Combining ep25 start with a higher boost cap (e.g. 3x instead of 1.5x) to amplify the effect of early hard mining.
- **Hard-mining end epoch**: Currently runs indefinitely once started. Adding an end epoch (e.g. stop at epoch 50) might let the model consolidate without continued hard-node pressure in late training.
