### PR TITLE
Phase 5: Transolver++ Ada-Temp — Per-Point Adaptive Slice Temperature (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 ada_temp=False, ada_temp_scale=0.1):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -154,6 +155,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.decouple_slice = decouple_slice
         self.zone_temp = zone_temp
         self.prog_slices = prog_slices
+        self.ada_temp = ada_temp
+        if ada_temp:
+            # Per-point temperature: mean of heads → per-head offset
+            self.temp_proj = nn.Linear(dim_head, heads)
+            nn.init.zeros_(self.temp_proj.weight)
+            nn.init.zeros_(self.temp_proj.bias)
+            self.temp_scale = nn.Parameter(torch.tensor(ada_temp_scale))
         if prog_slices:
             # Buffer for masking inactive slices; updated per-epoch by training loop
             self.register_buffer('slice_mask', torch.zeros(slice_num))
@@ -201,7 +209,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             .permute(0, 2, 1, 3)
             .contiguous()
         )
-        temp = self.temperature
+        temp = self.temperature  # [1, heads, 1, 1]
+        if self.ada_temp:
+            # Per-point adaptive temperature from local features
+            x_mean = x_mid.mean(dim=1)  # [B, N, dim_head] (mean across heads)
+            temp_offset = self.temp_proj(x_mean)  # [B, N, heads]
+            temp_offset = temp_offset.permute(0, 2, 1).unsqueeze(-1)  # [B, heads, N, 1]
+            temp = temp + self.temp_scale * temp_offset.sigmoid()  # [B, heads, N, 1]
         if self.zone_temp and zone_features is not None:
             # zone_features: [B, 3] → per-head offset [B, heads] → [B, heads, 1, 1]
             zone_offset = self.zone_temp_proj(zone_features).reshape(bsz, self.heads, 1, 1)
@@ -282,6 +296,8 @@ class TransolverBlock(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        ada_temp=False,
+        ada_temp_scale=0.1,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -307,6 +323,8 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            ada_temp=ada_temp,
+            ada_temp_scale=ada_temp_scale,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -484,6 +502,8 @@ class Transolver(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        ada_temp=False,
+        ada_temp_scale=0.1,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -554,6 +574,8 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
+                    ada_temp=ada_temp,
+                    ada_temp_scale=ada_temp_scale,
                 )
                 for idx in range(n_layers)
             ]
@@ -814,6 +836,9 @@ class Config:
     pressure_no_detach: bool = False    # allow gradient from vel back to pres head
     pressure_deep: bool = False         # 3-layer pressure head instead of 2
     pressure_separate_last_block: bool = False  # separate last TransolverBlock for pressure
+    # Phase 5: Ada-Temp per-point adaptive slice temperature
+    ada_temp: bool = False              # per-point adaptive temperature for slice routing
+    ada_temp_scale: float = 0.1         # initial scale for temperature offset
 
 
 cfg = sp.parse(Config)
