### PR TITLE
Phase 2: Training Schedule Optimization for 3-Hour Runs (8 parallel experiments)

### DIFF
--- a/train.py
+++ b/train.py
@@ -405,8 +405,8 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-MAX_TIMEOUT = 30.0  # minutes
-MAX_EPOCHS = 100
+MAX_TIMEOUT = 180.0  # minutes
+MAX_EPOCHS = 500
 
 
 @dataclass
@@ -421,6 +421,26 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    # Schedule params (tuned for 3-hour / 500-epoch runs)
+    warmup_total_iters: int = 20
+    warmup_start_factor: float = 0.2
+    cosine_T_max: int = 200
+    cosine_eta_min: float = 1e-5
+    ema_start_epoch: int = 40
+    ema_decay: float = 0.998
+    temp_anneal_epoch: int = 50
+    vol_ramp_epochs: int = 40
+    tandem_curriculum_epochs: int = 10
+    noise_anneal_epochs: int = 60
+    scheduler_type: str = "sequential"  # "sequential", "warm_restarts", "onecycle"
+    cosine_T_0: int = 50       # warm_restarts only
+    cosine_T_mult: int = 2     # warm_restarts only
+    onecycle_max_lr: float = 3e-3        # onecycle only
+    onecycle_epochs: int = 200           # onecycle only
+    onecycle_pct_start: float = 0.15    # onecycle only
+    onecycle_div_factor: float = 10.0   # onecycle only
+    onecycle_final_div_factor: float = 100.0  # onecycle only
+    use_lookahead: bool = True
 
 
 cfg = sp.parse(Config)
