### PR TITLE
FIX: Per-sample std computed on clean (pre-noise) targets

### DIFF
--- a/train.py
+++ b/train.py
@@ -674,14 +674,8 @@ for epoch in range(MAX_EPOCHS):
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / 60)
-            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
-            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
-            noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
 
-        # Per-sample std normalization: skip tandem samples (gap feature index 21)
+        # Per-sample std normalization: compute on CLEAN targets before noise
         raw_gap = x[:, 0, 21]
         is_tandem = raw_gap.abs() > 0.5
         B = y_norm.shape[0]
@@ -696,6 +690,13 @@ for epoch in range(MAX_EPOCHS):
                 else:
                     sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
             y_norm = y_norm / sample_stds
+
+        if model.training:
+            noise_progress = min(1.0, epoch / 60)
+            vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
+            p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
+            noise_scale_tgt = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
+            y_norm = y_norm + noise_scale_tgt * torch.randn_like(y_norm)
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
             out = model({"x": x})


### PR DESCRIPTION
## Hypothesis
At lines 692-698, per-sample std is computed from `y_norm[b, valid]`, but `y_norm` has ALREADY been contaminated with target noise (lines 678-682). This inflates the std because noise variance adds to signal variance: `Var(signal + noise) = Var(signal) + Var(noise)`. The inflated std means per-sample normalization divides by too-large values, artificially shrinking the target range and making the model see smaller gradients. The fix is to compute std on the clean targets BEFORE noise injection, then apply noise afterward. This is a pure correctness fix that should improve gradient signal quality.

## Instructions
In `train.py`, reorder the per-sample std computation to happen BEFORE target noise injection.

**Move the per-sample std block to BEFORE the noise block.** After line 676 (`y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]`), the code should be ordered:

**Step 1:** Per-sample std normalization (compute on clean targets):
```python
# Per-sample std normalization: compute on CLEAN targets before noise
raw_gap = x[:, 0, 21]
is_tandem = raw_gap.abs() > 0.5
B = y_norm.shape[0]
sample_stds = torch.ones(B, 1, 3, device=device)
channel_clamps = torch.tensor([0.1, 0.1, 0.5], device=device)
tandem_clamps = torch.tensor([0.3, 0.3, 1.0], device=device)
if model.training:
    for b in range(B):
        valid = mask[b]
        if is_tandem[b]:
            sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
        else:
            sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
    y_norm = y_norm / sample_stds
```

**Step 2:** THEN add target noise (after std normalization):
```python
if model.training:
    noise_progress = min(1.0, epoch / 60)
    vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
    p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
    noise_scale_tgt = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
    y_norm = y_norm + noise_scale_tgt * torch.randn_like(y_norm)
```

**Remove** the original noise block (old lines 677-682) and per-sample std block (old lines 684-698) so there is no duplication. The net effect is: std computed on clean y_norm, then divide, then add noise. Run with `--wandb_group noam-r22-fix-std-clean`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run:** `rsmx0e9i`  
**Epochs:** 59 (30-min timeout)  
**Peak memory:** 18.2 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5645 | 6.89 | 2.23 | **17.59** | 18.45 |
| ood_cond | 0.6867 | 3.56 | 1.30 | **13.93** | 11.70 |
| ood_re | 0.5324 | 2.89 | 1.08 | 27.90 | 46.66 |
| tandem | 1.6110 | 6.06 | 2.48 | **39.13** | 37.57 |
| **combined** | **0.8486** | — | — | — | — |

**vs baseline (val_loss=0.8326, mean3=22.88):** val/loss +1.9%, mean3=23.55 (+2.9%)

Detail: in_dist surf_p -2.0% (improved), ood_cond surf_p -0.4% (improved), tandem surf_p +6.5% (regressed)

### What happened

The fix marginally regresses overall. In_dist and ood_cond improve slightly, but tandem gets significantly worse (+6.5% on surf_p). This is the second experiment testing this hypothesis (PR #1654 tested it on the round-21 baseline and also found regression).

The underlying issue is that the target noise amplitude is tiny (vel: 0.015→0.003, p: 0.008→0.001 annealing over 60 epochs). The std inflation from this noise is at most ~1-3% for early epochs and negligible by mid-training. The theoretical bias exists but is too small to meaningfully affect learning.

A possible explanation for the tandem regression: tandem samples have the most varied field structures (two interacting airfoils), meaning their per-sample std is naturally larger. By computing std on clean targets, the normalization divides by a slightly smaller value, making tandem loss somewhat larger relative to non-tandem. This shifts the effective balance slightly against tandem learning.

### Suggested follow-ups
- **Drop per-sample std entirely:** The feature seems to consistently cause instability across test conditions. An ablation of the entire per-sample std block would clarify whether it helps or hurts overall.
- **Accept the existing order:** The "bug" is too small to matter given the noise schedule. The current implementation is acceptable as-is.
