### PR TITLE
Phase 6: Fore-Foil Dedicated SRF Head (ID=6) — Split from Single-Foil

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1004,6 +1004,10 @@ class Config:
     aft_foil_srf_film: bool = False          # FiLM conditioning on gap/stagger for aft-foil head
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
+    # Phase 6: Dedicated fore-foil surface refinement head (boundary ID=6 nodes only)
+    fore_foil_srf: bool = False              # enable dedicated head for fore-foil (ID=6) nodes; narrows srf_head to single-foil only
+    fore_foil_srf_hidden: int = 192          # hidden dim for fore-foil refinement head
+    fore_foil_srf_layers: int = 3            # number of hidden layers for fore-foil refinement head
 
 
 cfg = sp.parse(Config)
@@ -1212,10 +1216,27 @@ if cfg.aft_foil_srf:
           f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, "
           f"film={cfg.aft_foil_srf_film})")
 
+# Fore-foil (boundary ID=6) dedicated refinement head
+# When active, narrows existing srf_head to single-foil-only nodes
+fore_srf_head = None
+if cfg.fore_foil_srf:
+    fore_srf_head = AftFoilRefinementHead(
+        n_hidden=cfg.n_hidden,
+        out_dim=3,
+        hidden_dim=cfg.fore_foil_srf_hidden,
+        n_layers=cfg.fore_foil_srf_layers,
+        film=False,
+    ).to(device)
+    fore_srf_head = torch.compile(fore_srf_head, mode=cfg.compile_mode)
+    _fore_n_params = sum(p.numel() for p in fore_srf_head.parameters())
+    print(f"Fore-foil SRF head: {_fore_n_params:,} params "
+          f"(hidden={cfg.fore_foil_srf_hidden}, layers={cfg.fore_foil_srf_layers})")
+
 from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
 ema_aft_srf_head = None  # EMA copy of aft-foil SRF head
+ema_fore_srf_head = None  # EMA copy of fore-foil SRF head
 swad_initial_val = None
 swad_prev_val = float("inf")
 swad_checkpoints: list = []
@@ -1235,6 +1256,8 @@ if refine_head is not None:
     n_params += sum(p.numel() for p in refine_head.parameters())
 if aft_srf_head is not None:
     n_params += sum(p.numel() for p in aft_srf_head.parameters())
+if fore_srf_head is not None:
+    n_params += sum(p.numel() for p in fore_srf_head.parameters())
 
 
 class SAM:
@@ -1372,6 +1395,12 @@ if aft_srf_head is not None:
     base_opt.add_param_group({'params': _aft_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _aft_params):,} aft-foil SRF head params to optimizer")
 
+# Add fore-foil SRF head params to optimizer if enabled
+if fore_srf_head is not None:
+    _fore_params = list(fore_srf_head.parameters())
+    base_opt.add_param_group({'params': _fore_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _fore_params):,} fore-foil SRF head params to optimizer")
+
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
     _warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
@@ -1466,6 +1495,8 @@ for epoch in range(MAX_EPOCHS):
         refine_head.train()
     if aft_srf_head is not None:
         aft_srf_head.train()
+    if fore_srf_head is not None:
+        fore_srf_head.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
@@ -1544,11 +1575,15 @@ for epoch in range(MAX_EPOCHS):
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
-        if aft_srf_head is not None:
+        _fore_foil_mask = None
+        _is_tandem = None
+        if aft_srf_head is not None or fore_srf_head is not None:
             _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+            if fore_srf_head is not None:
+                _fore_foil_mask = is_surface & _is_tandem.unsqueeze(1) & ~_aft_foil_mask
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1675,7 +1710,12 @@ for epoch in range(MAX_EPOCHS):
                     pred = pred + refine_correction
                 else:
                     # Standard: extract surface nodes, apply MLP, scatter back
-                    surf_idx = is_surface.nonzero(as_tuple=False)  # [M, 2] (batch, node)
+                    # When fore_foil_srf active, narrow srf_head to single-foil (non-tandem) surface nodes only
+                    if fore_srf_head is not None and _is_tandem is not None:
+                        srf_apply_mask = is_surface & ~_is_tandem.unsqueeze(1)
+                    else:
+                        srf_apply_mask = is_surface
+                    surf_idx = srf_apply_mask.nonzero(as_tuple=False)  # [M, 2] (batch, node)
                     if surf_idx.numel() > 0:
                         surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
                         surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
