### PR TITLE
Triple combo: tandem curriculum + Fourier PE + target noise fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -661,8 +661,11 @@ for epoch in range(MAX_EPOCHS):
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
+        xy_for_range = raw_xy.clone()
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+        xy_min = xy_for_range.amin(dim=1, keepdim=True)
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+        xy_max = xy_for_range.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
@@ -679,7 +682,9 @@ for epoch in range(MAX_EPOCHS):
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
-            y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+            target_noise = noise_scale * torch.randn_like(y_norm)
+            target_noise = target_noise * mask.unsqueeze(-1).float()
+            y_norm = y_norm + target_noise
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]
@@ -710,7 +715,7 @@ for epoch in range(MAX_EPOCHS):
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.5)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
@@ -895,8 +900,11 @@ for epoch in range(MAX_EPOCHS):
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_for_range = raw_xy.clone()
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+                xy_min = xy_for_range.amin(dim=1, keepdim=True)
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+                xy_max = xy_for_range.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]


### PR DESCRIPTION
## Hypothesis
Three correctness fixes combined:
1. Tandem curriculum fix: fixes gap-feature detection
2. Fourier PE fix: excludes padding from coordinate normalization
3. Target noise masking: masks target noise to valid nodes

## Instructions
Apply ALL THREE fixes to `train.py`. Run with `--wandb_group noam-r23-triple-tandem-fourier-noise`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run:** vngm799s  
**Best epoch:** 58

### Metrics

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_p |
|-------|----------|---------|---------|--------|-------|
| in_dist | 0.5856 | 6.60 | 1.78 | **18.20** | 19.01 |
| ood_cond | 0.7225 | 3.21 | 1.15 | **14.63** | 11.80 |
| ood_re | 0.5278 | 2.91 | 1.00 | **27.72** | 46.77 |
| tandem | 1.6192 | 6.45 | 2.39 | **38.67** | 37.06 |
| **combined val/loss** | **0.8637** | | | | |

### vs Baseline

| Metric | Baseline | Experiment | Δ |
|--------|----------|------------|---|
| val/loss | 0.8326 | 0.8637 | +3.7% worse |
| in_dist surf_p | 17.94 | 18.20 | +1.5% |
| ood_cond surf_p | 13.98 | 14.63 | +4.6% |
| ood_re surf_p | 27.54 | 27.72 | +0.7% |
| tandem surf_p | 36.73 | 38.67 | +5.3% |

**Peak memory:** no OOM.

### What happened

**Negative across all splits.** The three-way combination is worse than any individual fix. The tandem regressions from each fix did compound (+5.3% vs individual fixes of ~3-4%) rather than sharing a common cause and canceling out.

The ood_cond regression (+4.6%) is also larger than expected — each individual fix was neutral-to-slightly-worse on ood_cond, but combined they show a larger degradation. This suggests the fixes interact negatively on OOD geometry.

Possible root cause: Each fix changes the effective training distribution (correct tandem detection, correct coordinate encoding, correct noise boundaries). Combined, they produce a meaningfully different training signal from what the baseline architecture was designed around. In a 30-minute run from scratch, the model may not have enough iterations to re-adapt to all three changes simultaneously.

### Suggested follow-ups

- **Apply fixes one at a time across longer horizons:** The individual results are noisy — a single fix may compound positively if the underlying architecture is re-tuned.
- **Tandem curriculum fix only:** This one showed -0.80 in the hypothesis — re-test in isolation on this branch baseline.
- **Investigate tandem regression source:** The tandem +5.3% regression across multiple fix experiments suggests the tandem samples have a different sensitivity to training signal changes. Profiling which specific change hurts tandem most would help.