### PR TITLE
SE reduction ratio 8 (from 4, stronger regularization)

### DIFF
--- a/train.py
+++ b/train.py
@@ -219,8 +219,8 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.spatial_bias[-1].bias)
         self.ln_1_post = nn.LayerNorm(hidden_dim)
         self.ln_2_post = nn.LayerNorm(hidden_dim)
-        self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
-        self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
+        self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 8)
+        self.se_fc2 = nn.Linear(hidden_dim // 8, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:


### PR DESCRIPTION
## Hypothesis
SE block uses n_hidden//4=48 intermediate dims. Ratio 8 (24 dims) is ImageNet-standard and was NEVER tuned here. Stronger SE regularization on channel attention.
## Instructions
Change `self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)` to `hidden_dim // 8` and same for `se_fc2` on lines 222-223. Run with `--wandb_group se-ratio-8`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** paay5xk3  
**Best epoch:** 57 / 57  

| Split | mae_surf_p | mae_surf_Ux | mae_surf_Uy | mae_vol_p |
|---|---|---|---|---|
| in_dist | 18.10 | 6.53 | 2.12 | 19.08 |
| ood_cond | 13.87 | 3.28 | 1.08 | 11.94 |
| ood_re | 28.00 | 2.90 | 0.96 | 46.81 |
| tandem | 38.86 | 6.34 | 2.41 | 38.40 |

**val/loss:** 0.8736 (baseline: 0.8469)  
**mean3 (in/ood_c/tan surf_p):** 23.61 (baseline: 23.07)  
**Peak memory:** ~18.5 GB  

**What happened:** Negative result. Halving the SE bottleneck dimension from 48 to 24 made things slightly worse across all splits. The larger 48-dim bottleneck appears better suited to this problem — perhaps the model needs enough capacity in the SE path to capture meaningful channel interactions given the 192-dim hidden space. The hypothesis that a tighter bottleneck provides beneficial regularization didn't hold here.

**Suggested follow-ups:**
- Try SE ratio 2 (96 dims, wider bottleneck) — the opposite direction, more capacity in SE path.
- Try removing SE entirely to see how much it contributes.