### PR TITLE
Warmup start_factor=0.5 (aggressive upper bracket)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.5, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]


### PR DESCRIPTION
## Hypothesis
Upper bracket of the start_factor sweep. At 0.5, initial LR=1.3e-3. The model may not need gentle warmup with the current well-conditioned architecture.
## Instructions
Change `start_factor=0.2` to `start_factor=0.5` on line 580. Run with `--wandb_group warmup-sf-05`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86

---

## Results

**W&B run:** puqdkpxv  (runtime: 32.0 min, state: failed due to pre-existing vis crash)

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6013 | 5.43 | 1.65 | 17.77 | 1.09 | 0.36 | 19.84 |
| val_ood_cond | 0.7180 | 3.29 | 1.03 | 14.60 | 0.69 | 0.27 | 12.38 |
| val_ood_re | 0.5322 | 2.81 | 0.89 | 27.61 | 0.79 | 0.36 | 46.62 |
| val_tandem_transfer | 1.6276 | 5.53 | 2.18 | 38.81 | 1.88 | 0.86 | 38.25 |
| **val_loss (best)** | **0.8697** | | | | | | |

**mean3_p** = (17.77+14.60+38.81)/3 = **23.73**

**vs baseline:** val_loss +0.0228 (+2.7%), mean3_p +0.66 (+2.9%) — **worse**

### What happened

start_factor=0.5 (initial LR=1.3e-3) is worse than start_factor=0.2 (initial LR=0.52e-3). The model benefits from a gentler warmup. With the higher starting LR, early epochs show more aggressive weight updates that push the optimizer into a slightly worse basin, especially for tandem geometry and ood_cond cases.

The in_dist and ood_re results are competitive (17.77 vs 17.65 and 27.61 vs 27.47), but tandem and ood_cond suffer. This pattern suggests the tandem geometry requires stable early learning — a high initial LR disrupts the formation of tandem-specific representations.

### Suggested follow-ups

- start_factor=0.3 (between current 0.2 and 0.5) to narrow the optimal point
- Or shorter warmup with same 0.2: total_iters=5 instead of 10 (faster ramp)