### PR TITLE
Phase 6: Asinh Velocity Transform — Compression on Ux/Uy Channels

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,9 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Asinh velocity transform
+    asinh_velocity: bool = False             # also transform velocity channels (Ux, Uy) with asinh
+    asinh_velocity_scale: float = 0.5       # scale factor before asinh: asinh(v * scale)
 
 
 cfg = sp.parse(Config)
@@ -1043,6 +1046,9 @@ with torch.no_grad():
         if cfg.asinh_pressure:
             _yp = _yp.clone()
             _yp[:, :, 2:3] = torch.asinh(_yp[:, :, 2:3] * cfg.asinh_scale)
+        if cfg.asinh_velocity:
+            _yp = _yp.clone()
+            _yp[:, :, 0:2] = torch.asinh(_yp[:, :, 0:2] * cfg.asinh_velocity_scale)
         _m = _mask.float().unsqueeze(-1)  # [B, N, 1]
         _phys_sum += (_yp * _m).sum(dim=(0, 1))
         _phys_sq_sum += (_yp ** 2 * _m).sum(dim=(0, 1))
@@ -1064,6 +1070,8 @@ if cfg.raw_targets or cfg.adaptive_norm:
             _yt = _y.clone()
             if cfg.adaptive_norm and cfg.asinh_pressure:
                 _yt[:, :, 2:3] = torch.asinh(_yt[:, :, 2:3] * cfg.asinh_scale)
+            if cfg.adaptive_norm and cfg.asinh_velocity:
+                _yt[:, :, 0:2] = torch.asinh(_yt[:, :, 0:2] * cfg.asinh_velocity_scale)
             _m = _mask.float().unsqueeze(-1)
             _raw_sum += (_yt * _m).sum(dim=(0, 1))
             _raw_sq_sum += (_yt ** 2 * _m).sum(dim=(0, 1))
@@ -1485,6 +1493,8 @@ for epoch in range(MAX_EPOCHS):
             y_adapt = y.clone()
             if cfg.asinh_pressure:
                 y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
+            if cfg.asinh_velocity:
+                y_adapt[:, :, 0:2] = torch.asinh(y_adapt[:, :, 0:2] * cfg.asinh_velocity_scale)
             y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
         else:
             y_phys = _phys_norm(y, Umag, q)
@@ -1494,6 +1504,9 @@ for epoch in range(MAX_EPOCHS):
             if cfg.asinh_pressure:
                 y_phys = y_phys.clone()
                 y_phys[:, :, 2:3] = torch.asinh(y_phys[:, :, 2:3] * cfg.asinh_scale)
+            if cfg.asinh_velocity:
+                y_phys = y_phys.clone()
+                y_phys[:, :, 0:2] = torch.asinh(y_phys[:, :, 0:2] * cfg.asinh_velocity_scale)
             y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         # Residual prediction: subtract freestream from normalized targets
         _freestream = None
@@ -1972,6 +1985,8 @@ for epoch in range(MAX_EPOCHS):
                     y_adapt = y.clone()
                     if cfg.asinh_pressure:
                         y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
+                    if cfg.asinh_velocity:
+                        y_adapt[:, :, 0:2] = torch.asinh(y_adapt[:, :, 0:2] * cfg.asinh_velocity_scale)
                     y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
                 else:
                     y_phys = _phys_norm(y, Umag, q)
@@ -1981,6 +1996,9 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.asinh_pressure:
                         y_phys = y_phys.clone()
                         y_phys[:, :, 2:3] = torch.asinh(y_phys[:, :, 2:3] * cfg.asinh_scale)
+                    if cfg.asinh_velocity:
+                        y_phys = y_phys.clone()
+                        y_phys[:, :, 0:2] = torch.asinh(y_phys[:, :, 0:2] * cfg.asinh_velocity_scale)
                     y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 # Residual prediction: subtract freestream in val loop
