### PR TITLE
Cosine similarity loss on sorted surface pressure profile

### DIFF
--- a/train.py
+++ b/train.py
@@ -751,6 +751,13 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 
+        # Cosine similarity profile loss: penalizes shape distortion of surface pressure profile
+        surf_p_pred = pred[:, :, 2] * is_surface.float()
+        surf_p_true = y_norm[:, :, 2] * is_surface.float()
+        cos_sim = F.cosine_similarity(surf_p_pred, surf_p_true, dim=1)
+        profile_loss = (1 - cos_sim).mean()
+        loss = loss + 0.1 * profile_loss
+
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None
         coarse_pool_size = 64
@@ -800,8 +807,8 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + 0.1 * profile_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + 0.1 * profile_loss
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)


### PR DESCRIPTION
## Hypothesis
L1 loss treats each surface node independently. Surface pressure forms a PROFILE (ordered curve along the airfoil). Cosine similarity on the sorted surface pressure vector penalizes shape distortion — a fundamentally different error signal than L1.
## Instructions
After computing surface pressure errors, add a profile-shape loss:
```python
# Sort surface nodes by saf (arc-length) per sample, compute cosine similarity
surf_p_pred = pred[:, :, 2] * is_surface.float()
surf_p_true = y_norm[:, :, 2] * is_surface.float()
cos_sim = F.cosine_similarity(surf_p_pred, surf_p_true, dim=1)
profile_loss = (1 - cos_sim).mean()
loss = loss + 0.1 * profile_loss
```
Run with `--wandb_group cosim-profile-loss`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** ob781sad  
**Best epoch:** 58 / 58  

| Split | mae_surf_p | mae_surf_Ux | mae_surf_Uy | mae_vol_p |
|---|---|---|---|---|
| in_dist | 18.48 | 5.18 | 1.56 | 19.31 |
| ood_cond | 14.32 | 2.61 | 0.95 | 12.33 |
| ood_re | 27.80 | 2.37 | 0.87 | 46.97 |
| tandem | 39.18 | 4.94 | 2.04 | 37.77 |

**val/loss:** 0.8692 (baseline: 0.8469)  
**mean3 (in/ood_c/tan surf_p):** 23.99 (baseline: 23.07)  
**Peak memory:** ~18.5 GB  

**What happened:** Negative result. The cosine similarity profile loss with weight 0.1 made things worse across all splits. The hypothesis is conceptually sound — cosine similarity does capture profile shape separately from magnitude — but there are practical issues here: (1) the surface pressure vector includes zeros for non-surface nodes, which distorts cosine similarity; (2) ordering is implicit in the node index rather than sorted by arc-length as described; (3) weight 0.1 may add too much competing signal. The model performs slightly worse than baseline on all metrics.

**Suggested follow-ups:**
- Try computing cosine similarity only over the surface nodes (gathering surface indices first) with proper arc-length sorting.
- Try a much smaller weight (0.01) to avoid interfering with the main L1 signal.