### PR TITLE
num_workers=8 (faster data loading, never changed from 4)

### DIFF
--- a/train.py
+++ b/train.py
@@ -474,7 +474,7 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
-loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
+loader_kwargs = dict(collate_fn=pad_collate, num_workers=8, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
 if cfg.debug:


### PR DESCRIPTION
## Hypothesis
num_workers=4 set once and NEVER changed across 1228 experiments. 96GB GPU machine has 32+ CPU cores. Doubling to 8 ensures GPU never waits for data. Pure throughput = more epochs.
## Instructions
Change `num_workers=4` to `num_workers=8` in loader_kwargs on line 477. Run with `--wandb_group workers-8`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run ID:** abamexir  
**Best epoch:** 60 (wall-clock timeout at ~30.0 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8603** | 0.8469 |
| val_in_dist | 0.5972 | — |
| val_tandem_transfer | 1.6105 | — |
| val_ood_cond | 0.6891 | — |
| val_ood_re | 0.5442 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 5.21 | 1.63 | 18.14 | 17.65 | +2.8% |
| val_tandem_transfer | 5.68 | 2.23 | 37.99 | 37.86 | +0.3% |
| val_ood_cond | 3.06 | 0.99 | **13.56** | 13.69 | **-1.0%** |
| val_ood_re | 2.52 | 0.79 | 27.76 | 27.47 | +1.1% |

**mean3 surf_p** = (18.14 + 13.56 + 37.99) / 3 = **23.23** (baseline: 23.07, delta: +0.7%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.10 | 0.36 | 19.15 |
| val_tandem_transfer | 1.92 | 0.86 | 37.03 |
| val_ood_cond | 0.71 | 0.27 | 11.87 |
| val_ood_re | 0.82 | 0.36 | 46.82 |

---

### What happened

**Negative result.** val/loss = 0.8603 vs baseline 0.8469 (+1.6% worse). mean3 surf_p = 23.23 vs 23.07 (+0.7% worse). The run reached epoch 60 (same as typical), so the extra workers did not produce additional epochs.

This training is GPU-bound, not data-loading bound. With `persistent_workers=True` and `prefetch_factor=2`, the 4-worker setup keeps the GPU continuously fed — the data pipeline is not the bottleneck. Doubling to 8 workers adds CPU overhead (more processes, more IPC) without any throughput benefit. The slightly worse metrics are likely noise around the baseline variance rather than a systematic effect of the change.

*Visualization crash* (same as previous PRs): `mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x58)` in `feature_cross`. Training metrics are unaffected.

---

### Suggested follow-ups

- **prefetch_factor=4**: If there is any data-loading bottleneck, larger prefetch buffer may help more than more workers. Still unlikely to matter given GPU-bound training.
- **Compile with max-autotune**: True GPU throughput improvements require model compilation. `torch.compile(model, mode="max-autotune")` can provide 10-20% kernel speedup, more valuable than data loading.
- **Async validation**: Run validation concurrently with training on a separate stream to reduce per-epoch overhead and effectively gain more training steps in 30 min.
