### PR TITLE
Sorted batch sampler (minimize padding waste for throughput)

### DIFF
--- a/train.py
+++ b/train.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, asdict
 from einops import rearrange
 from timm.layers import trunc_normal_
 from tqdm import tqdm
-from torch.utils.data import DataLoader, WeightedRandomSampler
+from torch.utils.data import DataLoader, WeightedRandomSampler, Sampler
 import simple_parsing as sp
 
 from data.utils import visualize
@@ -477,18 +477,39 @@ def _phys_denorm(y_p, Umag, q):
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
+
+class SortedBatchSampler(Sampler):
+    """Groups similar-sized samples into batches to minimize padding waste.
+    Batch order is shuffled each iteration for training randomness.
+    """
+    def __init__(self, sizes, batch_size, drop_last=True):
+        sorted_indices = sorted(range(len(sizes)), key=lambda i: sizes[i])
+        self.batches = [
+            sorted_indices[i:i + batch_size]
+            for i in range(0, len(sorted_indices), batch_size)
+        ]
+        if drop_last and self.batches and len(self.batches[-1]) < batch_size:
+            self.batches = self.batches[:-1]
+
+    def __iter__(self):
+        perm = torch.randperm(len(self.batches)).tolist()
+        for i in perm:
+            yield self.batches[i]
+
+    def __len__(self):
+        return len(self.batches)
+
+
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
     train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
                               shuffle=True, **loader_kwargs)
 else:
-    sampler = WeightedRandomSampler(
-        weights=sample_weights,
-        num_samples=len(train_ds),
-        replacement=True,
-    )
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
-                              sampler=sampler, **loader_kwargs)
+    # Pre-compute sample sizes once for sorted batching
+    print("Pre-computing sample sizes for sorted batch sampler...")
+    sample_sizes = [train_ds[i][0].shape[0] for i in range(len(train_ds))]
+    batch_sampler = SortedBatchSampler(sample_sizes, cfg.batch_size, drop_last=True)
+    train_loader = DataLoader(train_ds, batch_sampler=batch_sampler, **loader_kwargs)
 
 val_loaders = {
     name: DataLoader(subset, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)


### PR DESCRIPTION
## Optimization
Variable mesh sizes (85K-210K) cause massive padding waste. Sorting batches by mesh size minimizes padding, giving more effective throughput = more epochs in 30 min.
## Instructions
Implement a SortedBatchSampler that groups similar-sized meshes together. Add `drop_last=True`. See detailed implementation in hypothesis. Run with `--wandb_group sorted-batch-sampler`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** bi9v1yoj
**Runtime:** 1921s (79 epochs — 35% more epochs than baseline due to reduced padding!)

| Split | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8469 | 1.0149 | +19.8% worse |
| val_in_dist surf_p | 17.65 | 17.628 | -0.1% (essentially same!) |
| val_ood_cond surf_p | 13.69 | 18.609 | +35.9% worse |
| val_ood_re surf_p | 27.47 | 31.538 | +14.8% worse |
| val_tandem surf_p | 37.86 | 44.208 | +16.8% worse |

Detailed metrics (last epoch):
- in_dist: loss=0.5678, surf_p=17.628, surf_Ux=5.592, surf_Uy=1.667, vol_Ux=0.999, vol_Uy=0.331, vol_p=18.941
- ood_cond: loss=0.9106, surf_p=18.609, surf_Ux=6.087, surf_Uy=1.562, vol_Ux=0.869, vol_Uy=0.343, vol_p=16.147
- ood_re: loss=0.7153, surf_p=31.538, surf_Ux=5.909, surf_Uy=1.383, vol_Ux=0.940, vol_Uy=0.414, vol_p=50.290
- tandem: loss=1.8660, surf_p=44.208, surf_Ux=6.028, surf_Uy=2.223, vol_Ux=2.067, vol_Uy=0.940, vol_p=43.385

**What happened:** The throughput win was real (79 epochs, +35%) but came at a steep quality cost on OOD and tandem splits. Two problems:

1. **Lost weighted sampling**: The original WeightedRandomSampler oversampled certain training samples to balance the distribution. The SortedBatchSampler doesn't do this, likely underrepresenting OOD/tandem samples in early training.

2. **Correlated batches hurt optimization**: Sorting groups similar-sized meshes — likely small meshes early, large meshes late. This creates highly correlated batches within an epoch, which hurts SGD. The batch order shuffle helps somewhat but doesn't address within-batch correlation (similar flows for similar mesh sizes).

The in_dist split was essentially unaffected (17.628 vs 17.65), suggesting the throughput gain does help for well-represented in-distribution data. The OOD/tandem degradation is the critical problem.

**Suggested follow-ups:**
- Sorted bucketed batching + weighted sampling: maintain sample weights but within buckets of similar sizes — sort by size, group into buckets of ~100 samples, sample batches from within each bucket with replacement weighted by sample_weights
- Alternatively, just fix the padding problem at the dataloader level by pre-filtering to remove extremely large samples from the mini-batches