### PR TITLE
Combo: tandem curriculum fix + Fourier PE padding fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -660,9 +660,12 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
-        # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
+        # Normalize xy to [0,1] per-sample for consistent Fourier encoding (valid nodes only)
+        xy_for_range = raw_xy.clone()
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+        xy_min = xy_for_range.amin(dim=1, keepdim=True)
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+        xy_max = xy_for_range.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
@@ -710,7 +713,7 @@ for epoch in range(MAX_EPOCHS):
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.5)  # gap feature, same threshold as line 685
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
@@ -894,9 +897,12 @@ for epoch in range(MAX_EPOCHS):
                 x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
-                # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                # Normalize xy to [0,1] per-sample for consistent Fourier encoding (valid nodes only)
+                xy_for_range = raw_xy.clone()
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+                xy_min = xy_for_range.amin(dim=1, keepdim=True)
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+                xy_max = xy_for_range.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]


### PR DESCRIPTION
## Hypothesis
Two near-misses from round 22 individually came within striking distance of baseline (tandem curriculum fix: val_loss=0.8332, +0.0006; Fourier PE fix: val_loss=0.8380, +0.005). Both are correctness fixes that address independent bugs:
1. The tandem curriculum (lines 712-714) uses Fourier PE channels instead of the gap feature to detect tandem samples, accidentally excluding ALL samples for 10 epochs
2. The Fourier PE normalization (lines 663-666) includes padded positions in xy_min/xy_max, contaminating the coordinate range

These fixes are orthogonal — one fixes training data selection, the other fixes feature encoding. Their benefits should compound. The tandem fix improved in_dist by 0.80 and the Fourier PE fix improved ood_cond by 0.29. Together they may push past baseline.

## Instructions
Apply BOTH fixes to `train.py`:

**Fix 1: Tandem curriculum (lines 712-714)**
Replace:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```
With:
```python
if epoch < 10:
    is_tandem_curr = (x[:, 0, 21].abs() > 0.5)  # gap feature, same threshold as line 685
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```

**Fix 2: Fourier PE padding — TRAINING loop (lines 663-666)**
Replace:
```python
xy_min = raw_xy.amin(dim=1, keepdim=True)
xy_max = raw_xy.amax(dim=1, keepdim=True)
```
With:
```python
xy_for_range = raw_xy.clone()
xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
xy_min = xy_for_range.amin(dim=1, keepdim=True)
xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
xy_max = xy_for_range.amax(dim=1, keepdim=True)
```

**Fix 2: Fourier PE padding — VALIDATION loop (lines 897-899)**
Apply the same xy_min/xy_max masking fix in the validation loop where `raw_xy` min/max is computed.

No other changes. Run with `--wandb_group noam-r23-combo-tandem-fourier`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run:** `bojiztch`
**Epochs:** 61 best (30 min, wall-clock limit)
**Peak memory:** ~17.9 GB

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| in_dist | 0.5599 | 7.02 | 1.94 | 17.34 | 0.93 | 0.32 | 18.15 |
| ood_cond | 0.7037 | 3.43 | 1.19 | 14.24 | 0.62 | 0.25 | 11.78 |
| ood_re | 0.5331 | 3.08 | 1.07 | 27.74 | 0.74 | 0.35 | 46.61 |
| tandem | 1.6000 | 6.32 | 2.44 | 37.79 | 1.71 | 0.80 | 36.81 |
| **combined** | **0.8492** | | | | | | |

**surf_p mean3** (in + ood_c + tan) / 3 = (17.34 + 14.24 + 37.79) / 3 = **23.12**

### vs Baseline

| Metric | Baseline | This run | Δ |
|---|---|---|---|
| val/loss | 0.8326 | 0.8492 | +2.0% |
| surf_p in_dist | 17.94 | 17.34 | **-3.4%** |
| surf_p ood_cond | 13.98 | 14.24 | +1.9% |
| surf_p ood_re | 27.54 | 27.74 | +0.7% |
| surf_p tandem | 36.73 | 37.79 | +2.9% |
| surf_p mean3 | 22.88 | 23.12 | +1.0% |

### What happened

Mixed result. In_dist improved significantly (-3.4%) — the tandem curriculum fix is working, it now correctly excludes only tandem samples in the first 10 epochs rather than all samples. However, the combination worsened tandem (+2.9%), ood_cond (+1.9%), and overall val/loss (+2.0%).

The fixes are not synergistic. The Fourier PE fix (masking padding from coordinate range) appears to hurt when combined with the tandem curriculum fix. The Fourier PE normalization change may be slightly off — the xy_for_range clone approach adds memory and may introduce subtle issues with the clone/modification.

The tandem curriculum fix alone likely performs better (val_loss=0.8332 vs 0.8326 baseline). The Fourier PE fix alone (val_loss=0.8380) adds noise. Together they cancel any benefits.

### Suggested follow-ups

- Apply only the tandem curriculum fix (individually near-neutral, specifically fixes in_dist)
- The Fourier PE normalization issue may need a different approach — the current clone/mask method may have edge cases when all nodes in a sample are valid (normal samples have no padding, making the fix a no-op and safe)
- Investigate: does the Fourier PE fix help or hurt individually on the new baseline? It was tested on older code
