### PR TITLE
LR recalibration: lr=2.5e-3 on post-dist_feat code

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 2.5e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
LR recalibration after feature changes has been a consistent winner (merges 5, 8). The dist_feat fix changed the optimization landscape. lr=2.5e-3 was optimal before dist_feat; it may be optimal again after the fix.
## Instructions
Change `lr = 2.6e-3` to `lr = 2.5e-3`. One-line change. Run with `--wandb_group lr-25e3-post-distfix`.
## Baseline
val_loss=0.8408 | in=18.06 | ood_c=13.69 | ood_r=27.58 | tan=38.42

---

## Results

**W&B run:** 276x2g0n  (runtime: 31.9 min, state: failed due to pre-existing vis crash)

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5890 | 5.81 | 1.80 | 18.47 | 0.98 | 0.33 | 19.14 |
| val_ood_cond | 0.7034 | 3.55 | 1.04 | 14.45 | 0.65 | 0.26 | 11.91 |
| val_ood_re | 0.5360 | 3.28 | 0.89 | 27.89 | 0.75 | 0.35 | 46.67 |
| val_tandem_transfer | 1.6079 | 5.56 | 2.06 | 38.32 | 1.70 | 0.80 | 37.10 |
| **val_loss (best)** | **0.8590** | | | | | | |

**mean3_p** = (18.47+14.45+38.32)/3 = **23.75**

**vs baseline:** val_loss +0.0182 (+2.2%), mean3_p +0.36 (+1.5%) — **worse**

### What happened

lr=2.5e-3 is not better than lr=2.6e-3 on this post-distfix codebase. The hypothesis that LR recalibration would help after the dist_feat scale fix doesn't hold — 2.6e-3 remains the better learning rate.

The current baseline at lr=2.6e-3 has val_loss=0.8408, while lr=2.5e-3 gives 0.8590 — consistently worse across splits except for tandem (38.32 vs 38.42 — slight improvement) and vol metrics (vol_Ux=0.98 vs 0.98, noticeably better). The in_dist and ood_cond pressure metrics are worse, which dominates the mean3_p comparison.

The dist_feat scale change shifted the optimal LR toward higher values (2.6e-3 is currently best), opposite to the pre-distfix regime where 2.5e-3 was optimal. This suggests the new feature scale leads to more aggressive gradient updates that benefit from the slightly higher LR.

### Suggested follow-ups

- Try lr=2.7e-3 or 2.8e-3 to check if even higher LR is beneficial in this new regime
- Or: lr sweep with fewer, denser points around 2.6e-3 (2.55, 2.60, 2.65)