### PR TITLE
Phase 2 R6: Hyperparameter Tuning on New Baseline (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -639,10 +639,10 @@ class Config:
     adaln_sam: bool = False            # SAM optimizer in last 25% of training
     film_cond: bool = False            # FiLM conditioning (simpler alternative to AdaLN)
     adaln_zone_temp: bool = False      # zone-aware temperature modulation
-    # Phase 2 R5: tandem warm-in combinations
-    tandem_ramp: bool = False          # gradual tandem surface loss warm-in (0→1 over epochs 10-50)
+    # Phase 2 R5/R6: tandem warm-in + slice tuning (ramp+slice96 is new baseline)
+    tandem_ramp: bool = True           # gradual tandem surface loss warm-in (0→1 over epochs 10-50)
     foil2_dist: bool = False           # explicit foil-2 distance feature (from secondary dsdf)
-    slice_num: int = 48                # slice count (default 48, GPU6: 96)
+    slice_num: int = 96                # slice count (96 is new baseline, 48 was old default)
 
 
 cfg = sp.parse(Config)


### PR DESCRIPTION
## Hypothesis
The new baseline (tandem warm-in + 96 slices) may have a different optimal LR/schedule than the old config. Systematic HP tuning around the new config could find a better operating point. R5 showed T_max=200 reaches 0.708 on the old code — on the new code with ramp+slice96 it might break through.

## Instructions
Pull latest noam. MAX_TIMEOUT=180, MAX_EPOCHS=500. Use `--wandb_group "phase2-r6-hp"`.

### GPU 0: Baseline seed=42 (variance estimation)
`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "frieren/p2r6-base-s42" --wandb_group "phase2-r6-hp" --agent frieren`

### GPU 1: Baseline seed=123
`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "frieren/p2r6-base-s123" --wandb_group "phase2-r6-hp" --agent frieren`

### GPU 2: Baseline seed=456
`CUDA_VISIBLE_DEVICES=2 python train.py --wandb_name "frieren/p2r6-base-s456" --wandb_group "phase2-r6-hp" --agent frieren`

### GPU 3: T_max=200, eta_min=1e-5 (best R5 schedule tweak)
`CUDA_VISIBLE_DEVICES=3 python train.py --wandb_name "frieren/p2r6-t200" --wandb_group "phase2-r6-hp" --agent frieren`

### GPU 4: lr=1.3e-3, T_max=210
`CUDA_VISIBLE_DEVICES=4 python train.py --lr 1.3e-3 --wandb_name "frieren/p2r6-lr13-t210" --wandb_group "phase2-r6-hp" --agent frieren`

### GPU 5: lr=1.8e-3, T_max=200
`CUDA_VISIBLE_DEVICES=5 python train.py --lr 1.8e-3 --wandb_name "frieren/p2r6-lr18-t200" --wandb_group "phase2-r6-hp" --agent frieren`

### GPU 6: wd=1e-5
`CUDA_VISIBLE_DEVICES=6 python train.py --weight_decay 1e-5 --wandb_name "frieren/p2r6-wd" --wandb_group "phase2-r6-hp" --agent frieren`

### GPU 7: EMA from epoch 80, decay=0.9995
`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "frieren/p2r6-early-ema" --wandb_group "phase2-r6-hp" --agent frieren`

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| 0.699 | 14.6 | 10.1 | 35.1 | 25.4 |

---
## Results

Implementation note: GPU3 command was missing `--cosine_T_max 200` (used default 230) — I added it to match the description. GPU7 was missing `--ema_start_epoch 80 --ema_decay 0.9995` — I added both to implement "EMA from epoch 80, decay=0.9995". Config defaults updated to tandem_ramp=True, slice_num=96 (new baseline).

| GPU | Config | val/loss | p_in | p_oodc | p_tan | p_re | Peak mem | W&B run |
|-----|--------|----------|------|--------|-------|------|----------|---------|
| 0 | base-s42 | 0.7158 | 14.8 | 10.5 | 36.4 | 25.5 | 29.3GB | ov93vo5z |
| 1 | base-s123 | 0.7009 | 14.4 | 10.0 | 35.6 | 25.5 | 29.6GB | 4mce7hoh |
| 2 | base-s456 | 0.7071 | 14.9 | 10.1 | 36.0 | 25.6 | 29.0GB | prwchei9 |
| 3 | T_max=200 | 0.7025 | 14.5 | 10.0 | 35.8 | 25.3 | 28.7GB | zsa9nofd |
| 4 | lr=1.3e-3, T_max=210 | 0.7206 | 14.4 | 10.3 | 36.1 | 26.0 | 29.3GB | zq5h0z6b |
| 5 | lr=1.8e-3, T_max=200 | 0.7204 | 14.6 | 10.7 | 36.6 | 25.8 | 29.1GB | eqdwtpqr |
| 6 | wd=1e-5 | 0.7125 | 14.5 | 10.1 | 36.1 | 25.7 | 29.6GB | ee5nk7h3 |
| 7 | early EMA (ep80, 0.9995) | 0.7136 | 15.1 | 10.3 | 36.7 | 25.5 | 29.3GB | j3pch53o |

**No HP variant beats the 0.699 baseline.**

### What happened

**High variance is the main story.** The three baseline reruns (GPU0-2) gave val/loss of 0.7158, 0.7009, and 0.7071 — a spread of 0.015 from the same config. The R5 result of 0.6994 (which set the baseline) appears to be near the lucky end of this distribution rather than a robust improvement. Mean of GPU0-2: 0.7079 ± 0.008.

**T_max=200 (GPU3, 0.7025)** is the best HP variant, competitive with GPU1 (0.7009). Slightly better than current default T_max=230. The shorter cosine cycle may help with the ramp+slice96 config since the tandem loss warms in fully by epoch 50, and the cosine should align better with this.

**Lower LR hurts more than higher.** GPU4 (lr=1.3e-3, 0.7206) is significantly worse than default. GPU5 (lr=1.8e-3, 0.7204) is also worse. The 1.5e-3 default appears to be near-optimal for this config.

**Weight decay (GPU6, 0.7125)** and **early EMA (GPU7, 0.7136)** both slightly worse than the best baseline reruns but within variance.

Overall: the ramp+slice96 config is at best ~0.700 on average, with the 0.699 from R5 being a good run of the same basic config. HP tuning around this point doesn't yield clear improvements.

### Suggested follow-ups
1. **More seeds for baseline**: With variance ±0.008, need 5+ runs to reliably estimate mean. The reported 0.699 baseline may be optimistic — actual mean might be ~0.707.
2. **T_max=200 + larger run**: GPU3 with T_max=200 looked competitive (0.7025). Could be worth a dedicated 5-seed study.
3. **Architectural changes**: HP tuning has limited headroom. The next gains likely require architectural innovation (e.g., ramp+slice96+decouple from R5 suggestions, or attention to tandem-specific biases).
4. **Cosine restart schedule**: CosineAnnealingWarmRestarts with multiple cycles might escape local minima better than single cosine. The current single-cycle T_max=230 means the model sees one full LR decay — restarts could help.