### PR TITLE
Phase 4 BOLD: Surface-Only Training — Eliminate Volume Loss Entirely (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -754,6 +754,12 @@ class Config:
     vol_subsample_frac: float = 1.0     # fraction of volume nodes in loss after vol_ramp (0.8 = 80%)
     compile_mode: str = "default"       # torch.compile mode: "default", "max-autotune", "reduce-overhead"
     num_workers: int = 4                # data loader workers
+    # Phase 4: surface-only training
+    surface_only_loss: bool = False     # eliminate volume loss entirely, train only on surface nodes
+    heavy_surface: bool = False         # minimal volume loss (0.01x) with fixed high surface weight
+    surf_weight_fixed: float = 100.0    # fixed surface weight for heavy_surface mode
+    surface_pressure_only: bool = False # only train on surface pressure channel (ignore surface velocity)
+    surface_curriculum: bool = False    # curriculum: ramp vol_weight from 1.0 to 0.0 over training
 
 
 cfg = sp.parse(Config)
@@ -1372,6 +1378,13 @@ for epoch in range(MAX_EPOCHS):
         else:
             tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
+
+        # Surface-only training: also compute full-channel surface loss for surface_only mode
+        if cfg.surface_only_loss and not cfg.surface_pressure_only:
+            # All 3 channels on surface (not just pressure)
+            surf_all_per_sample = (abs_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / (surf_mask.sum(dim=1).clamp(min=1).float() * 3)
+            surf_loss_full = (surf_all_per_sample * tandem_boost).mean()
+
         if cfg.uncertainty_loss:
             bm = _base_model
             surf_ux_loss = (abs_err[:, :, 0:1] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
@@ -1381,37 +1394,57 @@ for epoch in range(MAX_EPOCHS):
                     surf_ux_loss * torch.exp(-2 * bm.log_sigma_surf_ux) / 2 + bm.log_sigma_surf_ux +
                     surf_uy_loss * torch.exp(-2 * bm.log_sigma_surf_uy) / 2 + bm.log_sigma_surf_uy +
                     surf_p_loss  * torch.exp(-2 * bm.log_sigma_surf_p)  / 2 + bm.log_sigma_surf_p)
+        elif cfg.surface_only_loss:
+            # Surface-only: no volume loss at all
+            if cfg.surface_pressure_only:
+                # Only surface pressure channel
+                loss = surf_weight * surf_loss
+            else:
+                # All surface channels (pressure-weighted + full)
+                loss = surf_weight * surf_loss + 5.0 * surf_loss_full
+        elif cfg.heavy_surface:
+            # Minimal volume loss + fixed high surface weight
+            loss = 0.01 * vol_loss + cfg.surf_weight_fixed * surf_loss
+        elif cfg.surface_curriculum:
+            # Curriculum: ramp vol_weight from 1.0 → 0.0 over training
+            curriculum_progress = min(1.0, epoch / max(cfg.cosine_T_max * 0.6, 1.0))
+            vol_curriculum_weight = 1.0 - curriculum_progress
+            loss = vol_curriculum_weight * vol_loss + surf_weight * surf_loss
         else:
             loss = vol_loss + surf_weight * surf_loss
 
-        # Multi-scale loss: coarse spatial pooling
+        # Multi-scale loss: coarse spatial pooling (skip for surface_only_loss since it's volume-based)
         _coarse_loss = None
-        coarse_pool_size = 64
-        B, N, C = pred.shape
-        n_groups = N // coarse_pool_size
-        if n_groups > 1:
-            # Sort by x-coordinate for spatially coherent groups
-            raw_x_coord = x[:, :, 0]  # x-coordinate
-            sort_idx = raw_x_coord.argsort(dim=1)
-            pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
-            y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
-            mask_sorted = torch.gather(mask, 1, sort_idx)
-            # Pool predictions and targets over groups of 64 nodes
-            pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
-            y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
-            mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
+        if not cfg.surface_only_loss:
+            coarse_pool_size = 64
+            B, N, C = pred.shape
+            n_groups = N // coarse_pool_size
+            if n_groups > 1:
+                # Sort by x-coordinate for spatially coherent groups
+                raw_x_coord = x[:, :, 0]  # x-coordinate
+                sort_idx = raw_x_coord.argsort(dim=1)
+                pred_sorted = torch.gather(pred, 1, sort_idx.unsqueeze(-1).expand_as(pred))
+                y_sorted = torch.gather(y_norm, 1, sort_idx.unsqueeze(-1).expand_as(y_norm))
+                mask_sorted = torch.gather(mask, 1, sort_idx)
+                # Pool predictions and targets over groups of 64 nodes
+                pred_trunc = pred_sorted[:, :n_groups * coarse_pool_size]
+                y_trunc = y_sorted[:, :n_groups * coarse_pool_size]
+                mask_trunc = mask_sorted[:, :n_groups * coarse_pool_size]
 
-            mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)  # [B, G, P, 1]
-            pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
-            y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
-            pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
-            y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
-            mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
+                mask_trunc_f = mask_trunc.float().reshape(B, n_groups, coarse_pool_size).unsqueeze(-1)  # [B, G, P, 1]
+                pred_g = pred_trunc.reshape(B, n_groups, coarse_pool_size, C)
+                y_g = y_trunc.reshape(B, n_groups, coarse_pool_size, C)
+                pred_coarse = (pred_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
+                y_coarse = (y_g * mask_trunc_f).sum(dim=2) / mask_trunc_f.sum(dim=2).clamp(min=1)
+                mask_coarse = mask_trunc.reshape(B, n_groups, coarse_pool_size).any(dim=2)
 
-            coarse_err = (pred_coarse - y_coarse).abs()
-            coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
-            _coarse_loss = coarse_loss
-            loss = loss + 1.0 * coarse_loss
+                coarse_err = (pred_coarse - y_coarse).abs()
+                coarse_loss = (coarse_err * mask_coarse.unsqueeze(-1)).sum() / mask_coarse.sum().clamp(min=1)
+                _coarse_loss = coarse_loss
+                if cfg.surface_curriculum:
+                    loss = loss + vol_curriculum_weight * coarse_loss
+                else:
+                    loss = loss + 1.0 * coarse_loss
 
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
@@ -1520,7 +1553,13 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
                         ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _train_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.surface_curriculum:
+            _train_log["train/vol_curriculum_weight"] = vol_curriculum_weight
+        if cfg.surface_only_loss or cfg.heavy_surface or cfg.surface_curriculum:
+            _train_log["train/surf_loss_raw"] = surf_loss.item()
+            _train_log["train/vol_loss_raw"] = vol_loss.item()
+        wandb.log(_train_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis — PARADIGM SHIFT
The current model trains on BOTH volume and surface nodes, with an adaptive surface weight. But our evaluation metric is ONLY surface MAE. What if we eliminate the volume loss entirely and train exclusively on surface node prediction?

**Why this is radical:** The model currently spends the majority of its gradient signal on volume nodes (~99% of nodes are volume, only ~1% are surface). Even with a surface weight of 5-50x, the volume gradient dominates. By removing volume loss:
1. ALL gradient signal goes to improving surface predictions
2. The model can allocate its entire representation capacity to surface accuracy
3. Training epochs are effectively faster (no volume loss computation)

**Counter-argument:** Volume nodes provide spatial context that helps surface predictions. The model needs to understand the global flow field to predict surface values. But the model still PROCESSES all nodes through its attention mechanism — we're only changing what nodes contribute to the LOSS.

**Variants to test:**
- **Full surface-only**: Zero volume loss weight
- **Heavy surface**: surf_weight=100, very small volume loss (0.01x baseline)
- **Surface pressure only**: Only train on surface pressure (ignore surface velocity)
- **Curriculum**: Start with balanced loss, transition to surface-only at epoch 50

## Instructions

### Modify `train.py`

1. **Add surface-only mode:**
```python
if cfg.surface_only_loss:
    # Skip volume loss entirely
    loss = surf_weight * surf_loss + 0.01 * re_loss + 0.01 * aoa_loss
    # Skip coarse loss too (it's volume-based)
elif cfg.heavy_surface:
    # Minimal volume loss
    loss = 0.01 * vol_loss + cfg.surf_weight_fixed * surf_loss
```

2. **Add CLI flags:**
```python
surface_only_loss: bool = False
heavy_surface: bool = False
surface_pressure_only: bool = False  # only pressure channel in surface loss
surface_curriculum: bool = False  # ramp vol_weight from 1.0 to 0.0
```

### GPU Assignments

| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0-2 | Surface-only, seeds 42-44 | \`--surface_only_loss --cosine_T_max 180 --disable_pcgrad\` |
| 3 | Heavy surface (sw=100) | \`--heavy_surface --surf_weight_fixed 100 --cosine_T_max 180 --disable_pcgrad\` |
| 4 | Surface pressure only | \`--surface_only_loss --surface_pressure_only --cosine_T_max 180 --disable_pcgrad\` |
| 5 | Surface curriculum (1.0→0.0 vol weight) | \`--surface_curriculum --cosine_T_max 180 --disable_pcgrad\` |
| 6-7 | Baseline seeds 86-87 (new baseline with T_max=180 + disable_pcgrad) | Standard |

### Training Commands

```bash
# GPUs 0-2: Surface-only multi-seed
for i in 0 1 2; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent tanjiro --wandb_name "tanjiro/p4-surfonly-s$((42+i))" \
    --wandb_group phase4-surface-only \
    --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --disable_pcgrad --surface_only_loss --seed $((42+i)) &
done

# GPU 3: Heavy surface weight
CUDA_VISIBLE_DEVICES=3 python train.py --agent tanjiro --wandb_name "tanjiro/p4-heavy-surf" \
  --wandb_group phase4-surface-only \
  --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --disable_pcgrad --heavy_surface --surf_weight_fixed 100 --seed 42 &

# GPU 4: Surface pressure only
CUDA_VISIBLE_DEVICES=4 python train.py --agent tanjiro --wandb_name "tanjiro/p4-surfpres-only" \
  --wandb_group phase4-surface-only \
  --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --disable_pcgrad --surface_only_loss --surface_pressure_only --seed 42 &

# GPU 5: Surface curriculum
CUDA_VISIBLE_DEVICES=5 python train.py --agent tanjiro --wandb_name "tanjiro/p4-surf-curriculum" \
  --wandb_group phase4-surface-only \
  --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --disable_pcgrad --surface_curriculum --seed 42 &

# GPUs 6-7: New baselines with T_max=180 + disable_pcgrad
for i in 6 7; do
  CUDA_VISIBLE_DEVICES=$i python train.py --agent tanjiro --wandb_name "tanjiro/p4-baseline-s$((80+i))" \
    --wandb_group phase4-baseline-seeds \
    --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 \
    --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
    --n_layers 3 --slice_num 96 --tandem_ramp \
    --domain_layernorm --domain_velhead --ema_decay 0.999 \
    --weight_decay 5e-5 --disable_pcgrad --seed $((80+i)) &
done
wait
```

## Baseline (Phase 4 Current)
| Metric | Mean (4 seeds) | Std |
|--------|---------------|-----|
| val/loss | 0.403 | 0.003 |
| p_in | 13.6 | 0.4 |
| p_oodc | 8.6 | 0.1 |
| p_tan | 33.1 | 0.6 |
| p_re | 24.7 | 0.1 |