### PR TITLE
Combo: init gain=0.8 + eta_min=1e-4

### DIFF
--- a/train.py
+++ b/train.py
@@ -325,7 +325,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.orthogonal_(module.weight, gain=0.8)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
Init gain=0.8 (vl=0.8520, +0.005) affects the start of training, while eta_min=1e-4 (vl=0.8593, +0.012) affects the end via a higher cosine floor. These are temporally orthogonal — the gain shapes the loss landscape the optimizer starts in, while eta_min determines how much the optimizer can still explore in later epochs. A gentler initialization might create a smoother landscape where the higher eta_min floor can find better late-training basins.

**Individual deltas**: gain=0.8 (+0.005), eta_min=1e-4 (+0.012)
**Expected interaction**: Temporal orthogonality (early vs late training). Smooth init landscape + more late exploration.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 328** — Change orthogonal init gain from 1.0 to 0.8:
   ```python
   nn.init.orthogonal_(module.weight, gain=0.8)
   ```

2. **Line 581** — Change eta_min from 5e-5 to 1e-4:
   ```python
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
   ```

Use `--wandb_group combo-initgain08-etamin1e4` and `--wandb_name noam/combo-initgain08-etamin1e4`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run:** `lng5pban`

| Split | val/loss | surf Ux | surf Uy | surf p | vol p |
|-------|----------|---------|---------|--------|-------|
| in-dist | 0.6117 | 6.44 | 2.07 | 18.85 | 19.62 |
| ood-cond | 0.6879 | 3.42 | 1.43 | **13.52** | — |
| ood-re | 0.5328 | 2.84 | 1.22 | 27.56 | 46.78 |
| tandem | 1.6503 | 6.46 | 2.71 | 39.55 | 38.52 |
| **combined** | **0.8707** | — | — | — | — |

**vs baseline:** val/loss 0.8707 vs 0.8469 (+0.024 worse)

Surface pressure comparison:
- in-dist: 18.85 vs 17.65 (+1.20 worse)
- ood-cond: **13.52 vs 13.69 (−0.17, slight improvement)**
- ood-re: 27.56 vs 27.47 (+0.09, neutral)
- tandem: 39.55 vs 37.86 (+1.69 worse)

**What happened:** No synergy — negative result. The combination of gain=0.8 and eta_min=1e-4 produced outcomes that roughly add up to the sum of their individual negatives (+0.005 + +0.012 ≈ +0.017, actual combined +0.024). There's no evidence of the hoped-for interaction where a smoother initial landscape amplifies the benefit of late-training exploration.

The ood-cond surface pressure did improve very slightly (−0.17 Pa), which is consistent with the pattern seen in several experiments where ood-cond benefits from gentler training signals. But in-dist and tandem hurt as expected.

The "temporal orthogonality" hypothesis isn't supported: the gain and eta_min don't have independent effects on different training phases — both seem to add training noise that compounds negatively.

**Suggested follow-ups:**
- Neither change individually nor combined helps — the current gain=1.0 and eta_min=5e-5 appear to be good defaults
- If further tuning is desired, consider trying eta_min=2e-5 (more aggressive cosine decay) rather than increasing it