### PR TITLE
Phase 4: Training Throughput — Get More Epochs in 3 Hours (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -748,6 +748,12 @@ class Config:
     two_phase_lr_2: float = 1e-4       # phase 2 LR
     snapshot_ensemble: bool = False    # GPU 6: average checkpoints at fixed epochs
     snapshot_epochs_str: str = "120,160,200"  # comma-separated snapshot epochs
+    # Phase 4: throughput optimization
+    val_every: int = 1                  # validate every N epochs (1 = every epoch)
+    disable_pcgrad: bool = False        # skip PCGrad dual-backward, use simple combined loss
+    vol_subsample_frac: float = 1.0     # fraction of volume nodes in loss after vol_ramp (0.8 = 80%)
+    compile_mode: str = "default"       # torch.compile mode: "default", "max-autotune", "reduce-overhead"
+    num_workers: int = 4                # data loader workers
 
 
 cfg = sp.parse(Config)
@@ -805,7 +811,7 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
-loader_kwargs = dict(collate_fn=pad_collate, num_workers=4, pin_memory=True,
+loader_kwargs = dict(collate_fn=pad_collate, num_workers=cfg.num_workers, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
 if cfg.debug:
@@ -901,7 +907,7 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
-model = torch.compile(model, mode="default")
+model = torch.compile(model, mode=cfg.compile_mode)
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
 from copy import deepcopy
@@ -1317,6 +1323,14 @@ for epoch in range(MAX_EPOCHS):
             vol_mask_train = torch.zeros_like(vol_mask)
             if n_keep > 0:
                 vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
+        elif cfg.vol_subsample_frac < 1.0:
+            vol_indices = vol_mask.nonzero(as_tuple=False)
+            n_vol = vol_indices.shape[0]
+            n_keep = max(int(n_vol * cfg.vol_subsample_frac), 1)
+            perm = torch.randperm(n_vol, device=vol_mask.device)[:n_keep]
+            vol_mask_train = torch.zeros_like(vol_mask)
+            if n_keep > 0:
+                vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
         else:
             vol_mask_train = vol_mask
 
@@ -1420,7 +1434,7 @@ for epoch in range(MAX_EPOCHS):
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
         is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+        use_pcgrad = (not cfg.disable_pcgrad) and is_indist_pcgrad.any() and is_ood_pcgrad.any()
 
         if use_pcgrad:
             n_a = is_indist_pcgrad.float().sum().clamp(min=1)
@@ -1577,6 +1591,19 @@ for epoch in range(MAX_EPOCHS):
                     sa[k].mul_((snapshot_n - 1) / snapshot_n).add_(snap[k].to(device) / snapshot_n)
 
     # --- Validate across all splits ---
+    _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
+    if not _do_val:
+        dt = time.time() - t0
+        wandb.log({
+            "train/vol_loss": epoch_vol,
+            "train/surf_loss": epoch_surf,
+            "epoch_time_s": dt,
+            "lr": scheduler.get_last_lr()[0],
+            "global_step": global_step,
+        })
+        print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
+        continue
+
     if cfg.swa_cyclic and swa_cyclic_model is not None:
         eval_model = swa_cyclic_model
     elif cfg.snapshot_ensemble and snapshot_avg_model is not None:
@@ -1851,6 +1878,7 @@ if best_metrics:
 else:
     print("No completed epochs (timeout too short?).")
 
+wandb.summary.update({"total_epochs": epoch + 1, "total_time_min": total_time})
 if best_metrics:
     wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})
 


### PR DESCRIPTION
## Hypothesis
Every failed experiment in Phase 4 has one thing in common: fewer epochs than the baseline. The baseline gets ~160 epochs in 3 hours at 65s/epoch. If we can reduce epoch time to 50-55s (via data loading optimization, compilation settings, or node subsampling), we'd get 195-215 epochs — effectively 25-35% more training iterations.

Key levers to try:
1. **Disable PCGrad** (the dual-backward pass): PCGrad computes 2 loss.backward() calls per batch when in-dist and OOD samples coexist. Disabling it saves ~30% of backward time.
2. **Increase num_workers**: Currently 4 workers for data loading. Testing 6 or 8.
3. **Volume node subsampling throughout training**: Instead of ramping from 10%→100% (current), keep subsampling to 80% throughout. Fewer nodes in loss computation = faster epochs.
4. **Disable validation on some epochs**: Currently validates every epoch across 4 splits. Validating every 2-3 epochs saves significant time.
5. **torch.compile mode='max-autotune'**: Currently uses mode='default'. 'max-autotune' may find faster kernels after a longer warmup.

**None of these change the model architecture — they only affect training speed. If we get more epochs, the model will see more data and converge further.**

## Instructions

### Modify `train.py`

1. **Add skip-validation flag:**
```python
val_every: int = 1  # validate every N epochs (1 = every epoch)
```
In training loop: `if (epoch + 1) % cfg.val_every == 0:`

2. **Add PCGrad disable flag:**
```python
disable_pcgrad: bool = False
```
When enabled, skip the PCGrad dual-backward and use simple combined loss.

3. **Add permanent volume subsampling:**
```python
vol_subsample_frac: float = 1.0  # fraction of volume nodes to use in loss (0.8 = 80%)
```
After vol_ramp completes, continue subsampling to vol_subsample_frac instead of using all nodes.

4. **Add compile mode flag:**
```python
compile_mode: str = "default"  # "default", "max-autotune", "reduce-overhead"
```

### GPU Assignments

| GPU | Experiment | Expected speedup | Key params |
|-----|-----------|-----------------|------------|
| 0 | Disable PCGrad | ~30% faster backward | `--disable_pcgrad` |
| 1 | Validate every 2 epochs | ~15% faster | `--val_every 2` |
| 2 | Validate every 3 epochs | ~25% faster | `--val_every 3` |
| 3 | 8 data workers | ~5% faster loading | `num_workers=8` in code |
| 4 | Vol subsample 80% permanently | ~10% faster loss | `--vol_subsample_frac 0.8` |
| 5 | PCGrad off + val_every=2 compound | ~40% faster | `--disable_pcgrad --val_every 2` |
| 6 | PCGrad off + val_every=2 + vol 80% | ~45% faster | `--disable_pcgrad --val_every 2 --vol_subsample_frac 0.8` |
| 7 | max-autotune compile | Varies | `--compile_mode max-autotune` |

### Training Commands

```bash
# GPU 0: Disable PCGrad
CUDA_VISIBLE_DEVICES=0 python train.py --agent alphonse --wandb_name "alphonse/p4-no-pcgrad" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --disable_pcgrad &

# GPU 1: Val every 2
CUDA_VISIBLE_DEVICES=1 python train.py --agent alphonse --wandb_name "alphonse/p4-val2" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --val_every 2 &

# GPU 2: Val every 3
CUDA_VISIBLE_DEVICES=2 python train.py --agent alphonse --wandb_name "alphonse/p4-val3" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --val_every 3 &

# GPU 3: 8 workers (modify num_workers in code to 8)
CUDA_VISIBLE_DEVICES=3 python train.py --agent alphonse --wandb_name "alphonse/p4-8workers" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 &

# GPU 4: Vol subsample 80%
CUDA_VISIBLE_DEVICES=4 python train.py --agent alphonse --wandb_name "alphonse/p4-vol80" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --vol_subsample_frac 0.8 &

# GPU 5: Compound (PCGrad off + val2)
CUDA_VISIBLE_DEVICES=5 python train.py --agent alphonse --wandb_name "alphonse/p4-fast-compound" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --disable_pcgrad --val_every 2 &

# GPU 6: Maximum throughput
CUDA_VISIBLE_DEVICES=6 python train.py --agent alphonse --wandb_name "alphonse/p4-max-throughput" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --disable_pcgrad --val_every 2 --vol_subsample_frac 0.8 &

# GPU 7: max-autotune compile
CUDA_VISIBLE_DEVICES=7 python train.py --agent alphonse --wandb_name "alphonse/p4-maxautotune" \
  --wandb_group phase4-throughput \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --compile_mode max-autotune &
wait
```

**Track both final metrics AND total epochs completed.** Report epoch count alongside val/loss and surface MAE. The key question is: does getting more epochs translate to better metrics?

## Baseline (Multi-Seed Validated)
| Metric | Mean | Std |
|--------|------|-----|
| val/loss | 0.405 | 0.004 |
| p_in | 13.6 | 0.5 |
| p_oodc | 8.7 | 0.3 |
| p_tan | 33.5 | 0.6 |
| p_re | 24.7 | 0.2 |

Baseline achieves ~160 epochs in 3 hours at ~65s/epoch.