### PR TITLE
Combo: init gain=0.8 + EMA start epoch 42

### DIFF
--- a/train.py
+++ b/train.py
@@ -325,7 +325,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.orthogonal_(module.weight, gain=0.8)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:
@@ -536,7 +536,7 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
+ema_start_epoch = 42
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())


### PR DESCRIPTION
## Hypothesis
Init gain=0.8 (vl=0.8520, +0.005) produces smaller weight magnitudes, meaning the model converges to a narrower valley in loss space. EMA start epoch 42 (vl=0.8617, +0.015) begins weight averaging 2 epochs later (from 40). With smaller weights and a narrower valley, the EMA averages over a more concentrated region, potentially producing a better averaged model. The delay also lets the model settle more fully into the narrower valley before averaging begins.

**Individual deltas**: gain=0.8 (+0.005), ema_start=42 (+0.015)
**Expected interaction**: Smaller weights = more concentrated trajectory. Later EMA start = averaging a tighter cluster.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 328** — Change orthogonal init gain from 1.0 to 0.8:
   ```python
   nn.init.orthogonal_(module.weight, gain=0.8)
   ```

2. **Line 539** — Change ema_start_epoch from 40 to 42:
   ```python
   ema_start_epoch = 42
   ```

Use `--wandb_group combo-initgain08-ema42` and `--wandb_name noam/combo-initgain08-ema42`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run:** ubspe12a | 59 epochs (timeout)

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.6080 | 5.62 | 1.78 | 18.61 | 19.95 |
| ood_cond | 0.7013 | 3.49 | 1.15 | 14.23 | 11.98 |
| ood_re | 0.5509 | 3.05 | 0.96 | 28.04 | 46.91 |
| tandem | 1.6251 | 5.57 | 2.23 | 38.12 | 37.19 |
| **combined** | **0.8713** | | | | |

**mean3 (in/ood_c/tan surf_p):** 23.65 vs baseline 23.07 (+2.5% worse)

**Peak memory:** ~same as baseline

**What happened:** No synergy — the combination is worse than both the individual changes and the baseline. All splits regressed: in-dist surf_p +5.4% (17.65→18.61), ood_cond +3.9% (13.69→14.23), tandem +0.7% (37.86→38.12). The hypothesis assumed smaller weights create a "narrower valley" that EMA benefits from, but the evidence contradicts this: gain=0.8 already individually regressed, and adding a later EMA start further hurt. If anything, the smaller gain may slow convergence and the later EMA start means fewer averaging epochs — both work against each other when individually suboptimal.

**Suggested follow-ups:**
- These two hyperparameters appear to be independently negative; no interaction benefit found
- If gain=0.8 ever becomes beneficial (e.g. combined with different LR or architecture), EMA start=40 remains the better pairing
