### PR TITLE
Phase 5: SDPA + Slice Count Sweep — Optimized Attention + More Slices (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 use_sdpa=False):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -147,6 +148,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.scale = dim_head**-0.5
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
+        self.use_sdpa = use_sdpa
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
         self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
         self.linear_no_attention = linear_no_attention
@@ -228,6 +230,15 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
         if self.linear_no_attention:
             out_slice_token = slice_token
+        elif self.use_sdpa:
+            # SDPA path: use F.scaled_dot_product_attention for fused attention
+            q_slice_token = self.to_q(slice_token).contiguous()  # [B, H, S, D]
+            slice_token_kv = slice_token.mean(dim=1, keepdim=True)
+            k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1).contiguous()
+            v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1).contiguous()
+            out_slice_token = F.scaled_dot_product_attention(
+                q_slice_token, k_slice_token, v_slice_token)
+            out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
         else:
             q_slice_token = self.to_q(slice_token)
             slice_token_kv = slice_token.mean(dim=1, keepdim=True)
@@ -282,6 +293,7 @@ class TransolverBlock(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        use_sdpa=False,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -307,6 +319,7 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            use_sdpa=use_sdpa,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -484,6 +497,7 @@ class Transolver(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        use_sdpa=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -554,6 +568,7 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
+                    use_sdpa=use_sdpa,
                 )
                 for idx in range(n_layers)
             ]
@@ -814,6 +829,8 @@ class Config:
     pressure_no_detach: bool = False    # allow gradient from vel back to pres head
     pressure_deep: bool = False         # 3-layer pressure head instead of 2
     pressure_separate_last_block: bool = False  # separate last TransolverBlock for pressure
+    # Phase 5: SDPA slice attention
+    use_sdpa: bool = False              # replace manual cosine attention with F.scaled_dot_product_attention
 
 
 cfg = sp.parse(Config)
@@ -966,6 +983,7 @@ model_config = dict(
     pressure_first=cfg.pressure_first,
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
+    use_sdpa=cfg.use_sdpa,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

frieren found that the Transolver's existing dual-projection attention (in_project_x + in_project_fx) is critical — removing in_project_fx hurts by 11%. But using F.scaled_dot_product_attention for the slice-to-slice attention step could provide a free speedup. Combined with a slice count sweep (96→128→192), this could enable more expressive models within the same VRAM budget.

## Instructions

1. Replace the manual attention computation in Physics_Attention_Irregular_Mesh.forward (the q_slice_token, k_slice_token, v_slice_token matmul) with F.scaled_dot_product_attention
2. Sweep slice counts to see if more slices improve accuracy

| GPU | SDPA | slice_num | Notes |
|-----|------|-----------|-------|
| 0 | yes | 96 | SDPA only (should match baseline) |
| 1 | yes | 128 | More slices |
| 2 | yes | 192 | Even more slices |
| 3 | yes | 64 | Fewer slices |
| 4 | yes | 128 | seed 43 |
| 5 | yes | 96 | seed 43 |
| 6 | no | 128 | Ablation: more slices without SDPA |
| 7 | no | 96 | Baseline |

## Baseline
val/loss 0.401, p_in 12.95, p_oodc 8.40, p_tan 33.8, p_re 24.7