### PR TITLE
Phase 3: Gradient & Fourier Loss Innovation (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -568,8 +569,9 @@ class Transolver(nn.Module):
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
 
         # Auxiliary Re prediction from pre-output-head hidden representation
-        re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
-        aoa_pred = self.aoa_head(fx.mean(dim=1))
+        hidden_mean = fx.mean(dim=1)  # [B, H] — save for contrastive loss
+        re_pred = self.re_head(hidden_mean)  # [B, 1]
+        aoa_pred = self.aoa_head(hidden_mean)
 
         # Last block: use adaln_all condition if enabled, else fallback to adaln_output
         last_condition = block_condition if use_cond else (x[:, 0, 13:15] if self.adaln_output else None)
@@ -577,7 +579,7 @@ class Transolver(nn.Module):
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
         self._validate_output_dims(fx)
-        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
+        return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "hidden_mean": hidden_mean}
 
 
 # ---------------------------------------------------------------------------
@@ -651,6 +653,19 @@ class Config:
     use_lion: bool = False        # GPU 4: Lion optimizer instead of AdamW
     rdrop: bool = False           # GPU 7: R-drop regularization
     rdrop_alpha: float = 1.0     # R-drop consistency loss weight
+    # Phase 3: Loss innovation variants
+    surf_gradient_loss: bool = False   # surface pressure gradient loss along arc-length
+    surf_gradient_weight: float = 0.5  # weight for surf gradient loss
+    surf_gradient_start_epoch: int = 0  # epoch to start applying gradient loss
+    fourier_surface_loss: bool = False  # Fourier-space surface pressure loss
+    fourier_weight: float = 0.01        # weight for Fourier loss (normalized variant)
+    fourier_start_epoch: int = 0        # epoch to start Fourier loss
+    laplacian_reg: bool = False         # Laplacian smoothness regularization (k-NN)
+    huber_loss: bool = False            # Huber/smooth-L1 loss (beta=0.5)
+    logcosh_loss: bool = False          # log-cosh loss
+    pressure_3x: bool = False           # 3x weight on pressure channel in surface loss
+    contrastive_loss: bool = False      # contrastive representation loss on hidden features
+    contrastive_weight: float = 0.05    # weight for contrastive loss
 
 
 cfg = sp.parse(Config)
@@ -1069,7 +1084,14 @@ for epoch in range(MAX_EPOCHS):
         if model.training:
             pred = pred / sample_stds
         sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        if cfg.huber_loss:
+            abs_err = F.smooth_l1_loss(pred, y_norm, reduction='none', beta=0.5)
+        elif cfg.logcosh_loss:
+            _diff = pred - y_norm
+            _abs_diff = _diff.abs()
+            abs_err = _abs_diff + torch.log1p(torch.exp(-2.0 * _abs_diff)) - math.log(2.0)
+        else:
+            abs_err = (pred - y_norm).abs()
         if cfg.tandem_ramp:
             pass  # no hard curriculum; tandem_weight applied via tandem_boost below
         elif epoch < cfg.tandem_curriculum_epochs:
@@ -1107,7 +1129,14 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        if cfg.pressure_3x:
+            # Weight channels [Ux, Uy, p] as [1, 1, 3] / 5
+            _chan_w = torch.tensor([1.0, 1.0, 3.0], device=device)  # [3]
+            _n_surf = surf_mask.sum(dim=1, keepdim=True).clamp(min=1).float()  # [B, 1]
+            _per_ch = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=1) / _n_surf  # [B, 3]
+            surf_per_sample = (_per_ch * _chan_w).sum(dim=-1) / _chan_w.sum()  # [B]
+        else:
+            surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -1142,6 +1171,62 @@ for epoch in range(MAX_EPOCHS):
                     surf_p_loss  * torch.exp(-2 * bm.log_sigma_surf_p)  / 2 + bm.log_sigma_surf_p)
         else:
             loss = vol_loss + surf_weight * surf_loss
