### PR TITLE
Phase 4 BOLD: Residual Prediction on Analytical Physics Prior (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -748,6 +748,11 @@ class Config:
     two_phase_lr_2: float = 1e-4       # phase 2 LR
     snapshot_ensemble: bool = False    # GPU 6: average checkpoints at fixed epochs
     snapshot_epochs_str: str = "120,160,200"  # comma-separated snapshot epochs
+    # Phase 4: Residual prediction
+    residual_prediction: bool = False  # predict residual from freestream prior
+    residual_surface_only: bool = False  # only use residual targets on surface nodes
+    residual_dist_prior: bool = False  # distance-scaled prior (1 at freestream, 0 at surface)
+    disable_pcgrad: bool = False       # disable PCGrad (use simple combined loss)
 
 
 cfg = sp.parse(Config)
@@ -1232,14 +1237,35 @@ for epoch in range(MAX_EPOCHS):
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
+        prior_phys = None  # freestream prior in Cp space
         if cfg.raw_targets:
             y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
         else:
             y_phys = _phys_norm(y, Umag, q)
+            if cfg.residual_prediction:
+                # Freestream prior in Cp space: Ux/Umag = cos(AoA), Uy/Umag = sin(AoA), p/q = 0
+                # Denormalize AoA from standardized input (index 14)
+                aoa_raw = x[:, 0, 14:15] * stats['x_std'][14] + stats['x_mean'][14]  # [B, 1]
+                prior_ux = torch.cos(aoa_raw).unsqueeze(1).expand_as(y_phys[:, :, 0:1])
+                prior_uy = torch.sin(aoa_raw).unsqueeze(1).expand_as(y_phys[:, :, 1:2])
+                prior_p = torch.zeros_like(y_phys[:, :, 2:3])
+                prior_phys = torch.cat([prior_ux, prior_uy, prior_p], dim=-1)
+                if cfg.residual_dist_prior:
+                    # Scale prior by distance-to-surface: 1 at freestream, 0 at surface
+                    dist_scale = (dist_feat / (dist_feat.max(dim=1, keepdim=True).values + 1e-8)).clamp(0, 1)
+                    prior_phys = prior_phys * dist_scale
+                if cfg.residual_surface_only:
+                    # Only subtract prior on surface nodes
+                    surf_float = is_surface.float().unsqueeze(-1)
+                    y_target = y_phys - prior_phys * surf_float
+                else:
+                    y_target = y_phys - prior_phys
+            else:
+                y_target = y_phys
             if cfg.log_pressure:
-                y_phys = y_phys.clone()
-                y_phys[:, :, 2:3] = y_phys[:, :, 2:3].abs().add(1).log() * y_phys[:, :, 2:3].sign()
-            y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                y_target = y_target.clone()
+                y_target[:, :, 2:3] = y_target[:, :, 2:3].abs().add(1).log() * y_target[:, :, 2:3].sign()
+            y_norm = (y_target - phys_stats["y_mean"]) / phys_stats["y_std"]
         if model.training and not cfg.no_target_noise:
             noise_progress = min(1.0, epoch / max(cfg.noise_anneal_epochs, 1))
             if cfg.half_target_noise:
@@ -1420,7 +1446,7 @@ for epoch in range(MAX_EPOCHS):
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
         is_indist_pcgrad = ~is_ood_pcgrad
-        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any()
+        use_pcgrad = is_indist_pcgrad.any() and is_ood_pcgrad.any() and not cfg.disable_pcgrad
 
         if use_pcgrad:
             n_a = is_indist_pcgrad.float().sum().clamp(min=1)
@@ -1635,10 +1661,27 @@ for epoch in range(MAX_EPOCHS):
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
                 else:
                     y_phys = _phys_norm(y, Umag, q)
+                    eval_prior_phys = None
+                    if cfg.residual_prediction:
+                        aoa_raw = x[:, 0, 14:15] * stats['x_std'][14] + stats['x_mean'][14]
+                        ep_ux = torch.cos(aoa_raw).unsqueeze(1).expand_as(y_phys[:, :, 0:1])
+                        ep_uy = torch.sin(aoa_raw).unsqueeze(1).expand_as(y_phys[:, :, 1:2])
+                        ep_p = torch.zeros_like(y_phys[:, :, 2:3])
+                        eval_prior_phys = torch.cat([ep_ux, ep_uy, ep_p], dim=-1)
+                        if cfg.residual_dist_prior:
+                            raw_dsdf_v = x[:, :, 2:10]
+                            dist_v = torch.log1p(raw_dsdf_v.abs().min(dim=-1, keepdim=True).values * 10.0)
+                            dist_scale_v = (dist_v / (dist_v.max(dim=1, keepdim=True).values + 1e-8)).clamp(0, 1)
+                            eval_prior_phys = eval_prior_phys * dist_scale_v
+                        if cfg.residual_surface_only:
+                            eval_prior_phys = eval_prior_phys * is_surface.float().unsqueeze(-1)
+                        y_target = y_phys - eval_prior_phys
+                    else:
+                        y_target = y_phys
                     if cfg.log_pressure:
-                        y_phys = y_phys.clone()
-                        y_phys[:, :, 2:3] = y_phys[:, :, 2:3].abs().add(1).log() * y_phys[:, :, 2:3].sign()
-                    y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                        y_target = y_target.clone()
+                        y_target[:, :, 2:3] = y_target[:, :, 2:3].abs().add(1).log() * y_target[:, :, 2:3].sign()
+                    y_norm = (y_target - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 # Per-sample std normalization: skip tandem samples
                 raw_gap = x[:, 0, 21]
@@ -1699,6 +1742,8 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.log_pressure:
                         pred_phys = pred_phys.clone()
                         pred_phys[:, :, 2:3] = pred_phys[:, :, 2:3].sign() * (pred_phys[:, :, 2:3].abs().exp() - 1)
+                    if cfg.residual_prediction and eval_prior_phys is not None:
+                        pred_phys = pred_phys + eval_prior_phys  # add prior back
                     if cfg.tight_denorm_clamps:
                         _pd = pred_phys.clone()
                         _pd[:, :, 0:1] = pred_phys[:, :, 0:1].clamp(-5, 5) * Umag


### PR DESCRIPTION
## Hypothesis — PARADIGM SHIFT
Instead of predicting raw flow fields from scratch, predict the RESIDUAL between a simple analytical approximation and the true CFD solution. This fundamentally changes what the neural network needs to learn.

**Why this is radical:** The current model must learn the ENTIRE flow field — from freestream conditions to boundary layer details. But ~80% of the flow field is predictable from simple physics (potential flow + boundary layer theory). If we provide this as a prior, the model only needs to learn the 20% that's hard — separation, wake interactions, tandem interference. This is analogous to skip connections in ResNets but at the problem level.

**Implementation:** 
1. Compute a simple analytical approximation for each sample at data loading time (or training time)
2. Train the model to predict y_residual = y_true - y_prior instead of y_true
3. At evaluation, reconstruct: y_pred = y_prior + model_output

**What is the prior?**
- **Freestream initialization**: Ux = Umag * cos(AoA), Uy = Umag * sin(AoA), p = 0. This is trivially computable from the input features.
- **The model already has access to the condition features** — so we're teaching it to predict how the flow DEVIATES from freestream, rather than the absolute values.

**torch.compile compatible:** Just changes the target computation, no new ops.

## Instructions

### Modify `train.py`

1. **Compute freestream prior before loss:**
```python
if cfg.residual_prediction:
    # Freestream prior: Ux = Umag * cos(AoA), Uy = Umag * sin(AoA), p = 0
    # In physics-normalized space, this is approximately: Ux_norm ≈ 1, Uy_norm ≈ 0, p_norm ≈ 0
    # But we need the actual Umag and AoA from input features
    aoa_rad = x[:, 0, 14:15] * stats['x_std'][14]  + stats['x_mean'][14]  # denormalize AoA
    # Simple prior: uniform flow in the AoA direction
    prior_ux = torch.cos(aoa_rad).unsqueeze(1).expand_as(y_phys[:, :, 0:1])  # [B, N, 1]
    prior_uy = torch.sin(aoa_rad).unsqueeze(1).expand_as(y_phys[:, :, 1:2])
    prior_p = torch.zeros_like(y_phys[:, :, 2:3])
    prior = torch.cat([prior_ux, prior_uy, prior_p], dim=-1)  # [B, N, 3] in Cp space
    
    # Compute residual target
    y_residual = y_phys - prior
    # Normalize residual instead of y_phys
    y_norm = (y_residual - phys_stats["y_mean"]) / phys_stats["y_std"]
    
    # At eval time: pred_phys = pred * std + mean + prior
```

2. **Modify evaluation to add prior back:**
```python
if cfg.residual_prediction:
    pred_residual = pred * phys_stats["y_std"] + phys_stats["y_mean"]
    pred_phys = pred_residual + prior  # add prior back
```

3. **Add CLI flag:** `residual_prediction: bool = False`

### GPU Assignments

| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0-2 | Residual prediction, seeds 42-44 | `--residual_prediction --cosine_T_max 180 --seed XX` |
| 3 | Residual prediction + disable_pcgrad | `--residual_prediction --cosine_T_max 180 --disable_pcgrad --seed 42` |
| 4 | Residual prediction + surface-only residual (volume uses raw) | `--residual_prediction --residual_surface_only --seed 42` |
| 5 | Residual prediction with position-dependent prior (distance-scaled) | `--residual_prediction --residual_dist_prior --seed 42` |
| 6-7 | Baselines seeds 80-81 (with T_max=180) | Standard new baseline |

## Baseline (Phase 4 Current)
| Metric | Mean (4 seeds) | Std |
|--------|---------------|-----|
| val/loss | 0.4016 | 0.001 |
| p_in | 13.3 | 0.2 |
| p_oodc | 8.3 | 0.2 |
| p_tan | 33.1 | 0.4 |
| p_re | 24.7 | 0.2 |