### PR TITLE
FIX: Fourier PE xy_min/max contaminated by padding coordinates

### DIFF
--- a/train.py
+++ b/train.py
@@ -660,8 +660,12 @@ for epoch in range(MAX_EPOCHS):
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
+        # Mask out padding before computing min/max to avoid contamination
+        big_val = 1e6
+        xy_for_min = raw_xy.where(mask.unsqueeze(-1), torch.full_like(raw_xy, big_val))
+        xy_for_max = raw_xy.where(mask.unsqueeze(-1), torch.full_like(raw_xy, -big_val))
+        xy_min = xy_for_min.amin(dim=1, keepdim=True)
+        xy_max = xy_for_max.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
@@ -890,8 +894,12 @@ for epoch in range(MAX_EPOCHS):
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                # Mask out padding before computing min/max
+                big_val = 1e6
+                xy_for_min = raw_xy.where(mask.unsqueeze(-1), torch.full_like(raw_xy, big_val))
+                xy_for_max = raw_xy.where(mask.unsqueeze(-1), torch.full_like(raw_xy, -big_val))
+                xy_min = xy_for_min.amin(dim=1, keepdim=True)
+                xy_max = xy_for_max.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]


### PR DESCRIPTION
## Bug
Lines 661-668: `xy_min = raw_xy.amin(dim=1)` includes padded zeros. After standardization, padded (0,0) becomes ~(-0.65, -0.15). This shifts the [0,1] Fourier PE normalization range, making it batch-composition-dependent.
## Instructions
Mask padding before computing min/max. Run with `--wandb_group fix-fourier-pe-padding`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** 5yjoms32  
**Best epoch:** 58

### Implementation

Applied the masking fix in both the training loop (line ~663) and validation loop (line ~897). Used `mask.unsqueeze(-1)` to gate valid nodes before amin/amax:
```python
big_val = 1e6
xy_for_min = raw_xy.where(mask.unsqueeze(-1), torch.full_like(raw_xy, big_val))
xy_for_max = raw_xy.where(mask.unsqueeze(-1), torch.full_like(raw_xy, -big_val))
xy_min = xy_for_min.amin(dim=1, keepdim=True)
xy_max = xy_for_max.amax(dim=1, keepdim=True)
xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
```

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5901 | 4.15 | 1.43 | **17.60** | 19.08 |
| ood_cond | 0.7133 | 2.92 | 0.98 | **14.19** | 12.16 |
| ood_re | 0.5521 | 2.48 | 0.81 | **27.98** | 46.82 |
| tandem | 1.6219 | 4.93 | 1.95 | **38.62** | 37.41 |
| **combined val/loss** | **0.8693** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8469 | 0.8693 | +2.7% worse |
| in_dist surf_p | 17.65 | 17.60 | **-0.3%** (essentially same) |
| ood_cond surf_p | 13.69 | 14.19 | +3.7% |
| ood_re surf_p | 27.47 | 27.98 | +1.9% |
| tandem surf_p | 37.86 | 38.62 | +2.0% |

**Peak memory:** no OOM.

### What happened

**Neutral-to-mildly-negative.** The bug fix is semantically correct but did not improve performance in the 30-minute training run.

The in_dist split is essentially unchanged (-0.3%), confirming the fix doesn't hurt in-distribution. The OOD and tandem splits are slightly worse, but all within the ~3-7% noise floor.

Most likely explanation: padding contamination in the Fourier PE normalization was minor in practice. Since batches sample from variable-mesh-size datasets, if most samples in a batch have similar N (low padding fraction), the padded zeros shift xy_min by only a small amount. The effect on Fourier PE features is therefore small, and within training noise.

The fix is still semantically correct and removes a batch-composition dependency. In longer runs or different batch configurations, it may matter more.

### Suggested follow-ups

- **Check padding statistics:** Log average padding fraction per batch to quantify the bug's actual magnitude.
- **The fix is correct** — keep it regardless of this 30-min result; it removes a subtle inconsistency.
- **Combine with other fixes:** If there are other normalization bugs, fixing them all together may show a clearer signal.