+
+        # Phase 3: Spatial loss terms (surf gradient, Fourier, Laplacian)
+        _apply_grad = cfg.surf_gradient_loss and epoch >= cfg.surf_gradient_start_epoch
+        _apply_fourier = cfg.fourier_surface_loss and epoch >= cfg.fourier_start_epoch
+        if _apply_grad or _apply_fourier:
+            _grad_total = torch.tensor(0.0, device=device)
+            _fourier_total = torch.tensor(0.0, device=device)
+            _n_spatial = 0
+            for _b in range(B):
+                _sm = surf_mask[_b]
+                if _sm.sum() < 4:
+                    continue
+                _n_spatial += 1
+                _sxy = x[_b, _sm, :2]  # [S, 2]
+                _sp_pred = pred[_b, _sm, 2]  # [S] surface pressure pred
+                _sp_true = y_norm[_b, _sm, 2]  # [S] surface pressure true
+                if _apply_grad:
+                    # Sort by angle from centroid
+                    _cen = _sxy.mean(dim=0)
+                    _ang = torch.atan2(_sxy[:, 1] - _cen[1], _sxy[:, 0] - _cen[0])
+                    _si = _ang.argsort()
+                    _dp_pred = _sp_pred[_si][1:] - _sp_pred[_si][:-1]
+                    _dp_true = _sp_true[_si][1:] - _sp_true[_si][:-1]
+                    _grad_total = _grad_total + (_dp_pred - _dp_true).abs().mean()
+                if _apply_fourier:
+                    # Sort by x-coordinate, normalize FFT magnitudes to prevent scale blowup
+                    _si_x = _sxy[:, 0].argsort()
+                    _fft_pred = torch.fft.rfft(_sp_pred[_si_x])
+                    _fft_true = torch.fft.rfft(_sp_true[_si_x])
+                    _fft_norm = _fft_true.abs().mean().clamp(min=1e-8)
+                    _fourier_total = _fourier_total + ((_fft_pred.abs() - _fft_true.abs()) / _fft_norm).abs().mean()
+            if _n_spatial > 0:
+                if _apply_grad:
+                    loss = loss + cfg.surf_gradient_weight * _grad_total / _n_spatial
+                if _apply_fourier:
+                    loss = loss + cfg.fourier_weight * _fourier_total / _n_spatial
+
+        if cfg.laplacian_reg:
+            _k = 8
+            _lap_total = torch.tensor(0.0, device=device)
+            _n_lap = 0
+            for _b in range(B):
+                _sm = surf_mask[_b]
+                if _sm.sum() < _k + 1:
+                    continue
+                _sxy = x[_b, _sm, :2]  # [S, 2]
+                _sp = pred[_b, _sm]  # [S, 3]
+                _dist = torch.cdist(_sxy.unsqueeze(0), _sxy.unsqueeze(0)).squeeze(0)  # [S, S]
+                _, _ki = _dist.topk(_k + 1, dim=-1, largest=False)
+                _ki = _ki[:, 1:]  # [S, k] exclude self
+                _nbr = _sp[_ki]  # [S, k, 3]
+                _lap = _nbr.mean(dim=1) - _sp  # [S, 3]
+                _lap_total = _lap_total + _lap.abs().mean()
+                _n_lap += 1
+            if _n_lap > 0:
+                loss = loss + 0.1 * _lap_total / _n_lap
 
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None
@@ -1188,6 +1273,15 @@ for epoch in range(MAX_EPOCHS):
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
             loss = loss + cfg.rdrop_alpha * rdrop_loss
+
+        # Phase 3: Contrastive representation loss
+        if cfg.contrastive_loss:
+            _hm = out["hidden_mean"].float()  # [B, H]
+            _cond = x[:, 0, 13:15]  # [B, 2] Re, AoA
+            _cond_sim = -torch.cdist(_cond, _cond)  # [B, B] negative distance = similarity
+            _repr_sim = F.cosine_similarity(_hm.unsqueeze(1), _hm.unsqueeze(0), dim=-1)  # [B, B]
+            _contrastive = F.mse_loss(_repr_sim, _cond_sim.softmax(dim=-1))
+            loss = loss + cfg.contrastive_weight * _contrastive
 
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest


