### PR TITLE
FIX: Target noise masked to valid nodes (re-test on dist_feat code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -679,7 +679,7 @@ for epoch in range(MAX_EPOCHS):
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+            y_norm = y_norm + noise_scale * torch.randn_like(y_norm) * mask.unsqueeze(-1).float()
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
Target noise (line ~682) is applied to ALL positions including padding. Padded targets become non-zero, which leaks into coarse pooling loss where group means include padded noisy values. Round 20 showed essentially neutral results on old code (+0.0047 val_loss). However, the dist_feat fix improved volume predictions significantly (the main beneficiary of correct distance info), and noisy padded targets in the coarse loss may now be adding more harmful signal since the model is trying harder to get volume predictions right.

## Instructions
In `train.py`, find the target noise block (around line 681-682):
```python
y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
```
Replace with:
```python
y_norm = y_norm + noise_scale * torch.randn_like(y_norm) * mask.unsqueeze(-1).float()
```
This is a 1-line change: append `* mask.unsqueeze(-1).float()` to mask noise to valid nodes only.

Run with `--wandb_group r21-fix-target-noise-padding`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** `jmj8rdna`
**Epochs:** 61 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5818 | 4.93 | 1.44 | 18.11 | 0.94 | 0.34 | 19.71 |
| ood_cond | 0.6765 | 2.40 | 0.93 | 13.63 | 0.63 | 0.25 | 11.99 |
| ood_re | 0.5309 | 2.14 | 0.82 | 27.81 | 0.74 | 0.35 | 46.93 |
| tandem | 1.6075 | 5.10 | 2.00 | 38.90 | 1.72 | 0.81 | 37.69 |
| **combined** | **0.8492** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (18.11 + 13.63 + 38.90) / 3 = **23.55**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8408 | 0.8492 | +1.0% |
| surf_p in_dist | 18.06 | 18.11 | +0.3% |
| surf_p ood_cond | 13.69 | 13.63 | -0.4% |
| surf_p ood_re | 27.58 | 27.81 | +0.8% |
| surf_p tandem | 38.42 | 38.90 | +1.2% |
| surf_p mean3 | 23.39 | 23.55 | +0.7% |

### What happened

Neutral-to-negative result. The fix slightly worsens most metrics; ood_cond is marginally better (-0.4%). The hypothesis that noisy padded targets are causing harm (now that volume predictions are more accurate) is not supported.

The result is consistent with Round 20 (+0.0047 val_loss) — the padded noise fix is essentially neutral regardless of the dist_feat fix. The coarse pooling loss likely uses mask or surf_mask already to avoid padding contamination, so padding noise doesn't leak in the way hypothesized.

The vol_Ux and vol_Uy metrics show improvement vs baseline (0.94 vs baseline, suggesting the dist_feat fix is already in the baseline), but vol_p is roughly the same.

### Suggested follow-ups

- The target noise masking fix appears genuinely neutral — not worth keeping
- Focus on other signal-improving changes for this round
