### PR TITLE
Phase 3: Revisit Best Phase 2 Near-Misses on Current Baseline (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -601,6 +601,7 @@ class Config:
     wandb_name: str | None = None
     agent: str | None = None
     debug: bool = False
+    seed: int = -1  # random seed (-1 = disabled)
     # Schedule params (tuned for 3-hour / 500-epoch runs)
     warmup_total_iters: int = 20
     warmup_start_factor: float = 0.2
@@ -771,6 +772,10 @@ model_config = dict(
     adaln_decouple=cfg.adaln_decouple,
     adaln_zone_temp=cfg.adaln_zone_temp,
 )
+
+if cfg.seed >= 0:
+    torch.manual_seed(cfg.seed)
+    torch.cuda.manual_seed_all(cfg.seed)
 
 model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad


### PR DESCRIPTION
## Hypothesis
Phase 2 produced several techniques that came tantalizingly close to beating baseline (within the ±0.008 variance band) but were tested on older code or with non-optimal configurations. Now that we have the ramp+slice96 baseline and 3h training budget, these near-misses deserve a clean re-test. Key candidates:

1. **LinearNO** (no Q/K/V attention): Reached val_loss=0.701 on old code — the simplest architecture that's competitive. On new baseline with ramp+slice96 it might cross over.
2. **AdaLN no-zero-init on last block only**: Phase 2 showed all-blocks AdaLN hurts val/loss but gives p_oodc<10. Restricting to last block may keep the OOD benefit without the cost.
3. **Decouple slice + ramp**: R5 showed decouple gave 0.7124 on old schedule. On current LR/schedule it might improve.
4. **T_max=200**: Consistently the best schedule tweak in R6 (0.7025 on seed rerun), approaching the 0.699 baseline.

This is the "25% on revisiting promising closed experiments" part of Phase 3 portfolio.

## Instructions

Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-revisit"`.

**All runs use `--tandem_ramp --slice_num 96`.**

### GPU 0: LinearNO on current baseline (no Q/K/V, direct slice aggregation)
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --linear_no_attention --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-linearno" --wandb_group "phase3-revisit" --agent alphonse
```

### GPU 1: LinearNO + field_decoder (best simplicity + best pressure head)
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --linear_no_attention --field_decoder --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-linearno-field" --wandb_group "phase3-revisit" --agent alphonse
```

### GPU 2: Decouple slice assignment on current baseline
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --adaln_decouple --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-decouple" --wandb_group "phase3-revisit" --agent alphonse
```

### GPU 3: T_max=200 + eta_min=1e-5 (best R6 schedule tweak)
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --cosine_T_max 200 --cosine_eta_min 1e-5 --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-t200" --wandb_group "phase3-revisit" --agent alphonse
```

### GPU 4: AdaLN output-head only (no all-blocks, no zero-init)
Phase 2 showed adaln_output on the last block doesn't hurt val/loss as much as all-blocks.
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --adaln_output --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-adaln-output" --wandb_group "phase3-revisit" --agent alphonse
```

### GPU 5: foil2_dist feature on current baseline
R6 showed 0.7008 (nearest to baseline). Clean re-test.
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --foil2_dist --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-foil2dist" --wandb_group "phase3-revisit" --agent alphonse
```

### GPU 6: Compound: T_max=200 + field_decoder + foil2_dist
Combine the three best near-misses from R6. Each targets a different aspect (schedule, output head, input features).
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --cosine_T_max 200 --field_decoder --foil2_dist --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-triple-compound" --wandb_group "phase3-revisit" --agent alphonse
```

### GPU 7: Multi-seed baseline (seed=777, for variance estimation)
We need more data points on the variance of the current config. Phase 2 R6 showed 0.7009-0.7158 across 3 seeds.
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --tandem_ramp --slice_num 96 --wandb_name "alphonse/p3-baseline-s777" --wandb_group "phase3-revisit" --agent alphonse
```
Set `torch.manual_seed(777); torch.cuda.manual_seed_all(777)` before model creation.

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re | W&B Run |
|----------|------|--------|-------|------|---------|
| **0.6994** | 14.6 | 10.1 | 35.1 | 25.4 | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |

---

## Results

### Round 1: AdamW near-miss revisit (8 parallel, ~230 epochs)

None beat the AdamW baseline 0.6994. foil2dist and T_max=200 came closest.

| Run | val/loss | p_in | p_oodc | p_tan | p_re | Mem | W&B |
|-----|---------|------|--------|-------|------|-----|-----|
| **Baseline (AdamW)** | **0.6994** | **14.6** | **10.1** | **35.1** | **25.4** | — | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |
| LinearNO | 0.7175 | 14.8 | 10.7 | 36.9 | 25.2 | 29.3GB | [s5gedbvl](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/s5gedbvl) |
| LinearNO + field_decoder | 0.7097 | 15.6 | 10.0 | 36.2 | 25.3 | 30.6GB | [x9ov1bjv](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/x9ov1bjv) |
| Decouple | 0.7157 | 15.4 | 10.0 | 35.9 | 25.9 | 32.9GB | [22y0fyox](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/22y0fyox) |
| T_max=200 | 0.7076 | 14.4 | 10.2 | 35.5 | 25.5 | 28.3GB | [v67xh5vm](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/v67xh5vm) |
| AdaLN output-head | 0.7155 | 15.9 | 9.8 | 36.1 | 25.7 | 29.7GB | [31x84dh1](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/31x84dh1) |
| foil2_dist | **0.7072** | **14.4** | **9.8** | 35.7 | 25.7 | 28.8GB | [cr71l4xw](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/cr71l4xw) |
| Triple compound (T200+field+foil2) | 0.7099 | 15.2 | 10.2 | **35.6** | **25.5** | 30.2GB | [1fc7zxa9](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/1fc7zxa9) |
| Baseline seed=777 | 0.7164 | 15.2 | 10.0 | 36.6 | 25.6 | 28.1GB | [jk2ef8ag](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/jk2ef8ag) |

**Round 1 findings:** Seed variance is ~0.017 (0.6994 vs 0.7164), larger than expected. foil2_dist is the most consistent near-miss. LinearNO definitively worse. AdaLN output and decouple add complexity without benefit.

---

### Round 2: Lion optimizer combinations (6 parallel, ~227 epochs, per advisor request)

New Lion baseline from PR #1737: val/loss=0.6532, p_oodc=8.4 ([fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx))

All runs: `--use_lion --lr 3e-4 --tandem_ramp --slice_num 96`

| Run | val/loss | p_in | p_oodc | p_tan | p_re | Mem | W&B |
|-----|---------|------|--------|-------|------|-----|-----|
| **Lion baseline** | **0.6532** | **13.9** | **8.4** | **35.8** | **24.6** | — | [fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx) |
| Lion + foil2_dist | **0.6527** | 14.2 | **8.4** | **35.2** | **24.5** | 28.4GB | [yb31bcwk](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/yb31bcwk) |
| Lion + T_max=200 | 0.6581 | 14.5 | 8.3 | 36.8 | 24.6 | 29.6GB | [dugnqe4s](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/dugnqe4s) |
| Lion + AdaLN output | 0.6607 | 18.4 | 8.3 | 35.5 | 24.6 | 28.8GB | [c7d4iay2](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/c7d4iay2) |
| Lion seed=1 | **0.6472** | 16.6 | **8.1** | **34.9** | **24.4** | 28.8GB | [c9llhod9](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/c9llhod9) |
| Lion seed=42 | **0.6480** | 14.6 | 8.2 | 35.6 | **24.4** | 28.4GB | [fasnycua](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fasnycua) |
| Lion seed=123 | 0.6638 | 15.4 | 8.2 | 36.8 | 24.5 | 29.1GB | [5bfuqx7v](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/5bfuqx7v) |

### What happened (Round 2)

**foil2_dist + Lion ≈ Lion baseline (within variance).** At 0.6527 vs 0.6532, the difference is 0.0005 — essentially a wash. foil2_dist adds the foil-2 distance feature but doesn't consistently improve over Lion alone.

**Lion variance is ~0.017 (same as AdamW).** Seeds: 0.6472, 0.6480, 0.6532, 0.6638. Mean ≈ 0.653, range 0.017. The "original" Lion baseline (0.6532) is right in the middle. Two seeds are better, one is worse — the baseline wasn't at the lucky end.

**T_max=200 doesn't stack with Lion.** 0.6581 > 0.6532. The cosine schedule with T_max=200 may conflict with Lion's sign-based updates, which are less sensitive to learning rate magnitude.

**AdaLN output is incompatible with Lion.** p_in=18.4 is dramatically worse than the Lion baseline (13.9). AdaLN conditioning interacts poorly with Lion's update dynamics, causing in-distribution pressure accuracy to collapse. Not worth pursuing.

**Lion seeds 1 and 42 are the best individual Lion runs so far** (0.6472, 0.6480), establishing a new best-of-seeds at 0.6472.

### Suggested follow-ups

1. **foil2_dist + Lion with seed=1** — combine the feature that's consistently near the top with the best Lion seed. If additive, could reach ~0.640.
2. **Lion is the clear optimizer choice** — all Lion runs outperform any AdamW variant. No need to revisit AdamW.
3. **Establish the foil2_dist vs Lion baseline on equal seeds** — run foil2_dist+Lion on seeds 1, 42, 123 to properly compare foil2_dist's contribution vs seed luck.
4. **AdaLN is incompatible with Lion** — close that direction.
