### PR TITLE
Soft-ramp tandem curriculum (fix detection + gradual reintroduction)

### DIFF
--- a/train.py
+++ b/train.py
@@ -709,10 +709,11 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
+        if epoch < 20:
+            is_tandem_curr = (x[:, 0, 21].abs() > 0.5)  # correct gap feature detection
+            tandem_ramp = min(1.0, epoch / 20.0)  # ramp from 0 to 1 over 20 epochs
+            sample_weight = torch.where(is_tandem_curr, tandem_ramp, 1.0).float()[:, None, None]
+            abs_err = abs_err * sample_weight
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 


### PR DESCRIPTION
## Hypothesis
The tandem curriculum fix (PR #1674) showed that correct gap-feature detection improves in_dist (-0.80) but regresses tandem (+0.96). The student suggested the regression is caused by a "shock" at epoch 10 when tandem samples are suddenly reintroduced at full weight. Instead of binary exclusion (0 for tandem, 1 for non-tandem) followed by sudden inclusion, use a soft ramp that gradually increases tandem sample weight from 0 to 1 over epochs 0-20.

This addresses the root cause of the tandem regression: the model needs gradual exposure to tandem complexity, not a step function. The ramp also extends the curriculum from 10 to 20 epochs, giving single-foil patterns more time to stabilize.

## Instructions
In `train.py`, replace the entire curriculum block (lines 712-715):

Replace:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
```
With:
```python
if epoch < 20:
    is_tandem_curr = (x[:, 0, 21].abs() > 0.5)  # correct gap feature detection
    tandem_ramp = min(1.0, epoch / 20.0)  # ramp from 0 to 1 over 20 epochs
    sample_weight = torch.where(is_tandem_curr, tandem_ramp, 1.0).float()[:, None, None]
    abs_err = abs_err * sample_weight
```

No other changes. Run with `--wandb_group noam-r23-tandem-soft-ramp`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run ID:** an0b5m1q  
**Best epoch:** 61 (wall-clock timeout at 30 min)  
**Peak memory:** ~18.0 GB

### Validation losses

| Split | val/loss | baseline |
|-------|----------|---------|
| Combined | **0.8444** | 0.8326 |
| val_in_dist | 0.5803 | — |
| val_tandem_transfer | 1.5922 | — |
| val_ood_cond | 0.6913 | — |
| val_ood_re | 0.5139 | — |

### Surface MAE

| Split | Ux | Uy | p | baseline p | delta |
|-------|----|----|---|------------|-------|
| val_in_dist | 5.71 | 1.63 | 18.10 | 17.94 | +0.9% |
| val_tandem_transfer | 5.29 | 2.08 | 38.36 | 36.73 | +4.4% |
| val_ood_cond | 2.46 | 0.92 | 14.16 | 13.98 | +1.3% |
| val_ood_re | 2.14 | 0.85 | **27.49** | 27.54 | **-0.2%** |

**mean3 surf_p** = (18.10 + 14.16 + 38.36) / 3 = **23.54** (baseline: 22.88, delta: +2.9%)

### Volume MAE

| Split | Ux | Uy | p |
|-------|----|----|---|
| val_in_dist | 0.94 | 0.32 | 18.31 |
| val_tandem_transfer | 1.67 | 0.79 | 36.65 |
| val_ood_cond | 0.61 | 0.25 | 11.77 |
| val_ood_re | 0.73 | 0.34 | 46.41 |

---

### What happened

**Negative result.** val/loss = 0.8444 vs baseline 0.8326 (+1.4% worse). mean3 surf_p = 23.54 vs 22.88 (+2.9% worse). Every split degraded except ood_re which was essentially flat (-0.2%).

The soft ramp extended the curriculum window from 10 to 20 epochs. With only 61 total training epochs, spending 20 epochs in partial-tandem mode is a significant fraction of the budget. The extended exclusion period means the model sees fewer tandem samples overall during training, which directly hurts tandem transfer performance (+4.4%).

The graduated re-introduction (0→1 ramp) did not smooth the "shock" enough to compensate for the reduced tandem exposure. The original 10-epoch hard cutoff appears to be a reasonable tradeoff — it excludes tandem samples just long enough to let single-foil patterns stabilize, then reintroduces them while the model still has significant gradient budget remaining.

Additionally, the detection change from `x[:, :, -8:].abs().sum() > 0.01` to `x[:, 0, 21].abs() > 0.5` may classify samples differently, potentially misidentifying some borderline tandem cases in either direction.

Note: post-training visualization crash (`RuntimeError: mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x58)`) is a pre-existing issue with the visualization path not adding Fourier PE; training metrics are unaffected.

---

### Suggested follow-ups

- **Shorter ramp (0-10 epochs)**: Keep the ramp idea but revert to 10 epochs total. A 10-epoch ramp (0→1 over epochs 0–10) would be gentler than the original hard cutoff at epoch 10, but less aggressive than extending to epoch 20.
- **Ramp with original detection**: Try the soft ramp with the original `x[:, :, -8:].abs().sum() > 0.01` detection to decouple whether the issue is the detection change or the ramp duration.
- **No curriculum at all**: The baseline without any tandem curriculum (noam-r21 baseline) may produce more consistent tandem performance. The curriculum was added to help single-foil convergence, but may not be worth the tandem cost.