### PR TITLE
Phase 2 R6: Tandem Deep-Dive on New Baseline (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -1545,11 +1545,32 @@ if best_metrics:
                 y_dev = y_true.unsqueeze(0).to(device)
                 is_surf_dev = is_surface.unsqueeze(0).to(device)
                 mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
+                raw_dsdf_vis = x_dev[:, :, 2:10]
+                dist_surf_vis = raw_dsdf_vis.abs().min(dim=-1, keepdim=True).values
+                dist_feat_vis = torch.log1p(dist_surf_vis * 10.0)
+                if cfg.canonicalize:
+                    aoa_rad_vis = x_dev[:, 0, 14:15]
+                    cos_a_vis = torch.cos(-aoa_rad_vis)
+                    sin_a_vis = torch.sin(-aoa_rad_vis)
+                    px_vis = x_dev[:, :, 0:1]; py_vis = x_dev[:, :, 1:2]
+                    x_dev = torch.cat([px_vis * cos_a_vis.unsqueeze(1) + py_vis * sin_a_vis.unsqueeze(1),
+                                       -px_vis * sin_a_vis.unsqueeze(1) + py_vis * cos_a_vis.unsqueeze(1),
+                                       x_dev[:, :, 2:]], dim=-1)
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)
-                x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                if cfg.foil2_dist:
+                    foil2_dist_vis = torch.log1p(raw_dsdf_vis[:, :, 4:8].abs().min(dim=-1, keepdim=True).values * 10.0)
+                    x_n = torch.cat([x_n, curv, dist_feat_vis, foil2_dist_vis], dim=-1)
+                else:
+                    x_n = torch.cat([x_n, curv, dist_feat_vis], dim=-1)
+                raw_xy_vis = x_n[:, :, :2]
+                xy_min_vis = raw_xy_vis.amin(dim=1, keepdim=True)
+                xy_max_vis = raw_xy_vis.amax(dim=1, keepdim=True)
+                xy_norm_vis = (raw_xy_vis - xy_min_vis) / (xy_max_vis - xy_min_vis + 1e-8)
+                freqs_vis = torch.cat([_base_model.fourier_freqs_fixed.to(device), _base_model.fourier_freqs_learned.abs()])
+                xy_scaled_vis = xy_norm_vis.unsqueeze(-1) * freqs_vis
+                fourier_pe_vis = torch.cat([xy_scaled_vis.sin().flatten(-2), xy_scaled_vis.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe_vis], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]


### PR DESCRIPTION
## Hypothesis
The new baseline already has tandem warm-in + 96 slices. p_tan=35.1 Pa is still 3.5x worse than p_oodc=10.1 Pa. This PR tests tandem-specific features that layer on top of the warm-in curriculum.

## Instructions
Pull latest noam. MAX_TIMEOUT=180, MAX_EPOCHS=500, lr=1.5e-3. Use `--wandb_group "phase2-r6-tandem"`.

### GPU 0: Foil-2 distance feature on new baseline
`CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "nezuko/p2r6-foil2-dist" --wandb_group "phase2-r6-tandem" --agent nezuko`

### GPU 1: Decouple-zone slice assignment on new baseline
`CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "nezuko/p2r6-decouple-zone" --wandb_group "phase2-r6-tandem" --agent nezuko`

### GPU 2: Foil-2 + decouple-zone combined
`CUDA_VISIBLE_DEVICES=2 python train.py --wandb_name "nezuko/p2r6-foil2-decouple" --wandb_group "phase2-r6-tandem" --agent nezuko`

### GPU 3: Extended warm-in (80 epoch ramp, was 0.688 in R5)
The 80-epoch ramp beat val/loss in R5 but regressed on surface. Try with surface-focused loss tweak.
`CUDA_VISIBLE_DEVICES=3 python train.py --wandb_name "nezuko/p2r6-ramp80-surfocus" --wandb_group "phase2-r6-tandem" --agent nezuko`

### GPU 4: Tandem 3x surf weight after warm-in (R5 was 0.703)
`CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "nezuko/p2r6-3x-surf" --wandb_group "phase2-r6-tandem" --agent nezuko`

### GPU 5: AdaLN + foil2-dist (OOD conditioning + tandem feature)
`CUDA_VISIBLE_DEVICES=5 python train.py --wandb_name "nezuko/p2r6-adaln-foil2" --wandb_group "phase2-r6-tandem" --agent nezuko`

### GPU 6: Inlet velocity canonicalization (GeoMPNN-inspired)
Rotate coords by -AoA before standardization. Tested in R4 but now on new code.
`CUDA_VISIBLE_DEVICES=6 python train.py --wandb_name "nezuko/p2r6-canonicalize" --wandb_group "phase2-r6-tandem" --agent nezuko`

### GPU 7: Per-foil output head (R5 best: 0.691 on old code)
Test on new ramp+slice96 baseline. Also add 1.5x surface weight to prevent volume dominance.
`CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "nezuko/p2r6-per-foil-1.5x" --wandb_group "phase2-r6-tandem" --agent nezuko`

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| 0.699 | 14.6 | 10.1 | **35.1** | 25.4 |

---
## Results

### Run summary

