### PR TITLE
Phase 6: Progressive Surface Focus Schedule — Curriculum Learning

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,8 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Progressive surface focus — curriculum schedule for surf_weight
+    surf_weight_ramp_epochs: int = 0         # epochs to ramp surf_weight from 1.0 to dynamic target (0=disabled)
 
 
 cfg = sp.parse(Config)
@@ -1376,7 +1378,13 @@ for epoch in range(MAX_EPOCHS):
     t0 = time.time()
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
-    surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    dynamic_surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+    # Progressive surface focus: ramp from 1.0 to dynamic target
+    if cfg.surf_weight_ramp_epochs > 0 and epoch < cfg.surf_weight_ramp_epochs:
+        ramp_frac = epoch / max(cfg.surf_weight_ramp_epochs, 1)
+        surf_weight = 1.0 + (dynamic_surf_weight - 1.0) * ramp_frac
+    else:
+        surf_weight = dynamic_surf_weight
 
     # --- Train ---
     model.train()


### PR DESCRIPTION
## Hypothesis

The current training applies a high `surf_weight` (dynamically clamped [5, 50]) from the very first epoch. This means the network receives a heavily amplified surface gradient signal before it has learned any useful bulk-flow representation.

**The problem:** Early in training, predictions are random. High surface weight forces the network to immediately optimize surface nodes — but without a good bulk-flow backbone, surface predictions are built on a poor foundation. This is analogous to training a segmentation model with full boundary weight from epoch 1, before the backbone has learned shape features.

**Curriculum learning solution:** Start with `surf_weight=1.0` (equal treatment of surface and volume nodes) and ramp up to the target value over a warm-in period. This forces the model to first build a coherent global flow field, then refine the surface predictions on that solid foundation.

**Distinct from existing mechanisms:**
- `tandem_ramp`: ramps tandem surface loss contribution from 0→1 over epochs 10-50 — this is tandem vs single-foil weighting, NOT surface vs volume
- Dynamic `surf_weight`: already adapts based on loss ratio — the proposal adds a curriculum schedule ON TOP of this
- `vol_ramp_epochs`: ramps volume weight, not surface weight

**Motivation from recent findings:**
- Deep supervision (#2097) showed p_in improves -1.7% when intermediate features get direct surface supervision — suggesting better backbone features help surface predictions
- The progressive schedule achieves a similar effect by letting the backbone develop freely before amplifying surface loss

## Instructions

**Step 1: Add flags** to argparse:
```python
parser.add_argument('--surf_weight_ramp_epochs', type=int, default=0,
                    help='Epochs to ramp surf_weight from 1.0 to dynamic target (0=disabled)')
```
Add to Config dataclass:
```python
surf_weight_ramp_epochs: int = 0   # 0 = disabled
```

**Step 2: In the training loop**, find where `surf_weight` is computed (around the dynamic surf_weight assignment). Add the curriculum schedule:

```python
# Progressive surface focus schedule
if cfg.surf_weight_ramp_epochs > 0 and epoch < cfg.surf_weight_ramp_epochs:
    # dynamic_surf_weight is the normal dynamic value (from loss ratio, clamped [5, 50])
    ramp_frac = epoch / max(cfg.surf_weight_ramp_epochs, 1)
    # Linear interpolation from 1.0 to dynamic target
    surf_weight = 1.0 + (dynamic_surf_weight - 1.0) * ramp_frac
else:
    surf_weight = dynamic_surf_weight  # existing behavior
```

Where `dynamic_surf_weight` is the existing value: `max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))`.

That's it — ~8 lines.

**Step 3: Log the effective surf_weight** for monitoring:
```python
if wandb.run:
    wandb.log({"train/effective_surf_weight": surf_weight}, step=global_step)
```

**Experiment runs** (2 ramp durations × 2 seeds):

```bash
# Ramp over 40 epochs (25% of training), seed 42
python train.py --agent nezuko \
  --wandb_name "nezuko/surframp-40ep-s42" \
  --wandb_group phase6/progressive-surface \
  --surf_weight_ramp_epochs 40 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

# Ramp over 40 epochs, seed 73
python train.py --agent nezuko \
  --wandb_name "nezuko/surframp-40ep-s73" \
  --wandb_group phase6/progressive-surface \
  --surf_weight_ramp_epochs 40 --seed 73 \
  [same flags]

# Ramp over 80 epochs (50% of training), seed 42
python train.py --agent nezuko \
  --wandb_name "nezuko/surframp-80ep-s42" \
  --wandb_group phase6/progressive-surface \
  --surf_weight_ramp_epochs 80 --seed 42 \
  [same flags]

# Ramp over 80 epochs, seed 73
python train.py --agent nezuko \
  --wandb_name "nezuko/surframp-80ep-s73" \
  --wandb_group phase6/progressive-surface \
  --surf_weight_ramp_epochs 80 --seed 73 \
  [same flags]
```

W&B group: `phase6/progressive-surface`

**What to report:**
- Surface MAE (p_in, p_oodc, p_tan, p_re) per run
- `train/effective_surf_weight` curve — does the ramp look correct?
- Whether 40ep or 80ep ramp is better
- Val/loss convergence profile — does the ramp change convergence speed?

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | Baseline |
|--------|----------|
| p_in   | **12.1** |
| p_oodc | **6.6**  |
| p_tan  | **29.1** |
| p_re   | **5.8**  |

Single-model references:
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```