### PR TITLE
Phase 6: SWAD — Stochastic Weight Averaging Densely

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -2154,14 +2154,26 @@ for epoch in range(MAX_EPOCHS):
             if val_loss_3split > swad_prev_val:
                 swad_done = True
                 if swad_checkpoints:
-                    avg_state = {k: torch.stack([c[k].float() for c in swad_checkpoints]).mean(0).to(device)
-                                 for k in swad_checkpoints[0]}
+                    avg_state = {k: torch.stack([c[0][k].float() for c in swad_checkpoints]).mean(0).to(device)
+                                 for k in swad_checkpoints[0][0]}
                     if ema_model is None:
                         ema_model = deepcopy(_base_model)
                     ema_model.load_state_dict(avg_state)
+                    # Also average refine head
+                    if refine_head is not None and swad_checkpoints[0][1] is not None:
+                        avg_refine = {k: torch.stack([c[1][k].float() for c in swad_checkpoints]).mean(0).to(device)
+                                      for k in swad_checkpoints[0][1]}
+                        _refine_base = refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head
+                        if ema_refine_head is None:
+                            ema_refine_head = deepcopy(_refine_base)
+                        ema_refine_head.load_state_dict(avg_refine)
             else:
                 snap = {k: v.cpu().clone() for k, v in _base_model.state_dict().items()}
-                swad_checkpoints.append(snap)
+                refine_snap = None
+                if refine_head is not None:
+                    _refine_base = refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head
+                    refine_snap = {k: v.cpu().clone() for k, v in _refine_base.state_dict().items()}
+                swad_checkpoints.append((snap, refine_snap))
                 if len(swad_checkpoints) > 20:
                     swad_checkpoints.pop(0)
             swad_prev_val = val_loss_3split


### PR DESCRIPTION
## Hypothesis

SWAD (Cha et al., NeurIPS 2021) averages model checkpoints densely from within a flat loss region, landing in a flatter basin with better generalization. The `--swad` flag is already implemented in train.py but has never been tested. SWAD is mechanistically distinct from snapshot ensemble (failed PR #1807, which averaged across widely-separated cyclical restarts). SWAD averages within a single stable plateau.

The flat-basin argument aligns with why Lion (sign-based, low-curvature updates) works well — we are already in a geometry where SWAD should thrive.

**Key difference from EMA:** EMA applies exponential decay to recent parameters. SWAD collects checkpoints during a validation-stable window and takes their uniform average — targeting the flat center of a loss basin rather than tracking the latest parameters.

## Instructions

### Code changes needed

**CRITICAL BUG FIX: SWAD does not average the surface refinement head.** The SWAD code in train.py (lines 2147-2167) only collects and averages `_base_model.state_dict()`. The `refine_head` is a SEPARATE module and is NOT included. You MUST fix this:

1. In the SWAD checkpoint collection (around line 2163), also collect refine_head state:
```python
snap = {k: v.cpu().clone() for k, v in _base_model.state_dict().items()}
refine_snap = {k: v.cpu().clone() for k, v in refine_head.state_dict().items()} if refine_head is not None else None
swad_checkpoints.append((snap, refine_snap))
```

2. In the SWAD averaging (around line 2156-2161), also average and load refine_head:
```python
avg_state = {k: torch.stack([c[0][k].float() for c in swad_checkpoints]).mean(0).to(device)
             for k in swad_checkpoints[0][0]}
if ema_model is None:
    ema_model = deepcopy(_base_model)
ema_model.load_state_dict(avg_state)

# Also average refine head
if refine_head is not None and swad_checkpoints[0][1] is not None:
    avg_refine = {k: torch.stack([c[1][k].float() for c in swad_checkpoints]).mean(0).to(device)
                  for k in swad_checkpoints[0][1]}
    if ema_refine_head is None:
        ema_refine_head = deepcopy(refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head)
    ema_refine_head.load_state_dict(avg_refine)
```

3. Update the `len(swad_checkpoints) > 20` check to work with tuples.

### Experiment matrix (8 GPUs)

| GPU | Config | Seed |
|-----|--------|------|
| 0 | Baseline (no SWAD) | 42 |
| 1 | Baseline (no SWAD) | 43 |
| 2 | `--swad` | 42 |
| 3 | `--swad` | 43 |
| 4 | `--swad` | 44 |
| 5 | `--swad` | 45 |
| 6 | `--swad` | 66 |
| 7 | `--swad` | 67 |

Use `--wandb_group phase6/swad-averaging` for all runs.

**Base command (SWAD):**
```bash
python train.py --agent edward --wandb_group phase6/swad-averaging \
  --wandb_name "edward/swad-s${seed}" \
  --swad \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed ${seed}
```

**Base command (baseline, no SWAD):**
Same as above but WITHOUT `--swad`.

### Important notes
- DO NOT modify MAX_EPOCHS (500) or MAX_TIMEOUT (180.0) in train.py
- SWAD suppresses EMA updates — this is expected behavior (line 1805)
- SWAD collection triggers when val_loss < 50% of initial val_loss
- SWAD averaging triggers when val_loss first goes UP during collection
- The sliding window is capped at 20 checkpoints

## Baseline

Current best (8-seed ensemble, PR #2080):
- p_in: **12.2** | p_oodc: **6.7** | p_tan: **29.1** | p_re: **5.8**

Single-model baseline (8-seed mean):
- p_in: **13.03** | p_oodc: **7.83** | p_tan: **30.29** | p_re: **6.45**

Compare SWAD single-model results against the SINGLE-MODEL baseline (not the ensemble).

## Reporting

Post a comment with results in table format including:
- Individual run metrics (p_in, p_oodc, p_tan, p_re) for all 8 runs
- Mean ± std for SWAD runs vs baseline runs
- W&B run IDs