### PR TITLE
Dist_feat scale 20 (finer near-surface resolution, exploit fix)

### DIFF
--- a/train.py
+++ b/train.py
@@ -653,7 +653,7 @@ for epoch in range(MAX_EPOCHS):
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
-        dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+        dist_feat = torch.log1p(dist_surf * 20.0)  # log-scale for better gradient flow
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -884,7 +884,7 @@ for epoch in range(MAX_EPOCHS):
 
                 raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
+                dist_feat = torch.log1p(dist_surf * 20.0)  # log-scale for better gradient flow
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1068,7 +1068,7 @@ if best_metrics:
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)
+                dist_feat = torch.log1p(dist_surf * 20.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()


### PR DESCRIPTION
## Hypothesis
The dist_feat formula is `log1p(dist_surf * 10.0)` (line ~656). The scale factor of 10 was chosen before the dist_feat fix. Now that dist_feat uses raw (unstandardized) dsdf values, the magnitude of dist_surf has changed. Increasing the scale to 20 doubles the near-surface resolution: nodes very close to the surface will have more distinct dist_feat values, giving the model finer-grained distance information in the boundary layer. This is a direct exploit of the fix — the raw dsdf values are smaller than the standardized ones, so a larger scale factor compensates and provides better separation.

## Instructions
In `train.py`, change the dist_feat scale in BOTH the training loop (line ~656) and validation loop (line ~887):
```python
# OLD (both locations):
dist_feat = torch.log1p(dist_surf * 10.0)
# NEW (both locations):
dist_feat = torch.log1p(dist_surf * 20.0)
```
This is a 1-line change applied in 2 locations (train and val loops). Also fix the visualization section if it exists (~line 1071) — check for `dist_feat = torch.log1p(dist_surf * 10.0)` there too.

Note: PR #1586 tried `dist_feat scale 5.0` on the OLD (broken) dist_feat code and was closed. That was going in the wrong direction AND on the wrong code. This tests the opposite direction on the correct code.

Run with `--wandb_group r21-dist-feat-novel`.

## Baseline
val_loss=0.8408 | in_dist=18.06 | ood_cond=13.69 | ood_re=27.58 | tandem=38.42

---

## Results

**W&B run:** v4k8ixsz  
**Epochs completed:** 59 (timeout at epoch 60)

### Implementation

Changed `dist_feat = torch.log1p(dist_surf * 10.0)` to `* 20.0` in all 3 locations (train loop line 656, val loop line 887, vis section line 1071).

### Metrics vs Baseline

| Metric | Baseline | Scale 20 | Delta |
|--------|----------|----------|-------|
| val_loss | 0.8408 | **0.8577** | +2.0% worse |
| in_dist surf MAE | 18.06 | 26.38 | +46% worse |
| ood_cond surf MAE | 13.69 | 19.09 | +39% worse |
| ood_re surf MAE | 27.58 | 32.13 | +17% worse |
| tandem surf MAE | 38.42 | 47.45 | +23% worse |

Surface MAE by channel (best epoch):
- in_dist: Ux=6.15, Uy=1.91, p=18.33
- ood_cond: Ux=3.93, Uy=1.02, p=14.14
- ood_re: Ux=3.60, Uy=0.85, p=27.68
- tandem: Ux=5.91, Uy=2.35, p=39.19

### What happened

Doubling the dist_feat scale from 10 to 20 hurts performance. Val_loss=0.8577 at 59 epochs vs baseline 0.8408. The val_loss was still trending down (0.8780→0.8753→0.8693→0.8630→0.8577, ~0.005/epoch) but would need ~34 more epochs to reach baseline — not achievable in this budget.

The higher scale compresses the distance representation: `log1p(x*20)` maps the same range of raw distances to a narrower range of output values (it saturates faster). For nodes that are far from the surface, the feature value is essentially the same regardless of actual distance — which might actually hurt generalization rather than help it.

Additionally, a larger scale factor makes the gradient of the dist_feat with respect to distance much larger for near-surface nodes (d/dx log1p(20x) = 20/(1+20x), vs 10/(1+10x) for scale 10). This may amplify noise in the boundary layer during training.

The in_dist Ux continues to be high (6.15 vs expected ~2-3), a pattern seen across many runs that don't converge well. The dist_feat scale appears to be well-tuned at 10 for this architecture.

### Suggested follow-ups

- The current scale 10 may be well-calibrated already — if the raw dsdf values are indeed small, log1p(x*10) and log1p(x*20) might both saturate before meaningful differences emerge
- Try scale 15 (less aggressive doubling) or scale 7 (going slightly lower) to understand the sensitivity
- Instead of a fixed scale, try a learnable scale parameter (similar to fourier_freqs_learned)