### PR TITLE
Phase 3 R12: Wider Model with Longer Training Budget (8 parallel)

### DIFF
--- a/.phase3r12
+++ b/.phase3r12
@@ -1,0 +1,1 @@
+# Phase 3 Round 12 experiment


### PR DESCRIPTION
## Hypothesis
R11 showed n_hidden=256 doesn't converge in 3h with lr=2e-4. Two approaches: (1) lower LR for wider model, (2) reduce batch size to get more gradient steps. Also test n_hidden=224 (intermediate width).

## Instructions
Pull latest noam. SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. **VERIFY val/loss converges to ~0.40.** Use `--wandb_group "phase3-r12-wider"`.

### GPU 0: n_hidden=224 (intermediate, may converge faster)
```bash
CUDA_VISIBLE_DEVICES=0 python train.py --n_hidden 224 --wandb_name "edward/r12-h224" --wandb_group "phase3-r12-wider" --agent edward
```

### GPU 1: n_hidden=256, lr=1e-4 (halved LR)
```bash
CUDA_VISIBLE_DEVICES=1 python train.py --n_hidden 256 --lr 1e-4 --wandb_name "edward/r12-h256-lr1e4" --wandb_group "phase3-r12-wider" --agent edward
```

### GPU 2: n_hidden=256, batch_size=2 (more gradient steps)
```bash
CUDA_VISIBLE_DEVICES=2 python train.py --n_hidden 256 --batch_size 2 --wandb_name "edward/r12-h256-bs2" --wandb_group "phase3-r12-wider" --agent edward
```

### GPU 3: n_hidden=256, lr=1.5e-4, warmup=20
```bash
CUDA_VISIBLE_DEVICES=3 python train.py --n_hidden 256 --lr 1.5e-4 --warmup_epochs 20 --wandb_name "edward/r12-h256-lr15-w20" --wandb_group "phase3-r12-wider" --agent edward
```

### GPU 4: n_hidden=224, seed=42
```bash
CUDA_VISIBLE_DEVICES=4 python train.py --n_hidden 224 --wandb_name "edward/r12-h224-s42" --wandb_group "phase3-r12-wider" --agent edward
```

### GPU 5: n_hidden=256, 2 layers (less depth for wider model)
```bash
CUDA_VISIBLE_DEVICES=5 python train.py --n_hidden 256 --n_layers 2 --wandb_name "edward/r12-h256-2L" --wandb_group "phase3-r12-wider" --agent edward
```

### GPU 6: n_hidden=224, lr=1.5e-4
```bash
CUDA_VISIBLE_DEVICES=6 python train.py --n_hidden 224 --lr 1.5e-4 --wandb_name "edward/r12-h224-lr15" --wandb_group "phase3-r12-wider" --agent edward
```

### GPU 7: Baseline verification
```bash
CUDA_VISIBLE_DEVICES=7 python train.py --wandb_name "edward/r12-baseline" --wandb_group "phase3-r12-wider" --agent edward
```

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| **0.3994** | 13.0 | 8.7 | 33.2 | 24.6 |

---

## Results

**Code change:** Added `warmup_epochs` as an alias for `warmup_total_iters` (overrides when > 0). The PR's `--warmup_epochs 20` command required this field; default warmup_total_iters was already 20.

**Note on baseline discrepancy:** The PR baseline of val/loss=0.3994 appears to be from R10 with `--domain_layernorm`. The default config (no domain_layernorm) converges to ~0.73 in 3 hours as verified by the GPU7 baseline run. All metrics below are compared against GPU7's actual result (val/loss=0.7299).

### Summary Table

