### PR TITLE
Phase 1 & Phase 2 Results Reference

### DIFF
--- a/instructions/phase_3_noam_results_2026-03-21 copy.md
+++ b/instructions/phase_3_noam_results_2026-03-21 copy.md
@@ -1,0 +1,695 @@
+Below are instructions for the next phase of this research programme - Phase 3.
+
+
+
+# The Next Phase of the Research Programme - Phase 3
+
+Based on the results from our Phase 1 experiments in <experiment_results_table> your task now is to conduct Phase 3 of this research programme.
+
+## Phase 3 - The Why
+
+We have run over 1000 experiments in phase 1 of this research programme - short experiments each taking 30 minutes. These can all be listed using the `list-experiments` skill. Now want to find the diamonds in the rough - what are the most promising experiment ideas that we have tried that will have a chance of better results with more training - up to 3 hours now. 
+
+## Merged PRs from experiments that worked
+
+For merged experiments that worked, we want to understand out of all the merged experiments, which are the ones that are most importnat for continued gains over 3 hours of training? Maybe there are some marginal experiments that we merged for marginal gains that we can consider ignoring?
+
+## Closed PRs from experiments that did not work
+
+For closed experiments that did not work, we want to understand out of all the closed experiments, which might have had promising potential results that we can consider re-opening now that we're training for 3 hours and not 30 minutes?
+
+
+## Base train.py 
+
+To help you understand where we're comming from, below is the entire, original train.py file. Compared to the train.py file that is now on this `noam` git branch you can see that the noam branch has evolved quite a lot.
+
+
+```python
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Train Transolver with structured benchmark splits.
+
+Reads a split manifest and stats file produced by data/split.py,
+then trains with four separate val tracks:
+  val_in_dist          — raceCar_single random holdout (interpolation sanity)
+  val_tandem_transfer  — raceCar_tandem Part2 (unseen tandem front foil)
+  val_ood_cond         — cruise Part1+3 frontier 20% (extreme AoA/gap/stagger)
+  val_ood_re           — cruise Part2 Re=4.445M (fully OOD Reynolds number)
+
+Run:
+  python train.py --agent <name> --wandb_name "<name>/<desc>"
+
+KNOWN LIMITATIONS (inherited from read-only prepare.py):
+  - Only NACA[0] and AoA[0] are encoded in x. Foil 2 is implicit in dsdf/saf.
+  - SURFACE_IDS=(5,6) misses boundary ID 7 (foil 2 surface in tandem data).
+    Tandem surface loss is therefore underweighted.
+"""
+
+import os
+import time
+from collections.abc import Mapping
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import wandb
+import yaml
+from dataclasses import dataclass, asdict
+from einops import rearrange
+from timm.layers import trunc_normal_
+from tqdm import tqdm
+from torch.utils.data import DataLoader, WeightedRandomSampler
+import simple_parsing as sp
+
+from data.utils import visualize
+from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
+
+
+# ---------------------------------------------------------------------------
+# Transolver model (inlined so students can
+# modify architecture and training script in a single file)
+# ---------------------------------------------------------------------------
+
+ACTIVATION = {
+    "gelu": nn.GELU,
+    "tanh": nn.Tanh,
+    "sigmoid": nn.Sigmoid,
+    "relu": nn.ReLU,
+    "leaky_relu": nn.LeakyReLU(0.1),
+    "softplus": nn.Softplus,
+    "ELU": nn.ELU,
+    "silu": nn.SiLU,
+}
+
+
+class MLP(nn.Module):
+    def __init__(self, n_input, n_hidden, n_output, n_layers=1, act="gelu", res=True):
+        super().__init__()
+        if act not in ACTIVATION:
+            raise NotImplementedError
+        act_fn = ACTIVATION[act]
+        self.n_input = n_input
+        self.n_hidden = n_hidden
+        self.n_output = n_output
+        self.n_layers = n_layers
+        self.res = res
+        self.linear_pre = nn.Sequential(nn.Linear(n_input, n_hidden), act_fn())
+        self.linear_post = nn.Linear(n_hidden, n_output)
+        self.linears = nn.ModuleList([nn.Sequential(nn.Linear(n_hidden, n_hidden), act_fn()) for _ in range(n_layers)])
+
+    def forward(self, x):
+        x = self.linear_pre(x)
+        for i in range(self.n_layers):
+            if self.res:
+                x = self.linears[i](x) + x
+            else:
+                x = self.linears[i](x)
+        x = self.linear_post(x)
+        return x
+
+
+class Physics_Attention_Irregular_Mesh(nn.Module):
+    """Physics attention for irregular meshes in 1D/2D/3D space."""
+
+    def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64):
+        super().__init__()
+        inner_dim = dim_head * heads
+        self.dim_head = dim_head
+        self.heads = heads
+        self.scale = dim_head**-0.5
+        self.softmax = nn.Softmax(dim=-1)
+        self.dropout = nn.Dropout(dropout)
+        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+
+        self.in_project_x = nn.Linear(dim, inner_dim)
+        self.in_project_fx = nn.Linear(dim, inner_dim)
+        self.in_project_slice = nn.Linear(dim_head, slice_num)
+        torch.nn.init.orthogonal_(self.in_project_slice.weight)
+        self.to_q = nn.Linear(dim_head, dim_head, bias=False)
+        self.to_k = nn.Linear(dim_head, dim_head, bias=False)
+        self.to_v = nn.Linear(dim_head, dim_head, bias=False)
+        self.to_out = nn.Sequential(
+            nn.Linear(inner_dim, dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x):
+        bsz, num_points, _ = x.shape
+
+        fx_mid = (
+            self.in_project_fx(x)
+            .reshape(bsz, num_points, self.heads, self.dim_head)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+        x_mid = (
+            self.in_project_x(x)
+            .reshape(bsz, num_points, self.heads, self.dim_head)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+        slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
+        slice_norm = slice_weights.sum(2)
+        slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
+        slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
+
+        q_slice_token = self.to_q(slice_token)
+        k_slice_token = self.to_k(slice_token)
+        v_slice_token = self.to_v(slice_token)
+        dropout_p = self.dropout.p if self.training else 0.0
+        out_slice_token = F.scaled_dot_product_attention(
+            q_slice_token,
+            k_slice_token,
+            v_slice_token,
+            dropout_p=dropout_p,
+            is_causal=False,
+        )
+
+        out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
+        out_x = rearrange(out_x, "b h n d -> b n (h d)")
+        return self.to_out(out_x)
+
+
+class TransolverBlock(nn.Module):
+    def __init__(
+        self,
+        num_heads: int,
+        hidden_dim: int,
+        dropout: float,
+        act="gelu",
+        mlp_ratio=4,
+        last_layer=False,
+        out_dim=1,
+        slice_num=32,
+    ):
+        super().__init__()
+        self.last_layer = last_layer
+        self.ln_1 = nn.LayerNorm(hidden_dim)
+        self.attn = Physics_Attention_Irregular_Mesh(
+            hidden_dim,
+            heads=num_heads,
+            dim_head=hidden_dim // num_heads,
+            dropout=dropout,
+            slice_num=slice_num,
+        )
+        self.ln_2 = nn.LayerNorm(hidden_dim)
+        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        if self.last_layer:
+            self.ln_3 = nn.LayerNorm(hidden_dim)
+            self.mlp2 = nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim),
+                nn.GELU(),
+                nn.Linear(hidden_dim, out_dim),
+            )
+
+    def forward(self, fx):
+        fx = self.attn(self.ln_1(fx)) + fx
+        fx = self.mlp(self.ln_2(fx)) + fx
+        if self.last_layer:
+            return self.mlp2(self.ln_3(fx))
+        return fx
+
+
+class Transolver(nn.Module):
+    def __init__(
+        self,
+        space_dim=1,
+        n_layers=5,
+        n_hidden=256,
+        dropout=0.0,
+        n_head=8,
+        act="gelu",
+        mlp_ratio=1,
+        fun_dim=1,
+        out_dim=1,
+        slice_num=32,
+        ref=8,
+        unified_pos=False,
+        output_fields: list[str] | None = None,
+        output_dims: list[int] | None = None,
+    ):
+        super().__init__()
+        self.__name__ = "UniPDE_3D"
+        self.ref = ref
+        self.unified_pos = unified_pos
+        if output_fields is None or output_dims is None:
+            raise ValueError("output_fields and output_dims must be provided")
+        if len(output_fields) != len(output_dims):
+            raise ValueError("output_fields and output_dims must have the same length")
+        if out_dim != sum(output_dims):
+            raise ValueError("out_dim must equal sum(output_dims)")
+        self.output_fields = output_fields
+        self.output_dims = output_dims
+
+        if self.unified_pos:
+            self.preprocess = MLP(
+                fun_dim + self.ref * self.ref * self.ref,
+                n_hidden * 2,
+                n_hidden,
+                n_layers=0,
+                res=False,
+                act=act,
+            )
+        else:
+            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)
+
+        self.n_hidden = n_hidden
+        self.space_dim = space_dim
+        self.blocks = nn.ModuleList(
+            [
+                TransolverBlock(
+                    num_heads=n_head,
+                    hidden_dim=n_hidden,
+                    dropout=dropout,
+                    act=act,
+                    mlp_ratio=mlp_ratio,
+                    out_dim=out_dim,
+                    slice_num=slice_num,
+                    last_layer=(idx == n_layers - 1),
+                )
+                for idx in range(n_layers)
+            ]
+        )
+        self.initialize_weights()
+        self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))
+
+    def initialize_weights(self):
+        self.apply(self._init_weights)
+
+    def _init_weights(self, module):
+        if isinstance(module, nn.Linear):
+            trunc_normal_(module.weight, std=0.02)
+            if module.bias is not None:
+                nn.init.constant_(module.bias, 0)
+        elif isinstance(module, (nn.LayerNorm, nn.BatchNorm1d)):
+            nn.init.constant_(module.bias, 0)
+            nn.init.constant_(module.weight, 1.0)
+
+    def get_grid(self, my_pos):
+        batchsize = my_pos.shape[0]
+        device = my_pos.device
+        dtype = my_pos.dtype
+
+        gridx = torch.linspace(-1.5, 1.5, self.ref, device=device, dtype=dtype)
+        gridx = gridx.view(1, self.ref, 1, 1, 1).repeat(batchsize, 1, self.ref, self.ref, 1)
+        gridy = torch.linspace(0, 2, self.ref, device=device, dtype=dtype)
+        gridy = gridy.view(1, 1, self.ref, 1, 1).repeat(batchsize, self.ref, 1, self.ref, 1)
+        gridz = torch.linspace(-4, 4, self.ref, device=device, dtype=dtype)
+        gridz = gridz.view(1, 1, 1, self.ref, 1).repeat(batchsize, self.ref, self.ref, 1, 1)
+        grid_ref = torch.cat((gridx, gridy, gridz), dim=-1).reshape(batchsize, self.ref**3, 3)
+
+        pos = torch.sqrt(((my_pos[:, :, None, :] - grid_ref[:, None, :, :]) ** 2).sum(dim=-1))
+        return pos.reshape(batchsize, my_pos.shape[1], self.ref * self.ref * self.ref).contiguous()
+
+    def _unpack_inputs(self, data, pos=None, condition=None):
+        if not isinstance(data, Mapping):
+            raise TypeError("Model input must be a Mapping with keys: x, pos, condition")
+        x = data.get("x")
+        pos = data.get("pos", pos)
+        condition = data.get("condition", condition)
+        return x, pos, condition
+
+    def _validate_output_dims(self, preds):
+        if sum(self.output_dims) != preds.shape[-1]:
+            raise ValueError("Sum of output_dims must match preds last dimension")
+
+    def forward(self, data, pos=None, condition=None):
+        x, pos, condition = self._unpack_inputs(data, pos=pos, condition=condition)
+        if x is None:
+            raise ValueError("Missing required input tensor: x")
+        if condition is not None:
+            raise ValueError("Transolver does not support conditioning inputs")
+
+        if self.unified_pos:
+            if pos is None:
+                raise ValueError("Missing required input tensor: pos")
+            new_pos = self.get_grid(pos)
+            x = torch.cat((x, new_pos), dim=-1)
+
+        fx = self.preprocess(x)
+        fx = fx + self.placeholder[None, None, :]
+
+        for block in self.blocks:
+            fx = block(fx)
+        self._validate_output_dims(fx)
+        return {"preds": fx}
+
+
+# ---------------------------------------------------------------------------
+# End Transolver model
+# ---------------------------------------------------------------------------
+
+
+MAX_TIMEOUT = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "30.0"))  # minutes
+MAX_EPOCHS = int(os.environ.get("SENPAI_MAX_EPOCHS", "50"))
+
+
+@dataclass
+class Config:
+    lr: float = 5e-4
+    weight_decay: float = 1e-4
+    batch_size: int = 4
+    surf_weight: float = 10.0
+    manifest: str = "data/split_manifest.json"
+    stats_file: str = "data/split_stats.json"
+    wandb_group: str | None = None
+    wandb_name: str | None = None
+    agent: str | None = None
+    debug: bool = False
+
+
+cfg = sp.parse(Config)
+
+if cfg.debug:
+    MAX_EPOCHS = 3
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))
+
+train_ds, val_splits, stats, sample_weights = load_data(
+    cfg.manifest, cfg.stats_file, debug=cfg.debug,
+)
+stats = {k: v.to(device) for k, v in stats.items()}
+
+
+def _umag_q(y, mask):
+    """Per-sample reference velocity and dynamic pressure from mean velocity.
+
+    Uses mean velocity of actual (unpadded) nodes as Umag proxy. For CFD flow
+    over airfoils, the domain-mean velocity tracks the freestream magnitude
+    across Re numbers (surface no-slip nodes reduce the mean slightly, but
+    consistently across all samples).
+
+    Returns:
+        Umag: [B, 1, 1], dynamic velocity magnitude, clamped ≥ 1.0
+        q:    [B, 1, 1], dynamic pressure = 0.5 * Umag^2
+    """
+    n_nodes = mask.float().sum(dim=1, keepdim=True).clamp(min=1.0)  # [B, 1]
+    Ux_mean = (y[:, :, 0] * mask.float()).sum(dim=1, keepdim=True) / n_nodes  # [B, 1]
+    Uy_mean = (y[:, :, 1] * mask.float()).sum(dim=1, keepdim=True) / n_nodes  # [B, 1]
+    Umag = (Ux_mean ** 2 + Uy_mean ** 2).sqrt().clamp(min=1.0).unsqueeze(-1)  # [B, 1, 1]
+    q = 0.5 * Umag ** 2
+    return Umag, q
+
+
+def _phys_norm(y, Umag, q):
+    """Normalize Ux→Ux/Umag, Uy→Uy/Umag, p→p/q (Cp)."""
+    y_p = y.clone()
+    y_p[:, :, 0:1] = y[:, :, 0:1] / Umag
+    y_p[:, :, 1:2] = y[:, :, 1:2] / Umag
+    y_p[:, :, 2:3] = y[:, :, 2:3] / q
+    return y_p
+
+
+def _phys_denorm(y_p, Umag, q):
+    """Reverse physics normalization: Ux/Umag→Ux, Uy/Umag→Uy, Cp→p."""
+    y = y_p.clone()
+    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-50, 50) * Umag
+    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-50, 50) * Umag
+    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-100, 100) * q
+    return y
+
+loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
+                     persistent_workers=True, prefetch_factor=2)
+
+if cfg.debug:
+    # Avoid sampler/length mismatch when train_ds is truncated
+    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
+                              shuffle=True, **loader_kwargs)
+else:
+    sampler = WeightedRandomSampler(
+        weights=sample_weights,
+        num_samples=len(train_ds),
+        replacement=True,
+    )
+    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
+                              sampler=sampler, **loader_kwargs)
+
+val_loaders = {
+    name: DataLoader(subset, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
+    for name, subset in val_splits.items()
+}
+
+model_config = dict(
+    space_dim=2,
+    fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
+    out_dim=3,
+    n_hidden=128,
+    n_layers=5,
+    n_head=4,
+    slice_num=64,
+    mlp_ratio=2,
+    output_fields=["Ux", "Uy", "p"],
+    output_dims=[1, 1, 1],
+)
+
+model = Transolver(**model_config).to(device)
+
+n_params = sum(p.numel() for p in model.parameters())
+optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)
+
+# --- wandb ---
+run = wandb.init(
+    entity=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team"),
+    project=os.environ.get("WANDB_PROJECT", "senpai-v1"),
+    group=cfg.wandb_group,
+    name=cfg.wandb_name,
+    tags=[cfg.agent] if cfg.agent else [],
+    config={
+        **asdict(cfg),
+        "model_config": model_config,
+        "n_params": n_params,
+        "train_samples": len(train_ds),
+        "val_samples": {k: len(v) for k, v in val_splits.items()},
+        "split_manifest": cfg.manifest,
+    },
+    mode=os.environ.get("WANDB_MODE", "online"),
+)
+
+# All metrics use global_step (gradient updates) as the x-axis.
+wandb.define_metric("global_step")
+wandb.define_metric("train/*", step_metric="global_step")
+wandb.define_metric("val/*", step_metric="global_step")
+for _sname in VAL_SPLIT_NAMES:
+    wandb.define_metric(f"{_sname}/*", step_metric="global_step")
+wandb.define_metric("lr", step_metric="global_step")
+wandb.define_metric("epoch_time_s", step_metric="global_step")
+wandb.define_metric("val_predictions", step_metric="global_step")
+
+model_dir = Path(f"models/model-{run.id}")
+model_dir.mkdir(parents=True)
+model_path = model_dir / "checkpoint.pt"
+with open(model_dir / "config.yaml", "w") as f:
+    yaml.dump(model_config, f)
+
+best_val = float("inf")
+best_metrics = {}
+global_step = 0
+train_start = time.time()
+
+for epoch in range(MAX_EPOCHS):
+    elapsed_min = (time.time() - train_start) / 60.0
+    if elapsed_min >= MAX_TIMEOUT:
+        print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {MAX_TIMEOUT} min). Stopping.")
+        break
+
+    t0 = time.time()
+
+    # --- Train ---
+    model.train()
+    epoch_vol = 0.0
+    epoch_surf = 0.0
+    n_batches = 0
+
+    pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
+    for x, y, is_surface, mask in pbar:
+        x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+        is_surface = is_surface.to(device, non_blocking=True)
+        mask = mask.to(device, non_blocking=True)
+
+        x = (x - stats["x_mean"]) / stats["x_std"]
+        y_norm = (y - stats["y_mean"]) / stats["y_std"]
+
+        pred = model({"x": x})["preds"]
+        sq_err = (pred - y_norm) ** 2
+
+        vol_mask = mask & ~is_surface
+        surf_mask = mask & is_surface
+        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
+        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+        loss = vol_loss + cfg.surf_weight * surf_loss
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        global_step += 1
+        wandb.log({"train/loss": loss.item(), "global_step": global_step})
+
+        epoch_vol += vol_loss.item()
+        epoch_surf += surf_loss.item()
+        n_batches += 1
+        pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
+
+    scheduler.step()
+    epoch_vol /= n_batches
+    epoch_surf /= n_batches
+
+    # --- Validate across all splits ---
+    model.eval()
+    val_metrics_per_split: dict[str, dict] = {}
+    val_loss_sum = 0.0
+
+    for split_name, vloader in val_loaders.items():
+        val_vol = 0.0
+        val_surf = 0.0
+        mae_surf = torch.zeros(3, device=device)
+        mae_vol = torch.zeros(3, device=device)
+        n_surf = 0
+        n_vol = 0
+        n_vbatches = 0
+
+        with torch.no_grad():
+            for x, y, is_surface, mask in tqdm(
+                vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
+            ):
+                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+                is_surface = is_surface.to(device, non_blocking=True)
+                mask = mask.to(device, non_blocking=True)
+
+                x = (x - stats["x_mean"]) / stats["x_std"]
+                y_norm = (y - stats["y_mean"]) / stats["y_std"]
+
+                pred = model({"x": x})["preds"]
+                sq_err = (pred - y_norm) ** 2
+
+                vol_mask = mask & ~is_surface
+                surf_mask = mask & is_surface
+                val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
+                val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+                n_vbatches += 1
+
+                pred_orig = pred * stats["y_std"] + stats["y_mean"]
+                err = (pred_orig - y).abs()
+                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
+                n_surf += surf_mask.sum().item()
+                n_vol += vol_mask.sum().item()
+
+        val_vol /= max(n_vbatches, 1)
+        val_surf /= max(n_vbatches, 1)
+        split_loss = val_vol + cfg.surf_weight * val_surf
+        mae_surf /= max(n_surf, 1)
+        mae_vol /= max(n_vol, 1)
+
+        val_metrics_per_split[split_name] = {
+            f"{split_name}/vol_loss":    val_vol,
+            f"{split_name}/surf_loss":   val_surf,
+            f"{split_name}/loss":        split_loss,
+            f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
+            f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
+            f"{split_name}/mae_vol_p":   mae_vol[2].item(),
+            f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
+            f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
+            f"{split_name}/mae_surf_p":  mae_surf[2].item(),
+        }
+        val_loss_sum += split_loss
+
+    # val/loss = mean across all splits; used for checkpoint selection
+    mean_val_loss = val_loss_sum / len(val_loaders)
+
+    dt = time.time() - t0
+
+    # --- Log to wandb ---
+    metrics = {
+        "train/vol_loss": epoch_vol,
+        "train/surf_loss": epoch_surf,
+        "val/loss": mean_val_loss,
+        "lr": scheduler.get_last_lr()[0],
+        "epoch_time_s": dt,
+    }
+    for split_metrics in val_metrics_per_split.values():
+        metrics.update(split_metrics)
+    metrics["global_step"] = global_step
+    wandb.log(metrics)
+
+    if torch.cuda.is_available():
+        peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
+    else:
+        peak_mem_gb = 0.0
+
+    tag = ""
+    if mean_val_loss < best_val:
+        best_val = mean_val_loss
+        best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss}
+        for split_metrics in val_metrics_per_split.values():
+            for k, v in split_metrics.items():
+                best_metrics[f"best_{k}"] = v
+        torch.save(model.state_dict(), model_path)
+        tag = f" * -> {model_path}"
+
+    split_summary = "  ".join(
+        f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
+        for name in VAL_SPLIT_NAMES
+    )
+    print(
+        f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
+        f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
+        f"val[{split_summary}]{tag}"
+    )
+
+
+# --- Final summary ---
+total_time = (time.time() - train_start) / 60.0
+print("\n" + "=" * 70)
+print(f"TRAINING COMPLETE ({total_time:.1f} min)")
+print("=" * 70)
+if best_metrics:
+    print(f"Best model at epoch {best_metrics['epoch']}  (val/loss={best_metrics['val_loss']:.4f})")
+    for split_name in VAL_SPLIT_NAMES:
+        k_p = f"best_{split_name}/mae_surf_p"
+        k_l = f"best_{split_name}/loss"
+        if k_p in best_metrics:
+            print(f"  {split_name:30s}  loss={best_metrics[k_l]:.4f}  mae_surf_p={best_metrics[k_p]:.1f}")
+else:
+    print("No completed epochs (timeout too short?).")
+
+if best_metrics:
+    wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})
+
+    print("\nGenerating flow field plots...")
+    model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
+    plot_dir = Path("plots") / run.id
+    n = 1 if cfg.debug else 4
+    for split_name, split_ds in val_splits.items():
+        images = visualize(model, split_ds, stats, device, n_samples=n, out_dir=plot_dir / split_name)
+        if images:
+            wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})
+
+wandb.finish()
+```
+
+
+## Ranking the experiments
+
+First of all consider how to rank the experiments. We absolutely do not have capcaity to run all the experiments due to limited GPU resources so keep pushing hard on the highest potential experiments and ideas.
+
+So, it is crucial to plan well here, and ensure that we're always picking the highest potential experiments while also ensuring we're still taking some big bets - we don't want only incremental gains here, about 50% of our research portfolio for Phase 3 should be interesting ideas that we tried but didn't work out in Phase 1 but still showed some promise. 
+
+If you read the PR bodies of the previous experiments you will see that there are details about how they ran as well as the results and suggested follow ups. 
+
+### Teamwork makes the dream work
+
+Given that we have a lot of planning and research to do here looking over these past experiments, you should use a Claude Code Team of agents to help you here. 
+
+# Phase 3 Research Kickoff - running these Phase 3 experiments
+
+You now have context and instructions for the next phase of this research programme. We have 3 hours of training per experiment and 5 students to run the experiments. Note that each student has 8 GPUs, so in order to accelerate research you can also ask each student to run multiple experiments in parallel by pinning the training to specific GPUs using the CUDA_VISIBLE_DEVICES environment variable - ensure in this case that the github PR Title and Body clearly states that multiple different hyptheses are being tested in parallel. Other than this, the setup is the same as the previous phase where you should check the open PRs for any idle students, experimental resutls etc. 
+
+Ensure that all these Phase 3 experiments also get a "phase:2" label so that you can easily identify them later, as well as all other other standard labels we use for experiments.
+
+## Final thoughts
+We have a lot of experimens and ideas to get through here. Good luck, you've got this, this is where we make the real gains on val/loss and surface MAE!


