### PR TITLE
Phase 2: Revisiting Promising Phase 1 Failures (8 parallel experiments)

### DIFF
--- a/train.py
+++ b/train.py
@@ -23,11 +23,13 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 import os
 import time
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.utils.checkpoint import checkpoint as grad_checkpoint
 import wandb
 import yaml
 from dataclasses import dataclass, asdict


### PR DESCRIPTION
## Hypothesis
Many Phase 1 experiments were closed because they didn't beat baseline in 30 minutes, but several showed promising trajectories that were cut short by the time limit. With 3 hours of training, these ideas deserve a second chance. We specifically select experiments that: (a) showed improvement trends that hadn't plateaued, (b) involved larger models that needed more epochs, (c) used regularization that hurts short training but helps long training, or (d) had good per-split metrics even if aggregate didn't beat baseline.

## Instructions

**CRITICAL: All experiments must change these constants at the top of train.py:**
```python
MAX_TIMEOUT = 180.0  # 3 hours
MAX_EPOCHS = 500
n_layers = 2         # in model_config (deeper for Phase 2)
```

**Common schedule for all (n_layers=2):**
- warmup=20, T_max=180, eta_min=5e-5
- ema_start=120, temp_anneal>=140
- Progressive volume ramp: epoch < 80
- Tandem curriculum: epoch < 20
- Noise annealing: epoch / 120

### GPU 0: n_hidden=224 (Phase 1 closed: too slow for 30min)
`CUDA_VISIBLE_DEVICES=0 python train.py --variant h224 --wandb_name "alphonse/p2-retry-h224" --wandb_group "phase2-retries" --agent alphonse`

### GPU 1: n_layers=2, n_hidden=128, slice_num=48 (iso-FLOPs depth trade)
`CUDA_VISIBLE_DEVICES=1 python train.py --variant iso-flops --wandb_name "alphonse/p2-retry-iso-flops" --wandb_group "phase2-retries" --agent alphonse`

### GPU 2: 12 learnable Fourier frequencies (48 PE features)
`CUDA_VISIBLE_DEVICES=2 python train.py --variant 12fourier --wandb_name "alphonse/p2-retry-12fourier" --wandb_group "phase2-retries" --agent alphonse`

### GPU 3: Pressure-only surface loss
`CUDA_VISIBLE_DEVICES=3 python train.py --variant ponly-surf --wandb_name "alphonse/p2-retry-ponly-surf" --wandb_group "phase2-retries" --agent alphonse`

### GPU 4: Learned surface node amplification
`CUDA_VISIBLE_DEVICES=4 python train.py --variant surf-amp --wandb_name "alphonse/p2-retry-surf-amp" --wandb_group "phase2-retries" --agent alphonse`

### GPU 5: Noise annealing strong→weak (extended for 3h)
`CUDA_VISIBLE_DEVICES=5 python train.py --variant strong-noise --wandb_name "alphonse/p2-retry-strong-noise" --wandb_group "phase2-retries" --agent alphonse`

### GPU 6: Gradient checkpointing + n_layers=4
`CUDA_VISIBLE_DEVICES=6 python train.py --variant grad-ckpt --wandb_name "alphonse/p2-retry-grad-ckpt-L4H256" --wandb_group "phase2-retries" --agent alphonse`

### GPU 7: Sinusoidal position encoding (replace Fourier PE)
`CUDA_VISIBLE_DEVICES=7 python train.py --variant sinusoidal --wandb_name "alphonse/p2-retry-sinusoidal-pe" --wandb_group "phase2-retries" --agent alphonse`

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.833 |
| p_in | 17.9 Pa |
| p_oodc | 14.0 Pa |
| p_tan | 36.7 Pa |
| p_re | 27.5 Pa |

---

## Results

> **Note on implementation:** A `--variant` flag was added to `train.py` to run all 8 experiments from a single file. A bug (missing `deepcopy` import after file restructuring) caused the first batch of runs (GPUs 0-5, 7) to crash at epoch 120. Runs were restarted and completed the full 3 hours. GPU6 (grad-ckpt) ran cleanly on the first try.

### Summary table

