### PR TITLE
Phase 4: Noise Schedule + Training Micro-Tuning Sweep (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -710,6 +710,7 @@ class Config:
     swa_start_epoch: int = 200   # epoch to start SWA (GPU 0: 200, GPU 6: 160)
     grad_accum_steps: int = 1    # GPU 2: gradient accumulation (step every N batches)
     half_target_noise: bool = False  # GPU 3: reduce target noise by 50%
+    no_target_noise: bool = False    # Phase 4: completely disable target noise injection
     use_lion: bool = False        # GPU 4: Lion optimizer instead of AdamW
     rdrop: bool = False           # GPU 7: R-drop regularization
     rdrop_alpha: float = 1.0     # R-drop consistency loss weight
@@ -1239,8 +1240,8 @@ for epoch in range(MAX_EPOCHS):
                 y_phys = y_phys.clone()
                 y_phys[:, :, 2:3] = y_phys[:, :, 2:3].abs().add(1).log() * y_phys[:, :, 2:3].sign()
             y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
-        if model.training:
-            noise_progress = min(1.0, epoch / cfg.noise_anneal_epochs)
+        if model.training and not cfg.no_target_noise:
+            noise_progress = min(1.0, epoch / max(cfg.noise_anneal_epochs, 1))
             if cfg.half_target_noise:
                 vel_noise = 0.0075 * (1 - noise_progress) + 0.0015 * noise_progress
                 p_noise = 0.004 * (1 - noise_progress) + 0.0005 * noise_progress


### PR DESCRIPTION
## Hypothesis
The current training pipeline has several noise/schedule parameters that were set during Phase 2/3 and never comprehensively tuned:

1. **Target noise schedule** (vel_noise 0.015→0.003, p_noise 0.008→0.001 over noise_anneal_epochs=60): These noise levels inject randomness into targets during training. The values were inherited from earlier phases — lowering them might help with longer training.

2. **Input noise** (0.05→0 over noise_anneal_epochs=60 on features 2:25): Feature noise during training acts as regularization. The scale (0.05) and anneal period (60 epochs) haven't been tuned.

3. **EMA start epoch** (140): The EMA model starts accumulating at epoch 140, leaving only ~20 epochs before timeout at ~160. Starting earlier or later could affect final quality.

4. **Cosine T_max** (230): Set for 500-epoch training, but we only complete ~160 epochs. The LR is still relatively high when training stops.

5. **Temperature annealing** (temp_anneal_epoch=50): The attention temperature is clamped at epoch 50. This timing was never optimized.

These are all **low-risk, no-new-code** experiments — just hyperparameter tuning of existing flags. The research review found that our 7.8% experiment win rate comes mostly from training dynamics changes, not architecture.

## Instructions

### GPU Assignments

| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0 | No target noise (vel=0, p=0) | `--half_target_noise` + set noise to 0 |
| 1 | EMA start=100 (earlier) | `--ema_start_epoch 100` |
| 2 | EMA start=120 | `--ema_start_epoch 120` |
| 3 | Cosine T_max=160 (match epochs) | `--cosine_T_max 160` |
| 4 | Cosine T_max=180 | `--cosine_T_max 180` |
| 5 | No input noise (noise_anneal_epochs=0) | `--noise_anneal_epochs 0` |
| 6 | Faster noise anneal (30 epochs) | `--noise_anneal_epochs 30` |
| 7 | Compound: T_max=160 + EMA start=100 | `--cosine_T_max 160 --ema_start_epoch 100` |

### Training Commands

```bash
# GPU 0: No target noise
CUDA_VISIBLE_DEVICES=0 python train.py --agent nezuko --wandb_name "nezuko/p4-no-target-noise" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --half_target_noise &

# GPU 1: EMA start=100
CUDA_VISIBLE_DEVICES=1 python train.py --agent nezuko --wandb_name "nezuko/p4-ema-start100" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --ema_start_epoch 100 &

# GPU 2: EMA start=120
CUDA_VISIBLE_DEVICES=2 python train.py --agent nezuko --wandb_name "nezuko/p4-ema-start120" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --ema_start_epoch 120 &

# GPU 3: T_max=160
CUDA_VISIBLE_DEVICES=3 python train.py --agent nezuko --wandb_name "nezuko/p4-tmax160" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 160 &

# GPU 4: T_max=180
CUDA_VISIBLE_DEVICES=4 python train.py --agent nezuko --wandb_name "nezuko/p4-tmax180" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 180 &

# GPU 5: No input noise
CUDA_VISIBLE_DEVICES=5 python train.py --agent nezuko --wandb_name "nezuko/p4-no-input-noise" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --noise_anneal_epochs 0 &

# GPU 6: Fast noise anneal
CUDA_VISIBLE_DEVICES=6 python train.py --agent nezuko --wandb_name "nezuko/p4-fast-anneal" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --noise_anneal_epochs 30 &

# GPU 7: Compound
CUDA_VISIBLE_DEVICES=7 python train.py --agent nezuko --wandb_name "nezuko/p4-compound-schedule" \
  --wandb_group phase4-noise-schedule \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 160 --ema_start_epoch 100 &
wait
```

## Baseline (Multi-Seed Validated)
| Metric | Mean | Std |
|--------|------|-----|
| val/loss | 0.405 | 0.004 |
| p_in | 13.6 | 0.5 |
| p_oodc | 8.7 | 0.3 |
| p_tan | 33.5 | 0.6 |
| p_re | 24.7 | 0.2 |