### PR TITLE
Tandem boost cap 3.0 (down from 4.0, never tuned)

### DIFF
--- a/train.py
+++ b/train.py
@@ -746,7 +746,7 @@ for epoch in range(MAX_EPOCHS):
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-        adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
+        adaptive_boost = max(1.0, min(3.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss


### PR DESCRIPTION
## Hypothesis
Cap=4.0 was never tuned. At current performance level, 4x boost may cause extreme gradient ratios. 3.0 is gentler.
## Instructions
Change `min(4.0, ...)` to `min(3.0, ...)` (line 749). Run with `--wandb_group boost-cap-3`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** xepts16k
**Runtime:** 1914s (58 epochs, visualization crash at end — pre-existing bug in base code)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.8914 | +5.2% worse |
| val_in_dist surf_p | 17.74 | 19.116 | +7.8% worse |
| val_ood_cond surf_p | 13.77 | 14.425 | +4.8% worse |
| val_ood_re surf_p | 27.52 | 28.072 | +2.0% worse |
| val_tandem surf_p | 37.72 | 39.301 | +4.2% worse |

Detailed metrics (last epoch):
- in_dist: loss=0.6265, surf_p=19.116, surf_Ux=5.779, surf_Uy=1.498, vol_Ux=1.135, vol_Uy=0.366, vol_p=20.617
- ood_cond: loss=0.7269, surf_p=14.425, surf_Ux=3.460, surf_Uy=0.988, vol_Ux=0.722, vol_Uy=0.275, vol_p=12.098
- ood_re: loss=0.5603, surf_p=28.072, surf_Ux=3.070, surf_Uy=0.859, vol_Ux=0.829, vol_Uy=0.365, vol_p=47.015
- tandem: loss=1.6517, surf_p=39.301, surf_Ux=5.665, surf_Uy=2.001, vol_Ux=1.932, vol_Uy=0.877, vol_p=38.352

**What happened:** Reducing the boost cap from 4.0 to 3.0 made things worse across all splits. Counterintuitively, the gentler cap hurts rather than helps — the model appears to need the stronger tandem boost (up to 4.0x) to properly learn from tandem samples. With a weaker cap, tandem samples receive less upweighting relative to the in-dist samples, so the model doesn't converge as well on tandem-specific features. The val/loss was still improving at epoch 57 (the last epoch), suggesting neither cap value is causing early collapse — just different convergence rates.

**Suggested follow-ups:**
- Try cap=5.0 or cap=6.0 to see if more aggressive boosting helps (the opposite direction)
- The cap is controlling a ratio of running losses, so it may be more principled to tune based on the typical loss ratio observed during training rather than a fixed value