### PR TITLE
Phase 6: SAM (Sharpness-Aware Minimization) on Asinh Baseline

### DIFF
--- a/cfd_tandemfoil/run_sweep.sh
+++ b/cfd_tandemfoil/run_sweep.sh
@@ -1,24 +1,36 @@
 #!/bin/bash
-# Phase 6 asinh s=0.75 multi-seed validation: 8 GPUs, seeds 42-49
+# Phase 6 SAM sweep: baseline vs SAM rho=0.02/0.05/0.1, 2 seeds each
+# SAM active from epoch 120 (last ~25% of training, matching original design intent)
+# Bug fix: old code used MAX_EPOCHS*0.75=375 which was unreachable; now uses sam_start_epoch
 set -e
 cd /workspace/senpai/cfd_tandemfoil
 
 BASE="python train.py --agent fern \
-  --wandb_group phase6/asinh-075-multiseed \
+  --wandb_group phase6/sam-v4 \
+  --asinh_pressure --asinh_scale 0.75 \
   --field_decoder --adaln_output --use_lion --lr 2e-4 \
   --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
   --n_layers 3 --slice_num 96 --tandem_ramp \
   --domain_layernorm --domain_velhead --ema_decay 0.999 \
   --weight_decay 5e-5 --cosine_T_max 160 --disable_pcgrad \
   --pressure_first --pressure_deep --residual_prediction \
-  --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
-  --asinh_pressure --asinh_scale 0.75"
+  --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3"
 
-for i in $(seq 0 7); do
-  seed=$((42 + i))
-  CUDA_VISIBLE_DEVICES=$i $BASE --seed $seed \
-    --wandb_name "fern/asinh-075-s${seed}" &
-done
+# GPU 0-1: Baseline (no SAM), seeds 42/43
+CUDA_VISIBLE_DEVICES=0 $BASE --seed 42 --wandb_name "fern/sam4-baseline-s42" &
+CUDA_VISIBLE_DEVICES=1 $BASE --seed 43 --wandb_name "fern/sam4-baseline-s43" &
+
+# GPU 2-3: SAM rho=0.05, seeds 42/43
+CUDA_VISIBLE_DEVICES=2 $BASE --adaln_sam --sam_rho 0.05 --sam_start_epoch 120 --seed 42 --wandb_name "fern/sam4-rho005-s42" &
+CUDA_VISIBLE_DEVICES=3 $BASE --adaln_sam --sam_rho 0.05 --sam_start_epoch 120 --seed 43 --wandb_name "fern/sam4-rho005-s43" &
+
+# GPU 4-5: SAM rho=0.1, seeds 42/43
+CUDA_VISIBLE_DEVICES=4 $BASE --adaln_sam --sam_rho 0.1 --sam_start_epoch 120 --seed 42 --wandb_name "fern/sam4-rho01-s42" &
+CUDA_VISIBLE_DEVICES=5 $BASE --adaln_sam --sam_rho 0.1 --sam_start_epoch 120 --seed 43 --wandb_name "fern/sam4-rho01-s43" &
+
+# GPU 6-7: SAM rho=0.02, seeds 42/43
+CUDA_VISIBLE_DEVICES=6 $BASE --adaln_sam --sam_rho 0.02 --sam_start_epoch 120 --seed 42 --wandb_name "fern/sam4-rho002-s42" &
+CUDA_VISIBLE_DEVICES=7 $BASE --adaln_sam --sam_rho 0.02 --sam_start_epoch 120 --seed 43 --wandb_name "fern/sam4-rho002-s43" &
 
 echo "All 8 runs launched. Waiting..."
 wait

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -874,6 +874,8 @@ class Config:
     adaln_decouple: bool = False       # decoupled slice assignment for tandem
     adaln_nozero: bool = False         # ablation: no zero-init on adaln projection
     adaln_sam: bool = False            # SAM optimizer in last 25% of training
+    sam_rho: float = 0.05              # SAM perturbation radius
+    sam_start_epoch: int = 0           # epoch to activate SAM (0 = from the start)
     film_cond: bool = False            # FiLM conditioning (simpler alternative to AdaLN)
     adaln_zone_temp: bool = False      # zone-aware temperature modulation
     # Phase 2 R5: tandem warm-in combinations
@@ -1290,7 +1292,7 @@ if refine_head is not None:
     base_opt.add_param_group({'params': _refine_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _refine_params):,} refinement head params to optimizer")
 
-sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
+sam_optimizer = SAM(base_opt, rho=cfg.sam_rho) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
     _warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
     _restarts = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
@@ -1769,7 +1771,7 @@ for epoch in range(MAX_EPOCHS):
             loss.backward()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * 0.75)
+        sam_active = sam_optimizer is not None and epoch >= cfg.sam_start_epoch
         _should_step = (cfg.grad_accum_steps <= 1 or
                         (batch_idx + 1) % cfg.grad_accum_steps == 0 or
                         batch_idx == len(train_loader) - 1)
@@ -1778,17 +1780,27 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.perturb()
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
+            # Detach all tensors from the first forward pass graph to avoid
+            # "backward through the graph a second time" errors.
+            _x2 = x.detach()
+            _sample_stds2 = sample_stds.detach()
+            _y_norm2 = y_norm.detach()
+            _vol_mask_train2 = vol_mask_train.detach()
+            _surf_mask2 = surf_mask.detach()
+            _tandem_boost2 = tandem_boost.detach()
+            _log_re_target2 = log_re_target.detach()
+            _aoa_target2 = aoa_target.detach()
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
-                pred2 = out2["preds"].float() / sample_stds
+                out2 = model({"x": _x2})
+                pred2 = out2["preds"].float() / _sample_stds2
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
-            abs_err2 = (pred2 - y_norm).abs()
-            vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-            surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-            surf_loss2 = (surf_ps2 * tandem_boost).mean()
-            re_loss2 = F.mse_loss(re_pred2, log_re_target)
-            aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)
+            abs_err2 = (pred2 - _y_norm2).abs()
+            vol_loss2 = (abs_err2 * _vol_mask_train2.unsqueeze(-1)).sum() / _vol_mask_train2.sum().clamp(min=1)
+            surf_ps2 = (abs_err2[:, :, 2:3] * _surf_mask2.unsqueeze(-1)).sum(dim=(1, 2)) / _surf_mask2.sum(dim=1).clamp(min=1).float()
+            surf_loss2 = (surf_ps2 * _tandem_boost2).mean()
+            re_loss2 = F.mse_loss(re_pred2, _log_re_target2)
+            aoa_loss2 = F.mse_loss(aoa_pred2, _aoa_target2)
             loss2 = vol_loss2 + surf_weight * surf_loss2 + 0.01 * re_loss2 + 0.01 * aoa_loss2
             loss2.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis
SAM finds flatter minima → better generalization. Now that asinh improves OOD, SAM may compound by making the model more robust.

| GPU | Config |
|-----|--------|
| 0-1 | Baseline s42/s43 |
| 2-3 | SAM rho=0.05 s42/s43 |
| 4-5 | SAM rho=0.1 s42/s43 |
| 6-7 | SAM rho=0.02 s42/s43 |

Implement SAM wrapper around Lion. Base: `python train.py --agent fern --wandb_group phase6/sam --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3`

Baseline (8-seed asinh s=0.75): p_in 13.03, p_oodc 7.83, p_tan 30.29, p_re 6.45