### PR TITLE
Phase 6: PCGrad 3-Way Task Split — Gradient Surgery for Tandem/Single/Extreme-Re

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1052,6 +1052,9 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
+    pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
+    pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
 
 
 cfg = sp.parse(Config)
@@ -1987,6 +1990,80 @@ for epoch in range(MAX_EPOCHS):
                     p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
                 else:
                     p.grad = (ga + gb) * 0.5
+        elif cfg.pcgrad_3way and is_tandem_batch.any() and (~is_tandem_batch).any():
+            # 3-way PCGrad: Group A=single-foil, B=tandem-normal, C=tandem-extreme-Re
+            re_vals = x[:, 0, 13]  # normalized log(Re), same for all nodes in sample
+            re_tandem = re_vals[is_tandem_batch]
+            if is_tandem_batch.sum() >= 4:
+                lo = torch.quantile(re_tandem, cfg.pcgrad_extreme_pct)
+                hi = torch.quantile(re_tandem, 1.0 - cfg.pcgrad_extreme_pct)
+                is_extreme = is_tandem_batch & ((re_vals < lo) | (re_vals > hi))
+                is_normal_tan = is_tandem_batch & ~is_extreme
+            else:
+                is_extreme = torch.zeros(B, dtype=torch.bool, device=device)
+                is_normal_tan = is_tandem_batch
+
+            def _grp_loss(mask_1d):
+                n = mask_1d.float().sum().clamp(min=1)
+                vol_mask_g = vol_mask_train & mask_1d.unsqueeze(1)
+                vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
+                surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
+                coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+
+            loss_A = _grp_loss(~is_tandem_batch)
+            # Only include non-empty groups to avoid backward() on no-grad tensors
+            task_losses_with_masks = [
+                (loss_A, (~is_tandem_batch)),
+                (_grp_loss(is_normal_tan), is_normal_tan),
+                (_grp_loss(is_extreme), is_extreme),
+            ]
+            task_losses = [l for l, m in task_losses_with_masks if m.any()]
+            if len(task_losses) == 0:
+                task_losses = [loss_A]  # fallback
+
+            # Compute per-task gradients with retain_graph
+            task_grads = []
+            for i, tl in enumerate(task_losses):
+                optimizer.zero_grad()
+                tl.backward(retain_graph=(i < len(task_losses) - 1))
+                task_grads.append([p.grad.clone() if p.grad is not None else None
+                                   for p in model.parameters()])
+
+            # PCGrad projection: project g_i onto normal plane of each g_j
+            def pcgrad_project(g_i, g_j):
+                dot = sum((a * b).sum() for a, b in zip(g_i, g_j) if a is not None and b is not None)
+                if dot < 0:
+                    norm_sq = sum((b * b).sum() for b in g_j if b is not None) + 1e-12
+                    return [a - (dot / norm_sq) * b if (a is not None and b is not None) else a
+                            for a, b in zip(g_i, g_j)]
+                return list(g_i)
+
+            n_tasks = len(task_grads)
+            projected = [list(g) for g in task_grads]
+            for i in range(n_tasks):
+                for j in range(n_tasks):
+                    if i != j:
+                        projected[i] = pcgrad_project(projected[i], task_grads[j])
+
+            # Sum projected gradients and write back
+            optimizer.zero_grad()
+            for param_idx, p in enumerate(model.parameters()):
+                parts = [projected[t][param_idx] for t in range(n_tasks)
+                         if projected[t][param_idx] is not None]
+                if parts:
+                    p.grad = sum(parts)
+
+            n_extreme = is_extreme.sum().item()
+            n_normal_tan = is_normal_tan.sum().item()
+            wandb.log({
+                "train/pcgrad3w_loss_A": loss_A.item(),
+                "train/pcgrad3w_n_extreme": n_extreme,
+                "train/pcgrad3w_n_normal_tan": n_normal_tan,
+                "global_step": global_step,
+            })
+            loss = sum(task_losses) / len(task_losses)  # for logging only
+            use_pcgrad = True  # downstream logic: treat as if pcgrad ran
         else:
             if cfg.grad_accum_steps <= 1:
                 optimizer.zero_grad()


### PR DESCRIPTION
## Hypothesis

PCGrad (Yu et al., NeurIPS 2020) resolves gradient conflicts between tasks by projecting each task's gradient onto the normal plane of any conflicting task's gradient. It was **disabled in PR #1846** due to 18% memory overhead without improvement — but the baseline has changed substantially since then (residual prediction, surface refinement, aft-foil SRF head, asinh transform).

The current **2.3x gap between p_in (13.19) and p_tan (30.05)** is the most likely consequence of gradient conflict between single-foil and tandem samples competing in the same training batch. The original 2-way PCGrad split (single-foil vs. all tandem) lumped "easy" and "hard" tandem samples together.

**Hypothesis:** A **3-way split** isolates gradient conflicts more precisely:

- **Group A**: single-foil samples (~is_tandem) — the p_in task
- **Group B**: tandem "normal" samples (is_tandem & ~is_extreme) — average tandem configurations
- **Group C**: tandem extreme-Re/AoA samples (is_tandem & is_extreme) — the hardest OOD tandem cases that dominate p_tan

Gradient surgery across 3 tasks (A, B, C) prevents the p_in signal from corrupting aft-foil representation AND prevents easy-tandem from diluting the gradient for hard-tandem. Expected: -2 to -5% p_tan, stable p_in.

