### PR TITLE
Dist_feat attention gating: modulate slice weights by surface proximity

### DIFF
--- a/train.py
+++ b/train.py
@@ -231,8 +231,12 @@ class TransolverBlock(nn.Module):
                 nn.Linear(hidden_dim, out_dim),
             )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, dist_feat=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+        # Sharpen attention near surface using dist_feat
+        if sb is not None and dist_feat is not None:
+            proximity_boost = torch.exp(-dist_feat * 3.0)  # [B, N, 1] -> 1.0 at surface, ~0 far away
+            sb = sb * (1.0 + 0.5 * proximity_boost)  # amplify spatial bias near surface
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
@@ -378,6 +382,7 @@ class Transolver(nn.Module):
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
         raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        dist_feat_for_attn = x[:, :, 25:26]  # dist_feat channel for attention gating
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
@@ -387,13 +392,13 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, dist_feat=dist_feat_for_attn)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
-        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem)
+        fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, dist_feat=dist_feat_for_attn)
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)


### PR DESCRIPTION
## Hypothesis
With dist_feat now computed correctly from raw dsdf, we have a reliable continuous distance-to-surface signal for every node. Currently this is just another input feature to the preprocessor. But distance-to-surface is a powerful structural prior: nodes near the surface need fine-grained attention (many slices with sharp weights), while far-field nodes are homogeneous and need less attention resolution. We can exploit this by adding a dist_feat-based gating to the spatial bias in the attention layer. This uses the correct dist_feat (from the fix in merge 10) to dynamically sharpen attention near the surface, where accuracy matters most.

## Instructions
(See PR body for full implementation details)

Run with `--wandb_group noam-r22-dist-attn-gate`.

## Baseline
Current best (11th merge, post-coarse-fix):
- **val_loss = 0.8326**
- val_in_dist = 17.94
- val_ood_cond = 13.98
- val_ood_re = 27.54
- val_tandem = 36.73

---

## Results

**W&B run:** tuu9o16q  
**Epochs completed:** 57 (timeout at epoch ~58-59)

### Implementation

Added `dist_feat` parameter to `TransolverBlock.forward` and used it to modulate the spatial bias:
```python
def forward(self, fx, raw_xy=None, tandem_mask=None, dist_feat=None):
    sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
    if sb is not None and dist_feat is not None:
        proximity_boost = torch.exp(-dist_feat * 3.0)
        sb = sb * (1.0 + 0.5 * proximity_boost)
    ...
```

Extracted `dist_feat_for_attn = x[:, :, 25:26]` in `Transolver.forward` and passed to all block calls.

### Metrics vs Baseline

| Metric | Baseline | Gate Result | Delta |
|--------|----------|-------------|-------|
| val_loss | 0.8326 | **0.8529** | +2.4% worse |
| in_dist surf MAE | 17.94 | 25.52 | +42% worse |
| ood_cond surf MAE | 13.98 | 18.04 | +29% worse |
| ood_re surf MAE | 27.54 | 31.22 | +13% worse |
| tandem surf MAE | 36.73 | 47.03 | +28% worse |

Surface MAE by channel (best epoch):
- in_dist: Ux=5.82, Uy=1.90, p=17.79
- ood_cond: Ux=2.97, Uy=1.11, p=13.95
- ood_re: Ux=2.56, Uy=0.98, p=27.68
- tandem: Ux=6.11, Uy=2.45, p=38.48

### What happened

The distance-gated attention hurt performance. Val_loss=0.8529 at 57 epochs vs baseline 0.8326. The val/loss was still trending down (0.8730→0.8658→0.8611→0.8563→0.8529, ~0.005/epoch) but needs ~41 more epochs to reach baseline — not achievable.

The issue is that the proximity boost `torch.exp(-dist_feat * 3.0)` creates a sharp hard-coded amplification near the surface (boost ≈ 1.0 at surface, ≈ 0 beyond a few units). This injects a fixed prior into the attention mechanism that conflicts with what the model has already learned via the spatial_bias network. The spatial_bias already receives `dist_feat` as the 4th input channel, so it already has the capability to learn proximity-dependent biases — adding the hardcoded exponential boost is redundant and potentially harmful.

The tandem MAE degradation is especially notable (47.03 vs 36.73, +28%). Tandem foils have complex interaction zones that may require more nuanced attention patterns that the hard proximity boost disrupts.

### Suggested follow-ups

- The idea of surface-proximity-aware attention is sound, but the implementation should be learnable rather than hardcoded
- Try a learned proximity gate: `nn.Parameter(torch.tensor(0.0)) * torch.exp(-dist_feat * learned_scale)` where both the magnitude and scale are learned
- The spatial_bias already has dist_feat as input — maybe the issue is just that it needs a higher-dim representation of proximity. Try adding a 2nd dist_feat channel (squared or log-log) to raw_xy