### PR TITLE
Frozen feature_cross at 2x scale (remove gradient noise)

### DIFF
--- a/train.py
+++ b/train.py
@@ -291,6 +291,7 @@ class Transolver(nn.Module):
         self.space_dim = space_dim
         self.feature_cross = nn.Linear(fun_dim + space_dim, fun_dim + space_dim, bias=False)
         nn.init.eye_(self.feature_cross.weight)  # start as identity
+        self.feature_cross.weight.requires_grad_(False)
         self.blocks = nn.ModuleList(
             [
                 TransolverBlock(
@@ -376,7 +377,7 @@ class Transolver(nn.Module):
             x = torch.cat((x, new_pos), dim=-1)
 
         x_cross = x * self.feature_cross(x)
-        x = x + 0.1 * x_cross  # residual with small scale
+        x = x + 0.2 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting


### PR DESCRIPTION
## Hypothesis
The feature_cross module drifts slowly from identity init, adding gradient noise. Freezing it at identity while doubling the scale to 0.2 removes gradient noise while strengthening the cross-feature signal.
## Instructions
```python
self.feature_cross.weight.requires_grad_(False)
# Change: 0.1 * x_cross -> 0.2 * x_cross
```
Run with `--wandb_group frozen-fcross-02`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B Run:** 2k9a8wu9
**Best epoch:** 61 (last logged; model still improving at termination)

### Metrics vs Baseline

| Split | surf_p | surf_Ux | surf_Uy |
|-------|--------|---------|---------|
| val_in_dist | 19.47 | 5.69 | 2.21 |
| val_ood_cond | 15.94 | — | — |
| val_ood_re | 28.73 | — | — |
| val_tandem_transfer | 39.93 | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8469 | 0.9228 | +0.0759 ↑ much worse |
| in surf_p | 17.65 | 19.47 | +1.82 ↑ worse |
| ood_c surf_p | 13.69 | 15.94 | +2.25 ↑ worse |
| ood_r surf_p | 27.47 | 28.73 | +1.26 ↑ worse |
| tan surf_p | 37.86 | 39.93 | +2.07 ↑ worse |
| mean3 surf_p | ~19.60 | 22.05 | +2.45 ↑ worse |

**Peak memory:** ~17.7 GB

### What happened

Strongly negative result. Freezing feature_cross at identity and doubling the scale causes a large performance drop across all splits.

When feature_cross.weight is frozen at identity, the transformation becomes:  (since identity matrix means feature_cross(x) = x, and the product is x * x). This applies a fixed nonlinear transformation with scale 0.2 instead of the learnable transformation with scale 0.1 in the baseline. The doubled scale (0.2 vs 0.1) combined with the fixed quadratic form likely creates a stronger distortion of the input features that the downstream model can't compensate for.

The hypothesis was that the feature_cross drifts and adds gradient noise — but the results suggest the opposite: feature_cross learns something useful that helps training. The gradient noise from learning feature_cross appears to be beneficial or neutral.

The model was still improving at the last logged epoch (60/61), with val/loss monotonically decreasing over the last 5 epochs, but at a significantly higher level than baseline.

### Suggested follow-ups

- Try freezing at scale 0.1 (no scale change) to isolate whether the freeze itself is harmful or just the doubled scale
- The feature_cross hypothesis may be correct but the scale increase overcorrects; try frozen at 0.05
- If the issue is gradient noise from feature_cross, try a lower learning rate for feature_cross parameters (e.g., 0.1x main LR) rather than full freeze