### PR TITLE
FIX: Per-sample std on clean targets (re-test on dist_feat code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -674,14 +674,9 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
+        # Computed on CLEAN y_norm before target noise to avoid inflated std
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
@@ -696,6 +691,13 @@ for epoch in range(MAX_EPOCHS):
                 else:
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
+
+        if model.training:
+            noise_progress = min(1.0, epoch / 60)
+            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
+            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
+            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})


### PR DESCRIPTION
## Hypothesis
Per-sample std (lines 684-698) is computed AFTER target noise is added (lines 677-682). The noise inflates the computed std, causing normalization to divide by too-large values — systematically shrinking targets. Round 20 showed +0.013 val_loss on old code, but the dist_feat fix changed input features significantly. The model now has correct surface proximity information, and correctly-scaled targets may interact better with the corrected distance signal.

## Instructions
In `train.py`, reorder the per-sample std computation to happen BEFORE target noise. Currently the code order (in the training section) is:

1. `y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]` (line ~676)
2. Target noise added (lines ~677-682)
3. Per-sample std computed on noised y_norm (lines ~684-698)

Change to:

1. `y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]` (line ~676)
2. Per-sample std computed on CLEAN y_norm (move the block from `raw_gap = x[:, 0, 21]` through `y_norm = y_norm / sample_stds` to here)
3. Target noise added AFTER std normalization

Concretely, move the entire block from line 685 (`raw_gap = x[:, 0, 21]`) through line 698 (`y_norm = y_norm / sample_stds`) to immediately after line 676 (`y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]`), BEFORE the noise addition block.

Run with `--wandb_group r21-fix-std-before-noise`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** `9nbmv1bc`  
**Epochs:** 59 (30-min timeout)  
**Peak memory:** 18.2 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5964 | 5.82 | 1.83 | **18.53** | 19.03 |
| ood_cond | 0.6890 | 2.52 | 0.98 | **13.97** | 11.65 |
| ood_re | 0.5432 | 2.18 | 0.84 | 28.01 | 46.78 |
| tandem | 1.6318 | 4.97 | 2.01 | **39.44** | 37.53 |
| **combined** | **0.8651** | — | — | — | — |

**vs baseline (val_loss=0.8408, mean3=23.39):** val/loss +2.9%, mean3=23.98 (+2.5%)

### What happened

The fix marginally regressed across all splits. The noise added to targets is small (vel: 0.015→0.003, p: 0.008→0.001 annealing over 60 epochs), so the std inflation from noise is minimal in absolute terms. Two likely explanations:

1. **Negligible bug:** The noise is tiny relative to signal amplitude. The std inflation is at most ~1-2% for early epochs (when noise is largest) and ~0.1% later. The "bug" simply has no meaningful effect on the final normalization quality.

2. **Training dynamics disruption:** By computing std on clean targets, the sample_stds become slightly smaller, making the division produce slightly larger normalized values. The model on the noam branch has been trained with the "noisy std" formulation, and the normalization scales it has learned are calibrated to it. Reversing the order subtly shifts the distribution the model sees.

The result is consistent with the earlier round-20 test showing +0.013 regression — this fix does not help. The per-sample std is robust to the small amounts of noise being added.

### Suggested follow-ups
- **Drop per-sample std entirely:** Given the normalization instability this feature has shown across tests, it may be worth ablating the per-sample std normalization completely to see if it helps or hurts overall.
- **Larger noise schedule:** If the noise were larger (as a separate experiment), the std inflation would matter more — but this seems like the wrong direction given noise is already decaying toward near-zero.
