### PR TITLE
FIX: Input noise masked to valid nodes only (re-test on dist_feat code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -670,7 +670,8 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
             noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+            noise = noise_scale * torch.randn_like(x[:, :, 2:25])
+            x[:, :, 2:25] = x[:, :, 2:25] + noise * mask.unsqueeze(-1).float()
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
Input noise (line ~672-673) is applied to ALL positions including padding. Padded nodes (zeros after standardization) become small random values, creating ghost nodes in attention. Round 20 showed +0.0216 val_loss on old code. But the dist_feat fix means padding nodes now also have a (potentially wrong) distance feature — if dist_feat for padded nodes is log1p(0)=0 while real volume nodes have larger values, the noise on padding is less distinguishable. Masking noise to valid nodes ensures padding stays at clean zeros, making it maximally distinguishable from real nodes.

## Instructions
In `train.py`, find the input noise block (around line 671-673):
```python
if model.training and epoch < 60:
    noise_scale = 0.05 * (1 - epoch / 60)
    x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
```
Replace with:
```python
if model.training and epoch < 60:
    noise_scale = 0.05 * (1 - epoch / 60)
    noise = noise_scale * torch.randn_like(x[:, :, 2:25])
    x[:, :, 2:25] = x[:, :, 2:25] + noise * mask.unsqueeze(-1).float()
```
This is a 2-line change: separate noise creation from application, and multiply by the padding mask.

Run with `--wandb_group r21-fix-input-noise-padding`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run ID:** `lkan4hxw`
**val/loss: 0.8607** (baseline: 0.8408, **+0.0199** — worse)

### Surface MAE

| Split | Ux | Uy | p | Δp vs baseline |
|---|---|---|---|---|
| in_dist | 6.37 | 1.96 | **18.72** | +0.66 ✗ |
| ood_cond | 2.88 | 1.09 | **14.64** | +0.95 ✗ |
| ood_regime | 2.29 | 0.93 | **27.61** | +0.03 ≈ |
| tandem | 6.15 | 2.37 | **38.50** | +0.08 ≈ |

### Volume MAE (p)

| Split | vol_p |
|---|---|
| in_dist | 19.56 |
| ood_cond | 12.13 |
| ood_regime | 46.63 |
| tandem | 37.37 |

**Peak memory:** ~50 GB (52% of 96 GB)

### What happened

Masking noise to valid nodes only makes things worse. The hypothesis was that noise on padding creates ghost nodes that confuse attention, but the results suggest the opposite: noise on padding is acting as a useful regularizer for the attention mechanism.

When padding nodes receive noise, the model must learn to ignore them via the mask, which forces the attention mechanism to develop stronger discrimination between real and padded positions. Removing this challenge makes the model more brittle. Additionally, the dist_feat argument may be weaker than expected — even if log1p(0)=0 for padding, the Fourier PE features are still non-zero at padded positions (they encode spatial coordinates that happen to be zero), so masked noise isn't as clean a separator as hypothesized.

ood_regime and tandem are essentially unchanged (+0.03, +0.08), while in_dist and ood_cond degrade meaningfully. The in/ood_c splits likely have tighter padding ratios, making the padding-noise regularization more important there.

### Suggested follow-ups
- The original input noise on all positions (including padding) appears beneficial — don't change it.
- If ghosting from padding is a real concern, try setting a learned padding embedding rather than relying on noise regularization.
- The dist_feat scale may be a more impactful lever than noise masking — worth revisiting scale values directly.