### PR TITLE
Dist-feat in spatial bias (5D input: x,y,curv,dist,is_surf)

### DIFF
--- a/train.py
+++ b/train.py
@@ -211,7 +211,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = nn.LayerNorm(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(4, 64), nn.GELU(),
+            nn.Linear(5, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -377,7 +377,7 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], x[:, :, 12:13]], dim=-1)  # x, y, curvature, dist, is_surf
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]


### PR DESCRIPTION
## Hypothesis
The spatial bias MLP in TransolverBlock currently reads a 4D input: raw_xy = [x, y, curvature, dist] (line ~380). Now that dist_feat is correctly computed, the spatial bias can also use the is_surface flag to create surface-specific attention routing. Adding is_surface as a 5th dimension to raw_xy lets the spatial bias MLP learn different slice routing patterns for surface vs volume nodes.

## Instructions
In train.py, find where raw_xy is constructed (line ~380) and add is_surface as 5th dim. Also update spatial_bias input dimension from 4 to 5. Run with --wandb_group r21-dist-feat-novel.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run**: dsv17c0t | **Epochs**: 60 | **Peak VRAM**: 17.6 GB

| Split | val/loss | mae_surf_Ux | mae_surf_Uy | mae_surf_p | mae_vol_Ux | mae_vol_Uy | mae_vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5869 | 4.61 | 1.35 | **18.15** | 0.95 | 0.33 | 19.11 |
| ood_cond | 0.6973 | 2.59 | 0.91 | **14.08** | 0.63 | 0.26 | 11.78 |
| ood_re | 0.5353 | 2.11 | 0.78 | **27.82** | 0.75 | 0.35 | 46.71 |
| tandem | 1.6226 | 5.15 | 1.81 | **39.51** | 1.71 | 0.81 | 38.05 |
| **combined** | **0.8605** | | | | | | |

**vs baseline (0.8408)**:

| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|---|---|---|---|
| in_dist | 18.06 | 18.15 | +0.09 (slightly worse) |
| ood_cond | 13.69 | 14.08 | **+0.39** (worse) |
| ood_re | 27.58 | 27.82 | +0.24 (worse) |
| tandem | 38.42 | 39.51 | **+1.09** (worse) |
| val/loss | 0.8408 | 0.8605 | **+0.020** (worse) |

### What happened

Adding is_surface as a 5th spatial bias input caused a regression (+0.020 val/loss). The spatial bias MLP learns slice routing patterns, and is_surface may be confusing it: it is a binary flag near-zero after standardization, while the other 4 inputs (x, y, curvature, dist) are continuous. The binary discontinuity may disrupt the smooth spatial attention patterns learned by the MLP.

The curvature+dist features already implicitly encode surface proximity: surface nodes have high curvature and dist≈0. Adding is_surface explicitly introduces redundant binary information in a different modality that appears to destabilize training.

The pre-existing visualization error (mat1/mat2 shape mismatch) appeared after training, not affecting metrics.

### Suggested follow-ups

- Try is_surface as a multiplicative gate on the spatial bias OUTPUT rather than an input: bias_out = bias * (1 + is_surface_scalar), which could be more stable
- The curvature+dist features may already be sufficient for surface/volume differentiation in spatial routing
- Consider a separate lightweight surface-attention boost that bypasses the slice mechanism rather than modifying spatial bias inputs