### PR TITLE
Tandem normalization clamps [0.2, 0.2, 0.8] (from [0.3, 0.3, 1.0])

### DIFF
--- a/train.py
+++ b/train.py
@@ -686,7 +686,7 @@ for epoch in range(MAX_EPOCHS):
         B = y_norm.shape[0]
         sample_stds = torch.ones(B, 1, 3, device=device)
         channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
-        tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+        tandem_clamps = torch.tensor([0.2, 0.2, 0.8], device=device)
         if model.training:
             for b in range(B):
                 valid = mask[b]
@@ -907,7 +907,7 @@ for epoch in range(MAX_EPOCHS):
                 B = y_norm.shape[0]
                 sample_stds = torch.ones(B, 1, 3, device=device)
                 channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
-                tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
+                tandem_clamps = torch.tensor([0.2, 0.2, 0.8], device=device)
                 for b in range(B):
                     valid = mask[b]
                     if is_tandem[b]:


### PR DESCRIPTION
## Hypothesis
Tandem per-sample std clamps [0.3, 0.3, 1.0] were set once and NEVER tuned. Non-tandem clamps are [0.1, 0.1, 0.5] — 3x tighter. Tightening tandem to [0.2, 0.2, 0.8] allows normalization to capture more variance, improving tandem pressure accuracy.
## Instructions
Change `tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)` to `torch.tensor([0.2, 0.2, 0.8], device=device)` on line 689 and the matching val loop line (~910). Run with `--wandb_group tandem-clamp-tighter`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** `5ttzp8p5`

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in-dist | 0.6231 | 5.57 | 1.35 | 17.74 | 1.08 | 0.36 | 18.91 |
| ood-cond | 0.7215 | 2.85 | 0.93 | **13.25** | — | — | 11.62 |
| ood-re | 0.5835 | 2.54 | 0.82 | 27.60 | — | — | 46.74 |
| tandem | 1.6164 | 4.81 | 1.76 | 38.07 | — | — | 37.50 |
| **combined** | **0.8861** | — | — | — | — | — | — |

**vs baseline:** val/loss 0.8861 vs 0.8469 (+0.039 worse)

Surface pressure comparison:
- in-dist: 17.74 vs 17.65 (+0.09, negligible)
- ood-cond: **13.25 vs 13.69 (−0.44, improvement)**
- ood-re: 27.60 vs 27.47 (+0.13, marginal)
- tandem: 38.07 vs 37.86 (+0.21, marginal)

**What happened:** Mixed result overall — negative. Tighter tandem clamps ([0.2, 0.2, 0.8]) improved ood-cond surface pressure by 0.44 Pa, but the combined val/loss was substantially worse (+0.039). The ood-cond improvement is the one notable finding.

Tighter clamps mean each tandem sample's per-sample std has a higher floor, which means the normalization divides by a larger value → predictions are scaled down more → the loss gradient per sample is amplified more during training. This may help ood-cond (which has different conditions but single-foil geometry) but the increased sensitivity to variance changes may be hurting the overall training dynamics, particularly for the harder tandem transfer case where large per-sample variance is expected and the clamp shouldn't be binding.

**Suggested follow-ups:**
- Try only tightening the pressure clamp: [0.3, 0.3, 0.8] — keep velocity clamps unchanged since the hypothesis was specifically about pressure
- Try [0.15, 0.15, 0.6] — even tighter to see if the ood-cond trend continues
- Check whether the original [0.3, 0.3, 1.0] clamps are actually binding for any samples (do tandem stds ever fall below these values?)