### PR TITLE
Phase 4: Multi-Scale Hierarchical Processing + Aggressive Augmentation (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1406,7 +1406,7 @@ for epoch in range(MAX_EPOCHS):
                 _lo = 1.0 - cfg.aug_scale_range
                 _scale = torch.rand(x.size(0), 1, 1, device=x.device) * (2 * cfg.aug_scale_range) + _lo
                 x[:, :, :2] = x[:, :, :2] * _scale
-            if cfg.aug == "aoa_perturb":
+            if cfg.aug in ("aoa_perturb", "random_erase_aoa", "random_erase_mild_aoa"):
                 _angle_deg = torch.rand(x.size(0), device=x.device) * 2.0 - 1.0
                 _angle_rad = _angle_deg * (torch.pi / 180.0)
                 _cos_a = torch.cos(_angle_rad).view(-1, 1, 1)
@@ -1438,10 +1438,11 @@ for epoch in range(MAX_EPOCHS):
                     y[_b, _in_region] = y[_cut_idx[_b], _in_region]
                     is_surface[_b, _in_region] = is_surface[_cut_idx[_b], _in_region]
             # Phase 4: RandomErasing — zero out random input feature channels
-            if cfg.aug == "random_erase":
+            if cfg.aug in ("random_erase", "random_erase_mild", "random_erase_aoa", "random_erase_mild_aoa"):
                 _B_aug, _N_aug, _D_aug = x.shape
+                _max_erase = 2 if cfg.aug in ("random_erase_mild", "random_erase_mild_aoa") else 4
                 for _b in range(_B_aug):
-                    _n_erase = torch.randint(1, 4, (1,)).item()
+                    _n_erase = torch.randint(1, _max_erase, (1,)).item()
                     _erase_dims = torch.randperm(_D_aug - 2, device=x.device)[:_n_erase] + 2
                     x[_b, :, _erase_dims] = 0.0
             # Phase 4: Spatial CutOut — zero features in a spatial region


### PR DESCRIPTION
## Hypothesis
The current model processes all mesh nodes at a single resolution. But CFD meshes have inherent multi-scale structure — coarse background mesh (zone 0) and dense refinement patches (zones 1,2). Processing these at different resolutions, with skip connections between scales, should improve both:

1. **Accuracy**: The model can learn scale-specific patterns (large-scale pressure gradients vs fine boundary layer details)
2. **Efficiency**: Coarse processing on background nodes saves compute, allowing more budget for fine surface details

Additionally, we combine this with aggressive augmentation strategies that haven't been tried: **RandomErasing** on input features, **CutOut** on spatial regions, and **Style Transfer augmentation** (perturbing the global statistics of flow fields while preserving local structure).

**Why multi-scale matters for our metrics:**
- p_tan (33.2, worst metric): Tandem predictions require capturing both the large-scale foil interaction (coarse) and fine boundary layer details (fine)
- p_re (24.6): Reynolds number changes affect different scales differently — bulk flow scaling vs boundary layer thickness

## Instructions

### Architecture Changes (modify `train.py`)

1. **Add `MultiScaleTransolver`** that processes at 2 resolutions:

```python
class MultiScaleTransolver(nn.Module):
    """Two-scale Transolver: coarse global + fine local processing."""
    
    def __init__(self, coarse_subsample=4096, fine_subsample=None, **kwargs):
        super().__init__()
        self.coarse_subsample = coarse_subsample
        self.fine_subsample = fine_subsample
        
        # Shared preprocessing
        self.preprocess = GatedMLP2(kwargs['fun_dim'] + kwargs['space_dim'],
                                     kwargs['n_hidden'] * 2, kwargs['n_hidden'])
        
        # Coarse branch: processes subsampled points
        self.coarse_block = TransolverBlock(
            num_heads=kwargs['n_head'], hidden_dim=kwargs['n_hidden'],
            dropout=0.0, slice_num=32, domain_layernorm=True
        )
        
        # Upsampling: scatter coarse features back to fine grid
        self.upsample_proj = nn.Linear(kwargs['n_hidden'], kwargs['n_hidden'])
        
        # Fine branch: processes all points with coarse context
        self.fine_block1 = TransolverBlock(
            num_heads=kwargs['n_head'], hidden_dim=kwargs['n_hidden'],
            dropout=0.0, slice_num=96, domain_layernorm=True
        )
        self.fine_block2 = TransolverBlock(
            num_heads=kwargs['n_head'], hidden_dim=kwargs['n_hidden'],
            dropout=0.0, slice_num=96, domain_layernorm=True,
            last_layer=True, out_dim=3, field_decoder=True
        )
        
        # Merge: combine coarse and fine features
        self.merge = nn.Linear(kwargs['n_hidden'] * 2, kwargs['n_hidden'])
    
    def forward(self, data):
        x = data['x']
        B, N, D = x.shape
        
        fx = self.preprocess(x)
        raw_xy = x[:, :, :2]  # for spatial bias
        
        # Coarse branch: farthest-point subsample
        K = min(self.coarse_subsample, N)
        # Simple uniform subsampling (farthest-point is better but slower)
        idx_coarse = torch.linspace(0, N-1, K).long().to(x.device)
        fx_coarse = fx[:, idx_coarse]
        raw_xy_coarse = raw_xy[:, idx_coarse]
        
        # Process coarse
        is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
        fx_coarse = self.coarse_block(fx_coarse, raw_xy=torch.cat([
            raw_xy_coarse, raw_xy_coarse.norm(dim=-1, keepdim=True),
            torch.zeros_like(raw_xy_coarse[:, :, :1])
        ], dim=-1), tandem_mask=is_tandem)
        
        # Upsample: scatter coarse features to all nodes via nearest-neighbor
        fx_coarse_up = self.upsample_proj(fx_coarse)
        # Simple: repeat coarse features to nearest indices
        dists = torch.cdist(raw_xy, raw_xy_coarse)  # [B, N, K]
        nearest = dists.argmin(dim=-1)  # [B, N]
        fx_coarse_full = fx_coarse_up.gather(1, nearest.unsqueeze(-1).expand(-1, -1, fx_coarse_up.shape[-1]))
        
        # Merge coarse context with fine features
        fx = self.merge(torch.cat([fx, fx_coarse_full], dim=-1))
        
        # Fine branch
        raw_xy_4d = torch.cat([raw_xy, raw_xy.norm(dim=-1, keepdim=True),
                                torch.zeros_like(raw_xy[:, :, :1])], dim=-1)
        fx = self.fine_block1(fx, raw_xy=raw_xy_4d, tandem_mask=is_tandem)
        fx = self.fine_block2(fx, raw_xy=raw_xy_4d, tandem_mask=is_tandem)
        
        return {"preds": fx, "re_pred": torch.zeros(B, 1, device=x.device),
                "aoa_pred": torch.zeros(B, 1, device=x.device)}
```

2. **Add aggressive augmentation strategies:**

```python
# RandomErasing: zero out random input feature channels
if cfg.aug == "random_erase":
    B, N, D = x.shape
    for b in range(B):
        n_erase = torch.randint(1, 4, (1,)).item()
        erase_dims = torch.randperm(D-2)[:n_erase] + 2  # skip pos dims
        x[b, :, erase_dims] = 0.0

# Spatial CutOut: zero out all features in a spatial region
if cfg.aug == "spatial_cutout":
    B = x.shape[0]
    for b in range(B):
        cx = x[b, :, 0].mean() + torch.randn(1, device=x.device) * x[b, :, 0].std() * 0.5
        cy = x[b, :, 1].mean() + torch.randn(1, device=x.device) * x[b, :, 1].std() * 0.5
        r = 0.1 + torch.rand(1, device=x.device).item() * 0.3
        mask = ((x[b, :, 0] - cx)**2 + (x[b, :, 1] - cy)**2) < r**2
        x[b, mask, 2:] = 0.0  # zero features but keep position

# Style perturbation: shift/scale global statistics
if cfg.aug == "style_perturb":
    B, N, C = y.shape
    for b in range(B):
        scale = 1.0 + 0.05 * torch.randn(1, C, device=y.device)
        shift = 0.02 * torch.randn(1, C, device=y.device) * y[b].std(dim=0, keepdim=True)
        y[b] = y[b] * scale + shift
```

3. **Add CLI flags:**
```python
multiscale: bool = False
multiscale_coarse_k: int = 4096
aug: str = "none"  # add "random_erase", "spatial_cutout", "style_perturb" to choices
```

### GPU Assignments

| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0 | Multi-scale (K=4096 coarse) | `--multiscale --multiscale_coarse_k 4096` |
| 1 | Multi-scale (K=8192 coarse) | `--multiscale --multiscale_coarse_k 8192` |
| 2 | Multi-scale + aoa_perturb | `--multiscale --multiscale_coarse_k 4096 --aug aoa_perturb --aug_full_dsdf_rot` |
| 3 | RandomErasing augmentation | `--aug random_erase` (baseline arch) |
| 4 | Spatial CutOut augmentation | `--aug spatial_cutout` (baseline arch) |
| 5 | Style perturbation augmentation | `--aug style_perturb` (baseline arch) |
| 6 | All 3 new augmentations combined (randomly pick one per batch) | `--aug random_aug_mix` |
| 7 | Baseline seed | Standard baseline |

### Training Commands

```bash
# GPU 0: Multi-scale K=4096
CUDA_VISIBLE_DEVICES=0 python train.py --agent edward --wandb_name "edward/p4-multiscale-4k" \
  --wandb_group phase4-multiscale \
  --use_lion --lr 2e-4 --high_p_clamp --tandem_ramp \
  --domain_layernorm --ema_decay 0.999 \
  --multiscale --multiscale_coarse_k 4096 &

# GPU 1: Multi-scale K=8192
CUDA_VISIBLE_DEVICES=1 python train.py --agent edward --wandb_name "edward/p4-multiscale-8k" \
  --wandb_group phase4-multiscale \
  --use_lion --lr 2e-4 --high_p_clamp --tandem_ramp \
  --domain_layernorm --ema_decay 0.999 \
  --multiscale --multiscale_coarse_k 8192 &

# GPU 2: Multi-scale + aug
CUDA_VISIBLE_DEVICES=2 python train.py --agent edward --wandb_name "edward/p4-multiscale-aug" \
  --wandb_group phase4-multiscale \
  --use_lion --lr 2e-4 --high_p_clamp --tandem_ramp \
  --domain_layernorm --ema_decay 0.999 \
  --multiscale --multiscale_coarse_k 4096 --aug aoa_perturb --aug_full_dsdf_rot &

# GPU 3: RandomErasing
CUDA_VISIBLE_DEVICES=3 python train.py --agent edward --wandb_name "edward/p4-random-erase" \
  --wandb_group phase4-augmentation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug random_erase --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 &

# GPU 4: Spatial CutOut
CUDA_VISIBLE_DEVICES=4 python train.py --agent edward --wandb_name "edward/p4-spatial-cutout" \
  --wandb_group phase4-augmentation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug spatial_cutout --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 &

# GPU 5: Style perturbation
CUDA_VISIBLE_DEVICES=5 python train.py --agent edward --wandb_name "edward/p4-style-perturb" \
  --wandb_group phase4-augmentation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug style_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 &

# GPU 6: Random augmentation mix
CUDA_VISIBLE_DEVICES=6 python train.py --agent edward --wandb_name "edward/p4-aug-mix" \
  --wandb_group phase4-augmentation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug random_aug_mix --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 &

# GPU 7: Baseline
CUDA_VISIBLE_DEVICES=7 python train.py --agent edward --wandb_name "edward/p4-baseline-seed42" \
  --wandb_group phase4-baseline-seeds \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --seed 42 &
wait
```

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.3994 |
| p_in | 13.0 |
| p_oodc | 8.7 |
| p_tan | 33.2 |
| p_re | 24.6 |