### PR TITLE
Restrict feature_cross to physical features only (not Fourier PE)

### DIFF
--- a/train.py
+++ b/train.py
@@ -289,7 +289,7 @@ class Transolver(nn.Module):
 
         self.n_hidden = n_hidden
         self.space_dim = space_dim
-        self.feature_cross = nn.Linear(fun_dim + space_dim, fun_dim + space_dim, bias=False)
+        self.feature_cross = nn.Linear(fun_dim + space_dim - 32, fun_dim + space_dim - 32, bias=False)
         nn.init.eye_(self.feature_cross.weight)  # start as identity
         self.blocks = nn.ModuleList(
             [
@@ -375,8 +375,10 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
-        x_cross = x * self.feature_cross(x)
-        x = x + 0.1 * x_cross  # residual with small scale
+        x_phys = x[:, :, :26]
+        x_cross = x_phys * self.feature_cross(x_phys)
+        x_phys = x_phys + 0.1 * x_cross
+        x = torch.cat([x_phys, x[:, :, 26:]], dim=-1)
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting


### PR DESCRIPTION
## Bug/Optimization
feature_cross operates on 58 dims (24 phys + 2 curv/dist + 32 Fourier PE). Crossing Fourier features with physical features creates meaningless products. Restricting to the first 26 physical features produces cleaner interactions.
## Instructions
```python
# In model init: feature_cross on physical dims only
self.feature_cross = nn.Linear(fun_dim + space_dim - 32, fun_dim + space_dim - 32, bias=False)
# In forward:
x_phys = x[:, :, :26]; x_cross = x_phys * self.feature_cross(x_phys)
x_phys = x_phys + 0.1 * x_cross; x = torch.cat([x_phys, x[:, :, 26:]], dim=-1)
```
Run with `--wandb_group fix-fcross-phys-only`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run ID:** 6rcc69e8  
**Best epoch:** 60 (wall-clock timeout at ~30.0 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.9009** | 0.8469 |
| val_in_dist | 0.6130 | — |
| val_tandem_transfer | 1.6799 | — |
| val_ood_cond | 0.7470 | — |
| val_ood_re | 0.5639 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 6.31 | 1.95 | 18.53 | 17.65 | +5.0% |
| val_tandem_transfer | 6.07 | 2.50 | 39.92 | 37.86 | +5.4% |
| val_ood_cond | 3.75 | 1.30 | 15.25 | 13.69 | **+11.4%** |
| val_ood_re | 3.25 | 1.10 | 28.13 | 27.47 | +2.4% |

**mean3 surf_p** = (18.53 + 15.25 + 39.92) / 3 = **24.57** (baseline: 23.07, delta: +6.5%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 1.13 | 0.38 | 19.94 |
| val_tandem_transfer | 1.96 | 0.90 | 39.02 |
| val_ood_cond | 0.74 | 0.28 | 12.75 |
| val_ood_re | 0.84 | 0.37 | 47.15 |

---

### What happened

**Clear negative result.** val/loss = 0.9009 vs baseline 0.8469 (+6.4% worse). mean3 surf_p = 24.57 vs 23.07 (+6.5% worse). All splits degraded significantly, especially ood_cond (+11.4%).

The hypothesis that Fourier×physical cross-products are "meaningless" was wrong. The feature_cross layer (initialized as identity) was learning to re-route information across the full 58-dim feature space, including interactions between Fourier PE components and physical features. These cross-interactions are actually useful — they allow the model to learn spatially-varying physical correlations where the Fourier basis encodes spatial frequency and the physical features encode local physics.

Restricting to 26×26 cross-products removes this information pathway entirely. The result is a weaker model, particularly on ood_cond which is the most geometry-sensitive split.

*Visualization crash* (different from before): `mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x384)` in `preprocess` (GatedMLP2) during post-training visualization. With the feature_cross fix, the visualization path no longer crashes at feature_cross but now crashes at preprocess which also expects 58 dims. Training metrics are unaffected.

---

### Suggested follow-ups

- **Reverse the restriction**: The evidence suggests the Fourier-physical cross-interactions are valuable. Do NOT restrict feature_cross — the 58×58 version should remain.
- **Feature_cross scale tuning**: Rather than restricting dimensions, try changing the residual scale from 0.1 to 0.05 or 0.2 to tune how much the cross-interaction contributes.
- **Fix visualization path**: The vis path doesn't add Fourier PE, so it fails at the preprocess layer. Adding Fourier PE in the visualization preprocessing (same as the training loop) would fix the crash.
