### PR TITLE
Phase 5: DeepONet with POD Basis — Branch-Trunk Architecture (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -642,6 +642,155 @@ class Transolver(nn.Module):
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred}
 
 
+class DeepONet(nn.Module):
+    """Branch-Trunk Deep Operator Network for CFD flow prediction.
+
+    Branch: encodes global conditions (Re, AoA, shape params) → P basis coefficients
+    Trunk: encodes local spatial features (pos, saf, dsdf) → P basis function values
+    Output: dot product of branch and trunk, per output channel.
+    """
+
+    def __init__(self, cond_dim=13, spatial_dim=58, n_basis=128, n_hidden=256,
+                 branch_layers=4, trunk_layers=4, out_dim=3, domain_heads=False,
+                 residual_nets=False):
+        super().__init__()
+        self.n_basis = n_basis
+        self.out_dim = out_dim
+        self.domain_heads = domain_heads
+        self.residual_nets = residual_nets
+
+        # Branch: global conditions → basis coefficients [3 * n_basis]
+        branch_mods = []
+        in_d = cond_dim
+        for i in range(branch_layers):
+            out_d = n_hidden
+            branch_mods.append(nn.Linear(in_d, out_d))
+            branch_mods.append(nn.GELU())
+            in_d = out_d
+        branch_mods.append(nn.Linear(n_hidden, out_dim * n_basis))
+        self.branch = nn.Sequential(*branch_mods)
+        if residual_nets:
+            self.branch_res = nn.ModuleList([
+                nn.Linear(n_hidden, n_hidden) for _ in range(branch_layers - 1)
+            ])
+
+        # Trunk: spatial features → basis function values [3 * n_basis]
+        trunk_mods = []
+        in_d = spatial_dim
+        for i in range(trunk_layers):
+            out_d = n_hidden
+            trunk_mods.append(nn.Linear(in_d, out_d))
+            trunk_mods.append(nn.GELU())
+            in_d = out_d
+        trunk_mods.append(nn.Linear(n_hidden, out_dim * n_basis))
+        self.trunk = nn.Sequential(*trunk_mods)
+        if residual_nets:
+            self.trunk_res = nn.ModuleList([
+                nn.Linear(n_hidden, n_hidden) for _ in range(trunk_layers - 1)
+            ])
+
+        # Bias per output channel
+        self.bias = nn.Parameter(torch.zeros(out_dim))
+
+        # Domain-specific output refinement
+        if domain_heads:
+            self.refine_single = nn.Sequential(nn.Linear(out_dim, 64), nn.GELU(), nn.Linear(64, out_dim))
+            self.refine_tandem = nn.Sequential(nn.Linear(out_dim, 64), nn.GELU(), nn.Linear(64, out_dim))
+            nn.init.zeros_(self.refine_single[-1].weight)
+            nn.init.zeros_(self.refine_single[-1].bias)
+            nn.init.zeros_(self.refine_tandem[-1].weight)
+            nn.init.zeros_(self.refine_tandem[-1].bias)
+
+        # Auxiliary heads (same interface as Transolver)
+        self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+        self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
+
+        self._init_weights()
+
+        # Fourier PE compatibility with Transolver training loop
+        self.register_buffer('fourier_freqs_fixed', torch.tensor([0.5, 2.0, 8.0, 32.0]))
+        self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+
+    def _init_weights(self):
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.orthogonal_(m.weight, gain=1.0)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+    def _branch_forward(self, conditions):
+        """Branch with optional residual connections."""
+        if not self.residual_nets:
+            return self.branch(conditions)
+        x = conditions
+        idx = 0
+        for i, layer in enumerate(self.branch):
+            if isinstance(layer, nn.GELU) and idx < len(self.branch_res):
+                # After GELU, apply residual if dims match
+                res = self.branch_res[idx](x)
+                x = layer(x) + res
+                idx += 1
+            else:
+                x = layer(x)
+        return x
+
+    def _trunk_forward(self, spatial):
+        """Trunk with optional residual connections."""
+        if not self.residual_nets:
+            return self.trunk(spatial)
+        x = spatial
+        idx = 0
+        for i, layer in enumerate(self.trunk):
+            if isinstance(layer, nn.GELU) and idx < len(self.trunk_res):
+                res = self.trunk_res[idx](x)
+                x = layer(x) + res
+                idx += 1
+            else:
+                x = layer(x)
+        return x
+
+    def forward(self, data, pos=None, condition=None):
+        if isinstance(data, dict):
+            x = data["x"]
+        else:
+            x = data
+        B, N, D = x.shape
+
+        # Extract global conditions from first node (same for all nodes)
+        # Indices: 11-23 cover NACA, AoA, Re, gap, stagger etc.
+        conditions = x[:, 0, 11:24]  # [B, 13]
+
+        # Branch: conditions → basis coefficients
+        branch_out = self._branch_forward(conditions)  # [B, 3*P]
+        branch_out = branch_out.view(B, self.out_dim, self.n_basis)  # [B, 3, P]
+
+        # Trunk: spatial features → basis values (using full x as spatial input)
+        trunk_out = self._trunk_forward(x)  # [B, N, 3*P]
+        trunk_out = trunk_out.view(B, N, self.out_dim, self.n_basis)  # [B, N, 3, P]
+
+        # Dot product: sum over basis functions
+        output = torch.einsum("bcp, bncp -> bnc", branch_out, trunk_out) + self.bias  # [B, N, 3]
+
+        # Domain-specific refinement
+        if self.domain_heads:
+            is_tandem = (x[:, 0, 21].abs() > 0.01)  # [B]
+            if is_tandem.any():
+                ref_s = self.refine_single(output)
+                ref_t = self.refine_tandem(output)
+                is_tan = is_tandem.view(-1, 1, 1).expand_as(output)
+                output = output + torch.where(is_tan, ref_t, ref_s)
+
+        # Auxiliary heads from branch hidden (use penultimate branch activation)
+        # Get hidden from branch by running up to second-to-last layer
+        h = conditions
+        for layer in list(self.branch)[:-1]:
+            h = layer(h)
+        re_pred = self.re_head(h)
+        aoa_pred = self.aoa_head(h)
+
+        return {"preds": output, "re_pred": re_pred, "aoa_pred": aoa_pred}
+
+
 # ---------------------------------------------------------------------------
 # End Transolver model
 # ---------------------------------------------------------------------------
