### PR TITLE
Add Hivemind to advisor and student pods

### DIFF
--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -40,6 +40,11 @@ cp "$WORKDIR/instructions/CLAUDE-ADVISOR.md" "$WORKDIR/CLAUDE.md"
 export PATH="$HOME/.claude/bin:$PATH"
 source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
+# --- Start Hivemind (streams CC session logs to hivemind.wandb.tools) ---
+mkdir -p ~/.claude/projects
+uvx --from wandb-hivemind hivemind run &
+echo "=== Hivemind started (PID=$!) ==="
+
 # --- Build prompt ---
 PROMPT="$(envsubst < "$WORKDIR/instructions/prompt-advisor.md" | sed '/^<!--$/,/^-->$/d')"
 

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -25,6 +25,11 @@ git config user.email "senpai-$STUDENT_NAME@senpai"
 export PATH="$HOME/.claude/bin:$PATH"
 source "$WORKDIR/k8s/install-weave-cc-plugin.sh"
 
+# --- Start Hivemind (streams CC session logs to hivemind.wandb.tools) ---
+mkdir -p ~/.claude/projects
+uvx --from wandb-hivemind hivemind run &
+echo "=== Hivemind started (PID=$!) ==="
+
 # --- Install role instructions ---
 cp instructions/CLAUDE-STUDENT.md "$WORKDIR/CLAUDE.md"
 


### PR DESCRIPTION
## Summary
- Adds `wandb-hivemind` as a background daemon to both advisor and student entrypoints
- Pre-creates `~/.claude/projects` so Hivemind's file watcher is ready before the first CC session
- Hivemind authenticates via `GITHUB_TOKEN` (already in pod secrets) and streams all CC session transcripts to `hivemind.wandb.tools`

## Testing
Tested on a live k8s pod (`hivemind-test`) that simulated the production flow:
1. Installed CC + Hivemind, ran 3 CC iterations in a loop against the senpai repo
2. All 3 sessions were discovered and synced successfully
3. The `mkdir -p ~/.claude/projects` fix ensures the watcher is active from iteration 1 (without it, Hivemind starts watching 0 directories)

Key log output from test:
```
Sync cycle: 3 succeeded, 0 skipped, 0 failed (3 processed)
Watching paths: ['/root/.claude/projects']
```

Note: "Web sync: Disabled (no Claude credentials)" appears in logs — this is expected and only affects claude.ai web session sync, not CC session capture.

## Test plan
- [ ] Deploy a student or advisor pod with this change
- [ ] Verify Hivemind sessions appear at hivemind.wandb.tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)