### PR TITLE
Spatially-adaptive attention temperature (per-node from spatial bias)

### DIFF
--- a/train.py
+++ b/train.py
@@ -162,7 +162,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         temp = self.temperature
         if tandem_mask is not None:
             temp = (temp + self.tandem_temp_offset * tandem_mask).clamp(min=1e-4)
-        slice_logits = self.in_project_slice(x_mid) / temp
+        if spatial_bias is not None:
+            per_node_temp = self.temperature * (1.0 + 0.1 * spatial_bias.abs().mean(dim=-1, keepdim=True).unsqueeze(1))
+        else:
+            per_node_temp = temp
+        slice_logits = self.in_project_slice(x_mid) / per_node_temp
         if spatial_bias is not None:
             slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
         slice_weights = self.softmax(slice_logits)


### PR DESCRIPTION
## Hypothesis
Attention temperature is GLOBAL (one scalar per head). But physically, near-surface nodes need SHARP routing while far-field nodes need SOFT routing. Use spatial_bias magnitude to modulate temperature per-node.
## Instructions
In attention forward, after computing spatial_bias:
```python
per_node_temp = self.temperature * (1.0 + 0.1 * spatial_bias.abs().mean(dim=-1, keepdim=True).unsqueeze(1))
```
Use per_node_temp instead of self.temperature when computing slice weights. Run with `--wandb_group spatial-adaptive-temp`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** 9in6167s | 58 epochs (timeout)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5971 | 4.26 | 1.71 | 17.90 | 19.10 |
| ood_cond | 0.7230 | 3.03 | 1.03 | 14.51 | 12.52 |
| ood_re | 0.5345 | 2.66 | 0.86 | 27.57 | 46.83 |
| tandem | 1.5884 | 4.92 | 2.18 | 37.50 | 37.17 |
| **combined** | **0.8607** | | | | |

**mean3 (in/ood_c/tan surf_p):** 23.30 vs baseline 23.07 (+1.0% worse)

**Peak memory:** ~same as baseline (no model size change)

**What happened:** Slight regression overall. Tandem improved (+1.0%: 37.86→37.50) but ood_cond worsened noticeably (-6.0%: 13.69→14.51). The formula increases temperature (softens routing) for nodes with high spatial_bias magnitude. This is likely the **opposite** of the intended effect: if near-surface nodes have large spatial_bias magnitudes, they get softer routing rather than sharper. The formula `1 + 0.1 * magnitude` always increases temperature, making routing softer everywhere it has any effect.

**Suggested follow-ups:**
- Invert the modulation: `per_node_temp = self.temperature / (1.0 + 0.1 * spatial_bias.abs().mean(...))` so nodes with larger spatial_bias get LOWER temperature (sharper routing)
- Use a learnable per-node temperature scaling via a small projection from spatial coords
- Log spatial_bias magnitude distribution across node types to confirm which direction the modulation should go
