### PR TITLE
Phase 6: Mesh-Density Weighted L1 — Upweight Fine-Mesh Regions

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,10 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Mesh-density weighted loss
+    mesh_density_weight: bool = False        # weight surface loss by inverse local mesh spacing
+    density_weight_k: int = 4                # number of nearest neighbors for spacing estimate
+    density_weight_clip: float = 10.0        # max weight clip to prevent extreme upweighting
 
 
 cfg = sp.parse(Config)
@@ -1361,6 +1365,31 @@ ema_val_loss = float("inf")
 ema_decay_val = 0.9
 best_metrics = {}
 global_step = 0
+
+
+@torch.no_grad()
+def _compute_density_weights(pos, is_surface, mask, k=4, clip=10.0):
+    """Compute per-node density weights for surface nodes. Returns [B, N] tensor (detached)."""
+    B, N, _ = pos.shape
+    weights = torch.ones(B, N, device=pos.device)
+    for b in range(B):
+        surf = is_surface[b] & mask[b]  # surface nodes that are valid
+        if surf.sum() < k + 1:
+            continue
+        surf_idx = surf.nonzero(as_tuple=True)[0]
+        surf_pos = pos[b, surf_idx]  # [S, 2]
+        # Compute pairwise distances for surface nodes only
+        dists = torch.cdist(surf_pos.unsqueeze(0), surf_pos.unsqueeze(0)).squeeze(0)  # [S, S]
+        # k+1 smallest distances (includes self=0), take k nearest after self
+        topk_dists, _ = dists.topk(k + 1, largest=False)  # [S, k+1]
+        local_spacing = topk_dists[:, 1:].mean(dim=1)  # [S], exclude self
+        w = 1.0 / (local_spacing + 1e-8)
+        w = w / w.mean()  # normalize to mean=1
+        w = w.clamp(max=clip)
+        weights[b, surf_idx] = w
+    return weights
+
+
 train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