@@ -521,7 +541,7 @@ model_config = dict(
     fun_dim=X_DIM - 2 + 2 + 32,  # +1 curv, +1 dist_feat, +32 fourier PE
     out_dim=3,
     n_hidden=192,  # regime-w: full width with finer routing
-    n_layers=1,       # was 2 — 1 layer for maximum epochs in 30 min
+    n_layers=2,
     n_head=3,
     slice_num=48,  # regime-h: more slices for finer spatial decomposition
     mlp_ratio=2,
@@ -536,8 +556,6 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
 ema_model = None
-ema_start_epoch = 40
-ema_decay = 0.998
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -576,12 +594,40 @@ base_opt = torch.optim.AdamW([
     {'params': attn_params, 'lr': cfg.lr * 0.5},
     {'params': other_params, 'lr': cfg.lr}
 ], weight_decay=cfg.weight_decay)
-optimizer = Lookahead(base_opt, k=10, alpha=0.8)
-warmup_scheduler = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.2, total_iters=10)
-cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_opt, T_max=62, eta_min=5e-5)
-scheduler = torch.optim.lr_scheduler.SequentialLR(
-    base_opt, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[10]
-)
+if cfg.use_lookahead:
+    optimizer = Lookahead(base_opt, k=10, alpha=0.8)
+else:
+    optimizer = base_opt
+if cfg.scheduler_type == "warm_restarts":
+    _warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
+    _restarts = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+        base_opt, T_0=cfg.cosine_T_0, T_mult=cfg.cosine_T_mult, eta_min=cfg.cosine_eta_min
+    )
+    scheduler = torch.optim.lr_scheduler.SequentialLR(
+        base_opt, schedulers=[_warmup, _restarts], milestones=[10]
+    )
+elif cfg.scheduler_type == "onecycle":
+    scheduler = torch.optim.lr_scheduler.OneCycleLR(
+        base_opt,
+        max_lr=[cfg.onecycle_max_lr * 0.5, cfg.onecycle_max_lr],
+        epochs=cfg.onecycle_epochs,
+        steps_per_epoch=len(train_loader),
+        pct_start=cfg.onecycle_pct_start,
+        div_factor=cfg.onecycle_div_factor,
+        final_div_factor=cfg.onecycle_final_div_factor,
+    )
+else:  # sequential (default)
+    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+        base_opt, start_factor=cfg.warmup_start_factor, total_iters=cfg.warmup_total_iters
+    )
+    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        base_opt, T_max=cfg.cosine_T_max, eta_min=cfg.cosine_eta_min
+    )
+    scheduler = torch.optim.lr_scheduler.SequentialLR(
+        base_opt, schedulers=[warmup_scheduler, cosine_scheduler],
+        milestones=[cfg.warmup_total_iters]
+    )
+step_scheduler_per_batch = (cfg.scheduler_type == "onecycle")
 
 # --- wandb ---
 run = wandb.init(
@@ -668,14 +714,14 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
-        if model.training and epoch < 60:
-            noise_scale = 0.05 * (1 - epoch / 60)
+        if model.training and epoch < cfg.noise_anneal_epochs:
+            noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
         y_phys = _phys_norm(y, Umag, q)
         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training:
-            noise_progress = min(1.0, epoch / 60)
+            noise_progress = min(1.0, epoch / cfg.noise_anneal_epochs)
             vel_noise = 0.015 * (1 - noise_progress) + 0.003 * noise_progress
             p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
@@ -709,7 +755,7 @@ for epoch in range(MAX_EPOCHS):
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if epoch < 10:
+        if epoch < cfg.tandem_curriculum_epochs:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
@@ -718,8 +764,8 @@ for epoch in range(MAX_EPOCHS):
 
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
-        if epoch < 40:
-            vol_keep_ratio = 0.05 + 0.95 * (epoch / 40)
+        if epoch < cfg.vol_ramp_epochs:
+            vol_keep_ratio = 0.05 + 0.95 * (epoch / cfg.vol_ramp_epochs)
             vol_indices = vol_mask.nonzero(as_tuple=False)
             n_vol = vol_indices.shape[0]
             n_keep = max(int(n_vol * vol_keep_ratio), 1)
@@ -837,13 +883,18 @@ for epoch in range(MAX_EPOCHS):
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         optimizer.step()
-        if epoch >= ema_start_epoch:
+        if step_scheduler_per_batch:
+            try:
+                scheduler.step()
+            except ValueError:
+                pass
+        if epoch >= cfg.ema_start_epoch:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
             else:
                 with torch.no_grad():
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
+                        ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -852,8 +903,9 @@ for epoch in range(MAX_EPOCHS):
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
-    scheduler.step()
-    if epoch >= 50:
+    if not step_scheduler_per_batch:
+        scheduler.step()
+    if epoch >= cfg.temp_anneal_epoch:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
     epoch_vol /= n_batches


### PR DESCRIPTION
## Hypothesis
All epoch-dependent schedules in the current code were tuned for ~70 epochs in 30 minutes. With 3 hours (6x budget), we need to find the optimal training recipe for longer runs. The LR schedule, warmup length, EMA timing, and curriculum epochs all need recalibration. This PR sweeps the key schedule dimensions at n_layers=2, n_hidden=192 (the reference deeper configuration).

## Instructions

**CRITICAL: All experiments must change these constants at the top of train.py:**
```python
MAX_TIMEOUT = 180.0  # 3 hours
MAX_EPOCHS = 500
n_layers = 2         # in model_config (was 1)
```

All 8 experiments use n_layers=2, n_hidden=192, slice_num=48 (the "baseline deeper" architecture). Only training schedules vary.

### GPU 0: Conservative long schedule
```python
# warmup: LinearLR start_factor=0.1, total_iters=30
# cosine: T_max=200, eta_min=1e-5
# ema_start_epoch = 130
# temp_anneal epoch >= 150
# volume ramp: epoch < 80 (scale to 80/40 ratio)
# tandem curriculum: epoch < 25
# noise annealing: epoch / 130
lr = 2.6e-3  # keep current
```
`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "fern/p2-schedule-conservative" --wandb_group "phase2-schedules" --agent fern`

### GPU 1: Aggressive warmup, tight cosine
```python
# warmup: total_iters=40, start_factor=0.05
# cosine: T_max=180, eta_min=5e-5
# ema_start_epoch = 100
# temp_anneal epoch >= 120
lr = 2.6e-3
```
`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "fern/p2-schedule-aggr-warmup" --wandb_group "phase2-schedules" --agent fern`

### GPU 2: Lower LR for longer convergence
```python
lr = 1.5e-3  # lower for longer training
# warmup: total_iters=20, start_factor=0.2
# cosine: T_max=200, eta_min=1e-5
# ema_start_epoch = 120
```
`CUDA_VISIBLE_DEVICES=2 python train.py --wandb_name "fern/p2-lr1.5e-3" --wandb_group "phase2-schedules" --agent fern`

### GPU 3: Much lower LR
```python
lr = 5e-4  # classic DL learning rate
# warmup: total_iters=15, start_factor=0.3
# cosine: T_max=250, eta_min=1e-6
# ema_start_epoch = 150
```
`CUDA_VISIBLE_DEVICES=3 python train.py --wandb_name "fern/p2-lr5e-4" --wandb_group "phase2-schedules" --agent fern`

### GPU 4: Cosine warm restarts (SGDR-style)
```python
# Replace SequentialLR with CosineAnnealingWarmRestarts:
# T_0=50, T_mult=2 (restarts at epoch 50, 150, 350...)
# Keep warmup for first 10 epochs, then switch to warm restarts
# eta_min=1e-5
lr = 2e-3
```
`CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "fern/p2-warm-restarts" --wandb_group "phase2-schedules" --agent fern`

### GPU 5: OneCycleLR
```python
# Replace scheduler with OneCycleLR:
# max_lr=3e-3, epochs=200, steps_per_epoch=len(train_loader)
# pct_start=0.15, div_factor=10, final_div_factor=100
# Remove separate warmup scheduler
```
`CUDA_VISIBLE_DEVICES=5 python train.py --wandb_name "fern/p2-onecycle" --wandb_group "phase2-schedules" --agent fern`

### GPU 6: Early EMA (start earlier, longer averaging)
```python
# ema_start_epoch = 30 (very early)
# ema_decay = 0.999 (slower averaging)
# Standard schedule otherwise: warmup=20, T_max=200
lr = 2.6e-3
```
`CUDA_VISIBLE_DEVICES=6 python train.py --wandb_name "fern/p2-early-ema" --wandb_group "phase2-schedules" --agent fern`

### GPU 7: No Lookahead ablation
```python
# Remove Lookahead wrapper — use raw AdamW directly
# optimizer = base_opt (not Lookahead(base_opt))
# Standard schedule: warmup=20, T_max=200
lr = 2.6e-3
```
`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "fern/p2-no-lookahead" --wandb_group "phase2-schedules" --agent fern`

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.833 |
| p_in | 17.9 Pa |
| p_oodc | 14.0 Pa |
| p_tan | 36.7 Pa |
| p_re | 27.5 Pa |

---
## Results

All 8 experiments ran for the full 3 hours (~250 epochs each). All beat the baseline.

### Per-experiment summary

| GPU | Experiment | val/loss | p_in | p_oodc | p_tan | p_re | Best Epoch | W&B Run |
|-----|------------|----------|------|--------|-------|------|------------|---------|
| 0 | Conservative long | 0.7290 | 14.5 | 11.0 | 37.0 | 25.6 | 250 | [htywsu4a](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/htywsu4a) |
| 1 | Aggr warmup | 0.7275 | 14.8 | 11.0 | 36.6 | 25.9 | 249 | [kwurqx0f](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/kwurqx0f) |
| 2 | lr=1.5e-3 | **0.7097** | 14.6 | **10.0** | **35.6** | 25.9 | 250 | [wb9clpjb](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/wb9clpjb) |
| 3 | lr=5e-4 | 0.7522 | 15.5 | 9.8 | 37.8 | 26.0 | 252 | [yml208qw](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/yml208qw) |
| 4 | Warm restarts | 0.7320 | 14.8 | 10.6 | 36.6 | 25.8 | **160** | [agcu721v](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/agcu721v) |
| 5 | OneCycleLR | 0.7415 | 14.6 | 10.9 | 37.9 | 25.9 | 245 | [0491bl6t](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/0491bl6t) |
| 6 | Early EMA | 0.7334 | 15.0 | 10.9 | 37.2 | 25.9 | 245 | [5o0p34ap](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/5o0p34ap) |
| 7 | No Lookahead | 0.7466 | 16.0 | 10.9 | 37.4 | 25.8 | 246 | [0k4hvpi3](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/0k4hvpi3) |
| — | **Baseline** | **0.833** | 17.9 | 14.0 | 36.7 | 27.5 | — | — |

### Best run detail: GPU2 lr=1.5e-3 (W&B: wb9clpjb)

| Split | val/loss | surf Ux | surf Uy | surf p | vol Ux | vol Uy | vol p |
|-------|----------|---------|---------|--------|--------|--------|-------|
| val_in_dist | 0.452 | 2.09 m/s | 0.84 m/s | 14.6 Pa | 0.648 | 0.227 | 14.0 Pa |
| val_tandem_transfer | 1.469 | 2.73 m/s | 1.24 m/s | 35.6 Pa | 1.422 | 0.658 | 33.6 Pa |
| val_ood_cond | 0.491 | 1.55 m/s | 0.55 m/s | 10.0 Pa | 0.435 | 0.175 | 8.1 Pa |
| val_ood_re | 0.428 | 1.56 m/s | 0.52 m/s | 25.9 Pa | 0.587 | 0.297 | 44.6 Pa |

Peak memory: ~27 GB (all GPUs similar)

### What happened

**It worked. All 8 variants beat the baseline significantly** (0.71-0.75 vs 0.833), confirming that 3-hour budget with n_layers=2 is a meaningful step forward.

**LR is the dominant factor.** GPU2 (lr=1.5e-3) was the clear winner at 0.7097. The default 2.6e-3 was tuned for 30-min runs; at 250 epochs it overshoots. Going lower to 5e-4 (GPU3) degrades Ux accuracy badly (surf_Ux 5-6 m/s vs 2-3 m/s for others), suggesting underpowered training.

**Lookahead helps.** GPU7 (no Lookahead, same schedule as GPU2) scored 0.7466 vs 0.7097 -- a ~5% degradation. Worth keeping.

**Warm restarts peaked at epoch 160** (GPU4) and didn't improve for 90 more epochs. T_0=50 fires too frequently for this run length; the model converged inside the first two cycles.

**OneCycleLR slightly underperforms** (0.7415). Schedule exhausted at epoch 200, leaving ~45 epochs at minimum LR.

**Conservative vs aggressive warmup** (GPU0 vs GPU1: 0.7290 vs 0.7275) -- nearly identical. Warmup shape doesn't matter at this scale.

**Early EMA** (GPU6, 0.7334) -- starting at epoch 30 vs 40 made little difference.

**Visualization bug** (pre-existing): all runs crashed at the post-training plot step due to missing Fourier PE in the vis inference path. Training metrics are unaffected.

### Suggested follow-ups

1. **lr=1.5e-3 is the new default for 3-hour runs** -- next sweeps should use this as baseline.
2. **Tighten LR**: try 1.0e-3 and 2.0e-3 to bracket the optimum.
3. **Warm restarts with longer cycles**: T_0=100, T_mult=2 may suit 250-epoch runs better.
4. **Fix vis bug**: vis inference path needs the same Fourier PE preprocessing as training.
5. **Confirm lookahead benefit at lr=1.5e-3**: GPU7 used 2.6e-3 so the comparison is not clean.
