### PR TITLE
Hard-mining 75th percentile (from median, focus on hardest nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -741,7 +741,7 @@ for epoch in range(MAX_EPOCHS):
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
-            thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
+            thresh = torch.nanquantile(surf_pres_masked.nan_to_num(0.0), 0.75, dim=1)  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else


### PR DESCRIPTION
## Hypothesis
Hard-mining uses median (50th) as threshold — the top 50% get 1.5x weight. At 75th percentile, only the top 25% get boosted, focusing gradient more aggressively on the hardest surface nodes.
## Instructions
Change `thresh = torch.nanmedian(surf_pres_masked, dim=1).values` to `thresh = torch.nanquantile(surf_pres_masked.nan_to_num(0.0), 0.75, dim=1)` on line 744. Run with `--wandb_group hardmine-p75`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** u6xawsab  
**Epochs completed:** 59 (timeout at epoch 60)

### Metrics vs Baseline

| Metric | Baseline | p75 Result | Delta |
|--------|----------|------------|-------|
| val_loss | 0.8469 | **0.8611** | +1.7% worse |
| in_dist surf MAE | 17.65 | 25.84 | +46% worse |
| ood_cond surf MAE | 13.69 | 18.44 | +35% worse |
| ood_re surf MAE | 27.47 | 31.45 | +14% worse |
| tandem surf MAE | 37.86 | 47.32 | +25% worse |

Surface MAE by channel (best epoch):
- in_dist: Ux=6.53, Uy=1.83, p=17.49
- ood_cond: Ux=3.46, Uy=1.15, p=13.83
- ood_re: Ux=2.97, Uy=0.99, p=27.48
- tandem: Ux=6.07, Uy=2.22, p=39.02

**Epoch time:** ~30.6s vs baseline ~28s

### What happened

Moving from median to p75 hurts overall performance. Val_loss=0.8611 at 59 epochs vs baseline 0.8469 at 62 epochs. The val/loss was still trending down (last 5: 0.8804→0.8745→0.8699→0.8639→0.8611) but at ~0.005/epoch, reaching baseline would take ~28 more epochs — well beyond the budget.

The most striking degradation is in **Ux** (in-dist: 6.53 vs baseline ~2-3). By focusing only on the top 25% hardest pressure nodes, the mining signal becomes so narrow that the model trades off Ux accuracy for pressure. The median threshold (top 50%) is a better balance: broad enough to maintain generalization across all channels, aggressive enough to focus on difficult nodes.

The p75 threshold also makes the hard_mask empty for many batches where the 75th percentile of pressure error is relatively uniform (especially early training), so the boosting is irregular and less stable.

### Suggested follow-ups

- Try p60 or p65 as a middle ground between median (50) and p75
- Try harder boost factor (2.0x instead of 1.5x) with median threshold — same spirit but more aggressive on more nodes
- The Ux degradation suggests the mining is too narrow; a per-channel hard-mining (separate thresholds for Ux, Uy, p) might be better than pressure-only thresholding