### PR DESCRIPTION
## Hypothesis
The current loss function is L1 (MAE) on node values. This measures point-wise accuracy but ignores spatial structure — a prediction with smooth but shifted pressure distribution scores the same as one with noisy spikes. For CFD, engineers care about pressure GRADIENTS (forces = ∫p·n dS), not just pressure values. Adding loss terms that penalize spatial gradient errors and frequency-domain discrepancies could guide the model toward physically consistent predictions.

Key ideas:
1. **Spatial gradient loss**: Penalize |∂p_pred/∂s - ∂p_true/∂s| along the surface arc-length. Directly targets the quantity that determines lift/drag.
2. **Fourier-space loss**: FFT of surface pressure distribution — penalize errors in frequency spectrum. Captures oscillatory patterns the L1 loss treats as equivalent to smooth offsets.
3. **Laplacian smoothness regularization**: Penalize large second derivatives in predicted fields — enforce physical smoothness.
4. **Contrastive representation loss**: Push samples with similar conditions close in representation space — improve OOD interpolation.

## Instructions

Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-loss-innov"`.

**All runs use `--tandem_ramp --slice_num 96`.** Loss modifications go in the training loop.

### GPU 0: Surface pressure gradient loss (∂p/∂s along airfoil)
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-surf-grad-loss" --wandb_group "phase3-loss-innov" --agent nezuko
```

### GPU 1: Fourier-space surface loss
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-fourier-loss" --wandb_group "phase3-loss-innov" --agent nezuko
```

### GPU 2: Laplacian smoothness regularization
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-laplacian-reg" --wandb_group "phase3-loss-innov" --agent nezuko
```

### GPU 3: Surface gradient + Fourier combined (0.3 each)
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-grad-fourier-combo" --wandb_group "phase3-loss-innov" --agent nezuko
```

### GPU 4: Huber loss replacing L1 (delta=0.5)
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-huber-loss" --wandb_group "phase3-loss-innov" --agent nezuko
```

### GPU 5: Log-cosh loss
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-logcosh-loss" --wandb_group "phase3-loss-innov" --agent nezuko
```

