### PR TITLE
Temperature clamp epoch 45 (5 earlier, align with EMA)

### DIFF
--- a/train.py
+++ b/train.py
@@ -849,7 +849,7 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= 45:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
     epoch_vol /= n_batches


### PR DESCRIPTION
## Hypothesis
Currently clamps at epoch 50, EMA starts at 40. Clamping at 45 gives 5 more clamped-EMA epochs for stable attention.
## Instructions
Change `epoch >= 50` to `epoch >= 45` (line 852). Run with `--wandb_group temp-clamp-ep45`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `rxe4c0ur`
**Epochs:** 61 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5973 | 5.36 | 1.88 | 18.53 | 1.09 | 0.35 | 19.39 |
| ood_cond | 0.7132 | 2.79 | 1.29 | 14.59 | 0.71 | 0.27 | 12.00 |
| ood_re | 0.5439 | 2.42 | 1.15 | 27.78 | 0.82 | 0.36 | 46.84 |
| tandem | 1.6297 | 5.71 | 2.30 | 38.66 | 1.93 | 0.86 | 37.81 |
| **combined** | **0.8710** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (18.53 + 14.59 + 38.66) / 3 = **23.93**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8477 | 0.8710 | +2.7% |
| surf_p in_dist | 17.74 | 18.53 | +4.5% |
| surf_p ood_cond | 13.77 | 14.59 | +6.0% |
| surf_p ood_re | 27.52 | 27.78 | +0.9% |
| surf_p tandem | 37.72 | 38.66 | +2.5% |
| surf_p mean3 | 23.08 | 23.93 | +3.7% |

### What happened

Negative result. Clamping temperature 5 epochs earlier (epoch 45 vs 50) worsened all splits, particularly in_dist (+4.5%) and ood_cond (+6.0%).

The hypothesis was that 5 more epochs of stable (clamped) attention under EMA would improve convergence. But the opposite occurred — early clamping restricts the temperature from its natural optimization path during epochs 45-49, constraining the model before it's ready. At epoch 45, the model is still mid-training: noise is still being applied (until epoch 60), the EMA has only been running 5 epochs, and the cosine schedule hasn't yet reached its decay floor. Restricting attention temperature at this stage prevents the model from adapting its slice sharpness to match the current learning signal.

The epoch 50 default appears to be well-chosen: by then, EMA has run 10 epochs and noise is winding down, so the model is stable enough to clamp without harming expressivity.

### Suggested follow-ups

- Test epoch 55 (later clamping — allow full noise-free optimization before clamping)
- Apply per-head clamping: only clamp heads that have exceeded the threshold, rather than always clamping block 0
- Investigate whether multiple blocks need temperature clamping (currently only blocks[0])
