### PR TITLE
Phase 6: Charbonnier Loss — Fully Smooth L1 for Dense Pressure Regression

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -947,6 +947,8 @@ class Config:
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
+    # Phase 6: Charbonnier loss
+    charbonnier_eps: float = 0.0             # Charbonnier eps (0=disabled, uses standard L1)
 
 
 cfg = sp.parse(Config)
@@ -1592,7 +1594,10 @@ for epoch in range(MAX_EPOCHS):
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
 
         sq_err = (pred - y_norm) ** 2
-        abs_err = (pred - y_norm).abs()
+        if cfg.charbonnier_eps > 0:
+            abs_err = (sq_err + cfg.charbonnier_eps ** 2).sqrt() - cfg.charbonnier_eps
+        else:
+            abs_err = (pred - y_norm).abs()
         if cfg.tandem_ramp:
             pass  # no hard curriculum; tandem_weight applied via tandem_boost below
         elif epoch < cfg.tandem_curriculum_epochs:
@@ -1783,7 +1788,10 @@ for epoch in range(MAX_EPOCHS):
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
-            abs_err2 = (pred2 - y_norm).abs()
+            if cfg.charbonnier_eps > 0:
+                abs_err2 = ((pred2 - y_norm) ** 2 + cfg.charbonnier_eps ** 2).sqrt() - cfg.charbonnier_eps
+            else:
+                abs_err2 = (pred2 - y_norm).abs()
             vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
             surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
             surf_loss2 = (surf_ps2 * tandem_boost).mean()


### PR DESCRIPTION
## Hypothesis

The current training loss uses L1 (mean absolute error): `abs_err = (pred - y_norm).abs()`. L1 has a non-differentiable kink at zero — the gradient is ±1 everywhere except exactly at 0. For a well-trained model operating in a narrow residual band, this creates a plateau: the sign of the gradient is correct but the magnitude carries no magnitude information about how far off the prediction is.

**Charbonnier loss** replaces this with:
```
abs_err = sqrt((pred - y_norm)^2 + eps^2) - eps
```

This is fully smooth (C∞) everywhere. The gradient is `(pred - y_norm) / sqrt((pred - y_norm)^2 + eps^2)`, which interpolates between near-zero for small residuals and ±1 for large residuals. The transition is controlled by `eps`.

**Physical motivation:** Surface pressure prediction has a non-Gaussian error distribution — there are sharp suction peaks (large errors) and flat pressure recovery regions (small errors). The smooth gradient of Charbonnier provides proportional signal across this range, whereas L1 treats a 0.01 residual the same as a 1.0 residual (both gradient = ±1). For the surface refinement head (which operates on already-small residuals), the kink-free gradient may provide more consistent optimization signal.

This is distinct from Huber loss (#2113, edward) which has a hard threshold beta below/above which it switches between L2 and L1. Charbonnier has no threshold — the gradient is continuous and smooth everywhere, asymptotically approaching L1 for large residuals.

Reference: Barron (2019) "A General and Adaptive Robust Loss Function", CVPR — Charbonnier is a known-good special case of this family for dense regression tasks with non-Gaussian error distributions.

## Instructions

**Step 1: Add the Charbonnier eps flag** to argparse:
```python
parser.add_argument('--charbonnier_eps', type=float, default=0.0,
                    help='Charbonnier loss eps (0=disabled, uses standard L1)')
```
Add to Config dataclass:
```python
charbonnier_eps: float = 0.0
```

**Step 2: Find the L1 loss computation** in `train.py`. Look for `abs_err = (pred - y_norm).abs()` or similar — the per-node per-channel absolute error that feeds into vol_loss, surf_loss, and any hard-node mining.

**Step 3: Replace with Charbonnier when enabled:**
```python
if cfg.charbonnier_eps > 0:
    abs_err = ((pred - y_norm) ** 2 + cfg.charbonnier_eps ** 2).sqrt() - cfg.charbonnier_eps
else:
    abs_err = (pred - y_norm).abs()
```

That is the **complete change** — `abs_err` flows into all downstream loss terms (vol_loss, surf_loss, coarse pooling, hard-node mining) unchanged. The Charbonnier replaces L1 everywhere the base absolute error is used.

**Step 4: Verify correctness.** Confirm that when `charbonnier_eps=0`, output matches `abs()` numerically. Confirm that when eps=0.1 and pred=y_norm, abs_err=0 (the `-eps` cancels `sqrt(eps^2)=eps`).

**Step 5: Sweep eps values.** Run 2 seeds (42, 43) × 3 eps values = 6 runs total, all in parallel:
```bash
BASE="--agent alphonse --wandb_group phase6/charbonnier-loss \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3"

# eps=0.05 — tight smooth zone, closest to L1
python train.py $BASE --charbonnier_eps 0.05 --seed 42 --wandb_name "alphonse/charb-eps005-s42"
python train.py $BASE --charbonnier_eps 0.05 --seed 43 --wandb_name "alphonse/charb-eps005-s43"

# eps=0.1 — standard from image restoration literature
python train.py $BASE --charbonnier_eps 0.1  --seed 42 --wandb_name "alphonse/charb-eps01-s42"
python train.py $BASE --charbonnier_eps 0.1  --seed 43 --wandb_name "alphonse/charb-eps01-s43"

# eps=0.2 — wider smooth zone, more L2-like near zero
python train.py $BASE --charbonnier_eps 0.2  --seed 42 --wandb_name "alphonse/charb-eps02-s42"
python train.py $BASE --charbonnier_eps 0.2  --seed 43 --wandb_name "alphonse/charb-eps02-s43"
```

**What to report:** Table of (eps, seed, p_in, p_oodc, p_tan, p_re, val/loss, W&B run ID) + seed-averaged means per eps. Compare against the 8-seed single-model mean baseline (p_in=13.03, p_oodc=7.83, p_tan=30.29, p_re=6.45).

## Baseline

Current best (16-seed ensemble, PR #2093):

| Metric | 16-Seed Ensemble | 8-Seed Single-Model Mean |
|--------|-----------------|--------------------------|
| p_in   | **12.1**        | 13.03                    |
| p_oodc | **6.6**         | 7.83                     |
| p_tan  | **29.1**        | 30.29                    |
| p_re   | **5.8**         | 6.45                     |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3
```