### PR TITLE
LR recalibration: lr=2.8e-3 (explore higher on new landscape)

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 2.8e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The dist_feat fix may have made the loss landscape smoother (correct distance signal provides better gradient direction), allowing a higher LR. We have tested lr=2.5e-3 and lr=2.6e-3 on this codebase but never gone above 2.6e-3. If the corrected dist_feat smooths the landscape, lr=2.8e-3 could allow faster convergence within the 30-min window — more effective epochs at a higher peak LR.

## Instructions
In `train.py`, change the learning rate in the Config dataclass (line ~415):
```python
# OLD:
lr: float = 2.6e-3
# NEW:
lr: float = 2.8e-3
```
This is a 1-line change.

Run with `--wandb_group r21-lr-recalibrate`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run ID:** 74eydfa3  
**Best epoch:** 61 (wall-clock timeout at ~30.0 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8519** | 0.8408 |
| val_in_dist | 0.5711 | — |
| val_tandem_transfer | 1.6375 | — |
| val_ood_cond | 0.6769 | — |
| val_ood_re | 0.5221 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 5.89 | 1.75 | **17.61** | 18.06 | **-2.5%** |
| val_tandem_transfer | 5.75 | 2.16 | 39.38 | 38.42 | +2.5% |
| val_ood_cond | 3.63 | 1.06 | 13.66 | 13.69 | -0.2% |
| val_ood_re | 3.27 | 0.90 | 27.58 | 27.58 | 0.0% |

**mean3 surf_p** = (17.61 + 13.66 + 39.38) / 3 = **23.55** (baseline: 23.39, delta: +0.7%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 0.94 | 0.33 | 18.45 |
| val_tandem_transfer | 1.72 | 0.81 | 37.54 |
| val_ood_cond | 0.61 | 0.25 | 11.68 |
| val_ood_re | 0.75 | 0.35 | 46.54 |

---

### What happened

**Borderline negative result with one notable improvement.** val/loss = 0.8519 vs baseline 0.8408 (+1.3% worse). mean3 surf_p = 23.55 vs 23.39 (+0.7% worse). However, val_in_dist surface pressure improved significantly (-2.5%, 17.61 vs 18.06), and ood_cond/ood_re are essentially flat (-0.2%, 0.0%).

The degradation is localized to val_tandem_transfer (+2.5%), which is a persistent weak spot across experiments. The val/loss is a weighted average, so the tandem regression dominates the combined metric even though 3 out of 4 splits improved or held flat.

The higher LR (2.8e-3 vs 2.6e-3) appears to help in-distribution learning but slightly destabilizes tandem generalization. This is consistent with higher LR giving faster convergence on the main distribution but less carefully interpolating OOD samples.

*Visualization crash* (same as previous PRs): `mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x58)` in `feature_cross`. Training metrics are unaffected.

---

### Suggested follow-ups

- **lr=2.7e-3**: Split the difference — 2.7e-3 may capture the in-dist benefit from 2.8e-3 without the tandem regression.
- **lr=2.8e-3 + higher tandem weight**: Combine the higher LR with increased tandem sampling weight to compensate for the tandem regression.
- **lr=3.0e-3**: Continue exploring if higher LR consistently helps in-dist — it may be that the landscape is flatter than previously assumed.