@@ -966,6 +991,8 @@ model_config = dict(
     pressure_first=cfg.pressure_first,
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
+    ada_temp=cfg.ada_temp,
+    ada_temp_scale=cfg.ada_temp_scale,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1584,7 +1611,13 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
                         ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.ada_temp:
+            # Log per-block temp_scale and temperature stats
+            for bi, block in enumerate(_base_model.blocks):
+                if hasattr(block.attn, 'temp_scale'):
+                    _log[f"ada_temp/block{bi}_scale"] = block.attn.temp_scale.item()
+        wandb.log(_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Replace the global (per-head) slice temperature in the Transolver's physics attention with a **per-point adaptive temperature**. Currently, all ~100K nodes share the same temperature parameter for slice routing. Ada-Temp (from Transolver++, ICML 2025) learns a per-node temperature, allowing surface nodes with sharp pressure gradients to form sharper slice assignments (lower temperature) while far-field volume nodes remain more diffuse (higher temperature).

**Why this should work:**
- Transolver++ (ICML 2025) showed **46% error reduction** from Ada-Temp alone on aircraft pressure prediction
- The current model uses `self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)` — a single scalar per head shared across ALL nodes
- Surface boundary layer nodes (where pressure gradients are sharpest) should route to slices more sharply — they need specialized physics states
- Far-field nodes should route diffusely — they share generic freestream physics
- This is the #2 ranked hypothesis from our research agent, with strong empirical backing from the Transolver++ paper

**Why this is different from previous work:**
- We tried zone_temp (PR #1838) which adds a per-sample offset based on (is_tandem, gap, Re) — this is per-NODE, much more fine-grained
- We tried tandem_temp_offset which adjusts temperature for tandem vs single samples — again per-sample, not per-node
- Ada-Temp is fundamentally different: each individual node gets its own temperature based on its local features

## Instructions

Modify the `Physics_Attention_Irregular_Mesh` class in `train.py` to support per-point adaptive temperature.

### Implementation:

In `Physics_Attention_Irregular_Mesh.__init__`, add:
```python
self.ada_temp = ada_temp  # new parameter
if ada_temp:
    # Per-point temperature projection: hidden features → 1 temp offset per head
    self.temp_proj = nn.Linear(dim_head, heads)
    nn.init.zeros_(self.temp_proj.weight)  # start as current model (no per-point variation)
    nn.init.zeros_(self.temp_proj.bias)
    self.temp_scale = nn.Parameter(torch.tensor(0.1))  # learnable scale for temp offset
```

In `Physics_Attention_Irregular_Mesh.forward`, replace the temperature computation:
```python
# BEFORE (current code):
temp = self.temperature  # [1, heads, 1, 1]

# AFTER (Ada-Temp):
if self.ada_temp:
    # x_mid: [B, heads, N, dim_head]
    # Compute per-node temperature offset from local features
    temp_offset = self.temp_proj(x_mid)  # [B, heads, N, heads] — take diagonal
    # We want [B, heads, N, 1] per-point offsets
    # Use mean of x_mid across heads for the projection
    x_mean = x_mid.mean(dim=1)  # [B, N, dim_head]
    temp_offset = self.temp_proj(x_mean)  # [B, N, heads]
    temp_offset = temp_offset.permute(0, 2, 1).unsqueeze(-1)  # [B, heads, N, 1]
    temp = self.temperature + self.temp_scale * temp_offset.sigmoid()  # [B, heads, N, 1]
else:
    temp = self.temperature
```

Then continue with existing code — `slice_logits = self.in_project_slice(x_mid) / temp` now uses per-point temperatures.

### Config additions:
```python
# In Config dataclass:
ada_temp: bool = False  # Per-point adaptive slice temperature
```

### Hyperparameters across 8 GPUs:

| GPU | ada_temp | temp_scale_init | Notes |
|-----|----------|----------------|-------|
| 0 | True | 0.1 | Default Ada-Temp |
| 1 | True | 0.05 | Smaller scale (more conservative) |
| 2 | True | 0.2 | Larger scale (more variation) |
| 3 | True | 0.1 | + Gumbel-Softmax slice routing (tau annealing) |
| 4 | True | 0.1 | + Separate temp_proj for tandem samples |
| 5 | True | 0.1 | + 2-layer temp_proj MLP (more expressive) |
| 6 | True | 0.1 | seed 43 (multi-seed validation of best config) |
| 7 | — | — | **Baseline** (pressure-first deep) for comparison |

### Training commands:
```bash
BASE="--agent thorfinn --field_decoder --adaln_output --use_lion --lr 2e-4 --cosine_T_max 180 --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 --disable_pcgrad --pressure_first --pressure_deep --seed 42"

CUDA_VISIBLE_DEVICES=0 python train.py $BASE --wandb_name "thorfinn/p5-adatemp-01" --wandb_group phase5-ada-temp --ada_temp --temp_scale 0.1
# ... GPUs 1-6

# GPU 7: Baseline
CUDA_VISIBLE_DEVICES=7 python train.py $BASE --wandb_name "thorfinn/p5-baseline" --wandb_group phase5-ada-temp
```

**torch.compile:** The per-point temperature is just a linear projection + sigmoid — fully compile-friendly. No dynamic shapes involved.

**This builds on the newly merged baseline** — pressure_first + pressure_deep from PR #1867.

## Baseline
| Metric | Value |
|--------|-------|
| val/loss | 0.401 ± 0.005 |
| p_in | 12.95 ± 0.3 |
| p_oodc | 8.40 ± 0.4 |
| p_tan | 33.8 ± 0.5 |
| p_re | 24.7 ± 0.2 |
| Baseline PRs | #1846 + #1867 |
| W&B project | wandb-applied-ai-team/senpai-v1 |

### Reproduce baseline:
```bash
python train.py --agent thorfinn --wandb_name "thorfinn/baseline" \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 180 --disable_pcgrad \
  --pressure_first --pressure_deep
```