### PR TITLE
Phase 5: Transolver-3 Amortized Training — Random Node Subsampling (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -807,6 +807,7 @@ class Config:
     val_every: int = 1                  # validate every N epochs (1 = every epoch)
     disable_pcgrad: bool = False        # skip PCGrad dual-backward, use simple combined loss
     vol_subsample_frac: float = 1.0     # fraction of volume nodes in loss after vol_ramp (0.8 = 80%)
+    node_subsample_frac: float = 1.0    # fraction of VOLUME nodes sampled before forward pass (1.0 = all)
     compile_mode: str = "default"       # torch.compile mode: "default", "max-autotune", "reduce-overhead"
     num_workers: int = 4                # data loader workers
     # Phase 4: Pressure-first sequential prediction
@@ -1320,6 +1321,41 @@ for epoch in range(MAX_EPOCHS):
                 p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+
+        # --- Pre-forward-pass node subsampling (amortized training) ---
+        # Keep ALL surface nodes; randomly subsample volume nodes.
+        # Reduces N in forward pass for actual compute/memory savings.
+        if model.training and cfg.node_subsample_frac < 1.0:
+            B_sub = x.shape[0]
+            keep_masks = []
+            for b in range(B_sub):
+                surf_b = is_surface[b] & mask[b]
+                vol_b = (~is_surface[b]) & mask[b]
+                vol_idx = vol_b.nonzero(as_tuple=False).squeeze(1)
+                n_vol = vol_idx.shape[0]
+                n_keep = max(int(n_vol * cfg.node_subsample_frac), 1)
+                perm = torch.randperm(n_vol, device=x.device)[:n_keep]
+                kept_vol = torch.zeros_like(vol_b)
+                kept_vol[vol_idx[perm]] = True
+                keep_masks.append(surf_b | kept_vol)
+            keep_counts = [km.sum().item() for km in keep_masks]
+            max_kept = max(keep_counts)
+            D_x = x.shape[-1]
+            x_sub = torch.zeros(B_sub, max_kept, D_x, device=x.device, dtype=x.dtype)
+            y_sub = torch.zeros(B_sub, max_kept, y_norm.shape[-1], device=y_norm.device, dtype=y_norm.dtype)
+            is_surf_sub = torch.zeros(B_sub, max_kept, device=x.device, dtype=torch.bool)
+            mask_sub = torch.zeros(B_sub, max_kept, device=x.device, dtype=torch.bool)
+            for b in range(B_sub):
+                kc = keep_counts[b]
+                idx = keep_masks[b].nonzero(as_tuple=False).squeeze(1)
+                x_sub[b, :kc] = x[b, idx]
+                y_sub[b, :kc] = y_norm[b, idx]
+                is_surf_sub[b, :kc] = is_surface[b, idx]
+                mask_sub[b, :kc] = True
+            x = x_sub
+            y_norm = y_sub
+            is_surface = is_surf_sub
+            mask = mask_sub
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]


### PR DESCRIPTION
## Hypothesis

Implement key ideas from **Transolver-3** (arXiv 2602.04940, Feb 2026): **amortized training** on random mesh subsets. Instead of processing ALL nodes per training step, randomly subsample a fraction (50-75%) of nodes. This provides:

1. **Throughput gain**: fewer nodes per step → faster steps → more epochs in 3 hours
2. **Implicit regularization**: different subsets each step = data augmentation via dropout on the mesh
3. **Memory savings**: smaller tensors → can increase batch_size or model width

**Why this should work:**
- Transolver-3 shows amortized training matches or beats full-mesh training on large-scale CFD benchmarks
- With 85K-209K nodes per sample, many are redundant (far-field nodes contain little information)
- Random subsampling acts as a form of stochastic regularization — each step sees a different view of the mesh
- The model must learn robust representations that generalize across subsets, not memorize specific node positions

## Instructions

Add `--node_subsample_frac` flag. During training, randomly subsample nodes:

```python
if cfg.node_subsample_frac < 1.0:
    N = x.shape[1]
    n_keep = int(N * cfg.node_subsample_frac)
    # Random indices, but always keep ALL surface nodes
    surf_idx = is_surf.nonzero(as_tuple=True)[1]  # [B, S]
    vol_idx = (~is_surf & mask).nonzero(as_tuple=True)[1]  # [B, V]
    # Keep all surface nodes + random subset of volume nodes
    n_vol_keep = max(n_keep - surf_idx.shape[0], 100)
    vol_keep = vol_idx[torch.randperm(vol_idx.shape[0])[:n_vol_keep]]
    keep_idx = torch.cat([surf_idx, vol_keep])
    x = x[:, keep_idx]
    y = y[:, keep_idx]
    mask = mask[:, keep_idx]
    is_surf = is_surf[:, keep_idx]
```

**Critical**: Always keep ALL surface nodes (they're the most important for surface MAE). Only subsample volume nodes.

### GPU Sweep:
| GPU | subsample_frac | batch_size | n_hidden | Notes |
|-----|---------------|------------|----------|-------|
| 0 | 0.50 | 4 | 192 | 50% nodes, standard config |
| 1 | 0.75 | 4 | 192 | 75% nodes |
| 2 | 0.50 | 6 | 192 | 50% nodes + larger batch |
| 3 | 0.50 | 4 | 256 | 50% nodes + wider model |
| 4 | 0.25 | 4 | 192 | 25% nodes (aggressive) |
| 5 | 0.50 | 6 | 256 | Combined: fewer nodes + bigger model + bigger batch |
| 6 | 0.75 | 4 | 192 | seed 43 |
| 7 | 1.00 | 4 | 192 | **Baseline** (full mesh) |

## Baseline
val/loss 0.401, p_in 12.95, p_oodc 8.40, p_tan 33.8, p_re 24.7

### Reproduce:
```bash
python train.py --agent thorfinn --wandb_name "thorfinn/baseline" \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp \
  --domain_layernorm --domain_velhead --ema_decay 0.999 \
  --weight_decay 5e-5 --cosine_T_max 180 --disable_pcgrad \
  --pressure_first --pressure_deep
```