### PR TITLE
Combo: tandem curriculum fix + warmup 15 epochs

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
 )
 
 # --- wandb ---
@@ -710,7 +710,7 @@ for epoch in range(MAX_EPOCHS):
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.5)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface


### PR DESCRIPTION
## Hypothesis
Two near-misses from round 22 that target different aspects of early training:
1. Tandem curriculum fix (val_loss=0.8332, +0.0006): fixes the broken tandem detection that accidentally excludes ALL samples for 10 epochs
2. Warmup 15 epochs (val_loss=0.8402): extends warmup from 10 to 15 epochs, which improved ood_cond by 4.1%

These interact synergistically: the tandem curriculum fix restores proper sample selection in epochs 0-9, while warmup 15 extends the gentle LR ramp. With the curriculum fix, epochs 0-9 now properly exclude only tandem samples (rather than all samples). Extending warmup to 15 means the LR is still ramping when tandem samples get reintroduced at epoch 10, providing a softer transition that should mitigate the epoch-10 shock that caused tandem regression in the standalone curriculum fix run.

## Instructions
Apply BOTH changes to `train.py`:

**Fix 1: Tandem curriculum (lines 712-714)**
Replace:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```
With:
```python
if epoch < 10:
    is_tandem_curr = (x[:, 0, 21].abs() > 0.5)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```

**Fix 2: Warmup 15 epochs**
Line 580 — Change `total_iters=10` to `total_iters=15`:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
```

Line 583 — Change the milestone from `[10]` to `[15]`:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
)
```

No other changes. Run with `--wandb_group noam-r23-combo-tandem-warmup15`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run ID:** `4rw7rgas`
**val/loss: 0.8731** (baseline: 0.8326, **+0.0405** — much worse)

### Surface MAE

| Split | Ux | Uy | p | Δp vs baseline |
|---|---|---|---|---|
| in_dist | 5.40 | 2.04 | **18.05** | +0.11 ≈ |
| ood_cond | 3.32 | 1.31 | **14.85** | +0.87 ✗ |
| ood_regime | 2.89 | 1.17 | **28.17** | +0.63 ✗ |
| tandem | 5.76 | 2.39 | **39.17** | +2.44 ✗ |

**mean3** (in / ood_c / tan surf_p): **(18.05 + 14.85 + 39.17) / 3 = 24.02** vs baseline 22.82 — **worse by 1.20**

### Volume MAE (p)

| Split | vol_p |
|---|---|
| in_dist | 18.72 |
| ood_cond | 12.10 |
| ood_regime | 46.84 |
| tandem | 37.93 |

**Peak memory:** ~74 GB (77% of 96 GB)

### What happened

The combination is worse than either change individually. The tandem regression (+2.44 on surf_p) is extreme — worse than either the standalone curriculum fix or standalone warmup 15 produced.

The hypothesis of synergy was wrong. The extended warmup (15 epochs) doesn't soften the transition at epoch 10 — it compounds the problem. With warmup 15, the model has an even lower LR at epoch 10 when tandem samples are reintroduced (the LR is still ramping from 0.2× to 1×). This means the model can't adapt quickly enough to the new distribution of samples, causing the tandem branch to diverge.

Additionally, the threshold change (0.01 → 0.5) in the tandem curriculum may be allowing some tandem samples with intermediate gap values to slip through in epochs 0-9, creating inconsistency between what the model learns early vs. late in training.

The two changes amplify each other's negatives rather than cancelling them: the curriculum fix creates an abrupt transition at epoch 10, and the extended warmup ensures the model is maximally underpowered exactly when that transition hits.

### Suggested follow-ups
- Test the curriculum fix alone with the 0.5 threshold (vs 0.01 threshold tested in r22) to isolate the threshold effect.
- If the goal is a softer epoch-10 transition, try a soft ramp for tandem weight (e.g., tandem weight from 0 → 1 over epochs 10-20) rather than an abrupt step.
- The standalone warmup 15 result (+0.0076 overall, but ood_cond improved) is a weaker result; consider whether it's worth the added complexity.