### PR TITLE
Phase 6: Sinusoidal Activation in Surface Refinement Head

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -448,6 +448,12 @@ class TransolverBlock(nn.Module):
         return fx
 
 
+class SinActivation(nn.Module):
+    """Sinusoidal activation for SIREN networks (Sitzmann et al. NeurIPS 2020)."""
+    def forward(self, x):
+        return torch.sin(x)
+
+
 class SurfaceRefinementHead(nn.Module):
     """Lightweight MLP that predicts additive corrections for surface nodes.
 
@@ -457,17 +463,27 @@ class SurfaceRefinementHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
-                 n_layers: int = 2, p_only: bool = False):
+                 n_layers: int = 2, p_only: bool = False,
+                 siren_srf: bool = False, omega0: float = 10.0):
+        import math
         super().__init__()
         self.p_only = p_only
         actual_out = 1 if p_only else out_dim  # 1 for pressure-only, 3 for all fields
+        act_cls = SinActivation if siren_srf else nn.GELU
         layers: list[nn.Module] = []
         # Input: hidden features (n_hidden) + base predictions (out_dim)
         in_dim = n_hidden + out_dim
         for i in range(n_layers):
-            layers.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
-            layers.append(nn.LayerNorm(hidden_dim))
-            layers.append(nn.GELU())
+            lin = nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim)
+            if siren_srf:
+                if i == 0:
+                    nn.init.uniform_(lin.weight, -1.0 / lin.in_features, 1.0 / lin.in_features)
+                else:
+                    bound = math.sqrt(6.0 / lin.in_features) / omega0
+                    nn.init.uniform_(lin.weight, -bound, bound)
+            layers.append(lin)
+            layers.append(nn.LayerNorm(hidden_dim))  # normalizes into sin's informative range
+            layers.append(act_cls())
         layers.append(nn.Linear(hidden_dim, actual_out))
         # Zero-init last layer so refinement starts as identity
         nn.init.zeros_(layers[-1].weight)
@@ -947,6 +963,9 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: SIREN activation in surface refinement head
+    siren_srf: bool = False                  # replace GELU with sin() in surface refinement head
+    siren_omega0: float = 10.0               # frequency scaling for SIREN initialization
 
 
 cfg = sp.parse(Config)
@@ -1132,6 +1151,8 @@ if cfg.surface_refine:
             hidden_dim=cfg.surface_refine_hidden,
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
+            siren_srf=cfg.siren_srf,
+            omega0=cfg.siren_omega0,
         ).to(device)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())


### PR DESCRIPTION
## Hypothesis

The SurfaceRefinementHead MLP uses GELU activations. Pressure distributions on airfoils are fundamentally periodic/oscillatory as a function of arc-length position — the Cp curve oscillates from the stagnation point around the suction surface to the pressure surface. GELU cannot represent these oscillatory patterns without many neurons.

Sinusoidal activations (SIREN, Sitzmann et al. NeurIPS 2020) naturally encode periodic structure via `sin(W*x + b)`. The key insight is to apply this **only to the surface refinement head** — not the main Transolver blocks. Previous attempts at full-model SIREN replacement failed catastrophically. The srf head is a small isolated MLP (~19K params) applied post-attention, so SIREN initialization can be applied cleanly.

**Physical motivation:** The srf_head maps hidden features → additive pressure corrections for surface nodes. Making this mapping sinusoidal aligns it with the known oscillatory structure of Cp distributions on airfoils.

**Target metrics:** p_in and p_tan (both depend on sharp suction peak representation).

## Instructions

### 1. Add SinActivation class (near top of train.py, after imports)

```python
class SinActivation(nn.Module):
    """Sinusoidal activation for SIREN networks (Sitzmann et al. NeurIPS 2020)."""
    def forward(self, x):
        return torch.sin(x)
```

### 2. Add new config flags (in Config dataclass, ~line 940)

```python
siren_srf: bool = False         # replace GELU with sin() in surface refinement head
siren_omega0: float = 10.0      # frequency scaling for SIREN init
```

### 3. Modify SurfaceRefinementHead.__init__

Add `siren_srf=False` and `omega0=10.0` arguments. Replace `nn.GELU()` with `SinActivation()` when `siren_srf=True`, and apply SIREN initialization:

```python
def __init__(self, n_hidden, out_dim, hidden_dim=128, n_layers=2, p_only=False,
             siren_srf=False, omega0=10.0):
    ...
    import math
    act_fn = SinActivation if siren_srf else nn.GELU
    
    for i in range(n_layers):
        lin = nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim)
        if siren_srf:
            if i == 0:
                nn.init.uniform_(lin.weight, -1.0 / lin.in_features, 1.0 / lin.in_features)
            else:
                bound = math.sqrt(6.0 / lin.in_features) / omega0
                nn.init.uniform_(lin.weight, -bound, bound)
        layers.append(lin)
        layers.append(nn.LayerNorm(hidden_dim))  # KEEP LayerNorm — stabilizes sin gradients
        layers.append(act_fn())
    
    layers.append(nn.Linear(hidden_dim, actual_out))
    nn.init.zeros_(layers[-1].weight)  # KEEP zero-init (identity start)
    nn.init.zeros_(layers[-1].bias)
```

**CRITICAL: Keep LayerNorm between sin layers.** This normalizes pre-activation values into the informative range of sin(), preventing gradient chaos. Without it, sin activation will almost certainly diverge.

### 4. Wire up in model construction (~line 1119)

Pass `siren_srf=cfg.siren_srf, omega0=cfg.siren_omega0` to `SurfaceRefinementHead(...)`.

### 5. Experiment matrix (8 GPUs)

| GPU | Config | Seed | Notes |
|-----|--------|------|-------|
| 0 | Baseline (GELU) | 42 | Control |
| 1 | Baseline (GELU) | 43 | Control |
| 2 | `--siren_srf --siren_omega0 1.0` | 42 | Low freq |
| 3 | `--siren_srf --siren_omega0 1.0` | 43 | Low freq |
| 4 | `--siren_srf --siren_omega0 10.0` | 42 | Med freq |
| 5 | `--siren_srf --siren_omega0 10.0` | 43 | Med freq |
| 6 | `--siren_srf --siren_omega0 30.0` | 42 | High freq (canonical SIREN) |
| 7 | `--siren_srf --siren_omega0 30.0` | 43 | High freq |

Use `--wandb_group phase6/siren-srf-head` for all runs.

**Base command:**
```bash
python train.py --agent alphonse --wandb_group phase6/siren-srf-head \
  --wandb_name "alphonse/siren-w${omega0}-s${seed}" \
  --siren_srf --siren_omega0 ${omega0} \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed ${seed}
```

### Important notes
- DO NOT modify MAX_EPOCHS (500) or MAX_TIMEOUT (180.0) in train.py
- Keep LayerNorm between sin layers — **non-negotiable for stability**
- Keep zero-init on last linear layer
- Only apply to `SurfaceRefinementHead`, NOT `SurfaceRefinementContextHead`
- If omega0=30.0 causes NaN despite LayerNorm, fall back to omega0=10.0 (that run is fine to stop and restart)

## Baseline

Current best (16-seed ensemble, PR #2093):
- p_in: **12.1** | p_oodc: **6.6** | p_tan: **29.1** | p_re: **5.8**

Single-model baseline (8-seed mean):
- p_in: **13.03** | p_oodc: **7.83** | p_tan: **30.29** | p_re: **6.45**

## Reporting

Post results with individual metrics for all 8 runs, mean ± std per omega0 vs baseline, any instability observations, and W&B run IDs.