### PR TITLE
FIX: Input noise masked to valid nodes only (no ghost nodes)

### DIFF
--- a/train.py
+++ b/train.py
@@ -670,7 +670,9 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
             noise_scale = 0.05 * (1 - epoch / 60)
-            x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+            input_noise = noise_scale * torch.randn_like(x[:, :, 2:25])
+            input_noise = input_noise * mask.unsqueeze(-1).float()  # zero noise on padded positions
+            x[:, :, 2:25] = x[:, :, 2:25] + input_noise
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]


### PR DESCRIPTION
## Hypothesis
At line 672-673, input noise is added to features at indices 2:25 for ALL positions including padded ones. Padded positions should have zero features (they represent non-existent mesh nodes), but adding noise to them creates "ghost nodes" with non-zero features that the model must learn to ignore. This is especially harmful now that dist_feat is correct — the model sees padded positions with physically meaningless dist_feat values plus noise, which pollutes the attention slice assignments. Masking noise to valid nodes only should give cleaner gradients and better surface accuracy.

## Instructions
In `train.py`, mask the input noise to only apply to valid (non-padded) positions.

**Lines 671-673** — Replace:
```python
if model.training and epoch < 60:
    noise_scale = 0.05 * (1 - epoch / 60)
    x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
```
With:
```python
if model.training and epoch < 60:
    noise_scale = 0.05 * (1 - epoch / 60)
    input_noise = noise_scale * torch.randn_like(x[:, :, 2:25])
    input_noise = input_noise * mask.unsqueeze(-1).float()  # zero noise on padded positions
    x[:, :, 2:25] = x[:, :, 2:25] + input_noise
```

No other changes. Run with `--wandb_group noam-r22-fix-input-noise`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73
- mean3 (in+ood_c+tan) = 22.88

---

## Results

**W&B run:** `vob6r36r`

| Split | Metric | Baseline | This run | Delta |
|-------|--------|----------|----------|-------|
| val/loss | — | 0.8326 | 0.8531 | +0.0205 ❌ |
| in_dist | mae_surf_p | 17.94 | 18.04 | +0.10 |
| ood_cond | mae_surf_p | 13.98 | 14.04 | +0.06 |
| ood_re | mae_surf_p | 27.54 | 27.89 | +0.35 |
| tandem | mae_surf_p | 36.73 | 38.65 | +1.92 ❌ |
| **mean3** | **surf_p** | **22.88** | **23.58** | **+0.70 ❌** |

Surface MAE detail (this run):
| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 5.36 | 1.83 | 18.04 |
| ood_cond | 2.56 | 1.14 | 14.04 |
| ood_re | 2.18 | 0.94 | 27.89 |
| tandem | 4.70 | 2.05 | 38.65 |

Volume MAE detail (this run):
| Split | Ux | Uy | p |
|-------|----|----|---|
| in_dist | 0.96 | 0.34 | 19.05 |
| ood_cond | 0.62 | 0.26 | 11.80 |
| ood_re | 0.75 | 0.35 | 46.69 |
| tandem | 1.71 | 0.80 | 36.77 |

### What happened

**Negative result.** Masking noise to valid nodes made things worse across all splits, with tandem degrading most (+1.92 on surf_p). The hypothesis was that ghost-node noise was polluting attention, but the results suggest the opposite: padding noise might have been providing mild regularization or helping the model learn to be robust to noisy inputs. Alternatively, padded nodes are zeroed out before loss computation anyway, so any noise there gets attenuated through the forward pass — the signal may not be harmful enough to matter.

Another possibility: the noise is applied after normalization, and padded positions are already near-zero after normalization (mean/std of near-zero values ≈ near-zero). So the original code was likely already applying negligible noise to padded positions in practice. This fix had no meaningful effect on what the model actually sees, but may have slightly changed gradient flow through the noise computation itself.

### Suggested follow-ups
- Try removing input noise entirely (set noise_scale=0) to confirm whether it helps or hurts on r22.
- If noise is genuinely beneficial, try reducing the scale (0.02 instead of 0.05) or shortening the decay window.
- The large tandem degradation suggests tandem generalization is fragile; a targeted tandem augmentation (e.g., dropout on gap/stagger features) might help more than generic input noise.