### PR TITLE
Phase 6: SAM Phase-Only — Flat Minima for Better OOD Generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -822,8 +822,8 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-MAX_TIMEOUT = 180.0  # minutes
-MAX_EPOCHS = 500
+MAX_TIMEOUT = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", 180.0))
+MAX_EPOCHS = int(os.environ.get("SENPAI_MAX_EPOCHS", 500))
 
 
 @dataclass
@@ -874,6 +874,8 @@ class Config:
     adaln_decouple: bool = False       # decoupled slice assignment for tandem
     adaln_nozero: bool = False         # ablation: no zero-init on adaln projection
     adaln_sam: bool = False            # SAM optimizer in last 25% of training
+    sam_rho: float = 0.05              # SAM perturbation radius (only used with --adaln_sam)
+    sam_start_frac: float = 0.75       # Fraction of MAX_EPOCHS at which SAM activates
     film_cond: bool = False            # FiLM conditioning (simpler alternative to AdaLN)
     adaln_zone_temp: bool = False      # zone-aware temperature modulation
     # Phase 2 R5: tandem warm-in combinations
@@ -1290,7 +1292,7 @@ if refine_head is not None:
     base_opt.add_param_group({'params': _refine_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _refine_params):,} refinement head params to optimizer")
 
-sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
+sam_optimizer = SAM(base_opt, rho=cfg.sam_rho) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
     _warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
     _restarts = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
@@ -1769,7 +1771,7 @@ for epoch in range(MAX_EPOCHS):
             loss.backward()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * 0.75)
+        sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * cfg.sam_start_frac)
         _should_step = (cfg.grad_accum_steps <= 1 or
                         (batch_idx + 1) % cfg.grad_accum_steps == 0 or
                         batch_idx == len(train_loader) - 1)
@@ -1777,18 +1779,26 @@ for epoch in range(MAX_EPOCHS):
             # SAM first step: perturb parameters toward gradient direction
             sam_optimizer.perturb()
             sam_optimizer.zero_grad()
+            # Detach all non-model tensors to avoid referencing freed graph
+            _sam_y = y_norm.detach()
+            _sam_stds = sample_stds.detach()
+            _sam_vmask = vol_mask_train.detach()
+            _sam_smask = surf_mask.detach()
+            _sam_tboost = tandem_boost.detach()
+            _sam_re_tgt = log_re_target.detach()
+            _sam_aoa_tgt = aoa_target.detach()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
-                pred2 = out2["preds"].float() / sample_stds
+                out2 = model({"x": x.detach()})
+                pred2 = out2["preds"].float() / _sam_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
-            abs_err2 = (pred2 - y_norm).abs()
-            vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-            surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
-            surf_loss2 = (surf_ps2 * tandem_boost).mean()
-            re_loss2 = F.mse_loss(re_pred2, log_re_target)
-            aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)
+            abs_err2 = (pred2 - _sam_y).abs()
+            vol_loss2 = (abs_err2 * _sam_vmask.unsqueeze(-1)).sum() / _sam_vmask.sum().clamp(min=1)
+            surf_ps2 = (abs_err2[:, :, 2:3] * _sam_smask.unsqueeze(-1)).sum(dim=(1, 2)) / _sam_smask.sum(dim=1).clamp(min=1).float()
+            surf_loss2 = (surf_ps2 * _sam_tboost).mean()
+            re_loss2 = F.mse_loss(re_pred2, _sam_re_tgt)
+            aoa_loss2 = F.mse_loss(aoa_pred2, _sam_aoa_tgt)
             loss2 = vol_loss2 + surf_weight * surf_loss2 + 0.01 * re_loss2 + 0.01 * aoa_loss2
             loss2.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
@@ -1819,7 +1829,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_refine_head.parameters(), _refine_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if sam_optimizer is not None:
+            log_dict["train/sam_active"] = int(sam_active)
+        wandb.log(log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -822,8 +822,8 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-MAX_TIMEOUT = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", 180.0))
-MAX_EPOCHS = int(os.environ.get("SENPAI_MAX_EPOCHS", 500))
+MAX_TIMEOUT = 180.0  # minutes
+MAX_EPOCHS = 500
 
 
 @dataclass
@@ -1771,7 +1771,7 @@ for epoch in range(MAX_EPOCHS):
             loss.backward()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * cfg.sam_start_frac)
