### PR TITLE
Phase 2: Depth × Width Scaling Grid (8 parallel experiments)

### DIFF
--- a/train.py
+++ b/train.py
@@ -405,8 +405,8 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-MAX_TIMEOUT = 30.0  # minutes
-MAX_EPOCHS = 100
+MAX_TIMEOUT = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "180"))
+MAX_EPOCHS = int(os.environ.get("SENPAI_MAX_EPOCHS", "500"))
 
 
 @dataclass
@@ -421,6 +421,20 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    # Architecture
+    n_layers: int = 1
+    n_hidden: int = 192
+    n_head: int = 3
+    slice_num: int = 48
+    # Schedule
+    warmup_iters: int = 10
+    cosine_t_max: int = 62
+    ema_start_epoch: int = 40
+    temp_anneal_epoch: int = 50
+    vol_ramp_end: int = 40
+    tandem_curr_end: int = 10
+    noise_anneal_denom: int = 60
+    hard_mining_epoch: int = 30
 
 
 cfg = sp.parse(Config)
@@ -520,10 +534,10 @@ model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE
     out_dim=3,
-    n_hidden=192,  # regime-w: full width with finer routing
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
-    n_head=3,
-    slice_num=48,  # regime-h: more slices for finer spatial decomposition
+    n_hidden=cfg.n_hidden,
+    n_layers=cfg.n_layers,
+    n_head=cfg.n_head,
+    slice_num=cfg.slice_num,
     mlp_ratio=2,
     output_fields=["Ux", "Uy", "p"],
     output_dims=[1, 1, 1],
@@ -536,7 +550,6 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
 ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())
@@ -577,10 +590,10 @@ base_opt = torch.optim.AdamW([
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
 optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
+warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=cfg.warmup_iters)
+cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=cfg.cosine_t_max, eta_min=5e-5)
 scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
+    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[cfg.warmup_iters]
 )
 
 # --- wandb ---
@@ -668,14 +681,14 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+        if model.training and epoch < cfg.noise_anneal_denom:
+            noise_scale = 0.05 * (1 - epoch / max(cfg.noise_anneal_denom, 1))
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_progress = min(1.0, epoch / 60)
+            noise_progress = min(1.0, epoch / max(cfg.noise_anneal_denom, 1))
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
@@ -709,7 +722,7 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
+        if epoch < cfg.tandem_curr_end:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
@@ -717,9 +730,9 @@ for epoch in range(MAX_EPOCHS):
         surf_mask = mask & is_surface
 
         # Progressive resolution: subsample volume nodes in loss early in training
-        # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+        # Ramps from 10% → 100% of volume nodes over first vol_ramp_end epochs
+        if epoch < cfg.vol_ramp_end:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / max(cfg.vol_ramp_end, 1))
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)
@@ -737,8 +750,8 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
-        # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
-        if epoch >= 30:
+        # Asymmetric hard-node mining for non-tandem samples after hard_mining_epoch (vectorized)
+        if epoch >= cfg.hard_mining_epoch:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
@@ -837,7 +850,7 @@ for epoch in range(MAX_EPOCHS):
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
-        if epoch >= ema_start_epoch:
+        if epoch >= cfg.ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
             else:
@@ -853,7 +866,7 @@ for epoch in range(MAX_EPOCHS):
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
     scheduler.step()
-    if epoch >= 50:
+    if epoch >= cfg.temp_anneal_epoch:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
     epoch_vol /= n_batches


### PR DESCRIPTION
## Hypothesis
The single biggest Phase 1 constraint was **n_layers=1**, chosen purely for throughput (more epochs in 30 minutes). With 3 hours of training, deeper and wider models should significantly outperform the current architecture. The original Transolver used 5 layers; our 1-layer model was a speed-accuracy tradeoff. More layers = more representational capacity for complex flow interactions, especially tandem wake dynamics.

## Instructions

**CRITICAL: All experiments must change these constants at the top of train.py:**
```python
MAX_TIMEOUT = 180.0  # 3 hours instead of 30 min
MAX_EPOCHS = 500     # Allow more epochs
```

Run 8 experiments in parallel, one per GPU. Each experiment varies `n_layers` and/or `n_hidden` in `model_config`, with schedules scaled proportionally to the estimated epoch count.

