### PR TITLE
FIX: Fourier PE xy_min/max excludes padding positions

### DIFF
--- a/train.py
+++ b/train.py
@@ -661,8 +661,11 @@ for epoch in range(MAX_EPOCHS):
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
+        xy_for_range = raw_xy.clone()
+        xy_for_range[~mask] = float('inf')
+        xy_min = xy_for_range.amin(dim=1, keepdim=True)
+        xy_for_range[~mask] = float('-inf')
+        xy_max = xy_for_range.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
@@ -895,8 +898,11 @@ for epoch in range(MAX_EPOCHS):
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_for_range = raw_xy.clone()
+                xy_for_range[~mask] = float('inf')
+                xy_min = xy_for_range.amin(dim=1, keepdim=True)
+                xy_for_range[~mask] = float('-inf')
+                xy_max = xy_for_range.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]


### PR DESCRIPTION
## Hypothesis
The Fourier positional encoding computes per-sample min/max of (x,y) to normalize coordinates to [0,1]. But `raw_xy = x[:, :, :2]` includes ALL nodes — including padded positions which have coordinates (0,0). This contaminates the normalization range: `xy_min` is pulled toward 0 and `xy_max` may be unaffected if the domain already includes 0, but the range is artificially widened. With the dist_feat and coarse pooling now correct, this is the next pipeline bug that leaks padding artifacts into the model. This was a near-winner in round 21 (val_loss=0.8394) — needs retesting on post-coarse-fix code.

## Instructions
In `train.py`, mask out padded positions before computing `xy_min` and `xy_max`. Apply this fix in BOTH the training loop and validation loop.

**Training loop (around lines 663-666):**
Replace:
```python
xy_min = raw_xy.amin(dim=1, keepdim=True)
xy_max = raw_xy.amax(dim=1, keepdim=True)
```
With:
```python
xy_for_range = raw_xy.clone()
xy_for_range[~mask] = float('inf')
xy_min = xy_for_range.amin(dim=1, keepdim=True)
xy_for_range[~mask] = float('-inf')
xy_max = xy_for_range.amax(dim=1, keepdim=True)
```

**Validation loop (around lines 898-900):**
Apply the same fix:
```python
xy_for_range = raw_xy.clone()
xy_for_range[~mask] = float('inf')
xy_min = xy_for_range.amin(dim=1, keepdim=True)
xy_for_range[~mask] = float('-inf')
xy_max = xy_for_range.amax(dim=1, keepdim=True)
```

Run with `--wandb_group noam-r22-fourier-pe-fix`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

Previous result on pre-fix code: val_loss = 0.8394.

---

## Results

**W&B run ID:** `fmq2pjug`
**val/loss: 0.8380** (baseline: 0.8326, **+0.0054** — slightly worse)

### Surface MAE

| Split | Ux | Uy | p | Δp vs baseline |
|---|---|---|---|---|
| in_dist | 6.70 | 1.96 | **17.93** | -0.01 ≈ |
| ood_cond | 3.64 | 1.23 | **13.69** | -0.29 ✓ |
| ood_regime | 3.11 | 1.08 | **27.58** | +0.04 ≈ |
| tandem | 6.00 | 2.19 | **37.63** | +0.90 ✗ |

**mean3** (in / ood_c / tan surf_p): **(17.93 + 13.69 + 37.63) / 3 = 23.08** vs baseline 22.88 — **worse by 0.20**

### Volume MAE (p)

| Split | vol_p |
|---|---|
| in_dist | 19.12 |
| ood_cond | 11.82 |
| ood_regime | 46.47 |
| tandem | 36.26 |

**Peak memory:** ~72 GB (75% of 96 GB)

### What happened

The fix helps ood_cond (-0.29 on surf_p) but hurts tandem (+0.90). Net val/loss is slightly worse (+0.0054) due to tandem dominating the combined loss.

The comparison to the round-21 run (val_loss=0.8394 on pre-coarse-fix) is informative: on the old code this fix showed a net benefit; on the current codebase (post-coarse-fix), the benefit is partially masked by the tandem regression. This suggests the coarse pooling fix interacts with the Fourier PE normalization — the coarse pooling now correctly handles spatial grouping, making the Fourier PE normalization range less critical for non-tandem splits, while the tandem case is more sensitive to it.

The tandem dataset has a different coordinate range (gap between foils) that doesn't match the single-foil domain. With the corrected PE normalization, the tandem spatial encoding may be pushed into a different frequency regime that doesn't generalize well from the single-foil training.

### Suggested follow-ups
- Test with a clamped approach rather than inf masking, to verify the +0.90 tandem regression isn't a numerical issue.
- Consider whether the Fourier PE should use global (dataset-level) normalization constants instead of per-sample, which would make tandem and non-tandem use consistent coordinate scales.
- The ood_cond improvement (-0.29) is real and suggests the fix is directionally correct for non-tandem cases.