### PR TITLE
Phase 4: Attention Enhancements — Sliding Window + Relative PE + Gating (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 multi_res_slices=False, gated_attn=False, sigmoid_attn=False):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -154,14 +155,34 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.decouple_slice = decouple_slice
         self.zone_temp = zone_temp
         self.prog_slices = prog_slices
+        self.multi_res_slices = multi_res_slices
+        self.gated_attn = gated_attn
+        self.sigmoid_attn = sigmoid_attn
         if prog_slices:
             # Buffer for masking inactive slices; updated per-epoch by training loop
             self.register_buffer('slice_mask', torch.zeros(slice_num))
 
         self.in_project_x = nn.Linear(dim, inner_dim)
         self.in_project_fx = nn.Linear(dim, inner_dim)
-        self.in_project_slice = nn.Linear(dim_head, slice_num)
-        torch.nn.init.orthogonal_(self.in_project_slice.weight)
+        if multi_res_slices:
+            # Multi-resolution: all heads project to max slice_num, but heads with
+            # fewer slices have their extra outputs masked. Compile-friendly (no loops).
+            self.slice_counts = [max(32, slice_num // 2), max(48, slice_num * 2 // 3), slice_num]
+            while len(self.slice_counts) < heads:
+                self.slice_counts.append(slice_num)
+            self.slice_counts = self.slice_counts[:heads]
+            # All heads project to slice_num (max), masked per-head in forward
+            self.in_project_slice = nn.Linear(dim_head, slice_num)
+            torch.nn.init.orthogonal_(self.in_project_slice.weight)
+            # Mask: [1, H, 1, slice_num] — 0 for active slices, -1e9 for inactive
+            _mr_mask = torch.zeros(1, heads, 1, slice_num)
+            for h_idx, sc in enumerate(self.slice_counts):
+                if sc < slice_num:
+                    _mr_mask[0, h_idx, 0, sc:] = -1e9
+            self.register_buffer('multi_res_mask', _mr_mask)
+        else:
+            self.in_project_slice = nn.Linear(dim_head, slice_num)
+            torch.nn.init.orthogonal_(self.in_project_slice.weight)
         if decouple_slice:
             # Separate slice projection for tandem samples
             self.in_project_slice_tandem = nn.Linear(dim_head, slice_num)
@@ -180,6 +201,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             nn.Dropout(dropout),
         )
         self.attn_scale = nn.Parameter(torch.ones(1, self.heads, 1, 1) * 10.0)
+        if gated_attn:
+            self.attn_gate = nn.Parameter(torch.zeros(1, heads, 1, 1))
         if learned_kernel:
             self.kernel_mlp = nn.Sequential(
                 nn.Linear(2 * dim_head, dim_head), nn.GELU(),
@@ -219,9 +242,15 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if spatial_bias is not None:
             slice_logits = slice_logits + 0.1 * spatial_bias.unsqueeze(1)
         if self.prog_slices:
-            # Apply slice mask: 0 for active slices, -1e9 for inactive (updated each epoch)
             slice_logits = slice_logits + self.slice_mask
-        slice_weights = self.softmax(slice_logits)
+        if self.multi_res_slices:
+            # Apply per-head mask: inactive slices get -1e9 before softmax
+            slice_logits = slice_logits + self.multi_res_mask
+        if self.sigmoid_attn:
+            slice_weights = torch.sigmoid(slice_logits)
+            slice_weights = slice_weights / (slice_weights.sum(dim=-1, keepdim=True) + 1e-8)
+        else:
+            slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -249,6 +278,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
+        if self.gated_attn:
+            out_x = torch.sigmoid(self.attn_gate) * out_x
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
         return self.to_out(out_x)
 
@@ -279,6 +310,9 @@ class TransolverBlock(nn.Module):
         dln_zeroinit=False,
         domain_velhead=False,
         prog_slices=False,
+        multi_res_slices=False,
+        gated_attn=False,
+        sigmoid_attn=False,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -302,6 +336,9 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            multi_res_slices=multi_res_slices,
+            gated_attn=gated_attn,
+            sigmoid_attn=sigmoid_attn,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -453,6 +490,9 @@ class Transolver(nn.Module):
         dln_zeroinit=False,
         domain_velhead=False,
         prog_slices=False,
+        multi_res_slices=False,
+        gated_attn=False,
+        sigmoid_attn=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -519,6 +559,9 @@ class Transolver(nn.Module):
                     dln_zeroinit=dln_zeroinit,
                     domain_velhead=domain_velhead if (idx == n_layers - 1) else False,
                     prog_slices=prog_slices,
+                    multi_res_slices=multi_res_slices,
+                    gated_attn=gated_attn,
+                    sigmoid_attn=sigmoid_attn,
                 )
                 for idx in range(n_layers)
             ]
@@ -747,6 +790,10 @@ class Config:
     two_phase_lr_2: float = 1e-4       # phase 2 LR
     snapshot_ensemble: bool = False    # GPU 6: average checkpoints at fixed epochs
     snapshot_epochs_str: str = "120,160,200"  # comma-separated snapshot epochs
