### PR TITLE
Combo: slice_residual_scale=0.2 + Lookahead k=8

### DIFF
--- a/train.py
+++ b/train.py
@@ -137,7 +137,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
-        self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
+        self.slice_residual_scale = nn.Parameter(torch.tensor(0.2))
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
             nn.Dropout(dropout),
@@ -576,7 +576,7 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+optimizer = Lookahead(base_opt, k=8, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(


### PR DESCRIPTION
## Hypothesis
slice_residual_scale=0.2 (vl=0.8575, +0.011) doubles the physics bypass, which creates a more direct gradient path through the attention block. Lookahead k=8 (vl=0.8615, +0.015) syncs more frequently, which stabilizes training. The stronger bypass could cause training oscillation (two competing paths: attention vs. bypass), and more frequent Lookahead syncs would dampen that oscillation. The bypass provides signal; Lookahead provides stability for that signal.

**Individual deltas**: slice_res=0.2 (+0.011), k=8 (+0.015)
**Expected interaction**: Stronger bypass = more oscillation risk; more frequent syncs = more stability. Architecture change stabilized by optimizer change.

## Instructions
Make exactly two changes to `train.py`:

1. **Line 140** — Change slice_residual_scale init from 0.1 to 0.2:
   ```python
   self.slice_residual_scale = nn.Parameter(torch.tensor(0.2))
   ```

2. **Line 579** — Change Lookahead k from 10 to 8:
   ```python
   optimizer = Lookahead(base_opt, k=8, alpha=0.8)
   ```

Use `--wandb_group combo-sliceres02-look8` and `--wandb_name noam/combo-sliceres02-look8`.

## Baseline
- val/loss = 0.8469 (current best)
- This is a combination experiment. Both changes individually regressed slightly. We are testing for synergy.

---

## Results

**W&B run**: z854jzzq | **Epochs**: 61 | **Peak VRAM**: 17.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5681 | 5.21 | 2.16 | **16.86** | 1.04 | 0.35 | 18.90 |
| ood_cond | 0.6758 | 3.56 | 1.49 | **13.52** | 0.71 | 0.26 | 11.56 |
| ood_re | 0.5298 | 3.16 | 1.34 | **27.52** | 0.82 | 0.36 | 46.74 |
| tandem | 1.6290 | 5.05 | 2.56 | **39.31** | 1.90 | 0.86 | 38.57 |
| **combined** | **0.8507** | | | | | | |

**vs baseline (0.8469)**:

| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|---|---|---|---|
| in_dist | 17.65 | 16.86 | **-0.79** (better) |
| ood_cond | 13.69 | 13.52 | **-0.17** (better) |
| ood_re | 27.47 | 27.52 | +0.05 (neutral) |
| tandem | 37.86 | 39.31 | **+1.45** (worse) |
| val/loss | 0.8469 | 0.8507 | **+0.0038** (worse) |

### What happened

The combo did not produce synergy. Overall val/loss is 0.8507 vs 0.8469 baseline — slightly worse. The individual results are mixed:

- In-dist and ood_cond surface pressure both improved slightly (likely noise-level improvements)
- Tandem surface pressure worsened by +1.45, which pulled up the combined val/loss
- The hypothesis that k=8 Lookahead would stabilize the stronger bypass appears incorrect — tandem performance suggests the combination may have actually made optimization less stable for the harder distribution shift

The pre-existing visualization error (mat1/mat2 shape mismatch) appeared after training, not affecting metrics.

### Suggested follow-ups

- Try slice_residual_scale as a **fixed constant** (not nn.Parameter) — if it's learnable it may converge to different values than 0.2 and the init doesn't matter much
- Try asymmetric Lookahead k: k=8 for attention params, k=10 for other params
- The in-dist improvement is interesting — test slice_residual_scale=0.15 as a midpoint between 0.1 (baseline) and 0.2