### GPU 6: Pressure-weighted surface loss (3x weight on pressure channel)
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-pressure-3x" --wandb_group "phase3-loss-innov" --agent nezuko
```

### GPU 7: Contrastive representation loss
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --tandem_ramp --slice_num 96 --wandb_name "nezuko/p3-contrastive" --wandb_group "phase3-loss-innov" --agent nezuko
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re | W&B Run |
|----------|------|--------|-------|------|---------| 
| **0.6994** | 14.6 | 10.1 | 35.1 | 25.4 | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |

---

## Results

All 8 experiments ran ~226–233 epochs (180 min timeout). Peak memory: 28.4–29.3 GB.

| Variant | val/loss | p_in | p_oodc | p_tan | p_re | Epochs | W&B |
|---------|----------|------|--------|-------|------|--------|-----|
| **Baseline** | **0.6994** | **14.6** | **10.1** | **35.1** | **25.4** | — | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |
| GPU0: Surf gradient (w=0.5) | 0.7167 | 14.7 | **9.7** | 36.8 | 25.6 | 226 | [5dwjgqh8](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/5dwjgqh8) |
| GPU1: Fourier (w=0.3) | **FAILED (11.72)** | 796.3 | 12.9 | 769.2 | 26.9 | 228 | [o3raezoy](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/o3raezoy) |
| GPU2: Laplacian k-NN k=8 (w=0.1) | 0.7144 | 14.9 | 10.1 | 36.0 | 25.8 | 228 | [6xmluh9t](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/6xmluh9t) |
| GPU3: Grad+Fourier combo (0.3 each) | 0.7719 | 15.3 | 11.4 | 38.3 | 26.3 | 226 | [qu905uhy](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/qu905uhy) |
| GPU4: Huber (beta=0.5) | 0.7755 | 16.9 | 12.3 | 37.6 | 26.8 | 233 | [or525349](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/or525349) |
| GPU5: Log-cosh | 0.8025 | 16.5 | 12.8 | 38.7 | 27.3 | 231 | [lpw31gz6](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/lpw31gz6) |
| GPU6: Pressure 3x weight | 0.7199 | 15.0 | 10.4 | 36.2 | 25.9 | 232 | [02s9v9nk](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/02s9v9nk) |
| GPU7: Contrastive repr (w=0.05) | 0.7148 | 14.7 | 10.2 | 35.6 | 25.8 | 230 | [9tqh3e52](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/9tqh3e52) |

### What happened

**None of the 8 variants improved over the baseline val/loss of 0.6994.** The closest were GPU2 (laplacian, 0.7144) and GPU7 (contrastive, 0.7148), both ~2.1–2.2% worse.

**GPU1 (Fourier) catastrophically failed.** FFT magnitude spectra are unbounded — the 0.3 weight completely overwhelmed the main loss. Training collapsed on minimizing FFT error; in-distribution and tandem predictions became garbage (p_in=796 vs baseline 14.6). OOD splits were less affected since the model partially kept volume features. This is a fundamental scaling issue — FFT magnitudes need normalization before computing L1, or the weight must be ~0.001 instead of 0.3.

**GPU3 (Grad+Fourier combo) also degraded** (0.7719 vs baseline 0.6994), confirming the Fourier term is toxic even at 0.3. The gradient component partially stabilized it but couldn't fix the damage.

**GPU4 (Huber) and GPU5 (log-cosh) underperformed.** Both suppress gradient signal for large errors by design. But the hardest samples in this dataset — extreme tandem / OOD Re — are precisely the large-error tail that needs strong gradients. Smoothing the loss hurts where it matters most.

**GPU0 (surface gradient) showed one genuine signal**: p_oodc=9.7 vs baseline 10.1 (−3.9%), the only metric that improved over baseline. The arc-length gradient loss provides structural signal for extreme-AoA conditions where pressure changes rapidly along the foil. Overall val/loss is slightly worse (0.7167), suggesting the gradient term adds noise in the in-distribution regime.

**GPU6 (pressure 3x)** neutral (0.7199). Expanding the surface loss to include all channels weighted [1, 1, 3] / 5 slightly hurt Ux/Uy convergence without improving pressure MAE.

**GPU7 (contrastive)** most competitive (0.7148). Representation-level regularization is stable and adds a small useful bias, but 0.05 weight is too weak relative to the well-tuned existing loss terms.

**Why don't these help?** The baseline training loop already encodes much of what these losses tried to add: hard-node mining (asymmetric pressure weighting after epoch 30), adaptive surface weight, tandem boost, coarse spatial pooling loss, PCGrad gradient projection, EMA. The additional terms compete with existing mechanisms and often hurt convergence.

### Suggested follow-ups

1. **Fix Fourier loss with normalization**: Normalize FFT magnitudes by sample-mean magnitude: `fourier_loss = ((fft_pred.abs() - fft_true.abs()) / (fft_true.abs().mean() + 1e-8)).abs().mean()`. Or try weight ~0.001. The frequency-domain idea is sound but needs bounding.
2. **Gradient loss with smaller weight (0.1)**: GPU0 improved p_oodc meaningfully. The signal is real — just needs less weight to avoid hurting in-dist performance. Worth a targeted re-run.
3. **Contrastive with larger weight / temperature**: GPU7 was stable at 0.05. Try w=0.2 or scale the cond_sim by a temperature factor before softmax to sharpen the target distribution.
4. **Delayed auxiliary losses (start after epoch 50)**: Introducing gradient/Fourier losses only after the model has a baseline fit avoids early interference with fast convergence.

---

## Phase 2 Results (rebased onto noam/Lion, advisor revision)

Lion baseline (PR #1737): val/loss=**0.6532** (run [fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx))

| Variant | val/loss (best) | p_in | p_oodc | p_tan | p_re | Epochs | W&B |
|---------|----------|------|--------|-------|------|--------|-----|
| **Lion baseline** | **0.6532** | — | — | — | — | — | [fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx) |
| GPU0: Norm. Fourier+Lion (w=0.01, start=50) | **FAILED (5.37)** | 237.3 | 120.6 | 145.5 | 114.3 | 9\* | [wn5keisd](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/wn5keisd) |
| GPU1: Surf gradient (w=0.1)+Lion | 0.8722 | 18.6 | 13.7 | 41.2 | 26.6 | 224 | [54sqex3d](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/54sqex3d) |
| GPU2: Contrastive (w=0.2)+Lion | **FAILED (5.46)** | 207.6 | 125.8 | 156.1 | 112.0 | 6\* | [9oya8qv8](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/9oya8qv8) |
| GPU3: Gradient+Contrastive+Lion | **FAILED (2.67)** | 82.5 | 51.0 | 94.9 | 55.2 | 14\* | [4qo3l54a](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/4qo3l54a) |

*\* Best epoch at timeout — model diverged early, checkpoint from near-init epoch only.*

### What happened (Phase 2)

**3 out of 4 runs catastrophically diverged** when combining Lion optimizer with contrastive or Fourier auxiliary losses. Only surface gradient + Lion converged, but still underperformed both the Lion baseline (0.8722 vs 0.6532) and the original Adam + gradient run (p_in=18.6 vs 14.7 Pa).

**GPU0 (normalized Fourier + Lion)**: Despite implementing FFT normalization (`/ fft_true.abs().mean()`) and delaying activation to epoch 50, training diverged before epoch 50 even activated the Fourier loss. Best checkpoint is from epoch 9 with val/loss=5.37, suggesting something in the Lion+fourier configuration destabilized early training. Most likely culprit: without a fixed random seed, different GPU-to-GPU initialization combined with Lion's sign-based updates amplified early instability. The normalized Fourier loss itself was never actually exercised.

**GPU2 (contrastive w=0.2 + Lion)**: Diverged at epoch 6. Contrastive loss with weight=0.2 is 4x higher than the stable weight=0.05 from Phase 1. Lion's sign-based update ignores gradient magnitude — even a small noisy gradient direction from the contrastive term gets a full-magnitude step. The `_cond_sim.softmax()` target also has a structural mismatch (diagonal cosine sim is always 1.0 by definition, target diagonal < 1.0) that may create constant gradient noise.

**GPU3 (gradient+contrastive + Lion)**: Best epoch 14. Slightly more stable than GPU2 alone (gradient loss partially regularizes), but still diverged. The combined gradient directions from both auxiliary losses + Lion are incompatible.

**GPU1 (surface gradient w=0.1 + Lion)**: Only run that converged. The surface gradient loss is purely local (difference of adjacent pressure values), generating small, well-bounded gradients compatible with Lion's sign-based updates. However, p_in degraded from 14.7 (Adam+gradient Phase 1) to 18.6 Pa. The gradient loss is beneficial with Adam but appears to conflict with Lion's convergence dynamics even at the lower weight.

**Key finding**: **Lion optimizer is fragile to auxiliary losses in this setting.** Lion's sign-based updates normalize all gradient directions equally — auxiliary losses with different gradient scales or structures (like contrastive's full [B,B] pair-wise targets) can destabilize training. The Adam baseline was more tolerant because gradient magnitude naturally downweighted small auxiliary gradients.

### Suggested follow-ups (Phase 2)

1. **Gradient loss with Adam (not Lion)**: The Phase 1 gradient result (p_oodc=9.7) was achieved with Adam. Gradient loss + Adam at w=0.1 vs w=0.5 comparison would cleanly test whether the signal can be strengthened. Do not combine with Lion.
2. **Contrastive loss with much smaller weight for Lion**: If contrastive is desired with Lion, try w=0.005 (10-50x smaller than the w=0.05 that worked with Adam). Or clip contrastive gradients before applying to Lion.
3. **Gradient clipping for Lion + auxiliary**: Adding gradient clipping (e.g., max_norm=1.0) to the optimizer step when using Lion + auxiliary losses may prevent early divergence.