### PR TITLE
Phase 2 R3: OOD Generalization on LinearNO (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -733,7 +733,7 @@ elif cfg.wsd_schedule:
         else:
             progress = (epoch - stable_end) / max(decay_end - stable_end, 1)
             eta_ratio = 5e-5 / cfg.lr
-            return max(eta_ratio, (1.0 - progress) ** 0.5)
+            return max(eta_ratio, max(0.0, 1.0 - progress) ** 0.5)
     scheduler = torch.optim.lr_scheduler.LambdaLR(base_opt, lr_lambda=_wsd_lambda)
 else:  # sequential cosine (default)
     warmup_scheduler = torch.optim.lr_scheduler.LinearLR(


### PR DESCRIPTION
## Hypothesis
Round 2 showed AdaLN achieves p_oodc=9.6 (best ever) and adaptive-temp gives p_oodc=9.8 — but both hurt other metrics. On the new LinearNO baseline, these OOD techniques may compound differently. This PR tests OOD generalization techniques on LinearNO.

## Instructions

**Pull latest noam (has LinearNO). All experiments:**
```python
MAX_TIMEOUT = 180.0
MAX_EPOCHS = 500
lr = 1.5e-3
weight_decay = 1e-5
n_layers = 2
```
T_max=230, ema_start=140, temp_anneal>=160. Use `--wandb_group "phase2-r3-ood"`.

### GPU 0: AdaLN on LinearNO output head
`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "tanjiro/p2r3-adaln" --wandb_group "phase2-r3-ood" --agent tanjiro`

### GPU 1: 4-group PCGrad on LinearNO
`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "tanjiro/p2r3-4group-pcgrad" --wandb_group "phase2-r3-ood" --agent tanjiro`

### GPU 2: EMA annealing on LinearNO
`CUDA_VISIBLE_DEVICES=2 python train.py --wandb_name "tanjiro/p2r3-ema-anneal" --wandb_group "phase2-r3-ood" --agent tanjiro`

### GPU 3: AdaLN + 4-group PCGrad combined
`CUDA_VISIBLE_DEVICES=3 python train.py --wandb_name "tanjiro/p2r3-adaln-pcgrad" --wandb_group "phase2-r3-ood" --agent tanjiro`

### GPU 4: SAM late-phase (last 25% of training only)
`CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "tanjiro/p2r3-sam-late" --wandb_group "phase2-r3-ood" --agent tanjiro`

### GPU 5: WSD schedule (Warmup-Stable-Decay)
`CUDA_VISIBLE_DEVICES=5 python train.py --wandb_name "tanjiro/p2r3-wsd" --wandb_group "phase2-r3-ood" --agent tanjiro`

### GPU 6: SWAD (overfit-aware weight averaging)
`CUDA_VISIBLE_DEVICES=6 python train.py --wandb_name "tanjiro/p2r3-swad" --wandb_group "phase2-r3-ood" --agent tanjiro`

### GPU 7: AdaLN + EMA annealing + WSD
`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "tanjiro/p2r3-ood-combo" --wandb_group "phase2-r3-ood" --agent tanjiro`

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.701 |
| p_in | 14.1 Pa |
| p_oodc | 10.1 Pa |
| p_tan | 35.1 Pa |
| p_re | 25.5 Pa |

---

## Results

### Summary table

| Run | Ep | val/loss | p_in | p_tan | p_oodc | p_re | VRAM | W&B |
|-----|----|----------|------|-------|--------|------|------|-----|
| **Baseline** | — | 0.701 | 14.1 | 35.1 | 10.1 | 25.5 | — | — |
| GPU0: AdaLN | 249 | 0.711 | 14.9 | 36.3 | 10.1 | 25.3 | 26.3 GB | 7ffkmd83 |
| GPU1: 4-grp-PCGrad | 252 | 0.711 | 15.0 | 36.5 | 10.1 | 25.2 | 26.6 GB | j46plfka |
| GPU2: EMA-anneal | 248 | 0.730 | 15.6 | 37.1 | 10.2 | 25.5 | 26.4 GB | ecp15z1j |
| GPU3: AdaLN+PCGrad | 249 | 0.727 | 16.8 | 38.0 | **9.8** | 25.3 | 26.6 GB | yz8rjkel |
| GPU4: SAM-late | 254 | 0.718 | 15.5 | 37.0 | 10.0 | 25.3 | 26.1 GB | th1pa4nc |
| GPU5: WSD ⚠️ | ~230 | 0.731 | 15.6 | 36.5 | 11.3 | 25.6 | 26.5 GB | pi4uccm0 |
| GPU6: SWAD ❌ | 243 | 2.675 | 66.3 | 82.6 | 57.0 | 63.1 | 26.6 GB | zhijj1i8 |
| GPU7: OOD-combo ⚠️ | ~230 | 0.737 | 18.3 | 36.5 | 10.0 | 25.6 | 26.0 GB | 7izu8oik |

⚠️ = crashed due to WSD lambda bug (progress > 1.0 → complex); results from last good epoch  
❌ = catastrophic failure (see analysis)

### Full surface MAE breakdown

| Run | split | surf_Ux | surf_Uy | surf_p | vol_p |
|-----|-------|---------|---------|--------|-------|
| GPU0-adaln | in_dist | 2.64 | 0.819 | 14.9 | 14.4 |
| | tandem | 3.43 | 1.195 | 36.3 | 34.2 |
| | oodc | 1.24 | 0.519 | 10.1 | 8.0 |
| | ood_re | 1.11 | 0.509 | 25.3 | 44.1 |
| GPU1-4grp-pcgrad | in_dist | 2.32 | 0.928 | 15.0 | 14.6 |
| | tandem | 2.74 | 1.320 | 36.5 | 34.6 |
| | oodc | 1.69 | 0.544 | 10.1 | 8.1 |
| | ood_re | 1.66 | 0.506 | 25.2 | 44.0 |
| GPU3-adaln+pcgrad | in_dist | 2.32 | 0.869 | 16.8 | 16.7 |
| | tandem | 3.00 | 1.227 | 38.0 | 36.1 |
| | oodc | 1.44 | 0.500 | **9.8** | 7.8 |
| | ood_re | 1.30 | 0.465 | 25.3 | 43.9 |
| GPU4-sam-late | in_dist | 3.50 | 1.089 | 15.5 | 15.4 |
| | tandem | 4.54 | 1.722 | 37.0 | 34.9 |
| | oodc | 1.43 | 0.626 | 10.0 | 8.1 |
| | ood_re | 1.24 | 0.557 | 25.3 | 44.1 |

### What happened

**None of the OOD techniques beat the baseline.** All functional runs show degradation on p_in (14.9–16.8 vs 14.1) and p_tan (36–38 vs 35.1). The techniques that improved OOD metrics in R2 don't transfer to LinearNO.

**GPU0 AdaLN (0.711):** Neutral. p_oodc=10.1 (no change), p_in slightly worse (14.9 vs 14.1). AdaLN adds conditioning overhead for zero gain on LinearNO.

**GPU1 4-group PCGrad (0.711):** Tied with AdaLN. Best p_re (25.2 vs 25.5 baseline), but marginal. 4 backward passes vs 2 — no accuracy benefit justifies the overhead.

**GPU2 EMA annealing (0.730):** Uniformly worse. Was p_oodc=9.9 in R2 but doesn't help on LinearNO. Starting EMA at epoch 80 (instead of 140) appears to hurt training stability.

**GPU3 AdaLN+PCGrad (0.727):** Best p_oodc=9.8 (marginally better than 10.1 baseline), but hurts p_in (16.8 vs 14.1) and p_tan (38.0 vs 35.1). Net negative overall.

**GPU4 SAM late-phase (0.718):** Neutral effect on OOD, slight degradation on p_in/p_tan. The sharpness-aware update in the last 25% of training didn't help generalization.

**GPU5 WSD (crashed at ep~231, partial val/loss=0.731):** Bug: `(1.0 - progress) ** 0.5` → complex when `progress > 1.0` after the decay phase ends at epoch 230. Fixed in code to `max(0.0, 1.0 - progress) ** 0.5`. Partial results worse than baseline.

**GPU6 SWAD (CATASTROPHIC, val/loss=2.675):** SWAD threshold triggered at val_loss~2.9 (threshold = `0.5 × initial_val_loss = 0.5 × 10.5`). The model was still far from convergence, and a brief val_loss uptick triggered `swad_done`, loading averaged early-training checkpoints into `ema_model`. All subsequent evaluations used this bad model. Root cause: `0.5 × initial_val` designed for fine-tuning (near-convergence), not from-scratch training.

**GPU7 OOD-combo (crashed at ep~231, val/loss=0.737):** Same WSD lambda crash. Worst p_in (18.3 Pa) of all runs — stacking adaln+ema_anneal(ep80)+wsd compounded the negatives.

### Bugs found in this PR
1. **WSD lambda complex number**: `(1.0 - progress) ** 0.5` when `progress > 1.0` → complex. Fixed to `max(0.0, 1.0 - progress) ** 0.5`. Note: WSD and ood-combo were already launched with the buggy version so results are partial.
2. **Visualization Fourier PE**: Fixed (missing sin/cos encoding before `vis_model()` call). Pre-existing `visualize()` signature mismatch (missing 3 args) caused all runs to fail plot generation.

### Suggested follow-ups
- **SWAD needs better triggering**: Don't use `0.5 × initial_val_loss` for from-scratch training. Either wait until epoch 100+ or use a relative improvement threshold (e.g., `val_loss < best_val_so_far × 1.1`).
- **4-group PCGrad start delayed**: Try starting 4-group PCGrad after epoch 50 when the groups are more distinguishable. Starting from epoch 0 may add noise when all groups are still poorly predicted.
- **OOD techniques vs LinearNO**: The attention simplification in LinearNO may already provide implicit regularization. The OOD gap is harder to close with these post-hoc methods.
- **Longer runs**: At ep~250 these are still improving. Extending to 400 epochs might reveal whether the OOD techniques provide late-phase benefits.