### PR TITLE
FIX: Coarse pooling uses unmasked mean (padding dilution)

### DIFF
--- a/train.py
+++ b/train.py
@@ -768,8 +768,11 @@ for epoch in range(MAX_EPOCHS):
             y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
             mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
-            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+            mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)
+            pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
+            y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
+            pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
+            y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
             mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
             coarse_err = (pred_coarse - y_coarse).abs()


### PR DESCRIPTION
## Bug
Lines 760-778: Coarse group means use `.mean(dim=2)` which includes padded zeros. Groups containing mixed real/padded nodes have diluted means. With variable mesh sizes, up to 50% of positions can be padding.
## Instructions
Use masked means for coarse groups:
```python
mask_trunc_f = mask_trunc.float().reshape(B, n_groups, pool).unsqueeze(-1)
pred_g = pred_trunc.reshape(B, n_groups, pool, C)
y_g = y_trunc.reshape(B, n_groups, pool, C)
pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
```
Run with `--wandb_group fix-coarse-masked-mean`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86

---

## Results

**W&B run:** 1yop5sof  (runtime: 31.9 min, state: failed due to pre-existing vis crash)

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5938 | 5.95 | 1.86 | 17.53 | 1.10 | 0.36 | 18.90 |
| val_ood_cond | 0.7049 | 3.69 | 1.33 | 14.34 | 0.72 | 0.27 | 12.30 |
| val_ood_re | 0.5464 | 3.29 | 1.16 | 28.00 | 0.82 | 0.36 | 47.21 |
| val_tandem_transfer | 1.6584 | 5.91 | 2.48 | 39.56 | 1.93 | 0.87 | 38.80 |
| **val_loss (best)** | **0.8759** | | | | | | |

**mean3_p** = (17.53+14.34+39.56)/3 = **23.81**

**vs baseline:** val_loss +0.0290 (+3.4%), mean3_p +0.74 (+3.2%) — **worse**

### What happened

Fixing the padding dilution bug made overall performance worse. The fix improved in_dist (17.53 vs 17.65 — actually better) but hurt tandem (39.56 vs 37.86) and ood_cond (14.34 vs 13.69).

The likely explanation: the original padding dilution was acting as an **accidental regularizer**. When coarse group means included padding zeros, the target was pulled toward zero — forcing the model to predict smaller-magnitude values in coarse groups. This gentle bias toward zero happens to help OOD generalization, particularly for tandem geometry where the pressure field has larger values. With proper masked means, the coarse targets are more accurate but the implicit zero-bias regularization is removed.

Alternatively: coarse groups near mesh boundaries (with mostly padding) previously had near-zero error in both prediction and target (both are zero-padded). With masked means, those groups are excluded from the coarse loss entirely, effectively reducing the number of loss terms and changing which spatial regions the model focuses on.

This is a good example of an accidentally helpful bug. The coarse loss may need explicit regularization (e.g., weight decay on the coarse predictions) if the masked mean is used.

### Suggested follow-ups

- Accept that the padding dilution is accidentally beneficial and leave it
- Or: use masked mean but add L2 regularization on pred_coarse (not y_coarse) to preserve the zero-pull effect