### PR TITLE
Reduced input noise 0.02 (from 0.05)

### DIFF
--- a/train.py
+++ b/train.py
@@ -669,7 +669,7 @@ for epoch in range(MAX_EPOCHS):
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+            noise_scale = 0.02 * (1 - epoch / 60)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)


### PR DESCRIPTION
## Hypothesis
With the coarse pooling and dist_feat fixes, the model gets cleaner training signals. Less input noise (0.02 instead of 0.05) may allow it to learn finer features.
## Instructions
Change `noise_scale = 0.05 * (1 - epoch / 60)` to `noise_scale = 0.02 * (1 - epoch / 60)`. Run with `--wandb_group reduced-noise-002`.
## Baseline
val_loss=0.8326 | in=17.94 | ood_c=13.98 | ood_r=27.54 | tan=36.73
---
## Results

**W&B run:** r6h7ec6s  
**Epochs completed:** 59 (timeout at 30 min)

| Split | val/loss | Surf Ux | Surf Uy | Surf p | Vol Ux | Vol Uy | Vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| in_dist | 0.5920 | 5.52 | 1.94 | 18.60 | 1.01 | 0.34 | 20.64 |
| ood_cond | 0.7178 | 2.88 | 1.05 | 14.72 | 0.65 | 0.26 | 12.08 |
| ood_re | 0.5421 | 2.41 | 0.89 | 28.02 | 0.75 | 0.36 | 46.70 |
| tandem | 1.6369 | 5.81 | 2.34 | 39.41 | 1.77 | 0.83 | 37.52 |
| **val/loss** | **0.8722** | | | | | | |

**vs baseline:** 0.8722 vs 0.8326 (+4.8% worse)

Surf MAE totals: in=26.06, ood_c=18.65, ood_r=31.32, tan=47.56  
Baseline:        in=17.94, ood_c=13.98, ood_r=27.54, tan=36.73

**Peak memory:** ~29 min runtime (1749s), well within 30-min budget.

### What happened

Reducing noise from 0.05→0.02 made training significantly worse — 4.8% above baseline. The model is still converging at epoch 59 (loss curve: 0.8878→0.8825→0.8775→0.8739→0.8722, ~0.004/epoch), but the trajectory suggests it would need ~100 more epochs to reach baseline 0.8326, which is far outside the 30-min budget.

The in_dist Ux MAE is unusually high (5.52 vs baseline ~2-3), a pattern seen in most experiments that underperform relative to baseline. This suggests the model is struggling with in-distribution generalization more than anything else.

Input noise at 0.05 likely acts as regularization — reducing it may have removed a beneficial training-time augmentation that helped the model generalize. With cleaner (less noisy) inputs, the model may be overfitting or finding a harder optimization landscape.

### Suggested follow-ups

- Try increasing noise (0.08–0.10) to see if more regularization helps
- Annealed noise schedule that starts higher (0.08) and decays to near-zero, rather than a fixed linear schedule
- Investigate why in_dist Ux MAE is consistently elevated across many experiments — may indicate a systematic issue with that split
