### PR TITLE
Combo: init gain=0.8 + Lookahead k=8

### DIFF
--- a/train.py
+++ b/train.py
@@ -325,7 +325,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.orthogonal_(module.weight, gain=0.8)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:
@@ -576,7 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=8, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
Init gain=0.8 (vl=0.8520, +0.005) reduces weight magnitudes, which affects gradient norms. Lookahead k=8 (vl=0.8615, +0.015) syncs slow weights more frequently (every 8 steps vs 10). With smaller initial weights, the fast-slow weight divergence is smaller, so more frequent syncs (k=8) keep the slow weights closer to the fast trajectory. This could reduce the oscillation that Lookahead introduces while preserving its smoothing benefit.

**Individual deltas**: gain=0.8 (+0.005), k=8 (+0.015)
**Expected interaction**: Smaller weights = smaller fast-slow divergence, making frequent syncs more stable.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 328** — Change orthogonal init gain from 1.0 to 0.8:
   ```python
   nn.init.orthogonal_(module.weight, gain=0.8)
   ```

2. **Line 579** — Change Lookahead k from 10 to 8:
   ```python
   optimizer = Lookahead(base_opt, k=8, alpha=0.8)
   ```

Use `--wandb_group combo-initgain08-look8` and `--wandb_name noam/combo-initgain08-look8`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B Run:** 0zula2nz
**Best epoch:** 61 (last logged; model still improving)

Note: Visualization crash post-training (same shape mismatch as other recent runs). Training metrics unaffected.

### Metrics vs Baseline

| Split | surf_p | surf_Ux | surf_Uy |
|-------|--------|---------|---------|
| val_in_dist | 17.89 | 4.99 | 1.62 |
| val_ood_cond | 13.99 | — | — |
| val_ood_re | 27.77 | — | — |
| val_tandem_transfer | 38.44 | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8469 | 0.8624 | +0.0155 ↑ slightly worse |
| in surf_p | 17.65 | 17.89 | +0.24 ↑ marginal |
| ood_c surf_p | 13.69 | 13.99 | +0.30 ↑ slight |
| ood_r surf_p | 27.47 | 27.77 | +0.30 ↑ slight |
| tan surf_p | 37.86 | 38.44 | +0.58 ↑ slight |
| mean3 surf_p | ~19.60 | 19.88 | +0.28 ↑ marginal |

**Peak memory:** ~17.7 GB

### What happened

Negative result — no synergy observed. The combination performs similarly to (or slightly worse than) the sum of individual regressions.

Individual regressions: gain=0.8 (+0.005 val/loss), k=8 (+0.015 val/loss). If independent, combined effect would be ~+0.020. Actual combined effect is +0.0155, so the combination is slightly better than additive but still below baseline.

The convergence curve shows the model was still improving at epoch 61 (last 5 epochs went from 0.8753 to 0.8624 monotonically), suggesting it hadn't fully converged. This could partially explain the above-baseline result.

The hypothesis that smaller initial weights + more frequent Lookahead syncs would be synergistic is not supported. The two changes appear to be roughly independent, with no meaningful positive interaction.

### Suggested follow-ups

- If these individual changes regressed, try reverting both to understand the interaction with the current baseline state (some baselines have drifted since individual experiments were run)
- The tandem degradation (+0.58) is smaller than typical regressions, suggesting these changes may be relatively neutral for the tandem split
- If gain=0.8 regresses and k=8 also regresses, likely neither should be pursued further unless specifically targeted