### PR TITLE
Input-based Umag estimation (break normalization dependency)

### DIFF
--- a/train.py
+++ b/train.py
@@ -316,6 +316,7 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.umag_head = nn.Sequential(nn.Linear(2, 16), nn.GELU(), nn.Linear(16, 1), nn.Softplus())
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
@@ -397,7 +398,8 @@ class Transolver(nn.Module):
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+        umag_pred = self.umag_head(x[:, 0, [13, 14]].float())  # [B, 1], predicted Umag from log_Re, AoA
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "umag_pred": umag_pred}
 
 
 # ---------------------------------------------------------------------------
@@ -701,9 +703,11 @@ for epoch in range(MAX_EPOCHS):
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
+            umag_pred = out["umag_pred"]
         pred = pred.float()
         re_pred = re_pred.float()
         aoa_pred = aoa_pred.float()
+        umag_pred = umag_pred.float()
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
@@ -783,6 +787,8 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+        umag_loss = (umag_pred - Umag.squeeze(-1)).pow(2).mean()
+        loss = loss + 0.01 * umag_loss
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
@@ -917,7 +923,9 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    pred = eval_model({"x": x})["preds"]
+                    val_out = eval_model({"x": x})
+                    pred = val_out["preds"]
+                    umag_pred_val = val_out["umag_pred"].float()  # [B, 1]
                 pred = pred.float()
                 pred_loss = pred / sample_stds
                 sq_err = (pred_loss - y_norm_scaled) ** 2
@@ -937,8 +945,11 @@ for epoch in range(MAX_EPOCHS):
                 n_vbatches += 1
 
                 # Denormalize: phys_stats → Cp space → original scale
+                # Use predicted Umag (from input features) for second-pass denormalization
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
-                pred_orig = _phys_denorm(pred_phys, Umag, q)
+                pred_umag = umag_pred_val.unsqueeze(-1).clamp(min=1.0)  # [B, 1, 1]
+                pred_q = 0.5 * pred_umag ** 2
+                pred_orig = _phys_denorm(pred_phys, pred_umag, pred_q)
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()
                 finite = err.isfinite()


### PR DESCRIPTION
## Hypothesis
The Cp normalization depends on Umag computed from TARGET velocity values — creating a circular dependency at inference. An auxiliary head that predicts Umag from input features (log_Re, AoA) alone could improve denormalization quality.
## Instructions
```python
self.umag_head = nn.Sequential(nn.Linear(2, 16), nn.GELU(), nn.Linear(16, 1), nn.Softplus())
# In forward: umag_pred = self.umag_head(x[:, 0, [13, 14]])
# Add MSE loss: 0.01 * (umag_pred - true_umag).pow(2).mean()
```
Use predicted Umag for a second-pass validation denormalization. Run with `--wandb_group umag-from-input`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** `9sm15vvq`

| Split | val/loss | surf Ux | surf Uy | surf p | vol p |
|-------|----------|---------|---------|--------|-------|
| in-dist | 0.5909 | 6.67 | 1.77 | **39.76** | 38.23 |
| ood-cond | 0.7027 | 4.43 | 1.08 | **29.59** | 24.22 |
| ood-re | 0.5393 | 3.81 | 0.90 | **39.89** | 56.31 |
| tandem | 1.6364 | 8.01 | 2.53 | **130.42** | 120.28 |
| **combined** | **0.8673** | — | — | — | — |

**vs baseline:** val/loss 0.8673 vs 0.8469 (+0.020 worse)

Physical-space MAE (surf_p), vs baseline:
- in-dist: **39.76 vs 17.65 (+22.11, catastrophic)**
- ood-cond: **29.59 vs 13.69 (+15.90, catastrophic)**
- ood-re: **39.89 vs 27.47 (+12.42, catastrophic)**
- tandem: **130.42 vs 37.86 (+92.56, catastrophic)**

Note: val/loss (0.8673) is computed in normalized space and is only slightly worse than baseline — the normalized-space prediction is approximately on par. The catastrophe is entirely in the denormalization step.

**What happened:** The normalized-space training loss is fine (+0.020), but using the predicted Umag for denormalization produces completely wrong physical-space predictions. The umag_head only has 30 epochs to learn an accurate Umag prediction from two input features (log_Re, AoA). If the head predicts Umag incorrectly — even by a factor of 2 — the entire Cp→pressure and Cv→velocity denormalization is wrong, scaling all predictions by the wrong factor. This made the physical MAE ~2-5x worse.

The umag_head likely needs much more training signal and epochs to become accurate enough for reliable denormalization. Additionally, Umag is not a simple function of log_Re and AoA alone — it depends on the actual flow field state. In theory it's correlated (higher Re → higher velocities), but the input-only prediction will be noisy.

**Suggested follow-ups:**
- Keep the umag_head auxiliary loss (0.01 weight) but do NOT use it for denormalization — just as an auxiliary regularizer that helps the model understand flow scaling; continue using true Umag (from y) for denormalization
- A weaker test: use a weighted blend:  in val denorm to see if predicted Umag improves slowly over epochs