### PR TITLE
Phase 3 R11: Domain-Specific Slice Attention Patterns (8 parallel)

### DIFF
--- a/train.py
+++ b/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 domain_qkv=False, tandem_temp_offset_init=0.0):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -148,7 +149,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
-        self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
+        self.tandem_temp_offset = nn.Parameter(torch.ones(1, heads, 1, 1) * tandem_temp_offset_init)
+        self.domain_qkv = domain_qkv
         self.linear_no_attention = linear_no_attention
         self.learned_kernel = learned_kernel
         self.decouple_slice = decouple_slice
@@ -174,6 +176,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.to_q = nn.Linear(dim_head, dim_head, bias=False)
         self.to_k = nn.Linear(dim_head, dim_head, bias=False)
         self.to_v = nn.Linear(dim_head, dim_head, bias=False)
+        if domain_qkv:
+            self.to_q_tandem = nn.Linear(dim_head, dim_head, bias=False)
+            self.to_k_tandem = nn.Linear(dim_head, dim_head, bias=False)
+            self.to_v_tandem = nn.Linear(dim_head, dim_head, bias=False)
         self.slice_residual_scale = nn.Parameter(torch.tensor(0.1))
         self.to_out = nn.Sequential(
             nn.Linear(inner_dim, dim),
@@ -229,10 +235,22 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if self.linear_no_attention:
             out_slice_token = slice_token
         else:
-            q_slice_token = self.to_q(slice_token)
-            slice_token_kv = slice_token.mean(dim=1, keepdim=True)
-            k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
-            v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
+            slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # [B, 1, S, D]
+            if self.domain_qkv and tandem_mask is not None:
+                is_tan = (tandem_mask > 0.5)  # [B, 1, 1, 1]
+                q_slice_token = torch.where(
+                    is_tan, self.to_q_tandem(slice_token), self.to_q(slice_token)
+                )  # [B, H, S, D]
+                k_slice_token = torch.where(
+                    is_tan, self.to_k_tandem(slice_token_kv), self.to_k(slice_token_kv)
+                ).expand(-1, self.heads, -1, -1)  # [B, H, S, D]
+                v_slice_token = torch.where(
+                    is_tan, self.to_v_tandem(slice_token_kv), self.to_v(slice_token_kv)
+                ).expand(-1, self.heads, -1, -1)  # [B, H, S, D]
+            else:
+                q_slice_token = self.to_q(slice_token)
+                k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
+                v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
             if self.learned_kernel:
                 B, H, S, D = q_slice_token.shape
                 q_exp = q_slice_token.unsqueeze(-2).expand(B, H, S, S, D)
@@ -279,6 +297,9 @@ class TransolverBlock(nn.Module):
         dln_zeroinit=False,
         domain_velhead=False,
         prog_slices=False,
+        domain_slice_proj=False,
+        domain_qkv=False,
+        tandem_temp_offset_init=0.0,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -299,9 +320,11 @@ class TransolverBlock(nn.Module):
             slice_num=slice_num,
             linear_no_attention=linear_no_attention,
             learned_kernel=learned_kernel,
-            decouple_slice=decouple_slice,
+            decouple_slice=decouple_slice or domain_slice_proj,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            domain_qkv=domain_qkv,
+            tandem_temp_offset_init=tandem_temp_offset_init,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -453,6 +476,9 @@ class Transolver(nn.Module):
         dln_zeroinit=False,
         domain_velhead=False,
         prog_slices=False,
+        domain_slice_proj=False,
+        domain_qkv=False,
+        tandem_temp_offset_init=0.0,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -519,6 +545,9 @@ class Transolver(nn.Module):
                     dln_zeroinit=dln_zeroinit,
                     domain_velhead=domain_velhead if (idx == n_layers - 1) else False,
                     prog_slices=prog_slices,
+                    domain_slice_proj=domain_slice_proj,
+                    domain_qkv=domain_qkv,
+                    tandem_temp_offset_init=tandem_temp_offset_init,
                 )
                 for idx in range(n_layers)
             ]
@@ -747,6 +776,10 @@ class Config:
     two_phase_lr_2: float = 1e-4       # phase 2 LR
     snapshot_ensemble: bool = False    # GPU 6: average checkpoints at fixed epochs
     snapshot_epochs_str: str = "120,160,200"  # comma-separated snapshot epochs
+    # Phase 3 R11: Domain-specific slice attention patterns
+    domain_slice_proj: bool = False    # domain-specific slice projection for single vs tandem
+    domain_qkv: bool = False           # domain-specific Q/K/V projections for single vs tandem
+    tandem_temp_offset: float = 0.0    # initial value for tandem temperature offset parameter
 
 
 cfg = sp.parse(Config)
