### PR TITLE
Phase 4: T_max=180 + No PCGrad — Additional Seeds for Validation (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -747,6 +747,7 @@ class Config:
     two_phase_lr_2: float = 1e-4       # phase 2 LR
     snapshot_ensemble: bool = False    # GPU 6: average checkpoints at fixed epochs
     snapshot_epochs_str: str = "120,160,200"  # comma-separated snapshot epochs
+    disable_pcgrad: bool = False       # disable PCGrad entirely
 
 
 cfg = sp.parse(Config)
@@ -1419,7 +1420,7 @@ for epoch in range(MAX_EPOCHS):
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
         is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+        use_pcgrad = (not cfg.disable_pcgrad) and is_indist_pcgrad.any() and is_ood_pcgrad.any()
 
         if use_pcgrad:
             n_a = is_indist_pcgrad.float().sum().clamp(min=1)


### PR DESCRIPTION
## Hypothesis
Fern (#1856) and Edward (#1857) are testing the compound T_max=180 + disable_pcgrad. This PR provides additional seeds (46-49, 50-53) to maximize statistical power for the most important Phase 4 finding.

**NO code changes** — existing CLI flags only.

## Instructions

| GPU | Experiment | Flags |
|-----|-----------|-------|
| 0-3 | T_max=180 + disable_pcgrad, seeds 46-49 | \`--cosine_T_max 180 --disable_pcgrad\` |
| 4-5 | T_max=180 only (no PCGrad change), seeds 46-47 | \`--cosine_T_max 180\` |
| 6-7 | Baseline seeds 76-77 | Standard baseline |

```bash
for i in 0 1 2 3; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent thorfinn --wandb_name "thorfinn/p4-t180-nopc-s$((46+i))" \
    --wandb_group phase4-combined-best \
    --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --disable_pcgrad --seed $((46+i)) &
done

for i in 4 5; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent thorfinn --wandb_name "thorfinn/p4-t180-s$((42+i))" \
    --wandb_group phase4-combined-best \
    --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --seed $((42+i)) &
done

for i in 6 7; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent thorfinn --wandb_name "thorfinn/p4-baseline-s$((70+i))" \
    --wandb_group phase4-baseline-seeds \
    --field_decoder --adaln_output --use_lion --lr 2e-4 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --seed $((70+i)) &
done
wait
```

## Baseline
| Metric | Mean | Std |
|--------|------|-----|
| val/loss | 0.403 | 0.004 |
| p_in | 13.5 | 0.5 |
| p_tan | 33.2 | 0.5 |
| p_oodc | 8.6 | 0.3 |
| p_re | 24.8 | 0.1 |