### PR TITLE
Phase 6: Gap/Stagger Perturbation Augmentation — Tandem OOD Robustness

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -906,6 +906,7 @@ class Config:
     aug_scale_range: float = 0.05   # half-range for scale augmentation (default ±5%)
     aug_start_epoch: int = 0        # delay augmentation onset until this epoch
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
+    aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1452,6 +1453,21 @@ for epoch in range(MAX_EPOCHS):
                     x[_b, _in_region] = x[_cut_idx[_b], _in_region]
                     y[_b, _in_region] = y[_cut_idx[_b], _in_region]
                     is_surface[_b, _in_region] = is_surface[_cut_idx[_b], _in_region]
+
+            # Gap/stagger perturbation augmentation (tandem samples only)
+            if cfg.aug_gap_stagger_sigma > 0.0:
+                _is_tandem_aug = (x[:, 0, 21].abs() > 0.01)  # [B] — matches existing tandem detection
+                if _is_tandem_aug.any():
+                    _B = x.size(0)
+                    # Per-sample Gaussian noise, broadcast to all N nodes
+                    _gap_noise  = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma
+                    _stag_noise = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma
+                    # Zero out noise for non-tandem samples (preserve single-foil sentinel exactly)
+                    _gap_noise  = _gap_noise  * _is_tandem_aug.float()
+                    _stag_noise = _stag_noise * _is_tandem_aug.float()
+                    # Apply: broadcast [B] → [B, 1] → adds to [B, N]
+                    x[:, :, 22] = x[:, :, 22] + _gap_noise.unsqueeze(1)
+                    x[:, :, 23] = x[:, :, 23] + _stag_noise.unsqueeze(1)
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

The model sees tandem samples at fixed (gap, stagger) values from the training distribution. By adding small Gaussian noise to the gap and stagger features during training, we force the model to generalize across the local neighborhood of each tandem geometry — a domain randomization strategy directly targeting the p_tan OOD axis.

**Motivation:** The tandem validation split (`val_tandem_transfer`) evaluates on unseen aft-foil geometries at novel gap/stagger combinations. The model must interpolate between seen (gap, stagger) pairs. Feature-space domain randomization during training explicitly expands the model's effective training distribution along these axes, improving robustness to unseen tandem configurations.

**Literature support:**
- SIMSHIFT (2025): Feature-space perturbation of conditioning variables reduces OOD gap in CFD surrogate models
- Domain Randomization (Tobin et al. 2017): Adding noise to conditioning variables is one of the most reliable generalization tools in sim-to-real transfer
- Gap/stagger augmentation has improved tandem prediction metrics in comparable multi-element airfoil studies

**Why this is different from existing augmentations:**
- `aoa_perturb`: perturbs angle-of-attack via full geometric rotation of mesh coordinates
- Gap/stagger perturbation: perturbs scalar conditioning features only (2 scalars), leaving all mesh coordinates unchanged
- Only affects tandem samples — single-foil sentinel (gap=0, stagger=0) is preserved exactly

**Key constraint:** Gap and stagger are broadcast to ALL nodes of a sample. The perturbation must be per-sample, applied to both the feature tensor and broadcast correctly across all N nodes.

## Instructions

### Feature layout verification

From `data/prepare_multi.py`, the 24-dim input `x` layout (0-indexed):
```
x[:, :,  0: 2] = pos (x, y coordinates)
x[:, :,  2: 4] = saf
x[:, :,  4:12] = dsdf
x[:, :, 12]    = is_surface
x[:, :, 13]    = log_Re
x[:, :, 14]    = AoA0_rad
x[:, :, 15:18] = NACA0 (3 values)
x[:, :, 18]    = AoA1_rad
x[:, :, 19:22] = NACA1 (3 values)
x[:, :, 22]    = gap      ← TARGET
x[:, :, 23]    = stagger  ← TARGET
```

**VERIFY BEFORE IMPLEMENTING:** Open `data/prepare_multi.py` and count the `torch.cat` entries to confirm indices 22 and 23 are gap and stagger. Add a sanity assertion during development:
```python
# Gap should be non-zero for tandem samples — if this fires, check your index
assert ((x[:, 0, 22].abs() > 0.01) == (x[:, 0, 21].abs() > 0.01)).all(), "Gap index check"
```