@@ -751,6 +900,13 @@ class Config:
     # Phase 4: throughput optimization
     val_every: int = 1                  # validate every N epochs (1 = every epoch)
     disable_pcgrad: bool = False        # skip PCGrad dual-backward, use simple combined loss
+    # Phase 5: DeepONet
+    model_type: str = "transolver"     # "transolver" or "deeponet"
+    n_basis: int = 128                  # number of basis functions for DeepONet
+    branch_layers: int = 4              # depth of branch network
+    trunk_layers: int = 4               # depth of trunk network
+    domain_heads_deeponet: bool = False # domain-specific output refinement
+    residual_deeponet: bool = False     # residual connections in branch/trunk
     vol_subsample_frac: float = 1.0     # fraction of volume nodes in loss after vol_ramp (0.8 = 80%)
     compile_mode: str = "default"       # torch.compile mode: "default", "max-autotune", "reduce-overhead"
     num_workers: int = 4                # data loader workers
@@ -905,7 +1061,22 @@ model_config = dict(
     prog_slices=cfg.prog_slices,
 )
 
-model = Transolver(**model_config).to(device)
+if cfg.model_type == "deeponet":
+    # fun_dim + space_dim = total input features after preprocessing
+    spatial_dim = model_config["fun_dim"] + model_config["space_dim"]
+    model = DeepONet(
+        cond_dim=13, spatial_dim=spatial_dim,
+        n_basis=cfg.n_basis, n_hidden=cfg.n_hidden,
+        branch_layers=cfg.branch_layers, trunk_layers=cfg.trunk_layers,
+        out_dim=3, domain_heads=cfg.domain_heads_deeponet,
+        residual_nets=cfg.residual_deeponet,
+    ).to(device)
+    model_config["model_type"] = "deeponet"
+    model_config["n_basis"] = cfg.n_basis
+    model_config["branch_layers"] = cfg.branch_layers
+    model_config["trunk_layers"] = cfg.trunk_layers
+else:
+    model = Transolver(**model_config).to(device)
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode=cfg.compile_mode)
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model


