### PR TITLE
Phase 5: Transolver++ Gumbel-Softmax — Discrete Slice Assignment (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 gumbel_softmax=False, gumbel_scale=0.1):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -154,6 +155,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.decouple_slice = decouple_slice
         self.zone_temp = zone_temp
         self.prog_slices = prog_slices
+        self.gumbel_softmax = gumbel_softmax
+        self.gumbel_scale = gumbel_scale
         if prog_slices:
             # Buffer for masking inactive slices; updated per-epoch by training loop
             self.register_buffer('slice_mask', torch.zeros(slice_num))
@@ -221,6 +224,10 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if self.prog_slices:
             # Apply slice mask: 0 for active slices, -1e9 for inactive (updated each epoch)
             slice_logits = slice_logits + self.slice_mask
+        if self.training and self.gumbel_softmax:
+            U = torch.zeros_like(slice_logits).uniform_().clamp(1e-6, 1 - 1e-6)
+            gumbel_noise = -(-U.log()).log()
+            slice_logits = slice_logits + self.gumbel_scale * gumbel_noise
         slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
@@ -282,6 +289,8 @@ class TransolverBlock(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        gumbel_softmax=False,
+        gumbel_scale=0.1,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -307,6 +316,8 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            gumbel_softmax=gumbel_softmax,
+            gumbel_scale=gumbel_scale,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -484,6 +495,8 @@ class Transolver(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        gumbel_softmax=False,
+        gumbel_scale=0.1,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -554,6 +567,8 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
+                    gumbel_softmax=gumbel_softmax,
+                    gumbel_scale=gumbel_scale,
                 )
                 for idx in range(n_layers)
             ]
@@ -814,6 +829,9 @@ class Config:
     pressure_no_detach: bool = False    # allow gradient from vel back to pres head
     pressure_deep: bool = False         # 3-layer pressure head instead of 2
     pressure_separate_last_block: bool = False  # separate last TransolverBlock for pressure
+    # Phase 5: Gumbel-Softmax discrete slice assignment
+    gumbel_softmax: bool = False        # add Gumbel noise to slice logits during training
+    gumbel_scale: float = 0.1           # scale of Gumbel noise (default 0.1)
 
 
 cfg = sp.parse(Config)
@@ -966,6 +984,8 @@ model_config = dict(
     pressure_first=cfg.pressure_first,
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
+    gumbel_softmax=cfg.gumbel_softmax,
+    gumbel_scale=cfg.gumbel_scale,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

The Transolver++ paper (ICML 2025) introduces Gumbel-Softmax reparameterization of slice assignment as a key improvement over the original Transolver. The core claim: replacing the standard softmax over slice logits with a Gumbel-Softmax during training encourages harder, more discrete slice assignments, which yields better-specialized physics slices and improved surface MAE (12–30% reported in paper).

We previously tested per-point adaptive temperature (PR #1879) but that is a different mechanism — it softens/sharpens softmax globally per point. Gumbel-Softmax adds structured noise to the logits before softmax, which encourages exploration of discrete assignments during training and collapses to argmax-like behavior at inference. **This specific mechanism has not been tested.**

Supporting reference: Gumbel-Softmax trick (Jang et al. ICLR 2017); Transolver++ (ICML 2025, extends Transolver with discrete slice routing).

## Instructions

All changes go in `cfd_tandemfoil/train.py`.

### Step 1 — Add Gumbel-Softmax noise injection in Physics_Attention_Irregular_Mesh.forward

In `Physics_Attention_Irregular_Mesh.forward`, after `slice_logits` is computed (just before the softmax that produces the slice weights / `attn`), add Gumbel noise during training:

```python
if self.training and getattr(self, 'gumbel_softmax', False):
    U = torch.zeros_like(slice_logits).uniform_().clamp(1e-6, 1 - 1e-6)
    gumbel_noise = -(-U.log()).log()
    slice_logits = slice_logits + self.gumbel_scale * gumbel_noise
# existing softmax follows unchanged
```

### Step 2 — Add flags to Physics_Attention_Irregular_Mesh.__init__

```python
self.gumbel_softmax = gumbel_softmax  # bool
self.gumbel_scale = gumbel_scale      # float, default 0.1
```

Thread these through `Model.__init__` and `parse_args` as:
- `--gumbel_softmax` (store_true)
- `--gumbel_scale` (float, default 0.1)

### Step 3 — Run 8-parallel GPU sweep

Use `--wandb_group phase5_gumbel` on all runs. Run these 8 configs in parallel:

| Run | gumbel_scale | notes |
|-----|-------------|-------|
| 1 | 0.01 | very small noise |
| 2 | 0.05 | small noise |
| 3 | 0.10 | **default — start here** |
| 4 | 0.20 | moderate |
| 5 | 0.50 | large |
| 6 | 0.10 + ada_temp | combined with adaptive temperature (--ada_temp if already merged) |
| 7 | 0.10 | seed=42 validation |
| 8 | baseline (no gumbel) | clean control run same conditions |

Each run uses the full baseline command plus `--gumbel_softmax --gumbel_scale <value>`:

```bash
python train.py --agent askeladd --wandb_name "askeladd/gumbel_scale_0.1" \
  --wandb_group phase5_gumbel \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 180 --disable_pcgrad \
  --pressure_first --pressure_deep \
  --gumbel_softmax --gumbel_scale 0.1
```

Adjust `--gumbel_scale` and `--wandb_name` per row. For the baseline control run, omit `--gumbel_softmax`.

**Key metrics to report:** val/loss, p_in, p_oodc, p_tan, p_re for every run.

## Baseline

**Current best (Phase 4 — PR #1867, Transolver + pressure_first + pressure_deep):**

| Metric | Mean (4 seeds) | Best single |
|--------|---------------|-------------|
| val/loss | 0.401 ± 0.005 | 0.395 |
| p_in | 12.95 ± 0.3 | 12.6 |
| p_oodc | 8.40 ± 0.4 | 8.0 |
| p_tan | 33.8 ± 0.5 | 33.3 |
| p_re | 24.7 ± 0.2 | 24.4 |

W&B group for baseline: search for runs from PR #1867 in the W&B project.

**Reproduce baseline:**
```bash
python train.py --agent <name> --wandb_name "<name>/baseline" \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 180 --disable_pcgrad \
  --pressure_first --pressure_deep
```