### PR TITLE
Phase 6: Test-Time Augmentation via AoA Perturbation

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,9 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Test-time augmentation via AoA perturbation
+    tta_aoa: bool = False                    # enable TTA via AoA perturbation at inference
+    tta_aoa_delta: float = 1.0              # AoA perturbation magnitude in degrees
 
 
 cfg = sp.parse(Config)
@@ -1943,6 +1946,10 @@ for epoch in range(MAX_EPOCHS):
                 is_surface = is_surface.to(device, non_blocking=True)
                 mask = mask.to(device, non_blocking=True)
 
+                # Save raw x for TTA passes
+                if cfg.tta_aoa:
+                    _tta_x_raw = x.clone()
+
                 raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
@@ -2106,6 +2113,95 @@ for epoch in range(MAX_EPOCHS):
                         pred_orig = _pd
                     else:
                         pred_orig = _phys_denorm(pred_phys, Umag, q)
+                # --- TTA: average pred_orig from AoA perturbations ---
+                if cfg.tta_aoa:
+                    _tta_preds = [pred_orig]
+                    for _tta_sign in [-1.0, 1.0]:
+                        _tta_deg = _tta_sign * cfg.tta_aoa_delta
+                        _tta_rad = _tta_deg * (torch.pi / 180.0)
+                        _tta_cos = torch.cos(torch.tensor(_tta_rad, device=device))
+                        _tta_sin = torch.sin(torch.tensor(_tta_rad, device=device))
+                        # Rotate raw x
+                        _xt = _tta_x_raw.clone()
+                        _xc, _yc = _xt[:, :, 0:1].clone(), _xt[:, :, 1:2].clone()
+                        _xt[:, :, 0:1] = _tta_cos * _xc - _tta_sin * _yc
+                        _xt[:, :, 1:2] = _tta_sin * _xc + _tta_cos * _yc
+                        if cfg.aug_full_dsdf_rot:
+                            for _di, _dj in [(2,3),(4,5),(6,7),(8,9)]:
+                                _dx = _xt[:, :, _di:_di+1].clone()
+                                _dy = _xt[:, :, _dj:_dj+1].clone()
+                                _xt[:, :, _di:_di+1] = _tta_cos * _dx - _tta_sin * _dy
+                                _xt[:, :, _dj:_dj+1] = _tta_sin * _dx + _tta_cos * _dy
+                        # Preprocess rotated x
+                        _t_dsdf = _xt[:, :, 2:10]
+                        _t_dist = torch.log1p(_t_dsdf.abs().min(dim=-1, keepdim=True).values * 10.0)
+                        _xt = (_xt - stats["x_mean"]) / stats["x_std"]
+                        _t_curv = _xt[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                        if cfg.foil2_dist:
+                            _t_f2 = torch.log1p(_t_dsdf[:, :, 4:8].abs().min(dim=-1, keepdim=True).values * 10.0)
+                            _xt = torch.cat([_xt, _t_curv, _t_dist, _t_f2], dim=-1)
+                        else:
+                            _xt = torch.cat([_xt, _t_curv, _t_dist], dim=-1)
+                        _t_xy = _xt[:, :, :2]
+                        _t_mn = _t_xy.amin(dim=1, keepdim=True)
+                        _t_mx = _t_xy.amax(dim=1, keepdim=True)
+                        _t_xyn = (_t_xy - _t_mn) / (_t_mx - _t_mn + 1e-8)
+                        _t_fr = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+                        _t_sc = _t_xyn.unsqueeze(-1) * _t_fr
+                        _t_fpe = torch.cat([_t_sc.sin().flatten(-2), _t_sc.cos().flatten(-2)], dim=-1)
+                        _xt = torch.cat([_xt, _t_fpe], dim=-1)
+                        # Model forward
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            _t_out = eval_model({"x": _xt})
+                            _t_pred = _t_out["preds"].float()
+                            _t_hid = _t_out["hidden"].float()
+                        if cfg.multiply_std:
+                            _t_pl = _t_pred * sample_stds
+                        else:
+                            _t_pl = _t_pred / sample_stds
+                        # Refinement head
+                        if eval_refine_head is not None:
+                            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                                if cfg.surface_refine_context:
+                                    _t_rc = eval_refine_head(_t_hid, _t_pl, is_surface, mask, _xt[:, :, :2]).float()
+                                    _t_pl = _t_pl + _t_rc
+                                else:
+                                    _t_si = is_surface.nonzero(as_tuple=False)
+                                    if _t_si.numel() > 0:
+                                        _t_sh = _t_hid[_t_si[:, 0], _t_si[:, 1]]
+                                        _t_sp = _t_pl[_t_si[:, 0], _t_si[:, 1]]
+                                        _t_corr = eval_refine_head(_t_sh, _t_sp).float()
+                                        _t_pl = _t_pl.clone()
+                                        _t_pl[_t_si[:, 0], _t_si[:, 1]] += _t_corr
+                            if cfg.multiply_std:
+                                _t_pred = _t_pl / sample_stds
+                            else:
+                                _t_pred = _t_pl * sample_stds
+                        # Add freestream back
+                        if cfg.residual_prediction and _v_freestream is not None:
+                            _t_pred = _t_pred + _v_freestream
+                        # Denormalize to physical space
+                        if cfg.raw_targets:
+                            _t_orig = _t_pred * raw_stats["y_std"] + raw_stats["y_mean"]
+                        elif cfg.adaptive_norm:
+                            _t_orig = _t_pred * raw_stats["y_std"] + raw_stats["y_mean"]
+                            if cfg.asinh_pressure:
+                                _t_orig = _t_orig.clone()
+                                _t_orig[:, :, 2:3] = torch.sinh(_t_orig[:, :, 2:3]) / cfg.asinh_scale
+                        else:
+                            _t_ph = _t_pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                            if cfg.asinh_pressure:
+                                _t_ph = _t_ph.clone()
+                                _t_ph[:, :, 2:3] = torch.sinh(_t_ph[:, :, 2:3]) / cfg.asinh_scale
+                            _t_orig = _phys_denorm(_t_ph, Umag, q)
+                        # Inverse rotate velocity back to original frame
+                        _ux = _t_orig[:, :, 0:1].clone()
+                        _uy = _t_orig[:, :, 1:2].clone()
+                        _t_orig[:, :, 0:1] = _tta_cos * _ux + _tta_sin * _uy
+                        _t_orig[:, :, 1:2] = -_tta_sin * _ux + _tta_cos * _uy
+                        _tta_preds.append(_t_orig)
+                    pred_orig = torch.stack(_tta_preds).mean(0)
+
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()
                 finite = err.isfinite()


### PR DESCRIPTION
## Hypothesis

The `aug="aoa_perturb"` training augmentation applies random ±1° AoA rotations during training to improve generalization. But at inference, the model receives a single input — no test-time augmentation is applied.

**Test-Time Augmentation (TTA)** evaluates the model at multiple slightly perturbed inputs and averages the predictions. For CFD surrogates, the natural perturbation is angle of attack: the pressure distribution at AoA=α is smooth and similar to the solution at AoA=α±δ.

**Physical motivation:** CFD solutions are smooth functions of AoA. A neural surrogate with residual overfitting will produce slightly different error patterns at AoA ± δ. Averaging these predictions cancels error components that vary rapidly with AoA (model artifacts) while preserving the true physical signal (which varies slowly).

**Key advantage: ZERO training cost.** This is an inference-only technique that can be applied to any existing checkpoint. If it works, it "stacks" with any future training improvement. 3× inference cost is the tradeoff.

**Never tested at inference time in this programme.** The `aoa_perturb` flag only exists for training.

## Instructions

**Step 1: Add TTA flags** to argparse:
```python
parser.add_argument('--tta_aoa', action='store_true', default=False,
                    help='Enable TTA via AoA perturbation at inference')
parser.add_argument('--tta_aoa_delta', type=float, default=1.0,
                    help='AoA perturbation magnitude in degrees')
```
Add to Config dataclass:
```python
tta_aoa: bool = False
tta_aoa_delta: float = 1.0
```

**Step 2: Implement TTA in the evaluation loop.** Find where the model is evaluated on validation splits. Apply AoA perturbation (coordinate rotation) to the input, run the model, then **rotate velocity predictions back** before averaging.

```python
if cfg.tta_aoa:
    aoa_deltas = [-cfg.tta_aoa_delta, 0.0, cfg.tta_aoa_delta]  # 3 views
    preds_list = []
    
    for delta in aoa_deltas:
        x_aug = x.clone()
        if abs(delta) > 1e-6:
            angle_rad = delta * (torch.pi / 180.0)
            cos_a = torch.cos(torch.tensor(angle_rad, device=x.device))
            sin_a = torch.sin(torch.tensor(angle_rad, device=x.device))
            # Rotate spatial coordinates (x[:,:,0:2])
            x_orig = x_aug[:, :, 0:1].clone()
            y_orig = x_aug[:, :, 1:2].clone()
            x_aug[:, :, 0:1] = cos_a * x_orig - sin_a * y_orig
            x_aug[:, :, 1:2] = sin_a * x_orig + cos_a * y_orig
        
        with torch.no_grad():
            pred = model(x_aug, ...)["preds"]
            # CRITICAL: Rotate velocity predictions BACK to original frame
            if abs(delta) > 1e-6:
                ux = pred[:, :, 0:1].clone()
                uy = pred[:, :, 1:2].clone()
                pred[:, :, 0:1] = cos_a * ux + sin_a * uy    # inverse rotation
                pred[:, :, 1:2] = -sin_a * ux + cos_a * uy
                # Pressure (channel 2) is scalar — no rotation needed
        preds_list.append(pred)
    
    final_pred = torch.stack(preds_list).mean(0)
else:
    final_pred = model(x, ...)["preds"]
```

**CRITICAL: Velocity inverse rotation.** The velocity predictions (Ux, Uy) are vectors and MUST be rotated back from the perturbed frame to the original frame before averaging. Pressure is a scalar and needs no rotation. Failing to unrotate will corrupt Ux/Uy predictions.

**Step 3: Find where `pos` / spatial coordinates are in `x`.** Look at the existing `aoa_perturb` training augmentation code to see which channels are the (x, y) coordinates. The TTA must apply the same rotation.

**Step 4: Also check if DSDF features need rotation.** The `aug_full_dsdf_rot` flag suggests that DSDF gradient features are also rotated during training augmentation. If the eval-time TTA rotates coordinates, it should also rotate DSDF features consistently. Check the training `aoa_perturb` implementation for which features get rotated.

**Experiment approach:** Train a baseline model, then evaluate it WITH and WITHOUT TTA. No retraining needed.

```bash
# Step 1: Train baseline (or use existing checkpoints)
python train.py --agent alphonse \
  --wandb_name "alphonse/tta-baseline-s42" \
  --wandb_group phase6/tta-aoa \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

# Step 2: Evaluate the SAME checkpoint with TTA
python train.py --agent alphonse \
  --wandb_name "alphonse/tta-delta1-s42" \
  --wandb_group phase6/tta-aoa \
  --tta_aoa --tta_aoa_delta 1.0 \
  --seed 42 [same flags] --eval_only  # if eval_only flag exists

# Step 3: Try different deltas
python train.py ... --tta_aoa --tta_aoa_delta 0.5 ...   # ±0.5°
python train.py ... --tta_aoa --tta_aoa_delta 2.0 ...   # ±2.0°
```

**If there's no `--eval_only` flag**, you'll need to add the TTA logic to the end-of-training evaluation block. In that case, train 4 runs: 2 seeds × (baseline eval vs TTA eval), and use the same checkpoint for both by saving and reloading.

**Alternative approach if eval_only is hard:** Implement TTA directly in the existing evaluation block that runs at the end of training. Add the `--tta_aoa` flag and apply TTA during the final validation evaluation. Then run 2 baseline + 2 TTA-enabled training runs (same seeds) and compare the final evaluation metrics.

W&B group: `phase6/tta-aoa`

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | Baseline |
|--------|----------|
| p_in   | **12.1** |
| p_oodc | **6.6**  |
| p_tan  | **29.1** |
| p_re   | **5.8**  |

Single-model references:
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```