### PR TITLE
Triple combo: tandem curriculum + Fourier PE + warmup 15

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
 )
 
 # --- wandb ---
@@ -660,9 +660,12 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
-        # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
+        # Normalize xy to [0,1] per-sample for consistent Fourier encoding (skip padded nodes)
+        xy_for_range = raw_xy.clone()
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+        xy_min = xy_for_range.amin(dim=1, keepdim=True)
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+        xy_max = xy_for_range.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
@@ -710,7 +713,7 @@ for epoch in range(MAX_EPOCHS):
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.5)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
@@ -894,9 +897,12 @@ for epoch in range(MAX_EPOCHS):
                 x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
-                # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                # Normalize xy to [0,1] per-sample for consistent Fourier encoding (skip padded nodes)
+                xy_for_range = raw_xy.clone()
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+                xy_min = xy_for_range.amin(dim=1, keepdim=True)
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+                xy_max = xy_for_range.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]


### PR DESCRIPTION
## Hypothesis
The three strongest near-misses from round 22, combined:
1. Tandem curriculum fix (val_loss=0.8332): in_dist improved by 0.80
2. Fourier PE fix (val_loss=0.8380): ood_cond improved by 0.29
3. Warmup 15 epochs (val_loss=0.8402): ood_cond improved by 4.1%

Each addresses a different aspect of the pipeline: data selection (curriculum), feature encoding (Fourier PE), and optimization trajectory (warmup). With all three fixes applied simultaneously:
- Epochs 0-9: only non-tandem samples trained (correct curriculum), with clean Fourier PE features, at a gentle ramping LR
- Epochs 10-14: tandem samples reintroduced while LR is still ramping (soft transition from warmup 15)
- Epoch 15+: full cosine decay begins with all samples and clean features

This is the highest-conviction combination. If the individual improvements are independent, the combined effect should exceed any single fix.

## Instructions
Apply ALL THREE changes to `train.py`:

**Fix 1: Tandem curriculum (lines 712-714)**
Replace:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```
With:
```python
if epoch < 10:
    is_tandem_curr = (x[:, 0, 21].abs() > 0.5)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
```

**Fix 2: Fourier PE padding — TRAINING loop (lines 663-666)**
Replace:
```python
xy_min = raw_xy.amin(dim=1, keepdim=True)
xy_max = raw_xy.amax(dim=1, keepdim=True)
```
With:
```python
xy_for_range = raw_xy.clone()
xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
xy_min = xy_for_range.amin(dim=1, keepdim=True)
xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
xy_max = xy_for_range.amax(dim=1, keepdim=True)
```

**Fix 2: Fourier PE padding — VALIDATION loop (lines 897-899)**
Apply the same xy_min/xy_max masking fix.

**Fix 3: Warmup 15 epochs**
Line 580 — Change `total_iters=10` to `total_iters=15`:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
```

Line 583 — Change the milestone from `[10]` to `[15]`:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
)
```

No other changes. Run with `--wandb_group noam-r23-triple-tandem-fourier-warmup`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run:** `q7iqoey2`  
**Epochs:** 59 (30-min timeout)  
**Peak memory:** 18.0 GB

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5988 | 6.86 | 1.95 | **17.99** | 19.46 |
| ood_cond | 0.7258 | 3.17 | 1.23 | **14.81** | 12.53 |
| ood_re | 0.5484 | 2.91 | 1.04 | 28.13 | 46.99 |
| tandem | 1.5429 | 6.78 | 2.53 | **37.39** | 36.56 |
| **combined** | **0.8540** | — | — | — | — |

**vs baseline (val_loss=0.8326, mean3=22.88):** val/loss +2.6%, mean3=23.40 (+2.2%)

Detail: in_dist +0.3%, ood_cond +5.9% (regressed), ood_re +2.1%, tandem +1.8%

### What happened

The triple combo performed worse than baseline on all metrics. This is a case of negative interaction: individually each fix showed small positive signals, but combined they hurt. Possible explanations:

1. **Warmup-curriculum interaction:** The tandem curriculum suppresses tandem samples for epochs 0-9, while warmup runs for 15 epochs. This means the model trains on non-tandem samples with a low LR through epoch 9, then suddenly starts seeing tandem samples while still in the warmup phase (epochs 10-14). This abrupt data distribution shift during the warmup period may disrupt the early representation learning.

2. **Fourier PE + longer warmup:** The Fourier PE masking fix produces different positional encodings for padded nodes (zeros instead of artifact coordinates). This changes the input distribution, and a longer warmup may actually overshoot the feature-calibration phase, spending too many gradient steps at low LR on the new feature space before converging to the cosine regime.

3. **Compounding noise from multiple changes:** Each individual fix is a small signal. When applied together, the noise from their interactions dominates. The r22 round showed only borderline improvements from each individual fix (all < 1% improvement, some marginally regressing), so their combination was always at risk of being net-negative.

### Suggested follow-ups
- **Pairwise combos:** Test tandem+fourier and tandem+warmup separately to identify which pair causes the most negative interaction.
- **Fourier PE fix only:** The Fourier PE fix seems the most mechanistically sound (correct padding logic); test it in isolation before combining.
- **Single dominant fix:** Given that none of the r22 fixes showed strong individual improvement, the current baseline may already be near a local optimum for these architectural dimensions.
