### PR TITLE
Enable autocompact for student and advisor sessions at 40% context

### DIFF
--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -25,9 +25,6 @@ git config user.email "senpai-$STUDENT_NAME@senpai"
 curl -fsSL https://claude.ai/install.sh | bash
 export PATH="$HOME/.claude/bin:$PATH"
 
-# --- Configure autocompact: compact at N% of context window (default 40% ≈ 80k on 200k) ---
-export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="${CLAUDE_AUTOCOMPACT_PCT_OVERRIDE:-40}"
-
 # --- Install Weave Claude Code Plugin ---
 source "$WORKDIR/tools/install-weave-cc-plugin.sh"
 


### PR DESCRIPTION
## Summary

Sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=40` for student pods so Claude Code automatically compacts context at ~40% of the context window (~400k tokens on a 1M model).

- Adds `--autocompact_pct` arg to `launch.py` (default 40), passed to the student ConfigMap
- Pod picks it up via `envFrom: configMapRef` 

🤖 Generated with [Claude Code](https://claude.com/claude-code)