### PR TITLE
Phase 6: Iterative Weight-Tied Transolver — Deeper via Block Reuse

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -601,6 +601,7 @@ class Transolver(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        n_iter=0,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -675,6 +676,13 @@ class Transolver(nn.Module):
                 for idx in range(n_layers)
             ]
         )
+        # Weight-tied iterative mode: keep only shared intermediate + last block
+        if n_iter > 0:
+            assert len(self.blocks) >= 2, "n_iter requires at least 2 blocks"
+            shared_block = self.blocks[0]   # shared intermediate (run n_iter times)
+            last_block = self.blocks[-1]    # last block (run once, has output heads)
+            self.blocks = nn.ModuleList([shared_block, last_block])
+        self.n_iter = n_iter if n_iter > 0 else len(self.blocks) - 1
         # Separate pressure pathway (pressure_separate_last_block):
         # Independent MLP + pres_head that processes shared hidden features
         self._pressure_separate = False  # set from Config after construction
@@ -787,8 +795,14 @@ class Transolver(nn.Module):
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
-        for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+        if self.n_iter > 0 and len(self.blocks) == 2:
+            # Weight-tied mode: run shared block (blocks[0]) n_iter times
+            for _ in range(self.n_iter):
+                fx = self.blocks[0](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+        else:
+            # Standard mode: run each distinct intermediate block once
+            for block in self.blocks[:-1]:
+                fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
 
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
@@ -947,6 +961,8 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Iterative Weight-Tied Transolver
+    n_iter: int = 0                          # if > 0, use weight-tied iterative intermediate blocks (0 = standard n_layers)
 
 
 cfg = sp.parse(Config)
@@ -1106,6 +1122,7 @@ model_config = dict(
     pressure_first=cfg.pressure_first,
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
+    n_iter=cfg.n_iter,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

The current Transolver uses 3 distinct blocks (`n_layers=3`): 2 intermediate blocks (different weights) + 1 final block. A key question is whether more computational depth would help — but simply adding more distinct blocks increases parameter count and risks overfitting.

**Weight-tied iteration** gives depth without more parameters: replace the 2 intermediate blocks with a SINGLE shared block run K times. This is inspired by Deep Equilibrium Networks (Bai et al. NeurIPS 2019) and Unrolled Optimization, applied here as a lightweight architectural change.

**Why it might help:** p_tan = 29.1 is 2.5x worse than p_in = 12.2. The tandem aft foil operates in the fore foil's wake — a complex long-range interaction. The hypothesis is this is a **receptive-field problem**: the 3-block architecture has limited range for fore→aft signal propagation. Running the same block K=3 or K=4 times effectively gives more computational steps for these long-range signals to propagate, without the parameter bloat of adding distinct blocks.

**Physical analogy:** RANS pressure-velocity coupling is itself an iterative solver (SIMPLE/PISO). Giving the model explicit iterative structure aligns its computational graph with the iterative nature of the underlying physics.

**Note on model scale-up (frieren #2100):** That PR tests deeper/wider with DISTINCT blocks (more unique parameters). This PR tests deeper with SHARED blocks (same or fewer parameters). The mechanisms are different — if scale-up fails, weight tying should still be tried; if scale-up succeeds, weight tying may further amplify it.

**Key paper:** Bai et al., "Deep Equilibrium Models", NeurIPS 2019. The unrolled K-iteration version (no Jacobian solver): Fung et al., "Fixed Point Networks", 2021.

## Instructions

### Code architecture (read this carefully before coding)

Looking at `train.py`, the Transolver has:
- `self.blocks`: a `ModuleList` of `n_layers` blocks
- In `forward`, lines ~790-808: loops over `self.blocks[:-1]` then calls `self.blocks[-1]` separately (the last block has `last_layer=True` and unique features: `field_decoder`, `adaln_output`, `domain_velhead`, `pressure_first`, `pressure_deep`)
- The intermediate blocks (`last_layer=False`) are identical in architecture — only their weights differ

### 1. Add new config flag (in Config dataclass, ~line 940)

```python
n_iter: int = 0  # if > 0, use weight-tied iterative intermediate blocks (0 = standard n_layers)
```

### 2. Modify Transolver.__init__ block creation (~lines 645-676)

Add a conditional after the existing block creation:

```python
# AFTER self.blocks = nn.ModuleList([...]) at line 645:
if cfg.n_iter > 0:
    # Weight-tied mode: keep only 2 blocks (shared intermediate + last)
    # blocks[0] = shared intermediate block (run n_iter times)
    # blocks[1] = last block (run once, retains all last_layer features)
    assert len(self.blocks) >= 2, "n_iter requires at least 2 blocks"
    shared_block = self.blocks[0]   # keep first block as the shared intermediate
    last_block = self.blocks[-1]    # keep last block as-is
    self.blocks = nn.ModuleList([shared_block, last_block])  # discard unused blocks
self.n_iter = cfg.n_iter if cfg.n_iter > 0 else len(self.blocks) - 1
```

### 3. Modify Transolver.forward block loop (~lines 790-812)

Replace the existing block loop with:

```python
# Instead of:
#   for block in self.blocks[:-1]:
#       fx = block(fx, ...)
# Use:
for _ in range(self.n_iter):
    fx = self.blocks[0](fx, raw_xy=raw_xy, tandem_mask=is_tandem,
                         condition=block_condition, zone_features=zone_features)
# Last block (unchanged):
fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem,
                      condition=last_condition, zone_features=zone_features)
```

**Note:** Make sure both the main path AND the `pressure_deep` path (if it has a separate block loop) are updated. Search for `self.blocks[:-1]` and update all occurrences.

### 4. Experiment matrix (8 GPUs)

| GPU | Config | Seed | Notes |
|-----|--------|------|-------|
| 0 | Baseline (n_iter=0, 3 distinct blocks) | 42 | Control |
| 1 | Baseline (n_iter=0, 3 distinct blocks) | 43 | Control |
| 2 | `--n_iter 2` (2 shared iters + 1 last) | 42 | Same depth, weight-tied |
| 3 | `--n_iter 2` (2 shared iters + 1 last) | 43 | Same depth, weight-tied |
| 4 | `--n_iter 3` (3 shared iters + 1 last) | 42 | +1 depth, weight-tied |
| 5 | `--n_iter 3` (3 shared iters + 1 last) | 43 | +1 depth, weight-tied |
| 6 | `--n_iter 4` (4 shared iters + 1 last) | 42 | +2 depth, weight-tied |
| 7 | `--n_iter 4` (4 shared iters + 1 last) | 43 | +2 depth, weight-tied |

Use `--wandb_group phase6/iterative-transolver` for all runs. Pass `--n_layers 3` for all runs to ensure consistent block construction.

**Base command:**
```bash
python train.py --agent thorfinn --wandb_group phase6/iterative-transolver \
  --wandb_name "thorfinn/iter-k${k}-s${seed}" \
  --n_iter ${k} \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --seed ${seed}
```

Baseline (n_iter=0): same command without `--n_iter`.

### Important notes
- DO NOT modify MAX_EPOCHS (500) or MAX_TIMEOUT (180.0) in train.py
- `--n_layers 3` is required to ensure 3 blocks are created before the weight-tying collapses them to 2
- Search for ALL occurrences of `self.blocks[:-1]` in forward() — there may be multiple (main path + optional pressure_deep path). Update all of them to use the `n_iter` loop.
- With `n_iter=2`, the model has slightly fewer parameters than baseline (blocks[1] is discarded). This is expected.
- Watch for gradient explosion with n_iter=4 — more unrolled steps = longer gradient path. The existing gradient clipping in train.py should handle this, but watch the grad_norm metric in W&B.
- Log `n_iter` and `n_params` in wandb at the start of training so we can compare

## Baseline

Current best (16-seed ensemble, PR #2093):
- p_in: **12.1** | p_oodc: **6.6** | p_tan: **29.1** | p_re: **5.8**

Single-model baseline (8-seed mean):
- p_in: **13.03** | p_oodc: **7.83** | p_tan: **30.29** | p_re: **6.45**

## Reporting

Post results with:
- Individual metrics for all 8 runs
- Mean ± std per n_iter vs baseline
- Parameter counts for each config (to confirm weight sharing works)
- Gradient norms (did any runs show instability?)
- W&B run IDs