### PR TITLE
FIX: Tandem curriculum uses gap feature (re-test on dist_feat code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -710,7 +710,7 @@ for epoch in range(MAX_EPOCHS):
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface


### PR DESCRIPTION
## Hypothesis
The tandem curriculum detection at line ~712 uses `x[:, :, -8:].abs().sum(dim=(1,2)) > 0.01` which checks the last 8 features. Since Fourier PE was added, these are sin/cos values (always non-zero), making the check True for ALL samples. This silently zeroes out `abs_err` for the first 10 epochs for all samples, creating an accidental "frozen warmup." Round 20 showed this hurt on the old code (+0.0207 val_loss), but the dist_feat fix fundamentally changed the optimization landscape — the model now has a correct distance signal and may benefit from the intended curriculum: training on non-tandem data immediately while delaying tandem.

## Instructions
In `train.py`, find the tandem curriculum block (around line 712-715):
```python
# OLD (broken — detects Fourier PE, not tandem):
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
```
Replace the detection line only:
```python
if epoch < 10:
    is_tandem_curr = (x[:, 0, 21].abs() > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
```
This is a 1-line change: replace `(x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)` with `(x[:, 0, 21].abs() > 0.01)`.

Run with `--wandb_group r21-fix-tandem-curriculum`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** jxg0ces8  
**Best epoch:** 58 / 58  

| Split | mae_surf_p | mae_surf_Ux | mae_surf_Uy | mae_vol_p |
|---|---|---|---|---|
| in_dist | 18.41 | 7.06 | 1.88 | 19.44 |
| ood_cond | 14.59 | 3.36 | 1.04 | 11.92 |
| ood_re | 28.06 | 2.89 | 0.91 | 46.91 |
| tandem | 39.38 | 6.07 | 2.21 | 37.66 |

**val/loss:** 0.8688 (baseline: 0.8408)  
**mean3 (in/ood_c/tan surf_p):** 24.13 (baseline: 23.39)  
**Peak memory:** ~18.5 GB  

**What happened:** Negative result. Fixing the tandem curriculum detection actually hurt: all splits are worse than the r21 baseline. The "broken" curriculum (zeroing abs_err for ALL samples for 10 epochs) was accidentally beneficial — it effectively created a 10-epoch frozen warm-up period where loss was nearly zero. This accidental behavior appears to act as a useful stabilization phase at the start of training. The correctly working curriculum (only zeroing tandem samples) removes this stabilization and performs worse.

**Suggested follow-ups:**
- The "broken" freeze is functionally equivalent to a 10-epoch warm-up with zero-loss, which may be providing useful early-training stability. Consider an explicit zero-loss warmup for all samples (epochs 0-10) followed by full training.
- Alternatively, keep the broken behavior intentionally and document it, since it helps.