### PR TITLE
Phase 6: Gradient Centralization — Zero-Mean Gradient Updates with Lion

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,16 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Gradient Centralization (GC-Lion)
+    gradient_centralization: bool = False    # remove gradient DC offset before optimizer step (Yong et al. ECCV 2020)
+
+
+def apply_gradient_centralization(model: nn.Module) -> None:
+    """Subtract gradient mean over input dims (GC, Yong et al. ECCV 2020)."""
+    for p in model.parameters():
+        if p.grad is not None and p.grad.dim() > 1:
+            axes = tuple(range(1, p.grad.dim()))
+            p.grad.data -= p.grad.data.mean(dim=axes, keepdim=True)
 
 
 cfg = sp.parse(Config)
@@ -1768,6 +1778,8 @@ for epoch in range(MAX_EPOCHS):
                 optimizer.zero_grad()
             loss.backward()
 
+        if cfg.gradient_centralization:
+            apply_gradient_centralization(model)
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * 0.75)
         _should_step = (cfg.grad_accum_steps <= 1 or


### PR DESCRIPTION
## Hypothesis

The Lion optimizer uses sign(gradient_EMA) for weight updates — discarding all gradient magnitude information. This means the model's update direction at each step is determined entirely by the sign of the mean gradient vector. If a weight matrix has gradients with a large DC offset (all components pointing in the same direction), Lion's sign operation is dominated by this shared direction, reducing effective gradient diversity.

**Gradient Centralization (GC)** (Yong et al., ECCV 2020) removes the DC component of gradients before the optimizer step. For a weight matrix W with gradient ∇W, GC computes:

```
∇W_centered = ∇W - mean(∇W, dim=[1, 2, ..., k-1], keepdim=True)
```

where the mean is taken over all dimensions except the first (output channels). This constrains the gradient update to be zero-mean across input dimensions.

**Why this helps with Lion specifically:** Lion uses sign(EMA(∇W_centered)) instead of sign(EMA(∇W)). By centering, we ensure that Lion's binary updates are more balanced across output neurons — no single direction dominates. This is especially important for our multi-task loss (volume + surface + surface_refine + re_head + aoa_head) where gradients from different task heads can create large DC components that bias the optimizer.

**Why this might help p_tan:** The tandem distribution is a small fraction of training data. Its gradient contributions may be systematically suppressed by the large DC offset from single-foil gradients. GC removes this bias, giving tandem-relevant gradient directions equal representation in Lion's sign operation.

**Novel interaction:** GC was originally validated with SGD and Adam. Its interaction with Lion's sign operation is unstudied — this is a genuinely novel combination. Zero extra parameters. ~5 lines. Zero inference cost.

**Paper:** Yong et al., "Gradient Centralization: A New Optimization Technique for Deep Neural Networks", ECCV 2020. Showed consistent 0.5-3% improvements on ImageNet with SGD/Adam.

## Instructions

**Step 1: Add flag to argparse:**
```python
parser.add_argument('--gradient_centralization', action='store_true', default=False,
                    help='Apply gradient centralization before optimizer step (GC-Lion)')
```
Add `gradient_centralization: bool = False` to Config dataclass.

**Step 2: Add GC function (top of file, near other utility functions):**
```python
def apply_gradient_centralization(model: nn.Module) -> None:
    """Subtract gradient mean over input dims (GC, Yong et al. ECCV 2020)."""
    for p in model.parameters():
        if p.grad is not None and p.grad.dim() > 1:
            axes = tuple(range(1, p.grad.dim()))
            p.grad.data -= p.grad.data.mean(dim=axes, keepdim=True)
```

**Step 3: Insert AFTER `loss.backward()` and BEFORE `torch.nn.utils.clip_grad_norm_` in the main training loop** (around line 1769-1771):

```python
        loss.backward()

        if cfg.gradient_centralization:
            apply_gradient_centralization(model)
        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
```

No other changes needed. GC applies to all weight tensors (dim > 1), skipping biases (dim=1).

**Note on PCGrad:** `--disable_pcgrad` is set in all runs below, so the PCGrad interaction is not relevant here.

**Experiment runs (2 seeds):**

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/grad-cent-s42" \
  --wandb_group phase6/gradient-centralization \
  --gradient_centralization --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

# Seed 73
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/grad-cent-s73" \
  --wandb_group phase6/gradient-centralization \
  --gradient_centralization --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```

W&B group: `phase6/gradient-centralization`

**What to report:**
- Surface MAE (p_in, p_oodc, p_tan, p_re) for each run — all 4 required, no NaN accepted
- val/loss at convergence
- W&B run IDs

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | Ensemble Baseline | Single-model 8-seed mean |
|--------|-------------------|--------------------------|
| p_in   | **12.1**          | 13.03 |
| p_oodc | **6.6**           | 7.83  |
| p_tan  | **29.1**          | 30.29 |
| p_re   | **5.8**           | 6.45  |

Single-model references (same seed comparison):
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```