### PR DESCRIPTION
## Hypothesis

Replace the entire Transolver with a **DeepONet (Deep Operator Network)** architecture using POD-enhanced basis functions. DeepONet (Lu et al., Nature Machine Intelligence 2021) learns operators by factoring the output into a **branch network** (encodes the input function/conditions) and a **trunk network** (encodes the output spatial coordinates). The output is the dot product of branch and trunk outputs, which is mathematically equivalent to learning a set of basis functions (trunk) and their coefficients (branch).

**Why this should work:**
- DeepONet has strong theoretical backing: universal approximation theorem for operators (Chen & Chen, 1995)
- The factored architecture is highly efficient: branch processes conditions ONCE per sample, trunk processes coordinates — no O(n²) attention needed
- POD (Proper Orthogonal Decomposition) enhancement: pre-compute the dominant flow modes from training data and use them to initialize/guide the trunk network's basis functions
- For our problem: branch encodes (Re, AoA, NACA shape, gap, stagger), trunk encodes (x, y, saf, dsdf, is_surface) → their product gives (Ux, Uy, p) at each point
- This is the most fundamentally different architecture from Transolver — no attention at all, pure MLP factorization
- Reference: https://arxiv.org/abs/2111.05512 (POD-DeepONet), https://arxiv.org/abs/1910.03193 (DeepONet original)