**Paper:** Yu et al., "Gradient Surgery for Multi-Task Learning," NeurIPS 2020. https://arxiv.org/abs/2001.06782

## Instructions

### Step 1: Add new flags

```python
# In argparse:
parser.add_argument('--pcgrad_3way', action='store_true',
                    help='3-way PCGrad: single-foil | tandem-normal | tandem-extreme-Re')
parser.add_argument('--pcgrad_extreme_pct', type=float, default=0.15,
                    help='Top/bottom percentile of Re to label as extreme (default: 0.15)')
# In Config dataclass:
pcgrad_3way: bool = False
pcgrad_extreme_pct: float = 0.15
```

### Step 2: Locate existing PCGrad code

```bash
grep -n "pcgrad\|PCGrad\|gradient_surgery\|disable_pcgrad" cfd_tandemfoil/train.py | head -30
```

Find where `cfg.disable_pcgrad` gates the existing 2-way gradient surgery. The new `--pcgrad_3way` flag is an independent path — keep `--disable_pcgrad` in the run command so only the new 3-way implementation runs.

### Step 3: Find the Re feature index

```bash
grep -n "reynolds\|re_idx\|re_feature\|RE\b\|feature.*re\|re.*feature" cfd_tandemfoil/train.py | head -20
```

The Reynolds number is available per-sample as one of the global condition features in `x`. Identify its channel index (likely in the range 18-25).

### Step 4: Group detection

After `is_tandem` is computed and before/during loss reduction:

```python
if cfg.pcgrad_3way:
    re_vals = x[:, 0, RE_FEATURE_IDX]   # [B] — one scalar Re per sample
    re_tandem = re_vals[is_tandem]
    if is_tandem.sum() >= 4:
        lo = torch.quantile(re_tandem, cfg.pcgrad_extreme_pct)
        hi = torch.quantile(re_tandem, 1.0 - cfg.pcgrad_extreme_pct)
        is_extreme = is_tandem & ((re_vals < lo) | (re_vals > hi))
        is_normal_tan = is_tandem & ~is_extreme
    else:
        is_extreme = torch.zeros(B, dtype=torch.bool, device=x.device)
        is_normal_tan = is_tandem
```

### Step 5: 3-way gradient surgery

```python
if cfg.pcgrad_3way:
    # Compute per-group mean loss from per-sample loss tensor (before reduction)
    loss_A = per_sample_loss[~is_tandem].mean()
    loss_B = per_sample_loss[is_normal_tan].mean() if is_normal_tan.any() else torch.tensor(0.0, device=device)
    loss_C = per_sample_loss[is_extreme].mean()     if is_extreme.any()    else torch.tensor(0.0, device=device)

    # Collect per-task gradients
    task_grads = []
    for task_loss in [loss_A, loss_B, loss_C]:
        optimizer.zero_grad()
        task_loss.backward(retain_graph=True)
        task_grads.append([p.grad.clone() if p.grad is not None else None
                           for p in model.parameters()])

    # Project conflicting gradients (standard PCGrad projection)
    def pcgrad_project(g_i, g_j):
        dot = sum((a * b).sum() for a, b in zip(g_i, g_j) if a is not None and b is not None)
        if dot < 0:
            norm_sq = sum((b * b).sum() for b in g_j if b is not None)
            if norm_sq > 1e-12:
                return [a - (dot / norm_sq) * b if a is not None and b is not None else a
                        for a, b in zip(g_i, g_j)]
        return g_i

    n = len(task_grads)
    projected = list(task_grads)
    for i in range(n):
        for j in range(n):
            if i != j:
                projected[i] = pcgrad_project(projected[i], task_grads[j])

    # Sum projected gradients and write back
    optimizer.zero_grad()
    for param_idx, p in enumerate(model.parameters()):
        parts = [projected[t][param_idx] for t in range(n)
                 if projected[t][param_idx] is not None]
        if parts:
            p.grad = sum(parts)

    optimizer.step()
    loss = (loss_A + loss_B + loss_C) / 3   # for logging only
else:
    loss.backward()
    optimizer.step()
```

> **Memory note:** 3 `backward(retain_graph=True)` calls increase peak VRAM. Current baseline uses ~38GB on 96GB cards — should be fine. If OOM, reduce `--slice_num 80` for this run only.

### Step 6: Experiment runs

Sweep `pcgrad_extreme_pct` in {0.10, 0.15}, 2 seeds each = 4 total runs:

```bash
# pct=0.15, seed 42
python train.py --agent askeladd \
  --wandb_name "askeladd/pcgrad3w-pct15-s42" \
  --wandb_group phase6/pcgrad-3way \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf

# pct=0.15, seed 73 — same flags + --seed 73
# pct=0.10, seed 42 — same flags + --pcgrad_extreme_pct 0.10
# pct=0.10, seed 73 — same flags + --pcgrad_extreme_pct 0.10 --seed 73
```

Run all 4 in parallel if VRAM allows. W&B group: `phase6/pcgrad-3way`

## Baseline

Current single-model baseline (PR #2104, +aft_foil_srf, 8-seed mean, seeds 42-49):

| Metric | 8-seed mean | Target to beat |
|--------|-------------|----------------|
| p_in   | **13.19 ± 0.33** | < 13.19 |
| p_oodc | **7.92 ± 0.17**  | < 7.92  |
| p_tan  | **30.05 ± 0.36** | **< 30.05** |
| p_re   | **6.45 ± 0.07**  | < 6.45  |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd --seed 42 \
  --wandb_name "askeladd/baseline-s42" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf
```