### PR TITLE
Phase 6: Smooth L1 (Huber) Loss — Node-Level Gradient Emphasis

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -945,6 +945,7 @@ class Config:
     # Phase 6: Asinh pressure transform
     asinh_pressure: bool = False             # transform pressure targets with asinh for dynamic range compression
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
+    smooth_l1_beta: float = 0.0              # 0 = standard L1, >0 = smooth L1 with this beta
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
 
@@ -1593,12 +1594,18 @@ for epoch in range(MAX_EPOCHS):
 
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
+        # Smooth L1 for loss gradient (or fall back to L1 when beta=0)
+        if cfg.smooth_l1_beta > 0:
+            loss_err = F.smooth_l1_loss(pred, y_norm, beta=cfg.smooth_l1_beta, reduction='none')
+        else:
+            loss_err = abs_err
         if cfg.tandem_ramp:
             pass  # no hard curriculum; tandem_weight applied via tandem_boost below
         elif epoch < cfg.tandem_curriculum_epochs:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
             sample_mask = (~is_tandem_curr).float()[:, None, None]
             abs_err = abs_err * sample_mask
+            loss_err = loss_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
@@ -1631,28 +1638,29 @@ for epoch in range(MAX_EPOCHS):
                 threshold = valid_dists.quantile(0.1)
                 near_wall = vol_mask_train & (vol_dist < threshold)
                 node_weight = (1.0 + near_wall.float()).unsqueeze(-1)  # 2x near-wall, 1x else
-                vol_loss = (abs_err * node_weight * vol_mask_train.float().unsqueeze(-1)).sum() / \
+                vol_loss = (loss_err * node_weight * vol_mask_train.float().unsqueeze(-1)).sum() / \
                            (node_weight.squeeze(-1) * vol_mask_train.float()).sum().clamp(min=1)
             else:
