### PR TITLE
Detach volume from attention gradient after epoch 40

### DIFF
--- a/train.py
+++ b/train.py
@@ -231,9 +231,15 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, epoch=0, is_surface=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
-        fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
+        attn_out = self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask)
+        if not self.last_layer and epoch >= 40 and is_surface is not None:
+            vol_mask = ~is_surface  # [B, N]
+            attn_out_detached = attn_out.clone()
+            attn_out_detached[vol_mask] = attn_out[vol_mask].detach()
+            attn_out = attn_out_detached
+        fx = self.ln_1_post(attn_out + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -362,7 +368,7 @@ class Transolver(nn.Module):
         if sum(self.output_dims) != preds.shape[-1]:
             raise ValueError("Sum of output_dims must match preds last dimension")
 
-    def forward(self, data, pos=None, condition=None):
+    def forward(self, data, pos=None, condition=None, epoch=0, is_surface=None):
         x, pos, condition = self._unpack_inputs(data, pos=pos, condition=condition)
         if x is None:
             raise ValueError("Missing required input tensor: x")
@@ -387,13 +393,13 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, epoch=epoch, is_surface=is_surface)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, epoch=epoch, is_surface=is_surface)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
@@ -697,7 +703,7 @@ for epoch in range(MAX_EPOCHS):
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x}, epoch=epoch, is_surface=is_surface)
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]


### PR DESCRIPTION
## Hypothesis
After epoch 40 (EMA start), volume predictions are well-converged but surface is still improving. 98% of attention gradient comes from volume nodes, drowning out the surface signal. Detaching volume node gradients through attention (but NOT the MLP) in the final 20 epochs focuses all routing optimization on surface.
## Instructions
In TransolverBlock forward, after epoch 40, detach volume nodes from attention output only. Thread `epoch` and `is_surface` into the block forward. Run with `--wandb_group detach-vol-attn-ep40`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** z55oyb8h  
**Best epoch:** 58

### Implementation

- Added `epoch` and `is_surface` params to `TransolverBlock.forward()` and `Transolver.forward()`
- After epoch 40 (non-last layers): clone attn_out, detach volume-node rows before residual add
- Training call site updated: `model({"x": x}, epoch=epoch, is_surface=is_surface)`

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.6084 | 6.04 | 1.78 | **18.73** | 20.19 |
| ood_cond | 0.6924 | 3.27 | 1.14 | **13.59** | 11.79 |
| ood_re | 0.5418 | 2.73 | 0.91 | **27.85** | 46.76 |
| tandem | 1.6470 | 5.72 | 2.15 | **39.44** | 39.02 |
| **combined val/loss** | **0.8724** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8469 | 0.8724 | +3.0% worse |
| in_dist surf_p | 17.65 | 18.73 | +6.1% |
| ood_cond surf_p | 13.69 | 13.59 | **-0.7%** (marginal gain) |
| ood_re surf_p | 27.47 | 27.85 | +1.4% |
| tandem surf_p | 37.86 | 39.44 | +4.2% |

**Peak memory:** no OOM.

### What happened

**Negative overall.** Detaching volume nodes from attention gradients after epoch 40 hurt in_dist (+6.1%) and tandem (+4.2%), with only marginal improvement on ood_cond (-0.7%, within noise).

The hypothesis assumed volume gradients crowd out surface signal in attention routing. But the results suggest that joint surface+volume routing is actually beneficial — when volume nodes are detached, the attention can't learn routing patterns that help both node types simultaneously. The model uses shared slice tokens (aggregated from both surface and volume nodes) to build its physics representation; decoupling them degrades the joint representation quality.

The in_dist regression is the most telling: in-distribution performance depends heavily on accurate volume field predictions (which use the same attention routing as surface). Detaching volume from routing optimization hurts the overall representation.

Note: the ood_cond marginal gain aligns with the hypothesis direction but is too small to be meaningful.

### Suggested follow-ups

- **Earlier detach (epoch 50+):** The EMA model is stronger later; try detaching only in the last 5-10 epochs when EMA dominates.
- **Partial detach:** Only detach far-field volume nodes (distance > threshold) rather than all volume nodes.
- **Gradient scaling instead of detach:** Use a soft weight on volume gradient (e.g., 0.1×) rather than hard detach, preserving joint routing signal while reducing its dominance.