### PR TITLE
SE block stochastic depth p=0.15 (implicit ensemble)

### DIFF
--- a/train.py
+++ b/train.py
@@ -238,6 +238,8 @@ class TransolverBlock(nn.Module):
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
+        if self.training and torch.rand(1).item() < 0.15:
+            se = torch.ones_like(se)  # skip SE modulation
         fx = fx * se
         if self.last_layer:
             return self.mlp2(self.ln_3(fx))


### PR DESCRIPTION
## Hypothesis
The SE block is a multiplicative modulation, not the main signal path. Dropping it with p=0.15 during training creates an implicit ensemble at zero inference cost. Previous DropPath attempts targeted the MLP (main signal), not the SE (auxiliary modulation).
## Instructions
In the SE computation, add stochastic skip:
```python
if self.training and torch.rand(1).item() < 0.15:
    se = torch.ones_like(se)  # skip SE modulation
fx = fx * se
```
Run with `--wandb_group se-droppath-015`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run**: znkcgjsu
**Best epoch**: 59
**val/loss**: 0.8796 (baseline: 0.8469, delta = +0.0327)

| Split | loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6042 | 5.7386 | 1.9928 | 18.0798 | 1.0853 | 0.3587 | 19.1642 |
| val_tandem_transfer | 1.6217 | 5.4230 | 2.4231 | 38.5826 | 1.8982 | 0.8631 | 38.0926 |
| val_ood_cond | 0.7361 | 3.4972 | 1.3124 | 14.6948 | 0.7433 | 0.2748 | 12.5041 |
| val_ood_re | 0.5565 | 3.1814 | 1.1579 | 28.0298 | 0.8389 | 0.3632 | 47.0592 |

**What happened**: Significantly worse across all splits (+0.0327 vs baseline). The SE block is not merely auxiliary — even at p=0.15, stochastic skipping creates significant training instability. The SE modulation provides per-sample gain control that is critical for handling the diverse range of flow conditions (racecar vs. cruise, different Reynolds numbers). Randomly bypassing it 15% of the time introduces high variance in the model output across batches, making the loss surface noisier.

Note: the hypothesis that SE is purely auxiliary modulation appears incorrect. The SE block effectively acts as an adaptive normalization layer, and losing it occasionally during training prevents the model from relying on it as a stable channel-wise scaling, effectively reducing the model capacity.

**Suggested follow-ups**:
- SE droppath at p=0.05 might be less damaging — smaller probability means less disruption
- Rather than completely bypassing, try SE scale dropout (randomly zero some SE channels rather than the entire SE)