### PR TITLE
Tighter Cp denorm clamps: vel [-5,5], p [-10,10]

### DIFF
--- a/train.py
+++ b/train.py
@@ -469,9 +469,9 @@ def _phys_norm(y, Umag, q):
 def _phys_denorm(y_p, Umag, q):
     """Reverse physics normalization: Ux/Umag→Ux, Uy/Umag→Uy, Cp→p."""
     y = y_p.clone()
-    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-10, 10) * Umag
-    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-10, 10) * Umag
-    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
+    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-5, 5) * Umag
+    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-5, 5) * Umag
+    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-10, 10) * q
     return y
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,


### PR DESCRIPTION
## Hypothesis
Denorm clamps vel [-10,10] and p [-20,20] were set once and NEVER tuned. Physical Cp values for subsonic airfoils are typically [-4,2]. Tighter bounds prevent the model from wasting capacity on implausible predictions.
## Instructions
Change `.clamp(-10, 10)` to `.clamp(-5, 5)` on lines 472-473 (velocity), and `.clamp(-20, 20)` to `.clamp(-10, 10)` on line 474 (pressure). Run with `--wandb_group tight-denorm`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** 1vqlbg9z
**Runtime:** 1918s (58 epochs, visualization crash at end — pre-existing bug)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8469 | 0.8731 | +3.1% worse |
| val_in_dist surf_p | 17.65 | 18.833 | +6.7% worse |
| val_ood_cond surf_p | 13.69 | 14.309 | +4.5% worse |
| val_ood_re surf_p | 27.47 | 27.635 | +0.6% neutral |
| val_tandem surf_p | 37.86 | 41.010 | +8.3% worse |

Detailed metrics (last epoch):
- in_dist: loss=0.5832, surf_p=18.833, surf_Ux=6.573, surf_Uy=2.180, vol_Ux=1.077, vol_Uy=0.352, vol_p=19.308
- ood_cond: loss=0.7033, surf_p=14.309, surf_Ux=2.826, surf_Uy=1.268, vol_Ux=0.709, vol_Uy=0.269, vol_p=12.437
- ood_re: loss=0.5402, surf_p=27.635, surf_Ux=2.408, surf_Uy=1.154, vol_Ux=0.821, vol_Uy=0.359, vol_p=46.746
- tandem: loss=1.6658, surf_p=41.010, surf_Ux=6.144, surf_Uy=2.643, vol_Ux=1.924, vol_Uy=0.880, vol_p=39.604

**What happened:** Tightening the clamps made things worse across all splits. The velocity clamp at ±5 is likely too aggressive — stagnation point velocities and flow accelerations on upper surface can easily exceed 5x freestream, so clipping these predictions prevents the model from accurately representing high-speed flow regions. The original ±10 range for velocity was probably appropriate. Tandem cases are hit hardest (+8.3%) because interference effects create more extreme local velocities. The ood_re case is essentially unchanged (+0.6%), suggesting pressure predictions weren't impacted much by the tighter velocity range.

**Suggested follow-ups:**
- The original clamps may actually be reasonable; if any tuning is warranted, try loosening rather than tightening (e.g., vel ±15, p ±30)
- Alternatively, use adaptive clamps based on the actual data distribution percentiles (e.g., clip at 99.9th percentile of training targets)