### PR TITLE
Phase 5: Pressure Gradient Loss — Supervise ∂p/∂x and ∂p/∂y (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -706,6 +706,87 @@ MAX_TIMEOUT = 180.0  # minutes
 MAX_EPOCHS = 500
 
 
+def _compute_pressure_gradients(p_vals, positions, surf_mask, k=4):
+    """Compute surface pressure gradients via weighted least-squares finite differences.
+
+    All computation on GPU. For each surface node, finds k nearest surface neighbors
+    and solves weighted least-squares for dp/dx, dp/dy.
+
+    Args:
+        p_vals: [B, N] pressure values (predicted or ground truth)
+        positions: [B, N, 2] xy coordinates
+        surf_mask: [B, N] bool mask for surface nodes
+        k: number of neighbors
+
+    Returns:
+        dp_dx, dp_dy: [total_surf_nodes] gradient components (flattened across batch)
+        valid_mask: [total_surf_nodes] bool mask for nodes with valid gradients
+    """
+    B, N = p_vals.shape
+    device = p_vals.device
+
+    all_dp_dx = []
+    all_dp_dy = []
+    all_lap = []
+    all_valid = []
+
+    for b in range(B):
+        s_mask = surf_mask[b]  # [N]
+        n_surf = s_mask.sum().item()
+        if n_surf < k + 1:
+            all_dp_dx.append(torch.zeros(n_surf, device=device))
+            all_dp_dy.append(torch.zeros(n_surf, device=device))
+            all_lap.append(torch.zeros(n_surf, device=device))
+            all_valid.append(torch.zeros(n_surf, dtype=torch.bool, device=device))
+            continue
+
+        s_pos = positions[b][s_mask]   # [n_surf, 2]
+        s_p = p_vals[b][s_mask]        # [n_surf]
+
+        # k-nearest neighbors via pairwise distance
+        # For efficiency, compute pairwise distances using broadcasting
+        diff = s_pos.unsqueeze(0) - s_pos.unsqueeze(1)  # [n_surf, n_surf, 2]
+        dist2 = (diff ** 2).sum(dim=-1)  # [n_surf, n_surf]
+        dist2.diagonal().fill_(float('inf'))  # exclude self
+
+        # Get k nearest neighbors
+        _, nn_idx = dist2.topk(k, dim=-1, largest=False)  # [n_surf, k]
+
+        # Compute gradient via weighted least-squares
+        dx = diff[torch.arange(n_surf, device=device).unsqueeze(1), nn_idx, 0]  # [n_surf, k]
+        dy = diff[torch.arange(n_surf, device=device).unsqueeze(1), nn_idx, 1]
+        dp = s_p[nn_idx] - s_p.unsqueeze(1)  # [n_surf, k]
+
+        d2 = dx ** 2 + dy ** 2 + 1e-10
+        w = 1.0 / d2  # inverse-distance weights
+
+        Wdx = w * dx
+        Wdy = w * dy
+        A11 = (Wdx * dx).sum(-1)
+        A12 = (Wdx * dy).sum(-1)
+        A22 = (Wdy * dy).sum(-1)
+        b1 = (Wdx * dp).sum(-1)
+        b2 = (Wdy * dp).sum(-1)
+
+        det = A11 * A22 - A12 * A12 + 1e-10
+        dp_dx = (A22 * b1 - A12 * b2) / det
+        dp_dy = (A11 * b2 - A12 * b1) / det
+
+        # Laplacian: sum of second derivatives (approximate via neighbor values)
+        # lap ≈ (2/k) * sum_j (p_j - p_i) / dist_ij^2
+        lap = (2.0 * (dp / d2).sum(-1))
+
+        all_dp_dx.append(dp_dx)
+        all_dp_dy.append(dp_dy)
+        all_lap.append(lap)
+        all_valid.append(torch.ones(n_surf, dtype=torch.bool, device=device))
+
+    return (torch.cat(all_dp_dx) if all_dp_dx else torch.zeros(0, device=device),
+            torch.cat(all_dp_dy) if all_dp_dy else torch.zeros(0, device=device),
+            torch.cat(all_lap) if all_lap else torch.zeros(0, device=device),
+            torch.cat(all_valid) if all_valid else torch.zeros(0, dtype=torch.bool, device=device))
+
+
 @dataclass
 class Config:
     lr: float = 1.5e-3
@@ -809,6 +890,14 @@ class Config:
     vol_subsample_frac: float = 1.0     # fraction of volume nodes in loss after vol_ramp (0.8 = 80%)
     compile_mode: str = "default"       # torch.compile mode: "default", "max-autotune", "reduce-overhead"
     num_workers: int = 4                # data loader workers
+    # Phase 5: Pressure gradient loss
+    grad_loss: bool = False              # enable surface pressure gradient loss
+    grad_loss_weight: float = 0.3        # lambda_grad multiplier
+    grad_loss_k: int = 4                 # k nearest neighbors for gradient computation
+    grad_loss_vol: bool = False          # also apply gradient loss on volume nodes
+    grad_loss_l2: bool = False           # use L2 (MSE) instead of L1 for gradient loss
+    grad_loss_laplacian: bool = False    # add Laplacian supervision term
+    grad_loss_lap_weight: float = 0.1    # weight for Laplacian term
     # Phase 4: Pressure-first sequential prediction
     pressure_first: bool = False        # predict p first, then condition v on p
     pressure_no_detach: bool = False    # allow gradient from vel back to pres head
@@ -1208,6 +1297,7 @@ for epoch in range(MAX_EPOCHS):
     model.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
+    epoch_grad_loss = 0.0
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
@@ -1448,6 +1538,38 @@ for epoch in range(MAX_EPOCHS):
         else:
             loss = vol_loss + surf_weight * surf_loss
 
+        # Pressure gradient loss: supervise dp/dx, dp/dy on surface nodes
+        _grad_loss_val = torch.tensor(0.0, device=device)
+        _lap_loss_val = torch.tensor(0.0, device=device)
+        if cfg.grad_loss and model.training:
+            _grad_mask = (mask & is_surface) if not cfg.grad_loss_vol else mask
+            pred_p = pred[:, :, 2]   # [B, N] predicted pressure
+            gt_p = y_norm[:, :, 2]   # [B, N] ground truth pressure
+            pos_xy = x[:, :, :2]     # [B, N, 2] spatial coordinates
+
+            pred_dp_dx, pred_dp_dy, pred_lap, valid = _compute_pressure_gradients(
+                pred_p, pos_xy, _grad_mask, k=cfg.grad_loss_k)
+            with torch.no_grad():
+                gt_dp_dx, gt_dp_dy, gt_lap, _ = _compute_pressure_gradients(
+                    gt_p, pos_xy, _grad_mask, k=cfg.grad_loss_k)
+
+            if valid.any():
+                pred_dp_dx = pred_dp_dx[valid]
+                pred_dp_dy = pred_dp_dy[valid]
+                gt_dp_dx = gt_dp_dx[valid]
+                gt_dp_dy = gt_dp_dy[valid]
+                if cfg.grad_loss_l2:
+                    _grad_loss_val = F.mse_loss(pred_dp_dx, gt_dp_dx) + F.mse_loss(pred_dp_dy, gt_dp_dy)
+                else:
+                    _grad_loss_val = F.l1_loss(pred_dp_dx, gt_dp_dx) + F.l1_loss(pred_dp_dy, gt_dp_dy)
+                loss = loss + cfg.grad_loss_weight * _grad_loss_val
+
+                if cfg.grad_loss_laplacian:
+                    pred_lap_v = pred_lap[valid]
+                    gt_lap_v = gt_lap[valid]
+                    _lap_loss_val = F.l1_loss(pred_lap_v, gt_lap_v)
+                    loss = loss + cfg.grad_loss_lap_weight * _lap_loss_val
+
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None
         coarse_pool_size = 64
@@ -1584,10 +1706,17 @@ for epoch in range(MAX_EPOCHS):
                     for ep, mp in zip(ema_model.parameters(), _base_model.parameters()):
                         ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.grad_loss:
+            _log_dict["train/grad_loss"] = _grad_loss_val.item()
+            _log_dict["train/lambda_grad"] = cfg.grad_loss_weight
+            if cfg.grad_loss_laplacian:
+                _log_dict["train/lap_loss"] = _lap_loss_val.item()
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
+        epoch_grad_loss += _grad_loss_val.item() if cfg.grad_loss else 0.0
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
@@ -1881,6 +2010,7 @@ for epoch in range(MAX_EPOCHS):
     metrics = {
         "train/vol_loss": epoch_vol,
         "train/surf_loss": epoch_surf,
+        "train/grad_loss_epoch": epoch_grad_loss / max(n_batches, 1) if cfg.grad_loss else 0.0,
         "val/loss": val_loss_3split,
         "val/loss_3split": val_loss_3split,
         "val/loss_4split": val_loss_4split,


### PR DESCRIPTION
## Hypothesis

Add auxiliary losses supervising the spatial pressure gradients ∂p/∂x and ∂p/∂y computed via finite differences between neighboring surface nodes. The model currently only minimizes pointwise pressure MAE — adding gradient supervision teaches it the spatial _structure_ of the pressure field, not just its values. This changes what the model optimizes, not its architecture or convergence dynamics.

**Why this should work:** Engineers care about lift and drag, which are integrals of pressure over the airfoil surface. A pressure field can have correct pointwise values but incorrect gradients, producing wrong integrated forces. Gradient supervision enforces first-order spatial consistency: peaks must be sharp where they should be sharp, plateaus where they should be flat. This is analogous to perceptual/style losses in image synthesis — it targets higher-order statistics that pointwise MAE misses entirely.

**Connection to physics:** The momentum equation gives ∇p = -ρ(u·∇)u + μ∇²u. Supervising ∇p directly applies a physics-derived constraint without solving the full PDE. This is a weak form of physics-informed training at zero computational cost relative to PINN approaches.

## Instructions

Run 8 parallel variants on 8 GPUs with `--wandb_group phase5_grad_loss`. All variants start from the baseline command.

### Step 1: Compute surface pressure gradients

Precompute surface node neighbor lists once at dataset load time. For each surface node, find k nearest surface neighbors and compute finite-difference gradient estimates:

```python
def compute_surface_pressure_gradients(p_surface, surface_pos, k=4):
    """
    p_surface: (N_surf,) pressure values on surface nodes
    surface_pos: (N_surf, 2) x,y coordinates of surface nodes
    Returns: dp_dx, dp_dy: (N_surf,) gradient components
    """
    from scipy.spatial import KDTree
    tree = KDTree(surface_pos)
    _, idx = tree.query(surface_pos, k=k+1)  # include self
    idx = idx[:, 1:]  # exclude self: (N_surf, k)
    
    dx = surface_pos[idx, 0] - surface_pos[:, None, 0]  # (N, k)
    dy = surface_pos[idx, 1] - surface_pos[:, None, 1]
    dp = p_surface[idx] - p_surface[:, None]            # (N, k)
    
    # Weighted least-squares: solve [dx, dy] @ [dp_dx, dp_dy]^T = dp
    dist2 = dx**2 + dy**2 + 1e-10
    w = 1.0 / dist2  # inverse-distance weights
    
    Wdx = w * dx; Wdy = w * dy
    A11 = (Wdx * dx).sum(-1); A12 = (Wdx * dy).sum(-1)
    A22 = (Wdy * dy).sum(-1); A21 = A12
    b1 = (Wdx * dp).sum(-1); b2 = (Wdy * dp).sum(-1)
    
    det = A11 * A22 - A12 * A21 + 1e-10
    dp_dx = (A22 * b1 - A12 * b2) / det
    dp_dy = (A11 * b2 - A21 * b1) / det
    return dp_dx, dp_dy
```

Precompute target gradients from GT pressure fields at dataset load. During training, compute predicted gradients from model output p.

### Step 2: Add gradient loss term

```python
# After forward pass, extract predicted surface pressure:
pred_p_surface = pred[surface_mask, 2]   # pressure channel
gt_p_surface   = target[surface_mask, 2]
surf_pos       = pos[surface_mask]       # (N_surf, 2)

# Compute gradients for predicted and target:
pred_dp_dx, pred_dp_dy = compute_surface_pressure_gradients(pred_p_surface, surf_pos, k=4)
gt_dp_dx,   gt_dp_dy   = compute_surface_pressure_gradients(gt_p_surface,   surf_pos, k=4)

loss_grad = F.l1_loss(pred_dp_dx, gt_dp_dx) + F.l1_loss(pred_dp_dy, gt_dp_dy)

# Total loss:
loss = loss_main + lambda_grad * loss_grad
```

### GPU Sweep Table

| GPU | Run name | lambda_grad | k neighbors | Notes |
|-----|----------|-------------|-------------|-------|
| 0 | tanjiro/grad-l0.1 | 0.1 | 4 | Conservative weight |
| 1 | tanjiro/grad-l0.3 | 0.3 | 4 | Moderate weight |
| 2 | tanjiro/grad-l1.0 | 1.0 | 4 | Equal to main loss |
| 3 | tanjiro/grad-l0.3-k6 | 0.3 | 6 | More neighbors |
| 4 | tanjiro/grad-l0.3-k8 | 0.3 | 8 | Even more neighbors |
| 5 | tanjiro/grad-surface-vol | 0.3 | 4 | Gradient loss on volume nodes too |
| 6 | tanjiro/grad-l2-loss | 0.3 | 4 | L2 (MSE) gradient loss instead of L1 |
| 7 | tanjiro/grad-laplacian | 0.3 | 4 | Add Laplacian ∇²p supervision as third term |

### Additional variant: Laplacian (GPU 7)

```python
# For GPU 7, also supervise the Laplacian (div of gradient):
# laplacian_p = dp2_dx2 + dp2_dy2
# Compute via second finite differences using the same neighbor lists
# loss_lap = F.l1_loss(pred_laplacian_p, gt_laplacian_p)
# total = loss_main + 0.3 * loss_grad + 0.1 * loss_lap
```

### What to log per run

- `train/loss_grad` — gradient loss term (unweighted)
- `train/loss_laplacian` — laplacian term if used
- `train/lambda_grad` — effective weight used
- Standard surface MAE metrics

### Baseline reproduce command

```bash
python train.py --agent tanjiro --wandb_name "tanjiro/<run_name>" \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 180 --disable_pcgrad \
  --pressure_first --pressure_deep \
  --wandb_group phase5_grad_loss
```

## Baseline

| Metric | Value |
|--------|-------|
| val/loss | 0.401 ± 0.005 |
| p_in (surface pressure, in-distribution) | 12.95 ± 0.3 |
| p_oodc (out-of-dist chord) | 8.40 ± 0.4 |
| p_tan (tandem config) | 33.8 ± 0.5 |
| p_re (Reynolds sweep) | 24.7 ± 0.2 |

Baseline W&B run: PR #1867. Memory: ~36.2 GB.

**Target**: Beat p_in (12.95) primarily — gradient supervision most directly improves pointwise pressure accuracy through consistency enforcement.