### PR TITLE
FIX: Per-sample std computed on NOISED targets (inflated stds)

### DIFF
--- a/train.py
+++ b/train.py
@@ -673,14 +673,8 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
-        # Per-sample std normalization: skip tandem samples (gap feature index 21)
+        # Per-sample std normalization: compute on clean y_norm before adding noise
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
@@ -694,6 +688,11 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
                 else:
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+            noise_progress = min(1.0, epoch / 60)
+            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
+            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
+            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
             y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Bug
Lines 676-697: Target noise is added BEFORE per-sample std is computed. The noise inflates std, causing the normalization to divide by too-large values, systematically shrinking targets. The model learns to predict smaller values than needed. Effect varies by epoch as noise anneals.
## Instructions
Move per-sample std computation BEFORE noise addition:
```python
# 1. Compute y_norm (clean)
y_norm = (y_phys - phys_stats['y_mean']) / phys_stats['y_std']
# 2. Compute per-sample stds on CLEAN y_norm
for b in range(B):
    valid = mask[b]
    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=clamps)
# 3. THEN add noise
if model.training and epoch < 60:
    y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
# 4. Divide by clean stds
y_norm = y_norm / sample_stds
```
Run with `--wandb_group fix-std-before-noise`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run**: woc76c82 | **Epochs**: 61 | **Peak VRAM**: 17.8 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5835 | 5.11 | 1.70 | **17.48** | 1.06 | 0.35 | 19.13 |
| ood_cond | 0.7042 | 3.17 | 1.13 | **14.03** | 0.72 | 0.27 | 11.81 |
| ood_re | 0.5396 | 2.69 | 0.93 | **27.62** | 0.83 | 0.36 | 46.57 |
| tandem | 1.6121 | 5.42 | 2.12 | **38.58** | 1.89 | 0.86 | 37.56 |
| **combined** | **0.8598** | | | | | | |

**vs baseline (0.8469)**:

| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|---|---|---|---|
| in_dist | 17.65 | 17.48 | -0.17 (marginal) |
| ood_cond | 13.69 | 14.03 | **+0.34** (worse) |
| ood_re | 27.47 | 27.62 | +0.15 (worse) |
| tandem | 37.86 | 38.58 | **+0.72** (worse) |
| val/loss | 0.8469 | 0.8598 | **+0.013** (worse) |

### What happened

The fix caused a regression (+0.013 val/loss). The "bug" — computing stds on noised targets — turns out to be functioning as **implicit adaptive noise scaling**: when noise is large (early in training), inflated stds cause  to be scaled down, effectively reducing the normalized noise amplitude. This acts as a soft curriculum that couples noise amplitude to std magnitude.

With the fix, stds are computed on clean y_norm and the full noise amplitude hits the normalized space, which appears to hurt optimization — particularly on tandem (+0.72 mae_surf_p) and ood_cond (+0.34).

The pre-existing visualization error (mat1/mat2 shape mismatch) appeared after training, not affecting metrics.

### Suggested follow-ups

- Accept the "bug" as a feature — the adaptive noise coupling may be intentional or at least beneficial. Document it.
- If the goal is truly to fix the std inflation: try reducing raw noise scales by 20-30% when computing stds post-noise, to preserve the adaptive scaling effect while fixing the systematic shrinkage
- Test removing target noise entirely to see if it's actually helping at all