### PR TITLE
FIX: Vis pipeline missing Fourier PE (inference correctness)

### DIFF
--- a/train.py
+++ b/train.py
@@ -1068,6 +1068,14 @@ if best_metrics:
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                raw_xy_vis = x_n[:, :, :2]
+                xy_min_vis = raw_xy_vis.amin(dim=1, keepdim=True)
+                xy_max_vis = raw_xy_vis.amax(dim=1, keepdim=True)
+                xy_norm_vis = (raw_xy_vis - xy_min_vis) / (xy_max_vis - xy_min_vis + 1e-8)
+                freqs_vis = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled_vis = xy_norm_vis.unsqueeze(-1) * freqs_vis
+                fourier_pe_vis = torch.cat([xy_scaled_vis.sin().flatten(-2), xy_scaled_vis.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_vis], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Bug
Lines 1060-1074: The vis/inference pipeline constructs 26-dim input but model expects 58-dim (includes 32 Fourier PE). Either crashes or produces wrong predictions.
## Instructions
Add Fourier PE computation to the vis pipeline, matching the training feature construction exactly. Run with `--wandb_group fix-vis-fourier-pe`.
## Baseline
val_loss=0.8469 | in=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86
---
## Results

**W&B run:** hztbhkyf

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5854 | 5.006 | 1.621 | 17.60 | 1.070 | 0.362 | 19.44 |
| val_tandem_transfer | 1.6287 | — | — | 39.0 | — | — | — |
| val_ood_cond | 0.7154 | — | — | 14.4 | — | — | — |
| val_ood_re | 0.5456 | — | — | 27.7 | — | — | — |
| **combined val/loss** | **0.8688** | | | | | | |

Baseline: val_loss=0.8469 | in_surf_p=17.65 | ood_c=13.69 | ood_r=27.47 | tan=37.86

Peak memory: 18.1 GB

**What happened:**
This is a correctness fix, not a performance experiment. The vis pipeline was constructing a 26-dim input (24 base features + curv + dist_feat) but the model expects 58-dim (26 + 32 Fourier PE). This would have caused a shape mismatch crash or silent garbage predictions in any code path that reached visualization.

The fix inserts the same Fourier PE computation that the training and val loops use: normalize xy coordinates per-sample, apply learned + fixed frequency banks, concatenate sin/cos features. All 16 visualization plots (4 samples x 4 splits) generated successfully.

Training metrics are in line with baseline (val/loss=0.8688 vs 0.8469, in_surf_p=17.60 vs 17.65) — the minor differences are normal run-to-run variation, confirming the fix did not affect training correctness.

**Suggested follow-ups:**
- Audit any other inference/eval code paths that construct features outside the main training loop to check for similar Fourier PE omissions.