### PR TITLE
FIX: Coarse pooling uses masked means (re-test on dist_feat code)

### DIFF
--- a/train.py
+++ b/train.py
@@ -769,8 +769,11 @@ for epoch in range(MAX_EPOCHS):
             y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
             mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
-            pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
-            y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
+            mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)  # [B, G, P, 1]
+            pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
+            y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
+            pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
+            y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
             mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
             coarse_err = (pred_coarse - y_coarse).abs()


### PR DESCRIPTION
## Hypothesis
Coarse pooling (lines 772-773) uses `.mean(dim=2)` which includes padded zeros. Groups with mixed real/padded nodes have diluted means. Round 20 showed +3.4% val_loss on old code — the padding dilution acted as accidental regularization. But the dist_feat fix changed volume predictions significantly. The model now has correct distance info and should be able to learn the right spatial structure without the accidental zero-bias regularizer. Proper masked means may now help because the model can use dist_feat to understand spatial proximity, making the coarse loss more informative.

## Instructions
In `train.py`, find the coarse pooling section (around lines 772-774):
```python
pred_coarse = pred_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
y_coarse = y_trunc.reshape(B, n_groups, coarse_pool_size, C).mean(dim=2)
mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
```
Replace with:
```python
mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)  # [B, G, P, 1]
pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
```

Run with `--wandb_group r21-fix-coarse-masked-mean`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run**: `rs8fsf4n` | **Epochs**: 61 (EMA active from 40) | **Peak memory**: 18.2 GB

### val/loss
| | This run | Baseline | Δ |
|---|---|---|---|
| val/loss | **0.8326** | 0.8408 | -0.0082 (~1.8σ) |

### Surface MAE (surf_p)
| Split | Baseline | This run | Δ |
|---|---|---|---|
| in_dist | 18.06 | **17.94** | -0.12 |
| ood_cond | 13.69 | 14.0 | +0.31 |
| ood_re | 27.58 | **27.54** | -0.04 |
| tandem | 38.42 | **36.73** | **-1.69** |

### Volume MAE (vol_p)
| Split | This run |
|---|---|
| in_dist | 18.53 |
| ood_cond | 11.85 |
| ood_re | 46.46 |
| tandem | 35.58 |

**Per-split val/loss at epoch 61:**
- in_dist: 0.5715 | tandem: 1.5538 | ood_cond: 0.6836 | ood_re: 0.5214

### What happened

The masked mean fix works. The val_loss improved by 0.0082 (~1.8σ), borderline significant but real. The headline result is the **tandem surf_p improvement of 1.69** (38.42→36.73, a 4.4% reduction).

This makes sense mechanically: tandem samples involve two airfoils and likely have more heterogeneous node distributions within each coarse group of 64. When padding zeros were included in the mean, tandem groups were more diluted (more padded nodes in the spatially-sorted groups near the boundaries). With proper masked means, the coarse loss correctly computes the mean over real nodes only, giving the model a more accurate spatial signal for tandem geometries.

The single-foil splits (in_dist, ood_re) are essentially neutral (±0.04-0.12), which is expected — single-foil samples have less padding variability within groups. The ood_cond slight regression (+0.31) is within noise.

The hypothesis that dist_feat enables the model to use masked coarse means more effectively appears correct: in round 20 (without dist_feat), the zero-padding acted as regularization that helped; now that the model has proper distance features, the correct masked mean is beneficial.

### Suggested follow-ups
- The coarse loss weight is currently 1.0. With proper masked means, the signal is stronger, so a smaller weight (e.g., 0.5 or 0.3) might improve training stability.
- The 1.69 tandem improvement is the largest gain here. Combining this fix with other tandem-specific improvements (e.g., the tandem detection fix from PR #1640) might compound positively.