### PR TITLE
Coarse loss gradient weighting by group distance variance

### DIFF
--- a/train.py
+++ b/train.py
@@ -776,8 +776,14 @@ for epoch in range(MAX_EPOCHS):
             y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
             mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
+            # Distance-based group weighting: near-surface groups get higher weight
+            dist_sorted = torch.gather(dist_surf.squeeze(-1), 1, sort_idx)[:, :n_groups * coarse_pool_size]
+            dist_g = dist_sorted.reshape(B, n_groups, coarse_pool_size)
+            group_mean_dist = (dist_g * mask_trunc.reshape(B, n_groups, coarse_pool_size).float()).sum(dim=2) / mask_trunc.reshape(B, n_groups, coarse_pool_size).float().sum(dim=2).clamp(min=1)
+            coarse_group_weight = (1.0 + 2.0 * torch.exp(-group_mean_dist * 3.0)).unsqueeze(-1)  # [B, G, 1]
+
             coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1) * coarse_group_weight).sum() / (mask_coarse.unsqueeze(-1) * coarse_group_weight).sum().clamp(min=1)
             _coarse_loss = coarse_loss
             loss = loss + 1.0 * coarse_loss
 


### PR DESCRIPTION
## Hypothesis
Now that coarse pooling correctly uses masked means, the coarse loss is a powerful multi-scale regularizer. But all spatial groups are weighted equally, regardless of how physically interesting they are. Groups near the airfoil surface (where dist_feat is small) have high spatial variance in the flow field — these are the groups that matter most for surface accuracy. Groups far from the foil (free-stream) are nearly uniform and easy to predict. Weighting coarse groups by the variance of dist_feat within each group focuses the coarse loss on the boundary layer region, where the model needs the most multi-scale guidance.

## Instructions
In `train.py`, in the coarse loss section (around lines 756-782), add group-level distance-based weighting.

After computing `mask_trunc_f` (line 772) and before computing `coarse_err` (line 779), add distance-based group weights using the already-computed `dist_surf`:

```python
# Gather dist_surf values for truncated/sorted nodes
dist_sorted = torch.gather(dist_surf.squeeze(-1), 1, sort_idx)[:, :n_groups * coarse_pool_size]
dist_g = dist_sorted.reshape(B, n_groups, coarse_pool_size)
# Mean distance per group: low = near surface = interesting
group_mean_dist = (dist_g * mask_trunc.reshape(B, n_groups, coarse_pool_size).float()).sum(dim=2) / mask_trunc.reshape(B, n_groups, coarse_pool_size).float().sum(dim=2).clamp(min=1)
# Weight: exponential decay with distance (near-surface groups get 3x weight)
coarse_group_weight = (1.0 + 2.0 * torch.exp(-group_mean_dist * 3.0)).unsqueeze(-1)  # [B, G, 1]
```

Then modify the coarse error computation. Replace:
```python
coarse_err = (pred_coarse - y_coarse).abs()
coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
```
With:
```python
coarse_err = (pred_coarse - y_coarse).abs()
coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1) * coarse_group_weight).sum() / (mask_coarse.unsqueeze(-1) * coarse_group_weight).sum().clamp(min=1)
```

Run with `--wandb_group noam-r22-coarse-grad-wt`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run ID:** 0gadqzcr  
**Best epoch:** 61 (wall-clock timeout at ~30.0 min)  
**Peak memory:** ~17.6 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8548** | 0.8326 |
| val_in_dist | 0.5839 | — |
| val_tandem_transfer | 1.5977 | — |
| val_ood_cond | 0.6956 | — |
| val_ood_re | 0.5421 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 4.04 | 1.31 | 17.76 | 17.94 | -1.0% |
| val_tandem_transfer | 5.03 | 1.89 | 38.23 | 36.73 | **+4.1%** |
| val_ood_cond | 2.19 | 0.89 | 13.99 | 13.98 | +0.1% |
| val_ood_re | 1.87 | 0.78 | 27.86 | 27.54 | +1.2% |

**mean3 surf_p** = (17.76 + 13.99 + 38.23) / 3 = **23.33** (baseline: 22.88, delta: +2.0%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 0.95 | 0.33 | 18.98 |
| val_tandem_transfer | 1.71 | 0.80 | 37.38 |
| val_ood_cond | 0.62 | 0.26 | 11.97 |
| val_ood_re | 0.76 | 0.35 | 46.83 |

---

### What happened

**Negative result.** val/loss = 0.8548 vs baseline 0.8326 (+2.7% worse). mean3 surf_p = 23.33 vs 22.88 (+2.0% worse). The main driver is val_tandem_transfer which regressed +4.1%.

val_in_dist improved slightly (-1.0%) and ood_cond/ood_re are essentially flat (+0.1%, +1.2%). The mixed signal suggests the distance weighting shifts capacity toward near-surface regions (as intended), but at the cost of the global consistency that the coarse loss normally enforces. Tandem cases require interpolating between two foil regions — the global coarse loss helps with this spatial extrapolation, and reducing its weight on far-field groups disrupts that.

The coarse loss serves two purposes: (1) near-surface pressure accuracy (improved by weighting), (2) global flow consistency for tandem cases (hurt by the weighting). The unweighted coarse loss provides a better balance for the current training regime.

*Visualization crash* (same as previous PRs): `mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x58)` in `feature_cross`. Training metrics are unaffected.

---

### Suggested follow-ups

- **Smaller weight multiplier**: Use `1.0 + 0.5 * exp(...)` instead of `1.0 + 2.0 * exp(...)` for gentler near-surface focus. The 3x multiplier may be too aggressive.
- **Hybrid approach**: Add a separate near-surface coarse loss term (weighted) while keeping the uniform coarse loss term, so global consistency is preserved while adding near-surface focus.
- **Distance weighting in surf_loss instead**: Rather than weighting the coarse loss, apply the exponential distance weighting directly to the surface MAE loss to focus training on hard boundary layer nodes.
