### PR TITLE
Phase 2 R5: DiWA Model Soup + Seed Diversity (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -21,8 +21,10 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
 """
 
 import os
+import sys
 import time
 from collections.abc import Mapping
+from copy import deepcopy
 from pathlib import Path
 
 import torch
@@ -490,7 +492,7 @@ MAX_EPOCHS = 500
 
 @dataclass
 class Config:
-    lr: float = 2.6e-3
+    lr: float = 1.5e-3
     weight_decay: float = 0.0
     batch_size: int = 4
     surf_weight: float = 20.0
@@ -503,9 +505,9 @@ class Config:
     # Schedule params (tuned for 3-hour / 500-epoch runs)
     warmup_total_iters: int = 20
     warmup_start_factor: float = 0.2
-    cosine_T_max: int = 200
+    cosine_T_max: int = 230
     cosine_eta_min: float = 1e-5
-    ema_start_epoch: int = 40
+    ema_start_epoch: int = 140
     ema_decay: float = 0.998
     temp_anneal_epoch: int = 50
     vol_ramp_epochs: int = 40
@@ -521,7 +523,7 @@ class Config:
     onecycle_final_div_factor: float = 100.0  # onecycle only
     use_lookahead: bool = True
     # Architecture flags (one per GPU)
-    linear_no_attention: bool = False  # GPU0: skip Q/K/V in slice attention
+    linear_no_attention: bool = True   # LinearNO baseline for this branch
     field_decoder: bool = False        # GPU1: separate vel/pres output heads
     learned_kernel: bool = False       # GPU2: MLP attention kernel
     uncertainty_loss: bool = False     # GPU3: Kendall uncertainty weighting
@@ -529,9 +531,19 @@ class Config:
     boundary_aware: bool = False       # GPU5: upweight near-wall volume nodes
     adaln_output: bool = False         # GPU6: AdaLN on output head
     soft_moe: bool = False             # GPU7: Soft MoE output
+    seed: int = 0                      # random seed (0 = no seeding)
+    tandem_ramp: bool = False          # ramp tandem weight from 0→1 over curriculum epochs
+    diwa_soup: bool = False            # post-training: average top checkpoints, evaluate only
+    diwa_greedy: bool = False          # post-training: greedy DiWA selection, evaluate only
+    diwa_run_ids: str = ""             # space-separated local run IDs for DiWA
 
 
 cfg = sp.parse(Config)
+
+if cfg.seed > 0:
+    torch.manual_seed(cfg.seed)
+    import numpy as np
+    np.random.seed(cfg.seed)
 
 if cfg.debug:
     MAX_EPOCHS = 3
@@ -648,13 +660,134 @@ torch._functorch.config.donated_buffer = False  # required for retain_graph=True
 model = torch.compile(model, mode="default")
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
-from copy import deepcopy
 ema_model = None
 swad_initial_val = None
 swad_prev_val = float("inf")
 swad_checkpoints: list = []
 swad_collecting = False
 swad_done = False
+
+
+def _eval_model_full(eval_model, freq_src=None):
+    """Run full validation across all splits. Returns (val_loss_4split, metrics_per_split)."""
+    if freq_src is None:
+        freq_src = _base_model
+    eval_model.eval()
+    val_metrics_per_split: dict[str, dict] = {}
+    val_loss_total = 0.0
+    n_valid = 0
+    ch_cl = torch.tensor([0.1, 0.1, 0.5], device=device)
+    ta_cl = torch.tensor([0.3, 0.3, 1.0], device=device)
+    with torch.no_grad():
+        for split_name, vloader in val_loaders.items():
+            val_vol = 0.0
+            val_surf = 0.0
+            mae_surf = torch.zeros(3, device=device)
+            mae_vol = torch.zeros(3, device=device)
+            n_surf = torch.zeros(3, device=device)
+            n_vol = torch.zeros(3, device=device)
+            n_vbatches = 0
+            for x, y, is_surface, mask in vloader:
+                x, y = x.to(device), y.to(device)
+                is_surface = is_surface.to(device)
+                mask = mask.to(device)
+                raw_dsdf = x[:, :, 2:10]
+                dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
+                dist_feat = torch.log1p(dist_surf * 10.0)
+                x = (x - stats["x_mean"]) / stats["x_std"]
+                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv, dist_feat], dim=-1)
+                raw_xy = x[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs = torch.cat([freq_src.fourier_freqs_fixed.to(device), freq_src.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                x = torch.cat([x, fourier_pe], dim=-1)
+                Umag, q = _umag_q(y, mask)
+                y_phys = _phys_norm(y, Umag, q)
+                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                raw_gap = x[:, 0, 21]
+                is_tandem = raw_gap.abs() > 0.5
+                B = y_norm.shape[0]
+                sample_stds = torch.ones(B, 1, 3, device=device)
+                for b in range(B):
+                    valid = mask[b]
+                    if is_tandem[b]:
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=ta_cl)
+                    else:
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=ch_cl)
+                y_norm_scaled = y_norm / sample_stds
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    pred = eval_model({"x": x})["preds"]
+                pred = pred.float()
+                pred_loss = pred / sample_stds
+                abs_err = (pred_loss - y_norm_scaled).abs().nan_to_num(0.0)
+                vol_mask = mask & ~is_surface
+                surf_mask = mask & is_surface
+                val_vol += min(
+                    (abs_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item(), 1e6)
+                val_surf += min(
+                    (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item(), 1e6)
+                n_vbatches += 1
+                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_orig = _phys_denorm(pred_phys, Umag, q)
+                y_clamped = y.clamp(-1e6, 1e6)
+                err = (pred_orig - y_clamped).abs()
+                finite = err.isfinite()
+                err = err.where(finite, torch.zeros_like(err))
+                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                n_surf += (surf_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+                n_vol += (vol_mask.unsqueeze(-1) * finite).sum(dim=(0, 1)).float()
+            val_vol /= max(n_vbatches, 1)
+            val_surf /= max(n_vbatches, 1)
+            split_loss = val_vol + cfg.surf_weight * val_surf
+            mae_surf /= n_surf.clamp(min=1)
+            mae_vol /= n_vol.clamp(min=1)
+            val_metrics_per_split[split_name] = {
+                f"{split_name}/loss": split_loss,
+                f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
+                f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
+                f"{split_name}/mae_surf_p":  mae_surf[2].item(),
+                f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
+                f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
+                f"{split_name}/mae_vol_p":   mae_vol[2].item(),
+            }
+            val_loss_total += split_loss
+            n_valid += 1
+    val_loss = val_loss_total / max(n_valid, 1)
+    return val_loss, val_metrics_per_split
+
+
+def _load_diwa_checkpoints(run_ids):
+    """Load state_dicts for DiWA from local models/ directory."""
+    state_dicts = []
+    for rid in run_ids:
+        ckpt = Path(f"models/model-{rid}/checkpoint.pt")
+        if not ckpt.exists():
+            print(f"  DiWA: checkpoint not found for run {rid}, skipping")
+            continue
+        sd = torch.load(ckpt, map_location=device, weights_only=True)
+        state_dicts.append((rid, sd))
+    return state_dicts
+
+
+def _average_state_dicts(state_dicts):
+    """Average state_dicts using only keys present with matching shapes in all."""
+    all_keys = set(state_dicts[0].keys())
+    for sd in state_dicts[1:]:
+        all_keys &= set(sd.keys())
+    avg = {}
+    for k in all_keys:
+        tensors = [sd[k].float() for sd in state_dicts]
+        if all(t.shape == tensors[0].shape for t in tensors):
+            avg[k] = torch.stack(tensors).mean(0)
+        else:
+            avg[k] = state_dicts[0][k]
+    return avg
+
 
 n_params = sum(p.numel() for p in model.parameters())
 
@@ -762,6 +895,69 @@ model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
+# --- DiWA / model-soup early exit (post-training evaluation only) ---
+if cfg.diwa_soup or cfg.diwa_greedy:
+    run_ids = cfg.diwa_run_ids.split() if cfg.diwa_run_ids.strip() else []
+    if not run_ids:
+        print("DiWA: no run IDs provided, exiting.")
+        wandb.finish()
+        sys.exit(0)
+    loaded = _load_diwa_checkpoints(run_ids)
+    if not loaded:
+        print("DiWA: no checkpoints found, exiting.")
+        wandb.finish()
+        sys.exit(0)
+    diwa_model = Transolver(**model_config).to(device)
+    diwa_model = torch.compile(diwa_model, mode="default")
+    _diwa_base = diwa_model._orig_mod if hasattr(diwa_model, '_orig_mod') else diwa_model
+    if cfg.diwa_soup:
+        print(f"DiWA soup: averaging {len(loaded)} checkpoints...")
+        avg_sd = _average_state_dicts([sd for _, sd in loaded])
+        result = _diwa_base.load_state_dict(avg_sd, strict=False)
+        print(f"  load_state_dict result: {result}")
+        val_loss, vm = _eval_model_full(diwa_model, freq_src=_diwa_base)
+        metrics = {"diwa/val_loss": val_loss}
+        for split_metrics in vm.values():
+            metrics.update({f"diwa/{k}": v for k, v in split_metrics.items()})
+        metrics["global_step"] = 0
+        wandb.log(metrics)
+        wandb.summary.update({"diwa_val_loss": val_loss})
+        print(f"DiWA soup val/loss = {val_loss:.4f}")
+    elif cfg.diwa_greedy:
+        print(f"DiWA greedy: selecting from {len(loaded)} checkpoints...")
+        best_loss = float("inf")
+        best_ids = []
+        for rid, sd in loaded:
+            _diwa_base.load_state_dict(sd, strict=False)
+            vl, _ = _eval_model_full(diwa_model, freq_src=_diwa_base)
+            if vl < best_loss:
+                best_loss = vl
+                best_ids = [rid]
+        # Greedily add remaining checkpoints if they improve
+        remaining = [(rid, sd) for rid, sd in loaded if rid not in best_ids]
+        for rid, sd in remaining:
+            candidate_ids = best_ids + [rid]
+            candidate_sds = [sd2 for rid2, sd2 in loaded if rid2 in candidate_ids]
+            avg_sd = _average_state_dicts(candidate_sds)
+            _diwa_base.load_state_dict(avg_sd, strict=False)
+            vl, _ = _eval_model_full(diwa_model, freq_src=_diwa_base)
+            if vl < best_loss:
+                best_loss = vl
+                best_ids = candidate_ids
+        print(f"DiWA greedy best set: {best_ids}, val/loss={best_loss:.4f}")
+        final_sds = [sd for rid, sd in loaded if rid in best_ids]
+        avg_sd = _average_state_dicts(final_sds)
+        _diwa_base.load_state_dict(avg_sd, strict=False)
+        val_loss, vm = _eval_model_full(diwa_model, freq_src=_diwa_base)
+        metrics = {"diwa/val_loss": val_loss, "diwa/n_models": len(best_ids)}
+        for split_metrics in vm.values():
+            metrics.update({f"diwa/{k}": v for k, v in split_metrics.items()})
+        metrics["global_step"] = 0
+        wandb.log(metrics)
+        wandb.summary.update({"diwa_val_loss": val_loss})
+    wandb.finish()
+    sys.exit(0)
+
 best_val = float("inf")
 ema_val_loss = float("inf")
 ema_decay_val = 0.9
@@ -856,8 +1052,17 @@ for epoch in range(MAX_EPOCHS):
         abs_err = (pred - y_norm).abs()
         if epoch < cfg.tandem_curriculum_epochs:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
-            sample_mask = (~is_tandem_curr).float()[:, None, None]
-            abs_err = abs_err * sample_mask
+            if cfg.tandem_ramp:
+                ramp = epoch / cfg.tandem_curriculum_epochs
+                tandem_weight = torch.where(
+                    is_tandem_curr,
+                    torch.full((x.shape[0],), ramp, device=device),
+                    torch.ones(x.shape[0], device=device),
+                )
+                abs_err = abs_err * tandem_weight[:, None, None]
+            else:
+                sample_mask = (~is_tandem_curr).float()[:, None, None]
+                abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 


### PR DESCRIPTION
## Hypothesis
R4 DiWA experiments crashed. DiWA (Diverse Weight Averaging) is a post-hoc technique that averages checkpoints from diverse training runs — proven to improve OOD generalization by 1.6% on DomainBed. Additionally, run-to-run variance on our baseline may be ~0.005, meaning a lucky seed could beat 0.701. This PR does seed diversity + checkpoint averaging.

## Instructions
Pull latest noam. MAX_TIMEOUT=180, MAX_EPOCHS=500, lr=1.5e-3. T_max=230, ema_start=140. Use \`--wandb_group "phase2-r5-diwa"\`.

### GPU 0-3: Diverse seeds with slightly varied configs
Run 4 independent training runs with different seeds and minor hyperparameter variation. Save checkpoints for later averaging.

GPU 0: seed=42, lr=1.5e-3 (baseline config, different seed)
\`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "alphonse/p2r5-seed42" --wandb_group "phase2-r5-diwa" --agent alphonse\`

GPU 1: seed=123, lr=1.5e-3
\`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "alphonse/p2r5-seed123" --wandb_group "phase2-r5-diwa" --agent alphonse\`

GPU 2: seed=456, lr=1.4e-3 (slightly lower)
\`CUDA_VISIBLE_DEVICES=2 python train.py --lr 1.4e-3 --wandb_name "alphonse/p2r5-seed456-lr14" --wandb_group "phase2-r5-diwa" --agent alphonse\`

GPU 3: seed=789, lr=1.6e-3 (slightly higher)
\`CUDA_VISIBLE_DEVICES=3 python train.py --lr 1.6e-3 --wandb_name "alphonse/p2r5-seed789-lr16" --wandb_group "phase2-r5-diwa" --agent alphonse\`

### GPU 4-5: Tandem-ramp + seed diversity
The best R4 idea with different seeds to check reproducibility.

GPU 4: tandem-ramp, seed=42
\`CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "alphonse/p2r5-ramp-seed42" --wandb_group "phase2-r5-diwa" --agent alphonse\`

GPU 5: tandem-ramp, seed=123
\`CUDA_VISIBLE_DEVICES=5 python train.py --wandb_name "alphonse/p2r5-ramp-seed123" --wandb_group "phase2-r5-diwa" --agent alphonse\`

### GPU 6: Tandem-ramp + T_max=200 + eta_min=1e-5 (best R5 config so far)
Tanjiro's t200-eta1e5 is leading R5 at 0.711. Combine with tandem-ramp.
\`CUDA_VISIBLE_DEVICES=6 python train.py --wandb_name "alphonse/p2r5-ramp-t200" --wandb_group "phase2-r5-diwa" --agent alphonse\`

### GPU 7: Tandem-ramp + AdaLN + T_max=200 (ultimate combo)
\`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "alphonse/p2r5-ramp-adaln-t200" --wandb_group "phase2-r5-diwa" --agent alphonse\`

### Post-training: DiWA Model Soup
After all runs complete, load the top-3 checkpoints and average their state_dicts. Evaluate the averaged model on all val splits. This is a free improvement that requires no additional training.

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| 0.701 | 14.1 | 10.1 | 35.1 | 25.5 |

---
## Results

All 8 runs completed (180-min wall-clock timeout, ~253 epochs). Peak memory: 26.6–26.9 GB.

### Individual run metrics

| GPU | Config | W&B ID | val/loss | p_in | p_oodc | p_tan | p_re |
|-----|--------|--------|----------|------|--------|-------|------|
| 0 | seed=42, lr=1.5e-3 | un4r9eit | 0.7176 | 15.3 | 10.3 | 37.2 | 25.2 |
| 1 | seed=123, lr=1.5e-3 | a3c5ctas | 0.7208 | 16.7 | 10.1 | 37.3 | 25.6 |
| 2 | seed=456, lr=1.4e-3 | hlf0qvm9 | 0.7186 | 16.7 | 10.4 | 36.4 | 25.4 |
| 3 | seed=789, lr=1.6e-3 | ig6ysqo4 | 0.7180 | 15.9 | 9.9 | 36.4 | 25.5 |
| 4 | tandem_ramp, seed=42 | 7j9auw6d | 0.7233 | 16.5 | 10.3 | 37.7 | 25.5 |
| 5 | tandem_ramp, seed=123 | m27xcib5 | 0.7108 | 16.7 | 10.2 | 35.6 | 25.5 |
| 6 | **tandem_ramp, T_max=200, eta_min=1e-5** | **bkshp8h5** | **0.7048** | **14.8** | **9.8** | **36.1** | **25.5** |
| 7 | tandem_ramp, adaln, T_max=200 | ihecinld | 0.7240 | 17.5 | 9.9 | 37.7 | 25.4 |

Baseline: val/loss=0.701, p_in=14.1, p_oodc=10.1, p_tan=35.1, p_re=25.5

### DiWA Model Soup

Ran soup on top-3 checkpoints by val/loss (GPU6 bkshp8h5, GPU5 m27xcib5, GPU0 un4r9eit). W&B: dkhd36rd.

Result: **val/loss=12.55** — catastrophic failure. Same failure mode as R4. `load_state_dict` returned `<All keys matched successfully>` (architectures are fully compatible), but averaging independently-trained models from different random seeds destroys the internal representations. Models trained from scratch with different seeds learn non-aligned feature representations; weight averaging produces incoherent weights.

### What happened

**Seed diversity**: Variance across seeds at fixed lr=1.5e-3 (GPU0–1) is 0.7176–0.7208, a spread of ~0.003. The hypothesis that "a lucky seed could beat 0.701" is not supported — all seeds land ~1.1–1.5% above the baseline. Run-to-run variance is ~0.003, not ~0.005.

**Tandem-ramp**: Mixed results. GPU5 (ramp, seed=123) at 0.7108 is the best tandem-ramp-only run. GPU4 (ramp, seed=42) at 0.7233 is much worse. No consistent benefit from the ramp alone.

**Best result**: GPU6 (tandem_ramp + T_max=200 + eta_min=1e-5) at **0.7048** — just 0.55% above the 0.701 baseline. The T_max=200 cosine schedule fits better for ~253 epochs than T_max=230. Tandem-ramp may contribute marginally here.

**AdaLN hurts**: GPU7 (tandem_ramp + adaln + T_max=200) at 0.7240 is the worst ramp run. AdaLN overhead harms rather than helps in this config.

**DiWA from scratch confirmed impossible**: Independent training from different seeds produces non-aligned internal representations. Confirmed twice (R4 and R5). Weight averaging only works with a shared pretrained initialization.

### Suggested follow-ups

- **DiWA with fine-tuning**: Take the best checkpoint (bkshp8h5 / GPU6), fine-tune 3–4 runs with different seeds for 20–30 epochs from that shared init, then average. Representations will remain aligned.
- **T_max=200 clean ablation**: GPU6's result strongly suggests T_max=200 is better than T_max=230 for this ~250-epoch budget. Worth confirming with a dedicated run.
- **tandem_ramp + T_max=200 is the best combo found in R5**: If advancing this branch, GPU6 config is the starting point.
- **GPU3 (seed=789, lr=1.6e-3) achieved p_oodc=9.9**: Marginally better than baseline's 10.1 on OOD-cond pressure. lr=1.6e-3 may warrant further study for OOD generalization.