### PR TITLE
Distance-aware surface loss: near-surface volume nodes boost surf gradients

### DIFF
--- a/train.py
+++ b/train.py
@@ -750,7 +750,16 @@ for epoch in range(MAX_EPOCHS):
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        loss = vol_loss + surf_weight * surf_loss
+
+        # Near-surface volume loss: volume nodes within boundary layer contribute to surface-like loss
+        near_surf_threshold = 0.02  # physical distance threshold (in raw dsdf units)
+        near_surf_mask = vol_mask_train & (dist_surf.squeeze(-1) < near_surf_threshold)
+        if near_surf_mask.any():
+            near_surf_loss = (abs_err[:, :, 2:3] * near_surf_mask.unsqueeze(-1)).sum() / near_surf_mask.sum().clamp(min=1)
+        else:
+            near_surf_loss = torch.tensor(0.0, device=device)
+
+        loss = vol_loss + surf_weight * surf_loss + 5.0 * near_surf_loss
 
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None
@@ -1073,6 +1082,14 @@ if best_metrics:
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                raw_xy_vis = x_n[:, :, :2]
+                xy_min_vis = raw_xy_vis.amin(dim=1, keepdim=True)
+                xy_max_vis = raw_xy_vis.amax(dim=1, keepdim=True)
+                xy_norm_vis = (raw_xy_vis - xy_min_vis) / (xy_max_vis - xy_min_vis + 1e-8)
+                freqs_vis = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled_vis = xy_norm_vis.unsqueeze(-1) * freqs_vis
+                fourier_pe_vis = torch.cat([xy_scaled_vis.sin().flatten(-2), xy_scaled_vis.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_vis], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
With both dist_feat and coarse pooling now correct, we can try a new idea: extend the surface loss to include volume nodes that are very close to the surface. The physical intuition is that the first row of volume cells adjacent to the airfoil (boundary layer) contains critical gradient information. Currently these nodes only contribute to vol_loss. If we add a secondary "near-surface" loss term that treats the closest volume nodes (dist_surf < threshold) like soft surface nodes, we get more supervision signal for boundary layer accuracy without changing the model architecture.

## Instructions
In `train.py`, add a near-surface volume loss term after the existing `surf_loss` computation (around line 752).

After `surf_loss = (surf_per_sample * tandem_boost).mean()` (line 752), add:

```python
# Near-surface volume loss: volume nodes within boundary layer contribute to surface-like loss
near_surf_threshold = 0.02  # physical distance threshold (in raw dsdf units)
near_surf_mask = vol_mask_train & (dist_surf.squeeze(-1) < near_surf_threshold)
if near_surf_mask.any():
    near_surf_loss = (abs_err[:, :, 2:3] * near_surf_mask.unsqueeze(-1)).sum() / near_surf_mask.sum().clamp(min=1)
else:
    near_surf_loss = torch.tensor(0.0, device=device)
```

Then modify the combined loss (line 753). Replace:
```python
loss = vol_loss + surf_weight * surf_loss
```
With:
```python
loss = vol_loss + surf_weight * surf_loss + 5.0 * near_surf_loss
```

The weight of 5.0 is between vol (1.0) and surf (~20-50), reflecting that these nodes are important but not as important as actual surface nodes. Run with `--wandb_group noam-r22-dist-surf-loss`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run:** 4wxwtg28

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.6107 | 3.281 | 1.002 | 19.04 | 1.047 | 0.370 | 17.28 |
| val_tandem_transfer | 1.6315 | — | — | 39.3 | — | — | — |
| val_ood_cond | 0.7213 | — | — | 14.3 | — | — | — |
| val_ood_re | 0.5657 | — | — | 28.4 | — | — | — |
| **combined val/loss** | **0.8823** | | | | | | |

Baseline: val_loss=0.8326 | in_dist=17.94 | ood_cond=13.98 | ood_re=27.54 | tandem=36.73
Delta: **+0.050** vs baseline (worse)

Peak memory: 17.5 GB

**What happened:**
Negative result. The near-surface volume loss added +0.050 to val/loss. In-dist surf_p degraded from 17.94 to 19.04 Pa (+1.1 Pa). Tandem and OOD also slightly worse.

Interestingly, surf_Ux and surf_Uy improved (3.28 vs baseline ~5+, 1.00 vs ~1.6), suggesting the near-surf loss is redirecting gradient toward velocity prediction at boundary-layer nodes — but this comes at the cost of pressure accuracy. The near_surf_loss uses only pressure (abs_err[:,:,2:3]) but the competing effects of this additional loss term on the adaptive surf_weight schedule and overall gradient balance appear to hurt pressure.

The root issue is likely that dist_surf < 0.02 selects a very small number of nodes (the mesh is not uniform), and their pressure error signal is noisier than the actual surface nodes — adding 5.0x weight on noisy near-surface pressure gradients hurts the overall optimization.

Note: vis pipeline Fourier PE fix also applied (same as PR #1652) to prevent crash during visualization.

**Suggested follow-ups:**
- Try a larger threshold (0.05) to include more boundary layer nodes and get a less noisy signal.
- Instead of pressure only, use full near_surf_loss across all 3 components.
- Use a soft distance-weighted term (exp(-dist_surf / sigma)) instead of a hard threshold.