### PR TITLE
FIX: phys_stats biased by large meshes (per-sample mean fix)

### DIFF
--- a/train.py
+++ b/train.py
@@ -508,9 +508,13 @@ with torch.no_grad():
         _Um, _q = _umag_q(_y, _mask)
         _yp = _phys_norm(_y, _Um, _q)
         _m = _mask.float().unsqueeze(-1)  # [B, N, 1]
-        _phys_sum += (_yp * _m).sum(dim=(0, 1))
-        _phys_sq_sum += (_yp ** 2 * _m).sum(dim=(0, 1))
-        _phys_n += _mask.float().sum().item()
+        # Per-sample means: each sample contributes equally regardless of node count
+        _n_nodes = _m.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1, 1]
+        _sample_mean = (_yp * _m).sum(dim=1) / _n_nodes.squeeze(1)  # [B, 3]
+        _sample_sq_mean = (_yp ** 2 * _m).sum(dim=1) / _n_nodes.squeeze(1)  # [B, 3]
+        _phys_sum += _sample_mean.sum(dim=0)
+        _phys_sq_sum += _sample_sq_mean.sum(dim=0)
+        _phys_n += _mask.shape[0]  # count samples, not nodes
 _pmean = (_phys_sum / _phys_n).float()
 _pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
 phys_stats = {"y_mean": _pmean, "y_std": _pstd}


### PR DESCRIPTION
## Bug
Lines 498-516: phys_stats sums over all nodes equally, so samples with more mesh nodes contribute more. Cruise meshes (210K nodes) contribute ~2.5x more than raceCar meshes (85K). This biases normalization toward cruise flow statistics.
## Instructions
Use per-sample means instead of raw node counts — see detailed implementation in hypothesis. Run with `--wandb_group fix-phys-stats-persample`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** 9h69e8f7  
**Epochs completed:** 59 (timeout at epoch 60)

### Implementation

Replaced the node-count-weighted accumulation with per-sample means:
```python
_n_nodes = _m.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1, 1]
_sample_mean = (_yp * _m).sum(dim=1) / _n_nodes.squeeze(1)  # [B, 3]
_sample_sq_mean = (_yp ** 2 * _m).sum(dim=1) / _n_nodes.squeeze(1)  # [B, 3]
_phys_sum += _sample_mean.sum(dim=0)
_phys_sq_sum += _sample_sq_mean.sum(dim=0)
_phys_n += _mask.shape[0]  # count samples, not nodes
```

The fix is confirmed to change the statistics:
- **Before** (node-weighted): mean=[0.9994, -0.0156, -0.2892], std=[0.449, 0.304, 1.101]
- **After** (per-sample): mean=[0.9993, -0.0190, -0.3353], std=[0.470, 0.318, 1.159]

Pressure mean shifted from -0.289 to -0.335 (more negative), and std increased by ~5%, suggesting smaller meshes (raceCar) have higher pressure variation that was being diluted.

### Metrics vs Baseline

| Metric | Baseline | Fix Result | Delta |
|--------|----------|------------|-------|
| val_loss | 0.8469 | **0.8670** | +2.4% worse |
| in_dist surf MAE | 17.65 | 26.99 | +53% worse |
| ood_cond surf MAE | 13.69 | 19.22 | +40% worse |
| ood_re surf MAE | 27.47 | 32.43 | +18% worse |
| tandem surf MAE | 37.86 | 47.11 | +25% worse |

**Epoch time:** ~30.6s (no change).

### What happened

Fixing the bias hurts performance. Val_loss=0.8670 at 59 epochs vs baseline 0.8469. The fix is "correct" in a data-science sense, but the model was trained with the biased statistics in mind — the training pipeline was implicitly tuned with cruise-weighted normalization. Changing the normalization shifts the loss landscape.

The per-sample statistics change the y_mean/y_std values, which affects both the target normalization in training AND the baseline signal seen by the model. The model must now re-learn with different targets. Since all hyperparameters (LR, clamp values, surf_weight) were tuned against the biased stats, they may be suboptimal for the corrected stats.

The val_loss trend (0.8833→0.8778→0.8731→0.8687→0.8670, ~0.004/epoch) shows it's still converging but slowly. Given the bug fix is real, this result is informative: the biased statistics were accidentally good for training, or the hyperparameters need re-tuning after this fix.

### Suggested follow-ups

- The bug fix is real. If we adopt it, we should re-tune: surf_weight scaling, LR, and y_norm clamping thresholds against the new statistics
- The higher std (1.159 vs 1.101 for pressure) means the loss landscape for pressure is steeper — try increasing surf_weight or reducing the pressure clamp threshold to compensate
- This is a fundamental change that may take multiple iterations to properly tune