+        sam_active = sam_optimizer is not None and epoch >= int(cfg.cosine_T_max * cfg.sam_start_frac)
         _should_step = (cfg.grad_accum_steps <= 1 or
                         (batch_idx + 1) % cfg.grad_accum_steps == 0 or
                         batch_idx == len(train_loader) - 1)


### PR DESCRIPTION
## Hypothesis

Sharpness-Aware Minimization (SAM) applied only in the **final 25% of training** will find flatter loss-landscape minima, reducing our high seed variance (p_in std=0.39, p_oodc std=0.19) and improving OOD generalization (p_oodc, p_re).

**The key insight:** SAM is already implemented in `train.py` (class `SAM`, line 1164). The flag `--adaln_sam` activates it for epochs >= 75% of T_max=160 (i.e., epoch ≥ 120). SAM doubles gradient computation cost during activation, but since it only runs in the last 25% of training, total overhead is ~6% total slowdown.

**Why phase-only SAM?** Full-SAM (all epochs) is expensive and can destabilize early training. Phase-only SAM polishes a converged model toward flatter basins. This is the approach of ESAM (Efficient SAM). Evidence: IJCAI 2024 shows SAM improves OOD for PDE regression; arXiv:2412.05169 shows +4.76% OOD average over Adam. Our seed variance (p_in std=0.39) suggests sharp basins — SAM's target.

**Extra hypothesis:** Lion's sign-based updates may need higher rho than the default 0.05 since Lion's effective step magnitude differs from Adam.

## Instructions

The `--adaln_sam` flag and `SAM` class are already in `train.py`. Add a `--sam_rho` CLI flag to control the perturbation radius:

**Step 1 — Add `sam_rho` to the config dataclass (after line 876):**
```python
sam_rho: float = 0.05  # SAM perturbation radius (only used with --adaln_sam)
```

**Step 2 — Use it in the SAM instantiation (line 1293):**
```python
# Replace:
sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
# With:
sam_optimizer = SAM(base_opt, rho=cfg.sam_rho) if cfg.adaln_sam else None
```

**Step 3 — Run all 8 GPUs with the full baseline command + SAM variants:**

Full baseline command (all runs use this base):
```bash
python train.py --agent frieren --wandb_group phase6/sam-phase-only \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```

| GPU | wandb_name | Extra flags | Seed |
|-----|-----------|-------------|------|
| 0 | frieren/baseline-s42 | (none) | 42 |
| 1 | frieren/baseline-s43 | (none) | 43 |
| 2 | frieren/sam-rho0.05-s42 | --adaln_sam --sam_rho 0.05 | 42 |
| 3 | frieren/sam-rho0.05-s43 | --adaln_sam --sam_rho 0.05 | 43 |
| 4 | frieren/sam-rho0.1-s42 | --adaln_sam --sam_rho 0.1 | 42 |
| 5 | frieren/sam-rho0.1-s43 | --adaln_sam --sam_rho 0.1 | 43 |
| 6 | frieren/sam-rho0.2-s42 | --adaln_sam --sam_rho 0.2 | 42 |
| 7 | frieren/sam-rho0.2-s43 | --adaln_sam --sam_rho 0.2 | 43 |

**What to report:**
- Surface MAE (p_in, p_oodc, p_tan, p_re) for each config
- Whether SAM reduces seed variance (compare std across seeds)
- Which rho value works best

## Baseline

Current 8-seed single-model mean (the target to beat):
| p_in | p_oodc | p_tan | p_re |
|------|--------|-------|------|
| 13.03 ± 0.39 | 7.83 ± 0.19 | 30.29 ± 0.47 | 6.45 ± 0.05 |

Current best (8-seed ensemble, PR #2076): p_in=12.4, p_oodc=6.7, p_tan=29.4, p_re=5.8

W&B: wandb-applied-ai-team/senpai-v1, group phase6/sam-phase-only