@@ -2089,6 +2107,9 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.asinh_pressure:
                         pred_adapt = pred_adapt.clone()
                         pred_adapt[:, :, 2:3] = torch.sinh(pred_adapt[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.asinh_velocity:
+                        pred_adapt = pred_adapt.clone()
+                        pred_adapt[:, :, 0:2] = torch.sinh(pred_adapt[:, :, 0:2]) / cfg.asinh_velocity_scale
                     pred_orig = pred_adapt
                 else:
                     pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
@@ -2098,6 +2119,9 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.asinh_pressure:
                         pred_phys = pred_phys.clone()
                         pred_phys[:, :, 2:3] = torch.sinh(pred_phys[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.asinh_velocity:
+                        pred_phys = pred_phys.clone()
+                        pred_phys[:, :, 0:2] = torch.sinh(pred_phys[:, :, 0:2]) / cfg.asinh_velocity_scale
                     if cfg.tight_denorm_clamps:
                         _pd = pred_phys.clone()
                         _pd[:, :, 0:1] = pred_phys[:, :, 0:1].clamp(-5, 5) * Umag
@@ -2312,6 +2336,9 @@ if best_metrics:
                         if cfg.asinh_pressure:
                             pred_adapt = pred_adapt.clone()
                             pred_adapt[:, :, 2:3] = torch.sinh(pred_adapt[:, :, 2:3]) / cfg.asinh_scale
+                        if cfg.asinh_velocity:
+                            pred_adapt = pred_adapt.clone()
+                            pred_adapt[:, :, 0:2] = torch.sinh(pred_adapt[:, :, 0:2]) / cfg.asinh_velocity_scale
                         y_pred = pred_adapt.squeeze(0).cpu()
                     else:
                         pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
@@ -2321,6 +2348,9 @@ if best_metrics:
                         if cfg.asinh_pressure:
                             pred_phys = pred_phys.clone()
                             pred_phys[:, :, 2:3] = torch.sinh(pred_phys[:, :, 2:3]) / cfg.asinh_scale
+                        if cfg.asinh_velocity:
+                            pred_phys = pred_phys.clone()
+                            pred_phys[:, :, 0:2] = torch.sinh(pred_phys[:, :, 0:2]) / cfg.asinh_velocity_scale
                         if cfg.tight_denorm_clamps:
                             _pd = pred_phys.clone()
                             _pd[:, :, 0:1] = pred_phys[:, :, 0:1].clamp(-5, 5) * Umag
@@ -2410,12 +2440,17 @@ if cfg.surface_refine and best_metrics:
                         y_adapt = y.clone()
                         if cfg.asinh_pressure:
                             y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
+                        if cfg.asinh_velocity:
+                            y_adapt[:, :, 0:2] = torch.asinh(y_adapt[:, :, 0:2] * cfg.asinh_velocity_scale)
                         y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
                     else:
                         y_phys = _phys_norm(y, Umag, q)
                         if cfg.asinh_pressure:
                             y_phys = y_phys.clone()
                             y_phys[:, :, 2:3] = torch.asinh(y_phys[:, :, 2:3] * cfg.asinh_scale)
+                        if cfg.asinh_velocity:
+                            y_phys = y_phys.clone()
+                            y_phys[:, :, 0:2] = torch.asinh(y_phys[:, :, 0:2] * cfg.asinh_velocity_scale)
                         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                     # Residual prediction
@@ -2489,6 +2524,9 @@ if cfg.surface_refine and best_metrics:
                     if cfg.asinh_pressure:
                         pred_phys_A = pred_phys_A.clone()
                         pred_phys_A[:, :, 2:3] = torch.sinh(pred_phys_A[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.asinh_velocity:
+                        pred_phys_A = pred_phys_A.clone()
+                        pred_phys_A[:, :, 0:2] = torch.sinh(pred_phys_A[:, :, 0:2]) / cfg.asinh_velocity_scale
                     # Physics denorm (skip for adaptive_norm — already in raw space)
                     pred_orig_A = pred_phys_A if cfg.adaptive_norm else _phys_denorm(pred_phys_A, Umag, q)
 
@@ -2510,6 +2548,9 @@ if cfg.surface_refine and best_metrics:
                     if cfg.asinh_pressure:
                         pred_manual_phys = pred_manual_phys.clone()
                         pred_manual_phys[:, :, 2:3] = torch.sinh(pred_manual_phys[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.asinh_velocity:
+                        pred_manual_phys = pred_manual_phys.clone()
+                        pred_manual_phys[:, :, 0:2] = torch.sinh(pred_manual_phys[:, :, 0:2]) / cfg.asinh_velocity_scale
                     # Step 6: undo physics norm: Ux*Umag, Uy*Umag, p*q
                     if cfg.adaptive_norm:
                         pred_manual_orig = pred_manual_phys
@@ -2530,6 +2571,9 @@ if cfg.surface_refine and best_metrics:
                     if cfg.asinh_pressure:
                         pred_norefine_phys = pred_norefine_phys.clone()
                         pred_norefine_phys[:, :, 2:3] = torch.sinh(pred_norefine_phys[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.asinh_velocity:
+                        pred_norefine_phys = pred_norefine_phys.clone()
+                        pred_norefine_phys[:, :, 0:2] = torch.sinh(pred_norefine_phys[:, :, 0:2]) / cfg.asinh_velocity_scale
                     pred_norefine_orig = pred_norefine_phys if cfg.adaptive_norm else _phys_denorm(pred_norefine_phys, Umag, q)
 
                     # Compute surface pressure MAE for all paths


### PR DESCRIPTION
## Hypothesis

The current asinh transform applies only to the pressure channel (index 2 of the 3-channel output). Velocity channels (Ux at index 0, Uy at index 1) are left untransformed. However, velocity in CFD wake flows also has highly non-Gaussian distributions: near-surface boundary layers have steep gradients, the far-field has near-zero velocity. Uy (cross-stream) has strong antisymmetry around the chord line.

Applying asinh compression to velocity channels reduces the effective dynamic range and makes the L1 loss less dominated by high-velocity regions — the same argument that motivated pressure asinh (PR #2054, p_oodc -6.1%).

## Instructions

### Code changes (~10 lines)

1. Find where the pressure asinh transform is applied in train.py. It should look something like:
\`\`\`python
_yp[:, :, 2:3] = torch.asinh(_yp[:, :, 2:3] * cfg.asinh_scale)
\`\`\`

2. Add a new flag and apply asinh to velocity channels:
\`\`\`python
# New config flags:
asinh_velocity: bool = False
asinh_velocity_scale: float = 0.5  # separate scale for velocity (different range than pressure)
\`\`\`

3. When `asinh_velocity=True`, also transform velocity channels:
\`\`\`python
if cfg.asinh_velocity:
    vel_scale = cfg.asinh_velocity_scale
    _yp[:, :, 0:2] = torch.asinh(_yp[:, :, 0:2] * vel_scale)
\`\`\`

4. Apply the INVERSE transform when computing predictions (postprocessing):
\`\`\`python
if cfg.asinh_velocity:
    vel_scale = cfg.asinh_velocity_scale
    pred[:, :, 0:2] = torch.sinh(pred[:, :, 0:2]) / vel_scale
\`\`\`

5. Verify the inverse is correct: `sinh(asinh(x * s)) / s = x` ✓

### Experiment matrix (8 GPUs)

| GPU | Config | Seed | Notes |
|-----|--------|------|-------|
| 0 | Baseline (no velocity asinh) | 42 | Control |
| 1 | Baseline (no velocity asinh) | 43 | Control |
| 2 | `--asinh_velocity --asinh_velocity_scale 0.3` | 42 | Mild compression |
| 3 | `--asinh_velocity --asinh_velocity_scale 0.3` | 43 | Mild compression |
| 4 | `--asinh_velocity --asinh_velocity_scale 0.5` | 42 | Medium compression |
| 5 | `--asinh_velocity --asinh_velocity_scale 0.5` | 43 | Medium compression |
| 6 | `--asinh_velocity --asinh_velocity_scale 1.0` | 42 | Strong compression |
| 7 | `--asinh_velocity --asinh_velocity_scale 1.0` | 43 | Strong compression |

Use `--wandb_group phase6/asinh-velocity` for all runs.

**Base command:**
\`\`\`bash
python train.py --agent alphonse --wandb_group phase6/asinh-velocity \
  --wandb_name "alphonse/asinh-vel-s${scale}-s${seed}" \
  --asinh_velocity --asinh_velocity_scale ${scale} \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed ${seed}
\`\`\`

### Important notes
- DO NOT modify MAX_EPOCHS (500) or MAX_TIMEOUT (180.0) in train.py
- The velocity scale should be SEPARATE from the pressure scale (0.75) — different physical ranges
- Start with scale 0.5 (smaller than pressure 0.75) since velocity range may differ
- Watch for divergence — if asinh compresses too much, gradients may vanish
- Also report velocity MAE metrics if available — we care about surface pressure MAE but velocity quality matters for physical consistency

## Baseline

Current best (8-seed ensemble, PR #2080):
- p_in: **12.2** | p_oodc: **6.7** | p_tan: **29.1** | p_re: **5.8**

Single-model baseline (8-seed mean):
- p_in: **13.03** | p_oodc: **7.83** | p_tan: **30.29** | p_re: **6.45**

## Reporting

Post results with individual metrics for all 8 runs, mean ± std per scale, and W&B run IDs.