### PR TITLE
Extended warmup 20 + cosine T_max=70 (slower ramp, longer anneal)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=20)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=70, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[20]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
The dual pipeline fixes have made the early training gradients much more informative. An extended warmup of 20 epochs (vs current 10) combined with a longer cosine anneal (T_max=70 vs 62) gives the model more time at moderate LR. The intuition: with correct coarse pooling, early epochs now contribute meaningful multi-scale gradients. A slower warmup avoids overshooting these correct-but-unfamiliar gradients. The longer cosine tail ensures the model doesn't run out of annealing budget before the 30-minute timeout.

## Instructions
In `train.py`, adjust the warmup and cosine schedule:

1. **Line 580** — Change to warmup over 20 epochs:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=20)
```

2. **Line 581** — Change to longer cosine:
```python
cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=70, eta_min=5e-5)
```

3. **Line 583** — Update milestone to match:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[20]
)
```

No other changes. Run with `--wandb_group noam-r22-warmup20-cos70`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run**: `3j6i6fp5` | **Epochs**: 61 (EMA active from 40) | **Peak memory**: 17.8 GB

### val/loss
| | This run | Baseline | Δ |
|---|---|---|---|
| val/loss | 0.8673 | **0.8326** | +0.0347 (~7.5σ worse) |

### Surface MAE (surf_p)
| Split | Baseline | This run | Δ |
|---|---|---|---|
| in_dist | 17.94 | 18.70 | +0.76 |
| ood_cond | 13.98 | 14.58 | +0.60 |
| ood_re | 27.54 | 28.08 | +0.54 |
| tandem | 36.73 | 38.55 | +1.82 |

### What happened

Clear regression. The 20-epoch warmup significantly hurt performance — doubling the warmup period costs 10 epochs of useful cosine annealing within the 30-minute budget.

With 61 total epochs:
- **Old** (10 warmup): 51 epochs in cosine phase (epochs 10–61)
- **New** (20 warmup): 41 epochs in cosine phase (epochs 20–61)

The model needs those 10 extra high-LR cosine epochs to converge. The new coarse pooling gradients were hypothesized to benefit from a slower ramp, but in practice the model was already receiving useful gradients from the improved coarse loss from epoch 1 — it doesn't need extra warmup time to "settle into" them.

The T_max=70 parameter (vs 62) spreads the cosine decay over more epochs, but since we start the cosine phase 10 epochs later, the model is actually *further* from convergence when the 30-minute timer fires.

**Verdict**: 10-epoch warmup is well-calibrated for this budget. The extended warmup is not worth the lost cosine-phase epochs.

### Suggested follow-ups
- Warmup=15 epochs (half-step) might be a useful intermediate test, though given this result it's unlikely to help.
- If the training budget were extended (e.g., 45 minutes), a 20-epoch warmup might break even. But within 30 minutes, don't extend warmup beyond 10.
- The cosine T_max sensitivity is worth checking independently: T_max=55 might converge faster for the 30-minute window.