### PR TITLE
LR rewinding at epoch 45: brief spike then rapid cooldown

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -849,6 +850,11 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
+    if epoch >= 45:
+        progress = min(1.0, (epoch - 45) / 10.0)
+        override_lr = cfg.lr * 0.5 * (1 + math.cos(math.pi * progress))
+        for pg in optimizer.param_groups:
+            pg['lr'] = max(override_lr, 5e-5)
     if epoch >= 50:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)


### PR DESCRIPTION
## Hypothesis
By epoch 45 the model is well-trained and EMA is averaging. A single brief LR spike (back to peak for 1 epoch, then rapid cosine decay over 10 epochs) helps EMA average across a wider parameter basin. Different from SGDR (multiple cycles) or SWA (flat LR).
## Instructions
After epoch 45, override the LR schedule:
```python
if epoch >= 45:
    progress = min(1.0, (epoch - 45) / 10.0)
    override_lr = lr * 0.5 * (1 + math.cos(math.pi * progress))
    for pg in optimizer.param_groups:
        pg['lr'] = max(override_lr, eta_min)
```
Run with `--wandb_group lr-rewind-ep45`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** kxcwqrgo  
**Epochs completed:** 59 (timeout at epoch 60)

### Metrics vs Baseline

| Metric | Baseline | LR-Rewind | Delta |
|--------|----------|-----------|-------|
| val_loss | 0.8469 | **0.9098** | +7.5% worse |
| in_dist surf MAE | 17.65 | 27.97 | +58% worse |
| ood_cond surf MAE | 13.69 | 21.17 | +55% worse |
| ood_re surf MAE | 27.47 | 34.04 | +24% worse |
| tandem surf MAE | 37.86 | 48.85 | +29% worse |

Surface MAE by channel (best epoch):
- in_dist: Ux=6.61, Uy=2.16, p=19.19
- ood_cond: Ux=4.49, Uy=1.44, p=15.25
- ood_re: Ux=4.05, Uy=1.23, p=28.76
- tandem: Ux=6.53, Uy=2.72, p=39.61

**LR schedule confirmed working** (logged LRs show spike at ~ep53 then decay to 5e-5 by ep55+).

### What happened

The LR rewind significantly hurt performance — 7.5% worse val_loss than baseline at comparable epochs. All splits are dramatically worse, with in/ood_cond surf MAE up 55-58%.

The rewind spike at epoch 45 disrupts a carefully converged model. By epoch 45, the cosine schedule has brought the LR down to ~1e-4, and EMA has been running for 5 epochs. Jumping back to peak LR (2.5e-3) causes large parameter updates that destabilize the model weights. The EMA then averages across a mix of good and destabilized parameters, producing a worse final model than if we'd left the schedule alone.

The key failure mode: this isn't SWA (which averages across a flat LR region). Cosine rewinding creates sharp perturbations. The EMA window captures both the pre-spike convergence and the post-spike exploration, but the exploration is unhelpful noise — not diversity across a flat basin.

The val_loss was still trending down at cutoff (0.9308→0.9211→0.9156→0.9120→0.9098) but at this point the LR is pinned at 5e-5 (eta_min), so it's just slow recovery from the spike.

### Suggested follow-ups

- Try the rewind at epoch 55 instead of 45 (less time for disruption to propagate through EMA)
- Try a smaller rewind factor (0.1x peak instead of 1.0x peak) — a gentle bump rather than a full spike
- The fundamental issue is that at epoch 45 the model is already deep in the cosine valley; rewinding that hard is too disruptive. SWA with a flat LR from epoch 50 onwards might be a safer version of this idea