### PR TITLE
Phase 2 R3: Compound Winners on LinearNO (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -23,6 +23,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 import os
 import time
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 
 import torch
@@ -221,12 +222,14 @@ class TransolverBlock(nn.Module):
         field_decoder=False,
         adaln_output=False,
         soft_moe=False,
+        zone_bias=False,
     ):
         super().__init__()
         self.last_layer = last_layer
         self.field_decoder = field_decoder
         self.adaln_output = adaln_output
         self.soft_moe = soft_moe
+        self.zone_bias = zone_bias
         self.ln_1 = nn.LayerNorm(hidden_dim)
         self.attn = Physics_Attention_Irregular_Mesh(
             hidden_dim,
@@ -252,6 +255,9 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        if zone_bias:
+            # Learned routing bias per zone: [0]=volume, [1]=surface (inferred from curvature)
+            self.zone_bias_param = nn.Parameter(torch.zeros(2, slice_num))
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             if soft_moe:
@@ -281,6 +287,11 @@ class TransolverBlock(nn.Module):
 
     def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
+        if self.zone_bias and raw_xy is not None:
+            # raw_xy[:,:,2] = curvature proxy: non-zero for surface nodes
+            is_surf = (raw_xy[:, :, 2:3].abs() > 0.01).float()  # [B, N, 1]
+            zone_b = is_surf * self.zone_bias_param[1] + (1 - is_surf) * self.zone_bias_param[0]  # [B, N, S]
+            sb = (sb + zone_b) if sb is not None else zone_b
         fx = self.ln_1_post(self.attn(self.ln_1(fx), spatial_bias=sb, tandem_mask=tandem_mask) + fx)
         fx = self.ln_2_post(self.mlp(self.ln_2(fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
@@ -327,6 +338,7 @@ class Transolver(nn.Module):
         adaln_output=False,
         soft_moe=False,
         uncertainty_loss=False,
+        zone_bias=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -379,6 +391,7 @@ class Transolver(nn.Module):
                     field_decoder=field_decoder if (idx == n_layers - 1) else False,
                     adaln_output=adaln_output if (idx == n_layers - 1) else False,
                     soft_moe=soft_moe if (idx == n_layers - 1) else False,
+                    zone_bias=zone_bias,
                 )
                 for idx in range(n_layers)
             ]
@@ -529,6 +542,9 @@ class Config:
     boundary_aware: bool = False       # GPU5: upweight near-wall volume nodes
     adaln_output: bool = False         # GPU6: AdaLN on output head
     soft_moe: bool = False             # GPU7: Soft MoE output
+    zone_bias: bool = False            # learned per-zone routing bias (surf vs vol)
+    adaptive_temp: bool = False        # gradual temperature sharpening from epoch 80
+    ema_anneal: bool = False           # EMA decay anneals from 0.99→cfg.ema_decay
 
 
 cfg = sp.parse(Config)
@@ -641,6 +657,7 @@ model_config = dict(
     adaln_output=cfg.adaln_output,
     soft_moe=cfg.soft_moe,
     uncertainty_loss=cfg.uncertainty_loss,
+    zone_bias=cfg.zone_bias,
 )
 
 model = Transolver(**model_config).to(device)
@@ -648,7 +665,6 @@ torch._functorch.config.donated_buffer = False  # required for retain_graph=True
 model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
-from copy import deepcopy
 ema_model = None
 swad_initial_val = None
 swad_prev_val = float("inf")
@@ -1010,12 +1026,17 @@ for epoch in range(MAX_EPOCHS):
             except ValueError:
                 pass
         if epoch >= cfg.ema_start_epoch and not cfg.swad:
+            if cfg.ema_anneal:
+                ema_progress = min(1.0, (epoch - cfg.ema_start_epoch) / max(MAX_EPOCHS - cfg.ema_start_epoch, 1))
+                ema_decay = 0.99 + (cfg.ema_decay - 0.99) * ema_progress
+            else:
+                ema_decay = cfg.ema_decay
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
             else:
                 with torch.no_grad():
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
-                        ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+                        ep.data.mul_(ema_decay).add_(mp.data, alpha=1 - ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -1029,6 +1050,12 @@ for epoch in range(MAX_EPOCHS):
     if epoch >= cfg.temp_anneal_epoch:
         with torch.no_grad():
             _base_model.blocks[0].attn.temperature.data.clamp_(max=0.25)
+    elif cfg.adaptive_temp and epoch >= 80:
+        # Gradual temperature sharpening: interpolate from 0.5 to 0.25 between epoch 80 and temp_anneal_epoch
+        progress = min(1.0, (epoch - 80) / max(cfg.temp_anneal_epoch - 80, 1))
+        adaptive_max_temp = 0.5 * (1 - progress) + 0.25 * progress
+        with torch.no_grad():
+            _base_model.blocks[0].attn.temperature.data.clamp_(max=adaptive_max_temp)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
     prev_vol_loss = epoch_vol
@@ -1263,11 +1290,20 @@ if best_metrics:
                 y_dev = y_true.unsqueeze(0).to(device)
                 is_surf_dev = is_surface.unsqueeze(0).to(device)
                 mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
+                raw_dsdf = x_dev[:, :, 2:10]
+                dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
+                dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                raw_xy = x_n[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs = torch.cat([_base_model.fourier_freqs_fixed.to(device), _base_model.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
Round 2 confirmed several techniques that each improve specific metrics. On the new LinearNO baseline, we test whether the best ideas compound. Key principle from R2: stacking too many changes hurts (full-combo was worse than individuals). So we test careful pairs/triples, not kitchen-sink combos.

## Instructions

**Pull latest noam (has LinearNO). All experiments:**
```python
MAX_TIMEOUT = 180.0
MAX_EPOCHS = 500
lr = 1.5e-3
weight_decay = 1e-5
n_layers = 2
```
T_max=230, ema_start=140, temp_anneal>=160. Use `--wandb_group "phase2-r3-compound"`.

### GPU 0: Soft MoE output on LinearNO
```python
# Replace single output MLP with 2-expert gated output:
# self.expert1 = nn.Sequential(Linear(h, h), GELU(), Linear(h, 3))
# self.expert2 = nn.Sequential(Linear(h, h), GELU(), Linear(h, 3))
# self.gate = nn.Sequential(Linear(h, 2), Softmax(dim=-1))
# output = gate[:,0:1] * expert1(fx) + gate[:,1:2] * expert2(fx)
# Was 0.715 in R2 on old arch. Should improve on LinearNO.
```
`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "alphonse/p2r3-soft-moe" --wandb_group "phase2-r3-compound" --agent alphonse`

### GPU 1: Learned attention kernel on LinearNO
```python
# Replace cosine similarity in slice attention with learned MLP kernel:
# self.kernel_mlp = nn.Sequential(Linear(dim_head*2, dim_head), GELU(), Linear(dim_head, 1))
# kernel(qi, kj) = kernel_mlp(cat(qi, kj)).squeeze(-1)
# Was 0.716 in R2 with p_oodc=10.1. Test on LinearNO.
```
`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "alphonse/p2r3-learned-kernel" --wandb_group "phase2-r3-compound" --agent alphonse`

### GPU 2: Boundary-aware near-wall weighting on LinearNO
```python
# Weight near-wall volume nodes 2x in vol_loss:
# near_wall = (dist_feat < dist_feat.quantile(0.1))  # closest 10% to surface
# vol_weight = torch.where(near_wall, 2.0, 1.0)
# vol_loss = (err * vol_mask * vol_weight).sum() / (vol_mask * vol_weight).sum()
# Was 0.723 in R2. Test on LinearNO.
```
`CUDA_VISIBLE_DEVICES=2 python train.py --wandb_name "alphonse/p2r3-boundary" --wandb_group "phase2-r3-compound" --agent alphonse`

### GPU 3: Soft MoE + adaptive temperature
```python
# Combine two orthogonal improvements: MoE for output specialization,
# adaptive-temp for input routing. These don't conflict.
```
`CUDA_VISIBLE_DEVICES=3 python train.py --wandb_name "alphonse/p2r3-moe-temp" --wandb_group "phase2-r3-compound" --agent alphonse`

### GPU 4: Field-specific pressure decoder on LinearNO
```python
# Separate pressure head with 2x hidden width:
# self.vel_head = nn.Sequential(Linear(h, h), GELU(), Linear(h, 2))
# self.pres_head = nn.Sequential(Linear(h, h*2), GELU(), Linear(h*2, 1))
# output = cat(vel_head(fx), pres_head(fx), dim=-1)
# Pressure is our key metric — give it a dedicated decoder
```
`CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "alphonse/p2r3-field-dec" --wandb_group "phase2-r3-compound" --agent alphonse`

### GPU 5: Field decoder + boundary-aware combined
```python
# Dedicated pressure head + near-wall volume weighting
# Both target surface pressure accuracy from different angles
```
`CUDA_VISIBLE_DEVICES=5 python train.py --wandb_name "alphonse/p2r3-field-boundary" --wandb_group "phase2-r3-compound" --agent alphonse`

### GPU 6: Soft MoE + zone-bias
```python
# MoE output specialization + zone-aware routing
# MoE helps the output adapt to different regimes
# Zone-bias helps the routing distinguish surface from volume
```
`CUDA_VISIBLE_DEVICES=6 python train.py --wandb_name "alphonse/p2r3-moe-zone" --wandb_group "phase2-r3-compound" --agent alphonse`

### GPU 7: Best-of-R2 triple: MoE + adaptive-temp + EMA-anneal
```python
# Three non-conflicting improvements: output specialization (MoE),
# input routing (adaptive-temp), optimization (EMA annealing)
```
`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "alphonse/p2r3-triple" --wandb_group "phase2-r3-compound" --agent alphonse`

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.701 |
| p_in | 14.1 Pa |
| p_oodc | 10.1 Pa |
| p_tan | 35.1 Pa |
| p_re | 25.5 Pa |

---

## Results

All 8 experiments ran for the full 3-hour budget (~239–253 epochs each). **None beat the baseline (0.701)**, but GPU7 (triple) came within 1% at 0.7082.

### CLI flags used

All experiments ran with `--lr 1.5e-3 --weight_decay 1e-5 --cosine_T_max 230 --ema_start_epoch 140 --temp_anneal_epoch 160 --linear_no_attention True`. Per-GPU additions:
- GPU0: `--soft_moe True`
- GPU1: `--learned_kernel True`
- GPU2: `--boundary_aware True`
- GPU3: `--soft_moe True --adaptive_temp True` (adaptive temp: gradual clamp from 0.5→0.25 between epoch 80 and 160)
- GPU4: `--field_decoder True`
- GPU5: `--field_decoder True --boundary_aware True`
- GPU6: `--soft_moe True --zone_bias True` (zone bias: learned per-zone routing offset via curvature proxy)
- GPU7: `--soft_moe True --adaptive_temp True --ema_anneal True` (EMA decay 0.99→0.998 over training)

### Summary table

| Experiment | val/loss | Δ baseline | p_in (Pa) | p_oodc (Pa) | p_tan (Pa) | p_re (Pa) | Peak Mem | W&B run |
|---|---|---|---|---|---|---|---|---|
| **Baseline (noam LinearNO)** | **0.701** | — | 14.1 | 10.1 | 35.1 | 25.5 | — | — |
| GPU7: triple (MoE+temp+EMA) | 0.7082 | +1.0% | 14.8 | 10.0 | 36.6 | 25.3 | 26.9 GB | kc1rw08j |
| GPU3: moe-temp (MoE+temp) | 0.7104 | +1.3% | 15.0 | 10.2 | 36.4 | 25.5 | 26.9 GB | 8oeob1s3 |
| GPU4: field-dec | 0.7122 | +1.6% | 14.7 | 10.4 | 36.6 | 25.2 | 27.8 GB | cjkgybcs |
| GPU2: boundary | 0.7172 | +2.3% | 15.4 | 10.0 | 36.5 | 25.4 | 26.6 GB | f3lga4bg |
| GPU6: moe-zone | 0.7175 | +2.4% | 16.6 | 10.2 | 36.4 | 25.3 | 27.5 GB | 9zvtwnx5 |
| GPU5: field-boundary | 0.7237 | +3.2% | 16.1 | 10.3 | 37.5 | 25.4 | 28.0 GB | 6u8h8gdn |
| GPU1: learned-kernel | 0.7276 | +3.8% | 16.7 | 10.3 | 37.6 | 25.3 | 26.0 GB | mqypkcw3 |
| GPU0: soft-moe alone | 0.7284 | +3.9% | 17.1 | 10.3 | 36.5 | 25.5 | 27.1 GB | x98fhyvh |

### What happened

**The LinearNO baseline is a tough floor to beat.** By skipping the Q/K/V projection and using direct slice aggregation, LinearNO is already very parameter-efficient, and adding extra modules on top consistently slightly degrades performance.

Key observations:

- **GPU7 (triple: MoE+temp+EMA)** at 0.7082 is the best, 1% above baseline. The combination of MoE output specialization, gradual temperature sharpening, and annealed EMA appears to improve generalization slightly but not enough to beat the baseline. Notably, p_oodc=10.0 matches the baseline exactly — the triple combination at least doesn't hurt OOD generalization.

- **GPU3 (MoE+adaptive_temp)** at 0.7104 is second. Dropping ema_anneal makes it slightly worse (0.7104 vs 0.7082), confirming EMA annealing helps a small amount in the triple.

- **GPU4 (field-dec)** at 0.7122 — dedicated pressure decoder with 2× hidden width gives the best p_in (14.7) of all variants but slightly worse p_oodc (10.4). The wider pressure head helps in-distribution but doesn't generalize as well.

- **GPU2 (boundary)** at 0.7172 — near-wall volume upweighting ties baseline on p_oodc (10.0). This is meaningful: the boundary-aware approach specifically helps OOD condition generalization at the cost of some in-dist performance.

- **GPU6 (MoE+zone-bias)** at 0.7175 — zone bias (adding a learned surface/volume routing offset) combined with MoE matches boundary-aware in val/loss but hurts p_in significantly (16.6 vs 14.7). The routing bias appears to overspecialize.

- **GPU5 (field+boundary)** at 0.7237 — combining field decoder and boundary awareness is WORSE than either alone. This is consistent with the R2 finding that combining techniques often hurts. These two modifications conflict: the wider pressure head is already specializing, and boundary weighting changes the training signal in a way that confuses it.

- **GPU1 (learned-kernel)** at 0.7276 — MLP attention kernel is the second worst. It adds computation (S×S×D pairs per head) but doesn't help. With LinearNO, the routing is already simplified; adding a complex kernel on top of it likely introduces unstable gradients early in training.

- **GPU0 (soft-moe alone)** at 0.7284 is worst — without adaptive_temp to sharpen routing, the MoE gates don't learn to specialize effectively. The two experts end up similar, providing no benefit over the baseline head.

### What I implemented for undefined features

The PR description referenced "adaptive-temp", "zone-bias", and "EMA-anneal" from R2 without specifying exact code. My implementations:

- **adaptive_temp**: From epoch 80 to `temp_anneal_epoch`, linearly interpolates the temperature max clamp from 0.5 to 0.25, providing gradual routing sharpening before the hard clamp at epoch 160.
- **zone_bias**: Adds `nn.Parameter(zeros(2, slice_num))` as learned per-zone routing offsets (surface vs volume, detected via curvature proxy in raw_xy), added to spatial_bias in each TransolverBlock.
- **ema_anneal**: EMA decay starts at 0.99 at `ema_start_epoch` and linearly increases to `cfg.ema_decay` (0.998) over training, allowing faster early adaptation.

If the advisor has different canonical implementations in mind for these, that may explain part of the gap.

### Suggested follow-ups

- **Triple on the standard attention (not LinearNO)**: The triple combination might work better without LinearNO, since the additional modules (MoE, adaptive_temp, EMA-anneal) might compensate for the lower expressiveness of the full attention path.
- **Field decoder only (no boundary)**: GPU4 shows field-dec alone is better than combined — a clean field-dec run with better pressure head width tuning (e.g., 3× instead of 2×) might get closer to the baseline.
- **Boundary-aware alone at higher surface weight**: GPU2's p_oodc matches the baseline at 10.0. Combining it with a higher `surf_weight` (e.g., 25) rather than another architectural change might push it below 10.
- **Canonical adaptive_temp/zone_bias from advisor**: If the original R2 implementations differ, re-testing with the canonical versions would clarify whether my implementations were close.