| Run | val/loss | p_in | p_oodc | p_tan | p_re | Epochs | Peak Mem | W&B ID |
|-----|----------|------|--------|-------|------|--------|----------|--------|
| **Baseline (R10 domain_ln ref)** | **0.3994** | **13.0** | **8.7** | **33.2** | **24.6** | — | — | — |
| GPU7: n_hidden=192 (baseline) | 0.7299 | 14.9 | 10.3 | 37.4 | 25.8 | 250 | 26.7GB | qhxkwkfa |
| GPU2: n_hidden=256, bs=2 | **0.7188** | 14.8 | 10.8 | 36.7 | 25.7 | 201 | 17.6GB | 22jb8g4y |
| GPU4: n_hidden=224, seed=42 | **0.7193** | **14.6** | **10.0** | 36.9 | 25.6 | 214 | 31.0GB | jj7qnxuy |
| GPU5: n_hidden=256, 2 layers | 0.7228 | 15.5 | 10.5 | **36.4** | 25.8 | 190 | 35.0GB | s60ihwoo |
| GPU0: n_hidden=224 | 0.7349 | 16.8 | 10.0 | 37.3 | 25.6 | 212 | 30.1GB | j6i7jqsv |
| GPU6: n_hidden=224, lr=1.5e-4 | 0.8810 | 18.3 | 13.3 | 39.9 | 27.7 | 214 | 31.0GB | q81rerxk |
| GPU3: n_hidden=256, lr=1.5e-4 | 0.8596 | 18.4 | 13.1 | 38.4 | 27.4 | 189 | 35.1GB | csfyo1z9 |
| GPU1: n_hidden=256, lr=1e-4 | 0.9471 | 19.9 | 15.5 | 40.9 | 28.9 | 189 | 34.0GB | d2m9si2e |

### What happened

**Wider models do not improve over n_hidden=192 in 3 hours.** The best runs (GPU2, GPU4) marginally beat baseline val/loss (0.719 vs 0.730) but the difference is noise-level.

1. **n_hidden=256 with default lr=1.5e-3 is slow to converge** — h256 runs reach 189-201 epochs vs 250 for baseline. This confirms R11's observation.

2. **batch_size=2 partially compensates for h256** — GPU2 (h256, bs=2) is the best h256 run (val/loss=0.719) at 201 epochs. It also uses far less memory (17.6GB vs 34-35GB). More gradient steps per time unit help, but performance is still at baseline level.

3. **Lower LR makes h256 worse, not better** — lr=1e-4 (GPU1: 0.947) and lr=1.5e-4 (GPU3: 0.860) are both worse than default lr=1.5e-3 at similar epoch count. Within a 3-hour budget, a lower LR just means less learning.

4. **n_hidden=224 converges similarly to n_hidden=192** — GPU0/4/6 reach 212-214 epochs; adding capacity does not help. The lr=1.5e-4 variant (GPU6: 0.881) is worse, consistent with point 3.

5. **The 0.40 target was not achieved** — no run broke below 0.71. The gap between 0.73 and 0.40 is dominated by val_tandem_transfer (~1.52 here vs the domain_layernorm result). Without DLN, tandem transfer simply cannot reach 0.40 in this architecture.

6. **Pre-existing visualization bug** — after each run completes ("Wall-clock limit reached"), the flow-field plot code crashes with `mat1 and mat2 shapes cannot be multiplied (84905x26 and 58x58)`. The plot code passes raw 26-dim features without Fourier PE. This only affects end-of-run plots; training metrics are correctly logged.

### Suggested follow-ups

- **Clarify baseline** — if 0.3994 (domain_layernorm) is the target to beat, future experiments should build on that config, not the plain default. Comparing h256 against the DLN baseline (or running h256+DLN) would be more informative.
- **Try n_hidden=256 + domain_layernorm** — DLN dramatically reduces tandem transfer loss; a wider model with DLN might actually improve over the 0.3994 reference.
- **Fix visualization bug** — flow-field plots fail on all runs due to raw features being passed without Fourier PE in the vis code (train.py line ~1891).
- **Longer budget for h256** — at 189 epochs the h256 runs appear still on the steep portion of the learning curve. A 6-hour run might reveal whether extra capacity eventually pays off.