### PR TITLE
Combo: warmup sf=0.3 + eta_min=1e-4

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,8 +577,8 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.3, total_iters=10)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
Both changes target the LR schedule but at opposite ends: start_factor=0.3 (vl=0.8548, +0.008) raises the initial LR floor, while eta_min=1e-4 (vl=0.8593, +0.012) raises the final LR floor. Together they compress the LR range — the model never goes as low or starts as low. This is a bet that the current LR range is too wide and the model spends too many steps at LR values that are either too small (early warmup) or too small (late cosine tail) to make progress.

**Individual deltas**: sf=0.3 (+0.008), eta_min=1e-4 (+0.012)
**Expected interaction**: Both narrow the LR range. The compressed schedule might keep the model in the productive LR zone longer.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 580** — Change warmup start_factor from 0.2 to 0.3
2. **Line 581** — Change eta_min from 5e-5 to 1e-4

Use `--wandb_group combo-warmup03-etamin1e4` and `--wandb_name noam/combo-warmup03-etamin1e4`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run:** cawbt6d1
**Runtime:** 1914s (58 epochs, visualization crash at end — pre-existing bug)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8469 | 0.8823 | +4.2% worse |
| val_in_dist surf_p | 17.65 | 18.697 | +5.9% worse |
| val_ood_cond surf_p | 13.69 | 14.336 | +4.7% worse |
| val_ood_re surf_p | 27.47 | 27.801 | +1.2% worse |
| val_tandem surf_p | 37.86 | 39.756 | +5.0% worse |

Detailed metrics (last epoch):
- in_dist: loss=0.6069, surf_p=18.697, surf_Ux=5.893, surf_Uy=1.626, vol_Ux=1.093, vol_Uy=0.365, vol_p=19.823
- ood_cond: loss=0.7177, surf_p=14.336, surf_Ux=3.460, surf_Uy=1.067, vol_Ux=0.733, vol_Uy=0.280, vol_p=12.379
- ood_re: loss=0.5430, surf_p=27.801, surf_Ux=3.022, surf_Uy=0.863, vol_Ux=0.824, vol_Uy=0.362, vol_p=46.874
- tandem: loss=1.6614, surf_p=39.756, surf_Ux=6.332, surf_Uy=2.174, vol_Ux=1.926, vol_Uy=0.883, vol_p=38.608

**What happened:** No synergy — the combination is worse than baseline by 4.2%. Both individual changes regressed slightly (sf=0.3: +0.008, eta_min=1e-4: +0.012), and combining them compounds the regression (+0.035), suggesting the changes add rather than subtract noise. The hypothesis that a compressed LR range would keep the model in a "productive zone" doesn't hold — the current default schedule (sf=0.2, eta_min=5e-5) appears to be well-tuned for this model and dataset.

**Suggested follow-ups:**
- The current defaults (sf=0.2, eta_min=5e-5) are good. LR schedule tuning is likely not a productive direction.
- If the compressed range idea is worth exploring, try only ONE end at a time (just raise eta_min, or just raise start_factor) with larger values (e.g., eta_min=3e-4) to see if a meaningful shift has any positive effect.