### PR TITLE
Phase 3: Synthetic Data Generation & Domain Adaptation (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -1202,10 +1202,6 @@ for epoch in range(MAX_EPOCHS):
         else:
             tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
-        if cfg.surf_oversample:
-            # Count surface nodes a second time in vol_loss to amplify surface gradients
-            surf_in_vol = (abs_err * surf_mask.unsqueeze(-1)).sum() / (vol_mask_train.sum() + surf_mask.sum()).clamp(min=1)
-            vol_loss = vol_loss + surf_in_vol
         if cfg.uncertainty_loss:
             bm = _base_model
             surf_ux_loss = (abs_err[:, :, 0:1] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
@@ -1217,6 +1213,10 @@ for epoch in range(MAX_EPOCHS):
                     surf_p_loss  * torch.exp(-2 * bm.log_sigma_surf_p)  / 2 + bm.log_sigma_surf_p)
         else:
             loss = vol_loss + surf_weight * surf_loss
+        if cfg.surf_oversample:
+            # Clean impl: add surface MAE as a separate term (proper per-surface-node averaging)
+            extra_surf = (abs_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = loss + extra_surf
         # Self-distillation: blend GT and EMA-teacher soft targets (active after EMA starts)
         if cfg.self_distill and ema_model is not None:
             ema_model.eval()
@@ -1463,25 +1463,13 @@ for epoch in range(MAX_EPOCHS):
                 y_norm_scaled = y_norm / sample_stds
 
                 if cfg.tta_eval:
-                    # 3-pass TTA: original, y-flipped (AoA negated), and jittered
+                    # 3-pass jitter-only TTA: average predictions with σ=0.01, 0.02, 0.03
                     _preds_tta = []
-                    # Pass 1: original
-                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        _preds_tta.append(eval_model({"x": x})["preds"].float())
-                    # Pass 2: y-flip (negate y-pos and AoA, flip Uy in output)
-                    _x_yflip = x.clone()
-                    _x_yflip[:, :, 1] = -_x_yflip[:, :, 1]   # negate y coordinate
-                    _x_yflip[:, :, 14] = -_x_yflip[:, :, 14]  # negate AoA0_rad
-                    _x_yflip[:, :, 18] = -_x_yflip[:, :, 18]  # negate AoA1_rad
-                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        _p_flip = eval_model({"x": _x_yflip})["preds"].float()
-                    _p_flip[:, :, 1] = -_p_flip[:, :, 1]  # flip Uy back
-                    _preds_tta.append(_p_flip)
-                    # Pass 3: small jitter on non-spatial features
-                    _x_jit = x.clone()
-                    _x_jit[:, :, 2:25] = _x_jit[:, :, 2:25] + 0.01 * torch.randn_like(_x_jit[:, :, 2:25])
-                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        _preds_tta.append(eval_model({"x": _x_jit})["preds"].float())
+                    for _sigma in [0.01, 0.02, 0.03]:
+                        _x_jit = x.clone()
+                        _x_jit[:, :, 2:25] = _x_jit[:, :, 2:25] + _sigma * torch.randn_like(_x_jit[:, :, 2:25])
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            _preds_tta.append(eval_model({"x": _x_jit})["preds"].float())
                     pred = torch.stack(_preds_tta).mean(0)
                 else:
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis
We've optimized the model architecture and loss extensively, but the TRAINING DATA has remained completely static across 1357 experiments. The dataset has fixed geometries and conditions. Several data-side innovations could break the plateau:

1. **Synthetic interpolation**: Generate new training samples by interpolating between existing samples in feature space.
2. **Test-Time Augmentation (TTA)**: At validation time, make multiple augmented predictions and average them.
3. **Self-training / pseudo-labeling**: Use the current model's predictions as soft targets for a second round of training.
4. **Feature engineering**: Derive new physics-informed input features from existing data.
5. **Noise curriculum**: Adaptive noise that adapts to per-sample difficulty.

## Instructions

Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-synthetic"`.

All runs use `--tandem_ramp --slice_num 96`.

## Baseline (Phase 3 Round 1)
| val/loss | p_in | p_oodc | p_tan | p_re | W&B Run |
|----------|------|--------|-------|------|---------| 
| **0.6994** | 14.6 | 10.1 | 35.1 | 25.4 | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) |

## Baseline (Post-Lion, Phase 3 Round 2)
| val/loss | p_in | p_oodc | p_tan | p_re | W&B Run |
|----------|------|--------|-------|------|---------| 
| **0.6532** | 13.9 | 8.4 | 35.8 | 24.6 | [fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx) |

---

## Results: Round 1 (8 parallel experiments)

| Experiment | val/loss | p_in | p_oodc | p_tan | p_re | Peak Mem | W&B Run | vs Baseline |
|------------|----------|------|--------|-------|------|----------|---------|-------------|
| Baseline | 0.6994 | 14.6 | 10.1 | 35.1 | 25.4 | — | [234pgpf5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/234pgpf5) | — |
| GPU0: synth_interp | 0.7182 | 14.8 | 10.1 | 37.7 | 25.5 | 29.2 GB | [tu9cwrde](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/tu9cwrde) | +0.019 |
| GPU1: TTA (y-flip) | 4.4011 | 95.1 | 114.1 | 117.8 | 120.3 | 29.5 GB | [98hugin8](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/98hugin8) | FAILURE |
| GPU2: self_distill | 0.7319 | 15.5 | 10.6 | 36.2 | 26.0 | 28.7 GB | [5hihlqnh](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/5hihlqnh) | +0.033 |
| GPU3: phys_features | **0.6988** | **13.9** | 10.5 | 36.3 | **25.4** | 29.4 GB | [c7esq6aj](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/c7esq6aj) | **-0.0006** |
| GPU4: adaptive_noise | 0.7206 | 15.8 | **9.9** | 36.6 | 25.6 | 28.3 GB | [w3f0001f](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/w3f0001f) | +0.021 |
| GPU5: surf_oversample | 0.7091 | 14.8 | 10.0 | **35.8** | 25.8 | 29.2 GB | [22ei3r9k](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/22ei3r9k) | +0.010 |
| GPU6: cond_weight | 0.7383 | 15.0 | 10.5 | 36.4 | 26.1 | 29.3 GB | [6tly9x9j](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/6tly9x9j) | +0.039 |
| GPU7: combined+TTA | 4.3734 | 94.1 | 113.2 | 119.5 | 120.2 | 29.6 GB | [rfvlbxis](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/rfvlbxis) | FAILURE |

---

## Results: Round 2 (Follow-up, rebased on noam with Lion)

**Changes**: Fixed TTA (jitter-only, 3 passes σ=0.01/0.02/0.03), fixed surf_oversample (clean separate loss term, proper per-surface-node averaging).

| Experiment | val/loss | p_in | p_oodc | p_tan | p_re | Peak Mem | W&B Run | vs Baseline |
|------------|----------|------|--------|-------|------|----------|---------|-------------|
| Baseline (Lion) | 0.6532 | 13.9 | 8.4 | 35.8 | 24.6 | — | [fzqe35yx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/fzqe35yx) | — |
| GPU0: phys_features+Lion | 8.5551 | 246.6 | 158.2 | 367.9 | 149.6 | 29.4 GB | [4thq4y04](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/4thq4y04) | DIVERGED |
| GPU1: TTA-jitter+Lion | 6.1980 | 196.7 | 156.4 | 215.2 | 145.1 | 29.2 GB | [bbtcucqo](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/bbtcucqo) | DIVERGED |
| GPU2: surf-oversample+Lion | 1.2502 | 32.4 | 23.7 | 52.8 | 36.9 | 29.6 GB | [owrfn1c5](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/owrfn1c5) | +0.597 |
| GPU3: phys+surf+Lion | **0.7372** | **14.1** | **12.1** | **36.4** | **26.0** | 29.7 GB | [dptb8fc2](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/dptb8fc2) | +0.084 |

All runs: 180 min wall-clock. Epochs completed: GPU0=226, GPU1=186, GPU2=228, GPU3=225.

---

### What happened (Round 2)

**Lion instability**: GPU0 and GPU1 diverged catastrophically — best checkpoint at epoch 8-10 (val/loss=8.55 and 6.19), with training loss reaching millions before recovering. Lion without LR reduction is clearly not stable enough for these configurations. The divergence pattern (best at epoch 8-10) suggests the model barely had time to improve before exploding.

**GPU0 (phys+Lion): DIVERGED** — Loss exploded at epoch ~138 (surf=745K, vol=629K), never fully recovered. The divergence at epoch 138 matches exactly when EMA starts tracking (epoch 140), but likely coincidence. The phys_features run WITHOUT Lion (round 1) converged fine to 0.6988 — this is purely a Lion stability issue.

**GPU1 (TTA-jitter+Lion): DIVERGED** — The jitter-only TTA (3 passes σ=0.01-0.03) did not cause the problem — this run also diverged at the optimizer level, same as GPU0. The best checkpoint (epoch 10) shows that training never converged even to a usable state.

**GPU2 (surf-oversample-clean+Lion): Partial convergence** — val/loss=1.2502 at epoch 88. The clean surf_oversample (adding surface MAE as a separate loss term with `extra_surf = (abs_err * surf_mask) / surf_mask.sum()`) caused slow convergence. Best at epoch 88 vs 228+ epochs available suggests the optimizer was still learning but not fast enough. The higher loss vs baseline (1.25 vs 0.65) shows the clean surf_oversample with Lion is suboptimal.

**GPU3 (phys+surf+Lion): Best result** — val/loss=0.7372 at epoch 225 (last checkpoint was also the best). P_in=14.1 vs baseline 13.9 — effectively matching. P_oodc=12.1 vs 8.4 (worse), p_tan=36.4 vs 35.8 (similar), p_re=26.0 vs 24.6 (similar). Still 0.084 above the new baseline. However, this run was still improving at epoch 225 (the * marker in the log = new best checkpoint), suggesting it would benefit from more training time.

**Root cause of GPU0/GPU1 divergence**: These runs diverge but GPU2/GPU3 don't, despite all using Lion. The runs may differ in which random data batches they see early in training (different DataLoader worker seeds), and Lion's sign-based updates with the default LR can diverge if early gradients point in bad directions. **The PR #1737 Lion optimizer uses the same LR as AdamW** — this is the problem. Lion typically requires LR ≈ 3-10× smaller than AdamW to be stable. With the same LR, it's a coin flip whether it diverges.

---

### Suggested follow-ups

1. **Lion LR calibration**: Test Lion with `lr = cfg.lr * 0.1` or `cfg.lr * 0.3`. The diverging GPU0/GPU1 runs suggest the default LR is too high for Lion in some configurations. This should be fixed at the optimizer level in the Lion PR.

2. **phys_features with AdamW**: Since phys_features clearly improved velocity predictions (1.38/0.57 vs 2.19/0.81 surf_Ux/Uy in round 1), and the round 2 Lion version diverged, the fair test is phys_features + AdamW (same as round 1 GPU3) as a long run. The round 1 result (0.6988) was essentially tied with old baseline (0.6994) but predates Lion.

3. **surf_oversample formulation**: The clean version (separate loss term) didn't help much with Lion. With AdamW, the original formulation showed dramatic velocity improvement (0.52/0.30). The clean formulation needs to be tested standalone with AdamW to separate the loss formulation from the optimizer question.

4. **GPU3 extended run**: The combined phys+surf+Lion run was still improving at epoch 225 (val/loss=0.7372, still above baseline 0.6532). A run with 300+ epochs might close the gap.