### PR TITLE
Fourier PE padding fix — seed 42 rerun

### DIFF
--- a/train.py
+++ b/train.py
@@ -41,6 +41,8 @@ from data.utils import visualize
 from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
 
 torch.set_float32_matmul_precision('high')
+torch.manual_seed(42)
+torch.cuda.manual_seed_all(42)
 
 
 # ---------------------------------------------------------------------------
@@ -661,8 +663,11 @@ for epoch in range(MAX_EPOCHS):
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
+        xy_for_range = raw_xy.clone()
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+        xy_min = xy_for_range.amin(dim=1, keepdim=True)
+        xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+        xy_max = xy_for_range.amax(dim=1, keepdim=True)
         xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
         freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
@@ -895,8 +900,11 @@ for epoch in range(MAX_EPOCHS):
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_for_range = raw_xy.clone()
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
+                xy_min = xy_for_range.amin(dim=1, keepdim=True)
+                xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
+                xy_max = xy_for_range.amax(dim=1, keepdim=True)
                 xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
                 freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]


### PR DESCRIPTION
## Hypothesis
The Fourier PE fix (PR #1669) achieved val_loss=0.8380 with notable ood_cond improvement (-0.29). The overall val_loss missed baseline by +0.005, driven by tandem regression (+0.90). A different seed may shift the tandem variance enough to bring the overall metric below baseline, since the ood_cond improvement appears to be a consistent signal.

## Instructions
Apply the Fourier PE padding fix to `train.py`:

**TRAINING loop (lines 663-666)** — Replace:
```python
xy_min = raw_xy.amin(dim=1, keepdim=True)
xy_max = raw_xy.amax(dim=1, keepdim=True)
```
With:
```python
xy_for_range = raw_xy.clone()
xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('inf')
xy_min = xy_for_range.amin(dim=1, keepdim=True)
xy_for_range[~mask.unsqueeze(-1).expand_as(raw_xy)] = float('-inf')
xy_max = xy_for_range.amax(dim=1, keepdim=True)
```

**VALIDATION loop (lines 897-899)** — Apply the same fix.

**Add seed at the top of the script (after imports, before any torch calls, around line 43):**
```python
torch.manual_seed(42)
torch.cuda.manual_seed_all(42)
```

Run with `--wandb_group noam-r23-fourier-pe-seed42`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73
- Previous run (default seed): val_loss=0.8380, ood_cond=13.69

---

## Results

**W&B run:** `tk9qp2xp`
**Runtime:** ~61 epochs (20191 steps)

| Split | val/loss | surf_p | surf_Ux | surf_Uy | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| **in_dist** | 0.5717 | 17.682 | 5.222 | 1.580 | 0.936 | 0.327 | 18.482 |
| **ood_cond** | 0.6999 | 14.280 | 2.239 | 0.919 | 0.610 | 0.253 | 11.902 |
| **ood_re** | 0.5349 | 27.969 | 1.877 | 0.777 | 0.733 | 0.350 | 46.748 |
| **tandem** | 1.5887 | 38.235 | 5.424 | 2.121 | 1.697 | 0.788 | 36.677 |
| **overall val/loss** | **0.8488** | — | — | — | — | — | — |

**Baseline comparison:**
| Metric | Baseline | This run | Delta |
|---|---|---|---|
| val/loss | 0.8326 | 0.8488 | **+1.9% (worse)** |
| in_dist surf_p | 17.94 | 17.682 | -1.5% (slightly better) |
| ood_cond surf_p | 13.98 | 14.280 | +2.2% (worse) |
| ood_re surf_p | 27.54 | 27.969 | +1.6% (slightly worse) |
| tandem surf_p | 36.73 | 38.235 | +4.1% (worse) |

**vs. previous Fourier PE run (default seed, val_loss=0.8380):**
| Metric | Prev seed | Seed 42 | Delta |
|---|---|---|---|
| val/loss | 0.8380 | 0.8488 | +1.3% (worse) |
| ood_cond surf_p | 13.69 | 14.280 | +4.3% (worse) |

**What happened:** Seed 42 did not help. The overall val/loss is 1.9% worse than baseline and 1.3% worse than the default-seed Fourier PE run. Notably, ood_cond — which was the strongest improvement in the previous run (13.69 vs 13.98) — regressed to 14.28 with seed 42. The tandem split is also worse (+4.1%). This suggests the ood_cond improvement in the previous Fourier PE run was partly due to random seed variance, not a consistent signal from the fix itself. Run ended with the pre-existing visualization crash.

**Suggested follow-ups:**
- The Fourier PE fix does not consistently beat baseline by seed variation alone. Consider combining with a more impactful change (tandem curriculum, loss weights) rather than relying on seed searches.
- Multiple seeds would be needed to determine if the fix has a reliable positive effect — but given 30-min timeout constraints, a different hypothesis is likely more productive.