### PR TITLE
Spatial bias scale 0.05 (halve spatial prior influence)

### DIFF
--- a/train.py
+++ b/train.py
@@ -164,7 +164,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             temp = (temp + self.tandem_temp_offset * tandem_mask).clamp(min=1e-4)
         slice_logits = self.in_project_slice(x_mid) / temp
         if spatial_bias is not None:
-            slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
+            slice_logits = slice_logits + 0.05 * spatial_bias.unsqueeze(1)
         slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)


### PR DESCRIPTION
## Hypothesis
The hard-coded `0.1 * spatial_bias` coefficient on line 167 was set once and NEVER tuned. With dist_feat giving richer spatial features, the model may benefit from less coordinate-based routing bias (0.05) letting content-based routing dominate.
## Instructions
Change `+ 0.1 * spatial_bias.unsqueeze(1)` to `+ 0.05 * spatial_bias.unsqueeze(1)` on line 167. Run with `--wandb_group spbias-005`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** lafopvsc  
**Best epoch:** 57

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.6099 | 5.37 | 1.65 | **18.46** | 19.26 |
| ood_cond | 0.7115 | 3.18 | 1.13 | **14.48** | 12.05 |
| ood_re | 0.5512 | 2.67 | 0.98 | **27.93** | 46.80 |
| tandem | 1.6183 | 5.35 | 2.09 | **38.07** | 37.54 |
| **combined val/loss** | **0.8727** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8469 | 0.8727 | +3.0% worse |
| in_dist surf_p | 17.65 | 18.46 | +4.6% |
| ood_cond surf_p | 13.69 | 14.48 | +5.8% |
| ood_re surf_p | 27.47 | 27.93 | +1.7% |
| tandem surf_p | 37.86 | 38.07 | +0.6% |

**Peak memory:** no OOM.

### What happened

**Mildly negative.** Halving the spatial bias coefficient from 0.1 to 0.05 degraded performance across all splits. All deltas are in the 1-6% range, partially overlapping the seed noise floor, but the consistent negative direction suggests this is a real regression rather than noise.

The result implies the current 0.1 scale is already well-calibrated — the spatial bias is providing useful coordinate-based routing signal that helps the model. Reducing it forces more weight onto content-based routing (from x_mid), which appears insufficient on its own to replicate the positional guidance.

The ood_cond drop (+5.8%) is the largest, suggesting that for out-of-distribution conditions, the spatial prior is especially important for routing nodes to appropriate slices.

### Suggested follow-ups

- **Try 0.2 (double):** If 0.05 hurts, maybe 0.2 helps — especially for tandem/OOD generalization where geometry is key.
- **Learnable coefficient:** Replace the scalar 0.1 with a learnable per-layer scale (initialized to 0.1) and let it adapt during training.
- **Ablate spatial bias entirely (0.0):** Confirms whether the bias is helping; if 0.0 is also worse than 0.1, we know the current scale is near-optimal.