### PR TITLE
Skip gate bias -3.0 (more closed, never tuned)

### DIFF
--- a/train.py
+++ b/train.py
@@ -311,7 +311,7 @@ class Transolver(nn.Module):
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
         self.skip_gate = nn.Sequential(nn.Linear(n_hidden, 1), nn.Sigmoid())
-        nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
+        nn.init.constant_(self.skip_gate[0].bias, -3.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))


### PR DESCRIPTION
## Hypothesis
Current -2.0 gives gate=0.12. At -3.0 gate=0.047 — skip connection starts nearly off, trusting the attention path. Never tuned.
## Instructions
Change `-2.0` to `-3.0` in skip_gate bias init (line 314). Run with `--wandb_group skipgate-bias-3`.
## Baseline
val_loss=0.8477 | in=17.74 | ood_c=13.77 | ood_r=27.52 | tan=37.72
---
## Results

**W&B run:** `5kbepc86`

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in-dist | 0.5881 | 5.56 | 1.93 | **17.66** | 1.05 | 0.35 | 18.89 |
| ood-cond | 0.6978 | 3.80 | 1.32 | **13.77** | 0.71 | 0.27 | 11.86 |
| ood-re | 0.5491 | 3.23 | 1.09 | 27.92 | 0.81 | 0.36 | 47.11 |
| tandem | 1.6399 | 5.37 | 2.23 | 39.48 | 1.89 | 0.86 | 38.59 |
| **combined** | **0.8687** | — | — | — | — | — | — |

**vs baseline:** val/loss 0.8687 vs 0.8477 (+0.021 worse)

Surface pressure comparison:
- in-dist: **17.66 vs 17.74 (−0.08, slight improvement)**
- ood-cond: **13.77 vs 13.77 (neutral, identical)**
- ood-re: 27.92 vs 27.52 (+0.40 worse)
- tandem: 39.48 vs 37.72 (+1.76 worse)

**What happened:** Partial result — mixed signals. The skip gate starting more closed (gate=0.047 vs 0.12) gives a small benefit on in-distribution and neutral on ood-cond. However, it hurts on ood-re and tandem. The combined val/loss is worse (+0.021), primarily dragged down by tandem transfer (+1.76 Pa).

Hypothesis: with the gate more closed initially, the model's attention path must do more work early in training without the skip regularization. This works well when the attention has enough signal (in-dist), but for the harder generalization splits (ood-re, tandem) the reduced skip contribution early in training leads the model to converge to a worse minimum.

The in-dist and ood-cond improvements (+0.08, neutral) are promising but small. The tandem degradation is the dominant effect.

**Suggested follow-ups:**
- Try -1.5 (gate=0.18, slightly more open) — the current -2.0 baseline may not be optimal in either direction; a more open gate might be better for tandem generalization
- Try keeping -3.0 but adding a gate warmup: linearly increase from -3.0 to -2.0 over the first 20 epochs so the skip path gradually activates