### PR TITLE
Warmup 15 epochs — seed 42 rerun

### DIFF
--- a/train.py
+++ b/train.py
@@ -41,6 +41,8 @@ from data.utils import visualize
 from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
 
 torch.set_float32_matmul_precision('high')
+torch.manual_seed(42)
+torch.cuda.manual_seed_all(42)
 
 
 # ---------------------------------------------------------------------------
@@ -577,10 +579,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Warmup 15 (PR #1668) achieved val_loss=0.8402 with the standout result of ood_cond surf_p=13.41 (-4.1% from baseline). The overall val_loss was +0.9% worse due to tandem regression. The ood_cond improvement is a strong and consistent signal (appeared in both round 21 and round 22 runs). A different seed may shift the tandem variance favorably.

## Instructions
In `train.py`, change the warmup schedule:

**Line 580** — Change `total_iters=10` to `total_iters=15`:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=15)
```

**Line 583** — Change the milestone from `[10]` to `[15]`:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[15]
)
```

**Add seed at the top of the script (after imports, before any torch calls, around line 43):**
```python
torch.manual_seed(42)
torch.cuda.manual_seed_all(42)
```

Run with `--wandb_group noam-r23-warmup15-seed42`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73
- Previous run (default seed): val_loss=0.8402, ood_cond=13.41

---

## Results

**W&B run:** `tt0azplp`
**Peak memory:** 17.9 GB
**Best epoch:** 61

### Metrics

| Split | val_loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 0.582 | 6.79 | 2.16 | **17.75** | 0.93 | 0.32 | 18.81 |
| ood_cond | 0.693 | 3.80 | 1.48 | **14.04** | 0.61 | 0.25 | 11.88 |
| ood_re | 0.543 | 3.39 | 1.35 | **28.11** | 0.73 | 0.35 | 46.98 |
| tandem | 1.596 | 6.22 | 2.59 | **38.84** | 1.69 | 0.79 | 37.24 |
| **combined** | **0.8534** | | | | | | |

### vs. Baseline (0.8326)

| Metric | Baseline | This run | Δ |
|--------|----------|----------|---|
| val_loss | 0.8326 | 0.8534 | +0.0208 (4.5σ worse) |
| in_dist surf_p | 17.94 | 17.75 | -0.19 ✓ |
| ood_cond surf_p | 13.98 | 14.04 | +0.06 ✗ |
| ood_re surf_p | 27.54 | 28.11 | +0.57 ✗ |
| tandem surf_p | 36.73 | 38.84 | +2.11 ✗ |

### vs. Previous warmup-15 run (no seed, val_loss=0.8402)

| Metric | No-seed run | Seed-42 run | Δ |
|--------|-------------|-------------|---|
| val_loss | 0.8402 | 0.8534 | +0.0132 worse |
| ood_cond surf_p | 13.41 | 14.04 | +0.63 (lost the signal) |

### What happened

Negative result. val/loss=0.8534 is 4.5σ worse than baseline (0.8326), and also worse than the previous no-seed warmup-15 run (0.8402). The seed42 rerun failed to reproduce the ood_cond improvement seen in the no-seed run (14.04 vs 13.41). That ood_cond improvement appears to have been noise — it does not hold across seeds. The tandem regression also remains (38.84 vs 36.73 baseline).

Conclusion: warmup-15 is not a reliable improvement. Longer warmup reduces the cosine-phase budget in the 30-minute window, which costs more than it gains.

### Suggested follow-ups

- The ood_cond signal was not robust across seeds, so warmup variations are likely exhausted.
- Consider whether the learning rate schedule itself (shape, peak value) is limiting, rather than just warmup length.
- Alternatively, focus on architectural changes (attention, pooling) given that schedule tuning has been consistently negative.