### PR TITLE
Phase 6: Contrastive Tandem-Single Regularization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,8 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Contrastive tandem-single regularization
+    contrastive_tandem_weight: float = 0.0   # weight for tandem-single contrastive loss (0=disabled)
 
 
 cfg = sp.parse(Config)
@@ -1349,6 +1351,7 @@ for _sname in VAL_SPLIT_NAMES:
 wandb.define_metric("lr", step_metric="global_step")
 wandb.define_metric("epoch_time_s", step_metric="global_step")
 wandb.define_metric("val_predictions", step_metric="global_step")
+wandb.define_metric("contrastive/*", step_metric="global_step")
 
 model_dir = Path(f"models/model-{run.id}")
 model_dir.mkdir(parents=True)
@@ -1720,6 +1723,21 @@ for epoch in range(MAX_EPOCHS):
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
             loss = loss + cfg.rdrop_alpha * rdrop_loss
 
+        # Contrastive tandem-single regularization
+        contrastive_loss_val = 0.0
+        if cfg.contrastive_tandem_weight > 0.0 and model.training:
+            if is_tandem_batch.any() and (~is_tandem_batch).any():
+                # Mean-pool hidden state per sample → [B, n_hidden]
+                h_mean = (hidden * mask.float().unsqueeze(-1)).sum(dim=1) / mask.float().sum(dim=1, keepdim=True).clamp(min=1)
+                # Mean centroid for tandem and single batches
+                h_tandem = h_mean[is_tandem_batch].mean(dim=0)
+                h_single = h_mean[~is_tandem_batch].mean(dim=0)
+                # Cosine similarity; push toward 0 (orthogonal)
+                cos_sim = F.normalize(h_tandem, dim=0) @ F.normalize(h_single, dim=0)
+                contrastive_loss = cfg.contrastive_tandem_weight * (1.0 + cos_sim)
+                loss = loss + contrastive_loss
+                contrastive_loss_val = contrastive_loss.item()
+
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
@@ -1819,7 +1837,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_refine_head.parameters(), _refine_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.contrastive_tandem_weight > 0.0 and contrastive_loss_val > 0:
+            _log_dict["contrastive/loss"] = contrastive_loss_val
+            _log_dict["contrastive/cos_sim"] = cos_sim.item()
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Tandem and single-foil configurations are drawn from physically distinct flow regimes, but the model handles both with the same weights. The model has no explicit incentive to maintain separate internal representations for these two regimes.

**The problem:** The attention mechanism's slice assignments are shared across tandem and single-foil samples within each batch. When the model learns to route single-foil nodes efficiently (which dominate the dataset), it may simultaneously damage its routing for tandem-specific patterns. This creates **representational entanglement**.

**Recent evidence this is the real bottleneck:**
- PR #2100 (Model Scale-Up) proved that p_tan is NOT capacity-limited — p_tan ~30-32 across all model scales (3L through 5L, 96 through 160 slices)
- PR #2101 (OHEM) proved that loss-level reweighting (on top of existing tandem_ramp) doesn't help — the problem is not about gradient magnitude
- These point to a **representation-level** issue: the model conflates tandem and single-foil hidden states

**Contrastive regularization solution:** Add a loss term that penalizes the model if the mean hidden representation of tandem samples is too close (in cosine similarity) to the mean hidden representation of single-foil samples within the same batch. This pushes the model to develop distinct internal representations for each flow regime.

**Reference:** Supervised contrastive loss (Khosla et al., NeurIPS 2020), adapted to intermediate features rather than final predictions.

## Instructions

**Step 1: Add flags** to argparse:
```python
parser.add_argument('--contrastive_tandem_weight', type=float, default=0.0,
                    help='Weight for tandem-single contrastive regularization (0=disabled, try 0.01)')
```
Add to Config dataclass:
```python
contrastive_tandem_weight: float = 0.0
```

**Step 2: Check if model already exposes hidden state.** Look at the model's forward return dict — if `model_out["hidden"]` is already available (the Transolver hidden state before the final output projection), use it directly. If not, add `"hidden": fx` to the model's output dict in `Transolver.forward`.

