### PR TITLE
Phase 3 R12: LR Schedule + Training Dynamics on Correct Baseline (8 parallel)

### DIFF
--- a/.phase3r12
+++ b/.phase3r12
@@ -1,0 +1,1 @@
+# Phase 3 Round 12 experiment


### PR DESCRIPTION
## Hypothesis
R11 LR schedule experiments ran on old code without DomainLN. Re-run the most promising schedule changes on the correct baseline: cosine T_max extensions, two-phase LR, warmup tuning.

## Instructions
Pull latest noam. **VERIFY val/loss ~0.40.** SENPAI_TIMEOUT_MINUTES=180, SENPAI_MAX_EPOCHS=500. Use `--wandb_group "phase3-r12-schedule"`.

### GPU 0: lr=3e-4 (restore original Lion LR, test stability with DomainLN)
### GPU 1: lr=1.5e-4 (more conservative)
### GPU 2: cosine_T_max=300 (gentler decay)
### GPU 3: warmup_epochs=20 (longer warmup)
### GPU 4: Two-phase: lr=3e-4 for 100 epochs then 1e-4
### GPU 5: weight_decay=5e-5 (very mild)
### GPU 6: lr=3e-4, seed=42
### GPU 7: Baseline verification

## Baseline
| val/loss | p_in | p_oodc | p_tan | p_re |
|----------|------|--------|-------|------|
| **0.3994** | 13.0 | 8.7 | 33.2 | 24.6 |

---

## Results

**⚠️ INCORRECT BASELINE — Results invalid for comparison to 0.3994 target**

All 8 runs used an incomplete model configuration. I only added `--domain_layernorm True --domain_velhead True` but **omitted the full R4+R10 compound flags** needed to match the correct baseline. This explains why baseline verification (GPU7) achieved val/loss=0.85 instead of the expected ~0.40.

**Missing flags (discovered by comparing configs with alphonse's concurrent R12 runs):**
- `--use_lion True` (Lion optimizer, not Adam)
- `--n_layers 3` (not 2)
- `--field_decoder True`
- `--adaln_output True`
- `--high_p_clamp True`
- `--slice_num 96` (not 48)
- `--tandem_ramp True`
- `--aug aoa_perturb --aug_full_dsdf_rot True`

These are the R4/R10 compound features that define the "correct baseline". Without them, the model is architecturally smaller (n_params: 1.1M vs 1.44M) and converges to a worse solution.

### Metrics (vs R11 default-config best seed=777: val/loss=0.7014, p_in=14.44, p_oodc=9.80, p_re=25.50, p_tan=35.39)

| GPU | Config | W&B Run | val/loss | best_ep | p_in | p_oodc | p_re | p_tan | Runtime |
|-----|--------|---------|----------|---------|------|--------|------|-------|---------|
| GPU0 | DLN+lr=3e-4 | 9yorbc30 | 0.81 | 229 | 17.01 | 11.88 | 26.75 | 38.97 | 182m |
| GPU1 | DLN+lr=1.5e-4 | pftik7sa | 0.90 | 229 | 17.96 | 14.16 | 27.88 | 39.87 | 182m |
| GPU2 | DLN+cosine_T_max=300 | 2r2txnm2 | 0.85 | 231 | 17.91 | 12.64 | 26.72 | 40.09 | 182m |
| GPU3 | DLN+warmup_total_iters=40 | 0gv996ei | 0.85 | 230 | 18.39 | 12.65 | 26.68 | 39.21 | 182m |
| GPU4 | DLN+two_phase_lr (3e-4→1e-4) | mpfks51x | **0.81** | 230 | **16.61** | **11.48** | 26.80 | **37.29** | 182m |
| GPU5 | DLN+wd=5e-5 | 6c8cl2ba | 0.86 | 231 | 18.12 | 12.38 | 27.40 | 39.75 | 182m |
| GPU6 | DLN+lr=3e-4, seed=42 | 77umgypk | **0.79** | 232 | **15.98** | **11.29** | **26.45** | **37.27** | 182m |
| GPU7 | DLN+lr=2e-4 baseline | fd1wx5fe | 0.85 | 231 | 16.85 | 12.79 | 27.19 | 39.29 | 182m |

GPU7 split losses: in_dist=0.571, ood_cond=0.655, ood_re=0.517, **tandem_transfer=1.663** (expected ~0.25 — confirms wrong model config)

All runs: state=failed (wall-clock exit without wandb.finish()), runtime 181-182 min, best_epoch 229-232.

### What happened

The PR said "Pull latest noam. VERIFY val/loss ~0.40" but didn't list all required baseline flags. The correct baseline requires the full R4+R10 compound (Lion, n_layers=3, field_decoder, adaln_output, high_p_clamp, slice_num=96, tandem_ramp, AoA aug). I only added DomainLN+velhead.

Despite invalid baseline, the relative LR ordering is informative on this smaller model:
- **GPU6 (lr=3e-4, seed=42)**: best overall — val/loss 0.79, p_oodc 11.29
- **GPU4 (two_phase_lr 3e-4→1e-4)**: competitive — val/loss 0.81, p_oodc 11.48
- **GPU1 (lr=1.5e-4)**: worst — needs more epochs to converge at low LR
- **GPU5 (weight_decay=5e-5)**: slight penalty from mild regularization on this config

tandem_transfer/loss=1.66 (vs expected ~0.25) confirms DomainLN isn't helping without the full compound — likely tandem_ramp=False is the biggest issue.

### Suggested follow-ups

1. **Re-run R12 with correct full compound flags** — most promising variants: lr=3e-4 (GPU6-style) and two_phase_lr 3e-4→1e-4 (GPU4-style) on the full R4+R10 compound baseline
2. **Investigate failed state** — wall-clock timeout should do a clean exit; consider adding `wandb.finish()` at timeout so runs end as "finished" not "failed"
3. **Relative trends likely transfer** — if lr=3e-4 beats lr=2e-4 on the small model, same is expected on the full model