### PR TITLE
Phase 3: Multi-Scale U-Net Architecture (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -454,6 +454,7 @@ class Transolver(nn.Module):
         coarse_refine=False,
         hier_slice=False,
         surf_refine=False,
+        surf_refine_lean=False,
         pct_style=False,
         dilated_slice=False,
         progressive_width=False,
@@ -473,6 +474,7 @@ class Transolver(nn.Module):
         self.coarse_refine = coarse_refine
         self.hier_slice = hier_slice
         self.surf_refine = surf_refine
+        self.surf_refine_lean = surf_refine_lean
         self.pct_style = pct_style
         self.dilated_slice = dilated_slice
         self.progressive_width = progressive_width
@@ -869,7 +871,8 @@ class Transolver(nn.Module):
             sr_sb = self.sr_spatial_bias(raw_xy)  # [B, N, sr_slices]
             sr_feat = F.gelu(self.sr_proj_up(fx))  # [B, N, sr_hidden]
             sr_feat = self.sr_ln1(self.sr_attn1(sr_feat, spatial_bias=sr_sb) + sr_feat)
-            sr_feat = self.sr_ln2(self.sr_attn2(sr_feat, spatial_bias=sr_sb) + sr_feat)
+            if not self.surf_refine_lean:
+                sr_feat = self.sr_ln2(self.sr_attn2(sr_feat, spatial_bias=sr_sb) + sr_feat)
             sr_delta = self.sr_proj_down(sr_feat)  # [B, N, out_dim]
             if is_surface is not None:
                 sr_delta = sr_delta * is_surface.float().unsqueeze(-1)
@@ -951,10 +954,12 @@ class Config:
     rdrop: bool = False           # GPU 7: R-drop regularization
     rdrop_alpha: float = 1.0     # R-drop consistency loss weight
     # Phase 3: multi-scale architecture variants (one per GPU)
+    n_layers: int = 2                  # number of Transolver blocks (default 2)
     unet_transolver: bool = False      # GPU0: U-Net encoder-decoder with skip connections
     coarse_refine: bool = False        # GPU1: coarse-to-fine 2-stage prediction
     hier_slice: bool = False           # GPU2: hierarchical slice attention (32→96)
     surf_refine: bool = False          # GPU3: surface-aware refinement head
+    surf_refine_lean: bool = False     # use 1 attention layer instead of 2 (less memory)
     pct_style: bool = False            # GPU4: PCT-style offset attention
     dilated_slice: bool = False        # GPU5: dilated slice attention (3 spatial scales)
     progressive_width: bool = False    # GPU6: 3 blocks with 128→192→256 hidden dim
@@ -1059,7 +1064,7 @@ model_config = dict(
     fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
-    n_layers=2,
+    n_layers=cfg.n_layers,
     n_head=3,
     slice_num=cfg.slice_num,
     mlp_ratio=2,
@@ -1082,6 +1087,7 @@ model_config = dict(
     coarse_refine=cfg.coarse_refine,
     hier_slice=cfg.hier_slice,
     surf_refine=cfg.surf_refine,
+    surf_refine_lean=cfg.surf_refine_lean,
     pct_style=cfg.pct_style,
     dilated_slice=cfg.dilated_slice,
     progressive_width=cfg.progressive_width,


### PR DESCRIPTION
## Hypothesis
The current Transolver processes all mesh nodes at a single resolution through 2 TransolverBlocks. CFD flows are inherently multi-scale: large-scale pressure fields, medium-scale boundary layers, and fine-scale surface features. U-Net-style architectures (encoder-decoder with skip connections at multiple resolutions) have been transformative in image segmentation and recent PDE solvers (U-FNO, U-shaped Vision Transformer). 

Key insight: the current model's coarse pooling loss already hints at multi-scale utility, but it only affects the loss, not the architecture. A true multi-scale architecture would PROCESS features at multiple resolutions, allowing the model to capture both global pressure gradients and local surface details.

This is a bold architectural change — the "50% on new architecture" part of Phase 3.

## Instructions

Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-multiscale"`.

**All runs use `--tandem_ramp --slice_num 96`.** These require significant modifications to the model architecture in train.py.

### GPU 0: U-Net Transolver (encoder-decoder with skip connections)
Add a downsampling path: after first TransolverBlock, random-subsample 50% of nodes (sorted by x-coord, keep every other), process through a second block at lower resolution, then upsample back and add skip connection from the high-res first block.

Architecture:
```
Input → Preprocess → Block1(N nodes) → Downsample(N/2) → Block2(N/2) → Upsample(N) + Skip → Output
```
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-unet-transolver" --wandb_group "phase3-multiscale" --agent edward
```

### GPU 1: Coarse-to-Fine Refinement (2-stage: coarse prediction → residual correction)
Stage 1: Subsample to 25% of nodes, predict coarse field. Stage 2: Interpolate coarse prediction to all nodes, predict residual correction. Similar to progressive training but in the architecture.
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-coarse-refine" --wandb_group "phase3-multiscale" --agent edward
```

### GPU 2: Hierarchical Slice Attention (coarse slices → fine slices cascade)
First block uses 32 slices (coarse global routing). Second block uses 96 slices but conditions on the coarse slice assignments from block 1. This creates a hierarchical spatial decomposition.
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-hierarchical-slice" --wandb_group "phase3-multiscale" --agent edward
```

### GPU 3: Surface-Aware Refinement Head
After the standard Transolver output, add a lightweight refinement network that only processes surface nodes: gather surface predictions, apply 2 additional attention layers among surface nodes only (much smaller sequence), refine predictions.
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-surf-refine" --wandb_group "phase3-multiscale" --agent edward
```

### GPU 4: Point Cloud Transformer (PCT-style) replacing Transolver
Replace the Transolver with a Point Cloud Transformer (Guo et al., 2021): offset attention + farthest point sampling for downsampling. PCT was designed for irregular point clouds (which is what meshes are).
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-pct" --wandb_group "phase3-multiscale" --agent edward
```

### GPU 5: Dilated Slice Attention (slices at multiple dilation rates)
Instead of one set of 96 slices, use 3 parallel slice attention heads at different "dilation rates" — first processes every node, second every 2nd node (spatially sorted), third every 4th node. Captures patterns at different spatial scales.
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-dilated-slice" --wandb_group "phase3-multiscale" --agent edward
```

### GPU 6: Encoder with 3 blocks (128→192→256 hidden dim, progressive widening)
Instead of fixed width, progressively widen: block1 at h=128 (fast, captures coarse), block2 at h=192 (medium), block3 at h=256 (detailed output). Use learned projections between widths.
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-progressive-width" --wandb_group "phase3-multiscale" --agent edward
```

### GPU 7: Parallel dual-path (surface-specialized + volume-specialized blocks)
Two parallel TransolverBlocks: one processes only surface nodes (with 48 slices), the other processes only volume nodes (with 48 slices). Their outputs are concatenated and projected back. This lets each path specialize.
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --tandem_ramp --slice_num 96 --wandb_name "edward/p3-dual-path" --wandb_group "phase3-multiscale" --agent edward
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re | W&B Run |
|----------|------|--------|-------|------|---------|
| **0.6994** | 14.6 | 10.1 | 35.1 | 25.4 | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |

---

## Results

All 8 variants ran for 162–303 epochs within the 180-min timeout. Training completed successfully; a pre-existing visualization bug (missing Fourier PE in the post-training vis call) caused a crash after `wandb.summary.update()`, so all metrics are saved in W&B but flow-field plots are absent.

### Results table

| Variant | val/loss | p_in | p_oodc | p_tan | p_re | Peak mem | W&B |
|---------|----------|------|--------|-------|------|----------|-----|
| **Baseline** | **0.6994** | **14.6** | **10.1** | **35.1** | **25.4** | ~19 GB | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |
| U-Net (GPU 0) | 0.7361 | 15.9 | 10.3 | 37.6 | 25.6 | 26 GB | [vpksg5vr](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/vpksg5vr) |
| Coarse-to-Fine (GPU 1) | 0.7498 | 15.6 | 11.5 | 36.4 | 25.8 | 22 GB | [r102o42r](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/r102o42r) |
| Hier. Slice (GPU 2) | 0.7105 | 15.5 | **9.7** | 36.2 | 25.6 | 27 GB | [4q95v57x](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/4q95v57x) |
| Surf. Refine (GPU 3) | 0.7074 | **13.9** | 10.3 | 35.6 | 25.7 | 34 GB | [8hnxr5pm](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/8hnxr5pm) |
| PCT-style (GPU 4) | 0.7108 | 14.5 | **10.0** | 36.5 | 25.6 | 29 GB | [nro6wmbz](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/nro6wmbz) |
| Dilated Slice (GPU 5) | 0.7534 | 15.5 | 11.4 | 37.2 | 26.2 | 38 GB | [jddebdfl](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/jddebdfl) |
| Prog. Width (GPU 6) | 0.7560 | 16.8 | 11.1 | 37.9 | 26.0 | 37 GB | [nan80zcs](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/nan80zcs) |
| Dual-Path (GPU 7) | 0.7421 | 15.3 | 10.5 | 38.3 | 25.7 | 28 GB | [i7tij4bd](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/i7tij4bd) |

_p_in/p_oodc/p_tan/p_re = mae_surf_p on val_in_dist / val_ood_cond / val_tandem_transfer / val_ood_re_

### What happened

**Negative result overall.** Every variant is worse than the baseline on val/loss (−1.1% to −8.1%). None beat the baseline overall. However, two variants show partial signal:

1. **Surface Refinement (surf_refine)**: Closest to baseline on val/loss (0.7074 vs 0.6994). More importantly, it has the best in-distribution surface pressure (p_in=13.9 vs 14.6 baseline, **−5.5% improvement**). The dedicated post-processing attention layers over surface nodes are clearly doing something useful for in-distribution pressure. The improvement doesn't generalize to tandem-transfer though (p_tan=35.6 vs 35.1), and the architecture adds +15 GB memory (34 GB vs 19 GB baseline).

2. **Hierarchical Slice (hier_slice)**: Best OOD condition pressure (p_oodc=9.7 vs 10.1 baseline, **−3.8% improvement**). Passing coarse slice weights as an attention bias into the second block provides useful global context for OOD conditions. val/loss is 0.7105 — worse overall but the individual split signal is real.

**Why multi-scale generally hurt:**
- The baseline's 2-block flat slice attention already captures scale implicitly — slices self-organize to represent different spatial scales.
- Explicit downsampling (U-Net, coarse-to-fine) throws away node information that the model needs.
- Adding parallel paths / extra blocks adds parameters but not better inductive bias for this specific mesh-PDE task.
- Dilated slice and progressive widening are particularly costly (38 GB, 37 GB) while producing the worst results.

### Suggested follow-ups

- **Surface Refinement is worth isolating**: Try surf_refine without the pre-existing `feature_cross` overhead; explore whether a single refinement attention layer (instead of 2) gives similar p_in gains at lower memory. The architecture idea is sound but the implementation should be made leaner (34 GB is expensive).
- **Hierarchical Slice deserves a cleaner ablation**: The coarse-to-fine slice bias is a cheap idea (+0 parameters). Try coarser first block (16 or 8 slices instead of 32) and stronger injection weight (currently zero-init linear).
- **The visualization bug should be fixed**: Post-training vis at line ~1791 passes `x_n` (26-dim) to a model expecting 58-dim input (missing 32-dim Fourier PE). This is a pre-existing bug unrelated to these changes.
- **Simpler baseline search first**: Before complex multi-scale, try just 3 standard Transolver blocks at fixed width — would use less code and may match or beat these results.

---

## Phase 3v2: Lion Optimizer Combinations

Rebased onto `noam` (Lion optimizer, PR #1737). Tested 4 combinations of architecture variants + Lion over 4 GPUs, 180-min timeout, 500 epoch max.

**New baseline**: val/loss=0.6532, p_in=13.9, p_oodc=8.4, p_tan=35.8, p_re=24.6 (run [fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx))

### Results table (Phase 3v2)

| Variant | val/loss | p_in | p_oodc | p_tan | p_re | Best epoch | W&B |
|---------|----------|------|--------|-------|------|------------|-----|
| **New baseline (Lion)** | **0.653** | **13.9** | **8.4** | **35.8** | **24.6** | 226 | [fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx) |
| surf_lean + Lion | 12.410 ⚠️ | 455 | 227 | 443 | 204 | 182 | [kb7skxc0](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/kb7skxc0) |
| hier_slice + Lion | 1.246 | 36.3 | 22.0 | 52.4 | 32.1 | 236 | [8gm7bia6](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/8gm7bia6) |
| 3-block + Lion | 12.429 ⚠️ | 142 | 145 | 116 | 142 | 6 | [z2jgb6i3](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/z2jgb6i3) |
| surf + hier + Lion | 1.212 | 29.7 | 20.3 | 50.4 | 33.2 | 140 | [vtov4lxo](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/vtov4lxo) |

_⚠️ = training diverged. p_in/p_oodc/p_tan/p_re = mae_surf_p on each val split._

### What happened

**Strong negative result: all 4 combinations failed to beat the plain Lion baseline.** Two of the four diverged catastrophically.

1. **surf_lean + Lion (diverged)**: val/loss=12.410 vs baseline 0.653. The 1-layer surface refinement head is completely unstable with Lion. Surface pressure blew up to 455 (baseline 13.9). Notably, the 2-layer surf_refine with AdamW reached p_in=13.9 (matching baseline) — so Lion's sign-based updates are incompatible with the surface attention head. The lean variant (1 layer) may also have been too weak to resist the aggressive sign gradients.

2. **3-block + Lion (diverged)**: best_val_loss=5.315 at epoch 6, then diverged to 12.429 by end. The 3-block architecture has more parameters and wider weight magnitudes per layer update — Lion's fixed-magnitude sign updates appear to be too aggressive for the deeper model at the default learning rate.

3. **hier_slice + Lion**: val/loss=1.246 (1.91x worse). p_oodc=22.0 vs baseline 8.4. The hierarchical slice attention, which showed p_oodc=9.7 with AdamW, is significantly worse with Lion. The coarse slice bias injection adds gradient paths that interfere with Lion's dynamics.

4. **surf + hier + Lion**: val/loss=1.212 (1.86x worse). Slightly better than hier_lion alone, but combines the instabilities of both modifications. p_in=29.7 vs baseline 13.9.

**Key insight**: Lion's improvement over AdamW (0.653 vs 0.699) comes from cleaner optimization of the minimal 2-block Transolver. All three architectural additions (surface heads, hierarchical slices, extra blocks) appear to add gradient heterogeneity that Lion's uniform sign-based updates cannot handle as well as AdamW's adaptive step sizes. This is consistent with literature: Lion works best for simple, overparameterized architectures and is known to require careful LR tuning when architectures are more complex.

Note: GPU2 and GPU3 hit a different post-training error (`_orig_mod.*` prefix from torch.compile vs non-compiled vis_model) in addition to the existing Fourier PE mismatch bug. Training metrics were all logged to W&B before any crash.

### Suggested follow-ups

- **Lion + lower LR for 3-block**: The 3-block divergence suggests the default Lion LR is too high for deeper models. Trying `--n_layers 3 --use_lion --lr 3e-5` (half the standard LR) might stabilize it.
- **surf_refine (2-layer) + lower Lion LR**: The lean (1-layer) version failed badly, but the 2-layer with Lion at a reduced LR might work. The surface head needs adaptive updates that Lion may not provide at default settings.
- **Decouple architecture from optimizer search**: Keep architecture experiments to AdamW and optimizer experiments to the clean baseline. The cross-product is large and many combinations are unstable.
- **Fix the visualization bugs**: (1) Fourier PE missing in vis call, (2) `_orig_mod.*` prefix from torch.compile checkpoint vs non-compiled vis model. Both are pre-existing bugs in the noam branch.