### Step 1: Add config flag

In the `Config` dataclass (near other `aug_*` flags):

```python
aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
```

### Step 2: Add augmentation in training loop

In the training loop, in the augmentation block (after the existing `aoa_perturb` block, around line ~1442), add:

```python
# Gap/stagger perturbation augmentation (tandem samples only)
if cfg.aug_gap_stagger_sigma > 0.0:
    _is_tandem_aug = (x[:, 0, 21].abs() > 0.01)  # [B] — matches existing tandem detection
    if _is_tandem_aug.any():
        _B = x.size(0)
        # Per-sample Gaussian noise, broadcast to all N nodes
        _gap_noise  = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma  # [B]
        _stag_noise = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma  # [B]
        # Zero out noise for non-tandem samples (preserve single-foil sentinel exactly)
        _gap_noise  = _gap_noise  * _is_tandem_aug.float()
        _stag_noise = _stag_noise * _is_tandem_aug.float()
        # Apply: broadcast [B] → [B, 1] → adds to [B, N]
        x[:, :, 22] = x[:, :, 22] + _gap_noise.unsqueeze(1)
        x[:, :, 23] = x[:, :, 23] + _stag_noise.unsqueeze(1)
```

This should go INSIDE the augmentation epoch guard (only runs when `cfg.aug_start_epoch <= epoch`).

### Step 3: Experiment runs (3 sigma × 2 seeds = 6 runs)

```bash
# sigma=0.02 (small perturbation)
python train.py --agent nezuko \
  --wandb_name "nezuko/gapstagger-s02-seed42" \
  --wandb_group phase6/gap-stagger-aug \
  --aug_gap_stagger_sigma 0.02 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3

python train.py --agent nezuko \
  --wandb_name "nezuko/gapstagger-s02-seed73" \
  --wandb_group phase6/gap-stagger-aug \
  --aug_gap_stagger_sigma 0.02 --seed 73 \
  [same flags as above]

# sigma=0.05 (medium perturbation — primary trial)
python train.py --agent nezuko \
  --wandb_name "nezuko/gapstagger-s05-seed42" \
  --wandb_group phase6/gap-stagger-aug \
  --aug_gap_stagger_sigma 0.05 --seed 42 \
  [same flags]

python train.py --agent nezuko \
  --wandb_name "nezuko/gapstagger-s05-seed73" \
  --wandb_group phase6/gap-stagger-aug \
  --aug_gap_stagger_sigma 0.05 --seed 73 \
  [same flags]

# sigma=0.10 (aggressive perturbation)
python train.py --agent nezuko \
  --wandb_name "nezuko/gapstagger-s10-seed42" \
  --wandb_group phase6/gap-stagger-aug \
  --aug_gap_stagger_sigma 0.10 --seed 42 \
  [same flags]

python train.py --agent nezuko \
  --wandb_name "nezuko/gapstagger-s10-seed73" \
  --wandb_group phase6/gap-stagger-aug \
  --aug_gap_stagger_sigma 0.10 --seed 73 \
  [same flags]
```

W&B group: `phase6/gap-stagger-aug`

### What to report

- Surface MAE (p_in, p_oodc, p_tan, p_re) for all 6 runs in a table with W&B run IDs
- Which sigma value performs best on p_tan (primary target)
- Whether p_in/p_oodc regress (tradeoff analysis)
- Val loss convergence — does augmentation slow early training?
- Whether any perturbed gap/stagger values went negative or out of physical range

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | 16-Ensemble |
|--------|------------|
| p_in   | **12.1** |
| p_oodc | **6.6**  |
| p_tan  | **29.1** |
| p_re   | **5.8**  |

Single-model 8-seed mean (used for merge decisions):

| Metric | 8-seed mean |
|--------|-------------|
| p_in   | 13.03 |
| p_oodc | 7.83  |
| p_tan  | 30.29 |
| p_re   | 6.45  |

Single-model references: seed=42: p_in≈12.71, p_oodc≈8.13 | seed=73: p_in≈12.2, p_oodc≈7.59