### PR TITLE
Warmup start_factor=0.3 (continue winning direction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.3, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]


### PR DESCRIPTION
## Hypothesis
start_factor 0.1→0.2 was the 9th merge. Continue sweeping upward — initial LR 7.8e-4 (vs 5.2e-4 at 0.2).
## Instructions
Change `start_factor=0.2` to `start_factor=0.3` on line 580. Run with `--wandb_group warmup-sf-03`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** `qu07de4g` | **best_epoch:** 58

| Metric | Baseline (sf=0.2) | sf=0.3 | Δ |
|--------|-------------------|--------|---|
| val/loss | 0.8469 | **0.8548** | +0.008 |
| in_dist surf p | 17.65 | 17.72 | +0.07 |
| ood_cond surf p | 13.69 | 14.02 | +0.33 |
| ood_re surf p | 27.47 | **27.36** | -0.11 |
| tandem surf p | 37.86 | 38.07 | +0.21 |
| mean3 | ~23.07 | 23.27 | +0.20 |

**Surface MAE detail (Ux / Uy / p):**
- in_dist: 5.38 / 1.82 / 17.72
- ood_cond: 3.66 / 1.17 / 14.02
- ood_re: 3.27 / 1.00 / 27.36
- tandem: 5.95 / 2.38 / 38.07

**Volume MAE (in_dist):** Ux=1.09, Uy=0.35, p=19.08

### What happened

Increasing start_factor beyond 0.2 gives **worse results** — confirming that 0.2 is the sweet spot for this setup. val/loss rose by +0.008 and ood_cond degraded by +0.33. Only ood_re saw a tiny improvement (-0.11).

The higher initial LR (7.8e-4 vs 5.2e-4 with sf=0.2) causes more aggressive early updates that hurt OOD generalization. The warmup sweep 0.1 → 0.2 improved, but the plateau appears at 0.2.

### Suggested follow-ups
- The warmup direction has been exhausted in both directions (0.1 was the merged baseline, 0.2 improved, 0.3 is worse)
- Try warmup length: change `total_iters=10` to `total_iters=8` (shorter warmup with sf=0.2)
- Try warmup schedule shape: cosine warmup instead of linear