### PR TITLE
Combo: workers=8 + eta_min=1e-4

### DIFF
--- a/train.py
+++ b/train.py
@@ -474,7 +474,7 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
-loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
+loader_kwargs = dict(collate_fn=pad_collate, num_workers=8, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
 if cfg.debug:
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
num_workers=8 (vl=0.8603, +0.013) gives more epochs in 30 min via faster data loading but regresses slightly, possibly because the extra epochs push into the cosine tail where LR is near-zero and overfit. eta_min=1e-4 (vl=0.8593, +0.012) raises the LR floor, which alone hurts but combined with more epochs could mean the model keeps learning productively in those extra epochs instead of stagnating.

**Individual deltas**: workers=8 (+0.013), eta_min=1e-4 (+0.012)
**Expected interaction**: The throughput gain gives more steps; the higher LR floor makes those extra steps productive. Classic throughput-x-optimization synergy.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 477** — Change num_workers from 4 to 8:
   ```python
   loader_kwargs = dict(collate_fn=pad_collate, num_workers=8, pin_memory=True,
                        persistent_workers=True, prefetch_factor=2)
   ```

2. **Line 581** — Change eta_min from 5e-5 to 1e-4:
   ```python
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
   ```

Use `--wandb_group combo-workers8-etamin1e4` and `--wandb_name noam/combo-workers8-etamin1e4`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run ID:** mm9crwf0  
**Best epoch:** 60 (wall-clock timeout at ~30.0 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8639** | 0.8469 |
| val_in_dist | 0.6071 | — |
| val_tandem_transfer | 1.6186 | — |
| val_ood_cond | 0.6955 | — |
| val_ood_re | 0.5343 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 6.36 | 2.13 | 18.30 | 17.65 | +3.7% |
| val_tandem_transfer | 6.02 | 2.47 | 38.66 | 37.86 | +2.1% |
| val_ood_cond | 3.38 | 1.18 | 13.99 | 13.69 | +2.2% |
| val_ood_re | 3.19 | 1.08 | 27.64 | 27.47 | +0.6% |

**mean3 surf_p** = (18.30 + 13.99 + 38.66) / 3 = **23.65** (baseline: 23.07, delta: +2.5%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.10 | 0.36 | 19.86 |
| val_tandem_transfer | 1.89 | 0.86 | 37.93 |
| val_ood_cond | 0.71 | 0.28 | 11.88 |
| val_ood_re | 0.81 | 0.36 | 46.66 |

---

### What happened

**Negative result — no synergy.** val/loss = 0.8639 vs baseline 0.8469 (+2.0% worse). mean3 surf_p = 23.65 vs 23.07 (+2.5% worse). The combined result is worse than either individual change alone.

The hypothesis of synergy between faster throughput and higher LR floor did not materialize. The run reached epoch 60 (same as baseline), confirming that num_workers=8 doesn't actually increase throughput — the GPU was already the bottleneck, not the data loader. With `persistent_workers=True` and `prefetch_factor=2`, 4 workers are sufficient.

Since there's no throughput gain, the combination reduces to just a `eta_min=1e-4` experiment, which is also a known regression. The compound effect is additive negative: both changes independently hurt (slightly), and together they hurt more.

*Visualization crash* (same as previous PRs): `mat1 and mat2 shapes cannot be multiplied` in `feature_cross`. Training metrics are unaffected.

---

### Suggested follow-ups

- **eta_min=7e-5**: Split the difference between the current 5e-5 and tested 1e-4. The boundary between beneficial and harmful LR floor may be narrow.
- **Workers back to 4, eta_min=1e-4**: Confirm that the eta_min change alone is the driver (no workers noise).
- **Verify GPU vs CPU bottleneck**: Profile actual GPU utilization. If it's consistently <95%, then the data loader IS the bottleneck and more workers could help.
