### PR TITLE
Phase 3 R8: Multi-EMA Variants + Surface Loss Tuning (8 parallel)

### DIFF
--- a/.phase3r8
+++ b/.phase3r8
@@ -1,0 +1,1 @@
+# Phase 3 Round 8 experiment


### PR DESCRIPTION
## Hypothesis
Tanjiro's R7 mema-sl (multi-EMA + surface-local) achieved p_in=12.9, p_oodc=8.1. This PR explores variants to find the optimal configuration: different EMA decays, different surface loss multipliers, and different numbers of EMA streams.

## Instructions

Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-r8-mema-variants"`.

### GPU 0: 2 EMA streams (0.995, 0.999) + surf_weight 2x
Lighter multi-EMA — only 2 streams reduces overhead, allows more epochs.
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "nezuko/r8-2ema-sl2x" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

### GPU 1: 3 EMA streams (0.995, 0.998, 0.999) + surf_weight 3x
Original multi-EMA + stronger surface weighting.
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "nezuko/r8-3ema-sl3x" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

### GPU 2: 3 EMA streams + surf_weight 1.5x (gentler)
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --wandb_name "nezuko/r8-3ema-sl15x" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

### GPU 3: 5 EMA streams (0.99, 0.995, 0.998, 0.999, 0.9995) + surf_weight 2x
More streams = smoother ensemble. Higher compute cost.
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --wandb_name "nezuko/r8-5ema-sl2x" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

### GPU 4: Multi-EMA but WEIGHT averaging (not prediction averaging) + surf 2x
Instead of averaging predictions, average the EMA model weights. Less diverse but cheaper at eval.
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "nezuko/r8-weight-avg-sl2x" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

### GPU 5: Multi-EMA (3 streams) + surface-local + le_te_dist feature
Add the le_te_dist feature from thorfinn R6 which gave best p_oodc=8.3. Test compound.
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --le_te_dist_feat --wandb_name "nezuko/r8-mema-sl-leted" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

### GPU 6: Multi-EMA (3 streams) + surface-local + local_re feature
Add local_re feature from thorfinn R6 which matched p_in=12.7.
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --local_re_feat --wandb_name "nezuko/r8-mema-sl-localre" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

### GPU 7: Multi-EMA delayed start (from epoch 50) + surf 2x
Let the model converge first before starting EMA tracking.
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "nezuko/r8-mema-delayed-sl2x" --wandb_group "phase3-r8-mema-variants" --agent nezuko
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| **0.3997** | ~13.8 (mean) | 8.8 | 33.2 | 24.8 |
| **tanjiro/r7-mema-sl** | **12.9** | **8.1** | 33.8 | **24.4** |

---

## Results
_To be filled by student_