| Variant | W&B ID | Epochs | val/loss | p_in | p_oodc | p_tan | p_re |
|---------|--------|--------|---------|------|--------|-------|------|
| **Baseline** | — | — | 0.699 | 14.6 | 10.1 | **35.1** | 25.4 |
| foil2-dist | jpuejoxn | 232 | **0.7008** | 14.2 | 10.0 | 35.8 | 25.5 |
| adaln-foil2 | 4nmim3el | 228 | 0.7108 | 15.3 | **9.8** | 36.0 | 25.7 |
| decouple-zone | 3nhqwf14 | 221 | 0.7171 | 14.3 | 10.3 | 36.8 | 25.5 |
| foil2-decouple | mqps8fiy | 221 | 0.7180 | 14.6 | 10.1 | 36.1 | 25.7 |
| canonicalize | k8ohp462 | 231 | 0.7208 | 14.4 | 12.0 | 35.5 | 25.6 |
| ramp80-surfocus | cu88qwzm | 233 | 0.7238 | 15.4 | 10.3 | 36.8 | 25.7 |
| per-foil | 6lv35eaf | 222 | 0.7248 | 15.3 | 10.2 | 36.6 | 25.7 |
| 3x-surf ⚠️ | 3bjvh2gm | 233 | 0.7311 | 15.5 | 10.2 | 36.5 | 25.8 |

⚠️ = velocity metrics collapsed (Ux_in=6.5, Uy_in=1.8), pressure metrics deceptively intact.

Note: all 8 runs show "failed" in W&B due to a post-training visualization bug (Fourier PE was missing from the viz preprocessing, causing a shape mismatch after training completed). Training metrics are valid. Fixed in this commit.

### What happened

**p_tan did not improve below 35.1.** Best R6 variant is foil2-dist at p_tan=35.8. This is the fourth consecutive round (R3, R4, R5, R6) where no architectural change breaks through the 35.1 Pa floor. The R6 new baseline (slice96 + tandem_ramp) itself sits at 35.1 — all 8 variants tested on top of it are worse.

**foil2-dist (GPU0) is closest to baseline overall**: val_loss=0.7008 essentially matches baseline 0.699. Adding the foil-2 distance feature (log1p of minimum dsdf magnitude for the second foil channels) marginally improves p_oodc (10.0 vs 10.1) but doesn't help p_tan. The dsdf channels already implicitly encode both-foil geometry — the explicit distance adds little new information.

**adaln-foil2 (GPU5) achieved p_oodc=9.8 Pa**: First variant across all rounds to break below 10 Pa on out-of-distribution conditioning. AdaLN output head (Re, AoA conditioning) combined with foil2_dist helps OOD generalization slightly. The p_tan (36.0) is still above baseline, suggesting the conditioning helps distribution shift but not the tandem slot-flow problem.

**canonicalize (GPU6): p_tan=35.5, p_oodc=12.0**: Closest p_tan result in R6 but at the cost of significantly degraded p_oodc (12.0 vs baseline 10.1). AoA rotation introduces variance across samples with different angles of attack — exactly the kind of variation p_oodc measures. The baseline already has AoA as an explicit channel, so rotation adds noise rather than removing it.

**3x-surf (GPU4) is harmful**: Velocity metrics collapse (Ux surface MAE: 6.5 vs baseline ~2.0). The 3× boost applied to `adaptive_boost` after warm-in completion drives the total effective surface weight to ~60×, overwhelming the velocity loss. Pressure metrics look reasonable only because the surface pressure loss is on a different scale.

**ramp80-surfocus (GPU3): p_tan=36.8**: Extending warm-in to 80 epochs + 1.5× surface weight during warm-in makes things worse. The surfocus flag increases surface weight early when the model hasn't learned good volume representations — this interferes with the natural adaptive weighting mechanism.

**foil2-decouple (GPU2) adds no benefit over foil2-dist alone**: p_tan: 36.1 (foil2-decouple) vs 35.8 (foil2-dist solo). Adding decoupled slice assignment to the foil2 distance feature doesn't compound. The decouple mechanism was already tested in R5/R6 standalone and shows consistent ~35.8-36.8 range.

**Core finding**: Across 4 rounds (R3, R4, R5, R6) and 32+ variants, p_tan=35.1 Pa has been tested against: zone-bias, adaptive-temp, AdaLN (all variants), surf2vol, foil2-dist, canonicalize, per-foil-head, decouple-slice, tandem-ramp (40 and 80 epoch), tandem-dropout, 3x-surf, ramp-surfocus, foil2-decouple. None moved the needle. This is a data or physics floor, not an architectural one.

### Suggested follow-ups

1. **Accept 35.1 Pa as a data floor**: Architecture changes are exhausted. The next meaningful experiment is counting tandem training samples — if fewer than ~300, more data is the only lever.
2. **adaln-foil2 is worth extending**: First variant to break below 10 Pa on p_oodc. Could be the foundation for a new R7 baseline targeting OOD generalization.
3. **Spatial pressure loss mask for slot region**: Instead of per-sample weighting, add a spatial mask for the slot region (chord range 0.0–0.3 between foils) with high pressure weight. This directly targets the high-error region without corrupting general training.
4. **Separate tandem model**: If more tandem data is available, train a specialist model on tandem samples only rather than a joint model with curriculum.