### Common schedule adjustments (scale proportionally to est. epochs)
For each configuration, estimate epochs = `180 * 60 / epoch_time_seconds`. Then set:
- `warmup total_iters = max(10, int(0.1 * est_epochs))`
- `cosine T_max = est_epochs - warmup`
- `ema_start_epoch = int(0.6 * est_epochs)`
- Temperature annealing epoch: change `if epoch >= 50` to `if epoch >= int(0.7 * est_epochs)`
- Progressive volume ramp: change `if epoch < 40` to `if epoch < int(0.4 * est_epochs)` and scale denominator
- Tandem curriculum: change `if epoch < 10` to `if epoch < int(0.1 * est_epochs)`
- Noise annealing: change `epoch / 60` to `epoch / int(0.6 * est_epochs)` everywhere

### GPU 0: n_layers=2, n_hidden=192 (baseline deeper)
`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "frieren/p2-L2-H192" --wandb_group "phase2-depth-width" --agent frieren`

### GPU 1: n_layers=3, n_hidden=192
`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "frieren/p2-L3-H192" --wandb_group "phase2-depth-width" --agent frieren`

### GPU 2: n_layers=4, n_hidden=192
`CUDA_VISIBLE_DEVICES=2 python train.py --wandb_name "frieren/p2-L4-H192" --wandb_group "phase2-depth-width" --agent frieren`

### GPU 3: n_layers=2, n_hidden=256
`CUDA_VISIBLE_DEVICES=3 python train.py --wandb_name "frieren/p2-L2-H256" --wandb_group "phase2-depth-width" --agent frieren`

### GPU 4: n_layers=2, n_hidden=320
`CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "frieren/p2-L2-H320" --wandb_group "phase2-depth-width" --agent frieren`

### GPU 5: n_layers=4, n_hidden=256
`CUDA_VISIBLE_DEVICES=5 python train.py --wandb_name "frieren/p2-L4-H256" --wandb_group "phase2-depth-width" --agent frieren`

### GPU 6: n_layers=2, n_hidden=192, slice_num=64
`CUDA_VISIBLE_DEVICES=6 python train.py --wandb_name "frieren/p2-L2-S64" --wandb_group "phase2-depth-width" --agent frieren`

### GPU 7: n_layers=2, n_hidden=192, slice_num=96
`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "frieren/p2-L2-S96" --wandb_group "phase2-depth-width" --agent frieren`

**Important**: The `fun_dim` in model_config stays the same (X_DIM - 2 + 2 + 32 = 56). Only `n_hidden`, `n_layers`, `n_head`, and `slice_num` change.

## Baseline
Current best metrics (Phase 1, noam HEAD, n_layers=1, n_hidden=192):
| Metric | Value |
|--------|-------|
| val/loss | 0.833 |
| p_in (in-dist surf_p MAE) | 17.9 Pa |
| p_oodc (OOD cond surf_p MAE) | 14.0 Pa |
| p_tan (tandem surf_p MAE) | 36.7 Pa |
| p_re (OOD Re surf_p MAE) | 27.5 Pa |

---

## Results

### Implementation note
All 8 schedule/architecture hyperparameters were made CLI-configurable in `train.py` (new flags: `--n_layers`, `--n_hidden`, `--n_head`, `--slice_num`, `--warmup_iters`, `--cosine_t_max`, `--ema_start_epoch`, `--temp_anneal_epoch`, `--vol_ramp_end`, `--tandem_curr_end`, `--noise_anneal_denom`, `--hard_mining_epoch`). This allows all 8 experiments to run in parallel with proportionally scaled schedules without separate train.py copies. End-of-run visualization errored (missing Fourier PE in vis code — pre-existing bug); training metrics were fully logged to W&B.

### Summary table

