### PR TITLE
Extended warmup: 15 epochs (re-test accidental frozen warmup)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=15)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
 )
 
 # --- wandb ---
@@ -1070,6 +1070,14 @@ if best_metrics:
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                raw_xy_vis = x_n[:, :, :2]
+                xy_min_vis = raw_xy_vis.amin(dim=1, keepdim=True)
+                xy_max_vis = raw_xy_vis.amax(dim=1, keepdim=True)
+                xy_norm_vis = (raw_xy_vis - xy_min_vis) / (xy_max_vis - xy_min_vis + 1e-8)
+                freqs_vis = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled_vis = xy_norm_vis.unsqueeze(-1) * freqs_vis
+                fourier_pe_vis = torch.cat([xy_scaled_vis.sin().flatten(-2), xy_scaled_vis.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_vis], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
The tandem curriculum bug (PR #1639) revealed that a 10-epoch "frozen warmup" (zero gradient for all samples) was accidentally beneficial (+0.0207 val_loss when removed). Rather than relying on the bug, we can get a similar effect by extending the LR warmup from 10 to 15 epochs with a lower start factor. This gives the model more time at low LR to stabilize the dist_feat feature representation before full-strength training. The dist_feat fix changed the model's input, and a gentler warmup may help the preprocessing MLP adapt to the new scale.

## Instructions
In `train.py`, change the warmup scheduler (line ~580):
```python
# OLD:
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
# NEW:
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=15)
```
Also update the milestone for SequentialLR (line ~583):
```python
# OLD:
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
)
# NEW:
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
)
```
Two changes: start_factor 0.2->0.1, total_iters 10->15, milestones [10]->[15].

Run with `--wandb_group r21-schedule-recalibrate`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** u2aoizu0

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5749 | 5.148 | 1.545 | 17.44 | 0.941 | 0.318 | 17.89 |
| val_tandem_transfer | 1.5663 | — | — | 37.3 | — | — | — |
| val_ood_cond | 0.6924 | — | — | 14.3 | — | — | — |
| val_ood_re | 0.5101 | — | — | 27.3 | — | — | — |
| **combined val/loss** | **0.8359** | | | | | | |

Baseline: val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42
Delta: **-0.005** vs baseline

Peak memory: 18.0 GB

**What happened:**
Small positive result. Extended warmup (15 epochs, start_factor=0.1) beats the 10-epoch baseline by ~0.005 val/loss. In-dist surf_p improved by 0.6 Pa (17.44 vs 18.06), tandem improved by 1.1 Pa (37.3 vs 38.42). OOD cond surf_p is marginally worse (+0.6 Pa). The improvement is modest but in the right direction — a gentler ramp from 10% LR over 15 epochs lets the model settle in the dist_feat representation space before full-strength gradients kick in.

Note: the vis pipeline was missing Fourier PE (model expects 58-dim, vis produced 26-dim) which would have crashed during visualization. Applied the same fix as PR #1652 here to enable the run to complete.

**Suggested follow-ups:**
- Try warmup-20 with start_factor=0.05 to push the gentle ramp further.
- Combine with LR recalibration (higher peak LR to compensate for delayed warmup).