### PR TITLE
Ablation: remove tandem curriculum entirely

### DIFF
--- a/train.py
+++ b/train.py
@@ -709,10 +709,6 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
-            is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -1073,6 +1069,14 @@ if best_metrics:
                 dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                raw_xy_vis = x_n[:, :, :2]
+                xy_min_vis = raw_xy_vis.amin(dim=1, keepdim=True)
+                xy_max_vis = raw_xy_vis.amax(dim=1, keepdim=True)
+                xy_norm_vis = (raw_xy_vis - xy_min_vis) / (xy_max_vis - xy_min_vis + 1e-8)
+                freqs_vis = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled_vis = xy_norm_vis.unsqueeze(-1) * freqs_vis
+                fourier_pe_vis = torch.cat([xy_scaled_vis.sin().flatten(-2), xy_scaled_vis.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_vis], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
The tandem curriculum (lines 712-715) was introduced to help the model learn single-foil patterns before tandem complexity. However, the current implementation is bugged (detects ALL samples as tandem, effectively zeroing gradients for 10 epochs). The fix from PR #1674 was essentially neutral on val_loss (+0.0006) — suggesting the curriculum itself may not be beneficial.

This ablation removes the curriculum entirely. If the curriculum is not helping (or is slightly harmful due to the epoch-10 shock when tandem samples are suddenly reintroduced), removing it should improve training efficiency and potentially val_loss by giving the model full data from epoch 0.

**Key insight:** The current bugged curriculum zeros ALL gradients for 10 epochs. The fact that the model trains well despite this suggests those 10 epochs are largely wasted. Removing the curriculum gives the model 10 more productive training epochs.

## Instructions
In `train.py`, delete the tandem curriculum block entirely (lines 712-715):

Delete these 4 lines:
```python
if epoch < 10:
    is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
    sample_mask = (~is_tandem_curr).float()[:, None, None]
    abs_err = abs_err * sample_mask
```

No other changes. Run with `--wandb_group noam-r23-remove-curriculum`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run:** q5qmcsj6

| Split | val/loss | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|---|
| val_in_dist | 0.5672 | 4.992 | 1.794 | 17.98 | 0.949 | 0.323 | 18.58 |
| val_tandem_transfer | 1.5862 | — | — | 37.9 | — | — | — |
| val_ood_cond | 0.6613 | — | — | 13.4 | — | — | — |
| val_ood_re | 0.5147 | — | — | 27.5 | — | — | — |
| **combined val/loss** | **0.8324** | | | | | | |

Baseline: val_loss=0.8326 | in_dist=17.94 | ood_cond=13.98 | ood_re=27.54 | tandem=36.73
Delta: **-0.0002** vs baseline (essentially neutral)

Peak memory: 18.2 GB

**What happened:**
Essentially neutral result. val/loss 0.8324 vs 0.8326 is indistinguishable from noise. Per-split: ood_cond surf_p improved (-0.58 Pa), tandem is slightly worse (+1.17 Pa), in_dist and ood_re are approximately equal.

This confirms the hypothesis that the tandem curriculum (in either its buggy or fixed form) has minimal effect on training outcomes. The model learns equally well from epoch 0 with full tandem data — the "wasted" 10 warm-up epochs don't meaningfully hurt (or help) final performance. The curriculum adds code complexity for no benefit and can be cleanly removed.

Note: vis pipeline Fourier PE fix also applied to prevent crash during visualization.

**Suggested follow-ups:**
- This result frees up the first 10 epochs — could invest them in a different curriculum (e.g., easier cases first sorted by Re number or geometry complexity).
- Alternatively, the curriculum slot could be used for a multi-stage LR schedule that starts higher and cools more aggressively in the first 10 epochs.