### PR TITLE
Combo: init gain=0.8 + slice_residual_scale=0.2

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,7 +137,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
-        self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
+        self.slice_residual_scale = nn.Parameter(torch.tensor(0.2))
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
@@ -325,7 +325,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.orthogonal_(module.weight, gain=0.8)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:


### PR DESCRIPTION
## Hypothesis
Both changes target the initialization/scaling of the model: orthogonal init gain=0.8 (vl=0.8520, +0.005) scales down all weights, while slice_residual_scale=0.2 (vl=0.8575, +0.011) doubles the physics bypass strength. The gain reduction shrinks the attention path while the residual scale amplifies the bypass — together they shift the balance toward the physics-informed shortcut in early training, potentially letting the attention path learn more efficiently without dominating prematurely.

**Individual deltas**: gain=0.8 (+0.005), slice_res=0.2 (+0.011)
**Expected interaction**: Both affect how attention vs. bypass compete. Smaller attention init + stronger bypass = more complementary roles.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 328** — Change orthogonal init gain from 1.0 to 0.8:
   ```python
   nn.init.orthogonal_(module.weight, gain=0.8)
   ```

2. **Line 140** — Change slice_residual_scale init from 0.1 to 0.2:
   ```python
   self.slice_residual_scale = nn.Parameter(torch.tensor(0.2))
   ```

Use `--wandb_group combo-initgain08-sliceres02` and `--wandb_name noam/combo-initgain08-sliceres02`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run ID:** `8lmtw4uq`
**val/loss: 0.8634** (baseline: 0.8469, **+0.0165** — worse)

### Surface MAE

| Split | Ux | Uy | p | Δp vs baseline |
|---|---|---|---|---|
| in_dist | 6.03 | 1.87 | **17.46** | -0.19 ✓ |
| ood_cond | 3.41 | 1.27 | **13.62** | -0.07 ✓ |
| ood_regime | 3.08 | 1.14 | **28.17** | +0.70 ✗ |
| tandem | 6.00 | 2.45 | **37.47** | -0.39 ✓ |

**mean3** (in / ood_c / tan surf_p): **(17.46 + 13.62 + 37.47) / 3 = 22.85** vs baseline 23.07 — improved by 0.22

### Volume MAE

| Split | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|
| in_dist | 1.08 | 0.36 | 19.47 |
| ood_cond | 0.70 | 0.27 | 12.03 |
| ood_regime | 0.82 | 0.36 | 46.95 |
| tandem | 1.92 | 0.86 | 37.38 |

**Peak memory:** ~50 GB (52% of 96 GB)

### What happened

No synergy. The combined val/loss degradation (0.8634) is almost exactly the sum of the two individual regressions (0.8469 + 0.005 + 0.011 ≈ 0.8629), meaning the two changes interact additively rather than complementarily.

The surface pressure picture is more nuanced: three of four splits improved (in, ood_c, tandem), with mean3 improving by 0.22. The ood_regime split degraded (+0.70 on surf_p), which is the biggest driver of the worse val/loss. This suggests the two changes help standard cases but hurt generalization to the most out-of-distribution regime.

The hypothesis that smaller attention init + stronger bypass would create complementary roles was not confirmed. Both changes likely reduce the expressiveness of the attention path in a correlated way, without unlocking the predicted synergy.

### Suggested follow-ups
- Test gain=0.9 (milder reduction) which may preserve ood generalization while still improving mean3.
- Consider whether slice_residual_scale should start at 0.1 but be allowed to grow freely — the learned value after training may be informative.
- Investigate why ood_regime is particularly sensitive to these init changes.