### PR TITLE
Phase 6: Boundary-ID One-Hot Feature — Explicit Surface-Type Conditioning

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1004,6 +1004,8 @@ class Config:
     aft_foil_srf_film: bool = False          # FiLM conditioning on gap/stagger for aft-foil head
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
+    # Phase 6: Boundary-ID one-hot feature conditioning
+    boundary_id_onehot: bool = False         # append 3-dim boundary-type one-hot to input (ID=5/6/7)
 
 
 cfg = sp.parse(Config)
@@ -1134,7 +1136,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32 + (3 if cfg.boundary_id_onehot else 0),  # +curv, +dist, [+foil2dist], +32 fourier PE, [+3 bid onehot]
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1549,6 +1551,17 @@ for epoch in range(MAX_EPOCHS):
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+        # Boundary-ID one-hot: compute from raw features before normalization
+        _bid_onehot = None
+        if cfg.boundary_id_onehot:
+            _b_saf_norm = x[:, :, 2:4].norm(dim=-1)           # [B, N]
+            _b_is_tandem = (x[:, 0, 22].abs() > 0.01)         # [B]
+            _bid_single = is_surface & ~_b_is_tandem.unsqueeze(1)                            # ID=5
+            _bid_fore   = is_surface & (_b_saf_norm <= 0.005) & _b_is_tandem.unsqueeze(1)   # ID=6
+            _bid_aft    = is_surface & (_b_saf_norm  > 0.005) & _b_is_tandem.unsqueeze(1)   # ID=7
+            _bid_onehot = torch.stack([
+                _bid_single.float(), _bid_fore.float(), _bid_aft.float()
+            ], dim=-1)  # [B, N, 3]
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1567,6 +1580,16 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
+        # Append boundary-ID one-hot if enabled (after all other features, before model input)
+        if _bid_onehot is not None:
+            x = torch.cat([x, _bid_onehot], dim=-1)  # input dim +3
+            if batch_idx == 0 and epoch == 0:
+                wandb.log({
+                    "bid/frac_single": _bid_single.float().mean().item(),
+                    "bid/frac_fore":   _bid_fore.float().mean().item(),
+                    "bid/frac_aft":    _bid_aft.float().mean().item(),
+                    "global_step": global_step,
+                })
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -2078,6 +2101,17 @@ for epoch in range(MAX_EPOCHS):
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
                     _v_gap_stagger = x[:, 0, 22:24]  # [B, 2]
+                # Boundary-ID one-hot for eval (same logic as training)
+                _v_bid_onehot = None
+                if cfg.boundary_id_onehot:
+                    _vb_saf_norm = x[:, :, 2:4].norm(dim=-1)
+                    _vb_is_tandem = (x[:, 0, 22].abs() > 0.01)
+                    _v_bid_single = is_surface & ~_vb_is_tandem.unsqueeze(1)
+                    _v_bid_fore   = is_surface & (_vb_saf_norm <= 0.005) & _vb_is_tandem.unsqueeze(1)
+                    _v_bid_aft    = is_surface & (_vb_saf_norm  > 0.005) & _vb_is_tandem.unsqueeze(1)
+                    _v_bid_onehot = torch.stack([
+                        _v_bid_single.float(), _v_bid_fore.float(), _v_bid_aft.float()
+                    ], dim=-1)  # [B, N, 3]
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -2096,6 +2130,9 @@ for epoch in range(MAX_EPOCHS):
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
+                # Append boundary-ID one-hot if enabled
+                if _v_bid_onehot is not None:
+                    x = torch.cat([x, _v_bid_onehot], dim=-1)  # input dim +3
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]


### PR DESCRIPTION
## Hypothesis

