### PR TITLE
Tandem-weighted checkpoint selection (tandem 2x, ood_re 1.5x)

### DIFF
--- a/train.py
+++ b/train.py
@@ -970,11 +970,18 @@ for epoch in range(MAX_EPOCHS):
         val_loss_sum += split_loss
 
     # 4-split val/loss (all splits) — used for checkpoint selection
+    # weights = [in_dist, tandem, ood_cond, ood_re]: tandem 2x, ood_re 1.5x
     _checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names
-    _checkpoint_losses = [val_metrics_per_split[n][f"{n}/loss"] for n in _checkpoint_names
-                          if not (torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isnan() or
-                                  torch.tensor(val_metrics_per_split[n][f"{n}/loss"]).isinf())]
-    val_loss_3split = sum(_checkpoint_losses) / max(len(_checkpoint_losses), 1)
+    _split_weights = {"val_in_dist": 1.0, "val_tandem_transfer": 2.0, "val_ood_cond": 1.0, "val_ood_re": 1.5}
+    _weighted_loss_sum = 0.0
+    _weight_total = 0.0
+    for n in _checkpoint_names:
+        v = val_metrics_per_split[n][f"{n}/loss"]
+        if not (torch.tensor(v).isnan() or torch.tensor(v).isinf()):
+            w = _split_weights[n]
+            _weighted_loss_sum += v * w
+            _weight_total += w
+    val_loss_3split = _weighted_loss_sum / max(_weight_total, 1e-8)
     ema_val_loss = val_loss_3split if ema_val_loss == float("inf") else ema_decay_val * ema_val_loss + (1 - ema_decay_val) * val_loss_3split
 
     # 4-split val/loss (all splits including ood_re)


### PR DESCRIPTION
## Hypothesis
Checkpoint selection equally weights all splits. But tandem (37.86) is 2x worse than in_dist (17.65). Weighting tandem 2x in checkpoint selection biases toward checkpoints better for the hardest split.
## Instructions
Change the checkpoint selection metric:
```python
# OLD: val_loss_3split = sum(losses) / len(losses)
# NEW: weights = [1.0, 2.0, 1.0, 1.5]  # in_dist, tandem, ood_cond, ood_re
val_loss_3split = sum(l*w for l,w in zip(losses, weights)) / sum(weights)
```
Run with `--wandb_group tandem-weighted-ckpt`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86

---

## Results

**W&B run:** vv9ep067  (runtime: 31.9 min, state: failed due to pre-existing vis crash)

Note: best_val_loss in W&B (0.9913) is the **weighted** checkpoint metric — not directly comparable to the baseline. The unweighted equivalent = (0.5882+1.6710+0.7135+0.5391)/4 = **0.8780**.

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5882 | 6.70 | 1.84 | 17.94 | 1.06 | 0.36 | 19.36 |
| val_ood_cond | 0.7135 | 3.43 | 1.10 | 14.52 | 0.72 | 0.27 | 12.36 |
| val_ood_re | 0.5391 | 3.08 | 0.95 | 27.70 | 0.83 | 0.36 | 47.00 |
| val_tandem_transfer | 1.6710 | 5.98 | 2.19 | 40.21 | 1.93 | 0.89 | 39.24 |

**mean3_p** = (17.94+14.52+40.21)/3 = **24.22**

**vs baseline (unweighted):** val_loss +0.0311 (+3.7%), mean3_p +1.15 (+5.0%) — **worse**

### What happened

Counterintuitively, weighting tandem 2x in checkpoint selection made tandem WORSE (40.21 vs 37.86 baseline). This is the key finding.

The checkpoint selection change only affects which epoch's weights are saved — it doesn't change the training dynamics. The weighted metric selects an epoch that balances the weighted composite, but that epoch may not be optimal for any individual split. Since tandem loss improves slowly (high absolute values), weighting it heavily pulls checkpoint selection toward an earlier epoch where tandem has just begun improving, sacrificing the later epochs where in_dist and ood splits are also better.

All splits degrade compared to baseline, suggesting the epoch selected by the weighted metric is simply a worse checkpoint overall — the loss landscape is such that all splits tend to improve together, making differential weighting counterproductive.

### Suggested follow-ups

- Track and save per-split best checkpoints separately, then ensemble at inference
- Or weight by normalized loss (divide each split's loss by its expected scale) rather than absolute value