### PR TITLE
FIX: Tandem curriculum uses gap feature (not Fourier PE)

### DIFF
--- a/train.py
+++ b/train.py
@@ -710,7 +710,7 @@ for epoch in range(MAX_EPOCHS):
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.5)  # gap feature, same threshold as line 685
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface


### PR DESCRIPTION
## Hypothesis
The tandem curriculum exclusion (lines 712-715) tries to skip tandem samples in early epochs to let the model learn simpler single-foil patterns first. But the detection uses `x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01` which indexes the LAST 8 features of x — these are the last 8 Fourier PE channels, NOT the gap feature. Since Fourier PE is non-zero for ALL samples (all samples have spatial coordinates), this condition is True for EVERY sample, meaning the curriculum currently excludes ALL samples in the first 10 epochs — the model trains on zero gradients for 10 epochs!

The correct tandem detection should use the gap feature at index 21 (before standardization it's the raw gap; after standardization at index 21 it's the standardized gap), which is what the rest of the code uses (line 383 in the model forward, line 685/734 in training). This fix should restore the intended curriculum behavior and reclaim 10 wasted epochs of training.

## Instructions
In `train.py`, fix the tandem detection in the curriculum section.

**Lines 712-714** — Replace:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```
With:
```python
if epoch < 10:
    is_tandem_curr = (x[:, 0, 21].abs() > 0.5)  # gap feature, same threshold as line 685
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```

No other changes. Run with `--wandb_group noam-r22-fix-tandem-curr`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run:** velavnml  
**Best epoch:** 62

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8326 | 0.8332 | +0.0006 |
| in_dist surf_p | 17.94 | **17.14** | **-0.80** |
| ood_cond surf_p | 13.98 | 13.87 | -0.11 |
| ood_re surf_p | 27.54 | 27.58 | +0.04 |
| tandem surf_p | 36.73 | 37.69 | +0.96 |

**Full surface MAE (Ux / Uy / p):**
- in_dist: 6.60 / 1.74 / 17.14
- ood_cond: 3.30 / 1.16 / 13.87
- ood_re: 2.90 / 1.00 / 27.58
- tandem: 6.42 / 2.47 / 37.69

**Volume MAE (Ux / Uy / p):**
- in_dist: 0.91 / 0.32 / 18.33
- ood_cond: 0.60 / 0.25 / 11.67
- ood_re: 0.73 / 0.35 / 46.58
- tandem: 1.65 / 0.78 / 36.24

**Peak memory:** not explicitly logged; no OOM observed.

### What happened

The fix is correct — the bug was real, but its practical impact on val/loss is within noise (Δ=+0.0006, essentially neutral). The results are mixed: in_dist surf_p improved by 0.80 and ood_cond by 0.11, while tandem surf_p regressed by 0.96. The overall val/loss is unchanged.

Why didn't fixing 10 wasted gradient epochs help more? Two plausible explanations: (1) The broken curriculum was inadvertently serving as a "warm start" — 10 epochs of near-zero gradients acts like a very small effective learning rate, letting the model slowly converge from initialization without tandem interference. (2) The tandem curriculum interacts with the progressive volume subsampling (epochs 0-40), which already gates what the model sees. Reclaiming 10 epochs of tandem exclusion may simply shift when tandem error accumulates, not eliminate it.

The tandem surf_p regression (+0.96) is the most concerning result. With the fix, the model sees only non-tandem samples for the first 10 epochs (as intended), then gets flooded with tandem samples at epoch 10. This may cause a mild shock that's slightly worse than the broken baseline's uniform near-zero update.

### Suggested follow-ups

1. **Longer curriculum window**: Try excluding tandem for 20-25 epochs instead of 10. If the benefit comes from letting single-foil patterns stabilize first, more epochs may be needed to see it.
2. **Softer tandem exclusion**: Instead of binary sample_mask (0 or 1), use a ramp (e.g., 0→1 over epochs 0-20) for tandem samples to avoid the epoch-10 shock.
3. **Remove the curriculum entirely**: Now that the bug is known, ablating the curriculum may show whether it helps or hurts with correct detection.
