### PR TITLE
Combo: slice_residual_scale=0.2 + eta_min=1e-4

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,7 +137,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
-        self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
+        self.slice_residual_scale = nn.Parameter(torch.tensor(0.2))
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
slice_residual_scale=0.2 (vl=0.8575, +0.011) strengthens the physics bypass in the attention block, while eta_min=1e-4 (vl=0.8593, +0.012) keeps the LR higher in late epochs. The stronger bypass might need more late-stage fine-tuning to properly calibrate the bypass-vs-attention balance. With eta_min=5e-5, the LR drops too low to adjust this balance; with 1e-4, the model has enough gradient signal in late epochs to properly calibrate the stronger bypass path.

**Individual deltas**: slice_res=0.2 (+0.011), eta_min=1e-4 (+0.012)
**Expected interaction**: Stronger bypass needs more late-epoch LR to calibrate. Architecture change + schedule change targeting different bottlenecks.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 140** — Change slice_residual_scale init from 0.1 to 0.2:
   ```python
   self.slice_residual_scale = nn.Parameter(torch.tensor(0.2))
   ```

2. **Line 581** — Change eta_min from 5e-5 to 1e-4:
   ```python
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
   ```

Use `--wandb_group combo-sliceres02-etamin1e4` and `--wandb_name noam/combo-sliceres02-etamin1e4`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run:** a68r1q16  
**Epochs completed:** 59 (timeout at epoch 60)

### Metrics vs Baseline

| Metric | Baseline | Combo Result | Delta |
|--------|----------|--------------|-------|
| val_loss | 0.8469 | **0.8839** | +4.4% worse |
| in_dist surf MAE | 17.65 | 25.97 | +47% worse |
| ood_cond surf MAE | 13.69 | 18.66 | +36% worse |
| ood_re surf MAE | 27.47 | 31.62 | +15% worse |
| tandem surf MAE | 37.86 | 47.83 | +26% worse |

Surface MAE by channel (best epoch):
- in_dist: Ux=6.03, Uy=1.86, p=18.08
- ood_cond: Ux=3.25, Uy=1.03, p=14.39
- ood_re: Ux=2.71, Uy=0.93, p=27.98
- tandem: Ux=6.08, Uy=2.47, p=39.28

### What happened

No synergy found. The combo (0.8839) is worse than either individual change (slice_res=0.2: 0.8575, eta_min=1e-4: 0.8593) and significantly worse than baseline (0.8469). The combination of a stronger bypass path AND a higher minimum LR creates conflicting pressures: the model can't find a stable equilibrium between the physics bypass signal and attention learning.

The val_loss was still trending down at cutoff (0.9008→0.8953→0.8911→0.8885→0.8839, ~0.0042/epoch) but would need ~88 more epochs to reach baseline — clearly not converging.

Again the in_dist Ux is notably high (6.03) compared to expected, consistent with what we see in other configurations that hurt convergence (similar pattern in hardmine-p75 and lr-rewind runs). This suggests these configurations interfere with the velocity field learning specifically.

### Suggested follow-ups

- The synergy hypothesis was reasonable but didn't hold — the two negative changes compound rather than compensate
- For slice_res, the issue may be the initialization value (0.2 is too large). Try 0.15 as a middle ground
- For eta_min, since higher eta_min always hurts, the LR schedule is probably well-tuned already