### PR TITLE
Retest: Surface-proximity volume loss weighting on post-coarse-fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -730,7 +730,10 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_mask_train = vol_mask
 
-        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+        # Distance-based weighting: nodes closer to surface get higher weight
+        # dist_surf is [B, N, 1], already computed from raw dsdf
+        vol_dist_weight = 1.0 + 2.0 * torch.exp(-dist_surf * 5.0)  # peaks at 3.0 near surface, 1.0 far away
+        vol_loss = (abs_err * vol_mask_train.unsqueeze(-1) * vol_dist_weight).sum() / (vol_mask_train.unsqueeze(-1) * vol_dist_weight).sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss


### PR DESCRIPTION
## Hypothesis
Surface-proximity volume loss weighting was a near-winner in round 21 (val_loss=0.8386 vs baseline 0.8408). The idea: volume nodes near the airfoil surface matter more for surface prediction accuracy because they carry the boundary layer gradients. With dist_feat now computed correctly from raw dsdf (not standardized), the distance values are physically meaningful. And with coarse pooling now using masked means, the gradient landscape is cleaner. This combination should make distance-based weighting more effective than before.

## Instructions
In train.py, add distance-based weighting to vol_loss around line 733. dist_surf is already computed from raw dsdf. No changes to validation loop.

Run with --wandb_group noam-r22-surf-prox-vol.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

Previous result on pre-fix code: val_loss = 0.8386.

---

## Results

**W&B run**: upa5ppac | **Epochs**: 61 | **Peak VRAM**: 18.0 GB

| Split | val/loss | mae_surf_p | mae_vol_p |
|---|---|---|---|
| in_dist | 0.5945 | **18.81** | 19.77 |
| ood_cond | 0.6963 | **14.34** | 11.96 |
| ood_re | 0.5404 | **27.87** | 46.73 |
| tandem | 1.6546 | **39.65** | 37.48 |
| **combined** | **0.8714** | | |

**vs baseline (0.8326)**:

| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|---|---|---|---|
| in_dist | 17.94 | 18.81 | **+0.87** (worse) |
| ood_cond | 13.98 | 14.34 | **+0.36** (worse) |
| ood_re | 27.54 | 27.87 | +0.33 (worse) |
| tandem | 36.73 | 39.65 | **+2.92** (significantly worse) |
| val/loss | 0.8326 | 0.8714 | **+0.039** (large regression) |

### What happened

Large regression (+0.039 val/loss). The distance-weighted volume loss significantly hurt performance, especially on tandem (+2.92 mae_surf_p). The previous near-win on pre-fix code (0.8386 vs 0.8408) does not carry over to the improved r22 baseline (0.8326).

Likely cause: the distance weight  effectively up-weights volume nodes near the surface by 3x. This changes the effective gradient magnitude distribution and may cause the optimizer to over-focus on the near-surface volume band at the expense of learning accurate far-field predictions. The tandem regression is particularly large, suggesting that tandem samples (which have more complex flow interactions between two foils) are more sensitive to this reweighting.

The pre-existing visualization error (mat1/mat2 shape mismatch) appeared after training, not affecting metrics.

### Suggested follow-ups

- The near-win in r21 may have been noise given the pre-fix code; with cleaner r22 baseline, this approach may simply not work
- Try softer weighting (1 + 0.5*exp(-dist*5)) to reduce the gradient imbalance
- Consider weighting only the pressure channel near the surface rather than all 3 channels, since pressure is the primary concern
- Accept that surface accuracy is better improved via surface-specific loss terms rather than vol loss reweighting