### PR TITLE
Phase 3 R4: Architecture Scale — Wider/Deeper + Cosine Schedule Tuning (8 parallel)

### DIFF
--- a/.phase3r4
+++ b/.phase3r4
@@ -1,0 +1,1 @@
+# Phase 3 R4 experiment


### PR DESCRIPTION
## Hypothesis
With high-p-clamp dramatically improving the loss landscape (36% val/loss reduction), the optimal model architecture/schedule may have shifted. Wider models, different head counts, and schedule changes that didn't help before might now be beneficial under this new normalization regime.

**All runs use updated baseline flags:**
```bash
--field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 2e-4
```

## Instructions
Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-r4-scale"`.

### GPU 0: n_hidden=256 (wider) + high_p_clamp
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 2e-4 --n_hidden 256 --wandb_name "edward/r4-wide256" --wandb_group "phase3-r4-scale" --agent edward
```

### GPU 1: n_hidden=128 (narrower) + high_p_clamp
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 2e-4 --n_hidden 128 --wandb_name "edward/r4-narrow128" --wandb_group "phase3-r4-scale" --agent edward
```

### GPU 2: cosine_T_max=300 (extend cosine schedule)
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 2e-4 --cosine_T_max 300 --wandb_name "edward/r4-cosine300" --wandb_group "phase3-r4-scale" --agent edward
```

### GPU 3: lr=3e-4 + high_p_clamp (check if higher LR better with high-p-clamp)
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 3e-4 --wandb_name "edward/r4-lr3e4" --wandb_group "phase3-r4-scale" --agent edward
```

### GPU 4: lr=1e-4 + high_p_clamp (more conservative)
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 1e-4 --wandb_name "edward/r4-lr1e4" --wandb_group "phase3-r4-scale" --agent edward
```

### GPU 5: wd=1e-4 + high_p_clamp
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 2e-4 --weight_decay 1e-4 --wandb_name "edward/r4-wd1e4" --wandb_group "phase3-r4-scale" --agent edward
```

### GPU 6: batch_size=6 + high_p_clamp (larger batch)
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 2e-4 --batch_size 6 --wandb_name "edward/r4-bs6" --wandb_group "phase3-r4-scale" --agent edward
```

### GPU 7: seed=42 baseline verification (new baseline with high_p_clamp)
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --field_decoder --adaln_output --use_lion --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --lr 2e-4 --seed 42 --wandb_name "edward/r4-seed42" --wandb_group "phase3-r4-scale" --agent edward
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| **0.4054** | 12.8 | 8.2 | 34.1 | 24.4 |

---

## Results

All 8 variants ran for 177–294 epochs within the 180-min timeout. The wider model (wide256) was the slowest (177 epochs). Training completed without divergence for all runs.

### Results table

| Variant | val/loss | p_in | p_oodc | p_tan | p_re | Best epoch | W&B |
|---------|----------|------|--------|-------|------|------------|-----|
| **Baseline** | **0.4054** | **12.8** | **8.2** | **34.1** | **24.4** | — | — |
| wide256 (GPU 0) | 0.4204 | 14.5 | 9.7 | 34.6 | 24.8 | 177 | [417u4uku](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/417u4uku) |
| narrow128 (GPU 1) | 0.4175 | 13.5 | 8.9 | 34.1 | 24.7 | 294 | [cb4et36s](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/cb4et36s) |
| cosine300 (GPU 2) | **0.4036** ✓ | 14.4 | 8.4 | **33.8** | **24.3** | 230 | [9y18juwx](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/9y18juwx) |
| lr3e-4 (GPU 3) | 0.4179 | 14.4 | 8.9 | 34.2 | 24.7 | 232 | [lnh4is9x](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/lnh4is9x) |
| lr1e-4 (GPU 4) | 0.4199 | 13.9 | 8.3 | 34.6 | 24.7 | 232 | [5dlgdgf8](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/5dlgdgf8) |
| wd1e-4 (GPU 5) | 0.4123 | **13.3** | 8.8 | 34.6 | 24.5 | 232 | [nfbrfd3w](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/nfbrfd3w) |
| bs6 (GPU 6) | 0.4121 | 13.7 | **8.3** | 34.6 | 24.5 | 226 | [0fnl64q7](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/0fnl64q7) |
| seed42 (GPU 7) | 0.4080 | **12.9** | 9.0 | 34.7 | 24.5 | 232 | [03sdcwzy](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/03sdcwzy) |

_p_in/p_oodc/p_tan/p_re = mae_surf_p on val_in_dist / val_ood_cond / val_tandem_transfer / val_ood_re_

### What happened

**Mixed result: mostly negative, one weak positive.** Most variants land within 0–4% of baseline. Key observations:

1. **cosine300 marginally beats the baseline** on val/loss (0.4036 vs 0.4054, −0.4%) and shows the best p_tan (33.8 vs 34.1) and p_re (24.3 vs 24.4). Extending the cosine schedule from T_max=230 to 300 allows the LR to stay slightly higher for longer, matching the actual run length. This makes sense: the baseline runs 232 epochs and the schedule hits its minimum near that point — cosine300 doesn't prematurely decay to near-zero LR. However, p_in (14.4) is worse than the baseline (12.8), so the improvement is primarily in OOD generalization, not in-distribution pressure.

2. **seed42 (variance check)**: val/loss=0.4080, p_in=12.9 — within random seed variance of the baseline (p_in=12.8). Confirms the baseline result is reproducible and stable.

3. **Width changes both hurt**: wide256 runs slowest (177 epochs) and finishes at 0.4204. At 180 min it hasn't converged — the wide model likely needs longer training. narrow128 converges faster (294 epochs) to 0.4175 but to a slightly worse minimum.

4. **LR search (lr3e-4, lr1e-4)**: Both are worse than the baseline lr=2e-4. The baseline LR appears well-tuned for the high_p_clamp regime.

5. **wd1e-4 and bs6** both reach ~0.412 — modest improvements over width/LR sweeps but still worse than baseline. Weight decay adds mild regularization; batch_size=6 gives slightly better gradient estimates.

### Suggested follow-ups

- **cosine300 + wider model**: cosine300 helps OOD (p_tan, p_re). The wide256 model with cosine300 might converge to a better OOD minimum if given more epochs (>300). Try `--n_hidden 256 --cosine_T_max 400` with the full budget.
- **cosine_T_max ablation**: The exact T_max matters because it controls when LR decays. Try T_max=250, 350 to bracket the optimum around the ~230 epoch average run length.
- **wide256 with longer budget**: wide256 at 177 epochs hasn't converged — try increasing `SENPAI_TIMEOUT_MINUTES=240` or `SENPAI_MAX_EPOCHS=350` to see if wider model catches up.
- **bs6 + cosine300 combo**: Both give marginal but consistent improvements. Their combination might be worth a single targeted run.
