### PR TITLE
Cosine T_max=55 (shorter annealing, faster cooldown)

### DIFF
--- a/train.py
+++ b/train.py
@@ -578,7 +578,7 @@ base_opt = torch.optim.AdamW([
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
 warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=55, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
     base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
 )


### PR DESCRIPTION
## Hypothesis
The cosine scheduler uses T_max=62 (line ~581). With warmup of 10 epochs and ~61 total epochs in 30 min, the cosine phase runs for ~51 epochs but T_max=62 means the LR never actually reaches eta_min — it stops at about cos(51/62 * pi) ~ 85% of the way through the cosine. Setting T_max=55 means the cosine completes in 55 post-warmup epochs, reaching eta_min around epoch 65 — closer to actual training end. This gives the model a deeper cooldown phase in the final epochs, which may help convergence with the new dist_feat landscape.

## Instructions
Change cosine scheduler T_max from 62 to 55 (line ~581). Run with `--wandb_group r21-schedule-recalibrate`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** gyodo82c  
**Best epoch:** 58

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5857 | 6.13 | 1.65 | **17.86** | 19.07 |
| ood_cond | 0.6768 | 3.38 | 1.09 | **13.61** | 11.65 |
| ood_re | 0.5348 | 3.09 | 0.95 | **27.81** | 46.76 |
| tandem | 1.6261 | 5.40 | 2.11 | **39.00** | 37.68 |
| **combined val/loss** | **0.8559** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8408 | 0.8559 | +1.8% worse |
| in_dist surf_p | 18.06 | 17.86 | **-1.1%** (marginal gain) |
| ood_cond surf_p | 13.69 | 13.61 | **-0.6%** (marginal gain) |
| ood_re surf_p | 27.58 | 27.81 | +0.8% |
| tandem surf_p | 38.42 | 39.00 | +1.5% |

**Peak memory:** no OOM.

### What happened

**Mixed / neutral.** In_dist and ood_cond surface pressure improved slightly (-1.1%, -0.6%), but the combined val/loss is higher (+1.8%) due to tandem regression (+1.5%) and ood_re (+0.8%). All deltas are within the seed noise floor.

With T_max=55, at epoch 58 (48 post-warmup steps), the LR is at cos(48/55 × π) ≈ 1% of the LR range — essentially at eta_min. The faster cooldown gives a deeper low-LR phase in late epochs, which marginally helps in-dist and ood_cond but slightly hurts tandem. This may indicate tandem benefits from continued high-LR updates to explore the loss landscape, while single-foil splits benefit from fine-tuning.

### Suggested follow-ups

- **T_max=50:** Even shorter cosine could push the effect further; test if in_dist keeps improving.
- **T_max=45 + eta_min=1e-4:** Combined lower T_max and higher floor — model converges faster and stays at a non-negligible LR.
- **Per-split analysis:** The divergent tandem vs single-foil trend suggests the tandem geometry needs more exploration time in late epochs.