### PR TITLE
Multi-scale coarse cascade: pool sizes 32+64+128 (exploit correct pooling)

### DIFF
--- a/train.py
+++ b/train.py
@@ -752,34 +752,37 @@ for epoch in range(MAX_EPOCHS):
         surf_loss = (surf_per_sample * tandem_boost).mean()
         loss = vol_loss + surf_weight * surf_loss
 
-        # Multi-scale loss: coarse spatial pooling
+        # Multi-scale coarse loss: cascade at 3 pool sizes
         _coarse_loss = None
-        coarse_pool_size = 64
-        B, N, C = pred.shape
-        n_groups = N // coarse_pool_size
-        if n_groups > 1:
-            # Sort by x-coordinate for spatially coherent groups
-            raw_x_coord = x[:, :, 0]  # x-coordinate
-            sort_idx = raw_x_coord.argsort(dim=1)
-            pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
-            y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
-            mask_sorted = torch.gather(mask, 1, sort_idx)
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
-            y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
+        for coarse_pool_size in [32, 64, 128]:
+            B, N, C = pred.shape
+            n_groups = N // coarse_pool_size
+            if n_groups > 1:
+                raw_x_coord = x[:, :, 0]
+                sort_idx = raw_x_coord.argsort(dim=1)
+                pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
+                y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
+                mask_sorted = torch.gather(mask, 1, sort_idx)
+                pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
+                y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
+                mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
-            mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)  # [B, G, P, 1]
-            pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
-            y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
-            pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
-            y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
-            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
+                mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)
+                pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
+                y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
+                pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
+                y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
+                mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
-            coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            _coarse_loss = coarse_loss
-            loss = loss + 1.0 * coarse_loss
+                coarse_err = (pred_coarse - y_coarse).abs()
+                cl = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+                if _coarse_loss is None:
+                    _coarse_loss = cl
+                else:
+                    _coarse_loss = _coarse_loss + cl
+
+        if _coarse_loss is not None:
+            loss = loss + 0.5 * _coarse_loss  # reduced per-scale weight since we have 3 scales
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)


### PR DESCRIPTION
## Hypothesis
Now that coarse pooling correctly uses masked means, we can exploit it at multiple scales. The current single-scale coarse loss (pool_size=64) captures one spatial frequency of error. Adding coarse losses at pool_size=32 (fine) and pool_size=128 (coarse) creates a multi-scale cascade that regularizes the model at three spatial resolutions simultaneously. This is analogous to multi-scale discriminators in GANs or Laplacian pyramids in image processing. The fine scale (32) catches local boundary layer errors; the medium (64) catches wake structure; the coarse (128) catches large-scale pressure distribution.

## Instructions
In `train.py`, replace the single-scale coarse loss block (lines 756-782) with a multi-scale version.

Replace the entire block from `_coarse_loss = None` through `loss = loss + 1.0 * coarse_loss` with:

```python
# Multi-scale coarse loss: cascade at 3 pool sizes
_coarse_loss = None
for coarse_pool_size in [32, 64, 128]:
    B, N, C = pred.shape
    n_groups = N // coarse_pool_size
    if n_groups > 1:
        raw_x_coord = x[:, :, 0]
        sort_idx = raw_x_coord.argsort(dim=1)
        pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
        y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
        mask_sorted = torch.gather(mask, 1, sort_idx)
        pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
        y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
        mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]

        mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)
        pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
        y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
        pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
        y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
        mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)

        coarse_err = (pred_coarse - y_coarse).abs()
        cl = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
        if _coarse_loss is None:
            _coarse_loss = cl
        else:
            _coarse_loss = _coarse_loss + cl

if _coarse_loss is not None:
    loss = loss + 0.5 * _coarse_loss  # reduced per-scale weight since we have 3 scales
```

Note the weight is 0.5 (vs old 1.0) because we sum 3 scales — the total coarse contribution is ~1.5x the old single-scale, a modest increase. Run with `--wandb_group noam-r22-multiscale-coarse`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run:** u5bgkrdk (`senku/multiscale-coarse-cascade`, group: `noam-r22-multiscale-coarse`)
**Epochs completed:** 56 (30-min timeout; loss still improving at end)
**Peak memory:** N/A (not logged)

### Metrics (best = final epoch)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 3.79 | 1.46 | **18.30** | 0.98 | 0.35 | 19.88 |
| val_ood_cond | 2.25 | 0.89 | **13.73** | 0.64 | 0.26 | 11.56 |
| val_ood_re | 2.06 | 0.75 | **27.82** | 0.75 | 0.35 | 46.68 |
| val_tandem | 3.80 | 1.82 | **39.05** | 1.74 | 0.81 | 37.63 |

**val/loss:** 0.8637 (baseline: 0.8326, **+0.0311 — worse**)

### Comparison vs baseline (surf_p)

| Split | Baseline | Result | Delta |
|---|---|---|---|
| in_dist | 17.94 | 18.30 | +0.36 (worse) |
| ood_cond | 13.98 | 13.73 | -0.25 (improved) |
| ood_re | 27.54 | 27.82 | +0.28 (slightly worse) |
| tandem | 36.73 | 39.05 | +2.32 (much worse) |
| mean3 (in+ood+re) | 19.82 | 19.95 | +0.13 (slightly worse) |

### What happened

Negative result. The multi-scale coarse cascade hurt performance compared to the single-scale baseline, with val/loss rising +0.0311. The tandem split was hit hardest (+2.32 on surf_p), suggesting the additional loss scales may be disrupting the model's ability to generalize to tandem geometries.

The hypothesis was that multiple spatial resolutions would provide complementary regularization. However, the combined coarse contribution is ~1.5x the old single-scale (sum of 3 scales × 0.5 weight), which may be over-regularizing. The coarse loss acts as a regularizer that smooths predictions spatially — too much of it may suppress the fine-grained variation the model needs to resolve local pressure gradients, especially for the complex tandem foil geometry.

Another possibility: re-sorting by x-coordinate three times per step adds some computational overhead and the run completed fewer epochs (56 vs 61 for the baseline), meaning the model was further from convergence. However, the loss trajectory doesn't suggest the model was on a steeper descent that would overcome the gap.

### Suggested follow-ups

- Try just adding scale 128 alongside 64 (skip 32) to avoid over-regularization at fine scales, with weight 0.5 each — total contribution same as old 1.0.
- Try keeping single-scale (64) but with a lower weight (e.g., 0.5 instead of 1.0) to see if the baseline coarse loss was already slightly too strong.
- Consider caching the sort_idx across scales (same sort is recomputed 3x per step) as a micro-optimization if this idea is revisited.