### PR TITLE
Slice residual scale init=0.2 (from 0.1, stronger physics bypass)

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,7 +137,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
-        self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
+        self.slice_residual_scale = nn.Parameter(torch.tensor(0.2))
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),


### PR DESCRIPTION
## Hypothesis
`slice_residual_scale` initialized at 0.1 — set once during the slice residual merge and NEVER tuned. Stronger initial scale (0.2) preserves more local physics information before Q/K/V attention.
## Instructions
Change `torch.tensor(0.1)` to `torch.tensor(0.2)` on line 140. Run with `--wandb_group slice-res-02`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run**: bbj69hjt
**Best epoch**: 61
**val/loss**: 0.8575 (baseline: 0.8469, delta = +0.0106)

| Split | loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5904 | 5.9592 | 2.0186 | 17.9638 | 1.0759 | 0.3520 | 19.2456 |
| val_tandem_transfer | 1.6063 | 5.5838 | 2.3314 | 37.9512 | 1.9055 | 0.8502 | 37.3161 |
| val_ood_cond | 0.6986 | 3.9239 | 1.3658 | 13.8811 | 0.7258 | 0.2667 | 11.9676 |
| val_ood_re | 0.5346 | 3.5208 | 1.2189 | 27.6582 | 0.8273 | 0.3578 | 46.7981 |

**What happened**: Worse across all splits (+0.0106 vs baseline). The velocity MAEs (surf Ux and Uy) are notably degraded compared to baseline, suggesting that starting with stronger residual bypass confuses the attention mechanism early in training. The residual scale of 0.1 is a good initializer — starting larger biases the model toward bypassing the global slice attention entirely before it has learned useful slice representations. The parameter will be learned from 0.1 anyway, so the initial value mainly affects early training dynamics. 0.1 is appropriate.

**Suggested follow-ups**:
- Try initializing to 0.05 to see if even less residual bypass improves over 0.1
- The learned value at the end of training (after 60+ epochs) is more informative — check what slice_residual_scale converges to