@@ -1697,6 +1737,17 @@ for epoch in range(MAX_EPOCHS):
                     aft_correction = aft_srf_head(aft_hidden, aft_pred, _aft_cond).float()
                 pred = pred.clone()
                 pred[aft_idx[:, 0], aft_idx[:, 1]] = pred[aft_idx[:, 0], aft_idx[:, 1]] + aft_correction
+
+        # Fore-foil dedicated refinement head: additive correction on boundary ID=6 nodes only
+        if fore_srf_head is not None and model.training and _fore_foil_mask is not None:
+            fore_idx = _fore_foil_mask.nonzero(as_tuple=False)  # [F, 2] (batch, node)
+            if fore_idx.numel() > 0:
+                fore_hidden = hidden[fore_idx[:, 0], fore_idx[:, 1]]  # [F, n_hidden]
+                fore_pred = pred[fore_idx[:, 0], fore_idx[:, 1]]      # [F, 3]
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    fore_correction = fore_srf_head(fore_hidden, fore_pred).float()
+                pred = pred.clone()
+                pred[fore_idx[:, 0], fore_idx[:, 1]] = pred[fore_idx[:, 0], fore_idx[:, 1]] + fore_correction
 
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
@@ -1934,6 +1985,15 @@ for epoch in range(MAX_EPOCHS):
                     with torch.no_grad():
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _aft_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+            # EMA for fore-foil SRF head
+            if fore_srf_head is not None:
+                _fore_base = fore_srf_head._orig_mod if hasattr(fore_srf_head, '_orig_mod') else fore_srf_head
+                if ema_fore_srf_head is None:
+                    ema_fore_srf_head = deepcopy(_fore_base)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_fore_srf_head.parameters(), _fore_base.parameters()):
+                            ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -2047,6 +2107,14 @@ for epoch in range(MAX_EPOCHS):
             eval_aft_srf_head.eval()
         elif aft_srf_head is not None:
             aft_srf_head.eval()
+    # Select fore-foil SRF head for eval (EMA if available)
+    eval_fore_srf_head = fore_srf_head
+    if fore_srf_head is not None:
+        if ema_fore_srf_head is not None and ema_model is not None and eval_model is ema_model:
+            eval_fore_srf_head = ema_fore_srf_head
+            eval_fore_srf_head.eval()
+        elif fore_srf_head is not None:
+            fore_srf_head.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -2071,13 +2139,17 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                # Aft-foil mask for eval (same logic as training)
+                # Aft-foil and fore-foil masks for eval (same logic as training)
                 _eval_aft_mask = None
-                if eval_aft_srf_head is not None:
+                _eval_fore_mask = None
+                _v_is_tandem = None
+                if eval_aft_srf_head is not None or eval_fore_srf_head is not None:
                     _v_saf_norm = x[:, :, 2:4].norm(dim=-1)
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
                     _v_gap_stagger = x[:, 0, 22:24]  # [B, 2]
+                    if eval_fore_srf_head is not None:
+                        _eval_fore_mask = is_surface & _v_is_tandem.unsqueeze(1) & ~_eval_aft_mask
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -2179,7 +2251,12 @@ for epoch in range(MAX_EPOCHS):
                             ).float()
                             pred_loss = pred_loss + refine_correction
                         else:
-                            surf_idx = is_surface.nonzero(as_tuple=False)
+                            # When fore_foil_srf active, narrow srf_head to single-foil (non-tandem) surface nodes
+                            if eval_fore_srf_head is not None and _v_is_tandem is not None:
+                                eval_srf_apply_mask = is_surface & ~_v_is_tandem.unsqueeze(1)
+                            else:
+                                eval_srf_apply_mask = is_surface
+                            surf_idx = eval_srf_apply_mask.nonzero(as_tuple=False)
                             if surf_idx.numel() > 0:
                                 surf_hidden = _eval_hidden[surf_idx[:, 0], surf_idx[:, 1]]
                                 surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
@@ -2203,6 +2280,22 @@ for epoch in range(MAX_EPOCHS):
                             _aft_corr = eval_aft_srf_head(_ah, _ap, _ac).float()
                         pred_loss = pred_loss.clone()
                         pred_loss[aft_idx[:, 0], aft_idx[:, 1]] += _aft_corr
