### PR TITLE
Fourier freqs init [0.5,1.5,4,12] (fill gaps between fixed freqs)

### DIFF
--- a/train.py
+++ b/train.py
@@ -317,7 +317,7 @@ class Transolver(nn.Module):
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
-        self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self.fourier_freqs_learned = nn.Parameter(torch.tensor([0.5, 1.5, 4.0, 12.0]))
 
     def initialize_weights(self):
         self.apply(self._init_weights)


### PR DESCRIPTION
## Hypothesis
Learnable Fourier freqs initialized at [1,3,6,16] and NEVER tuned. Fixed freqs are [0.5,2,8,32]. Starting learnable at [0.5,1.5,4,12] fills spectral gaps instead of overlapping.
## Instructions
Change `nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))` to `nn.Parameter(torch.tensor([0.5, 1.5, 4.0, 12.0]))` on line 320. Run with `--wandb_group fourier-init-gap`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B Run:** t679bwcl
**Best epoch:** 61 (last logged; model still improving at termination)

Note: A visualization error occurred post-training (shape mismatch in vis_model) but all 61 training epochs logged correctly. Run state shows 'running' because the process exited without a W&B flush after the vis crash.

### Metrics vs Baseline

| Split | surf_p | surf_Ux | surf_Uy |
|-------|--------|---------|---------|
| val_in_dist | 18.67 | 6.44 | 1.86 |
| val_ood_cond | 13.84 | — | — |
| val_ood_re | 27.76 | — | — |
| val_tandem_transfer | 39.72 | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8469 | 0.8722 | +0.0253 ↑ worse |
| in surf_p | 17.65 | 18.67 | +1.02 ↑ worse |
| ood_c surf_p | 13.69 | 13.84 | +0.15 ↑ worse |
| ood_r surf_p | 27.47 | 27.76 | +0.29 ↑ worse |
| tan surf_p | 37.86 | 39.72 | +1.86 ↑ worse |
| mean3 surf_p | ~19.60 | 20.09 | +0.49 ↑ worse |

**Peak memory:** ~17.7 GB

**Final learned freqs:** 0.58, 1.82, 3.79, 12.32 (initialized at 0.5, 1.5, 4.0, 12.0)

### What happened

Negative result. Gap-filling initialization hurts performance across all splits.

The final learned frequencies (0.58, 1.82, 3.79, 12.32) are close to initialization, suggesting the model didn't learn to move them much. The original initialization [1.0, 3.0, 6.0, 16.0] likely places the learnable freqs in a more useful spectral region relative to the fixed freqs [0.5, 2.0, 8.0, 32.0].

Interestingly, the fixed freqs already include 0.5 (low frequency coverage), and the gap-filling init put a learnable freq at 0.5 too — this creates overlap at the low end with no gain. The original [1.0, 3.0, 6.0, 16.0] initialization provides intermediate coverage (between 0.5 and 2.0, between 2.0 and 8.0, between 8.0 and 32.0) which may be more informative.

The visualization crashed post-training with a shape error in `vis_model` (`84905x26 vs 58x58`) — this appears to be a bug in how the visualization code loads the model (likely assuming a different feature dimension). It does not affect training metrics.

### Suggested follow-ups

- Try [1.5, 5.0, 10.0, 25.0] — place learned freqs in the middle of each gap between fixed freqs (0.5→2: mid=1.25→1.5, 2→8: mid=5, 8→32: mid~10,25) for more uniform coverage
- The original [1,3,6,16] may be at a local optimum; try perturbing by ±20% to see sensitivity
- Check what freqs the original init converges to — if already similar to gap-filling values, the init may not matter much