### PR TITLE
Phase 3 R9: DB-MTL Log-Transform Loss + Gradient Normalization (8 parallel)

### DIFF
--- a/.phase3r9
+++ b/.phase3r9
@@ -1,0 +1,1 @@
+# Phase 3 R9 plateau protocol


### PR DESCRIPTION
## Hypothesis — PLATEAU PROTOCOL
DB-MTL (ICLR 2024): log-transform the PCGrad group losses before backward to equalize loss scales, then normalize gradient magnitudes. Parameter-free, Lion-compatible.

## Instructions
Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. `--wandb_group "phase3-r9-dbmtl"`.

### Implementation
In PCGrad block, replace: `loss_a = vol_loss_a + surf_weight * surf_loss_a + ...`
With: `loss_a = log(vol_loss_a + 1e-6) + surf_weight * log(surf_loss_a + 1e-6) + ...`

For gradient normalization: after computing grads_a and grads_b, normalize to max L2 norm.

### GPU 0-3: Log-transform only (4 seeds)
### GPU 4-5: Log-transform + gradient norm (2 seeds)
### GPU 6: Log-transform + higher surf_weight (test scale interaction)
### GPU 7: AdamW comparison

```bash
CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "tanjiro/r9-dbmtl-default" --wandb_group "phase3-r9-dbmtl" --agent tanjiro
# ... 7 more runs with different seeds/configs
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| **0.3997** | ~13.8 | 8.8 | 33.2 | 24.8 |

**Ref:** [DB-MTL (ICLR 2024)](https://arxiv.org/abs/2308.12029)

---
## Results
_To be filled by student_