### PR TITLE
Phase 4: Combined Best Findings — T_max=180 + disable_pcgrad + val_every=2 (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -747,6 +747,9 @@ class Config:
     two_phase_lr_2: float = 1e-4       # phase 2 LR
     snapshot_ensemble: bool = False    # GPU 6: average checkpoints at fixed epochs
     snapshot_epochs_str: str = "120,160,200"  # comma-separated snapshot epochs
+    # Phase 4: combined best findings
+    disable_pcgrad: bool = False       # disable PCGrad (use single combined loss)
+    val_every: int = 1                 # run validation every N epochs (1 = every epoch)
 
 
 cfg = sp.parse(Config)
@@ -1121,6 +1124,7 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+val_metrics_per_split: dict[str, dict] = {}
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -1419,7 +1423,7 @@ for epoch in range(MAX_EPOCHS):
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
         is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any() and not cfg.disable_pcgrad
 
         if use_pcgrad:
             n_a = is_indist_pcgrad.float().sum().clamp(min=1)
@@ -1576,6 +1580,7 @@ for epoch in range(MAX_EPOCHS):
                     sa[k].mul_((snapshot_n - 1) / snapshot_n).add_(snap[k].to(device) / snapshot_n)
 
     # --- Validate across all splits ---
+    _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0  # always validate first epoch
     if cfg.swa_cyclic and swa_cyclic_model is not None:
         eval_model = swa_cyclic_model
     elif cfg.snapshot_ensemble and snapshot_avg_model is not None:
@@ -1588,10 +1593,14 @@ for epoch in range(MAX_EPOCHS):
         eval_model = model
     eval_model.eval()
     model.eval()
-    val_metrics_per_split: dict[str, dict] = {}
-    val_loss_sum = 0.0
+
+    if _do_val:
+        val_metrics_per_split = {}
+        val_loss_sum = 0.0
 
     for split_name, vloader in val_loaders.items():
+        if not _do_val:
+            break  # skip validation loop entirely
         val_vol = 0.0
         val_surf = 0.0
         mae_surf = torch.zeros(3, device=device)
@@ -1735,6 +1744,20 @@ for epoch in range(MAX_EPOCHS):
             f"{split_name}/mae_surf_p":  mae_surf[2].item(),
         }
         val_loss_sum += split_loss
+
+    if not _do_val:
+        # Skip validation — log train metrics only
+        dt = time.time() - t0
+        peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9 if torch.cuda.is_available() else 0.0
+        wandb.log({"train/vol_loss": epoch_vol, "train/surf_loss": epoch_surf,
+                    "lr": scheduler.get_last_lr()[0], "epoch_time_s": dt, "global_step": global_step})
+        learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
+        for i, f in enumerate(learned_freqs):
+            wandb.log({f"fourier_freq_{i}": f})
+        print(f"Epoch {epoch+1:3d} ({dt:.0f}s) [{peak_mem_gb:.1f}GB]  "
+              f"train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  val[skipped]")
+        model.train()
+        continue
 
     # 4-split val/loss (all splits) — used for checkpoint selection
     _checkpoint_names = VAL_SPLIT_NAMES  # all 4 splits instead of _3split_names


### PR DESCRIPTION
## Hypothesis
Phase 4 identified two independent improvements:
1. **T_max=180** (nezuko #1845): val/loss=0.3985, p_in=12.9, p_tan=32.4
2. **disable_pcgrad** (alphonse #1846): val/loss=0.3941, p_in=13.1, p_tan=32.7

Both are undergoing multi-seed validation separately. This PR tests their **compound** — if both are real improvements operating through different mechanisms (schedule optimization vs throughput gain), they should stack.

**NO code changes needed** — rebase onto the latest noam (which now includes bug fixes from #1850) and use existing CLI flags.

## Instructions

### GPU Assignments (all seeded for comparability)

| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0 | T_max=180 + disable_pcgrad, seed 42 | `--cosine_T_max 180 --disable_pcgrad --seed 42` |
| 1 | T_max=180 + disable_pcgrad, seed 43 | `--cosine_T_max 180 --disable_pcgrad --seed 43` |
| 2 | T_max=180 + disable_pcgrad, seed 44 | `--cosine_T_max 180 --disable_pcgrad --seed 44` |
| 3 | T_max=180 + disable_pcgrad, seed 45 | `--cosine_T_max 180 --disable_pcgrad --seed 45` |
| 4 | T_max=180 + disable_pcgrad + val_every=2, seed 42 | `--cosine_T_max 180 --disable_pcgrad --val_every 2 --seed 42` |
| 5 | T_max=180 + disable_pcgrad + val_every=2, seed 43 | `--cosine_T_max 180 --disable_pcgrad --val_every 2 --seed 43` |
| 6 | Baseline seed 72 | Standard baseline |
| 7 | Baseline seed 73 | Standard baseline |

### Training Commands

```bash
# GPUs 0-3: T_max=180 + disable_pcgrad (4 seeds)
for i in 0 1 2 3; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent fern --wandb_name "fern/p4-best-compound-s$((42+i))" \
    --wandb_group phase4-combined-best \
    --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --disable_pcgrad --seed $((42+i)) &
done

# GPUs 4-5: + val_every=2
for i in 4 5; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent fern --wandb_name "fern/p4-best-val2-s$((38+i))" \
    --wandb_group phase4-combined-best \
    --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --disable_pcgrad --val_every 2 --seed $((38+i)) &
done

# GPUs 6-7: Baselines
for i in 6 7; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent fern --wandb_name "fern/p4-baseline-s$((66+i))" \
    --wandb_group phase4-baseline-seeds \
    --field_decoder --adaln_output --use_lion --lr 2e-4 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --seed $((66+i)) &
done
wait
```

## Baseline (Multi-Seed Validated)
| Metric | Mean | Std |
|--------|------|-----|
| val/loss | 0.403 | 0.004 |
| p_in | 13.5 | 0.5 |
| p_oodc | 8.6 | 0.3 |
| p_tan | 33.2 | 0.5 |
| p_re | 24.8 | 0.1 |

**Improvement threshold:** val/loss < 0.395 or p_tan < 31 across 4+ seeds.