+                        # Back-compute pred for denormalization
+                        if cfg.multiply_std:
+                            pred = pred_loss / sample_stds
+                        else:
+                            pred = pred_loss * sample_stds
+
+                # Apply fore-foil SRF head during validation
+                if eval_fore_srf_head is not None and _eval_fore_mask is not None:
+                    fore_idx = _eval_fore_mask.nonzero(as_tuple=False)
+                    if fore_idx.numel() > 0:
+                        _fh = _eval_hidden[fore_idx[:, 0], fore_idx[:, 1]]
+                        _fp = pred_loss[fore_idx[:, 0], fore_idx[:, 1]]
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            _fore_corr = eval_fore_srf_head(_fh, _fp).float()
+                        pred_loss = pred_loss.clone()
+                        pred_loss[fore_idx[:, 0], fore_idx[:, 1]] += _fore_corr
                         # Back-compute pred for denormalization
                         if cfg.multiply_std:
                             pred = pred_loss / sample_stds
@@ -2381,6 +2474,11 @@ for epoch in range(MAX_EPOCHS):
                 aft_srf_head._orig_mod if hasattr(aft_srf_head, '_orig_mod') else aft_srf_head
             )
             torch.save(_aft_save.state_dict(), model_dir / "aft_srf_head.pt")
