### PR TITLE
FIX: Target noise applied to padded positions (coarse loss leak)

### DIFF
--- a/train.py
+++ b/train.py
@@ -678,7 +678,7 @@ for epoch in range(MAX_EPOCHS):
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+            y_norm = y_norm + noise_scale * torch.randn_like(y_norm) * mask.unsqueeze(-1).float()
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Bug
Lines 676-681: Target noise applied to ALL positions. Padded targets become non-zero. This leaks into coarse pooling loss where group means include padded noisy values.
## Instructions
Mask target noise: `y_norm = y_norm + noise_scale * torch.randn_like(y_norm) * mask.unsqueeze(-1).float()`. Run with `--wandb_group fix-target-noise-mask`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B Run:** ko34j254
**Best epoch:** 61 (last logged; model still improving)

Note: Visualization crash post-training (shape mismatch in vis_model). Training metrics unaffected.

### Metrics vs Baseline

| Split | surf_p | surf_Ux | surf_Uy |
|-------|--------|---------|---------|
| val_in_dist | 17.58 | 5.41 | 2.04 |
| val_ood_cond | 13.56 | — | — |
| val_ood_re | 27.61 | — | — |
| val_tandem_transfer | 38.30 | — | — |

| Metric | Baseline | This run | Delta |
|--------|----------|----------|-------|
| val/loss | 0.8469 | 0.8516 | +0.0047 ↔ noise |
| in surf_p | 17.65 | 17.58 | -0.07 ↓ marginal better |
| ood_c surf_p | 13.69 | 13.56 | -0.13 ↓ marginal better |
| ood_r surf_p | 27.47 | 27.61 | +0.14 ↑ marginal worse |
| tan surf_p | 37.86 | 38.30 | +0.44 ↑ slight worse |
| mean3 surf_p | ~19.60 | 19.58 | -0.02 ↔ no change |

**Peak memory:** ~17.7 GB

### What happened

Essentially neutral — within the noise floor (~0.01 val/loss). The bug fix does not produce a meaningful improvement.

The in_dist and ood_cond splits improve slightly, while ood_re and tandem regress slightly. These differences are all smaller than the ~0.01 noise floor between runs with the same seed.

The likely reason the fix doesn't help much: padded positions in the dataset are probably filled with zeros (common in CFD datasets with variable mesh sizes), so adding noise to zero-padded targets is numerically equivalent to adding noise to a position that the model never actually attends to (since the padding mask prevents those positions from contributing to losses). The 'coarse pooling loss leak' may be minimal in practice because the coarse pooling already uses the mask.

The model was still improving monotonically over the last 5 epochs (0.8660 → 0.8516), suggesting it hadn't fully converged.

### Suggested follow-ups

- This fix is still correct and should be merged as a code quality improvement even though the metric impact is negligible
- If the dataset does have non-zero padding values, the fix would be more impactful; worth checking the data loader
- The slight tandem degradation (+0.44) is suspicious for a 'bug fix' — could indicate that the noise on padded positions was actually helping tandem generalization as an accidental regularizer