### PR TITLE
Phase 6: Stochastic Depth (DropPath) — Implicit Ensemble Regularization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -253,6 +253,22 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         return self.to_out(out_x)
 
 
+class DropPath(nn.Module):
+    """Stochastic Depth (Huang et al., ECCV 2016). Drops entire residual paths."""
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x):
+        if not self.training or self.drop_prob == 0.0:
+            return x
+        keep_prob = 1.0 - self.drop_prob
+        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
+        rand_t = torch.rand(shape, dtype=x.dtype, device=x.device)
+        rand_t = torch.floor(rand_t + keep_prob)
+        return x * rand_t / keep_prob
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -282,6 +298,7 @@ class TransolverBlock(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        drop_prob=0.0,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -334,6 +351,7 @@ class TransolverBlock(nn.Module):
         )
         nn.init.zeros_(self.spatial_bias[-1].weight)
         nn.init.zeros_(self.spatial_bias[-1].bias)
+        self.drop_path = DropPath(drop_prob) if drop_prob > 0.0 else nn.Identity()
         self.ln_1_post = _LN(hidden_dim)
         self.ln_2_post = _LN(hidden_dim)
         self.se_fc1 = nn.Linear(hidden_dim, hidden_dim // 4)
@@ -403,12 +421,12 @@ class TransolverBlock(nn.Module):
             cond_out = self.adaln_net(condition)  # [B, H*4]
             s1, b1, s2, b2 = cond_out.chunk(4, dim=-1)  # each [B, H]
             fx_norm = _ln(self.ln_1, fx) * (1 + s1.unsqueeze(1)) + b1.unsqueeze(1)
-            fx = _ln(self.ln_1_post, self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
+            fx = _ln(self.ln_1_post, self.drop_path(self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features)) + fx)
             fx_norm = _ln(self.ln_2, fx) * (1 + s2.unsqueeze(1)) + b2.unsqueeze(1)
-            fx = _ln(self.ln_2_post, self.mlp(fx_norm) + fx)
+            fx = _ln(self.ln_2_post, self.drop_path(self.mlp(fx_norm)) + fx)
         else:
-            fx = _ln(self.ln_1_post, self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
-            fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
+            fx = _ln(self.ln_1_post, self.drop_path(self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features)) + fx)
+            fx = _ln(self.ln_2_post, self.drop_path(self.mlp(_ln(self.ln_2, fx))) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
@@ -601,6 +619,7 @@ class Transolver(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        drop_path_rate=0.0,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -642,6 +661,8 @@ class Transolver(nn.Module):
         self.space_dim = space_dim
         self.feature_cross = nn.Linear(fun_dim + space_dim, fun_dim + space_dim, bias=False)
         nn.init.eye_(self.feature_cross.weight)  # start as identity
+        # Linear stochastic depth schedule: layer 0 gets 0, last layer gets drop_path_rate
+        _dpr = [drop_path_rate * i / max(n_layers - 1, 1) for i in range(n_layers)]
         self.blocks = nn.ModuleList(
             [
                 TransolverBlock(
@@ -671,6 +692,7 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
+                    drop_prob=_dpr[idx],
                 )
                 for idx in range(n_layers)
             ]
@@ -947,6 +969,8 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Stochastic Depth
+    drop_path_rate: float = 0.0             # stochastic depth max drop rate (0=disabled, linear schedule across layers)
 
 
 cfg = sp.parse(Config)
@@ -1106,6 +1130,7 @@ model_config = dict(
     pressure_first=cfg.pressure_first,
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
+    drop_path_rate=cfg.drop_path_rate,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

Transolver's 3 blocks have no stochastic regularization. Stochastic Depth (DropPath) randomly skips entire residual branches during training, creating an implicit ensemble of subnetworks of varying depth. This forces the model to learn more **redundant, robust representations** that don't rely on any single block — a form of structural regularization proven to improve OOD generalization in ViT, DeiT, and Swin Transformer.

**Why this might help p_tan especially:** The tandem foil OOD is the hardest case (p_tan=30.29 vs p_in=13.03). The model may be overfitting to structural patterns in single-foil geometry that break under tandem interference. DropPath prevents over-reliance on specific block computation paths, encouraging more geometry-agnostic representations.

**Paper:** Huang et al., "Deep Networks with Stochastic Depth", ECCV 2016. Used in DeiT (Touvron 2021, best drop_path_rate=0.1 for small models) and virtually all modern ViT variants. Not in our dead-ends list.

## Instructions

Add a `DropPath` module and apply it in the Transolver blocks. The change is ~20 lines in `train.py`.

**Step 1: Add DropPath class** (add near other utility classes, before the `Physics_Attention_Structured_Mesh` definition):

```python
class DropPath(nn.Module):
    """Stochastic Depth (Huang et al., ECCV 2016). Drops entire residual paths."""
    def __init__(self, drop_prob: float = 0.0):
        super().__init__()
        self.drop_prob = drop_prob

    def forward(self, x):
        if not self.training or self.drop_prob == 0.0:
            return x
        keep_prob = 1.0 - self.drop_prob
        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
        rand_t = torch.rand(shape, dtype=x.dtype, device=x.device)
        rand_t = torch.floor(rand_t + keep_prob)
        return x * rand_t / keep_prob
```

**Step 2: Add `--drop_path_rate` argument** to the argparse section:

```python
parser.add_argument('--drop_path_rate', type=float, default=0.0,
                    help='Stochastic depth drop path rate (0=disabled, try 0.1)')
```

**Step 3: Pass drop path rates to TransolverBlock** using a linear schedule (deeper layers drop more):

In the `Transolver` model `__init__`, where TransolverBlocks are created, compute per-layer rates and pass them:

```python
# Compute per-layer drop path rates (linear schedule, layer 0 gets lowest rate)
dpr = [cfg.drop_path_rate * i / max(cfg.n_layers - 1, 1) for i in range(cfg.n_layers)]
# For n_layers=3 and drop_path_rate=0.1: dpr = [0.0, 0.05, 0.1]
```

Pass `dpr[i]` to each `TransolverBlock` constructor. In `TransolverBlock.__init__`:

```python
self.drop_path = DropPath(drop_prob) if drop_prob > 0.0 else nn.Identity()
```

In `TransolverBlock.forward()`, apply to both attention and FFN residuals:

```python
# BEFORE: x = x + self.attn(self.norm1(x), ...)
# AFTER:
x = x + self.drop_path(self.attn(self.norm1(x), ...))
# Similarly for FFN:
x = x + self.drop_path(self.ffn(self.norm2(x)))
```

**Experiment runs:** Try two drop rates with two seeds each (run all 4 sequentially):

```bash
# Rate 0.1, seeds 42 and 73
python train.py --agent askeladd --wandb_name "askeladd/dp01-seed42" \
  --wandb_group phase6/stochastic-depth --drop_path_rate 0.1 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

python train.py --agent askeladd --wandb_name "askeladd/dp01-seed73" \
  --wandb_group phase6/stochastic-depth --drop_path_rate 0.1 --seed 73 \
  [same flags as above]

python train.py --agent askeladd --wandb_name "askeladd/dp02-seed42" \
  --wandb_group phase6/stochastic-depth --drop_path_rate 0.2 --seed 42 \
  [same flags]

python train.py --agent askeladd --wandb_name "askeladd/dp02-seed73" \
  --wandb_group phase6/stochastic-depth --drop_path_rate 0.2 --seed 73 \
  [same flags]
```

W&B group: `phase6/stochastic-depth`

## Baseline

Current best single-model metrics (8-seed mean, seeds 66-73):
| Metric | Baseline |
|--------|----------|
| p_in | 13.03 |
| p_oodc | 7.83 |
| p_tan | 30.29 |
| p_re | 6.45 |

Individual seed references:
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

Ensemble (8 seeds 66-73): p_in=12.2, p_oodc=6.7, p_tan=29.1, p_re=5.8

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd --wandb_name "askeladd/baseline-seed42" \
  --seed 42 --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```