### PR TITLE
FIX: Target noise masked to valid nodes only

### DIFF
--- a/train.py
+++ b/train.py
@@ -679,7 +679,9 @@ for epoch in range(MAX_EPOCHS):
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+            target_noise = noise_scale * torch.randn_like(y_norm)
+            target_noise = target_noise * mask.unsqueeze(-1).float()  # zero noise on padded positions
+            y_norm = y_norm + target_noise
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis
At lines 678-682, target noise is added to `y_norm` for ALL positions including padded ones. Masking target noise to valid nodes is a pure correctness fix.

## Instructions
Mask the target noise to only apply to valid positions. Run with `--wandb_group noam-r22-fix-target-noise`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run:** fcbyshyh  
**Best epoch:** 58

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5707 | 7.16 | 2.15 | **17.56** | 18.61 |
| ood_cond | 0.6821 | 4.12 | 1.32 | **13.80** | 11.77 |
| ood_re | 0.5344 | 3.79 | 1.16 | **27.79** | 46.74 |
| tandem | 1.5945 | 6.99 | 2.57 | **38.09** | 36.82 |
| **combined val/loss** | **0.8454** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8326 | 0.8454 | +1.5% worse |
| in_dist surf_p | 17.94 | 17.56 | **-2.1%** |
| ood_cond surf_p | 13.98 | 13.80 | **-1.3%** |
| ood_re surf_p | 27.54 | 27.79 | +0.9% |
| tandem surf_p | 36.73 | 38.09 | +3.7% worse |

**Peak memory:** no OOM.

### What happened

**Mixed — in_dist and ood_cond improved, tandem regressed.** The target noise masking gives small improvements on in_dist (-2.1%) and ood_cond (-1.3%), but tandem gets notably worse (+3.7%). Combined val/loss is slightly higher (+1.5%).

The tandem regression is the most concerning signal. Tandem samples have different mesh topology (two foils), and the fix changes the target signal they receive at padded positions. If tandem samples have a different padding pattern than single-foil samples, this fix differentially changes their effective noise level.

The fix is semantically correct — padding positions should not receive target noise since they're ignored in the loss. But the 30-minute run doesn't show a clear benefit, possibly because:
1. Padding fraction is small (noise contamination was minor)
2. The stochastic change in training signal interacts poorly with the seed in this run

### Suggested follow-ups

- **Keep the fix** — it's semantically correct regardless of this result.
- **Investigate tandem padding:** Check if tandem samples have higher padding fractions, which would make this fix differentially affect them.
- **Combine with target-noise reduction:** If the fix exposes that padding contamination was accidentally helping (acting as regularization), reducing target noise scale might compensate.