### PR TITLE
Phase 3: Field Decoder + Width Scaling Compound (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -654,6 +654,7 @@ class Config:
     # Phase 3: compound experiments
     seed: int = -1                     # random seed (-1 = no seeding)
     n_layers: int = 2                  # number of TransolverBlocks (default 2)
+    use_lion: bool = False             # use Lion optimizer instead of AdamW
 
 
 cfg = sp.parse(Config)
@@ -839,6 +840,38 @@ class SAM:
                 if hasattr(p, '_sam_e_w'):
                     p.data.sub_(p._sam_e_w)
                     del p._sam_e_w
+
+
+class Lion(torch.optim.Optimizer):
+    """Lion optimizer (Chen et al., 2023). Sign-based updates, ~2x less memory than AdamW.
+
+    Use lr ~3-10x lower than AdamW (e.g. lr=3e-4 instead of 1.5e-3).
+    """
+    def __init__(self, params, lr=3e-4, betas=(0.9, 0.99), weight_decay=0.0):
+        defaults = dict(lr=lr, betas=betas, weight_decay=weight_decay)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                state = self.state[p]
+                if 'exp_avg' not in state:
+                    state['exp_avg'] = torch.zeros_like(p.data)
+                exp_avg = state['exp_avg']
+                b1, b2 = group['betas']
+                update = exp_avg * b1 + p.grad * (1 - b1)
+                p.data.add_(update.sign(), alpha=-group['lr'])
+                if group['weight_decay'] > 0:
+                    p.data.mul_(1 - group['lr'] * group['weight_decay'])
+                exp_avg.mul_(b2).add_(p.grad, alpha=1 - b2)
+        return loss
 
 
 class Lookahead:


### PR DESCRIPTION
## Hypothesis
Phase 2 R6 showed two independently strong results: (1) field_decoder achieves best surf_p_in=14.38 Pa (vs 14.6 baseline) by giving pressure a dedicated 2x-wider decoder head, and (2) h=256 achieves best p_tan=34.97 Pa (nearly matching 35.1 baseline) with extra capacity. These target different metrics through orthogonal mechanisms. Combining them should compound both gains.

## Instructions

Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-field-compound"`.

**All runs must set `--tandem_ramp --slice_num 96` (current baseline config).**

### GPU 0: field_decoder standalone (cheapest potential win)
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --field_decoder --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-field-dec" --wandb_group "phase3-field-compound" --agent frieren
```

### GPU 1: field_decoder + seed=42 (variance check)
Set `torch.manual_seed(42); torch.cuda.manual_seed_all(42)` before model creation.
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --field_decoder --seed 42 --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-field-dec-s42" --wandb_group "phase3-field-compound" --agent frieren
```

### GPU 2: h=256 + field_decoder (compound)
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --n_hidden 256 --field_decoder --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-h256-field" --wandb_group "phase3-field-compound" --agent frieren
```

### GPU 3: h=256 + field_decoder + T_max=180 (align cosine to ~191-epoch budget)
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --n_hidden 256 --field_decoder --cosine_T_max 180 --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-h256-field-t180" --wandb_group "phase3-field-compound" --agent frieren
```

### GPU 4: h=256 + field_decoder + lr=1.2e-3 (scaled LR for more params)
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --n_hidden 256 --field_decoder --lr 1.2e-3 --cosine_T_max 180 --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-h256-field-lr12" --wandb_group "phase3-field-compound" --agent frieren
```

### GPU 5: h=256 standalone (isolate width effect)
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --n_hidden 256 --cosine_T_max 180 --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-h256-alone" --wandb_group "phase3-field-compound" --agent frieren
```

### GPU 6: field_decoder + adaln_output (OOD conditioning on output head only)
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --field_decoder --adaln_output --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-field-adaln-out" --wandb_group "phase3-field-compound" --agent frieren
```

### GPU 7: field_decoder + n_layers=3 (extra depth)
Modify `model_config` to set `n_layers=3` for this run.
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --field_decoder --n_layers 3 --tandem_ramp --slice_num 96 --wandb_name "frieren/p3-field-3layer" --wandb_group "phase3-field-compound" --agent frieren
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re | W&B Run |
|----------|------|--------|-------|------|---------||  **0.6994** | 14.6 | 10.1 | 35.1 | 25.4 | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |

---

## Results

### Round 1: AdamW compound experiments

| GPU | Config | val/loss | p_in | p_oodc | p_tan | p_re | Peak Mem | Epochs | W&B |
|-----|--------|----------|------|--------|-------|------|----------|--------|-----|
| **Baseline** | tandem_ramp + slice96 | **0.6994** | 14.6 | 10.1 | 35.1 | 25.4 | — | — | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |
| 0 | field_decoder | 0.7145 | 14.7 | 10.2 | 36.0 | 25.8 | 30.6 GB | 222 | [90y1v9mn](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/90y1v9mn) |
| 1 | field_decoder + seed=42 | 0.7040 | 14.6 | 10.3 | 34.6 | 25.9 | 29.4 GB | 222 | [uef417e8](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/uef417e8) |
| 2 | h=256 + field_decoder | 0.7284 | 15.1 | 10.5 | 37.0 | 25.8 | 40.6 GB | 171 | [gybayuuh](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/gybayuuh) |
| 3 | h=256 + field_decoder + T_max=180 | 0.7169 | 15.1 | 10.3 | 36.3 | 25.7 | 39.7 GB | 171 | [qo4u7jlm](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/qo4u7jlm) |
| 4 | h=256 + field_decoder + lr=1.2e-3 | 0.7161 | 14.2 | 10.1 | 36.8 | 25.7 | 39.5 GB | 172 | [cbvz5h7y](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/cbvz5h7y) |
| 5 | h=256 standalone + T_max=180 | 0.7071 | 15.2 | 10.0 | 35.5 | 25.7 | 37.8 GB | 179 | [xmon408o](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/xmon408o) |
| 6 | field_decoder + adaln_output | 0.7063 | 14.9 | 9.7 | 35.3 | 25.7 | 30.2 GB | 222 | [08epp8h3](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/08epp8h3) |
| 7 | field_decoder + n_layers=3 | 0.7188 | 14.7 | 10.8 | 36.2 | 26.0 | 37.8 GB | 170 | [ljb759u8](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/ljb759u8) |

Round 1 finding: No compound gains with AdamW. field_decoder+adaln_output showed best p_oodc=9.7. h=256 is compute-budget-limited at this 3-hour window. Advisor directed follow-up with Lion optimizer.

### Round 2: Lion optimizer (advisor-directed follow-up)

| Config | val/loss | p_in | p_oodc | p_tan | p_re | Peak Mem | Epochs | W&B |
|--------|----------|------|--------|-------|------|----------|--------|-----|
| **Baseline** | **0.6994** | 14.6 | 10.1 | 35.1 | 25.4 | — | — | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |
| **field_decoder + adaln_output + Lion lr=3e-4** | **0.6373** | **14.2** | **7.9** | **34.5** | **24.5** | 31.0 GB | 222 | [hj8x5227](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/hj8x5227) |
| h=256 + Lion lr=3e-4 | 0.6599 | **13.8** | 8.4 | 36.6 | 24.7 | 37.2 GB | 180 | [8ewfbewr](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/8ewfbewr) |

### Detailed metrics — Lion runs

| Run | val split | surf_Ux | surf_Uy | surf_p | vol_Ux | vol_Uy | vol_p |
|-----|-----------|---------|---------|--------|--------|--------|-------|
| hj8x5227 | val_in_dist | 2.53 | 0.68 | 14.2 | 0.59 | 0.20 | 13.0 |
| hj8x5227 | val_tandem | 3.13 | 1.06 | 34.5 | 1.33 | 0.61 | 32.3 |
| hj8x5227 | val_ood_cond | 1.88 | 0.48 | 7.9 | 0.34 | 0.13 | 6.1 |
| hj8x5227 | val_ood_re | 1.68 | 0.47 | 24.5 | 0.51 | 0.26 | 43.1 |
| 8ewfbewr | val_in_dist | 2.92 | 0.68 | 13.8 | 0.62 | 0.20 | 12.7 |
| 8ewfbewr | val_tandem | 3.72 | 1.10 | 36.6 | 1.40 | 0.65 | 34.5 |
| 8ewfbewr | val_ood_cond | 1.99 | 0.50 | 8.4 | 0.34 | 0.14 | 6.4 |
| 8ewfbewr | val_ood_re | 1.78 | 0.46 | 24.7 | 0.52 | 0.27 | 43.2 |

### What happened

**Round 1 (AdamW):** No compound gains. See Round 1 findings above.

**Round 2 (Lion): Major breakthrough.**

1. **field_decoder + adaln_output + Lion (hj8x5227)**: val/loss=0.6373 — a **9.0% improvement** over the AdamW baseline (0.6994). Beats every metric:
   - p_oodc: 7.9 Pa (-22% vs baseline 10.1) — biggest single-metric gain in the entire project
   - p_re: 24.5 Pa (-3.5% vs baseline 25.4)
   - p_tan: 34.5 Pa (-1.7% vs baseline 35.1)
   - p_in: 14.2 Pa (-2.7% vs baseline 14.6)
   - 31.0 GB peak memory (same as AdamW field_decoder+adaln_output at 30.2 GB)

2. **h=256 + Lion (8ewfbewr)**: val/loss=0.6599 — a **5.7% improvement** over baseline. Best single-field result: p_in=13.8 Pa (vs 14.6 baseline). But p_tan=36.6 is worse than baseline — the wider model trades in-distribution gain for tandem degradation. Still, the overall val/loss is excellent.

**Why Lion works so much better here:** Lion's sign-based updates provide stronger, more uniform parameter updates per step compared to AdamW's adaptive scaling. At the same 3-hour budget, Lion drives the model to a much better minimum. The field_decoder+adaln_output architecture appears to be a particularly good match for Lion — the dedicated pressure head and adaptive conditioning benefit from Lion's stronger convergence pressure.

**Key insight**: The Round 1 AdamW runs were genuinely compute-budget-limited, not architecture-limited. With Lion, field_decoder+adaln_output achieves p_oodc=7.9 vs 9.7 with AdamW — a 19% further improvement from the same architecture just by switching optimizers.

### Suggested follow-ups

1. **Lion + field_decoder + adaln_output is the new strong baseline** — this should be merged and used as the Phase 3 baseline for further experiments.
2. **Lion + h=256 + field_decoder + adaln_output**: The compound of all three winning components hasn't been tried with Lion yet.
3. **Lion + seed diversity (2-3 seeds)**: Confirm variance of the Lion+field_dec+adaln result.
4. **Lion lr sensitivity (1e-4, 5e-4)**: The lr=3e-4 was chosen from thorfinn's experiment; a sweep might find a better value.
5. **h=256 + Lion + field_decoder**: The h=256 model with Lion gets p_in=13.8 but loses on p_tan. Adding field_decoder's dedicated pressure head might fix p_tan.