### PR DESCRIPTION
Reference document for Phase 1 and Phase 2 experiment results on the `noam` branch. These tables were moved here from the Phase 3 instructions file to keep that doc focused on actionable guidance.

---

# Phase 1 Experiment Results

<experiment_results_table>

## Noam Branch — Phase 1 Experiment Results

> Generated 2026-03-21 | Source: GitHub PRs (base branch: `noam`) × W&B project `wandb-applied-ai-team/senpai-v1`
> **Sources**: `✓` = W&B-validated (`best_val_loss` summary, 4-split mean) | `~` = PR-reported only
> **Lower is better** for all metrics. 🔥 = ≥5% improvement on val/loss or p_oodc vs prior best.

---

### Table 1 — All 96 Merged PRs (ordered by merge datetime)

| PR | Date | Time | W&B Run | val/loss | Δval/loss | Src | p\_in | Δp\_in | p\_oodc | Δp\_oodc | p\_tan | Δp\_tan | p\_re | Δp\_re | Title |
|---:|------|------|---------|----------:|----------:|-----|------:|-------:|-------:|--------:|------:|--------:|------:|-------:|-------|
| 368 🔥 | 2026-03-16 | 06:36 | `mn2be3sz` | 6.1319 | — | ✓ | 119.7 | — | 86.8 | — | 113.2 | — | 310.3 | — | Surface weight 20 + L1 surface loss |
| 366 🔥 | 2026-03-16 | 07:30 | `npf2olp3` | 5.6041 | -0.5278 | ✓ | 103.2 | -16.5 | 89.2 | +2.4 | 102.4 | -10.7 | 86.8 | -223.5 | L1 surface loss + bf16 autocast + lr=3e-3 with warmu |
| 374 🔥 | 2026-03-16 | 08:09 | `cwcldejw` | 3.5966 | -2.0 | ✓ | 65.3 | -37.9 | 53.4 | -35.8 | 70.8 | -31.7 | — | — | Smaller model (2 layers) for more epochs in 30 minut |
| 376 🔥 | 2026-03-16 | 08:55 | `ecow7a4s` | 2.9942 | -0.6024 | ✓ | 46.4 | -18.9 | 46.7 | -6.7 | 65.4 | -5.4 | — | — | 1-layer model for maximum epochs in 30 minutes |
| 378 🔥 | 2026-03-16 | 09:35 | `dmna3zvh` | 2.6682 | -0.3260 | ✓ | 39.0 | -7.4 | 40.1 | -6.7 | 59.2 | -6.2 | — | — | Deeper output head (2-layer MLP instead of single li |
| 382 🔥 | 2026-03-16 | 10:14 | `ek47dvs5` | 2.5247 | -0.1435 | ✓ | 33.5 | -5.5 | 38.0 | -2.0 | 58.4 | -0.7517 | — | — | Fewer slices (slice_num=32) for faster attention |
| 386 | 2026-03-16 | 11:04 | `v10t4fwz` | 2.4928 | -0.0319 | ✓ | 33.7 | +0.1676 | 37.2 | -0.8357 | 56.4 | -2.0 | — | — | Target noise regularization (0.01 std Gaussian noise |
| 392 🔥 | 2026-03-16 | 11:59 | `wgvva2o9` | 2.7931 | +0.3002 | ✓ | 27.1 | -6.6 | 28.3 | -8.8 | 47.7 | -8.7 | — | — | Physics-based Cp normalization (predict non-dimensio |
| 400 | 2026-03-16 | 13:28 | `—` | — | — | — | — | — | — | — | — | — | 35.7 | -51.1 | Robust denormalization (NaN guards + clamping for va |
| 405 | 2026-03-16 | 14:15 | `—` | — | — | — | — | — | — | — | — | — | — | — | Surface weight schedule (ramp from 5→30 over trainin |
| 420 🔥 | 2026-03-16 | 16:32 | `sn98scun` | 2.8876 | +0.0945 | ✓ | 26.0 | -1.0 | 26.1 | -2.2 | 45.8 | -1.9 | 35.5 | -0.2078 | L1 loss for volume (unified L1 for all nodes) |
| 423 | 2026-03-16 | 17:15 | `—` | 2.8139 | -0.0737 | ~ | — | — | — | — | — | — | — | — | 5-epoch warmup with unified L1 loss |
| 443 | 2026-03-16 | 22:07 | `m9wxqi76` | 2.7737 | -0.0402 | ~ | 25.2 | -0.7867 | 26.9 | +0.8039 | 44.8 | -0.9711 | 34.0 | -1.5 | Multi-scale loss: coarse spatial pooling for large-s |
| 454 | 2026-03-16 | 22:53 | `—` | — | — | — | 26.0 | +0.7900 | 27.0 | +0.1000 | 45.0 | +0.1800 | 34.5 | +0.4500 | Xavier uniform initialization (replace trunc_normal  |
| 438 | 2026-03-16 | 22:53 | `660kx60h` | — | — | — | 25.7 | -0.3300 | 26.2 | -0.8000 | 45.1 | +0.1200 | 34.4 | -0.0800 | Progressive resolution: surface-focused loss early,  |
| 432 | 2026-03-16 | 22:53 | `0765q207` | 2.7488 | -0.0249 | ✓ | 24.9 | -0.8300 | 25.2 | -1.0 | 44.8 | -0.3223 | 33.7 | -0.6540 | Lookahead optimizer: slow-weight averaging for flatt |
| 469 | 2026-03-16 | 23:32 | `—` | 2.6599 | -0.0889 | ~ | 25.9 | +1.0 | 25.6 | +0.4078 | 44.8 | -0.0177 | 33.7 | -0.0460 | Learnable placeholder scale+shift (replace random bi |
| 468 🔥 | 2026-03-16 | 23:32 | `vhe1uv4u` | 2.6852 | +0.0253 | ✓ | 24.4 | -1.5 | 24.2 | -1.3 | 45.4 | +0.5995 | 33.0 | -0.6616 | Slice temperature init 0.25 (sharper early attention |
| 461 | 2026-03-16 | 23:32 | `—` | 2.6890 | +0.0038 | ~ | 23.9 | -0.4314 | 23.6 | -0.5984 | 44.9 | -0.4695 | 33.0 | -0.0484 | Orthogonal initialization for attention projections |
| 459 | 2026-03-16 | 23:32 | `wd37l4dq` | 2.7040 | +0.0150 | ✓ | 23.1 | -0.8174 | 23.2 | -0.4055 | 43.8 | -1.1 | 32.5 | -0.4510 | Surface pressure 2x channel weight in L1 loss |
| 466 | 2026-03-16 | 23:32 | `rhukrqth` | 2.7051 | +0.0011 | ✓ | 23.8 | +0.6692 | 24.9 | +1.6 | 44.1 | +0.2942 | 33.9 | +1.3 | Progressive resolution: start at 5% volume (more agg |
| 482 🔥 | 2026-03-17 | 00:19 | `ymsozmey` | 2.6211 | -0.0840 | ✓ | 23.3 | -0.4994 | 22.6 | -2.3 | 44.6 | +0.5637 | 32.6 | -1.3 | Deeper preprocess MLP (1 residual hidden layer) |
| 479 | 2026-03-17 | 00:19 | `3h3shh2n` | 2.6543 | +0.0332 | ✓ | 24.8 | +1.5 | 22.5 | -0.0878 | 43.5 | -1.1 | 32.2 | -0.3997 | Multi-scale coarse loss weight 1.0 (halved from 2.0) |
| 489 | 2026-03-17 | 00:54 | `—` | 2.6900 | +0.0357 | ~ | 23.2 | -1.6 | 24.0 | +1.5 | 45.5 | +2.0 | 32.2 | +0.0657 | Orthogonal init gain=sqrt(2) (ReLU-optimal) |
| 490 | 2026-03-17 | 00:55 | `c6p7asf0` | 2.6346 | -0.0554 | ✓ | 23.8 | +0.5996 | 25.5 | +1.5 | 43.7 | -1.8 | 33.1 | +0.8075 | Cosine eta_min=1e-5 (productive final epochs) |
| 513 | 2026-03-17 | 01:54 | `1alc5n9r` | 2.5756 | -0.0590 | ✓ | 22.5 | -1.3 | 24.0 | -1.5 | 42.1 | -1.5 | 32.1 | -0.9767 | Multi-query attention (shared K,V across heads) |
| 524 | 2026-03-17 | 02:50 | `—` | 2.6454 | +0.0698 | ~ | 22.5 | -0.0031 | 24.0 | +0.0032 | 42.1 | +0.0014 | 32.1 | -0.0008 | Cosine eta_min=1e-4 (warmer floor) |
| 597 | 2026-03-17 | 07:39 | `—` | — | — | — | 24.2 | +1.7 | 21.9 | -2.2 | 46.4 | +4.3 | 31.9 | -0.1700 | Per-sample std normalization (skip tandem to preserv |
| 621 | 2026-03-17 | 08:39 | `4vo3h6qd` | 2.4032 | -0.2422 | ✓ | 23.9 | -0.2953 | 22.4 | +0.4830 | 44.2 | -2.2 | 31.8 | -0.1265 | Per-channel clamp in per-sample norm ([0.1, 0.1, 0.5 |
| 618 | 2026-03-17 | 08:39 | `—` | 2.4356 | +0.0324 | ~ | 24.2 | +0.2953 | 21.9 | -0.4830 | 46.4 | +2.2 | 31.9 | +0.1265 | Cosine similarity attention (scale-invariant physics |
| 622 | 2026-03-17 | 08:39 | `6tj8bkbi` | — | — | — | 23.4 | -0.7900 | 21.7 | -0.1600 | 46.2 | -0.2400 | 31.3 | -0.5900 | Differential LR: attention 1.5e-3, rest 3e-3 (stable |
| 616 | 2026-03-17 | 08:40 | `4yxulgb3` | 2.4381 | +0.0025 | ✓ | 21.7 | -1.7 | 22.9 | +1.2 | 43.7 | -2.4 | 32.1 | +0.7818 | Tandem surface weight 1.5x boost (address tandem reg |
| 633 🔥 | 2026-03-17 | 09:37 | `—` | 2.3944 | -0.0437 | ~ | 23.2 | +1.5 | 22.6 | -0.3071 | 45.7 | +2.0 | 32.5 | +0.3582 | Pressure-focused noise (0.005 for p, 0.01 for vel) |
| 629 | 2026-03-17 | 09:37 | `—` | — | — | — | 22.3 | -0.9100 | 23.1 | +0.5200 | 44.9 | -0.8400 | 32.2 | -0.2500 | Per-head learnable attn_scale (4 independent scale p |
| 662 | 2026-03-17 | 11:29 | `w4kchas8` | 2.3940 | 0 | ✓ | 21.1 | -1.3 | 23.0 | -0.0652 | 45.0 | +0.1082 | 31.8 | -0.4195 | Cosine T_max=75 (match actual epoch count) |
| 679 | 2026-03-17 | 12:30 | `—` | 2.3965 | +0.0025 | ~ | 19.7 | -1.3 | 23.0 | -0.0548 | — | — | 32.0 | +0.1995 | Late EMA from epoch 65 (decay=0.998, last 15% only) |
| 710 | 2026-03-17 | 14:33 | `2ulea75x` | 2.3421 | -0.0544 | ✓ | 20.5 | +0.8179 | 22.9 | -0.0228 | 42.7 | -2.3 | 32.3 | +0.2965 | Combined: fix surf_weight ramp + save EMA checkpoint |
| 736 | 2026-03-17 | 15:34 | `—` | — | — | — | 21.5 | +0.9421 | 22.7 | -0.2672 | 44.3 | +1.5 | 31.6 | -0.6865 | Adaptive surface weight (loss-ratio based, clamped 5 |
| 741 | 2026-03-17 | 16:33 | `cntlwqsv` | 2.3272 | -0.0149 | ✓ | 21.2 | -0.2606 | 21.6 | -1.1 | 43.5 | -0.8242 | 32.0 | +0.3805 | Coordinate-conditioned slice assignment (spatial pri |
| 756 | 2026-03-17 | 17:37 | `o5symwr0` | — | — | — | 21.2 | +0.0006 | 21.6 | +0.0026 | 43.5 | +0.0042 | 32.0 | 0 | Squeeze-and-Excitation channel attention after MLP |
| 768 | 2026-03-17 | 17:45 | `—` | — | — | — | 21.2 | 0 | 21.6 | 0 | 43.5 | 0 | 32.0 | 0 | Data curriculum: skip tandem for first 10 epochs |
| 772 🔥 | 2026-03-17 | 18:24 | `juiz2mx1` | 2.2974 | -0.0298 | ✓ | 21.4 | +0.2090 | 21.3 | -0.2401 | 43.1 | -0.3156 | 31.4 | -0.5605 | SE-block: commit actual code changes (resubmit from  |
| 773 🔥 | 2026-03-17 | 19:13 | `src08csk` | 2.2138 | -0.0837 | ✓ | 20.5 | -0.9428 | 21.4 | +0.0872 | 41.3 | -1.8 | 31.4 | -0.0573 | Post-norm: rebase from updated noam (resubmit) |
| 775 | 2026-03-17 | 19:26 | `toqcnura` | 2.2772 | +0.0634 | ✓ | 21.0 | +0.5135 | 22.6 | +1.1 | 44.0 | +2.7 | 32.1 | +0.7720 | Sandwich LayerNorm (pre-norm AND post-norm for stabi |
| 780 | 2026-03-17 | 19:27 | `obgrkvxe` | — | — | — | 21.4 | +0.3503 | 23.1 | +0.4885 | — | — | 31.6 | -0.5842 | Auxiliary Reynolds number prediction (regularize Re- |
| 774 | 2026-03-17 | 19:28 | `j26hyfor` | 2.2887 | +0.0115 | ✓ | 21.0 | -0.3728 | 21.7 | -1.3 | 42.9 | -1.1 | 31.3 | -0.2235 | Preprocess-to-output skip connection (zero-init line |
| 800 | 2026-03-17 | 21:37 | `vbcsks47` | 2.2217 | -0.0670 | ✓ | 21.2 | +0.1913 | 20.5 | -1.3 | 41.2 | -1.7 | 30.9 | -0.3811 | Slice-token residual bypass (resubmit on current noa |
| 818 | 2026-03-18 | 00:24 | `f7lro0xd` | 2.2217 | 0 | ~ | 22.3 | +1.1 | 22.1 | +1.6 | — | — | 31.5 | +0.5946 | Fix ood_re volume overflow (tighter denorm clamps +  |
| 849 🔥 | 2026-03-18 | 00:39 | `—` | 2.2217 | 0 | ~ | 20.9 | -1.4 | 19.7 | -2.3 | 42.8 | +1.6 | 30.9 | -0.6400 | Remove weight decay (test over-regularization hypoth |
| 858 | 2026-03-18 | 01:20 | `sk2srxw0` | 2.2217 | 0 | ~ | — | — | — | — | — | — | — | — | No weight decay + EMA from epoch 40 (compound) |
| 911 | 2026-03-18 | 04:37 | `i8cd9kzk` | 2.1997 | -0.0220 | ✓ | 20.0 | -0.8800 | 20.6 | +0.8599 | 40.4 | -2.4 | 30.8 | -0.1451 | Surface curvature proxy from dsdf features (25th inp |
| 1035 | 2026-03-18 | 17:53 | `—` | 2.2155 | +0.0158 | ~ | 20.2 | +0.2100 | 19.7 | -0.8499 | 42.1 | +1.7 | 30.6 | -0.1049 | Sinusoidal position encoding in spatial bias MLP |
| 1052 🔥 | 2026-03-18 | 18:50 | `—` | 2.2117 | -0.0038 | ~ | 18.6 | -1.7 | 18.5 | -1.2 | 41.6 | -0.5000 | 29.6 | -1.1 | Wider model n_hidden=160 + torch.compile |
| 1061 🔥 | 2026-03-18 | 19:40 | `—` | 2.0996 | -0.1121 | ~ | 17.4 | -1.2 | 18.4 | -0.1300 | 40.2 | -1.4 | 29.5 | -0.0700 | Wider model n_hidden=192 (capacity scaling) |
| 1051 | 2026-03-18 | 19:40 | `—` | 2.2117 | +0.1121 | ~ | 19.7 | +2.3 | 20.4 | +2.0 | 40.9 | +0.7200 | 30.4 | +0.8900 | Learnable Fourier frequencies (optimize spatial scal |
| 1054 | 2026-03-18 | 20:38 | `tvvjs1if` | 2.2117 | 0 | ~ | 19.7 | 0 | 20.4 | 0 | 40.9 | 0 | 30.4 | 0 | Coordinate-normalized Fourier PE (normalize x,y to [ |
| 1066 | 2026-03-18 | 20:38 | `38rsqz32` | 2.0996 | -0.1121 | ~ | 18.6 | -1.1 | 18.5 | -1.8 | 41.6 | +0.7100 | 29.6 | -0.8200 | Feature interaction layer (polynomial cross) on wide |
| 1074 | 2026-03-18 | 20:39 | `—` | — | — | — | 18.4 | -0.2000 | 18.1 | -0.4200 | 39.3 | -2.3 | 29.5 | -0.0100 | Cosine T_max=76, eta_min=5e-5 (align LR schedule + s |
| 1086 🔥 | 2026-03-18 | 21:24 | `2s55on1l` | 1.9608 | -0.1388 | ✓ | 18.2 | -0.1529 | 15.5 | -2.6 | 38.5 | -0.8053 | 28.8 | -0.7007 | Spatially-sorted coarse pooling loss (x-coordinate o |
| 1082 | 2026-03-18 | 21:24 | `—` | — | — | — | 18.4 | +0.1829 | 15.5 | -0.0567 | 38.5 | -0.0447 | 28.9 | +0.0607 | Volume loss scale 0.1x (surface gradient dominance) |
| 1088 | 2026-03-18 | 21:25 | `—` | — | — | — | 18.1 | -0.2600 | 15.5 | +0.0500 | 39.0 | +0.5200 | 29.2 | +0.2900 | Learned surface node feature amplification (boost su |
| 1085 | 2026-03-18 | 21:25 | `—` | — | — | — | 18.6 | +0.4400 | 15.4 | -0.0900 | 38.6 | -0.4500 | 28.8 | -0.3800 | Noise annealing: strong early (0.015) → weak late (0 |
| 1078 🔥 | 2026-03-18 | 21:27 | `—` | — | — | — | 18.4 | -0.1600 | 14.7 | -0.7600 | 38.4 | -0.2000 | 28.8 | -0.0300 | Tandem-inclusive per-sample normalization (relaxed p |
| 1079 | 2026-03-18 | 21:27 | `v3ji6qwn` | — | — | — | 18.9 | +0.4700 | 15.7 | +1.0 | 40.2 | +1.8 | 28.7 | -0.0800 | Auxiliary AoA prediction head (complement Re auxilia |
| 1081 | 2026-03-18 | 21:28 | `—` | — | — | — | 18.0 | -0.9000 | 15.1 | -0.6500 | 38.6 | -1.6 | 28.6 | -0.1100 | EMA-smoothed val loss for checkpoint selection |
| 1084 | 2026-03-18 | 21:28 | `39bs1yit` | — | — | — | 19.0 | +0.9800 | 16.7 | +1.6 | 39.7 | +1.0 | 29.6 | +1.0 | Learned sigmoid gate on preprocess-to-output skip |
| 1102 | 2026-03-18 | 22:49 | `—` | — | — | — | 18.8 | -0.1600 | 16.0 | -0.6700 | 39.4 | -0.2400 | 29.5 | -0.1000 | 8 learnable Fourier frequencies (32 PE features) on  |
| 1110 | 2026-03-18 | 22:50 | `—` | 1.9452 | -0.0156 | ~ | 18.2 | -0.6600 | 16.6 | +0.6200 | 39.0 | -0.4200 | 29.4 | -0.1500 | Extended warmup to 10 epochs (from 5) on fixed code |
| 1116 | 2026-03-18 | 23:48 | `—` | — | — | — | 18.2 | 0 | 14.6 | -2.0 | 39.8 | +0.7700 | 28.5 | -0.8900 | Pressure-only surface loss (focus gradient signal on |
| 1121 | 2026-03-18 | 23:48 | `nb1jqor0` | 1.9476 | +0.0024 | ✓ | 19.1 | +0.9043 | 15.4 | +0.8110 | 38.8 | -1.0 | 29.4 | +0.9046 | GLU-gated preprocess MLP (SwiGLU-style feature extra |
| 1122 | 2026-03-18 | 23:48 | `—` | — | — | — | 18.8 | -0.2443 | 16.7 | +1.3 | 39.1 | +0.3074 | 29.1 | -0.2546 | 4-split checkpoint selection (include val_ood_re) |
| 1128 🔥 | 2026-03-19 | 00:40 | `w5ti3umi` | 0.8799 | -1.1 | ✓ | 17.9 | -0.8948 | 14.3 | -2.3 | 38.3 | -0.7836 | 28.3 | -0.8504 | Adaptive tandem gradient weighting (dynamic boost fr |
| 1130 | 2026-03-19 | 00:41 | `xbj50yag` | — | — | — | 18.2 | +0.3248 | 14.8 | +0.4377 | 38.6 | +0.3136 | 28.6 | +0.3204 | Cosine T_max=62 (align LR schedule to actual 72-epoc |
| 1131 | 2026-03-19 | 00:41 | `6a0p0mvn` | 0.8967 | +0.0167 | ✓ | 18.2 | -0.0230 | 14.5 | -0.2450 | 38.9 | +0.3139 | 28.7 | +0.0909 | Surface pressure gradient regularization (penalize s |
| 1147 | 2026-03-19 | 02:10 | `—` | — | — | — | 17.7 | -0.5370 | 14.3 | -0.1950 | 38.6 | -0.3239 | 28.5 | -0.2109 | Wavelet-Fourier PE: 4 fixed log-spaced + 4 learnable |
| 1155 | 2026-03-19 | 02:10 | `g56zo1a8` | 0.8855 | -0.0111 | ✓ | 18.0 | +0.2916 | 14.3 | +0.0260 | 39.1 | +0.5526 | 28.5 | -0.0360 | Input feature augmentation (Gaussian noise on geomet |
| 1167 🔥 | 2026-03-19 | 03:00 | `3x7ydmtk` | 0.8540 | -0.0316 | ✓ | 17.8 | -0.1800 | 13.6 | -0.7542 | 38.9 | -0.2429 | 27.2 | -1.2 | Deeper GLU preprocess (2 gated hidden layers) |
| 1168 | 2026-03-19 | 03:00 | `hrrwqpzc` | 0.8958 | +0.0418 | ✓ | 18.0 | +0.1542 | 14.4 | +0.8433 | 38.6 | -0.2870 | 28.6 | +1.4 | Tandem-specific learned temperature offset in attent |
| 1161 | 2026-03-19 | 03:01 | `kxvnac5l` | 0.8878 | -0.0080 | ✓ | 18.5 | +0.5671 | 14.1 | -0.2984 | 38.8 | +0.1492 | 28.2 | -0.3656 | Curvature-conditioned spatial bias (geometry-aware s |
| 1179 | 2026-03-19 | 03:52 | `61hzokyi` | 0.8419 | -0.0459 | ✓ | 17.9 | -0.6527 | 13.3 | -0.7974 | 37.0 | -1.7 | 27.4 | -0.8330 | Late attention temperature annealing (clamp to 0.25  |
| 1176 | 2026-03-19 | 03:52 | `h20hc9v3` | 0.8504 | +0.0085 | ✓ | 17.3 | -0.6096 | 14.1 | +0.8008 | 37.9 | +0.8305 | 27.6 | +0.1590 | Deeper spatial bias MLP (3-layer, 64-dim hidden) |
| 1175 | 2026-03-19 | 03:52 | `nyf4lyrr` | 0.8620 | +0.0116 | ✓ | 17.6 | +0.2949 | 14.6 | +0.4647 | 38.1 | +0.2074 | 27.7 | +0.1748 | Asymmetric hard-node mining (non-tandem only, top-50 |
| 1191 | 2026-03-19 | 04:43 | `uszo7e0m` | 0.8662 | +0.0041 | ✓ | 18.1 | +0.5770 | 14.7 | +0.1132 | 37.5 | -0.5303 | 27.9 | +0.2116 | Cosine T_max=72 (keep LR above floor during EMA phas |
| 1187 | 2026-03-19 | 04:44 | `—` | — | — | — | 19.4 | +1.3 | 14.1 | -0.6181 | 39.6 | +2.0 | 28.1 | +0.1157 | Progressive temperature annealing (smooth ramp 0.5→0 |
| 1188 | 2026-03-19 | 04:44 | `zfkh9wcs` | 0.8656 | -0.0006 | ✓ | 17.9 | -1.6 | 14.1 | -0.0292 | 38.7 | -0.8357 | 27.7 | -0.3851 | Vectorized hard-node mining (same algorithm, faster  |
| 1250 | 2026-03-19 | 10:24 | `—` | — | — | — | — | — | — | — | — | — | — | — | Regime H: slice_num=48, n_hidden=160 (finer routing, |
| 1265 | 2026-03-19 | 11:18 | `—` | — | — | — | 18.0 | +0.1055 | 13.5 | -0.5708 | 37.8 | -0.9243 | 27.8 | +0.1151 | Regime W: Restore width at 48 slices (n_hidden=192,  |
| 1313 | 2026-03-19 | 13:47 | `j0ay8k68` | 0.8602 | -0.0054 | ✓ | 17.5 | -0.4886 | 13.5 | -0.0051 | 38.9 | +1.1 | 27.5 | -0.2947 | n_head=3 at n_hidden=192 (fewer but wider heads, 64- |
| 1323 | 2026-03-19 | 14:33 | `gmmvbn8s` | 0.8600 | 0 | ✓ | 17.1 | -0.3908 | 14.4 | +0.9073 | 38.3 | -0.6343 | 27.8 | +0.3428 | Per-head tandem temperature offset (fix tandem regre |
| 1348 | 2026-03-19 | 15:51 | `9ms94ykg` | 0.8555 | -0.0045 | ✓ | 17.5 | +0.3651 | 13.6 | -0.8081 | 38.5 | +0.2294 | 27.6 | -0.2708 | lr=2.5e-3 on per-head tandem temp code (gentler LR f |
| 1456 | 2026-03-19 | 23:03 | `78fy2yi7` | 0.8525 | -0.0030 | ✓ | 17.0 | -0.4446 | 13.9 | +0.3085 | 38.1 | -0.3852 | 27.6 | +0.0478 | PCGrad: OOD splits vs in-dist gradient projection |
| 1473 | 2026-03-20 | 01:01 | `rnn009xv` | 0.8525 | 0 | ~ | 17.8 | +0.8089 | 13.7 | -0.2426 | 36.4 | -1.8 | 27.8 | +0.1549 | Continuous distance-to-surface feature for all nodes |
| 1518 | 2026-03-20 | 03:30 | `2ktoqp97` | 0.8477 | -0.0048 | ✓ | 17.7 | -0.1016 | 13.8 | +0.1085 | 37.7 | +1.4 | 27.5 | -0.2547 | LR 2.6e-3 (slightly higher LR for dist code) |
| 1588 | 2026-03-20 | 08:22 | `g3hoijk2` | 0.8469 | -0.0008 | ✓ | 17.7 | -0.0848 | 13.7 | -0.0814 | 37.9 | +0.1428 | 27.5 | -0.0496 | Warmup start_factor=0.2 (faster initial LR ramp) |
| 1645 | 2026-03-20 | 12:40 | `56vedhzk` | 0.8408 | -0.0061 | ✓ | 18.1 | +0.4085 | 13.7 | +0.0039 | 38.4 | +0.5557 | 27.6 | +0.1135 | FIX: dist_feat computed from standardized dsdf (wron |
| 1658 🔥 | 2026-03-20 | 13:47 | `rs8fsf4n` | 0.8326 | -0.0083 | ✓ | 17.9 | -0.1183 | 14.0 | +0.2903 | 36.7 | -1.7 | 27.5 | -0.0356 | FIX: Coarse pooling uses masked means (re-test on di |

---

### Table 2 — Key Breakthroughs

| PR | Date | Event | val/loss | Δval/loss | p\_oodc | Δp\_oodc | p\_tan | Δp\_tan |
|---:|------|-------|--------:|----------:|-------:|--------:|------:|--------:|
| 368 | 2026-03-16 | Starting point (noam track) | 6.1319 | — | 86.8 | — | 113.2 | — |
| 374 | 2026-03-16 | 🔥 2-layer model — more epochs in 30-min budget | 3.5966 | -2.5 | 53.4 | -33.4 | 70.8 | -42.4 |
| 376 | 2026-03-16 | 🔥 1-layer model — maximum epochs | 2.9942 | -0.6024 | 46.7 | -6.7 | 65.4 | -5.4 |
| 378 | 2026-03-16 | Deeper output head (2-layer MLP) | 2.6682 | -0.3260 | 40.1 | -6.7 | 59.2 | -6.2 |
| 382 | 2026-03-16 | Fewer slices slice_num=32 | 2.5247 | -0.1435 | 38.0 | -2.0 | 58.4 | -0.7517 |
| 392 | 2026-03-16 | 🔥 Physics Cp normalization (val_loss regresses; p_oodc: 40→28) | 2.7931 | +0.2684 | 28.3 | -9.7 | 47.7 | -10.7 |
| 420 | 2026-03-16 | Unified L1 loss + enables val_ood_re tracking | 2.8876 | +0.0945 | 26.1 | -2.2 | 45.8 | -1.9 |
| 482 | 2026-03-17 | Deeper preprocess MLP | 2.6211 | -0.2665 | 22.6 | -3.5 | 44.6 | -1.1 |
| 621 | 2026-03-17 | Per-channel clamp in per-sample norm | 2.4032 | -0.2179 | 22.4 | -0.2597 | 44.2 | -0.4725 |
| 741 | 2026-03-17 | Coord-conditioned slice assignment | 2.3272 | -0.0760 | 21.6 | -0.7656 | 43.5 | -0.7207 |
| 773 | 2026-03-17 | 🔥 Post-norm (layer norm reordering) | 2.2138 | -0.1134 | 21.4 | -0.1504 | 41.3 | -2.1 |
| 800 | 2026-03-17 | Slice-token residual bypass | 2.2217 | +0.0079 | 20.5 | -0.9717 | 41.2 | -0.1101 |
| 1061 | 2026-03-18 | 🔥 Wider model n_hidden=192 | 2.0996 | -0.1221 | 18.4 | -2.1 | 40.2 | -1.0 |
| 1086 | 2026-03-18 | 🔥 Spatially-sorted coarse pooling (p_oodc: 18.4→15.5) | 1.9608 | -0.1388 | 15.5 | -2.9 | 38.5 | -1.7 |
| 1121 | 2026-03-18 | GLU-gated preprocess MLP (SwiGLU) | 1.9476 | -0.0132 | 15.4 | -0.1557 | 38.8 | +0.2278 |
| 1128 | 2026-03-19 | ⚠️ Metric change: 4-split incl. val_ood_re + adaptive tandem gradient | 0.8799 | -1.1 | 14.3 | -1.1 | 38.3 | -0.4762 |
| 1167 | 2026-03-19 | 🔥 Deeper GLU preprocess (2 gated layers) | 0.8540 | -0.0260 | 13.6 | -0.7305 | 38.9 | +0.6133 |
| 1179 | 2026-03-19 | Late attention temperature annealing | 0.8419 | -0.0121 | 13.3 | -0.2525 | 37.0 | -1.9 |
| 1658 | 2026-03-20 | 🔥 FIX: coarse pooling masked means (current best) | 0.8326 | -0.0093 | 14.0 | +0.6420 | 36.7 | -0.3110 |

---

### Table 3 — Overall Trajectory

| Metric | Start (PR #368) | Best achieved | Best PR | Reduction |
|--------|----------------:|--------------:|--------:|----------:|
| val/loss (pre-metric-change, comparable) | 6.1319 | 1.9452 | #1110 | −68% |
| val/loss (post-metric-change, comparable) | 0.8799 | 0.8326 | #1658 | −5.4% |
| p\_in (val\_in\_dist surf\_p MAE, Pa) | 119.7 | 17.0 | #1456 | −86% |
| p\_oodc (val\_ood\_cond surf\_p MAE, Pa) | 86.8 | 13.3 | #1179 | −85% |
| p\_tan (val\_tandem surf\_p MAE, Pa) | 113.2 | 36.4 | #1473 | −68% |
| p\_re (val\_ood\_re surf\_p MAE, Pa) | ~310 | 27.2 | #1167 | ~−91% |

---

### Metric Notes

#### val/loss scale change at PR #1128

The jump from ~1.95 (PR #1121) to ~0.88 (PR #1128) is a **metric scale change, not a model leap**.

PR #1122 changed checkpoint selection to include `val_ood_re` in the 4-split mean.
Since `val_ood_re` carries significantly lower loss than `val_tandem_transfer`,
the mean dropped. The 3-split equivalent (in_dist + ood_cond + tandem) at PR #1128 was ~0.98 — consistent with the prior trend.

**All val/loss values in the 0.83–0.90 range are directly comparable to each other.**
Do not compare val/loss values before PR #1128 directly to those after.

#### Surface pressure MAE (pa\_\*)

All surface MAE values are `mae_surf_p` at the best checkpoint epoch, extracted from
W&B summary (`best_best_{split}/mae_surf_p`) or PR-reported tables.
Units: Pa (pressure, dimensional). Lower is better.

#### Tandem split

The `val_tandem_transfer` split tests zero-shot generalization to tandem airfoil configurations
(two airfoils in proximity). It lags the other splits significantly (36.7 Pa vs 13–18 Pa for
single-foil splits) and remains the primary open challenge.

#### W&B validation

55 of 96 PRs had W&B run IDs. All cross-validated PR-reported metrics matched W&B to within
rounding error. No discrepancies detected. Remaining 41 PRs use PR-reported values only.

</experiment_results_table>

---

# Phase 2 Reults

We ran a brief PHASE 2 based on the results from Phase 1 experiments and extrapolation of what might work. 

  ┌────────────┬────────────────────────────────────────────┐
  │   Round    │                   Merged                   │
  ├────────────┼────────────────────────────────────────────┤
  │ R1 #1702   │ LR schedule → 0.833 → 0.710                │
  ├────────────┼────────────────────────────────────────────┤
  │ R2 #1707   │ LinearNO → 0.710 → 0.701                   │
  ├────────────┼────────────────────────────────────────────┤
  │ R5 #1720   │ Tandem warm-in + 96 slices → 0.701 → 0.699 │
  ├────────────┼────────────────────────────────────────────┤
  │ R3, R4, R6 │ Nothing beat baseline                      │
  └────────────┴────────────────────────────────────────────┘

  - val/loss 0.833 → 0.699 (-16.1%), p_oodc 13.3 → 10.1 Pa (-24.1%), 6 rounds, ~270 experiments.

Each of these 200+ experiment PRs has a `phase:2` tag that you can filter on - first use a team of sub-agents to filter on the `phase:2` tag deeply understand what was tried, the impact on the architecture and results. Combine these up into a single report and use this to guide your research for Phase 3 - write this report out to a wandb Report using the wandb-primary skill and markdown as well as the wandb docs.


## Base train.py 

To help you understand where we're comming from, below is the entire, original train.py file. Compared to the train.py file that is now on this `noam` git branch you can see that the noam branch has evolved quite a lot.


```python
# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
# SPDX-License-Identifier: Apache-2.0
# SPDX-PackageName: senpai

"""Train Transolver with structured benchmark splits.

Reads a split manifest and stats file produced by data/split.py,
then trains with four separate val tracks:
  val_in_dist          — raceCar_single random holdout (interpolation sanity)
  val_tandem_transfer  — raceCar_tandem Part2 (unseen tandem front foil)
  val_ood_cond         — cruise Part1+3 frontier 20% (extreme AoA/gap/stagger)
  val_ood_re           — cruise Part2 Re=4.445M (fully OOD Reynolds number)

Run:
  python train.py --agent <name> --wandb_name "<name>/<desc>"

KNOWN LIMITATIONS (inherited from read-only prepare.py):
  - Only NACA[0] and AoA[0] are encoded in x. Foil 2 is implicit in dsdf/saf.
  - SURFACE_IDS=(5,6) misses boundary ID 7 (foil 2 surface in tandem data).
    Tandem surface loss is therefore underweighted.
"""

import os
import time
from collections.abc import Mapping
from pathlib import Path

import torch
import torch.nn as nn
import torch.nn.functional as F
import wandb
import yaml
from dataclasses import dataclass, asdict
from einops import rearrange
from timm.layers import trunc_normal_
from tqdm import tqdm
from torch.utils.data import DataLoader, WeightedRandomSampler
import simple_parsing as sp

from data.utils import visualize
from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES


# ---------------------------------------------------------------------------
# Transolver model (inlined so students can
# modify architecture and training script in a single file)
# ---------------------------------------------------------------------------

ACTIVATION = {
    "gelu": nn.GELU,
    "tanh": nn.Tanh,
    "sigmoid": nn.Sigmoid,
    "relu": nn.ReLU,
    "leaky_relu": nn.LeakyReLU(0.1),
    "softplus": nn.Softplus,
    "ELU": nn.ELU,
    "silu": nn.SiLU,
}


class MLP(nn.Module):
    def __init__(self, n_input, n_hidden, n_output, n_layers=1, act="gelu", res=True):
        super().__init__()
        if act not in ACTIVATION:
            raise NotImplementedError
        act_fn = ACTIVATION[act]
        self.n_input = n_input
        self.n_hidden = n_hidden
        self.n_output = n_output
        self.n_layers = n_layers
        self.res = res
        self.linear_pre = nn.Sequential(nn.Linear(n_input, n_hidden), act_fn())
        self.linear_post = nn.Linear(n_hidden, n_output)
        self.linears = nn.ModuleList([nn.Sequential(nn.Linear(n_hidden, n_hidden), act_fn()) for _ in range(n_layers)])

    def forward(self, x):
        x = self.linear_pre(x)
        for i in range(self.n_layers):
            if self.res:
                x = self.linears[i](x) + x
            else:
                x = self.linears[i](x)
        x = self.linear_post(x)
        return x


class Physics_Attention_Irregular_Mesh(nn.Module):
    """Physics attention for irregular meshes in 1D/2D/3D space."""

    def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64):
        super().__init__()
        inner_dim = dim_head * heads
        self.dim_head = dim_head
        self.heads = heads
        self.scale = dim_head**-0.5
        self.softmax = nn.Softmax(dim=-1)
        self.dropout = nn.Dropout(dropout)
        self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)

        self.in_project_x = nn.Linear(dim, inner_dim)
        self.in_project_fx = nn.Linear(dim, inner_dim)
        self.in_project_slice = nn.Linear(dim_head, slice_num)
        torch.nn.init.orthogonal_(self.in_project_slice.weight)
        self.to_q = nn.Linear(dim_head, dim_head, bias=False)
        self.to_k = nn.Linear(dim_head, dim_head, bias=False)
        self.to_v = nn.Linear(dim_head, dim_head, bias=False)
        self.to_out = nn.Sequential(
            nn.Linear(inner_dim, dim),
            nn.Dropout(dropout),
        )

    def forward(self, x):
        bsz, num_points, _ = x.shape

        fx_mid = (
            self.in_project_fx(x)
            .reshape(bsz, num_points, self.heads, self.dim_head)
            .permute(0, 2, 1, 3)
            .contiguous()
        )
        x_mid = (
            self.in_project_x(x)
            .reshape(bsz, num_points, self.heads, self.dim_head)
            .permute(0, 2, 1, 3)
            .contiguous()
        )
        slice_weights = self.softmax(self.in_project_slice(x_mid) / self.temperature)
        slice_norm = slice_weights.sum(2)
        slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
        slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))

        q_slice_token = self.to_q(slice_token)
        k_slice_token = self.to_k(slice_token)
        v_slice_token = self.to_v(slice_token)
        dropout_p = self.dropout.p if self.training else 0.0
        out_slice_token = F.scaled_dot_product_attention(
            q_slice_token,
            k_slice_token,
            v_slice_token,
            dropout_p=dropout_p,
            is_causal=False,
        )

        out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
        out_x = rearrange(out_x, "b h n d -> b n (h d)")
        return self.to_out(out_x)


class TransolverBlock(nn.Module):
    def __init__(
        self,
        num_heads: int,
        hidden_dim: int,
        dropout: float,
        act="gelu",
        mlp_ratio=4,
        last_layer=False,
        out_dim=1,
        slice_num=32,
    ):
        super().__init__()
        self.last_layer = last_layer
        self.ln_1 = nn.LayerNorm(hidden_dim)
        self.attn = Physics_Attention_Irregular_Mesh(
            hidden_dim,
            heads=num_heads,
            dim_head=hidden_dim // num_heads,
            dropout=dropout,
            slice_num=slice_num,
        )
        self.ln_2 = nn.LayerNorm(hidden_dim)
        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
        if self.last_layer:
            self.ln_3 = nn.LayerNorm(hidden_dim)
            self.mlp2 = nn.Sequential(
                nn.Linear(hidden_dim, hidden_dim),
                nn.GELU(),
                nn.Linear(hidden_dim, out_dim),
            )

    def forward(self, fx):
        fx = self.attn(self.ln_1(fx)) + fx
        fx = self.mlp(self.ln_2(fx)) + fx
        if self.last_layer:
            return self.mlp2(self.ln_3(fx))
        return fx


class Transolver(nn.Module):
    def __init__(
        self,
        space_dim=1,
        n_layers=5,
        n_hidden=256,
        dropout=0.0,
        n_head=8,
        act="gelu",
        mlp_ratio=1,
        fun_dim=1,
        out_dim=1,
        slice_num=32,
        ref=8,
        unified_pos=False,
        output_fields: list[str] | None = None,
        output_dims: list[int] | None = None,
    ):
        super().__init__()
        self.__name__ = "UniPDE_3D"
        self.ref = ref
        self.unified_pos = unified_pos
        if output_fields is None or output_dims is None:
            raise ValueError("output_fields and output_dims must be provided")
        if len(output_fields) != len(output_dims):
            raise ValueError("output_fields and output_dims must have the same length")
        if out_dim != sum(output_dims):
            raise ValueError("out_dim must equal sum(output_dims)")
        self.output_fields = output_fields
        self.output_dims = output_dims

        if self.unified_pos:
            self.preprocess = MLP(
                fun_dim + self.ref * self.ref * self.ref,
                n_hidden * 2,
                n_hidden,
                n_layers=0,
                res=False,
                act=act,
            )
        else:
            self.preprocess = MLP(fun_dim + space_dim, n_hidden * 2, n_hidden, n_layers=0, res=False, act=act)

        self.n_hidden = n_hidden
        self.space_dim = space_dim
        self.blocks = nn.ModuleList(
            [
                TransolverBlock(
                    num_heads=n_head,
                    hidden_dim=n_hidden,
                    dropout=dropout,
                    act=act,
                    mlp_ratio=mlp_ratio,
                    out_dim=out_dim,
                    slice_num=slice_num,
                    last_layer=(idx == n_layers - 1),
                )
                for idx in range(n_layers)
            ]
        )
        self.initialize_weights()
        self.placeholder = nn.Parameter((1 / n_hidden) * torch.rand(n_hidden, dtype=torch.float))

    def initialize_weights(self):
        self.apply(self._init_weights)

    def _init_weights(self, module):
        if isinstance(module, nn.Linear):
            trunc_normal_(module.weight, std=0.02)
            if module.bias is not None:
                nn.init.constant_(module.bias, 0)
        elif isinstance(module, (nn.LayerNorm, nn.BatchNorm1d)):
            nn.init.constant_(module.bias, 0)
            nn.init.constant_(module.weight, 1.0)

    def get_grid(self, my_pos):
        batchsize = my_pos.shape[0]
        device = my_pos.device
        dtype = my_pos.dtype

        gridx = torch.linspace(-1.5, 1.5, self.ref, device=device, dtype=dtype)
        gridx = gridx.view(1, self.ref, 1, 1, 1).repeat(batchsize, 1, self.ref, self.ref, 1)
        gridy = torch.linspace(0, 2, self.ref, device=device, dtype=dtype)
        gridy = gridy.view(1, 1, self.ref, 1, 1).repeat(batchsize, self.ref, 1, self.ref, 1)
        gridz = torch.linspace(-4, 4, self.ref, device=device, dtype=dtype)
        gridz = gridz.view(1, 1, 1, self.ref, 1).repeat(batchsize, self.ref, self.ref, 1, 1)
        grid_ref = torch.cat((gridx, gridy, gridz), dim=-1).reshape(batchsize, self.ref**3, 3)

        pos = torch.sqrt(((my_pos[:, :, None, :] - grid_ref[:, None, :, :]) ** 2).sum(dim=-1))
        return pos.reshape(batchsize, my_pos.shape[1], self.ref * self.ref * self.ref).contiguous()

    def _unpack_inputs(self, data, pos=None, condition=None):
        if not isinstance(data, Mapping):
            raise TypeError("Model input must be a Mapping with keys: x, pos, condition")
        x = data.get("x")
        pos = data.get("pos", pos)
        condition = data.get("condition", condition)
        return x, pos, condition

    def _validate_output_dims(self, preds):
        if sum(self.output_dims) != preds.shape[-1]:
            raise ValueError("Sum of output_dims must match preds last dimension")

    def forward(self, data, pos=None, condition=None):
        x, pos, condition = self._unpack_inputs(data, pos=pos, condition=condition)
        if x is None:
            raise ValueError("Missing required input tensor: x")
        if condition is not None:
            raise ValueError("Transolver does not support conditioning inputs")

        if self.unified_pos:
            if pos is None:
                raise ValueError("Missing required input tensor: pos")
            new_pos = self.get_grid(pos)
            x = torch.cat((x, new_pos), dim=-1)

        fx = self.preprocess(x)
        fx = fx + self.placeholder[None, None, :]

        for block in self.blocks:
            fx = block(fx)
        self._validate_output_dims(fx)
        return {"preds": fx}


# ---------------------------------------------------------------------------
# End Transolver model
# ---------------------------------------------------------------------------


MAX_TIMEOUT = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", "30.0"))  # minutes
MAX_EPOCHS = int(os.environ.get("SENPAI_MAX_EPOCHS", "50"))


@dataclass
class Config:
    lr: float = 5e-4
    weight_decay: float = 1e-4
    batch_size: int = 4
    surf_weight: float = 10.0
    manifest: str = "data/split_manifest.json"
    stats_file: str = "data/split_stats.json"
    wandb_group: str | None = None
    wandb_name: str | None = None
    agent: str | None = None
    debug: bool = False


cfg = sp.parse(Config)

if cfg.debug:
    MAX_EPOCHS = 3

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
print(f"Device: {device}" + (" [DEBUG MODE]" if cfg.debug else ""))

train_ds, val_splits, stats, sample_weights = load_data(
    cfg.manifest, cfg.stats_file, debug=cfg.debug,
)
stats = {k: v.to(device) for k, v in stats.items()}


def _umag_q(y, mask):
    """Per-sample reference velocity and dynamic pressure from mean velocity.

    Uses mean velocity of actual (unpadded) nodes as Umag proxy. For CFD flow
    over airfoils, the domain-mean velocity tracks the freestream magnitude
    across Re numbers (surface no-slip nodes reduce the mean slightly, but
    consistently across all samples).

    Returns:
        Umag: [B, 1, 1], dynamic velocity magnitude, clamped ≥ 1.0
        q:    [B, 1, 1], dynamic pressure = 0.5 * Umag^2
    """
    n_nodes = mask.float().sum(dim=1, keepdim=True).clamp(min=1.0)  # [B, 1]
    Ux_mean = (y[:, :, 0] * mask.float()).sum(dim=1, keepdim=True) / n_nodes  # [B, 1]
    Uy_mean = (y[:, :, 1] * mask.float()).sum(dim=1, keepdim=True) / n_nodes  # [B, 1]
    Umag = (Ux_mean ** 2 + Uy_mean ** 2).sqrt().clamp(min=1.0).unsqueeze(-1)  # [B, 1, 1]
    q = 0.5 * Umag ** 2
    return Umag, q


def _phys_norm(y, Umag, q):
    """Normalize Ux→Ux/Umag, Uy→Uy/Umag, p→p/q (Cp)."""
    y_p = y.clone()
    y_p[:, :, 0:1] = y[:, :, 0:1] / Umag
    y_p[:, :, 1:2] = y[:, :, 1:2] / Umag
    y_p[:, :, 2:3] = y[:, :, 2:3] / q
    return y_p


def _phys_denorm(y_p, Umag, q):
    """Reverse physics normalization: Ux/Umag→Ux, Uy/Umag→Uy, Cp→p."""
    y = y_p.clone()
    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-50, 50) * Umag
    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-50, 50) * Umag
    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-100, 100) * q
    return y

loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
                     persistent_workers=True, prefetch_factor=2)

if cfg.debug:
    # Avoid sampler/length mismatch when train_ds is truncated
    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
                              shuffle=True, **loader_kwargs)
else:
    sampler = WeightedRandomSampler(
        weights=sample_weights,
        num_samples=len(train_ds),
        replacement=True,
    )
    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
                              sampler=sampler, **loader_kwargs)

val_loaders = {
    name: DataLoader(subset, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
    for name, subset in val_splits.items()
}

model_config = dict(
    space_dim=2,
    fun_dim=X_DIM - 2,  # X_DIM=24; fun_dim + space_dim must equal x.shape[-1]
    out_dim=3,
    n_hidden=128,
    n_layers=5,
    n_head=4,
    slice_num=64,
    mlp_ratio=2,
    output_fields=["Ux", "Uy", "p"],
    output_dims=[1, 1, 1],
)

model = Transolver(**model_config).to(device)

n_params = sum(p.numel() for p in model.parameters())
optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay)
scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=MAX_EPOCHS)

# --- wandb ---
run = wandb.init(
    entity=os.environ.get("WANDB_ENTITY", "wandb-applied-ai-team"),
    project=os.environ.get("WANDB_PROJECT", "senpai-v1"),
    group=cfg.wandb_group,
    name=cfg.wandb_name,
    tags=[cfg.agent] if cfg.agent else [],
    config={
        **asdict(cfg),
        "model_config": model_config,
        "n_params": n_params,
        "train_samples": len(train_ds),
        "val_samples": {k: len(v) for k, v in val_splits.items()},
        "split_manifest": cfg.manifest,
    },
    mode=os.environ.get("WANDB_MODE", "online"),
)

# All metrics use global_step (gradient updates) as the x-axis.
wandb.define_metric("global_step")
wandb.define_metric("train/*", step_metric="global_step")
wandb.define_metric("val/*", step_metric="global_step")
for _sname in VAL_SPLIT_NAMES:
    wandb.define_metric(f"{_sname}/*", step_metric="global_step")
wandb.define_metric("lr", step_metric="global_step")
wandb.define_metric("epoch_time_s", step_metric="global_step")
wandb.define_metric("val_predictions", step_metric="global_step")

model_dir = Path(f"models/model-{run.id}")
model_dir.mkdir(parents=True)
model_path = model_dir / "checkpoint.pt"
with open(model_dir / "config.yaml", "w") as f:
    yaml.dump(model_config, f)

best_val = float("inf")
best_metrics = {}
global_step = 0
train_start = time.time()

for epoch in range(MAX_EPOCHS):
    elapsed_min = (time.time() - train_start) / 60.0
    if elapsed_min >= MAX_TIMEOUT:
        print(f"Wall-clock limit reached ({elapsed_min:.1f} min >= {MAX_TIMEOUT} min). Stopping.")
        break

    t0 = time.time()

    # --- Train ---
    model.train()
    epoch_vol = 0.0
    epoch_surf = 0.0
    n_batches = 0

    pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
    for x, y, is_surface, mask in pbar:
        x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
        is_surface = is_surface.to(device, non_blocking=True)
        mask = mask.to(device, non_blocking=True)

        x = (x - stats["x_mean"]) / stats["x_std"]
        y_norm = (y - stats["y_mean"]) / stats["y_std"]

        pred = model({"x": x})["preds"]
        sq_err = (pred - y_norm) ** 2

        vol_mask = mask & ~is_surface
        surf_mask = mask & is_surface
        vol_loss = (sq_err * vol_mask.unsqueeze(-1)).sum() / vol_mask.sum().clamp(min=1)
        surf_loss = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
        loss = vol_loss + cfg.surf_weight * surf_loss

        optimizer.zero_grad()
        loss.backward()
        optimizer.step()
        global_step += 1
        wandb.log({"train/loss": loss.item(), "global_step": global_step})

        epoch_vol += vol_loss.item()
        epoch_surf += surf_loss.item()
        n_batches += 1
        pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")

    scheduler.step()
    epoch_vol /= n_batches
    epoch_surf /= n_batches

    # --- Validate across all splits ---
    model.eval()
    val_metrics_per_split: dict[str, dict] = {}
    val_loss_sum = 0.0

    for split_name, vloader in val_loaders.items():
        val_vol = 0.0
        val_surf = 0.0
        mae_surf = torch.zeros(3, device=device)
        mae_vol = torch.zeros(3, device=device)
        n_surf = 0
        n_vol = 0
        n_vbatches = 0

        with torch.no_grad():
            for x, y, is_surface, mask in tqdm(
                vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
            ):
                x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
                is_surface = is_surface.to(device, non_blocking=True)
                mask = mask.to(device, non_blocking=True)

                x = (x - stats["x_mean"]) / stats["x_std"]
                y_norm = (y - stats["y_mean"]) / stats["y_std"]

                pred = model({"x": x})["preds"]
                sq_err = (pred - y_norm) ** 2

                vol_mask = mask & ~is_surface
                surf_mask = mask & is_surface
                val_vol += (sq_err * vol_mask.unsqueeze(-1)).sum().item() / vol_mask.sum().clamp(min=1).item()
                val_surf += (sq_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
                n_vbatches += 1

                pred_orig = pred * stats["y_std"] + stats["y_mean"]
                err = (pred_orig - y).abs()
                mae_surf += (err * surf_mask.unsqueeze(-1)).sum(dim=(0, 1))
                mae_vol += (err * vol_mask.unsqueeze(-1)).sum(dim=(0, 1))
                n_surf += surf_mask.sum().item()
                n_vol += vol_mask.sum().item()

        val_vol /= max(n_vbatches, 1)
        val_surf /= max(n_vbatches, 1)
        split_loss = val_vol + cfg.surf_weight * val_surf
        mae_surf /= max(n_surf, 1)
        mae_vol /= max(n_vol, 1)

        val_metrics_per_split[split_name] = {
            f"{split_name}/vol_loss":    val_vol,
            f"{split_name}/surf_loss":   val_surf,
            f"{split_name}/loss":        split_loss,
            f"{split_name}/mae_vol_Ux":  mae_vol[0].item(),
            f"{split_name}/mae_vol_Uy":  mae_vol[1].item(),
            f"{split_name}/mae_vol_p":   mae_vol[2].item(),
            f"{split_name}/mae_surf_Ux": mae_surf[0].item(),
            f"{split_name}/mae_surf_Uy": mae_surf[1].item(),
            f"{split_name}/mae_surf_p":  mae_surf[2].item(),
        }
        val_loss_sum += split_loss

    # val/loss = mean across all splits; used for checkpoint selection
    mean_val_loss = val_loss_sum / len(val_loaders)

    dt = time.time() - t0

    # --- Log to wandb ---
    metrics = {
        "train/vol_loss": epoch_vol,
        "train/surf_loss": epoch_surf,
        "val/loss": mean_val_loss,
        "lr": scheduler.get_last_lr()[0],
        "epoch_time_s": dt,
    }
    for split_metrics in val_metrics_per_split.values():
        metrics.update(split_metrics)
    metrics["global_step"] = global_step
    wandb.log(metrics)

    if torch.cuda.is_available():
        peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
    else:
        peak_mem_gb = 0.0

    tag = ""
    if mean_val_loss < best_val:
        best_val = mean_val_loss
        best_metrics = {"epoch": epoch + 1, "val_loss": mean_val_loss}
        for split_metrics in val_metrics_per_split.values():
            for k, v in split_metrics.items():
                best_metrics[f"best_{k}"] = v
        torch.save(model.state_dict(), model_path)
        tag = f" * -> {model_path}"

    split_summary = "  ".join(
        f"{name}={val_metrics_per_split[name][f'{name}/loss']:.4f}"
        for name in VAL_SPLIT_NAMES
    )
    print(
        f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
        f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  "
        f"val[{split_summary}]{tag}"
    )


# --- Final summary ---
total_time = (time.time() - train_start) / 60.0
print("\n" + "=" * 70)
print(f"TRAINING COMPLETE ({total_time:.1f} min)")
print("=" * 70)
if best_metrics:
    print(f"Best model at epoch {best_metrics['epoch']}  (val/loss={best_metrics['val_loss']:.4f})")
    for split_name in VAL_SPLIT_NAMES:
        k_p = f"best_{split_name}/mae_surf_p"
        k_l = f"best_{split_name}/loss"
        if k_p in best_metrics:
            print(f"  {split_name:30s}  loss={best_metrics[k_l]:.4f}  mae_surf_p={best_metrics[k_p]:.1f}")
else:
    print("No completed epochs (timeout too short?).")

if best_metrics:
    wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})

    print("\nGenerating flow field plots...")
    model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
    plot_dir = Path("plots") / run.id
    n = 1 if cfg.debug else 4
    for split_name, split_ds in val_splits.items():
        images = visualize(model, split_ds, stats, device, n_samples=n, out_dir=plot_dir / split_name)
        if images:
            wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})

wandb.finish()
```