### PR TITLE
Retest: Warmup 15 epochs on post-coarse-fix code

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Warmup 15 epochs was our closest near-winner in round 21 (val_loss=0.8359 vs baseline 0.8408). That result was achieved on pre-coarse-fix code where masked pooling was wrong. With the coarse pooling now fixed (masked means), the loss landscape has changed. A longer warmup (15 epochs vs current 10) gives the optimizer more time to find a good basin before the cosine decay kicks in. The coarse fix changed gradient magnitudes, so the model may benefit even more from a gentler ramp.

## Instructions
In `train.py`, change the warmup schedule from 10 epochs to 15 epochs:

1. **Line 580** — Change `total_iters=10` to `total_iters=15`:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
```

2. **Line 583** — Change the milestone from `[10]` to `[15]`:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
)
```

No other changes. Run with `--wandb_group noam-r22-warmup15`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

Previous result on pre-fix code: val_loss = 0.8359 (very close to old baseline of 0.8408).

---

## Results

**W&B run:** `gpk3hsmc`
**Epochs:** 61 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5863 | 6.10 | 2.00 | 17.92 | 0.95 | 0.32 | 18.32 |
| ood_cond | 0.6619 | 2.49 | 1.07 | 13.41 | 0.62 | 0.25 | 11.39 |
| ood_re | 0.5220 | 2.26 | 0.91 | 27.60 | 0.74 | 0.34 | 46.57 |
| tandem | 1.5906 | 6.60 | 2.46 | 38.24 | 1.68 | 0.79 | 37.20 |
| **combined** | **0.8402** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (17.92 + 13.41 + 38.24) / 3 = **23.19**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8326 | 0.8402 | +0.9% |
| surf_p in_dist | 17.94 | 17.92 | flat |
| surf_p ood_cond | 13.98 | 13.41 | **-4.1%** |
| surf_p ood_re | 27.54 | 27.60 | flat |
| surf_p tandem | 36.73 | 38.24 | **+4.1%** |
| surf_p mean3 | 22.88 | 23.19 | +1.4% |

### What happened

Mixed result. ood_cond improved significantly (-4.1%) but tandem regressed by the same amount (+4.1%), resulting in a net neutral mean3. Val/loss is worse (+0.9%).

The previous warmup-15 result on old code (val_loss=0.8359 vs old baseline 0.8408, delta -0.0049) was a small improvement. On the new baseline, the result reverses — this suggests the coarse pooling fix changed the loss landscape in a way that affects how warmup interacts with tandem generalization.

With 15 warmup epochs (vs 10), the cosine schedule starts 5 epochs later. This delays reaching peak LR and may reduce the effective training signal for tandem samples in early epochs, which are underrepresented in each batch.

### Suggested follow-ups

- The ood_cond improvement (-4.1%) is notable — warmup-15 may be helping non-tandem generalization
- Test warmup-12 as a midpoint between 10 and 15
- The tandem regression may be related to early-epoch tandem curriculum (epoch < 10 tandem exclusion) — with 15-epoch warmup, the tandem reintroduction at epoch 10 coincides with still-warming-up LR
