### PR TITLE
Phase 5: Wall Distance Feature — Physics-Informed Input for Boundary Layer (8 parallel)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -840,22 +840,18 @@ stats = {k: v.to(device) for k, v in stats.items()}
 if cfg.walldist:
     base_ds = train_ds.dataset if hasattr(train_ds, 'dataset') else train_ds
     cache = base_ds._cache
-    print(f"Computing wall distance for {len(cache)} cached samples...")
+    from scipy.spatial import cKDTree
+    print(f"Computing wall distance for {len(cache)} cached samples (KDTree)...")
     for idx in sorted(cache.keys()):
         x, y, is_surf = cache[idx]
-        pos = x[:, :2]  # [N, 2]
-        surf_pos = pos[is_surf]  # [N_surf, 2]
+        pos = x[:, :2].numpy()  # [N, 2]
+        surf_pos = pos[is_surf.numpy()]  # [N_surf, 2]
         if surf_pos.shape[0] == 0:
             wd = torch.zeros(x.shape[0], 1)
         else:
-            # Compute in chunks to avoid OOM for large meshes
-            n = pos.shape[0]
-            chunk = 4096
-            wd_parts = []
-            for i in range(0, n, chunk):
-                d = torch.cdist(pos[i:i+chunk].unsqueeze(0), surf_pos.unsqueeze(0)).squeeze(0)
-                wd_parts.append(d.min(dim=-1).values)
-            wd = torch.cat(wd_parts).unsqueeze(-1)  # [N, 1]
+            tree = cKDTree(surf_pos)
+            dists, _ = tree.query(pos, k=1)
+            wd = torch.tensor(dists, dtype=torch.float32).unsqueeze(-1)  # [N, 1]
         if cfg.walldist_log:
             wd = torch.log1p(wd)
         x_new = torch.cat([x, wd], dim=-1)


### PR DESCRIPTION
## Hypothesis

Add wall distance (minimum distance to nearest airfoil surface node) as a 25th input feature. Wall distance is a fundamental quantity in RANS turbulence modeling — it determines boundary layer thickness, wall shear stress, and the transition between near-wall and free-stream physics. The model currently has signed distance fields (SDF) but no explicit wall distance.

**Why this should work:**
- In Phase 5 Round 1, nezuko's walldist experiment (#1875) showed the walldist variant beat its own baseline by 6.5% (0.409 vs 0.442 val/loss). However, that baseline was missing pressure_first, so it wasn't compared to our full baseline.
- Wall distance is THE single most important feature in RANS turbulence modeling (used by k-omega SST, SA, etc.)
- The existing SDF features capture distance to the nearest surface with sign, but SDF is relative to the closest foil boundary. Wall distance captures the minimum distance to ANY surface node, which is different near the gap between foils.
- Partially redundant with existing dist_feat but provides a cleaner geometric signal.
- Zero architecture change. Just adds 1 extra input dimension.

**Previous result (PR #1875, nezuko):** Promising but incomplete — tested without pressure_first. This is the proper controlled test.

## Instructions

See first comment for implementation.

## Baseline (8-seed)
val/loss 0.404+/-0.004, p_in 13.33+/-0.58, p_oodc 8.37+/-0.22, p_tan 33.57+/-0.44, p_re 24.58+/-0.13