### PR TITLE
Dist-feat gated surface attention boost (exploit correct distance)

### DIFF
--- a/train.py
+++ b/train.py
@@ -316,6 +316,8 @@ class Transolver(nn.Module):
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.dist_gate = nn.Sequential(nn.Linear(1, 32), nn.GELU(), nn.Linear(32, 1), nn.Sigmoid())
+        nn.init.constant_(self.dist_gate[-2].bias, 0.0)  # starts at sigmoid(0) = 0.5
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
 
@@ -394,6 +396,10 @@ class Transolver(nn.Module):
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
         fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        # Extract dist_feat from input: it's at index 25 (after 24 raw + 1 curv)
+        dist_input = data["x"][:, :, 25:26]  # dist_feat = log1p(dist_surf * 10)
+        dist_scale = 1.0 + 0.5 * self.dist_gate(dist_input)  # range [1.0, 1.5] — boost near surface
+        fx = fx * dist_scale
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
Now that dist_feat is correctly computed from raw dsdf, it provides a reliable continuous distance-to-surface signal. We can use this to give the model an explicit surface-proximity gate: multiply the hidden representation by a learned function of dist_feat before the final output layer. Nodes near the surface (low dist_feat) get boosted, helping the model allocate more capacity to surface accuracy — the most important metric. This is a lightweight 2-layer MLP that reads dist_feat and outputs a per-node scaling factor.

## Instructions
In the `Transolver.__init__` method (after the `self.aoa_head` definition, around line 318), add:
```python
self.dist_gate = nn.Sequential(nn.Linear(1, 32), nn.GELU(), nn.Linear(32, 1), nn.Sigmoid())
nn.init.constant_(self.dist_gate[-2].bias, 0.0)  # starts at sigmoid(0) = 0.5
```

In the `Transolver.forward` method, after `fx = self.blocks[-1](...)` (line ~396) and before `gate = self.skip_gate(fx_pre)` (line ~397), add:
```python
# Extract dist_feat from input: it's at index 25 (after 24 raw + 1 curv)
dist_input = data["x"][:, :, 25:26]  # dist_feat = log1p(dist_surf * 10)
dist_scale = 1.0 + 0.5 * self.dist_gate(dist_input)  # range [1.0, 1.5] — boost near surface
fx = fx * dist_scale
```

This adds ~65 parameters. The gate learns to upweight surface-proximal representations.

Run with `--wandb_group r21-dist-feat-novel`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** k86f7d4i (`senku/dist-feat-gated-surface-boost`, group: `r21-dist-feat-novel`)
**Epochs completed:** 59 (30-min timeout; loss still improving at end)
**Peak memory:** N/A (not logged)

### Metrics (best = final epoch)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 5.48 | 2.02 | **17.86** | 0.95 | 0.32 | 18.71 |
| val_ood_cond | 3.41 | 1.29 | **14.29** | 0.62 | 0.25 | 11.64 |
| val_ood_re | 2.96 | 1.10 | **28.07** | 0.75 | 0.35 | 46.86 |
| val_tandem | 5.67 | 2.40 | **37.52** | 1.69 | 0.78 | 36.46 |

**val/loss:** 0.8494 (baseline: 0.8408, **+0.0086 — slightly worse**)

### Comparison vs baseline (surf_p)

| Split | Baseline | Result | Delta |
|---|---|---|---|
| in_dist | 18.06 | 17.86 | -0.20 (improved) |
| ood_cond | 13.69 | 14.29 | +0.60 (worse) |
| ood_re | 27.58 | 28.07 | +0.49 (worse) |
| tandem | 38.42 | 37.52 | -0.90 (improved) |
| mean3 (in+ood+re) | 19.78 | 20.07 | +0.29 (worse) |

### What happened

Slightly negative overall. The dist_gate hypothesis — that a learned gate on dist_feat would boost surface accuracy — did not deliver a clear improvement. val/loss degraded by +0.0086. Two splits (in_dist, tandem) showed small surface_p improvements, but ood_cond and ood_re got worse, and the mean3 surface_p rose from 19.78 to 20.07.

The gate initialized at sigmoid(0)=0.5, producing a dist_scale in [1.0, 1.5]. It's possible the gate is adding noise rather than signal: scaling up near-surface hidden states may amplify already-large errors rather than helping the model learn better representations. It may also interfere with the existing skip_gate mechanism that already conditions outputs on fx_pre.

Note: val/loss was still declining at epoch 59 (the best and final epoch), so training was cut by the timeout. The gap vs baseline is unlikely to flip positive given its sign and magnitude.

### Suggested follow-ups

- Apply dist_gate earlier (e.g., to the input features before the transformer blocks) to bias attention allocation rather than scaling post-block representations.
- Try additive conditioning instead of multiplicative: a residual bias term conditioned on dist_feat.
- Verify empirically whether attention weights already correlate with dist_feat — if so, the model is learning this implicitly and the explicit gate is redundant.