### PR TITLE
Phase 6: OHEM — Online Hard Example Mining for Tandem Configs

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,10 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Online Hard Example Mining
+    ohem: bool = False              # enable per-sample EMA loss tracking and soft upweighting
+    ohem_weight: float = 1.5       # weight multiplier for hard samples (above threshold)
+    ohem_threshold_pct: int = 75   # percentile threshold for hard sample classification
 
 
 cfg = sp.parse(Config)
@@ -1006,6 +1010,18 @@ def _phys_denorm(y_p, Umag, q):
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=cfg.num_workers, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
+
+
+class IndexedDataset(torch.utils.data.Dataset):
+    """Wraps a dataset to return (item, dataset_index) for OHEM index tracking."""
+    def __init__(self, dataset):
+        self.dataset = dataset
+
+    def __getitem__(self, idx):
+        return self.dataset[idx], idx
+
+    def __len__(self):
+        return len(self.dataset)
 
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
@@ -1074,6 +1090,31 @@ if cfg.raw_targets or cfg.adaptive_norm:
     print(f"  {_label} stats — mean: {_raw_mean.tolist()}, std: {_raw_std.tolist()}")
 else:
     raw_stats = None
+
+# OHEM: per-sample EMA loss buffer and indexed train loader (rebuilt after stats computation)
+if cfg.ohem:
+    n_train_samples = len(train_ds)
+    sample_ema_loss = torch.ones(n_train_samples) * 0.5  # CPU buffer, init to 0.5
+    OHEM_DECAY = 0.9
+
+    def _indexed_collate(batch):
+        data = [item[0] for item in batch]
+        indices = torch.tensor([item[1] for item in batch], dtype=torch.long)
+        return (*pad_collate(data), indices)
+
+    _ohem_loader_kwargs = {**loader_kwargs, 'collate_fn': _indexed_collate}
+    _indexed_ds = IndexedDataset(train_ds)
+    if cfg.debug:
+        train_loader = DataLoader(_indexed_ds, batch_size=cfg.batch_size,
+                                  shuffle=True, **_ohem_loader_kwargs)
+    else:
+        train_loader = DataLoader(_indexed_ds, batch_size=cfg.batch_size,
+                                  sampler=sampler, **_ohem_loader_kwargs)
+    print(f"OHEM enabled: weight={cfg.ohem_weight}, threshold_pct={cfg.ohem_threshold_pct}, "
+          f"EMA_decay={OHEM_DECAY}, n_samples={n_train_samples}")
+else:
+    sample_ema_loss = None
+    OHEM_DECAY = None
 
 model_config = dict(
     space_dim=2,
@@ -1389,7 +1430,12 @@ for epoch in range(MAX_EPOCHS):
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     if cfg.grad_accum_steps > 1:
         optimizer.zero_grad()
-    for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
+    for batch_idx, _batch in enumerate(pbar):
+        if cfg.ohem:
+            x, y, is_surface, mask, batch_indices = _batch
+        else:
+            x, y, is_surface, mask = _batch
+            batch_indices = None
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -1643,6 +1689,8 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
+        # Save raw surf_per_sample for OHEM EMA tracking (before hard-node mining modifies it)
+        surf_per_sample_raw = surf_per_sample.detach()
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
@@ -1661,7 +1709,25 @@ for epoch in range(MAX_EPOCHS):
                                        torch.ones(B, device=device))
         else:
             tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