**Step 3: Add contrastive loss in the training loop** (after the forward pass, before backward):

```python
if cfg.contrastive_tandem_weight > 0.0:
    # hidden: [B, N, n_hidden] — Transolver output before final projection
    hidden = model_out["hidden"]  # or wherever the hidden state is accessible
    is_tandem = (x[:, 0, 21].abs() > 0.01)   # [B] bool — detect tandem samples
    
    if is_tandem.any() and (~is_tandem).any():
        # Mean-pool hidden state per sample → [B, n_hidden]
        h_mean = hidden.mean(dim=1)  # [B, n_hidden]
        
        # Mean centroid for tandem and single batches
        h_tandem = h_mean[is_tandem].mean(dim=0)      # [n_hidden]
        h_single = h_mean[~is_tandem].mean(dim=0)     # [n_hidden]
        
        # Cosine similarity ∈ [-1, 1]; we want it small/negative
        cos_sim = F.normalize(h_tandem, dim=0) @ F.normalize(h_single, dim=0)
        # Loss: (1 + cos_sim) → 0 when orthogonal, 2 when identical
        contrastive_loss = cfg.contrastive_tandem_weight * (1.0 + cos_sim)
        loss = loss + contrastive_loss
        
        # Log for monitoring
        if epoch % 10 == 0:
            wandb.log({
                "contrastive/cos_sim": cos_sim.item(),
                "contrastive/loss": contrastive_loss.item(),
            }, step=global_step)
```

**Important notes:**
- The `F.normalize` ensures scale-invariant comparison
- `(1.0 + cos_sim)` is zero when reps are anti-aligned (-1) and 2.0 when identical (+1)
- Weight 0.01 is conservative — should not degrade p_in
- Only activates when batch contains BOTH tandem and single-foil samples

**Experiment runs** (sweep 3 weights, 2 seeds each):

```bash
# Weight 0.01 (conservative), seeds 42 + 73
python train.py --agent tanjiro \
  --wandb_name "tanjiro/contrast-w001-s42" \
  --wandb_group phase6/contrastive-tandem \
  --contrastive_tandem_weight 0.01 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

python train.py --agent tanjiro \
  --wandb_name "tanjiro/contrast-w001-s73" \
  --wandb_group phase6/contrastive-tandem \
  --contrastive_tandem_weight 0.01 --seed 73 \
  [same flags]

# Weight 0.05 (moderate), seeds 42 + 73
python train.py --agent tanjiro \
  --wandb_name "tanjiro/contrast-w005-s42" \
  --wandb_group phase6/contrastive-tandem \
  --contrastive_tandem_weight 0.05 --seed 42 \
  [same flags]

python train.py --agent tanjiro \
  --wandb_name "tanjiro/contrast-w005-s73" \
  --wandb_group phase6/contrastive-tandem \
  --contrastive_tandem_weight 0.05 --seed 73 \
  [same flags]

# Weight 0.1 (strong), seeds 42 + 73
python train.py --agent tanjiro \
  --wandb_name "tanjiro/contrast-w01-s42" \
  --wandb_group phase6/contrastive-tandem \
  --contrastive_tandem_weight 0.1 --seed 42 \
  [same flags]

python train.py --agent tanjiro \
  --wandb_name "tanjiro/contrast-w01-s73" \
  --wandb_group phase6/contrastive-tandem \
  --contrastive_tandem_weight 0.1 --seed 73 \
  [same flags]
```

W&B group: `phase6/contrastive-tandem`

**What to report:**
- Surface MAE (p_in, p_oodc, p_tan, p_re) per run
- `contrastive/cos_sim` at convergence — how separated are the representations?
- Whether higher weight helps or hurts p_tan
- Whether higher weight degrades p_in (regression check)

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | Baseline |
|--------|----------|
| p_in   | **12.1** |
| p_oodc | **6.6**  |
| p_tan  | **29.1** |
| p_re   | **5.8**  |

Single-model references:
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```