### PR TITLE
Combo: tandem curriculum fix + target noise masking

### DIFF
--- a/train.py
+++ b/train.py
@@ -679,7 +679,9 @@ for epoch in range(MAX_EPOCHS):
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+            target_noise = noise_scale * torch.randn_like(y_norm)
+            target_noise = target_noise * mask.unsqueeze(-1).float()
+            y_norm = y_norm + target_noise
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]
@@ -710,7 +712,7 @@ for epoch in range(MAX_EPOCHS):
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.5)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface


### PR DESCRIPTION
## Hypothesis
Two correctness fixes from round 22:
1. Tandem curriculum fix (val_loss=0.8332, +0.0006): fixes tandem detection that accidentally uses Fourier PE channels instead of gap feature
2. Target noise masking (val_loss=0.8454): masks target noise to valid nodes only

Both improved in_dist and ood_cond individually (tandem fix: in_dist -0.80; noise fix: in_dist -2.1%, ood_cond -1.3%). Both regressed tandem. The tandem regressions may partially cancel: the curriculum fix changes WHEN tandem samples are trained, while the noise fix changes HOW targets are perturbed. With the curriculum fix restoring proper tandem exclusion in early epochs, the noise masking may have a cleaner signal-to-noise ratio during the critical single-foil pre-training phase.

## Instructions
Apply BOTH fixes to train.py (tandem curriculum detection fix + target noise masking).
Run with --wandb_group noam-r23-combo-tandem-noise.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run**: su3gu9ee | **Epochs**: 61 | **Peak VRAM**: 18.2 GB

| Split | val/loss | mae_surf_p |
|---|---|---|
| in_dist | 0.5755 | **18.0** |
| ood_cond | 0.6926 | **14.1** |
| ood_re | 0.5265 | **27.7** |
| tandem | 1.6071 | **38.5** |
| **combined** | **0.8504** | |

**vs baseline (0.8326)**:

| Split | Baseline mae_surf_p | This run mae_surf_p | Delta |
|---|---|---|---|
| in_dist | 17.94 | 18.0 | +0.06 (marginal) |
| ood_cond | 13.98 | 14.1 | +0.12 (slightly worse) |
| ood_re | 27.54 | 27.7 | +0.16 (slightly worse) |
| tandem | 36.73 | 38.5 | **+1.77** (worse) |
| val/loss | 0.8326 | 0.8504 | **+0.018** (worse) |

**vs individual fixes**:
| Fix | val/loss | Delta vs baseline |
|---|---|---|
| Tandem curriculum alone | 0.8332 | +0.0006 |
| Target noise masking alone | 0.8454 | +0.013 |
| **Combo (this run)** | **0.8504** | **+0.018** |

### What happened

The combo performed worse than either individual fix (+0.018 vs +0.0006 and +0.013). The two fixes don't synergize — instead they appear to interfere. The tandem curriculum fix correctly excludes tandem in epoch < 10, which changes the gradient landscape during warm-up. The target noise masking changes the noise distribution (zeros for padded nodes). The interaction of these two changes seems to disrupt training more than either does alone, particularly on tandem (+1.77 mae_surf_p).

The tandem regression pattern from target noise masking is amplified in the combo. Possibly: with correct tandem exclusion in early epochs, the model builds a cleaner single-foil representation, then the masked noise (which creates different statistics for tandem vs non-tandem samples) disrupts the tandem transfer phase.

The pre-existing visualization error appeared after training, not affecting metrics.

### Suggested follow-ups

- The tandem curriculum fix is a very small improvement (+0.0006) — may be within noise; not worth combining with other regressions
- Target noise masking alone consistently hurts; consider removing target noise entirely to see if it helps or hurts
- The tandem regression across many experiments suggests something fundamental about the training setup; focus may be better placed on understanding why tandem is consistently hard rather than adding complexity