### PR TITLE
Phase 4: Weight Decay Fine-Tuning Sweep + Multi-Seed Validation (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1910,8 +1910,11 @@ if best_metrics:
                     else:
                         y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
             samples.append((x[:, :2], y_true, y_pred, is_surface))
-        images = visualize(samples, out_dir=plot_dir / split_name)
-        if images:
-            wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})
+        try:
+            images = visualize(samples, out_dir=plot_dir / split_name)
+            if images:
+                wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})
+        except TypeError:
+            pass  # visualize() signature mismatch — skip plotting, metrics already saved
 
 wandb.finish()


### PR DESCRIPTION
## Hypothesis
PR #1833 showed weight_decay=5e-5 improves baseline (val/loss 0.3994→0.3985, p_tan 33.2→31.9). The optimal weight decay value likely lies in the range [1e-5, 1e-4]. A fine-grained sweep with multi-seed validation will identify the exact optimum and confirm the improvement is robust.

This is a low-risk, high-value experiment — weight decay is orthogonal to architectural changes and can compound with any future improvements.

**NOTE:** The noam branch was updated after PR #1833 merge. You must rebase onto the latest noam before running. The new baseline now includes `--weight_decay 5e-5` and a visualization fix.

## Instructions

Run 8 experiments on 8 GPUs — a sweep of weight decay values with seed 42 for consistency, plus multi-seed validation of the best value.

### GPU Assignments

| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0 | wd=1e-5 | `--weight_decay 1e-5 --seed 42` |
| 1 | wd=2e-5 | `--weight_decay 2e-5 --seed 42` |
| 2 | wd=3e-5 | `--weight_decay 3e-5 --seed 42` |
| 3 | wd=5e-5 (new baseline, seed 42) | `--weight_decay 5e-5 --seed 42` |
| 4 | wd=7e-5 | `--weight_decay 7e-5 --seed 42` |
| 5 | wd=1e-4 | `--weight_decay 1e-4 --seed 42` |
| 6 | wd=5e-5 (seed 43) | `--weight_decay 5e-5 --seed 43` |
| 7 | wd=5e-5 (seed 44) | `--weight_decay 5e-5 --seed 44` |

### Training Commands

```bash
# GPU 0-5: Weight decay sweep
for i in 0 1 2 3 4 5; do
  wd_vals=(1e-5 2e-5 3e-5 5e-5 7e-5 1e-4)
  wd=${wd_vals[$i]}
  CUDA_VISIBLE_DEVICES=$i python train.py --agent violet --wandb_name "violet/p4-wd-sweep-$wd" \
    --wandb_group phase4-wd-sweep \
    --field_decoder --adaln_output --use_lion --lr 2e-4 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay $wd --seed 42 &
done

# GPUs 6-7: Multi-seed validation of wd=5e-5
for i in 6 7; do
  seed=$((43 + i - 6))
  CUDA_VISIBLE_DEVICES=$i python train.py --agent violet --wandb_name "violet/p4-wd5e5-seed$seed" \
    --wandb_group phase4-wd-sweep \
    --field_decoder --adaln_output --use_lion --lr 2e-4 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --seed $seed &
done
wait
```

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.3985 |
| p_in | 13.3 |
| p_oodc | 8.4 |
| p_tan | 31.9 |
| p_re | 24.7 |

W&B run: [ace002qd](https://wandb.ai/wandb-applied-ai-team/senpai-v1/runs/ace002qd)

Baseline command: `python train.py --agent <name> --wandb_name "<name>/baseline" --field_decoder --adaln_output --use_lion --lr 2e-4 --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5`