**Why this is different from the INR decoder attempt (#1849):**
- PR #1849 only replaced the output head with a coordinate-conditioned MLP — the backbone was still Transolver
- This replaces EVERYTHING: no Transolver, no attention, no slice mechanism
- Pure branch-trunk factorization from input to output

## Instructions

**Delete the entire Transolver model** and replace with a DeepONet architecture.

### Architecture:

```python
class DeepONet(nn.Module):
    """Branch-Trunk Deep Operator Network with POD basis.
    
    Branch: encodes global condition params → P basis coefficients
    Trunk: encodes local spatial features → P basis function values
    Output: sum(branch_i * trunk_i) for i=1..P, per output channel
    """
    
    def __init__(self, cond_dim, spatial_dim, n_basis=128, n_hidden=256):
        # Branch network: global conditions → basis coefficients
        self.branch = nn.Sequential(
            nn.Linear(cond_dim, n_hidden), nn.GELU(),
            nn.Linear(n_hidden, n_hidden), nn.GELU(),
            nn.Linear(n_hidden, n_hidden), nn.GELU(),
            nn.Linear(n_hidden, 3 * n_basis),  # 3 output channels × P basis
        )
        
        # Trunk network: spatial position + local features → basis values
        self.trunk = nn.Sequential(
            nn.Linear(spatial_dim, n_hidden), nn.GELU(),
            nn.Linear(n_hidden, n_hidden), nn.GELU(),
            nn.Linear(n_hidden, n_hidden), nn.GELU(),
            nn.Linear(n_hidden, 3 * n_basis),  # 3 channels × P basis
        )
        
        # Learnable bias per output channel
        self.bias = nn.Parameter(torch.zeros(3))
    
    def forward(self, data):
        x = data["x"]  # [B, N, 24]
        
        # Extract global conditions (same for all nodes in a sample)
        # Re, AoA, NACA0(3), AoA1, NACA1(3), gap, stagger = indices from x[0]
        conditions = x[:, 0, [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]]  # [B, cond_dim]
        
        # Spatial features (per-node)
        spatial = x  # [B, N, 24] — includes pos, saf, dsdf, is_surface
        # Add Fourier PE (same as current model)
        
        # Branch: [B, 3*P]
        branch_out = self.branch(conditions)  # [B, 3*P]
        branch_out = branch_out.view(B, 3, n_basis)  # [B, 3, P]
        
        # Trunk: [B, N, 3*P] 
        trunk_out = self.trunk(spatial)  # [B, N, 3*P]
        trunk_out = trunk_out.view(B, N, 3, n_basis)  # [B, N, 3, P]
        
        # Dot product: [B, N, 3]
        output = torch.einsum("bcp, bncp -> bnc", branch_out, trunk_out) + self.bias
        
        return {"preds": output}
```

### Key Enhancements:

1. **POD-Enhanced Trunk Initialization:**
   - Before training, compute SVD of the training flow fields: Y ≈ U Σ V^T
   - The top-P right singular vectors V[:P] are the dominant flow modes
   - Initialize the trunk network's final layer to approximate these modes
   - This gives the network a massive head start — it begins predicting flow patterns that actually occur

2. **Conditional Branch with Fourier Features:**
   - Apply random Fourier features to the condition inputs for better expressivity
   - Use a deeper branch network (4-6 layers) since this is the main capacity bottleneck

3. **Multi-Scale Trunk:**
   - Use multiple Fourier frequency scales in the trunk's spatial encoding
   - This helps capture both the smooth freestream and the sharp boundary layer gradients

4. **Domain-Specific Heads:**
   - Separate final layers for single-foil vs tandem (similar to domain_velhead)
   - Different bias terms for each domain

### Hyperparameters across 8 GPUs:

| GPU | n_basis | branch_hidden | trunk_hidden | branch_layers | Notes |
|-----|---------|--------------|-------------|--------------|-------|
| 0 | 128 | 256 | 256 | 4 | Default DeepONet |
| 1 | 256 | 256 | 256 | 4 | More basis functions |
| 2 | 128 | 512 | 512 | 4 | Wider networks |
| 3 | 128 | 256 | 256 | 6 | Deeper branch |
| 4 | 64 | 256 | 256 | 4 | Fewer basis + POD init |
| 5 | 128 | 256 | 256 | 4 | + Domain-specific heads |
| 6 | 128 | 256 | 256 | 4 | + Residual connections in branch/trunk |
| 7 | — | — | — | — | **Baseline** for comparison |

### Training commands:
```bash
BASE="--agent frieren --use_lion --lr 2e-4 --cosine_T_max 180 --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --tandem_ramp --ema_decay 0.999 --weight_decay 5e-5 --disable_pcgrad --seed 42"

CUDA_VISIBLE_DEVICES=0 python train.py $BASE --wandb_name "frieren/p5-deeponet-128b" --wandb_group phase5-deeponet --model_type deeponet --n_basis 128 --n_hidden 256

# GPU 7: Baseline
CUDA_VISIBLE_DEVICES=7 python train.py $BASE --wandb_name "frieren/p5-baseline" --wandb_group phase5-deeponet --field_decoder --adaln_output --n_layers 3 --slice_num 96 --domain_layernorm --domain_velhead
```

**torch.compile:** DeepONet is pure MLPs — this should be the most compile-friendly architecture of all Phase 5 experiments. Expect fast training.

**VRAM note:** No attention mechanism means VRAM usage will be much lower than the current 34 GB. Consider increasing batch_size from 4 to 8 or even 16 to see more data per epoch.

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.403 ± 0.003 |
| p_in | 13.6 ± 0.4 |
| p_oodc | 8.6 ± 0.1 |
| p_tan | 33.1 ± 0.6 |
| p_re | 24.7 ± 0.1 |
| Baseline PR | #1846 |
| W&B project | wandb-applied-ai-team/senpai-v1 |

### Reproduce baseline:
```bash
python train.py --agent frieren --wandb_name "frieren/baseline" \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 180 --disable_pcgrad
```