@@ -896,6 +929,9 @@ model_config = dict(
     dln_zeroinit=cfg.dln_zeroinit,
     domain_velhead=cfg.domain_velhead,
     prog_slices=cfg.prog_slices,
+    domain_slice_proj=cfg.domain_slice_proj,
+    domain_qkv=cfg.domain_qkv,
+    tandem_temp_offset_init=cfg.tandem_temp_offset,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis
DomainLN gives each domain separate normalization. Velhead gives separate outputs. The next frontier: domain-specific ATTENTION patterns. The slice attention (96 slices) currently uses shared slice assignments for both single and tandem flows. But tandem flows need different slice patterns (wake-interaction slices, cross-foil slices) than single-foil flows (boundary layer slices, trailing edge slices).

Options:
1. Domain-specific slice projection weights (separate in_project_slice for single vs tandem)
2. More slices for tandem (128 vs 96 for single)
3. Domain-specific temperature for slice attention

## Instructions
Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-r11-domslice"`.

### GPU 0: Domain-specific slice projection (separate in_project_slice per domain)
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --wandb_name "alphonse/r11-domslice-proj" --wandb_group "phase3-r11-domslice" --agent alphonse
```

### GPU 1: Domain-specific slice projection, seed=1
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --wandb_name "alphonse/r11-domslice-proj-s1" --wandb_group "phase3-r11-domslice" --agent alphonse
```

### GPU 2: 128 slices (more slices, both domains)
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --slice_num 128 --wandb_name "alphonse/r11-128slices" --wandb_group "phase3-r11-domslice" --agent alphonse
```

### GPU 3: 64 slices (fewer slices, test if 96 is overparameterized)
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --slice_num 64 --wandb_name "alphonse/r11-64slices" --wandb_group "phase3-r11-domslice" --agent alphonse
```

### GPU 4: Domain-specific Q/K/V projections (separate for single vs tandem)
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --wandb_name "alphonse/r11-domqkv" --wandb_group "phase3-r11-domslice" --agent alphonse
```

### GPU 5: Separate tandem temperature offset (already exists, but tune: tandem_temp_offset=0.3)
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --tandem_temp_offset 0.3 --wandb_name "alphonse/r11-tantemp-03" --wandb_group "phase3-r11-domslice" --agent alphonse
```

### GPU 6: tandem_temp_offset=0.5
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --tandem_temp_offset 0.5 --wandb_name "alphonse/r11-tantemp-05" --wandb_group "phase3-r11-domslice" --agent alphonse
```

### GPU 7: 4 layers (test if DomainLN enables stable 4-layer training)
Previously 4 layers diverged. With DomainLN+velhead+lr=2e-4, it may now be stable.
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --n_layers 4 --wandb_name "alphonse/r11-4layers" --wandb_group "phase3-r11-domslice" --agent alphonse
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| **0.4047** | 13.6 | 8.6 | 33.4 | 24.7 |

---

## Results

All 8 runs completed at the 180-minute wall-clock limit (~153–170 epochs). Implementation notes: PR commands omitted the explicit new flags for GPUs 0, 1, and 4; I added `--domain_slice_proj True` (GPU 0/1) and `--domain_qkv True` (GPU 4), plus the full baseline config (`--field_decoder True --adaln_output True --use_lion True --lr 2e-4 --n_layers 3 --slice_num 96 --aug aoa_perturb --aug_full_dsdf_rot True --high_p_clamp True --domain_layernorm True --domain_velhead True`) to all runs.

| Run | val/loss | p_in | p_oodc | p_tan | p_re | Mem | W&B |
|-----|---------|------|--------|-------|------|-----|-----|
| **Baseline** | **0.4047** | **13.6** | **8.6** | **33.4** | **24.7** | — | — |
| Domain slice proj | 0.4095 | 13.3 | 8.9 | 33.6 | 25.0 | 46.5GB | [xkg9rc85](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/xkg9rc85) |
| Domain slice proj seed=1 | 0.4095 | 13.5 | 9.0 | 34.4 | 24.7 | 45.5GB | [4ojvncqi](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/4ojvncqi) |
| 128 slices | 0.4124 | 13.9 | 8.7 | 33.4 | 24.9 | 43.8GB | [ik76bqmu](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/ik76bqmu) |
| 64 slices | 0.4066 | 13.6 | 8.6 | 33.8 | 24.7 | 38.8GB | [7o1ybyq2](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/7o1ybyq2) |
| Domain QKV | 0.4111 | 13.4 | 8.9 | 33.9 | 24.7 | 41.8GB | [rbernde6](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/rbernde6) |
| tandem_temp_offset=0.3 | 0.4123 | 13.8 | 8.7 | 34.1 | 24.9 | 40.9GB | [e6ujvmjt](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/e6ujvmjt) |
| **tandem_temp_offset=0.5** | **0.4044** | **13.5** | **8.4** | **33.0** | **24.8** | 41.5GB | [hs254fz1](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/hs254fz1) |
| 4 layers | 0.4699 | 18.6 | 11.1 | 37.5 | 26.4 | 49.8GB | [qdk4oddu](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/qdk4oddu) |

### What happened

**tandem_temp_offset=0.5 marginally beats baseline (0.4044 vs 0.4047).** p_oodc=8.4 is the best in this round (vs baseline 8.6), and p_tan=33.0 is also slightly better. The gap is 0.0003, well within seed variance, but the direction is consistent with the temperature offset helping tandem slice attention. tandem_temp_offset=0.3 is notably worse (0.4123), suggesting the higher offset is needed to meaningfully separate the tandem softmax temperature.

**Domain-specific slice projection adds overhead but doesn't improve quality.** Both seed runs land at 0.4095 (consistent across seeds), 0.0048 above baseline. The extra `in_project_slice_tandem` layer (+5 GB memory) doesn't help — the shared slice projection generalizes well across both domains. Two-seed consistency rules out seed luck.

**Domain QKV (0.4111) similarly fails to improve.** Separate Q/K/V for tandem/single adds complexity (+2–3 GB) without benefit. The attention over slice tokens works the same across domains; the domain-specificity has already been handled by DomainLN and velhead at higher levels.

**More slices hurts; fewer slices matches baseline.** 128 slices (0.4124) is the worst of the slice-count runs. 64 slices (0.4066) is only 0.0019 above baseline despite using 18.8% less memory (38.8 GB vs 46.5+ GB). The current 96-slice default is likely over-parameterized for this dataset size.

**4-layer training still diverges (0.4699, p_in=18.6).** DomainLN + velhead + lr=2e-4 is not sufficient to stabilize 4 layers. p_in=18.6 vs baseline 13.6 indicates catastrophic in-distribution degradation. Progressive growth (R8) would be needed to enable 4-layer training.

### Suggested follow-ups

1. **tandem_temp_offset=0.5 + more seeds** — the 0.0003 margin is noise. 3 seeds would confirm or deny a real signal.
2. **64 slices as the new baseline** — 64 slices matches baseline quality (0.4066 vs 0.4047) while saving ~7 GB memory. If confirmed, switching to 64 slices frees capacity for other architectural experiments.
3. **tandem_temp_offset tuning sweep (0.5–1.5)** — the jump from 0.3 (hurts) to 0.5 (matches/beats baseline) is large. A sweep from 0.5 to 1.5 might find a clearer optimum.
4. **Close domain-specific slice/QKV directions** — both add complexity without benefit. Not worth revisiting.

---

### Round 2: 4-seed validation of tantemp05 + 2-seed domslice (per advisor request)

Rebased onto latest noam (merge #7: EMA decay=0.999). All runs use full baseline config.

| Run | Seed | val/loss | p_in | p_oodc | p_tan | p_re | W&B |
|-----|------|---------|------|--------|-------|------|-----|
| tantemp05 | 0 | 0.4100 | 13.8 | 9.4 | 33.9 | 24.7 | [cy46j04b](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/cy46j04b) |
| tantemp05 | 1 | 0.4092 | 14.0 | 8.8 | 33.2 | 24.8 | [dusdrbht](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/dusdrbht) |
| tantemp05 | 42 | 0.4088 | 13.7 | 9.2 | 33.4 | 24.8 | [p034bgw7](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/p034bgw7) |
| tantemp05 | 123 | 0.4081 | 13.4 | 9.0 | 33.8 | 24.9 | [ksxsor6q](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/ksxsor6q) |
| domslice_proj | 42 | 0.4104 | 13.7 | 8.7 | 34.5 | 24.6 | [5yzps3kh](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/5yzps3kh) |
| domslice_proj | 123 | 0.4052 | 13.7 | 8.7 | 33.5 | 24.8 | [b14ka53g](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/b14ka53g) |

**tantemp05 mean val/loss = 0.4090 (range 0.4081–0.4100)**, all 4 seeds worse than the original single-seed result (0.4044) and above the R11 baseline (0.4047). The original 0.4044 was seed-lucky. The EMA decay=0.999 change in noam may also have shifted the landscape — p_oodc ranges 8.8–9.4 vs R11 baseline 8.6, not consistently better.

**domslice_proj seed=123 (0.4052) is the strongest new individual result**, better than the R11-round-1 seed=0 result (0.4095). With all 3 seeds: 0.4052, 0.4095, 0.4104 → mean 0.4084. Still above the R11 baseline 0.4047.

Neither tantemp05 nor domslice_proj robustly beats the baseline across seeds.