### PR TITLE
Triple: gain=0.8 + sf=0.3 + eta_min=1e-4

### DIFF
--- a/train.py
+++ b/train.py
@@ -325,7 +325,7 @@ class Transolver(nn.Module):
     def _init_weights(self, module):
         if isinstance(module, nn.Linear):
             if module.weight.dim() >= 2:
-                nn.init.orthogonal_(module.weight, gain=1.0)
+                nn.init.orthogonal_(module.weight, gain=0.8)
             else:
                 nn.init.normal_(module.weight, std=0.01)
             if module.bias is not None:
@@ -577,8 +577,8 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.3, total_iters=10)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
This triple combination hits three different training phases: initialization (gain=0.8, +0.005), early training (sf=0.3, +0.008), and late training (eta_min=1e-4, +0.012). The theory: gain=0.8 creates a smoother loss landscape from the start; sf=0.3 gets the model to productive LR faster; eta_min=1e-4 keeps the model learning in late epochs. Each alone slightly regresses, but together they form a coherent narrative: gentler start -> faster ramp -> sustained late learning. The total individual regression is +0.025, so synergy needs to overcome that — but the three changes are maximally orthogonal in time.

**Individual deltas**: gain=0.8 (+0.005), sf=0.3 (+0.008), eta_min=1e-4 (+0.012) = +0.025 total
**Expected interaction**: Temporal orthogonality across all three training phases. If any two interact positively, the third is free.

## Instructions
Make exactly three changes to `train.py`:

1. **Line 328** — Change orthogonal init gain from 1.0 to 0.8:
   ```python
   nn.init.orthogonal_(module.weight, gain=0.8)
   ```

2. **Line 580** — Change warmup start_factor from 0.2 to 0.3:
   ```python
   warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.3, total_iters=10)
   ```

3. **Line 581** — Change eta_min from 5e-5 to 1e-4:
   ```python
   cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=1e-4)
   ```

Use `--wandb_group combo-triple-init-warmup-eta` and `--wandb_name noam/combo-triple-init-warmup-eta`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a 3-way combination experiment. All changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run:** 9kztl3c9  
**Best epoch:** 58 / 58  

| Split | mae_surf_p | mae_surf_Ux | mae_surf_Uy | mae_vol_p |
|---|---|---|---|---|
| in_dist | 17.99 | 6.69 | 1.84 | 19.54 |
| ood_cond | 13.80 | 4.12 | 1.31 | 11.94 |
| ood_re | 27.90 | 3.74 | 1.09 | 47.03 |
| tandem | 39.08 | 6.55 | 2.49 | 38.14 |

**val/loss:** 0.8719 (baseline: 0.8469)  
**mean3 (in/ood_c/tan surf_p):** 23.62 (baseline: 23.07)  
**Peak memory:** ~18.5 GB  

**What happened:** Negative result. No synergy observed. The triple combination is roughly additive of the individual regressions (+0.025 total individual, +0.025 observed here), suggesting the three changes don't interact at all — they're each independently unhelpful rather than each offsetting the others. The temporal orthogonality hypothesis didn't hold: these changes don't compensate each other across training phases. The baseline LR schedule and init gain appear well-calibrated for this problem.

**Suggested follow-ups:**
- Since all individual tweaks regress, the current baseline schedule (gain=1.0, sf=0.2, eta_min=5e-5) appears close to optimal for this architecture and dataset. Focus on architectural changes instead.