### PR TITLE
Combo: warmup sf=0.3 + Lookahead k=8

### DIFF
--- a/train.py
+++ b/train.py
@@ -576,8 +576,8 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+optimizer = Lookahead(base_opt, k=8, alpha=0.8)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.3, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]


### PR DESCRIPTION
## Hypothesis
Warmup start_factor=0.3 (vl=0.8548, +0.008) gives the model a higher initial LR, potentially causing some early instability that Lookahead smooths out. Lookahead k=8 (vl=0.8615, +0.015) syncs slow weights more frequently, providing stronger stability. The combination means: higher initial LR (more early signal) but with more frequent slow-weight corrections (less risk of divergence). The Lookahead acts as a safety net for the more aggressive warmup.

**Individual deltas**: sf=0.3 (+0.008), k=8 (+0.015)
**Expected interaction**: Higher warmup provides more signal; more frequent Lookahead syncs prevent that signal from causing instability.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 580** — Change warmup start_factor from 0.2 to 0.3:
   ```python
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.3, total_iters=10)
   ```

2. **Line 579** — Change Lookahead k from 10 to 8:
   ```python
   optimizer = Lookahead(base_opt, k=8, alpha=0.8)
   ```

Use `--wandb_group combo-warmup03-look8` and `--wandb_name noam/combo-warmup03-look8`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run:** 5ipnx4t4  (runtime: 31.9 min, state: failed due to pre-existing vis crash)

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5961 | 4.58 | 1.76 | 17.84 | 1.08 | 0.36 | 19.13 |
| val_ood_cond | 0.6877 | 2.70 | 1.01 | 13.74 | 0.70 | 0.26 | 11.47 |
| val_ood_re | 0.5271 | 2.28 | 0.83 | 27.54 | 0.80 | 0.36 | 46.53 |
| val_tandem_transfer | 1.6218 | 5.53 | 2.28 | 38.71 | 1.89 | 0.85 | 37.87 |
| **val_loss (best)** | **0.8582** | | | | | | |

**mean3_p** = (17.84+13.74+38.71)/3 = **23.43**

**vs baseline:** val_loss +0.0113 (+1.3%), mean3_p +0.36 (+1.6%) — **worse**

### What happened

No synergy between sf=0.3 and k=8. The combination is worse than baseline, though less so than many other experiments in this series. 

Notably, ood_cond (13.74) nearly matches baseline (13.69) — the Lookahead k=8 benefit on ood_cond is preserved. But tandem (38.71 vs 37.86) and in_dist (17.84 vs 17.65) are slightly worse. The higher initial LR from sf=0.3 appears to slightly destabilize in_dist and tandem geometry learning even with more frequent Lookahead syncs.

The hypothesis that k=8 would compensate for sf=0.3 instability doesn't hold. More frequent syncs (k=8) don't prevent the increased LR at early epochs from pushing the optimizer toward a slightly worse local minimum.

### Suggested follow-ups

- k=8 alone with sf=0.2: test if the k=8 Lookahead benefit observed on ood_cond is real (vs. noise)
- Lower k further: k=5 would sync every 5 steps, much more aggressive stability