### PR TITLE
Phase 4 BOLD: Coarse-to-Fine Node Curriculum — Physical Node Removal for Speedup (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -754,6 +754,11 @@ class Config:
     vol_subsample_frac: float = 1.0     # fraction of volume nodes in loss after vol_ramp (0.8 = 80%)
     compile_mode: str = "default"       # torch.compile mode: "default", "max-autotune", "reduce-overhead"
     num_workers: int = 4                # data loader workers
+    # Phase 4: coarse-to-fine node curriculum
+    coarse_to_fine: bool = False        # physically remove volume nodes early, ramp to 100%
+    coarse_to_fine_start: float = 0.15  # start fraction of volume nodes
+    coarse_to_fine_epochs: int = 100    # epochs to ramp to 100%
+    coarse_surf_weight: float = -1.0    # override surf_weight during coarse phase (-1 = no override)
 
 
 cfg = sp.parse(Config)
@@ -1139,6 +1144,9 @@ for epoch in range(MAX_EPOCHS):
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Override surf_weight during coarse-to-fine phase
+    if cfg.coarse_to_fine and cfg.coarse_surf_weight > 0 and epoch < cfg.coarse_to_fine_epochs:
+        surf_weight = cfg.coarse_surf_weight
 
     # --- Train ---
     model.train()
@@ -1153,6 +1161,34 @@ for epoch in range(MAX_EPOCHS):
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
+
+        # --- Coarse-to-fine: physically remove volume nodes for speedup ---
+        if cfg.coarse_to_fine and model.training:
+            frac = min(1.0, cfg.coarse_to_fine_start + (1.0 - cfg.coarse_to_fine_start) * epoch / cfg.coarse_to_fine_epochs)
+            if frac < 1.0:
+                B, N, D = x.shape
+                keep_masks = []
+                for b in range(B):
+                    surf_idx = is_surface[b].nonzero(as_tuple=True)[0]
+                    vol_idx = (~is_surface[b] & mask[b]).nonzero(as_tuple=True)[0]
+                    n_vol_keep = max(int(len(vol_idx) * frac), 1)
+                    vol_keep = vol_idx[torch.randperm(len(vol_idx), device=x.device)[:n_vol_keep]]
+                    keep_idx = torch.cat([surf_idx, vol_keep]).sort().values
+                    keep_masks.append(keep_idx)
+                # Compact: gather only kept nodes
+                max_keep = max(len(m) for m in keep_masks)
+                x_compact = torch.zeros(B, max_keep, D, device=x.device, dtype=x.dtype)
+                y_compact = torch.zeros(B, max_keep, 3, device=y.device, dtype=y.dtype)
+                mask_compact = torch.zeros(B, max_keep, dtype=torch.bool, device=x.device)
+                is_surface_compact = torch.zeros(B, max_keep, dtype=torch.bool, device=x.device)
+                for b in range(B):
+                    n = len(keep_masks[b])
+                    x_compact[b, :n] = x[b, keep_masks[b]]
+                    y_compact[b, :n] = y[b, keep_masks[b]]
+                    mask_compact[b, :n] = True
+                    is_surface_compact[b, :n] = is_surface[b, keep_masks[b]]
+                x, y, mask, is_surface = x_compact, y_compact, mask_compact, is_surface_compact
+                wandb.log({"train/coarse_frac": frac, "train/coarse_nodes": max_keep}, commit=False)
 
         # --- Data augmentation (training-only, applied before normalization) ---
         if model.training and cfg.aug != "none" and epoch >= cfg.aug_start_epoch:


### PR DESCRIPTION
## Hypothesis — RADICAL THROUGHPUT APPROACH
Train on 15% of volume nodes initially, ramping to 100% over 100 epochs. CRITICALLY, physically REMOVE the dropped nodes from the forward pass (don't zero them) using torch.gather to compact the input tensors. This gives a genuine 3-5x speedup in early epochs → many more gradient updates → better converged early representations.

**Difference from previous progressive mesh (#1843):** PR #1843 ZEROED dropped nodes without removing them from the forward pass — NO speedup. This PR PHYSICALLY REMOVES them, making each forward pass genuinely faster.

**Evidence:** arXiv:2509.13138 showed 50% training time reduction with node subsampling.

**Key:** Surface nodes are ALWAYS kept at full resolution. Only volume nodes are subsampled.

## Instructions

### Modify data processing in training loop:

```python
if cfg.coarse_to_fine and model.training:
    frac = min(1.0, 0.15 + 0.85 * epoch / cfg.coarse_to_fine_epochs)
    if frac < 1.0:
        B, N, D = x.shape
        keep_masks = []
        for b in range(B):
            surf_idx = is_surface[b].nonzero(as_tuple=True)[0]
            vol_idx = (~is_surface[b] & mask[b]).nonzero(as_tuple=True)[0]
            n_vol_keep = max(int(len(vol_idx) * frac), 1)
            vol_keep = vol_idx[torch.randperm(len(vol_idx))[:n_vol_keep]]
            keep_idx = torch.cat([surf_idx, vol_keep]).sort().values
            keep_masks.append(keep_idx)
        
        # Compact: gather only kept nodes
        max_keep = max(len(m) for m in keep_masks)
        # Pad to same length and gather
        x_compact = torch.zeros(B, max_keep, D, device=x.device)
        y_compact = torch.zeros(B, max_keep, 3, device=y.device)
        mask_compact = torch.zeros(B, max_keep, dtype=torch.bool, device=x.device)
        is_surface_compact = torch.zeros(B, max_keep, dtype=torch.bool, device=x.device)
        for b in range(B):
            n = len(keep_masks[b])
            x_compact[b, :n] = x[b, keep_masks[b]]
            y_compact[b, :n] = y[b, keep_masks[b]]
            mask_compact[b, :n] = True
            is_surface_compact[b, :n] = is_surface[b, keep_masks[b]]
        
        x, y, mask, is_surface = x_compact, y_compact, mask_compact, is_surface_compact
```

### CLI flags:
```python
coarse_to_fine: bool = False
coarse_to_fine_start: float = 0.15  # start fraction of volume nodes
coarse_to_fine_epochs: int = 100  # epochs to ramp to 100%
```

### GPU Assignments
| GPU | Experiment |
|-----|-----------|
| 0-2 | Coarse-to-fine (15%→100%, 100ep), seeds 42-44 |
| 3 | Coarse-to-fine (30%→100%, 80ep) |
| 4 | Coarse-to-fine (10%→100%, 120ep) — more aggressive |
| 5 | Coarse-to-fine with surface weight=100 during coarse phase |
| 6-7 | Baseline seeds 96-97 |

All with \`--cosine_T_max 180 --disable_pcgrad\`

## Baseline
| Metric | Mean | Std |
|--------|------|-----|
| val/loss | 0.403 | 0.003 |
| p_tan | 33.1 | 0.6 |