### PR TITLE
Attention scale init=5.0 (from 10.0, softer initial attention)

### DIFF
--- a/train.py
+++ b/train.py
@@ -142,7 +142,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
         )
-        self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 5.0)
 
     def forward(self, x, spatial_bias=None, tandem_mask=None):
         bsz, num_points, _ = x.shape


### PR DESCRIPTION
## Hypothesis
`self.attn_scale` initialized at 10.0 and NEVER tuned. Softer initial scale (5.0) lets the model explore more broadly in early training.
## Instructions
Change `* 10.0` to `* 5.0` on line 145. Run with `--wandb_group attn-scale-5`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** 9gqdfubk | 59 epochs (timeout)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5881 | 6.43 | 2.11 | 17.99 | 19.26 |
| ood_cond | 0.6914 | 3.94 | 1.32 | 13.67 | 11.55 |
| ood_re | 0.5413 | 3.51 | 1.13 | 27.79 | 46.80 |
| tandem | 1.6428 | 6.18 | 2.52 | 38.93 | 38.14 |
| **combined** | **0.8659** | | | | |

**mean3 (in/ood_c/tan surf_p):** 23.53 vs baseline 23.07 (+2.0% worse)

**Peak memory:** ~same as baseline (no change to model size)

**What happened:** Softer initial attention scale (5.0 vs 10.0) slightly hurt performance across all splits. In-dist surf_p went from 17.65 → 17.99 (+1.9%), tandem from 37.86 → 38.93 (+2.8%). Only ood_cond showed a marginal improvement (13.69 → 13.67). The current 10.0 init appears well-calibrated — it likely keeps slices sufficiently separated early in training, helping the model assign points to distinct slices. A softer scale of 5.0 may allow too much overlap between slices during the critical early-learning phase, reducing the representational diversity that slice-based attention relies on.

**Suggested follow-ups:**
- Try attn_scale init=20.0 (harder initial separation) to test the other direction
- Make attn_scale learnable per-head with different init strategies
- Investigate whether the learned final value of attn_scale differs between 5.0 and 10.0 inits (if they converge to a similar value, init doesn't matter; if they diverge, the init sets the operating regime)