### PR TITLE
Per-sample std: multiply instead of divide (upweight hard samples)

### DIFF
--- a/train.py
+++ b/train.py
@@ -694,7 +694,7 @@ for epoch in range(MAX_EPOCHS):
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
                 else:
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
-            y_norm = y_norm / sample_stds
+            y_norm = y_norm * sample_stds.clamp(max=3.0)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})
@@ -705,7 +705,7 @@ for epoch in range(MAX_EPOCHS):
         re_pred = re_pred.float()
         aoa_pred = aoa_pred.float()
         if model.training:
-            pred = pred / sample_stds
+            pred = pred * sample_stds.clamp(max=3.0)
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:


### PR DESCRIPTION
## Hypothesis
Current per-sample std DIVIDES — implicitly downweighting high-variance (hard) samples. Try MULTIPLYING instead: hard samples contribute MORE to loss, giving stronger gradient signal from the most informative samples.
## Instructions
Change: `y_norm = y_norm / sample_stds` to `y_norm = y_norm * sample_stds.clamp(max=3.0)`. Same for pred. Run with `--wandb_group persample-std-multiply`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** `d7wisaz5`
**Epochs:** 61 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_p |
|---|---|---|
| in_dist | 0.6475 | 19.3 |
| ood_cond | 0.8306 | 16.5 |
| ood_re | 0.6259 | 29.2 |
| tandem | 1.6845 | 40.3 |
| **combined** | **0.9471** | |

**surf_p mean3** = (19.3 + 16.5 + 40.3) / 3 = **25.37**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8469 | 0.9471 | +11.8% |
| surf_p in_dist | 17.65 | 19.3 | +9.3% |
| surf_p ood_cond | 13.69 | 16.5 | +20.5% |
| surf_p ood_re | 27.47 | 29.2 | +6.3% |
| surf_p tandem | 37.86 | 40.3 | +6.5% |
| surf_p mean3 | 23.07 | 25.37 | +10.0% |

### What happened

Clear negative result. Multiplying by std (clamped at 3.0) significantly worsened all metrics, with ood_cond suffering the most (+20.5%).

The fundamental problem: train/eval mismatch. During training, the model outputs are scaled up by sample_stds before computing loss. But at eval time, there is no std scaling — the model must produce raw predictions that match unscaled targets. By multiplying during training, the model learns to produce small outputs (since they'll be amplified), but at eval these small predictions are compared directly against full-magnitude targets.

Additionally, multiplying amplifies high-variance (hard) samples but these are often OOD conditions and noisy tandem configurations. Amplifying their loss contribution directs optimization toward noisy signal, degrading generalization.

The current divide approach is principled: it normalizes per-sample variance so the loss gradient is scale-invariant, treating a "large" prediction error on a high-variance sample equivalently to a proportionally smaller error on a low-variance sample.

### Suggested follow-ups

- The division approach is correct; the std normalization problem is elsewhere
- If hard-sample upweighting is desired, do it more directly: use a separate per-sample loss weight based on sample difficulty, rather than changing the target normalization
