### PR TITLE
Phase 5: Full AB-UPT Architecture — Complete Model Replacement (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -450,6 +450,7 @@ class ABUPT(nn.Module):
             anc_preds = self.output_head(anc_decoded)
 
         # Scatter anchor predictions back to full mesh (non-anchor nodes get 0)
+        anc_preds = anc_preds.float()  # ensure float32 for scatter (autocast may give bf16)
         preds = torch.zeros(B, N, anc_preds.shape[-1], device=dev)
         anchor_idx = torch.cat([si, vi], dim=1)
         anchor_valid = torch.cat([smask, vmask], dim=1)


### PR DESCRIPTION
## Hypothesis

Implement the FULL AB-UPT (Anchored-Branched Universal Physics Transformer) from arXiv:2502.09692, completely replacing the current Transolver. Previous attempt (#1899) was a simplified partial implementation that missed critical components. This time we implement the full model faithfully.

**Why this is different from #1899:**
- Full RoPE positional encoding from continuous 2D coordinates (not learnable embeddings)
- GNO supernode pooling for geometry encoding (not direct feature projection)
- Shared-weight surface-volume cross-attention blocks in the "pscscs" pattern
- Position-sampled anchors from the mesh (not learnable tokens)
- Separate surface and volume decoder branches with anchor attention

**Architecture:** 3-branch design — geometry branch (1 GNO + 1 self-attn), physics blocks (1 perceiver + 9 shared-weight transformer), surface decoder (2 blocks), volume decoder (2 blocks). dim=192, heads=3, ~10M params.

**Key advantage:** Full global attention on anchor subsets (2048 surface + 4096 volume) instead of slice-based soft clustering. Should capture long-range pressure propagation better.

**References:**
- Paper: https://arxiv.org/abs/2502.09692
- Official code: https://github.com/Emmi-AI/anchored-branched-universal-physics-transformers
- Training framework: https://github.com/Emmi-AI/noether
- Config: https://github.com/Emmi-AI/noether/blob/main/tutorial/configs/model/ab_upt.yaml

## Instructions

**IMPORTANT:** This is a COMPLETE model replacement. Delete the entire Transolver model (Physics_Attention_Irregular_Mesh, TransolverBlock, Transolver classes) and replace with a full AB-UPT implementation. Keep the training pipeline, data loading, loss computation, and evaluation code.

A detailed 950-line implementation guide is at: tmp/AB_UPT_IMPLEMENTATION_GUIDE.md — read it thoroughly before starting.

See the first comment below for key implementation notes.

## Baseline
val/loss 0.401+/-0.005, p_in 12.95+/-0.3, p_oodc 8.40+/-0.4, p_tan 33.8+/-0.5, p_re 24.7+/-0.2