### PR TITLE
Warmup 12 epochs (midpoint between 10 and 15)

### DIFF
--- a/train.py
+++ b/train.py
@@ -577,10 +577,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=12)
 cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[12]
 )
 
 # --- wandb ---


### PR DESCRIPTION
## Hypothesis
Warmup 15 (PR #1668) improved ood_cond by 4.1% but regressed tandem by 4.1%. The tandem regression may be caused by too much delay before peak LR — tandem samples are reintroduced at epoch 10, and with warmup 15, the LR is still only at ~67% of peak. By epoch 12, the LR would be at ~87% of peak, closer to full strength.

Warmup 12 is the midpoint: longer than the current 10 (which benefits ood_cond) but shorter than 15 (which may avoid the tandem regression). This tests whether the ood_cond improvement from longer warmup can be retained while keeping the tandem penalty smaller.

## Instructions
In `train.py`, change the warmup schedule:

**Line 580** — Change `total_iters=10` to `total_iters=12`:
```python
warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=12)
```

**Line 583** — Change the milestone from `[10]` to `[12]`:
```python
scheduler = torch.optim.lr_scheduler.SequentialLR(
    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[12]
)
```

No other changes. Run with `--wandb_group noam-r23-warmup12`.

## Baseline
- **val_loss = 0.8326**
- in_dist surf_p = 17.94
- ood_cond surf_p = 13.98
- ood_re surf_p = 27.54
- tandem surf_p = 36.73

---

## Results

**W&B run:** 9prxjk75 (`senku/warmup-12-epochs`, group: `noam-r23-warmup12`)
**Epochs completed:** 57 (30-min timeout; loss still improving at end)
**Peak memory:** N/A (not logged)

### Metrics (best = final epoch)

| Split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|---|---|---|---|---|---|---|
| val_in_dist | 7.33 | 2.04 | **17.81** | 0.95 | 0.33 | 18.84 |
| val_ood_cond | 4.20 | 1.20 | **14.65** | 0.63 | 0.26 | 12.28 |
| val_ood_re | 3.78 | 1.04 | **28.05** | 0.75 | 0.35 | 46.71 |
| val_tandem | 6.45 | 2.30 | **39.23** | 1.72 | 0.81 | 37.79 |

**val/loss:** 0.8644 (baseline: 0.8326, **+0.0318 — worse**)

### Comparison vs baseline (surf_p)

| Split | Baseline | Result | Delta |
|---|---|---|---|
| in_dist | 17.94 | 17.81 | -0.13 (improved) |
| ood_cond | 13.98 | 14.65 | +0.67 (worse) |
| ood_re | 27.54 | 28.05 | +0.51 (worse) |
| tandem | 36.73 | 39.23 | +2.50 (much worse) |
| mean3 (in+ood+re) | 19.82 | 20.17 | +0.35 (worse) |

### What happened

Negative result. Warmup 12 failed to achieve the hoped-for balance. The hypothesis predicted it would improve ood_cond (like warmup 15) while keeping tandem regression small (unlike warmup 15). Instead, it made ood_cond worse (+0.67 vs baseline) and the tandem penalty was the largest we've seen in this warmup ablation (+2.50). val/loss rose +0.0318 from baseline.

Comparing warmup 10 (baseline) vs warmup 12 (this): all splits degraded except in_dist surf_p which improved marginally (-0.13). This is consistent with a pattern where longer warmup hurts OOD generalization rather than helping it — the additional 2 epochs of sub-peak LR may be enough to lock the model into a narrower in-distribution optimum before it learns the broader OOD structure.

The tandem regression (+2.50) is especially puzzling given that tandem samples are reintroduced at epoch 10, so the model has 2+ full-LR epochs of tandem training even with warmup 12. The cause may be that tandem generalization is sensitive to early-training dynamics in ways not fully captured by the warmup schedule alone.

Note: the run completed 57 epochs vs the baseline's likely 60+, so the model is slightly further from convergence. However, the magnitude of degradation (+0.0318 val/loss) is too large to attribute to this difference.

### Suggested follow-ups

- The warmup ablation pattern (10=best, 12/15=worse) suggests the default warmup=10 is already well-tuned. Consider dropping this line of investigation.
- If ood_cond improvement is the goal, look for complementary approaches (e.g., data augmentation for OOD conditions, or OOD-specific loss weighting) rather than warmup schedule changes.
- The tandem split consistently degrades with warmup changes, suggesting it may be sensitive to early LR dynamics that weren't captured in this hypothesis.