### PR TITLE
Phase 4: Phase 3 Loose Ends — Compound Validation + Best Config Sweep (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1877,11 +1877,21 @@ if best_metrics:
                 y_dev = y_true.unsqueeze(0).to(device)
                 is_surf_dev = is_surface.unsqueeze(0).to(device)
                 mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
+                raw_dsdf = x_dev[:, :, 2:10]
+                dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
+                dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                 curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                dist_surf = x_n[:, :, 2:10].abs().min(dim=-1, keepdim=True).values
-                dist_feat = torch.log1p(dist_surf * 10.0)
                 x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                # Fourier PE (must match training loop)
+                raw_xy = x_n[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                x_n = torch.cat([x_n, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y_dev, mask)
                 pred = vis_model({"x": x_n})["preds"].float()
                 if cfg.raw_targets:


### PR DESCRIPTION
## Hypothesis
Phase 3 identified several promising configurations that were never fully validated with multi-seed runs or longer training. With 3 hours per experiment, these configurations now have time to converge. This PR validates the most promising Phase 3 findings:

1. **Weight decay 1e-4** (PR #1816): Achieved p_tan=32.4, p_oodc=8.3 in a single run — needs multi-seed validation to confirm this beats baseline p_tan=33.2
2. **EMA start_epoch=50 + decay=0.999** (PR #1813): Showed p_in=12.69 in single seed — earlier EMA accumulation may help with longer training
3. **Compound learned normalization** (PR #1782): p_oodc=8.31 with compound per-sample std on top of DomainLN — never reproduced
4. **Wider model n_hidden=256** (PRs #1806, #1817): Never converged in Phase 3 (only reached 126-189 epochs). With 3 hours, should reach 250+ epochs
5. **INR decoder** (PR #1770): Matched baseline at only 154 epochs — with longer training could surpass it
6. **FAMO with Lion** (PR #1818): Ran with AdamW instead of Lion by mistake, results 3x worse than baseline. Needs to be re-run correctly with Lion optimizer

## Instructions

### GPU Assignments — Each GPU runs one Phase 3 loose end

| GPU | Experiment | Key changes from baseline |
|-----|-----------|--------------------------|
| 0 | Weight decay 1e-4 (seed 42) | `--weight_decay 1e-4` |
| 1 | Weight decay 1e-4 (seed 43) | `--weight_decay 1e-4 --seed 43` |
| 2 | EMA start_epoch=50, decay=0.999 | `--ema_start_epoch 50 --ema_decay 0.999` |
| 3 | EMA start_epoch=50, decay=0.9995 | `--ema_start_epoch 50 --ema_decay 0.9995` |
| 4 | Wider model n_hidden=256 (3h budget) | `--n_hidden 256 --lr 1.5e-4` (slightly lower lr for stability) |
| 5 | Wider model n_hidden=256 + 4 heads | `--n_hidden 256 --lr 1.5e-4` (n_head will auto-adjust) |
| 6 | Weight decay 1e-4 + EMA start=50 compound | `--weight_decay 1e-4 --ema_start_epoch 50 --ema_decay 0.999` |
| 7 | Weight decay 5e-5 (lighter regularization) | `--weight_decay 5e-5` |

### Training Commands

```bash
# GPU 0: Weight decay 1e-4 seed 42
CUDA_VISIBLE_DEVICES=0 python train.py --agent violet --wandb_name "violet/p4-wd1e4-s42" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 1e-4 --seed 42 &

# GPU 1: Weight decay 1e-4 seed 43
CUDA_VISIBLE_DEVICES=1 python train.py --agent violet --wandb_name "violet/p4-wd1e4-s43" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 1e-4 --seed 43 &

# GPU 2: EMA start_epoch=50, decay=0.999
CUDA_VISIBLE_DEVICES=2 python train.py --agent violet --wandb_name "violet/p4-ema50-d999" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead \
  --ema_start_epoch 50 --ema_decay 0.999 &

# GPU 3: EMA start_epoch=50, decay=0.9995
CUDA_VISIBLE_DEVICES=3 python train.py --agent violet --wandb_name "violet/p4-ema50-d9995" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead \
  --ema_start_epoch 50 --ema_decay 0.9995 &

# GPU 4: Wider model n_hidden=256
CUDA_VISIBLE_DEVICES=4 python train.py --agent violet --wandb_name "violet/p4-wide256" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 1.5e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --n_hidden 256 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 &

# GPU 5: Wider model + different config
CUDA_VISIBLE_DEVICES=5 python train.py --agent violet --wandb_name "violet/p4-wide256-v2" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 1e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --n_hidden 256 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --warmup_total_iters 30 --cosine_T_max 350 &

# GPU 6: Compound: weight_decay + early EMA
CUDA_VISIBLE_DEVICES=6 python train.py --agent violet --wandb_name "violet/p4-wd-ema-compound" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead \
  --weight_decay 1e-4 --ema_start_epoch 50 --ema_decay 0.999 &

# GPU 7: Lighter weight decay
CUDA_VISIBLE_DEVICES=7 python train.py --agent violet --wandb_name "violet/p4-wd5e5" \
  --wandb_group phase4-p3-validation \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 &
wait
```

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.3994 |
| p_in | 13.0 |
| p_oodc | 8.7 |
| p_tan | 33.2 |
| p_re | 24.6 |

Phase 3 best results for reference:
- Weight decay 1e-4: val/loss=0.3998, p_tan=32.4, p_oodc=8.3
- EMA start=50: p_in=12.69
- Compound learned norm: p_oodc=8.31