### PR TITLE
LR recalibration: lr=2.0e-3 on post-dual-fix code

### DIFF
--- a/train.py
+++ b/train.py
@@ -411,7 +411,7 @@ MAX_EPOCHS = 100
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 2.0e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0


### PR DESCRIPTION
## Hypothesis
The two recent pipeline fixes (correct dist_feat + correct coarse masked pooling) fundamentally changed the gradient landscape. The coarse loss now produces correct gradients (no padding dilution), and dist_feat provides a meaningful continuous signal. The current lr=2.6e-3 was tuned on the old (buggy) landscape. With cleaner gradients, the optimal learning rate may be lower — the model can extract more signal per step, so it needs less aggressive stepping. Testing lr=2.0e-3: a ~23% reduction that should reduce overshooting in the now-cleaner loss surface.

## Instructions
In `train.py`, change the base learning rate:

**Line 414** — Change `lr: float = 2.6e-3` to:
```python
lr: float = 2.0e-3
```

No other changes. Run with `--wandb_group noam-r22-lr-recal`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run:** d9bhnadp  (runtime: 32.0 min, state: failed due to pre-existing vis crash)

| Split | loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5882 | 5.26 | 1.81 | 18.22 | 1.01 | 0.34 | 19.38 |
| val_ood_cond | 0.7076 | 2.65 | 0.96 | 14.15 | 0.66 | 0.26 | 11.54 |
| val_ood_re | 0.5493 | 2.28 | 0.87 | 28.09 | 0.78 | 0.36 | 46.79 |
| val_tandem_transfer | 1.6075 | 5.17 | 2.04 | 38.64 | 1.78 | 0.82 | 37.26 |
| **val_loss (best)** | **0.8632** | | | | | | |

**mean3_p** = (18.22+14.15+38.64)/3 = **23.67**

**vs baseline:** val_loss +0.0306 (+3.7%), mean3_p +0.79 (+3.5%) — **worse**

### What happened

lr=2.0e-3 is too conservative for the post-dual-fix code. The current lr=2.6e-3 baseline (val_loss=0.8326) significantly outperforms lr=2.0e-3 (0.8632). The hypothesis that cleaner gradients prefer a lower LR doesn't hold here.

The worst degradation is in tandem transfer (38.64 vs 36.73 baseline), suggesting the model needs the higher LR to explore the tandem parameter space effectively. At 2.0e-3, tandem representations don't form as well within the 30-minute budget.

The dual-fix improvements appear to work best at the existing lr=2.6e-3 — the cleaner gradient signal is being used effectively at the original LR, not requiring downward recalibration.

### Suggested follow-ups

- Try lr=2.8e-3 or 3.0e-3 to check if even higher LR is beneficial now that gradients are cleaner
- Or sweep narrowly: 2.4e-3, 2.6e-3 (current), 2.8e-3 to bracket the optimum