### PR TITLE
Phase 6: Fourier Feature Position Encoding — Spectral Bias Correction

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -696,6 +696,7 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        self._fourier_features = 0  # set from cfg after construction
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -784,6 +785,12 @@ class Transolver(nn.Module):
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
         fx = self.preprocess(x)
+        # Random Fourier Feature residual (if enabled via cfg post-construction)
+        if self._fourier_features > 0 and hasattr(self, 'fourier_B') and hasattr(self, 'fourier_proj'):
+            pos_xy = x[:, :, :2]  # [B, N, 2] — normalized (x, y) coordinates
+            proj = (2 * torch.pi * pos_xy) @ self.fourier_B.to(pos_xy)  # [B, N, fourier_features]
+            fourier_enc = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)  # [B, N, 2F]
+            fx = fx + self.fourier_proj(fourier_enc)  # zero-init → residual starts at 0
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
@@ -947,6 +954,9 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Random Fourier Feature position encoding (spectral bias correction)
+    fourier_features: int = 0               # number of random Gaussian Fourier frequency bands (0=disabled, try 16 or 32)
+    fourier_scale: float = 10.0             # Gaussian scale for Fourier feature sampling
 
 
 cfg = sp.parse(Config)
@@ -1110,6 +1120,16 @@ model_config = dict(
 
 model = Transolver(**model_config).to(device)
 model._pressure_separate = cfg.pressure_separate_last_block
+# Random Fourier Feature setup (post-construction to avoid save_config issues)
+if cfg.fourier_features > 0:
+    torch.manual_seed(0)  # fixed seed for reproducible random frequencies
+    B_matrix = torch.randn(2, cfg.fourier_features) * cfg.fourier_scale
+    model.register_buffer('fourier_B', B_matrix)
+    _fourier_proj = torch.nn.Linear(2 * cfg.fourier_features, cfg.n_hidden, bias=True)
+    torch.nn.init.zeros_(_fourier_proj.weight)
+    torch.nn.init.zeros_(_fourier_proj.bias)
+    model.fourier_proj = _fourier_proj.to(device)
+    model._fourier_features = cfg.fourier_features
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode=cfg.compile_mode)
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model


### PR DESCRIPTION
## Hypothesis

Neural networks have a well-known **spectral bias**: they preferentially fit low-frequency components of a function before high-frequency ones (Rahaman et al., ICML 2019). This is a problem for sharp pressure peaks at airfoil leading edges and suction peaks, which require high-frequency spatial representations.

**Random Fourier Features (Tancik et al., NeurIPS 2020)** maps input positional coordinates through random sinusoidal projections before passing them to the network:

```
γ(x) = [sin(2π B x), cos(2π B x)]
```

where B is sampled from a Gaussian with tunable scale σ. This is the same key insight behind positional encoding in Transformers (Vaswani et al.) and NeRF (Mildenhall et al., 2020) — it lifts the coordinate representation into a higher-frequency basis, allowing the network to fit sharp spatial features without spectral bias.

**Why this matters here:** The model struggles most with:
- p_tan = 29.1 — aft-foil suction peaks in tandem configurations (sharp, localized)
- p_in = 12.1 — single-foil leading-edge suction peaks

Both are characterized by very sharp pressure gradients in small spatial regions. The current model's L1 surface loss on these sharp features is limited by the network's tendency to under-predict peak magnitudes. Richer frequency encoding of spatial positions should help the model "see" these sharp features more clearly.

**Key distinction from augmentation:** This is not a data augmentation — it's a change to how spatial coordinates are represented to the model. The Fourier features replace or augment the raw (x, y) coordinate channels in the node features with a higher-dimensional representation that spans multiple frequency bands.

**Paper evidence:** Tancik et al. (NeurIPS 2020) demonstrated that Fourier feature networks achieve 10-40x lower error on high-frequency regression tasks vs standard MLPs. The benefit was largest for tasks with sharp spatial features (exactly our case). Mildenhall et al. (NeRF) used it for 3D scene reconstruction — we're doing 2D pressure field reconstruction.

## Instructions

The change adds Fourier feature encoding to the positional coordinate channels of the input features.