-        surf_loss = (surf_per_sample * tandem_boost).mean()
+        # OHEM: update per-sample EMA and compute normalized soft weights
+        if cfg.ohem and batch_indices is not None:
+            with torch.no_grad():
+                sample_ema_loss[batch_indices] = (
+                    OHEM_DECAY * sample_ema_loss[batch_indices] +
+                    (1 - OHEM_DECAY) * surf_per_sample_raw.cpu()
+                )
+            batch_ema = sample_ema_loss[batch_indices].to(device)
+            ohem_threshold = torch.quantile(batch_ema, cfg.ohem_threshold_pct / 100.0)
+            ohem_weights = torch.where(
+                batch_ema > ohem_threshold,
+                torch.full((len(batch_indices),), cfg.ohem_weight, device=device),
+                torch.ones(len(batch_indices), device=device),
+            )
+            # Normalize to unit mean so effective LR is unchanged
+            ohem_weights = ohem_weights / ohem_weights.mean().clamp(min=1e-8)
+            surf_loss = (surf_per_sample * tandem_boost * ohem_weights).mean()
+        else:
+            surf_loss = (surf_per_sample * tandem_boost).mean()
         if cfg.uncertainty_loss:
             bm = _base_model
             surf_ux_loss = (abs_err[:, :, 0:1] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
@@ -1888,6 +1954,17 @@ for epoch in range(MAX_EPOCHS):
                 sa = snapshot_avg_model.state_dict()
                 for k in snap:
                     sa[k].mul_((snapshot_n - 1) / snapshot_n).add_(snap[k].to(device) / snapshot_n)
+
+    # OHEM epoch-level stats logging
+    if cfg.ohem and sample_ema_loss is not None:
+        _ohem_thresh = sample_ema_loss.quantile(cfg.ohem_threshold_pct / 100.0)
+        _hard_mask_epoch = sample_ema_loss > _ohem_thresh
+        wandb.log({
+            "ohem/hard_mean_loss": sample_ema_loss[_hard_mask_epoch].mean().item(),
+            "ohem/easy_mean_loss": sample_ema_loss[~_hard_mask_epoch].mean().item(),
+            "ohem/hard_count": int(_hard_mask_epoch.sum().item()),
+            "global_step": global_step,
+        }, commit=False)
 
     # --- Validate across all splits ---
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1


### PR DESCRIPTION
## Hypothesis

The current training uses uniform L1 loss across all 1,322 samples. Tandem configurations are persistently harder (p_tan=29.1 vs p_in=12.1) — the model likely has a subset of samples with consistently high loss that receive the same gradient weight as easy samples. Online Hard Example Mining (OHEM) dynamically tracks a per-sample exponential moving average of loss and upweights persistently hard samples, forcing the model to allocate more capacity to the difficult tandem configurations.

This is distinct from the failed #2000 (OOD-Focused Training) which crashed due to aggressive gradient-based sample selection. OHEM uses a gentle weight multiplier (1.5x) with EMA smoothing — it changes the loss weighting, not the sampling distribution. It also complements the existing `--tandem_ramp` which ramps up tandem sample weights during training; OHEM adds data-adaptive within-tandem reweighting.

**Reference:** OHEM (Shrivastava et al., CVPR 2016). Well-validated in detection (SSD, Faster-RCNN) and dense prediction tasks.

## Instructions

Add OHEM per-sample loss tracking to `cfd_tandemfoil/train.py`. Add three new argparse flags: `--ohem` (bool), `--ohem_weight` (float, default 1.5), `--ohem_threshold_pct` (int, default 75).

**Step 1: Initialize per-sample EMA loss buffer (before training loop)**
```python
if cfg.ohem:
    n_train_samples = len(train_dataset)
    sample_ema_loss = torch.ones(n_train_samples) * 0.5  # on CPU, init to 0.5
    OHEM_DECAY = 0.9
```

**Step 2: Track sample indices in DataLoader**
Ensure the DataLoader returns sample indices alongside data. If the dataset doesn't already return indices, wrap it:
```python
class IndexedDataset(torch.utils.data.Dataset):
    def __init__(self, dataset):
        self.dataset = dataset
    def __getitem__(self, idx):
        return self.dataset[idx], idx
    def __len__(self):
        return len(self.dataset)

if cfg.ohem:
    train_dataset = IndexedDataset(train_dataset)
```

**Step 3: In the training loop, after forward pass, replace loss reduction**
```python
if cfg.ohem:
    with torch.no_grad():
        per_sample_loss = F.l1_loss(pred, target, reduction='none').mean(dim=(1, 2))  # [B]
    # Update EMA on CPU
    sample_ema_loss[batch_indices] = (
        OHEM_DECAY * sample_ema_loss[batch_indices] +
        (1 - OHEM_DECAY) * per_sample_loss.detach().cpu()
    )
    # Compute weights for this batch
    threshold = torch.quantile(sample_ema_loss[batch_indices], cfg.ohem_threshold_pct / 100.0)
    ohem_weights = torch.where(
        sample_ema_loss[batch_indices].to(device) > threshold.to(device),
        torch.full((len(batch_indices),), cfg.ohem_weight, device=device),
        torch.ones(len(batch_indices), device=device)
    )
    loss = (ohem_weights * per_sample_loss).mean()
else:
    loss = F.l1_loss(pred, target)
```

**Step 4: Log OHEM stats each epoch**
```python
if cfg.ohem:
    hard_mask = sample_ema_loss > sample_ema_loss.quantile(cfg.ohem_threshold_pct / 100.0)
    wandb.log({
        "ohem/hard_mean_loss": sample_ema_loss[hard_mask].mean().item(),
        "ohem/easy_mean_loss": sample_ema_loss[~hard_mask].mean().item(),
        "ohem/hard_count": hard_mask.sum().item(),
    }, step=epoch)
```

**Run all 8 GPUs:**
```bash
# 2 baseline seeds (control — run same config without --ohem)
CUDA_VISIBLE_DEVICES=0 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/baseline-s42" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 42 &

CUDA_VISIBLE_DEVICES=1 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/baseline-s73" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 73 &

# OHEM w=1.5, pct=75 (primary config) — 3 seeds
CUDA_VISIBLE_DEVICES=2 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/ohem-w1.5-p75-s42" \
  --ohem --ohem_weight 1.5 --ohem_threshold_pct 75 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 42 &

CUDA_VISIBLE_DEVICES=3 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/ohem-w1.5-p75-s66" \
  --ohem --ohem_weight 1.5 --ohem_threshold_pct 75 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 66 &

CUDA_VISIBLE_DEVICES=4 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/ohem-w1.5-p75-s73" \
  --ohem --ohem_weight 1.5 --ohem_threshold_pct 75 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 73 &

# OHEM w=2.0, pct=75 (stronger weight) — 2 seeds
CUDA_VISIBLE_DEVICES=5 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/ohem-w2.0-p75-s42" \
  --ohem --ohem_weight 2.0 --ohem_threshold_pct 75 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 42 &

CUDA_VISIBLE_DEVICES=6 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/ohem-w2.0-p75-s73" \
  --ohem --ohem_weight 2.0 --ohem_threshold_pct 75 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 73 &

# OHEM w=1.5, pct=90 (top-10% hardest only) — 1 seed
CUDA_VISIBLE_DEVICES=7 python train.py --agent tanjiro \
  --wandb_group phase6/ohem --wandb_name "tanjiro/ohem-w1.5-p90-s42" \
  --ohem --ohem_weight 1.5 --ohem_threshold_pct 90 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed 42 &

wait
```

**Implementation notes:**
- `sample_ema_loss` buffer stays on CPU — only moved to device for weight computation
- Log `ohem/hard_mean_loss` each epoch to watch for instability. If it keeps rising, the weighting is diverging — reduce `ohem_weight`
- Do NOT modify the eval loop — OHEM only affects training
- Run the 2 baselines alongside OHEM to confirm no code regressions

## What to Report

For each run: p_in, p_oodc, p_tan, p_re, val/loss, W&B run ID.

Key comparisons:
1. OHEM w=1.5 vs baseline (same seed) — does p_tan improve?
2. OHEM w=2.0 vs w=1.5 — does stronger weighting help or hurt?
3. OHEM pct=90 vs pct=75 — top-10% vs top-25% upweighting
4. Report `ohem/hard_count` at convergence — what fraction of samples are persistently hard?

## Baseline

Current best (16-seed ensemble, PR #2093):
| Metric | 16-Ensemble | Single-model mean (8 seeds) |
|--------|------------|------------------------------|
| p_in | **12.1** | 13.03 |
| p_oodc | **6.6** | 7.83 |
| p_tan | **29.1** | 30.29 |
| p_re | **5.8** | 6.45 |

**Compare OHEM single-seed results against the single-model mean** (13.03 / 7.83 / 30.29 / 6.45), not the ensemble. A meaningful improvement is >1 std below mean: p_in < 12.56, p_oodc < 7.27, p_tan < 29.35, p_re < 6.29.

W&B project: wandb-applied-ai-team/senpai-v1