+    # Phase 4: Attention enhancements
+    multi_res_slices: bool = False     # multi-resolution slice counts per head
+    gated_attn: bool = False           # learnable gate on attention output
+    sigmoid_attn: bool = False         # sigmoid attention instead of softmax for slice weights
 
 
 cfg = sp.parse(Config)
@@ -896,6 +943,9 @@ model_config = dict(
     dln_zeroinit=cfg.dln_zeroinit,
     domain_velhead=cfg.domain_velhead,
     prog_slices=cfg.prog_slices,
+    multi_res_slices=cfg.multi_res_slices,
+    gated_attn=cfg.gated_attn,
+    sigmoid_attn=cfg.sigmoid_attn,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1863,8 +1913,11 @@ if best_metrics:
     elif ema_model is not None:
         vis_model = ema_model
     else:
-        vis_model = model
-    vis_model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
+        vis_model = _base_model  # use uncompiled model for visualization (avoids recompilation)
+    _sd = torch.load(model_path, map_location=device, weights_only=True)
+    # Strip _orig_mod. prefix from compiled model state dicts
+    _sd = {k.removeprefix("_orig_mod."): v for k, v in _sd.items()}
+    vis_model.load_state_dict(_sd)
     vis_model.eval()
     plot_dir = Path("plots") / run.id
     n = 1 if cfg.debug else 4
@@ -1910,7 +1963,48 @@ if best_metrics:
                     else:
                         y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
             samples.append((x[:, :2], y_true, y_pred, is_surface))
-        images = visualize(samples, out_dir=plot_dir / split_name)
+        # Inline visualization from pre-computed samples
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+        _vis_dir = plot_dir / split_name
+        _vis_dir.mkdir(parents=True, exist_ok=True)
+        images = []
+        for _si, (_pos, _yt, _yp, _is) in enumerate(samples):
+            _pos_np = _pos.numpy()
+            _yt_np = _yt.numpy()
+            _yp_np = _yp.numpy()
+            _is_np = _is.numpy()
+            _near = (_pos_np[:, 0] >= -1) & (_pos_np[:, 0] <= 2) & (_pos_np[:, 1] >= 0)
+            _px, _py = _pos_np[_near, 0], _pos_np[_near, 1]
+            _gt_vmag = np.sqrt(_yt_np[_near, 0]**2 + _yt_np[_near, 1]**2)
+            _pr_vmag = np.sqrt(_yp_np[_near, 0]**2 + _yp_np[_near, 1]**2)
+            _gt_p, _pr_p = _yt_np[_near, 2], _yp_np[_near, 2]
+            fig, axes = plt.subplots(2, 3, figsize=(20, 10))
+            for ax in axes.flat:
+                ax.set_aspect("equal")
+            axes[0, 0].scatter(_px, _py, c=_gt_vmag, s=0.5, cmap="viridis", edgecolors="none")
+            axes[0, 0].set_title("|U| GT")
+            axes[0, 1].scatter(_px, _py, c=_pr_vmag, s=0.5, cmap="viridis", edgecolors="none")
+            axes[0, 1].set_title("|U| Pred")
+            _ev = _gt_vmag - _pr_vmag
+            _evm = max(abs(_ev.min()), abs(_ev.max()), 1e-6)
+            axes[0, 2].scatter(_px, _py, c=_ev, s=0.5, cmap="RdBu_r", vmin=-_evm, vmax=_evm, edgecolors="none")
+            axes[0, 2].set_title("|U| Error")
+            axes[1, 0].scatter(_px, _py, c=_gt_p, s=0.5, cmap="RdBu_r", edgecolors="none")
+            axes[1, 0].set_title("p GT")
+            axes[1, 1].scatter(_px, _py, c=_pr_p, s=0.5, cmap="RdBu_r", edgecolors="none")
+            axes[1, 1].set_title("p Pred")
+            _ep = _gt_p - _pr_p
+            _epm = max(abs(_ep.min()), abs(_ep.max()), 1e-6)
+            axes[1, 2].scatter(_px, _py, c=_ep, s=0.5, cmap="RdBu_r", vmin=-_epm, vmax=_epm, edgecolors="none")
+            axes[1, 2].set_title("p Error")
+            plt.tight_layout()
+            _path = _vis_dir / f"val_sample_{_si}.png"
+            fig.savefig(_path, dpi=150)
+            plt.close(fig)
+            images.append(_path)
         if images:
             wandb.log({f"val_predictions/{split_name}": [wandb.Image(str(p)) for p in images], "global_step": global_step})
 


### PR DESCRIPTION
## Hypothesis
Instead of replacing the Transolver architecture, enhance its attention mechanism with techniques that maintain torch.compile compatibility. Three targeted modifications:

1. **Relative Positional Encoding in attention**: The current spatial_bias uses a learned MLP from raw coordinates, but doesn't encode *relative* positions between nodes. Adding relative PE (like RoPE or ALiBi adapted for 2D) would improve the model's ability to reason about spatial relationships.

2. **Multi-Head Attention with different slice counts per head**: Currently all heads use the same 96 slices. Using varied slice counts (e.g., 48, 64, 96, 128) across heads gives multi-resolution attention — some heads capture coarse patterns, others fine details.

3. **Gated attention output**: Add a learnable gate on the attention output that can modulate how much each layer contributes. This has been shown to improve training dynamics in deep transformers (Parisotto et al., 2020).

4. **Sigmoid attention** (replacing softmax): Recent work shows sigmoid attention can outperform softmax in transformers (Ramapuram et al., 2024). Since our slice attention already uses learned temperatures, sigmoid might be a natural fit.

**Why these help within the existing architecture:**
- All changes are small modifications to existing components
- They maintain torch.compile compatibility (no new dynamic ops)
- They don't add significant compute overhead
- They target the specific bottleneck (attention quality) rather than throughput

## Instructions

### Architecture Changes (modify `train.py`)

1. **Multi-resolution slicing**: Modify `Physics_Attention_Irregular_Mesh` to use different slice counts per head:
```python
# In __init__:
if multi_res_slices:
    # Different slice projections per head group
    self.slice_counts = [48, 64, 96, 128]  # per head-group
    self.in_project_slices = nn.ModuleList([
        nn.Linear(dim_head, sc) for sc in self.slice_counts
    ])
else:
    self.in_project_slice = nn.Linear(dim_head, slice_num)
```

2. **Gated attention residual**: Add a learnable gate on attention output:
```python
if gated_attn:
    self.attn_gate = nn.Parameter(torch.zeros(1, heads, 1, 1))
    # In forward:
    out_x = torch.sigmoid(self.attn_gate) * out_x
```

3. **Sigmoid attention**: Replace softmax with sigmoid in slice assignment:
```python
if sigmoid_attn:
    slice_weights = torch.sigmoid(slice_logits)
    slice_weights = slice_weights / (slice_weights.sum(dim=-1, keepdim=True) + 1e-8)
```

4. **Add CLI flags:**
```python
multi_res_slices: bool = False
gated_attn: bool = False
sigmoid_attn: bool = False
```

### GPU Assignments

| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0 | Multi-resolution slices | `--multi_res_slices` |
| 1 | Gated attention | `--gated_attn` |
| 2 | Sigmoid attention | `--sigmoid_attn` |
| 3 | Multi-res + gated | `--multi_res_slices --gated_attn` |
| 4 | Sigmoid + gated | `--sigmoid_attn --gated_attn` |
| 5 | All three combined | `--multi_res_slices --gated_attn --sigmoid_attn` |
| 6 | Multi-res + wd=5e-5 | `--multi_res_slices --weight_decay 5e-5` |
| 7 | Baseline with wd=5e-5 | Standard new baseline |

All experiments use the standard baseline flags plus the above modifications.

### Training Commands

```bash
# GPU 0: Multi-resolution slices
CUDA_VISIBLE_DEVICES=0 python train.py --agent alphonse --wandb_name "alphonse/p4-multires" \
  --wandb_group phase4-attention \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --multi_res_slices &

# GPU 1: Gated attention
CUDA_VISIBLE_DEVICES=1 python train.py --agent alphonse --wandb_name "alphonse/p4-gated-attn" \
  --wandb_group phase4-attention \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --gated_attn &

# GPU 2: Sigmoid attention
CUDA_VISIBLE_DEVICES=2 python train.py --agent alphonse --wandb_name "alphonse/p4-sigmoid-attn" \
  --wandb_group phase4-attention \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --sigmoid_attn &

# GPU 3: Multi-res + gated
CUDA_VISIBLE_DEVICES=3 python train.py --agent alphonse --wandb_name "alphonse/p4-multires-gated" \
  --wandb_group phase4-attention \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --multi_res_slices --gated_attn &

# GPU 4: Sigmoid + gated
CUDA_VISIBLE_DEVICES=4 python train.py --agent alphonse --wandb_name "alphonse/p4-sigmoid-gated" \
  --wandb_group phase4-attention \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --sigmoid_attn --gated_attn &

# GPU 5: All three
CUDA_VISIBLE_DEVICES=5 python train.py --agent alphonse --wandb_name "alphonse/p4-all-attn" \
  --wandb_group phase4-attention \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --multi_res_slices --gated_attn --sigmoid_attn &

# GPU 6: Multi-res + wd=5e-5
CUDA_VISIBLE_DEVICES=6 python train.py --agent alphonse --wandb_name "alphonse/p4-multires-wd" \
  --wandb_group phase4-attention \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --multi_res_slices --weight_decay 5e-5 &

# GPU 7: Baseline with wd=5e-5
CUDA_VISIBLE_DEVICES=7 python train.py --agent alphonse --wandb_name "alphonse/p4-baseline-wd5e5" \
  --wandb_group phase4-baseline-seeds \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --seed 47 &
wait
```

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.3985 |
| p_in | 13.3 |
| p_oodc | 8.4 |
| p_tan | 31.9 |
| p_re | 24.7 |