| Config | val/loss | p_in (Pa) | p_oodc (Pa) | p_tan (Pa) | p_re (Pa) | Epochs | Peak GB | W&B run |
|--------|----------|-----------|-------------|------------|-----------|--------|---------|---------|
| **Baseline** (L1-H192-S48) | 0.833 | 17.9 | 14.0 | 36.7 | 27.5 | — | — | — |
| L2-H192-S48 | **0.729** | 14.7 | 11.0 | 36.9 | 25.6 | 246 | 26.5 | re9l7qfk |
| L3-H192-S48 | 0.735 | 15.5 | **10.7** | 36.6 | 25.8 | 164 | 33.1 | 9bu9et39 |
| L4-H192-S48 | 0.942 | 19.8 | 14.2 | 44.2 | 27.6 | 142 | 39.6 | c9lucb3x |
| L2-H256-S48 | 0.733 | **14.6** | 10.9 | 37.2 | 25.7 | 195 | 34.2 | 8z7lipfj |
| L2-H320-S48 | 0.733 | 14.9 | 10.9 | 36.7 | 25.9 | 154 | 42.4 | 93hbequs |
| L4-H256-S48 | 1.003 | 19.7 | 16.4 | 45.6 | 29.2 | 96 | 51.1 | 62x4gznj |
| **L2-H192-S64** | **0.729** | 15.0 | 11.0 | 36.5 | 25.7 | 224 | **26.2** | zaq7s3h3 |
| L2-H192-S96 | 0.732 | 15.1 | 11.2 | **36.2** | 26.0 | 198 | 29.6 | fziz60ks |

### In-distribution MAE detail (best checkpoint, val_in_dist)
| Config | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|--------|---------|---------|--------|--------|--------|-------|
| L2-H192 | 1.74 m/s | 0.67 m/s | 14.7 Pa | 0.70 m/s | 0.23 m/s | 14.7 Pa |
| L2-S64  | 1.75 m/s | 0.67 m/s | 15.0 Pa | 0.70 m/s | 0.24 m/s | 14.7 Pa |

### What happened

**n_layers=2 is the clear winner.** Every 2-layer config beat the 1-layer baseline by a large margin (~12–14% on val/loss: 0.729–0.733 vs 0.833). The hypothesis was correct — depth was the bottleneck. Going from 1→2 layers gave the biggest single gain of Phase 1+2.

**n_layers=4 failed badly.** Both L4-H192 (0.942) and L4-H256 (1.003) are significantly *worse* than baseline. At 4 layers, the models are slower per epoch (~72–92 s vs ~42–57 s for 2-layer), so they only reached 96–142 epochs vs 154–246 for 2-layer. The deeper architectures need more time to converge than 3 hours allows. The train/loss for L4-H192 (0.579) vs L2-H192 (0.203) confirms the 4-layer models are still far from convergence — this is a training budget issue, not a fundamental architecture failure.

**Width scaling shows diminishing returns.** L2-H256 (0.733) and L2-H320 (0.733) barely improve over L2-H192 (0.729) while using 34–42 GB vs 26.5 GB. Not worth the memory premium.

**Slice scaling is mildly helpful at S64.** L2-S64 (val/loss=0.7294) edges out L2-H192 (0.7295) by a hair and uses slightly *less* memory (26.2 GB vs 26.5 GB), making it the best efficiency/performance tradeoff. S96 (0.732) slightly underperforms S64 — too many slices may over-fragment the routing.

**Tandem pressure is stuck.** All 2-layer models hover at 36.2–37.2 Pa for p_tan, barely different from the 36.7 Pa baseline. The tandem ceiling is the known SURFACE_IDS=(5,6) limitation (missing foil 2 boundary nodes), not model capacity. Depth and width don't help here.

**Pressure improvements elsewhere are solid.** p_in improved 18% (17.9→14.6 Pa best), p_oodc improved 24% (14.0→10.7 Pa best with L3-H192), p_re improved 7% (27.5→25.6 Pa).

### Suggested follow-ups

1. **L4 with 6h budget**: L4-H192 and L4-H256 are clearly undertrained (train/loss still 0.58 at end). Run them for 6 hours — if they converge past the 2-layer configs, deeper architectures may be worth it for a final model.
2. **L2-H256-S64 combined**: Try n_layers=2, n_hidden=256, slice_num=64 — combining modest width boost with routing improvement. The individual gains are small but may combine.
3. **L3-H192 deserves more time**: At 164 epochs it beats all 2-layer configs on p_oodc (10.7 Pa) and is essentially tied on val/loss. 6 hours may pull it ahead.
4. **Tandem surface fix**: Adding boundary ID 7 (foil 2 surface) to SURFACE_IDS would directly improve p_tan — this is the primary ceiling.
5. **Recommended next default**: **L2-S64** (run zaq7s3h3) — best val/loss, lowest memory, good convergence. Recommended base for Phase 3.