### PR TITLE
Phase 4: Advanced Feature Engineering — Zone/Boundary/Wall-Normal Encodings (8 parallel)

### DIFF
--- a/cfd_tandemfoil/data/prepare_multi.py
+++ b/cfd_tandemfoil/data/prepare_multi.py
@@ -13,11 +13,16 @@ For single-foil samples: AoA1=0, NACA1=[0,0,0], gap=0, stagger=0.
 The 0-sentinel is distinguishable from real tandem values (cruise gap min ≈ -0.8,
 racecar gap min ≈ 0.4), so the model can learn to attend to it appropriately.
 
-x layout (N, 24):
+x layout (N, X_STORED_DIM=26):
   [pos(2), saf(2), dsdf(8), is_surface(1), log_Re(1),
    AoA0_rad(1), NACA0(3),
-   AoA1_rad(1), NACA1(3), gap(1), stagger(1)]
-   = 2+2+8+1+1+1+3+1+3+1+1 = 24 dimensions
+   AoA1_rad(1), NACA1(3), gap(1), stagger(1),
+   boundary_raw(1), zoneID_raw(1)]
+   = 2+2+8+1+1+1+3+1+3+1+1+1+1 = 26 stored dimensions
+
+The first 24 dims (X_DIM) are the core features used for normalization and model input.
+Dims 24-25 are raw metadata (boundary type, zone ID) carried through for optional
+feature engineering in train.py. They are extracted and stripped before standardization.
 
 Model config: space_dim=2, fun_dim=22  →  preprocess MLP input = 24.
 """
@@ -33,7 +38,8 @@ from data.prepare import load_pickle, DATA_ROOT, parse_naca, pad_collate  # noqa
 # Includes foil 2 surface (ID 7) — fixes the SURFACE_IDS=(5,6) gap in prepare.py
 SURFACE_IDS_MULTI = (5, 6, 7)
 
-X_DIM = 24  # total x feature dimension
+X_DIM = 24  # core x feature dimension (for normalization and model input)
+X_STORED_DIM = 26  # stored dimension (core + boundary_raw + zoneID_raw)
 
 
 def preprocess_sample_multi(sample):
@@ -73,6 +79,11 @@ def preprocess_sample_multi(sample):
     gap = float(gap_val) if gap_val is not None else 0.0
     stagger = float(stagger_val) if stagger_val is not None else 0.0
 
+    # Raw metadata for optional feature engineering in train.py
+    boundary_raw = sample.boundary.float().unsqueeze(1)  # (N, 1) — boundary type 0-7
+    zone_raw = (sample.zoneID.float().unsqueeze(1) if hasattr(sample, 'zoneID')
+                else torch.zeros(n, 1))  # (N, 1) — mesh zone 0-2
+
     x = torch.cat([
         sample.pos.float(),                                        # 2
         sample.saf.float(),                                        # 2
@@ -85,9 +96,11 @@ def preprocess_sample_multi(sample):
         torch.tensor(naca1, dtype=torch.float32).expand(n, 3),     # 3
         torch.full((n, 1), gap),                                   # 1
         torch.full((n, 1), stagger),                               # 1
-    ], dim=1)  # 2+2+8+1+1+1+3+1+3+1+1 = 24
+        boundary_raw,                                               # 1
+        zone_raw,                                                   # 1
+    ], dim=1)  # 2+2+8+1+1+1+3+1+3+1+1+1+1 = 26
 
-    assert x.shape[1] == X_DIM, f"Expected {X_DIM} features, got {x.shape[1]}"
+    assert x.shape[1] == X_STORED_DIM, f"Expected {X_STORED_DIM} features, got {x.shape[1]}"
 
     y = sample.y.float()
     return x, y, is_surface

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -38,7 +38,7 @@ from torch.utils.data import DataLoader, WeightedRandomSampler
 import simple_parsing as sp
 
 from data.utils import visualize
-from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
+from data.prepare_multi import X_DIM, X_STORED_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
 
 torch.set_float32_matmul_precision('high')
 
@@ -747,6 +747,12 @@ class Config:
     two_phase_lr_2: float = 1e-4       # phase 2 LR
     snapshot_ensemble: bool = False    # GPU 6: average checkpoints at fixed epochs
     snapshot_epochs_str: str = "120,160,200"  # comma-separated snapshot epochs
+    # Phase 4: advanced feature engineering
+    add_boundary_onehot: bool = False  # one-hot encode boundary type (0-7) → +8 dims
+    add_zone: bool = False             # one-hot encode mesh zone ID (0-2) → +3 dims
+    add_wall_normal: bool = False      # wall-normal direction for surface nodes → +2 dims
+    add_mesh_density: bool = False     # local mesh density proxy → +1 dim
+    add_foil_relative: bool = False    # distance/angle to foil centroids → +4 dims
 
 
 cfg = sp.parse(Config)
@@ -868,9 +874,20 @@ if cfg.raw_targets:
 else:
     raw_stats = None
 
+# Phase 4: compute extra feature dimensions from flags
+extra_feat_dim = sum([
+    8 if cfg.add_boundary_onehot else 0,
+    3 if cfg.add_zone else 0,
+    2 if cfg.add_wall_normal else 0,
+    1 if cfg.add_mesh_density else 0,
+    4 if cfg.add_foil_relative else 0,
+])
+if extra_feat_dim > 0:
+    print(f"Phase 4 extra features: +{extra_feat_dim} dims")
+
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32 + extra_feat_dim,  # +curv, +dist, [+foil2dist], +32 fourier PE, +extra
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1111,6 +1128,50 @@ model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
 
+def _compute_extra_features(raw_boundary, raw_zone, raw_pos, raw_dsdf, dist_surf, is_surface):
+    """Compute Phase 4 extra input features based on config flags.
+
+    Returns list of (B, N, d_i) tensors to concatenate to x.
+    """
+    extra = []
+    if cfg.add_boundary_onehot:
+        boundary_oh = F.one_hot(raw_boundary.clamp(0, 7), 8).float()
+        extra.append(boundary_oh)
+    if cfg.add_zone:
+        zone_oh = F.one_hot(raw_zone.clamp(0, 2), 3).float()
+        extra.append(zone_oh)
+    if cfg.add_wall_normal:
+        nx = raw_dsdf[:, :, 0:1]
+        ny = raw_dsdf[:, :, 1:2]
+        normal_mag = (nx**2 + ny**2).sqrt().clamp(min=1e-6)
+        wall_normal = torch.cat([nx / normal_mag, ny / normal_mag], dim=-1)
+        wall_normal = wall_normal * is_surface.float().unsqueeze(-1)
+        extra.append(wall_normal)
+    if cfg.add_mesh_density:
+        mesh_density = torch.log1p(1.0 / dist_surf.clamp(min=1e-6))
+        extra.append(mesh_density)
+    if cfg.add_foil_relative:
+        foil1_mask = (raw_boundary == 5) | (raw_boundary == 6)  # [B, N]
+        foil2_mask = (raw_boundary == 7)  # [B, N]
+        f1_sum = (raw_pos * foil1_mask.unsqueeze(-1).float()).sum(dim=1)  # [B, 2]
+        f1_count = foil1_mask.float().sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1]
+        f1_center = f1_sum / f1_count  # [B, 2]
+        f2_sum = (raw_pos * foil2_mask.unsqueeze(-1).float()).sum(dim=1)
+        f2_count = foil2_mask.float().sum(dim=1, keepdim=True).clamp(min=1)
+        f2_center = f2_sum / f2_count
+        has_f2 = (foil2_mask.float().sum(dim=1) > 0).float().unsqueeze(-1)  # [B, 1]
+        f2_center = has_f2 * f2_center + (1 - has_f2) * f1_center
+        d1 = raw_pos - f1_center.unsqueeze(1)  # [B, N, 2]
+        d2 = raw_pos - f2_center.unsqueeze(1)
+        r1 = d1.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+        r2 = d2.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+        angle1 = torch.atan2(d1[:, :, 1:2], d1[:, :, 0:1])
+        angle2 = torch.atan2(d2[:, :, 1:2], d2[:, :, 0:1])
+        foil_rel = torch.cat([torch.log1p(r1), angle1, torch.log1p(r2), angle2], dim=-1)
+        extra.append(foil_rel)
+    return extra
+
+
 best_val = float("inf")
 ema_val_loss = float("inf")
 ema_decay_val = 0.9
@@ -1146,6 +1207,12 @@ for epoch in range(MAX_EPOCHS):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
+
+        # Phase 4: extract raw metadata before augmentation/standardization
+        raw_boundary = x[:, :, 24].long()  # (B, N) boundary type 0-7
+        raw_zone = x[:, :, 25].long()      # (B, N) mesh zone 0-2
+        raw_pos_for_feat = x[:, :, :2].clone()  # save raw pos for foil-relative
+        x = x[:, :, :X_DIM]  # trim to core 24 features
 
         # --- Data augmentation (training-only, applied before normalization) ---
         if model.training and cfg.aug != "none" and epoch >= cfg.aug_start_epoch:
@@ -1227,6 +1294,10 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
+        # Phase 4: append extra features
+        _extra = _compute_extra_features(raw_boundary, raw_zone, raw_pos_for_feat, raw_dsdf, dist_surf, is_surface)
+        if _extra:
+            x = torch.cat([x] + _extra, dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -1608,6 +1679,12 @@ for epoch in range(MAX_EPOCHS):
                 is_surface = is_surface.to(device, non_blocking=True)
                 mask = mask.to(device, non_blocking=True)
 
+                # Phase 4: extract raw metadata
+                raw_boundary = x[:, :, 24].long()
+                raw_zone = x[:, :, 25].long()
+                raw_pos_for_feat = x[:, :, :2].clone()
+                x = x[:, :, :X_DIM]
+
                 raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
@@ -1629,6 +1706,10 @@ for epoch in range(MAX_EPOCHS):
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
+                # Phase 4: append extra features
+                _extra = _compute_extra_features(raw_boundary, raw_zone, raw_pos_for_feat, raw_dsdf, dist_surf, is_surface)
+                if _extra:
+                    x = torch.cat([x] + _extra, dim=-1)
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
@@ -1863,8 +1944,11 @@ if best_metrics:
     elif ema_model is not None:
         vis_model = ema_model
     else:
-        vis_model = model
-    vis_model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
+        vis_model = _base_model  # use uncompiled model to avoid torch.compile shape issues
+    _vis_sd = torch.load(model_path, map_location=device, weights_only=True)
+    # Strip _orig_mod. prefix from compiled model state dict keys
+    _vis_sd = {k.replace("_orig_mod.", ""): v for k, v in _vis_sd.items()}
+    vis_model.load_state_dict(_vis_sd)
     vis_model.eval()
     plot_dir = Path("plots") / run.id
     n = 1 if cfg.debug else 4
@@ -1877,21 +1961,30 @@ if best_metrics:
                 y_dev = y_true.unsqueeze(0).to(device)
                 is_surf_dev = is_surface.unsqueeze(0).to(device)
                 mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
-                raw_dsdf = x_dev[:, :, 2:10]
-                dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
+                # Phase 4: extract raw metadata and trim
+                _vis_boundary = x_dev[:, :, 24].long()
+                _vis_zone = x_dev[:, :, 25].long()
+                _vis_raw_pos = x_dev[:, :, :2].clone()
+                x_dev = x_dev[:, :, :X_DIM]
+                raw_dsdf_vis = x_dev[:, :, 2:10]
+                dist_surf = raw_dsdf_vis.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
-                # Fourier PE (must match training loop)
-                raw_xy = x_n[:, :, :2]
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
-                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
-                x_n = torch.cat([x_n, fourier_pe], dim=-1)
+                # Fourier PE (match training pipeline)
+                _vis_xy = x_n[:, :, :2]
+                _vis_xy_min = _vis_xy.amin(dim=1, keepdim=True)
+                _vis_xy_max = _vis_xy.amax(dim=1, keepdim=True)
+                _vis_xy_norm = (_vis_xy - _vis_xy_min) / (_vis_xy_max - _vis_xy_min + 1e-8)
+                _vis_freqs = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                _vis_xy_scaled = _vis_xy_norm.unsqueeze(-1) * _vis_freqs
+                _vis_fourier = torch.cat([_vis_xy_scaled.sin().flatten(-2), _vis_xy_scaled.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, _vis_fourier], dim=-1)
+                # Phase 4: extra features
+                _vis_extra = _compute_extra_features(_vis_boundary, _vis_zone, _vis_raw_pos, raw_dsdf_vis, dist_surf, is_surf_dev)
+                if _vis_extra:
+                    x_n = torch.cat([x_n] + _vis_extra, dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 if cfg.raw_targets:


### PR DESCRIPTION
## Hypothesis
The current 24-dim input features miss several physically meaningful signals that are available in the raw data. Adding these features could significantly improve predictions, especially in regions where the model currently struggles (boundary layers, wake regions, tandem interaction zones):

1. **Boundary type one-hot encoding** (7 dims): The model currently only knows "is_surface" (binary). But boundary types 0-7 encode rich information: interior vs inlet vs outlet vs wall vs foil1 vs foil2. This is critical for tandem cases where foil1/foil2 distinction matters.

2. **Zone ID encoding** (3 dims): Mesh zone 0 (background), zone 1 (foil1 refinement), zone 2 (foil2 refinement) tell the model about local mesh resolution and proximity to foils.

3. **Wall-normal direction vectors** (2 dims): For surface nodes, compute the outward-facing normal direction from dsdf gradients. This helps the model understand flow direction relative to the surface — critical for pressure prediction.

4. **Local mesh density** (1 dim): Number of nearby nodes (proxy via dsdf magnitudes). Denser mesh regions are more important.

5. **Relative position to foil centroids** (4 dims): Distance and angle to foil 1 and foil 2 centroids. Helps the model understand spatial context in tandem configurations.

**Key insight:** The current model gets all its geometric understanding from pos (2), saf (2), dsdf (8), and is_surface (1). That's only 13 geometric dims. Adding boundary type, zone, and wall-normal features could add 12 more geometric dims, nearly doubling the geometric information available.

## Instructions

### Data Pipeline Changes (modify `prepare_multi.py`)

**NOTE: You have permission to modify `prepare_multi.py` for Phase 4. Do NOT modify split files.**

1. **Modify `preprocess_sample_multi()` to add new features:**

```python
def preprocess_sample_multi_v2(sample, add_boundary_onehot=False, add_zone=False, 
                                add_wall_normal=False, add_mesh_density=False,
                                add_foil_relative=False):
    """Extended preprocessing with additional physics-informed features."""
    # ... existing code up to building x ...
    
    extra_features = []
    
    if add_boundary_onehot:
        # One-hot encode boundary type (0-7)
        boundary = sample.boundary.long()
        boundary_oh = torch.zeros(n, 8, dtype=torch.float32)
        boundary_oh.scatter_(1, boundary.unsqueeze(1).clamp(0, 7), 1.0)
        extra_features.append(boundary_oh)  # +8 dims
    
    if add_zone:
        # Zone ID as features (0=background, 1=foil1-refine, 2=foil2-refine)
        zone = sample.zoneID.float() if hasattr(sample, 'zoneID') else torch.zeros(n)
        zone_oh = torch.zeros(n, 3, dtype=torch.float32)
        zone_idx = zone.long().clamp(0, 2)
        zone_oh.scatter_(1, zone_idx.unsqueeze(1), 1.0)
        extra_features.append(zone_oh)  # +3 dims
    
    if add_wall_normal:
        # Approximate wall-normal from dsdf gradient for surface nodes
        dsdf = sample.dsdf.float()  # [N, 8]
        # Use first dsdf gradient pair as surface normal proxy
        nx = dsdf[:, 0:1]  # x-component of nearest surface gradient
        ny = dsdf[:, 1:2]  # y-component
        normal_mag = (nx**2 + ny**2).sqrt().clamp(min=1e-6)
        wall_normal = torch.cat([nx / normal_mag, ny / normal_mag], dim=1)
        # Zero out for non-surface nodes
        wall_normal = wall_normal * is_surface.float().unsqueeze(1)
        extra_features.append(wall_normal)  # +2 dims
    
    if add_mesh_density:
        # Proxy for local mesh density: inverse of min dsdf magnitude
        dsdf_mag = dsdf.norm(dim=-1, keepdim=True).clamp(min=1e-6)
        mesh_density = 1.0 / dsdf_mag
        mesh_density = torch.log1p(mesh_density)  # log scale
        extra_features.append(mesh_density)  # +1 dim
    
    if add_foil_relative:
        # Distance and angle to foil centroids
        pos = sample.pos.float()  # [N, 2]
        foil1_mask = (sample.boundary == 5) | (sample.boundary == 6)
        if foil1_mask.any():
            foil1_center = pos[foil1_mask].mean(0, keepdim=True)  # [1, 2]
        else:
            foil1_center = torch.zeros(1, 2)
        
        foil2_mask = sample.boundary == 7
        if foil2_mask.any():
            foil2_center = pos[foil2_mask].mean(0, keepdim=True)
        else:
            foil2_center = foil1_center  # fallback for single-foil
        
        # Relative distance and angle
        d1 = pos - foil1_center
        d2 = pos - foil2_center
        r1 = d1.norm(dim=-1, keepdim=True).clamp(min=1e-6)
        r2 = d2.norm(dim=-1, keepdim=True).clamp(min=1e-6)
        angle1 = torch.atan2(d1[:, 1:2], d1[:, 0:1])
        angle2 = torch.atan2(d2[:, 1:2], d2[:, 0:1])
        extra_features.append(torch.cat([torch.log1p(r1), angle1, torch.log1p(r2), angle2], dim=1))  # +4 dims
    
    if extra_features:
        x = torch.cat([x] + extra_features, dim=1)
    
    return x, y, is_surface
```

2. **Update `X_DIM` dynamically** based on which features are enabled. The model's `fun_dim` must match.

3. **Add CLI flags to train.py Config:**
```python
add_boundary_onehot: bool = False
add_zone: bool = False
add_wall_normal: bool = False
add_mesh_density: bool = False
add_foil_relative: bool = False
```

4. **Update the model's `fun_dim` calculation** in train.py to account for extra features.

### GPU Assignments

| GPU | Experiment | Features added |
|-----|-----------|---------------|
| 0 | Boundary one-hot only | `--add_boundary_onehot` |
| 1 | Zone encoding only | `--add_zone` |
| 2 | Wall-normal + mesh density | `--add_wall_normal --add_mesh_density` |
| 3 | Foil-relative positions | `--add_foil_relative` |
| 4 | All features combined | `--add_boundary_onehot --add_zone --add_wall_normal --add_mesh_density --add_foil_relative` |
| 5 | Top-3 features (boundary + zone + wall-normal) | `--add_boundary_onehot --add_zone --add_wall_normal` |
| 6 | Boundary + foil-relative (tandem-focused) | `--add_boundary_onehot --add_foil_relative` |
| 7 | Baseline seed 42 | Standard baseline |

### Training Commands

```bash
# GPU 0: Boundary one-hot
CUDA_VISIBLE_DEVICES=0 python train.py --agent nezuko --wandb_name "nezuko/p4-feat-boundary" \
  --wandb_group phase4-features \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --add_boundary_onehot &

# GPU 1: Zone encoding
CUDA_VISIBLE_DEVICES=1 python train.py --agent nezuko --wandb_name "nezuko/p4-feat-zone" \
  --wandb_group phase4-features \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --add_zone &

# GPU 2: Wall-normal + mesh density
CUDA_VISIBLE_DEVICES=2 python train.py --agent nezuko --wandb_name "nezuko/p4-feat-wallnorm-density" \
  --wandb_group phase4-features \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --add_wall_normal --add_mesh_density &

# GPU 3: Foil-relative positions
CUDA_VISIBLE_DEVICES=3 python train.py --agent nezuko --wandb_name "nezuko/p4-feat-foilrel" \
  --wandb_group phase4-features \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --add_foil_relative &

# GPU 4: All features combined
CUDA_VISIBLE_DEVICES=4 python train.py --agent nezuko --wandb_name "nezuko/p4-feat-all" \
  --wandb_group phase4-features \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --add_boundary_onehot --add_zone --add_wall_normal --add_mesh_density --add_foil_relative &

# GPU 5: Top-3 features
CUDA_VISIBLE_DEVICES=5 python train.py --agent nezuko --wandb_name "nezuko/p4-feat-top3" \
  --wandb_group phase4-features \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --add_boundary_onehot --add_zone --add_wall_normal &

# GPU 6: Tandem-focused features
CUDA_VISIBLE_DEVICES=6 python train.py --agent nezuko --wandb_name "nezuko/p4-feat-tandem" \
  --wandb_group phase4-features \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --add_boundary_onehot --add_foil_relative &

# GPU 7: Baseline
CUDA_VISIBLE_DEVICES=7 python train.py --agent nezuko --wandb_name "nezuko/p4-baseline-seed42" \
  --wandb_group phase4-baseline-seeds \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --seed 42 &
wait
```

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.3994 |
| p_in | 13.0 |
| p_oodc | 8.7 |
| p_tan | 33.2 |
| p_re | 24.6 |