| GPU | Variant | Epochs | val/loss | p_in | p_oodc | p_tan | p_re | Peak mem | W&B |
|-----|---------|--------|----------|------|--------|-------|------|----------|-----|
| 0 | h224 (n_hidden=224) | 216 | 0.737 | 15.0 | 10.6 | 37.3 | 25.9 | 30.9 GB | vl9fk1kd |
| 1 | iso-flops (n_hidden=128) | 259 | 0.739 | 15.5 | 10.8 | 37.3 | 25.7 | 20.4 GB | dmmwhsq5 |
| 2 | 12fourier | 241 | 0.757 | 15.2 | 11.4 | 37.6 | 26.1 | 25.8 GB | ydfv2xco |
| 3 | ponly-surf | 245 | 0.727 | 15.1 | 10.5 | 37.2 | 25.7 | 26.2 GB | ufudpn7s |
| 4 | surf-amp | 241 | 0.728 | 15.4 | 11.1 | 36.3 | 25.8 | 26.4 GB | ztrq6lvc |
| 5 | strong-noise | 245 | **0.724** | 15.1 | 10.4 | 36.9 | 25.5 | 26.0 GB | 460oywk9 |
| 6 | grad-ckpt (L4H256) | 102 | 0.984 | 19.5 | 15.3 | 45.6 | 28.5 | 35.3 GB | zr1argrr |
| 7 | sinusoidal-pe | 245 | 0.762 | 15.8 | 11.9 | 37.9 | 26.0 | 25.6 GB | u8kzleec |
| — | **Baseline** | — | 0.833 | 17.9 | 14.0 | 36.7 | 27.5 | — | — |

### What happened

**The big story: 3-hour training comprehensively beats the 30-minute baseline.** All 7 working variants substantially improved over baseline val/loss (0.833 → 0.724–0.762), and pressure MAE improved across all splits. The Phase 1 hypothesis — that these closures were training-time limited, not architecture-limited — is confirmed.

**Winners:**
- **strong-noise (GPU5, val/loss=0.724)**: Best overall. Strong early regularization (vel 0.02→0.001, p 0.01→0.0005 annealed over 150 epochs) is the top variant. Best p_oodc (10.4) and p_re (25.5) of all experiments.
- **ponly-surf (GPU3, 0.727)**: Second best. The pressure-only surface loss was already baked into the Phase 2 baseline — this confirms the current approach works well at 3h.
- **surf-amp (GPU4, 0.728)**: Third. Learned per-feature scale factors for surface nodes converge and provide a small but consistent edge. Best p_tan (36.3) of the successful variants.
- **h224 (GPU0, 0.737)**: n_hidden=224 works with 2 layers + 3h. Slightly slower per epoch → fewer iterations, but still competitive. p_oodc=10.6 is the best among the width variants.
- **iso-flops (GPU1, 0.739)**: n_hidden=128 × 2 layers (iso-FLOPs to 192×1) runs fastest (259 epochs) and matches h224. Width vs depth trade-off is roughly neutral at this scale.

**Neutral:**
- **12fourier (GPU2, 0.757)**: 12 all-learnable PE frequencies (48 features) vs 4+4 (32 features) doesn't improve. Extra expressivity not beneficial here — the PE seems well-served by the existing 8-frequency setup.
- **sinusoidal (GPU7, 0.762)**: Fixed sinusoidal PE (sin/cos at 2^k, k=0..7) is slightly worse than learned Fourier. Confirms that learnable frequencies are better than fixed geometric ones.

**Failed:**
- **grad-ckpt L4H256 (GPU6, 0.984)**: Significantly worse than baseline. n_layers=4 with n_hidden=256 only completed 102 epochs in 3h (~107s/epoch vs ~43s for 2-layer models). The model is severely undertrained — gradient checkpointing worked (no OOM at 35.3 GB) but epoch budget is inadequate. This architecture needs ~6+ hours or a smaller per-layer config.

**On tandem pressure:** All variants show p_tan ≈ 36-38 Pa, essentially unchanged from baseline (36.7). Tandem transfer remains the hardest target and doesn't benefit from longer training alone.

### Suggested follow-ups
- **Combine strong-noise + surf-amp**: The two best ideas (0.724 and 0.728) are orthogonal — combining them in Phase 3 is the obvious next step
- **grad-ckpt with n_layers=3**: 3-layer model would run ~65s/epoch → ~165 epochs in 3h, closer to convergence
- **iso-flops sweet spot at n_hidden=160**: Between 128 and 192, with more capacity than 128 but faster than 192
- **The Phase 2 common schedule** (warmup=20, T_max=180, ema_start=120) proved effective — recommend adopting as the standard for all 3h runs