-                vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+                vol_loss = (loss_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         else:
-            vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+            vol_loss = (loss_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
         surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        surf_per_sample_loss = (loss_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1] — used for hard-node detection
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            surf_per_sample_loss = (loss_err[:, :, 2:3] * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
@@ -1661,12 +1669,12 @@ for epoch in range(MAX_EPOCHS):
                                        torch.ones(B, device=device))
         else:
             tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
-        surf_loss = (surf_per_sample * tandem_boost).mean()
+        surf_loss = (surf_per_sample_loss * tandem_boost).mean()
         if cfg.uncertainty_loss:
             bm = _base_model
-            surf_ux_loss = (abs_err[:, :, 0:1] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-            surf_uy_loss = (abs_err[:, :, 1:2] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
-            surf_p_loss  = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            surf_ux_loss = (loss_err[:, :, 0:1] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            surf_uy_loss = (loss_err[:, :, 1:2] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            surf_p_loss  = (loss_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
             loss = (vol_loss    * torch.exp(-2 * bm.log_sigma_vol)    / 2 + bm.log_sigma_vol +
                     surf_ux_loss * torch.exp(-2 * bm.log_sigma_surf_ux) / 2 + bm.log_sigma_surf_ux +
                     surf_uy_loss * torch.exp(-2 * bm.log_sigma_surf_uy) / 2 + bm.log_sigma_surf_uy +
@@ -1731,10 +1739,10 @@ for epoch in range(MAX_EPOCHS):
             n_b = is_ood_pcgrad.float().sum().clamp(min=1)
             vol_mask_a = vol_mask_train & is_indist_pcgrad.unsqueeze(1)
             vol_mask_b = vol_mask_train & is_ood_pcgrad.unsqueeze(1)
-            vol_loss_a = (abs_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
-            vol_loss_b = (abs_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
-            surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
-            surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
+            vol_loss_a = (loss_err * vol_mask_a.unsqueeze(-1)).sum() / vol_mask_a.sum().clamp(min=1)
+            vol_loss_b = (loss_err * vol_mask_b.unsqueeze(-1)).sum() / vol_mask_b.sum().clamp(min=1)
+            surf_loss_a = (surf_per_sample_loss * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
+            surf_loss_b = (surf_per_sample_loss * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
             loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
             loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
@@ -1784,8 +1792,9 @@ for epoch in range(MAX_EPOCHS):
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
             abs_err2 = (pred2 - y_norm).abs()
-            vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-            surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            loss_err2 = F.smooth_l1_loss(pred2, y_norm, beta=cfg.smooth_l1_beta, reduction='none') if cfg.smooth_l1_beta > 0 else abs_err2
+            vol_loss2 = (loss_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
+            surf_ps2 = (loss_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
             surf_loss2 = (surf_ps2 * tandem_boost).mean()
             re_loss2 = F.mse_loss(re_pred2, log_re_target)
             aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)


### PR DESCRIPTION
## Hypothesis

The current loss uses L1 (absolute error), which gives **equal gradient magnitude (±1) to all prediction errors** regardless of size. This means a node with a residual of 0.01 receives the same gradient as a node with a residual of 2.0.

Smooth L1 loss (Huber loss) changes this: for errors smaller than a threshold `beta`, the gradient is **proportional to the error magnitude** (L2-like behavior: gradient = error/beta). For errors larger than `beta`, the gradient reverts to constant magnitude (L1-like). The net effect:

- **Small-error nodes** receive proportionally weaker gradient → model pays less attention to already-well-predicted nodes
- **Large-error nodes** receive proportionally stronger gradient relative to small-error nodes → implicit node-level hard example mining

This is fundamentally different from sample-level reweighting (OHEM, #2101 — failed) because it operates **within each sample**, not across samples. High-error nodes on the tandem foil's suction peak receive more relative gradient signal without disrupting the batch composition.

**Mathematical distinction:**
- L1: `gradient = sign(error)` — equal-magnitude gradient for all nodes
- Smooth L1: `gradient = error/beta` when `|error| < beta` — proportional (weaker) for small errors; `gradient = sign(error)` when `|error| >= beta` (L1 regime)
- The result: large-error nodes get proportionally MORE weight relative to small-error nodes

**Why this might help p_tan:** Tandem pressure errors concentrate at leading edges and separation bubbles — these are the large-error nodes. Under smooth L1, these receive proportionally stronger gradient signal relative to the many near-zero-error volume nodes, focusing optimization on where it matters most.

**Key references:**
- Fast R-CNN (Girshick, 2015) — smooth L1 outperformed L2 for bounding box regression
- SSD (Liu et al., 2016) — smooth L1 consistently preferred for dense regression

## Instructions

**Step 1: Add flag to argparse:**
```python
parser.add_argument('--smooth_l1_beta', type=float, default=0.0,
                    help='Smooth L1 (Huber) loss beta threshold. 0.0 = standard L1.')
```
Add to Config dataclass:
```python
smooth_l1_beta: float = 0.0  # 0 = standard L1, >0 = smooth L1 with this beta
```

**Step 2: Change the loss error computation.** Find the line (approx line 1595):
```python
abs_err = (pred - y_norm).abs()
```
Replace with:
```python
# True L1 for metrics and running statistics (always interpretable)
abs_err = (pred - y_norm).abs()
# Smooth L1 for loss gradient (or fall back to L1 when beta=0)
if cfg.smooth_l1_beta > 0:
    loss_err = F.smooth_l1_loss(pred, y_norm, beta=cfg.smooth_l1_beta, reduction='none')
else:
    loss_err = abs_err
```

**Step 3: Replace `abs_err` → `loss_err` in ALL loss computation paths.** Keep `abs_err` for metrics:

- Vol loss: `vol_loss = (loss_err * vol_mask_train...).sum() / ...`
- Surf per-sample: use `loss_err` when computing `surf_per_sample`
- Surf per-channel losses (surf_ux_loss, surf_uy_loss, surf_p_loss): use `loss_err`
- Coarse loss (if present): use `loss_err`
- Keep `abs_err` everywhere it feeds into `running_tandem_loss`, `running_nontandem_loss`, EMA val stats, or W&B metric logging

**Step 4: Run 6 experiments** (3 beta values × 2 seeds):

```bash
# beta=0.5: L2 regime for errors < 0.5 in asinh-space (~most surface nodes)
python train.py --agent edward \
  --wandb_name "edward/smooth-l1-b05-s42" --wandb_group phase6/smooth-l1 \
  --smooth_l1_beta 0.5 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

python train.py --agent edward \
  --wandb_name "edward/smooth-l1-b05-s73" --wandb_group phase6/smooth-l1 \
  --smooth_l1_beta 0.5 --seed 73 [same flags]

# beta=1.0: moderate threshold
python train.py --agent edward \
  --wandb_name "edward/smooth-l1-b10-s42" --wandb_group phase6/smooth-l1 \
  --smooth_l1_beta 1.0 --seed 42 [same flags]

python train.py --agent edward \
  --wandb_name "edward/smooth-l1-b10-s73" --wandb_group phase6/smooth-l1 \
  --smooth_l1_beta 1.0 --seed 73 [same flags]

# beta=2.0: conservative — L2 regime for most errors
python train.py --agent edward \
  --wandb_name "edward/smooth-l1-b20-s42" --wandb_group phase6/smooth-l1 \
  --smooth_l1_beta 2.0 --seed 42 [same flags]

python train.py --agent edward \
  --wandb_name "edward/smooth-l1-b20-s73" --wandb_group phase6/smooth-l1 \
  --smooth_l1_beta 2.0 --seed 73 [same flags]
```

W&B group: `phase6/smooth-l1`

**IMPORTANT:** Use `abs_err` for all reported metrics (p_in, p_oodc, p_tan, p_re) — these must remain in true L1 space for comparison with baseline. Only the gradient computation changes.

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | 16-Ensemble | Single-model mean |
|--------|-------------|-------------------|
| p_in   | **12.1**    | 13.03             |
| p_oodc | **6.6**     | 7.83              |
| p_tan  | **29.1**    | 30.29             |
| p_re   | **5.8**     | 6.45              |

Single-model references (seeds 42 & 73, standard L1):
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/baseline-l1-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```