### PR TITLE
Combo: workers=8 + warmup sf=0.3

### DIFF
--- a/train.py
+++ b/train.py
@@ -474,7 +474,7 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
-loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
+loader_kwargs = dict(collate_fn=pad_collate, num_workers=8, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
 if cfg.debug:
@@ -577,7 +577,7 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.3, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]


### PR DESCRIPTION
## Hypothesis
workers=8 (vl=0.8603, +0.013) provides faster data loading, meaning more gradient steps within 30 min. warmup sf=0.3 (vl=0.8548, +0.008) ramps to peak LR faster. Together, more steps + faster LR ramp = the model reaches peak learning rate at effectively the same wall-clock time but with more total gradient updates. The extra early-phase steps at productive LR could compound into better feature learning that propagates through the rest of training.

**Individual deltas**: workers=8 (+0.013), sf=0.3 (+0.008)
**Expected interaction**: More steps/epoch + faster warmup = more productive gradient updates in the critical early phase.

## Instructions
1. num_workers=8, 2. start_factor=0.3. Use --wandb_group combo-workers8-warmup03.

## Baseline
- val/loss = 0.8469 (current best)

---

## Results

**W&B run**: fe5pwezx
**Best epoch**: 61
**val/loss**: 0.8653 (baseline: 0.8469, delta = +0.0184)

| Split | loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5780 | 4.7874 | 1.6503 | 17.0400 | 1.0639 | 0.3558 | 19.0401 |
| val_tandem_transfer | 1.6207 | 5.0646 | 2.1074 | 38.6842 | 1.9015 | 0.8621 | 37.6477 |
| val_ood_cond | 0.7070 | 2.9461 | 1.1151 | 13.8877 | 0.7347 | 0.2774 | 12.0609 |
| val_ood_re | 0.5553 | 2.5735 | 0.9961 | 27.9832 | 0.8330 | 0.3680 | 46.8160 |

**What happened**: Overall worse (+0.0184), but an interesting split: in_dist surf_p is the best seen so far (17.04 vs 17.65 baseline). The OOD and tandem splits got worse. The combination does not produce the hoped-for synergy — more workers speeds up data loading but the larger warmup start_factor destabilizes early learning for the OOD distributions. The combo trades OOD performance for in-dist gains.

The individual workers=8 experiment showing +0.013 suggests this branch diverged from the warmup-factor-02 base correctly (start_factor was already 0.2 on this branch, and we changed only to 0.3). However, combining both changes with the current baseline (which uses start_factor=0.2 from warmup-factor-02) results in a net regression, suggesting that start_factor=0.3 is the primary culprit for degradation.

**Suggested follow-ups**:
- The in-dist improvement (17.04 vs 17.65) is notable. Check if workers=8 alone (without sf=0.3) produces this in-dist gain
- The degradation on OOD splits is larger than the in-dist gain, so overall this is not worthwhile