+        if fore_srf_head is not None:
+            _fore_save = ema_fore_srf_head if ema_fore_srf_head is not None else (
+                fore_srf_head._orig_mod if hasattr(fore_srf_head, '_orig_mod') else fore_srf_head
+            )
+            torch.save(_fore_save.state_dict(), model_dir / "fore_srf_head.pt")
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(


### PR DESCRIPTION
## Hypothesis

PR #2104 confirmed that giving the aft-foil (boundary ID=7) its own dedicated Surface Refinement Head improves **p_tan by -0.8%** (30.05 vs 30.29, 8-seed mean) — now merged into baseline. The aft-foil gets dedicated capacity because it operates in the wake with qualitatively different pressure distributions.

The **same logic applies to the fore-foil (boundary ID=6)**. Currently, the main `srf_head` serves both:
- ID=5 — single-foil surface nodes (simple, non-interactive flow)
- ID=6 — fore-foil tandem surface nodes (accelerated channel flow, modified lift from aft-foil presence)

The fore-foil in tandem sees aerodynamically distinct flow: gap acceleration increases local velocity, the aft foil's blockage modifies the upstream pressure distribution. A shared correction MLP with single-foil nodes cannot specialize to these effects. A **dedicated `fore_srf_head`** for ID=6 nodes should let the model learn richer fore-foil corrections, complementing the aft-foil SRF already merged.

**Key:** Zero-init on the last linear layer means worst-case this is identity — no regression risk. Single-foil samples have no ID=6 nodes so p_in is not affected.

**Prior work:** PR #2104 (merged) — dedicated aft-foil SRF. No prior experiment split fore-foil from single-foil.

## Instructions

You already have the SAF proxy from #2104 to identify aft-foil nodes (`saf_norm > 0.005` in tandem samples). Now extend the approach to split the remaining `srf_head` into single-foil (ID=5) and fore-foil (ID=6).

### Step 1 — Add config flags

```python
# In Config dataclass:
fore_foil_srf: bool = False
fore_foil_srf_hidden: int = 192
fore_foil_srf_layers: int = 3
```

### Step 2 — Init the fore-foil SRF head in `Transolver.__init__`

```python
if cfg.fore_foil_srf:
    self.fore_srf_head = SurfaceRefinementHead(
        n_hidden=cfg.n_hidden,
        hidden_size=cfg.fore_foil_srf_hidden,
        n_layers=cfg.fore_foil_srf_layers,
        out_dim=3,
    )
else:
    self.fore_srf_head = None
```

### Step 3 — Identify fore-foil nodes in `Transolver.forward`

Re-use your SAF proxy from #2104. You already compute `is_aft` (aft-foil = aft_mask). Now add:

```python
# Tandem indicator per sample (from gap feature, same as in #2104)
is_tandem_sample = (x[:, 0, 21].abs() > <your_threshold>)  # [B]
B, N = boundary_id_or_surface_mask.shape  # or however you get B, N

# Fore-foil: surface nodes in tandem samples that are NOT aft-foil
is_aft = <your existing aft-foil mask from #2104>  # [B, N]
is_fore = is_surface_mask & is_tandem_sample.unsqueeze(1).expand(-1, N) & ~is_aft  # [B, N]
```

### Step 4 — Narrow existing `srf_head` to single-foil only when --fore_foil_srf active

```python
if self.fore_srf_head is not None:
    # Narrow srf_head to single-foil only (non-tandem surface nodes)
    srf_apply_mask = is_surface_mask & ~is_tandem_sample.unsqueeze(1).expand(-1, N)
else:
    srf_apply_mask = is_surface_mask  # original: all surface nodes

# Apply srf_head using srf_apply_mask
if srf_apply_mask.any():
    srf_hidden = hidden[srf_apply_mask]
    srf_base = out[srf_apply_mask]
    srf_delta = self.srf_head(srf_hidden, srf_base)
    out[srf_apply_mask] += srf_delta
```

### Step 5 — Apply fore_srf_head to fore-foil (ID=6) nodes

```python
if self.fore_srf_head is not None and is_fore.any():
    fore_hidden = hidden[is_fore]
    fore_base = out[is_fore]
    fore_delta = self.fore_srf_head(fore_hidden, fore_base)
    out[is_fore] += fore_delta
```

### Step 6 — Run 6 experiments with `--wandb_group phase6/fore-foil-srf`

**Important:** The new baseline includes `--aft_foil_srf`. All runs must include it.

| GPU | Config | wandb_name | Seed |
|-----|--------|-----------|------|
| 0 | Baseline (aft_srf only, control) | fern/fore-srf-base-s42 | 42 |
| 1 | Baseline (aft_srf only, control) | fern/fore-srf-base-s43 | 43 |
| 2 | `--fore_foil_srf` (192/3L) | fern/fore-srf-s42 | 42 |
| 3 | `--fore_foil_srf` (192/3L) | fern/fore-srf-s43 | 43 |
| 4 | `--fore_foil_srf --fore_foil_srf_hidden 256 --fore_foil_srf_layers 4` | fern/fore-srf-lg-s42 | 42 |
| 5 | `--fore_foil_srf --fore_foil_srf_hidden 256 --fore_foil_srf_layers 4` | fern/fore-srf-lg-s43 | 43 |

Full base command (all runs include **both** `--aft_foil_srf` and optionally `--fore_foil_srf`):
```bash
cd cfd_tandemfoil && nohup env PYTHONUNBUFFERED=1 CUDA_VISIBLE_DEVICES=<gpu> python train.py \
  --agent fern --wandb_name "fern/<name>" --wandb_group phase6/fore-foil-srf \
  --seed <seed> \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf \
  [--fore_foil_srf] [--fore_foil_srf_hidden 256 --fore_foil_srf_layers 4] \
  > logs/<name>.log 2>&1 &
```

**Do NOT override SENPAI_MAX_EPOCHS or SENPAI_TIMEOUT_MINUTES.**

## What to report

- Surface MAE for each config: p_in, p_oodc, p_tan, p_re (and W&B run IDs)
- Does `--fore_foil_srf` improve p_tan? By how much vs. control baseline?
- Does larger capacity (256/4L) help vs default (192/3L)?
- Is p_in stable? (Expected: yes — fore-foil head only fires on ID=6 tandem nodes)
- How did you identify fore-foil nodes? (Expected: `is_surface & is_tandem & ~is_aft_foil`)
- Node count sanity check: how many fore-foil vs aft-foil vs single-foil nodes per batch?

## Baseline

Current best (PR #2104 merged — +aft_foil_srf, 8-seed mean, seeds 42-49):

| Metric | 8-seed mean (aft_srf) | Target to beat |
|--------|----------------------|----------------|
| p_in | 13.19 ± 0.33 | < 13.19 |
| p_oodc | 7.92 ± 0.17 | < 7.92 |
| p_tan | **30.05 ± 0.36** | **< 30.05** |
| p_re | 6.45 ± 0.07 | < 6.45 |

For merge decisions, compare your 2-seed avg against the 8-seed mean (p_tan < 30.05 is primary target).

Reproduce baseline:
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf
```