**Step 1: Add `--fourier_features` and `--fourier_scale` flags** to argparse:
```python
parser.add_argument('--fourier_features', type=int, default=0,
                    help='Number of Fourier feature frequency bands (0=disabled, try 16 or 32)')
parser.add_argument('--fourier_scale', type=float, default=10.0,
                    help='Gaussian scale for Fourier feature sampling (controls frequency range)')
```
Add to Config dataclass:
```python
fourier_features: int = 0      # 0 = disabled
fourier_scale: float = 10.0   # frequency scale
```

**Step 2: Create the Fourier feature projection matrix** (fixed random, registered as a buffer):

In the Transolver model `__init__`:
```python
if cfg.fourier_features > 0:
    # Sample fixed random projection matrix: [2, fourier_features]
    # The 2 input dims are the (x, y) spatial coordinates
    B_matrix = torch.randn(2, cfg.fourier_features) * cfg.fourier_scale
    self.register_buffer('fourier_B', B_matrix)  # fixed (no gradient)
    # Project to match n_hidden input dim — add a small linear to integrate with existing encoding
    self.fourier_proj = nn.Linear(2 * cfg.fourier_features, cfg.n_hidden, bias=True)
    nn.init.zeros_(self.fourier_proj.weight)
    nn.init.zeros_(self.fourier_proj.bias)
```

Zero-init ensures the model starts from baseline behavior and learns to use Fourier features gradually.

**Step 3: Apply in the model's forward pass**, after the position embedding but before the first TransolverBlock:

Find where `x` (node features) is first embedded in the model, and locate the position / coordinate channels. In Transolver, spatial positions are typically passed as `pos` or included in the first few channels of `x`.

```python
if self.cfg.fourier_features > 0 and self.fourier_B is not None:
    # pos: [B, N, 2] — (x, y) coordinates of mesh nodes
    # Project: [B, N, 2] @ [2, F] = [B, N, F]
    proj = (2 * torch.pi * pos) @ self.fourier_B  # [B, N, fourier_features]
    fourier_enc = torch.cat([torch.sin(proj), torch.cos(proj)], dim=-1)  # [B, N, 2F]
    # Add to existing node embedding as a residual
    fx = fx + self.fourier_proj(fourier_enc)  # [B, N, n_hidden]
```

The zero-init of `fourier_proj` means the model starts as the current baseline.

**Step 4: Find where `pos` is available.** Check how the model receives coordinates. If `pos` is part of `x` (the first 2 channels), extract it: `pos = x[:, :, :2]` or wherever the (x, y) node coordinates are stored. Look at the existing code for where `pos` is used in the embedding step.

**Experiment runs** (try two scales with 2 seeds each):

```bash
# 16 features, scale=10, seed 42
python train.py --agent askeladd \
  --wandb_name "askeladd/ff-f16-sc10-s42" \
  --wandb_group phase6/fourier-features \
  --fourier_features 16 --fourier_scale 10.0 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

# 16 features, scale=10, seed 73
python train.py --agent askeladd \
  --wandb_name "askeladd/ff-f16-sc10-s73" \
  --wandb_group phase6/fourier-features \
  --fourier_features 16 --fourier_scale 10.0 --seed 73 \
  [same flags as above]

# 32 features, scale=10, seed 42
python train.py --agent askeladd \
  --wandb_name "askeladd/ff-f32-sc10-s42" \
  --wandb_group phase6/fourier-features \
  --fourier_features 32 --fourier_scale 10.0 --seed 42 \
  [same flags as above]

# 32 features, scale=10, seed 73
python train.py --agent askeladd \
  --wandb_name "askeladd/ff-f32-sc10-s73" \
  --wandb_group phase6/fourier-features \
  --fourier_features 32 --fourier_scale 10.0 --seed 73 \
  [same flags as above]
```

If you have VRAM headroom, run all 4 in parallel. The Fourier feature projection adds negligible parameters (<1% overhead).

W&B group: `phase6/fourier-features`

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | Baseline |
|--------|----------|
| p_in   | **12.1** |
| p_oodc | **6.6**  |
| p_tan  | **29.1** |
| p_re   | **5.8**  |

Single-model references:
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd \
  --wandb_name "askeladd/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```