### PR TITLE
Velocity-to-pressure cross-attention in output head

### DIFF
--- a/train.py
+++ b/train.py
@@ -225,11 +225,12 @@ class TransolverBlock(nn.Module):
         nn.init.zeros_(self.se_fc2.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
-            self.mlp2 = nn.Sequential(
+            self.mlp2_hidden = nn.Sequential(
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.GELU(),
-                nn.Linear(hidden_dim, out_dim),
             )
+            self.vel_out = nn.Linear(hidden_dim, out_dim - 1)  # Ux, Uy
+            self.pres_out = nn.Linear(hidden_dim + 1, 1)  # h + v_mag -> p
 
     def forward(self, fx, raw_xy=None, tandem_mask=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
@@ -240,7 +241,11 @@ class TransolverBlock(nn.Module):
         se = torch.sigmoid(self.se_fc2(se))
         fx = fx * se
         if self.last_layer:
-            return self.mlp2(self.ln_3(fx))
+            h = self.mlp2_hidden(self.ln_3(fx))
+            vel_pred = self.vel_out(h)
+            v_mag = vel_pred.detach().pow(2).sum(-1, keepdim=True)
+            p_pred = self.pres_out(torch.cat([h, v_mag], dim=-1))
+            return torch.cat([vel_pred, p_pred], dim=-1)
         return fx
 
 


### PR DESCRIPTION
## Hypothesis
Bernoulli's equation links velocity and pressure. The shared output head predicts them independently. A lightweight cross-attention where pressure prediction uses velocity magnitude as an extra feature injects this physics. Never tried architecturally — previous attempts were at the loss level.
## Instructions
After computing velocity predictions, use their magnitude to inform pressure:
```python
vel_pred = self.vel_out(h)
v_mag = vel_pred.detach().pow(2).sum(-1, keepdim=True)
p_pred = self.pres_out(torch.cat([h, v_mag], dim=-1))  # pres_out becomes Linear(193, 1)
```
Run with `--wandb_group vel-to-pres-cross`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run ID:** anwq4ba4  
**Best epoch:** 59 (wall-clock timeout at ~30.0 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8685** | 0.8469 |
| val_in_dist | 0.5997 | — |
| val_tandem_transfer | 1.6252 | — |
| val_ood_cond | 0.6975 | — |
| val_ood_re | 0.5517 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 6.11 | 1.98 | 17.88 | 17.65 | +1.3% |
| val_tandem_transfer | 6.29 | 2.43 | 38.31 | 37.86 | +1.2% |
| val_ood_cond | 3.88 | 1.06 | 13.95 | 13.69 | +1.9% |
| val_ood_re | 3.47 | 0.96 | 27.91 | 27.47 | +1.6% |

**mean3 surf_p** = (17.88 + 13.95 + 38.31) / 3 = **23.38** (baseline: 23.07, delta: +1.3%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.06 | 0.36 | 18.81 |
| val_tandem_transfer | 1.91 | 0.86 | 38.08 |
| val_ood_cond | 0.71 | 0.26 | 12.07 |
| val_ood_re | 0.84 | 0.37 | 46.92 |

---

### What happened

**Negative result.** val/loss = 0.8685 vs baseline 0.8469 (+2.6% worse). mean3 surf_p = 23.38 vs 23.07 (+1.3% worse). All splits uniformly degraded by 1-2%.

The velocity-to-pressure coupling via `v_mag = ||vel_pred||²` didn't help. The `.detach()` prevents gradients from flowing back through the velocity head when computing pressure, which means the pressure head cannot co-optimize its velocity dependency — it learns pressure given *whatever velocity the vel_head produces*, but can't signal to vel_head to produce velocity that's more useful for pressure prediction.

More fundamentally, the model likely already captures the Bernoulli-like coupling implicitly through the transformer: the shared hidden representation `h` already encodes information linking velocity and pressure magnitudes. Adding an explicit `v_mag` feature provides information already accessible from `h`, but introduces a detached dependency that slightly perturbs the optimization landscape.

The parameter overhead is minimal (the new pres_out has +1 input parameter), so the degradation is purely from the architectural constraint, not capacity.

*Visualization crash* (same as previous PRs): `mat1 and mat2 shapes cannot be multiplied` in `feature_cross`. Training metrics are unaffected.

---

### Suggested follow-ups

- **Without detach**: Remove `.detach()` so gradient flows through vel_head into pres_out. This allows the velocity head to learn representations that are more informative for pressure prediction (Bernoulli coupling via gradient flow).
- **Bernoulli residual**: Instead of using v_mag as an input, compute Bernoulli-implied pressure (`p_bernoulli = 0.5 * v_mag`) and add it as a residual: `p_pred = pres_head(h) + learned_scale * p_bernoulli`. This injects physics as a prior rather than a constraint.
- **Input v_mag from true x**: The input features include Umag (x[:, :, 20]). Using ground-truth Umag rather than predicted vel magnitude avoids the detach issue entirely.