@@ -1457,6 +1486,7 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        _raw_pos = x[:, :, :2].clone()  # save raw xy before normalization for density weights
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1638,7 +1668,13 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Mesh-density weighted surface loss
+        if cfg.mesh_density_weight:
+            _dw = _compute_density_weights(_raw_pos, is_surface, mask, k=cfg.density_weight_k, clip=cfg.density_weight_clip)
+            surf_per_sample = (abs_err[:, :, 2:3] * _dw.unsqueeze(-1) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / \
+                              (_dw * surf_mask.float()).sum(dim=1).clamp(min=1)
+        else:
+            surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -1652,7 +1688,11 @@ for epoch in range(MAX_EPOCHS):
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            if cfg.mesh_density_weight:
+                surf_per_sample = (surf_pres * hard_weights * _dw.unsqueeze(-1) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / \
+                                  (_dw * surf_mask.float()).sum(dim=1).clamp(min=1)
+            else:
+                surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
@@ -1819,7 +1859,14 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_refine_head.parameters(), _refine_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.mesh_density_weight and '_dw' in dir():
+            _surf_dw = _dw[surf_mask]
+            if _surf_dw.numel() > 0:
+                _step_log["train/density_weight_mean"] = _surf_dw.mean().item()
+                _step_log["train/density_weight_max"] = _surf_dw.max().item()
+                _step_log["train/density_weight_std"] = _surf_dw.std().item()
+        wandb.log(_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

In unstructured CFD meshes, node spacing is finer near surfaces (especially leading/trailing edges and suction peaks) and coarser in the far field. The current L1 loss treats every node equally — but fine-mesh nodes in high-gradient regions (suction peaks, leading edges) are disproportionately important for surface MAE accuracy.

**The fix:** Weight each node's loss contribution by `1 / local_mesh_spacing` (the inverse of the mean distance to its k-nearest neighbors). This makes the loss proportional to physical domain area rather than node count, effectively upweighting the fine-mesh regions where errors matter most.

**Why this should help:**
- Leading-edge suction peaks have the sharpest pressure gradients and the finest mesh spacing — they drive surface MAE errors
- The model may currently "smooth over" these peaks because each peak-region node contributes equally to the loss as a far-field volume node
- Density weighting forces the model to prioritize fitting the high-curvature, high-gradient regions

**Distinct from PR #1893 (ID=7 upweighting):** That upweighted by boundary ID (topological). This upweights by mesh density (geometric). Density weighting naturally finds leading edges, trailing edges, and suction peaks — the physically important regions — without requiring manual boundary-ID logic.

**Paper:** Alet et al., "Mesh-based simulation with deep learning", NeurIPS 2019 — uses per-node area/volume weighting in GNN physics simulations.

## Instructions

**Step 1: Add flags** to argparse:
```python
parser.add_argument('--mesh_density_weight', action='store_true', default=False,
                    help='Weight loss by inverse local mesh spacing (upweight fine-mesh regions)')
parser.add_argument('--density_weight_k', type=int, default=4,
                    help='Number of nearest neighbors for local spacing estimate')
parser.add_argument('--density_weight_clip', type=float, default=10.0,
                    help='Max weight clip to prevent extreme upweighting at singularities')
```
Add to Config dataclass:
```python
mesh_density_weight: bool = False
density_weight_k: int = 4
density_weight_clip: float = 10.0
```

**Step 2: Compute density weights during data loading or at the start of training.**

The key is computing `local_spacing` for each node — the mean distance to its k-nearest neighbors:

```python
if cfg.mesh_density_weight:
    from scipy.spatial import cKDTree
    # pos: [N, 2] — spatial coordinates of mesh nodes (per sample)
    # Precompute weights for each sample in the dataset
    density_weights_cache = {}
    for idx in range(len(train_dataset)):
        sample = train_dataset[idx]
        pos = sample['x'][:, :2].numpy()  # (x, y) coordinates
        tree = cKDTree(pos)
        dists, _ = tree.query(pos, k=cfg.density_weight_k + 1)  # +1 for self
        local_spacing = dists[:, 1:].mean(axis=1)  # exclude self-distance
        w = 1.0 / (local_spacing + 1e-8)
        w = w / w.mean()  # normalize to mean=1 (preserves effective LR)
        w = np.clip(w, 0, cfg.density_weight_clip)  # clip extreme values
        density_weights_cache[idx] = torch.from_numpy(w).float()
```

**Note:** If all samples share the same mesh topology, compute this ONCE for one sample and reuse. If meshes differ per sample, compute per-sample and cache.

**Alternative (on-the-fly with PyTorch, if meshes are shared):**
```python
# Using knn from torch_geometric or manual computation
from torch_cluster import knn  # if available
# or compute distances manually via cdist
dists = torch.cdist(pos.unsqueeze(0), pos.unsqueeze(0)).squeeze(0)  # [N, N]
topk_dists, _ = dists.topk(cfg.density_weight_k + 1, largest=False)  # smallest k+1
local_spacing = topk_dists[:, 1:].mean(dim=1)  # exclude self
```

**Step 3: Apply weights in the loss computation:**

```python
if cfg.mesh_density_weight:
    per_node_loss = F.l1_loss(pred, target, reduction='none')  # [B, N, C]
    # density_w: [B, N] or [N] if shared mesh
    weighted_loss = (per_node_loss * density_w.unsqueeze(-1)).mean()
else:
    weighted_loss = F.l1_loss(pred, target)
```

Apply to surface nodes only (or both surface and volume — try both).

**Experiment runs** (2 seeds, apply to surface nodes only):

```bash
# Density-weighted loss, seed 42
python train.py --agent thorfinn \
  --wandb_name "thorfinn/density-w-s42" \
  --wandb_group phase6/mesh-density-loss \
  --mesh_density_weight --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

# Density-weighted loss, seed 73
python train.py --agent thorfinn \
  --wandb_name "thorfinn/density-w-s73" \
  --wandb_group phase6/mesh-density-loss \
  --mesh_density_weight --seed 73 \
  [same flags]

# With higher clip (20.0) for more aggressive upweighting, seed 42
python train.py --agent thorfinn \
  --wandb_name "thorfinn/density-w-clip20-s42" \
  --wandb_group phase6/mesh-density-loss \
  --mesh_density_weight --density_weight_clip 20.0 --seed 42 \
  [same flags]

# With higher clip (20.0), seed 73
python train.py --agent thorfinn \
  --wandb_name "thorfinn/density-w-clip20-s73" \
  --wandb_group phase6/mesh-density-loss \
  --mesh_density_weight --density_weight_clip 20.0 --seed 73 \
  [same flags]
```

W&B group: `phase6/mesh-density-loss`

**What to report:**
- Surface MAE (p_in, p_oodc, p_tan, p_re) per run
- Histogram of computed density weights (what does the weight distribution look like?)
- Whether clipping at 10 vs 20 matters

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | Baseline |
|--------|----------|
| p_in   | **12.1** |
| p_oodc | **6.6**  |
| p_tan  | **29.1** |
| p_re   | **5.8**  |

Single-model references:
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```