### PR TITLE
AdamW beta1=0.85 (untouched default across 1228 experiments)

### DIFF
--- a/train.py
+++ b/train.py
@@ -575,7 +575,7 @@ other_params = [p for n, p in model.named_parameters() if not any(k in n for k i
 base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
-], weight_decay=cfg.weight_decay)
+], weight_decay=cfg.weight_decay, betas=(0.85, 0.999))
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)


### PR DESCRIPTION
## Hypothesis
Beta1 has been 0.9 (PyTorch default) across ALL 1228 experiments — never once changed. Beta2 was tested but beta1 was completely ignored. With PCGrad creating synthetic gradient projections, a faster-decaying first moment (0.85) tracks projected directions more accurately.
## Instructions
Add `betas=(0.85, 0.999)` to the AdamW constructor (line 575-578). Run with `--wandb_group beta1-085`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** hznqs2ml | **Epochs:** 61 | **Peak VRAM:** ~17.5 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|-------|----------|-------------|-------------|------------|------------|------------|-----------|
| val_in_dist | 0.5919 | 6.07 | 2.12 | 18.22 | 1.07 | 0.36 | 19.73 |
| val_ood_cond | 0.7012 | 3.50 | 1.18 | 13.80 | 0.71 | 0.27 | 11.83 |
| val_ood_re | 0.5562 | 3.04 | 0.95 | 28.14 | 0.82 | 0.36 | 47.13 |
| val_tandem_transfer | 1.6175 | 6.34 | 2.53 | 38.31 | 1.89 | 0.87 | 37.99 |
| **val/loss** | **0.8667** | | | | | | |

**vs baseline (0.8469):** +0.020 (worse)

| Metric | beta1=0.85 | Baseline | Delta |
|--------|------------|----------|-------|
| mae_surf_p in_dist | 18.22 | 17.65 | +0.57 |
| mae_surf_p ood_cond | 13.80 | 13.69 | +0.11 |
| mae_surf_p ood_re | 28.14 | 27.47 | +0.67 |
| mae_surf_p tandem | 38.31 | 37.86 | +0.45 |

**What happened:** beta1=0.85 is uniformly worse than the default 0.9 across all splits (+0.020 val/loss, +0.57 in-dist pressure). A faster-decaying first moment means the optimizer relies more on recent gradient estimates and less on accumulated history. This appears to hurt: with Lookahead(k=10), the inner loop already does 10 fast updates, so the outer slow weights already have built-in momentum smoothing. Reducing beta1 may be destabilizing this interaction — the PCGrad-projected gradients at each step are already noisy, and beta1=0.9 provides better averaging over them.

**Suggested follow-ups:**
- The default beta1=0.9 is well-suited for this optimizer stack (AdamW + Lookahead + PCGrad). Tuning beta1 further in the other direction (0.95) is unlikely to help given the Lookahead interaction.
- If optimizer tuning is worth pursuing, consider the Lookahead alpha (currently 0.8) or k (currently 10) as they have been untested since their introduction.