### PR TITLE
Split final projection: separate vel/pressure Linear

### DIFF
--- a/train.py
+++ b/train.py
@@ -225,11 +225,12 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
+            self.mlp2_trunk = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
             )
+            self.vel_out = nn.Linear(hidden_dim, 2)
+            self.pres_out = nn.Linear(hidden_dim, 1)
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -240,7 +241,8 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.mlp2_trunk(self.ln_3(fx))
+            return torch.cat([self.vel_out(h), self.pres_out(h)], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Previous separate head attempts (#1137, #1158, #1415, #1479) duplicated entire MLPs. Never tried: keep shared 2-layer MLP trunk, split ONLY the final Linear(192,3) into Linear(192,2) for velocity and Linear(192,1) for pressure. 1 extra line, near-zero param cost, completely decouples pressure gradient from velocity in the last layer.
## Instructions
In TransolverBlock, when last_layer=True, replace the final layer of mlp2:
```python
# Instead of one Linear(192, 3):
self.vel_out = nn.Linear(hidden_dim, 2)
self.pres_out = nn.Linear(hidden_dim, 1)
# In forward:
h = self.mlp2_trunk(self.ln_3(fx))  # shared trunk: Linear(192,192) -> GELU
return torch.cat([self.vel_out(h), self.pres_out(h)], dim=-1)
```
Run with `--wandb_group split-vel-pres-proj`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** `6rlzziwk` | **best_epoch:** 56

| Metric | Baseline | Split proj | Δ |
|--------|----------|-----------|---|
| val/loss | 0.8469 | **0.8738** | +0.027 |
| in_dist surf p | 17.65 | 18.63 | +0.98 |
| ood_cond surf p | 13.69 | 13.91 | +0.22 |
| ood_re surf p | 27.47 | 27.98 | +0.51 |
| tandem surf p | 37.86 | 38.55 | +0.69 |
| mean3 | ~23.07 | 23.70 | +0.63 |

**Surface MAE detail (Ux / Uy / p):**
- in_dist: 4.54 / 1.60 / 18.63
- ood_cond: 2.90 / 1.11 / 13.91
- ood_re: 2.53 / 0.99 / 27.98
- tandem: 4.79 / 2.11 / 38.55

**Volume MAE (in_dist):** Ux=1.12, Uy=0.36, p=19.22

### What happened

Splitting the final projection **did not help** — clearly worse on all metrics (+3.2% val/loss). The in_dist pressure degraded most (+0.98). The decoupled gradient for pressure actually hurts, not helps.

This is consistent with the hypothesis being wrong: velocity and pressure are physically coupled through the Navier-Stokes equations. Decoupling the pressure gradient at the output layer prevents the model from learning shared representations that capture this coupling. The shared trunk + shared final layer appears to benefit from cross-field interactions in the weight matrix.

In summary: the 4 previous failed attempts at separated heads were not just due to MLP duplication overhead — the architectural separation itself is the problem.

### Suggested follow-ups
- No further splits of velocity/pressure are warranted given 5 failed attempts now
- Instead, task-specific loss weighting (e.g., upweight pressure channel) might be more effective than architectural separation