### PR TITLE
Phase 6: Multi-Scale Deep Supervision — Auxiliary Loss on Intermediate Features

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,9 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Deep supervision — auxiliary loss on intermediate hidden features
+    deep_supervision: bool = False           # enable auxiliary head on pre-final-block hidden features
+    aux_loss_weight: float = 0.1             # weight for auxiliary surface loss
 
 
 cfg = sp.parse(Config)
@@ -1139,6 +1142,18 @@ if cfg.surface_refine:
           f"(hidden={cfg.surface_refine_hidden}, layers={cfg.surface_refine_layers}, "
           f"p_only={cfg.surface_refine_p_only}, context={cfg.surface_refine_context})")
 
+# Deep supervision auxiliary head (training-only, not in EMA/eval)
+aux_head = None
+if cfg.deep_supervision:
+    aux_head = nn.Sequential(
+        nn.Linear(cfg.n_hidden, cfg.n_hidden // 2),
+        nn.GELU(),
+        nn.Linear(cfg.n_hidden // 2, 3),  # predict [Ux, Uy, p]
+    ).to(device)
+    aux_head = torch.compile(aux_head, mode=cfg.compile_mode)
+    _aux_n_params = sum(p.numel() for p in aux_head.parameters())
+    print(f"Deep supervision aux head: {_aux_n_params:,} params (weight={cfg.aux_loss_weight})")
+
 from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
@@ -1159,6 +1174,8 @@ snapshot_epoch_list = [int(e) for e in cfg.snapshot_epochs_str.split(",")] if cf
 n_params = sum(p.numel() for p in model.parameters())
 if refine_head is not None:
     n_params += sum(p.numel() for p in refine_head.parameters())
+if aux_head is not None:
+    n_params += sum(p.numel() for p in aux_head.parameters())
 
 
 class SAM:
@@ -1290,6 +1307,12 @@ if refine_head is not None:
     base_opt.add_param_group({'params': _refine_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _refine_params):,} refinement head params to optimizer")
 
+# Add deep supervision aux head params to optimizer if enabled
+if aux_head is not None:
+    _aux_params = list(aux_head.parameters())
+    base_opt.add_param_group({'params': _aux_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _aux_params):,} aux head params to optimizer")
+
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
     _warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
@@ -1382,8 +1405,11 @@ for epoch in range(MAX_EPOCHS):
     model.train()
     if refine_head is not None:
         refine_head.train()
+    if aux_head is not None:
+        aux_head.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
+    epoch_aux = 0.0
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
@@ -1703,6 +1729,18 @@ for epoch in range(MAX_EPOCHS):
             _coarse_loss = coarse_loss
             loss = loss + 1.0 * coarse_loss
 
+        # Deep supervision: auxiliary loss on intermediate hidden features
+        _aux_loss_val = 0.0
+        if cfg.deep_supervision and aux_head is not None and model.training:
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                aux_pred = aux_head(hidden)  # [B, N, 3]
+            aux_pred = aux_pred.float()
+            # Surface-only auxiliary loss (L1)
+            aux_err = (aux_pred - y_norm).abs()
+            aux_loss = (aux_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = loss + cfg.aux_loss_weight * aux_loss
+            _aux_loss_val = aux_loss.item()
+
         log_re_target = x[:, 0, 13:14]  # log(Re) from input features (same for all nodes)
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
@@ -1823,6 +1861,7 @@ for epoch in range(MAX_EPOCHS):
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
+        epoch_aux += _aux_loss_val
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
@@ -1874,6 +1913,7 @@ for epoch in range(MAX_EPOCHS):
                     _blk.attn.slice_mask[active:].fill_(-1e9)
     epoch_vol /= n_batches
     epoch_surf /= n_batches
+    epoch_aux /= n_batches
     prev_vol_loss = epoch_vol
     prev_surf_loss = epoch_surf
     # Snapshot ensemble: save running average at specified epochs
@@ -1893,13 +1933,16 @@ for epoch in range(MAX_EPOCHS):
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
     if not _do_val:
         dt = time.time() - t0
-        wandb.log({
+        _log = {
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
             "epoch_time_s": dt,
             "lr": scheduler.get_last_lr()[0],
             "global_step": global_step,
-        })
+        }
+        if cfg.deep_supervision:
+            _log["train/aux_loss"] = epoch_aux
+        wandb.log(_log)
         print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
         continue
 
@@ -2198,6 +2241,8 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+    if cfg.deep_supervision:
+        metrics["train/aux_loss"] = epoch_aux
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f


### PR DESCRIPTION
## Hypothesis

The model's forward pass computes `fx_deep = fx` just before the last TransolverBlock (saved as `model_out["hidden"]`). Adding an auxiliary head that predicts surface targets from these intermediate features creates a deep supervision signal. This forces earlier blocks to produce more useful intermediate representations, reducing vanishing gradient effects in the 3-block Transolver.

Deep supervision is proven effective in nnUNet (Isensee et al.), HED (edge detection), and FNO variants. The mechanism is: direct gradient flow from surface targets to pre-final-block features, improving the physics attention in intermediate blocks.

## Instructions

### Code changes (~15 lines)

1. Add an auxiliary head after the model is created:
```python
# After model creation, add auxiliary prediction head
aux_head = nn.Sequential(
    nn.Linear(cfg.n_hidden, cfg.n_hidden // 2),
    nn.GELU(),
    nn.Linear(cfg.n_hidden // 2, 3)  # predict [Ux, Uy, p]
).to(device)
```

2. Add `aux_head` parameters to the optimizer:
```python
base_opt.add_param_group({'params': list(aux_head.parameters()), 'lr': _base_lr})
```

3. In the training loop, after the main forward pass, compute auxiliary loss:
```python
if cfg.deep_supervision and model.training:
    hidden = model_out["hidden"]  # [B, N, n_hidden] — intermediate features
    aux_pred = aux_head(hidden)   # [B, N, 3]
    # Apply surface mask
    aux_surf_pred = aux_pred[surface_mask]  # surface nodes only
    aux_surf_target = targets[surface_mask]
    aux_loss = cfg.aux_loss_weight * F.l1_loss(aux_surf_pred, aux_surf_target)
    loss = loss + aux_loss
    wandb.log({"train/aux_loss": aux_loss.item()})
```

4. New config flags:
```python
deep_supervision: bool = False
aux_loss_weight: float = 0.1  # weight for auxiliary loss
```

5. **Important:** The auxiliary head is NOT used at inference time. Only the main model predictions are used for evaluation.

### Experiment matrix (8 GPUs)

| GPU | Config | Seed | Notes |
|-----|--------|------|-------|
| 0 | Baseline (no aux loss) | 42 | Control |
| 1 | Baseline (no aux loss) | 43 | Control |
| 2 | `--deep_supervision --aux_loss_weight 0.05` | 42 | Light aux |
| 3 | `--deep_supervision --aux_loss_weight 0.05` | 43 | Light aux |
| 4 | `--deep_supervision --aux_loss_weight 0.1` | 42 | Medium aux |
| 5 | `--deep_supervision --aux_loss_weight 0.1` | 43 | Medium aux |
| 6 | `--deep_supervision --aux_loss_weight 0.2` | 42 | Strong aux |
| 7 | `--deep_supervision --aux_loss_weight 0.2` | 43 | Strong aux |

Use `--wandb_group phase6/deep-supervision` for all runs.

**Base command:**
```bash
python train.py --agent nezuko --wandb_group phase6/deep-supervision \
  --wandb_name "nezuko/deepsup-w${weight}-s${seed}" \
  --deep_supervision --aux_loss_weight ${weight} \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed ${seed}
```

### Important notes
- DO NOT modify MAX_EPOCHS (500) or MAX_TIMEOUT (180.0) in train.py
- The `model_out["hidden"]` tensor is computed before the last TransolverBlock — verify this by checking the model's forward method
- The auxiliary head must NOT be included in the EMA model or SWAD checkpoints — it's training-only
- Surface mask extraction: look at how the main loss computes surface predictions to find the right mask variable
- Log `train/aux_loss` separately to monitor whether the auxiliary signal is informative

## Baseline

Current best (8-seed ensemble, PR #2080):
- p_in: **12.2** | p_oodc: **6.7** | p_tan: **29.1** | p_re: **5.8**

Single-model baseline (8-seed mean):
- p_in: **13.03** | p_oodc: **7.83** | p_tan: **30.29** | p_re: **6.45**

## Reporting

Post results with:
- Individual metrics for all 8 runs
- Mean ± std for each aux_loss_weight vs baseline
- aux_loss convergence curves (does it decrease? plateau?)
- W&B run IDs