### PR TITLE
Surface-proximity volume loss weighting (exploit correct dist_feat)

### DIFF
--- a/train.py
+++ b/train.py
@@ -730,7 +730,12 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        # Upweight volume nodes near surface using dist_feat (boundary layer emphasis)
+        # dist_feat = log1p(dist_surf * 10), near-surface nodes have small values
+        # weight = 1 + 2 * exp(-dist_feat): near surface (~0) -> 3.0, far away (~3) -> 1.1
+        vol_proximity_weight = (1.0 + 2.0 * torch.exp(-dist_feat)).squeeze(-1)  # [B, N]
+        vol_w = vol_proximity_weight * vol_mask_train.float()
+        vol_loss = (abs_err * vol_w.unsqueeze(-1)).sum() / vol_w.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss


### PR DESCRIPTION
## Hypothesis
The dist_feat fix gives us a reliable continuous distance-to-surface. Volume nodes near the airfoil surface contain the boundary layer — the region where flow gradients are steepest and most informative for surface pressure prediction. Currently all volume nodes are weighted equally in the loss. By upweighting volume nodes within the boundary layer (small dist_feat), we focus the model on the physics that matters most for surface accuracy. This is a loss-only change with zero model parameter overhead.

## Instructions
In `train.py`, after the volume/surface mask computation (around line 716-717):
```python
vol_mask = mask & ~is_surface
surf_mask = mask & is_surface
```
Add a proximity-based weighting for the volume loss. Find the vol_loss computation (around line 733):
```python
# OLD:
vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
```
Replace with:
```python
# NEW: upweight volume nodes near surface using dist_feat
# dist_feat = log1p(dist_surf * 10), so near-surface nodes have small values
# Use exponential decay: weight = 1 + 2 * exp(-dist_feat)
# Near surface (dist_feat~0): weight~3.0. Far away (dist_feat~3): weight~1.1
vol_proximity_weight = (1.0 + 2.0 * torch.exp(-dist_feat)).squeeze(-1)  # [B, N]
vol_w = vol_proximity_weight * vol_mask_train.float()
vol_loss = (abs_err * vol_w.unsqueeze(-1)).sum() / vol_w.sum().clamp(min=1)
```

Note: `dist_feat` is already computed earlier in the loop (around line 656). Make sure it's still in scope at the vol_loss computation point.

Run with `--wandb_group r21-dist-feat-novel`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** mtw1l1j0  
**Best epoch:** 61

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8408 | **0.8386** | **-0.0022** |
| in_dist surf_p | 18.06 | 18.44 | +0.38 |
| ood_cond surf_p | 13.69 | 13.31 | -0.38 |
| ood_re surf_p | 27.58 | 27.60 | +0.02 |
| tandem surf_p | 38.42 | 38.37 | -0.05 |

**Full surface MAE (Ux / Uy / p):**
- in_dist: 4.37 / 1.21 / 18.44
- ood_cond: 2.35 / 0.74 / 13.31
- ood_re: 1.88 / 0.62 / 27.60
- tandem: 4.71 / 1.67 / 38.37

**Volume MAE (Ux / Uy / p):**
- in_dist: 0.94 / 0.32 / 19.26
- ood_cond: 0.60 / 0.25 / 11.48
- ood_re: 0.72 / 0.34 / 46.42
- tandem: 1.69 / 0.79 / 37.19

**Peak memory:** not explicitly logged; no OOM observed.

### What happened

The hypothesis worked. val/loss improved to 0.8386 (new best, Δ=-0.0022 vs 0.8408 baseline). The proximity weighting is zero-overhead at inference and adds minimal compute at training time.

The overall improvement is driven mainly by ood_cond (surf_p -0.38) and tandem (surf_p -0.05), with in_dist surf_p slightly regressing (+0.38). The pattern makes sense: ood_cond and tandem cases likely have more complex boundary layers near the foil surface, so emphasizing those nodes in the volume loss gives the model better spatial gradients in the regions that matter most for surface pressure prediction.

The weighting function (1 + 2·exp(-dist_feat)) is smooth and well-behaved: nodes with dist_feat≈0 (right at the surface boundary) get 3× weight, while far-field nodes asymptotically approach 1× weight. Because dist_feat = log1p(dist_surf * 10), the transition from 3× to ~1× happens over roughly the first chord length — a physically reasonable boundary layer thickness.

One subtlety: the progressive volume subsampling (epoch < 40) applies before the weighting, so early training randomly drops volume nodes, then applies proximity weights to the kept nodes. This seems fine — the weighting still biases the *selected* nodes toward the surface.

### Suggested follow-ups

1. **Tune the weight multiplier**: The 2.0 factor in `1 + 2·exp(-dist_feat)` was the PR's suggestion. Testing 1.0 or 3.0 could reveal whether higher boundary-layer emphasis helps further.
2. **Apply proximity weighting in validation loss too**: Currently only in training. Though val loss is used for model selection, the weighted training already achieves the improvement.
3. **Combine with surface-weight annealing**: The adaptive surf_weight already focuses on surface pressure; a tuned dist_feat proximity weight in combination might further exploit the boundary layer structure.
