### PR TITLE
Phase 4 BOLD: Pressure-First Sequential Prediction — Predict p Then Condition v (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -350,16 +350,8 @@ class TransolverBlock(nn.Module):
                 self.expert2 = nn.Sequential(
                     nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim)
                 )
-            elif domain_velhead:
-                # Domain-specific output heads: separate for single-foil vs tandem
-                self.velhead_single = nn.Sequential(
-                    nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim)
-                )
-                self.velhead_tandem = nn.Sequential(
-                    nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim)
-                )
-            elif field_decoder and pressure_first:
-                # Pressure-first: predict p, then condition v on p
+            elif pressure_first:
+                # Pressure-first: predict p, then condition v on p (takes priority over domain_velhead/field_decoder)
                 if pressure_deep:
                     self.pres_head = nn.Sequential(
                         nn.Linear(hidden_dim, hidden_dim * 2), nn.GELU(),
@@ -373,6 +365,14 @@ class TransolverBlock(nn.Module):
                 # Velocity head conditioned on predicted pressure: input is hidden_dim + 1
                 self.vel_head_conditioned = nn.Sequential(
                     nn.Linear(hidden_dim + 1, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, 2)
+                )
+            elif domain_velhead:
+                # Domain-specific output heads: separate for single-foil vs tandem
+                self.velhead_single = nn.Sequential(
+                    nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim)
+                )
+                self.velhead_tandem = nn.Sequential(
+                    nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim)
                 )
             elif field_decoder:
                 self.vel_head = nn.Sequential(
@@ -422,6 +422,13 @@ class TransolverBlock(nn.Module):
             if self.soft_moe:
                 gate = self.gate_net(fx_ln)  # [B, N, 2]
                 return gate[:, :, 0:1] * self.expert1(fx_ln) + gate[:, :, 1:2] * self.expert2(fx_ln)
+            elif self.pressure_first:
+                # Pressure-first: predict p, then condition v on p
+                p_pred = self.pres_head(fx_ln)  # [B, N, 1]
+                p_cond = p_pred if self.pressure_no_detach else p_pred.detach()
+                vel_input = torch.cat([fx_ln, p_cond], dim=-1)  # [B, N, H+1]
+                v_pred = self.vel_head_conditioned(vel_input)  # [B, N, 2]
+                return torch.cat([v_pred, p_pred], dim=-1)
             elif self.domain_velhead:
                 out_s = self.velhead_single(fx_ln)
                 out_t = self.velhead_tandem(fx_ln)
@@ -429,13 +436,6 @@ class TransolverBlock(nn.Module):
                     is_tan = (tandem_mask.view(-1) > 0.5).view(-1, 1, 1)
                     return torch.where(is_tan.expand_as(out_s), out_t, out_s)
                 return out_s
-            elif self.field_decoder and self.pressure_first:
-                # Pressure-first: predict p, then condition v on p
-                p_pred = self.pres_head(fx_ln)  # [B, N, 1]
-                p_cond = p_pred if self.pressure_no_detach else p_pred.detach()
-                vel_input = torch.cat([fx_ln, p_cond], dim=-1)  # [B, N, H+1]
-                v_pred = self.vel_head_conditioned(vel_input)  # [B, N, 2]
-                return torch.cat([v_pred, p_pred], dim=-1)
             elif self.field_decoder:
                 return torch.cat([self.vel_head(fx_ln), self.pres_head(fx_ln)], dim=-1)
             elif self.adaln_output and condition is not None:


### PR DESCRIPTION
## Hypothesis — PARADIGM SHIFT
Predict pressure FIRST with a dedicated pathway, then condition velocity prediction on the predicted pressure. The current shared backbone forces pressure and velocity gradients to compete. Separating them eliminates this multi-task conflict.

**Evidence:**
- ML4CFD competition OB-GNN: Separate models per field to avoid gradient conflicts
- LatentFlow (arXiv:2508.16648): Pressure-conditioned velocity reconstruction
- Pressure is our hardest channel (p_tan=33.1) — giving it its own pathway focuses capacity

**torch.compile compatible:** Just reorders operations within the existing field_decoder.

## Instructions

### Modify last TransolverBlock:

```python
if cfg.pressure_first:
    # Step 1: Predict pressure
    p_pred = self.pres_head(fx_ln)  # [B, N, 1]
    
    # Step 2: Condition velocity on predicted pressure
    p_detached = p_pred.detach()  # no gradient from vel back to pres
    vel_input = torch.cat([fx_ln, p_detached], dim=-1)
    v_pred = self.vel_head_conditioned(vel_input)  # wider input: H+1 → 2
    
    return torch.cat([v_pred, p_pred], dim=-1)
```

### CLI flags:
```python
pressure_first: bool = False
```

### GPU Assignments
| GPU | Experiment | Key params |
|-----|-----------|------------|
| 0-2 | Pressure-first, seeds 42-44 | \`--pressure_first --cosine_T_max 180 --disable_pcgrad\` |
| 3 | Pressure-first + no detach (gradient flows both ways) | \`--pressure_first --pressure_no_detach\` |
| 4 | Pressure-first + deeper pressure head (3 layers) | \`--pressure_first --pressure_deep\` |
| 5 | Pressure-first + separate backbone layers for p | \`--pressure_first --pressure_separate_last_block\` |
| 6-7 | Baseline seeds 92-93 | Standard |

## Baseline
| Metric | Mean | Std |
|--------|------|-----|
| val/loss | 0.403 | 0.003 |
| p_tan | 33.1 | 0.6 |