The aft-foil SRF head (PR #2104, -0.8% p_tan) proved that boundary-type specialization improves surface predictions. But the SRF head acts only as a **post-hoc correction** — the Transolver attention blocks that precede it have already processed nodes without knowing which surface type they belong to.

**The fix:** Append a 3-dim one-hot vector encoding boundary ID (ID=5 single-foil surface, ID=6 fore-foil surface, ID=7 aft-foil surface) to every mesh node's input feature vector **before** it enters the first attention block. Volume nodes receive the zero vector.

Why this should help:
- The model currently must infer surface type from geometric cues alone (SDF, curvature, spatial coordinates) — an implicit signal the attention layers must disentangle from flow physics
- Explicit conditioning propagates boundary-type information through **all 3 Transolver blocks from layer 0**, giving the attention mechanism a clean, unambiguous routing signal
- The aft-foil SRF improvement (-0.8% p_tan) came from specializing a 2-layer MLP post-hoc; this experiment gives the full 3-layer Transolver backbone the same signal — strictly stronger conditioning
- Expected gain: -3 to -8% p_tan. Low implementation risk (~15 LoC). Complementary to and stackable with the SRF heads.

**Key distinction from SRF experiments:** SRF adds a specialized output correction. This adds a specialized input signal. They are complementary.

## Instructions

**Step 1: Add the flag to argparse and Config:**

```python
# argparse:
parser.add_argument('--boundary_id_onehot', action='store_true', default=False,
                    help='Append 3-dim boundary-ID one-hot to input features (ID=5/6/7)')

# Config dataclass:
boundary_id_onehot: bool = False
```

**Step 2: Compute the one-hot BEFORE standardization (raw features intact).**

Use the same SAF proxy that PR #2104 validated (100% recall, 0% false positives at threshold 0.005):

```python
if cfg.boundary_id_onehot:
    # x[:, :, 2:4] = signed angle field (SAF) components
    _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)              # [B, N]
    # Tandem detection: find the column that flags tandem config in x
    # (reuse whatever is_tandem logic already exists in the codebase)
    _is_tandem = (x[:, 0, 22].abs() > 0.01).unsqueeze(1)   # [B, 1] — verify col idx

    _bid_single = is_surface & ~_is_tandem                  # ID=5: single-foil
    _bid_fore   = is_surface & (_raw_saf_norm <= 0.005) & _is_tandem   # ID=6: fore-foil
    _bid_aft    = is_surface & (_raw_saf_norm  > 0.005) & _is_tandem   # ID=7: aft-foil
    _bid_onehot = torch.stack([
        _bid_single.float(),
        _bid_fore.float(),
        _bid_aft.float()
    ], dim=-1)                                              # [B, N, 3]
```

**Important:** Check the actual column index for the tandem indicator in `x`. Look for how the codebase already detects `is_tandem` or the single/tandem flag in the raw feature tensor, and use that exact index. Do not guess.

**Step 3: Append the one-hot to `x` just before the input projection:**

```python
if cfg.boundary_id_onehot:
    x = torch.cat([x, _bid_onehot], dim=-1)   # input dim +3
```

The model's input projection is dynamically sized — no other changes needed.

**Step 4: Add a sanity-check log** (log once at training start):
```python
# Log fraction of nodes per boundary type to verify detection
if cfg.boundary_id_onehot and epoch == 0 and batch_idx == 0:
    wandb.log({
        "bid/frac_single": _bid_single.float().mean().item(),
        "bid/frac_fore":   _bid_fore.float().mean().item(),
        "bid/frac_aft":    _bid_aft.float().mean().item(),
    })
```

**Training commands (2 seeds):**

```bash
# Seed 42
python train.py --agent thorfinn \
  --wandb_name "thorfinn/bid-onehot-s42" \
  --wandb_group phase6/boundary-id-onehot \
  --boundary_id_onehot --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf

# Seed 43
python train.py --agent thorfinn \
  --wandb_name "thorfinn/bid-onehot-s43" \
  --wandb_group phase6/boundary-id-onehot \
  --boundary_id_onehot --seed 43 \
  [same flags as above]
```

**What to report:**
- Surface MAE (p_in, p_oodc, p_tan, p_re) per run + W&B run IDs
- Boundary type fractions from the sanity-check log (confirm detection is working)
- Any training instability

## Baseline

Current single-model baseline (PR #2104, 8-seed mean, seeds 42-49) — all runs must include `--aft_foil_srf`:

| Metric | 8-seed mean | Target |
|--------|------------|--------|
| p_in   | **13.19 ± 0.33** | < 13.19 |
| p_oodc | **7.92 ± 0.17**  | < 7.92  |
| p_tan  | **30.05 ± 0.36** | **< 30.05** ← primary |
| p_re   | **6.45 ± 0.07**  | < 6.45  |

Per-seed references (with `--aft_foil_srf`, PR #2104):
- seed=42: p_in=13.4, p_tan=29.8, p_oodc=7.7, p_re=6.4
- seed=43: p_in=13.2, p_tan=29.3, p_oodc=7.8, p_re=6.4

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --seed 42 \
  --wandb_name "thorfinn/baseline-aft-srf" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf
```