### PR TITLE
Phase 2 R4: Compound Best + DiWA Soup (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,8 +21,10 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 """
 
 import os
+import sys
 import time
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 
 import torch
@@ -490,7 +492,7 @@ MAX_EPOCHS = 500
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 1.5e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -503,9 +505,9 @@ class Config:
     # Schedule params (tuned for 3-hour / 500-epoch runs)
     warmup_total_iters: int = 20
     warmup_start_factor: float = 0.2
-    cosine_T_max: int = 200
+    cosine_T_max: int = 230
     cosine_eta_min: float = 1e-5
-    ema_start_epoch: int = 40
+    ema_start_epoch: int = 140
     ema_decay: float = 0.998
     temp_anneal_epoch: int = 50
     vol_ramp_epochs: int = 40
@@ -521,7 +523,7 @@ class Config:
     onecycle_final_div_factor: float = 100.0  # onecycle only
     use_lookahead: bool = True
     # Architecture flags (one per GPU)
-    linear_no_attention: bool = False  # GPU0: skip Q/K/V in slice attention
+    linear_no_attention: bool = True   # LinearNO baseline for this branch
     field_decoder: bool = False        # GPU1: separate vel/pres output heads
     learned_kernel: bool = False       # GPU2: MLP attention kernel
     uncertainty_loss: bool = False     # GPU3: Kendall uncertainty weighting
@@ -529,6 +531,13 @@ class Config:
     boundary_aware: bool = False       # GPU5: upweight near-wall volume nodes
     adaln_output: bool = False         # GPU6: AdaLN on output head
     soft_moe: bool = False             # GPU7: Soft MoE output
+    # DiWA / SWA flags
+    diwa_soup: bool = False         # GPU0: average top checkpoints, evaluate only (no training)
+    diwa_greedy: bool = False       # GPU1: greedy DiWA selection, evaluate only (no training)
+    diwa_run_ids: str = ""          # space-separated local run IDs for DiWA checkpoints
+    swa: bool = False               # GPU7: stochastic weight averaging snapshots
+    swa_start_epoch: int = 180      # epoch to start collecting SWA snapshots
+    swa_freq: int = 5               # collect SWA snapshot every N epochs
 
 
 cfg = sp.parse(Config)
@@ -648,13 +657,13 @@ torch._functorch.config.donated_buffer = False  # required for retain_graph=True
 model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
-from copy import deepcopy
 ema_model = None
 swad_initial_val = None
 swad_prev_val = float("inf")
 swad_checkpoints: list = []
 swad_collecting = False
 swad_done = False
+swa_checkpoints: list = []
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -772,6 +781,200 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+
+
+def _eval_model_full(eval_model, freq_src=None):
+    """Run full validation across all splits. Returns (val_loss_4split, metrics_per_split)."""
+    if freq_src is None:
+        freq_src = _base_model
+    eval_model.eval()
+    val_metrics_per_split: dict[str, dict] = {}
+    val_loss_total = 0.0
+    n_valid = 0
+    ch_cl = torch.tensor([0.1, 0.1, 0.5], device=device)
+    ta_cl = torch.tensor([0.3, 0.3, 1.0], device=device)
+    with torch.no_grad():
+        for split_name, vloader in val_loaders.items():
+            val_vol = val_surf = 0.0
+            mae_surf = torch.zeros(3, device=device)
+            mae_vol = torch.zeros(3, device=device)
+            n_surf = torch.zeros(3, device=device)
+            n_vol_c = torch.zeros(3, device=device)
+            n_vbatches = 0
+            for x, y, is_surface, mask in tqdm(vloader, desc=f"[diwa/{split_name}]", leave=False):
+                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                is_surface = is_surface.to(device, non_blocking=True)
+                mask = mask.to(device, non_blocking=True)
+                raw_dsdf = x[:, :, 2:10]
+                dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
+                dist_feat = torch.log1p(dist_surf * 10.0)
+                x_n = (x - stats["x_mean"]) / stats["x_std"]
+                curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                raw_xy = x_n[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs = torch.cat([freq_src.fourier_freqs_fixed.to(device), freq_src.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe], dim=-1)
+                Umag, q = _umag_q(y, mask)
+                y_phys = _phys_norm(y, Umag, q)
+                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                raw_gap = x_n[:, 0, 21]
+                is_tandem = raw_gap.abs() > 0.5
+                B = y_norm.shape[0]
+                sample_stds = torch.ones(B, 1, 3, device=device)
+                for b in range(B):
+                    valid = mask[b]
+                    sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=ta_cl if is_tandem[b] else ch_cl)
+                y_norm_scaled = y_norm / sample_stds
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred = eval_model({"x": x_n})["preds"]
+                pred = pred.float() / sample_stds
+                abs_err = (pred - y_norm_scaled).abs().nan_to_num(0.0)
+                vol_mask = mask & ~is_surface
+                surf_mask = mask & is_surface
+                val_vol += min(
+                    (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(), 1e6)
+                val_surf += min(
+                    (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item(), 1e6)
+                n_vbatches += 1
+                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_orig = _phys_denorm(pred_phys, Umag, q)
+                y_clamped = y.clamp(-1e6, 1e6)
+                err = (pred_orig - y_clamped).abs()
+                finite = err.isfinite()
+                err = err.where(finite, torch.zeros_like(err))
+                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+                n_vol_c += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+            val_vol /= max(n_vbatches, 1)
+            val_surf /= max(n_vbatches, 1)
+            split_loss = val_vol + cfg.surf_weight * val_surf
+            mae_surf /= n_surf.clamp(min=1)
+            mae_vol /= n_vol_c.clamp(min=1)
+            val_metrics_per_split[split_name] = {
+                f"{split_name}/loss":        split_loss,
+                f"{split_name}/vol_loss":    val_vol,
+                f"{split_name}/surf_loss":   val_surf,
+                f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
+                f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
+                f"{split_name}/mae_surf_p":  mae_surf[2].item(),
+                f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
+                f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
+                f"{split_name}/mae_vol_p":   mae_vol[2].item(),
+            }
+            val_loss_total += split_loss
+            n_valid += 1
+    val_loss = val_loss_total / max(n_valid, 1)
+    return val_loss, val_metrics_per_split
+
+
+def _load_diwa_checkpoints(run_ids):
+    """Load state_dicts for DiWA from local models/ directory."""
+    state_dicts = []
+    for rid in run_ids:
+        ckpt = Path(f"models/model-{rid}/checkpoint.pt")
+        if not ckpt.exists():
+            print(f"  DiWA: checkpoint not found for run {rid}, skipping")
+            continue
+        sd = torch.load(ckpt, map_location=device, weights_only=True)
+        state_dicts.append((rid, sd))
+        print(f"  DiWA: loaded {rid} ({ckpt})")
+    return state_dicts
+
+
+def _average_state_dicts(state_dicts):
+    """Average state_dicts, only for keys present with matching shapes in all."""
+    all_keys = set(state_dicts[0].keys())
+    for sd in state_dicts[1:]:
+        all_keys &= set(sd.keys())
+    avg = {}
+    for k in all_keys:
+        tensors = [sd[k].float() for sd in state_dicts]
+        if all(t.shape == tensors[0].shape for t in tensors):
+            avg[k] = torch.stack(tensors).mean(0)
+        else:
+            avg[k] = state_dicts[0][k]
+    return avg
+
+
+# ---------------------------------------------------------------------------
+# DiWA evaluation (GPU 0 & 1 only): load checkpoints, average, evaluate
+# ---------------------------------------------------------------------------
+if cfg.diwa_soup or cfg.diwa_greedy:
+    run_ids = cfg.diwa_run_ids.split() if cfg.diwa_run_ids.strip() else []
+    if not run_ids:
+        print("DiWA: no diwa_run_ids specified — nothing to do.")
+        wandb.finish()
+        sys.exit(0)
+
+    loaded = _load_diwa_checkpoints(run_ids)
+    if not loaded:
+        print("DiWA: no checkpoints loaded — exiting.")
+        wandb.finish()
+        sys.exit(0)
+
+    # Create a fresh model for evaluation (same architecture, not compiled)
+    diwa_model = Transolver(**model_config).to(device)
+
+    if cfg.diwa_soup:
+        print(f"DiWA soup: averaging {len(loaded)} checkpoints...")
+        avg_sd = _average_state_dicts([sd for _, sd in loaded])
+        result = diwa_model.load_state_dict(avg_sd, strict=False)
+        if result.missing_keys:
+            print(f"  Missing keys: {result.missing_keys[:5]}")
+        diwa_model.eval()
+        val_loss, vm = _eval_model_full(diwa_model, freq_src=diwa_model)
+        print(f"DiWA soup val/loss = {val_loss:.4f}")
+        metrics = {"diwa/val_loss": val_loss, "diwa/n_checkpoints": len(loaded), "global_step": 1}
+        for sm in vm.values():
+            metrics.update(sm)
+        wandb.log(metrics)
+        wandb.summary.update({"diwa_val_loss": val_loss})
+
+    elif cfg.diwa_greedy:
+        print(f"DiWA greedy: testing {len(loaded)} checkpoints starting from {loaded[0][0]}...")
+        # Start with the best checkpoint (assume first = best)
+        best_sd = loaded[0][1]
+        diwa_model.load_state_dict(best_sd, strict=False)
+        diwa_model.eval()
+        best_loss, _ = _eval_model_full(diwa_model, freq_src=diwa_model)
+        soup_ids = [loaded[0][0]]
+        soup_sds = [best_sd]
+        print(f"  Seed checkpoint {loaded[0][0]}: val_loss={best_loss:.4f}")
+
+        for rid, sd in loaded[1:]:
+            candidate_sds = soup_sds + [sd]
+            avg_sd = _average_state_dicts(candidate_sds)
+            diwa_model.load_state_dict(avg_sd, strict=False)
+            diwa_model.eval()
+            cand_loss, _ = _eval_model_full(diwa_model, freq_src=diwa_model)
+            if cand_loss < best_loss:
+                best_loss = cand_loss
+                soup_sds = candidate_sds
+                soup_ids.append(rid)
+                print(f"  + {rid}: val_loss={cand_loss:.4f} IMPROVED (soup={soup_ids})")
+            else:
+                print(f"  - {rid}: val_loss={cand_loss:.4f} no improvement, skipping")
+
+        # Final eval with greedy soup
+        final_avg = _average_state_dicts(soup_sds)
+        diwa_model.load_state_dict(final_avg, strict=False)
+        val_loss, vm = _eval_model_full(diwa_model, freq_src=diwa_model)
+        print(f"DiWA greedy final val/loss = {val_loss:.4f} (soup: {soup_ids})")
+        metrics = {"diwa/val_loss": val_loss, "diwa/n_checkpoints": len(soup_ids), "global_step": 1}
+        for sm in vm.values():
+            metrics.update(sm)
+        wandb.log(metrics)
+        wandb.summary.update({"diwa_val_loss": val_loss, "diwa_soup_ids": str(soup_ids)})
+
+    wandb.finish()
+    sys.exit(0)
+
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -1034,6 +1237,12 @@ for epoch in range(MAX_EPOCHS):
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
 
+    # SWA snapshot collection (epoch-level, after training step)
+    if cfg.swa and not cfg.swad and epoch >= cfg.swa_start_epoch and (epoch - cfg.swa_start_epoch) % cfg.swa_freq == 0:
+        snap = {k: v.cpu().clone() for k, v in _base_model.state_dict().items()}
+        swa_checkpoints.append(snap)
+        print(f"  SWA: collected snapshot #{len(swa_checkpoints)} (epoch {epoch+1})")
+
     # --- Validate across all splits ---
     eval_model = ema_model if ema_model is not None else model
     eval_model.eval()
@@ -1229,6 +1438,19 @@ for epoch in range(MAX_EPOCHS):
         f"val[{split_summary}]{tag}"
     )
 
+
+# --- SWA final averaging ---
+if cfg.swa and swa_checkpoints:
+    print(f"SWA: averaging {len(swa_checkpoints)} snapshots collected from epoch {cfg.swa_start_epoch}...")
+    avg_state = {
+        k: torch.stack([c[k].float() for c in swa_checkpoints]).mean(0).to(device)
+        for k in swa_checkpoints[0]
+    }
+    if ema_model is None:
+        ema_model = deepcopy(_base_model)
+    ema_model.load_state_dict(avg_state)
+    torch.save(ema_model.state_dict(), model_path)
+    print(f"SWA: averaging done. Model saved to {model_path}.")
 
 # --- Final summary ---
 total_time = (time.time() - train_start) / 60.0


### PR DESCRIPTION
## Hypothesis
DiWA (NeurIPS 2022) showed that averaging weights from independently trained models improves OOD generalization by 1.6%. We have 70+ finished checkpoints from Rounds 1-3. This PR combines DiWA model soup with the most promising individual improvements from prior rounds.

## Instructions
Pull latest noam. MAX_TIMEOUT=180, MAX_EPOCHS=500, lr=1.5e-3. T_max=230, ema_start=140. Use `--wandb_group "phase2-r4-compound"`.

### GPU 0: DiWA model soup (top-5 Round 2/3 checkpoints)
Load the 5 best checkpoints from R2/R3 (linearno 0.701, lr15-wd 0.706, h256 0.706, zone-temp 0.710, adaln 0.711). Average their state_dicts. Evaluate on all val splits. No training needed — just averaging and evaluation.
`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "alphonse/p2r4-diwa-top5" --wandb_group "phase2-r4-compound" --agent alphonse`

### GPU 1: DiWA greedy selection (add models only if they improve val/loss)
Start with best checkpoint (linearno 0.701). Greedily add: if avg(current_soup, new_model) improves val/loss, keep it. Test all 20+ checkpoints with val/loss < 0.725.
`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "alphonse/p2r4-diwa-greedy" --wandb_group "phase2-r4-compound" --agent alphonse`

### GPU 2: Best LinearNO + wd=1e-5 (retrain from scratch)
The lr15-wd rebase got 0.706. Try the exact same config but with better random seed / longer warmup (20 epochs instead of current). Sometimes retraining beats the original.
`CUDA_VISIBLE_DEVICES=2 python train.py --lr 1.5e-3 --weight_decay 1e-5 --wandb_name "alphonse/p2r4-linearno-wd-v2" --wandb_group "phase2-r4-compound" --agent alphonse`

### GPU 3: Best LinearNO + lr=1.8e-3 + wd=1e-5
R3 tanjiro showed lr=1.8e-3 slightly better than 1.5e-3. Combine with wd=1e-5.
`CUDA_VISIBLE_DEVICES=3 python train.py --lr 1.8e-3 --weight_decay 1e-5 --wandb_name "alphonse/p2r4-lr18-wd" --wandb_group "phase2-r4-compound" --agent alphonse`

### GPU 4: Best LinearNO + EMA from epoch 80 (earlier) + decay=0.9995
Earlier EMA start + slower decay for longer averaging window.
`CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "alphonse/p2r4-early-ema-slow" --wandb_group "phase2-r4-compound" --agent alphonse`

### GPU 5: Best LinearNO + cosine T_max=250 (longer LR schedule)
The current T_max=230 may cut off too early. Extend to 250.
`CUDA_VISIBLE_DEVICES=5 python train.py --wandb_name "alphonse/p2r4-tmax250" --wandb_group "phase2-r4-compound" --agent alphonse`

### GPU 6: Best LinearNO + 30-epoch warmup + lr=2e-3
Higher peak LR with longer warmup to stabilize.
`CUDA_VISIBLE_DEVICES=6 python train.py --lr 2e-3 --wandb_name "alphonse/p2r4-lr2e-3-warm30" --wandb_group "phase2-r4-compound" --agent alphonse`

### GPU 7: Best LinearNO + stochastic weight averaging (SWA)
Use SWA from epoch 180: average model weights every 5 epochs for the last 20% of training. Different from EMA — equal weighting of snapshots.
`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "alphonse/p2r4-swa" --wandb_group "phase2-r4-compound" --agent alphonse`

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| 0.701 | 14.1 | 10.1 | 35.1 | 25.5 |

---
## Results

### Summary table

| GPU | Config | val/loss | p_in | p_oodc | p_tan | p_re | W&B ID |
|-----|--------|----------|------|--------|-------|------|--------|
| Baseline | LinearNO | 0.701 | 14.1 | 10.1 | 35.1 | 25.5 | — |
| GPU0 | DiWA soup (top-5 avg) | **FAILED** (12.60) | — | — | — | — | lsvfm0g1 |
| GPU1 | DiWA greedy | **FAILED** (8.29) | — | — | — | — | 3hqtye7w |
| GPU2 | LinearNO + wd=1e-5 v2 | 0.7154 (+2.1%) | 15.7 | 10.2 | 36.1 | 25.3 | lc1sa018 |
| GPU3 | LinearNO + lr=1.8e-3 + wd=1e-5 | 0.7277 (+3.8%) | 15.4 | 10.2 | 37.6 | 25.5 | dkxp9iy4 |
| GPU4 | LinearNO + EMA start=80, decay=0.9995 | 0.7201 (+2.7%) | 16.0 | 10.2 | 37.0 | 25.4 | 7ft7oemd |
| GPU5 | LinearNO + cosine T_max=250 | 0.7167 (+2.2%) | 16.0 | 10.0 | 37.3 | 25.4 | eymh4xgf |
| GPU6 | LinearNO + lr=2e-3 + warmup=30 | 0.7184 (+2.5%) | 15.8 | 10.3 | 36.1 | 25.3 | puuwlk6l |
| GPU7 | LinearNO + SWA (epoch 180, freq=5) | 0.7222 (+3.0%) | 15.1 | 10.4 | 37.0 | 25.6 | aksm7ate |

Peak memory: ~26.4 GB. Epochs completed: ~250–255 (180-min timeout).

### What happened

**DiWA (GPU0 & GPU1) — catastrophic failure.** The checkpoints from R2/R3 branches (pe-fix, noise-anneal, rpb, ponly-surf, boundary) were saved with an older model architecture that predates `slice_residual_scale`, `feature_cross`, `re_head`, `aoa_head`, `out_skip`, and `skip_gate` parameters added in noam's later revisions. Loading these with `strict=False` leaves `slice_residual_scale` at init value 0.1, adding `0.1 * slice_token` to attention outputs for models trained without that term — producing garbage predictions (val/loss 8–12 vs baseline 0.701). The greedy algorithm found no R2/R3 checkpoint that even approached the baseline.

**Training runs (GPU2–7) — all slightly worse than baseline (0.701).** Best: GPU2 (wd=1e-5) at 0.7154. Key observations:
- lr=1.8e-3 + wd=1e-5 (GPU3) worse than lr=1.5e-3 — higher lr hurt when wd is applied
- T_max=250 (GPU5) 2nd best, matched baseline p_oodc=10.0
- Early EMA start=80 + decay=0.9995 (GPU4) did not help — long averaging window amplifies early noisy checkpoints
- SWA 15 snapshots (epoch 180–255): 0.7222, worse than EMA. Limited snapshot window may drag average back. SWA p_in=15.1 slightly better than most other training runs on that metric.

All runs were still descending at timeout (~255 epochs), but the gap to baseline is consistent and unlikely to close with more epochs alone.

### Suggested follow-ups
1. **DiWA with matching-architecture checkpoints**: Requires checkpoints from runs on *this branch* (same model version). Once R4/R5 finishes several runs, retry DiWA.
2. **wd=1e-5 + T_max=250 combined**: GPU2 and GPU5 were best. Combining may be additive.
3. **SWA with cosine warm restarts + earlier start**: Diverse snapshots from restarts would improve SWA coverage.
4. **Full 500-epoch run (6h)**: All runs still descending at timeout — deeper training may show real differences.