### PR TITLE
Phase 6: Langevin Gradient Noise (SGLD) — Stochastic Exploration for Lion

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1004,6 +1004,8 @@ class Config:
     aft_foil_srf_film: bool = False          # FiLM conditioning on gap/stagger for aft-foil head
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
+    # Phase 6: Langevin noise (SGLD-style parameter perturbation after Lion step)
+    langevin_noise: float = 0.0              # noise scale; 0 = disabled. Anneals to 0 at 80% of training.
 
 
 cfg = sp.parse(Config)
@@ -1909,6 +1911,22 @@ for epoch in range(MAX_EPOCHS):
                 scheduler.step()
             except ValueError:
                 pass
+        # Langevin noise: SGLD-style parameter perturbation (anneals to 0 at 80% of training)
+        if cfg.langevin_noise > 0.0 and (use_pcgrad or _should_step):
+            _ln_scale = cfg.langevin_noise * max(0.0, 1.0 - epoch / (cfg.cosine_T_max * 0.8))
+            if _ln_scale > 0.0:
+                with torch.no_grad():
+                    for p in model.parameters():
+                        if p.requires_grad:
+                            p.data.add_(torch.randn_like(p.data) * _ln_scale)
+                    if refine_head is not None:
+                        for p in refine_head.parameters():
+                            if p.requires_grad:
+                                p.data.add_(torch.randn_like(p.data) * _ln_scale)
+                    if aft_srf_head is not None:
+                        for p in aft_srf_head.parameters():
+                            if p.requires_grad:
+                                p.data.add_(torch.randn_like(p.data) * _ln_scale)
         if epoch >= cfg.ema_start_epoch and not cfg.swad and not cfg.swa and not cfg.swa_cyclic and not cfg.snapshot_ensemble:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
@@ -1935,7 +1953,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _aft_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.langevin_noise > 0.0:
+            _log_dict["train/langevin_scale"] = cfg.langevin_noise * max(0.0, 1.0 - epoch / (cfg.cosine_T_max * 0.8))
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Lion is a sign-based optimizer: every gradient update is quantized to ±1 per parameter. This eliminates the inherent stochasticity that SGD/Adam get for free from minibatch gradient variance. Once Lion's sign has converged for a weight, it stays locked unless the gradient distribution changes meaningfully.

Adding calibrated Gaussian noise to parameters **after** each Lion step implements Stochastic Gradient Langevin Dynamics (SGLD) — a Bayesian optimization technique that encourages exploration of flat minima in the loss landscape. We anneal the noise to zero before EMA starts (~epoch 140), so EMA averages over a stabilized, noise-free basin rather than noisy checkpoints.

**Why this might help p_in:** L1 surface MAE on in-distribution single-foil samples (p_in=13.19) has headroom vs the ensemble floor (p_in=12.1). Lion's deterministic sign quantization may trap the model in a sharp local minimum. Langevin noise forces exploration of nearby parameter space, potentially finding flatter basins that generalize better. The noise is completely orthogonal to the loss function — L1 gradient structure is fully preserved.

**Key constraint:** EMA only captures the last ~20 epochs. Noise must be near-zero well before epoch 140. We use a linear decay schedule: `noise_scale = cfg.langevin_noise * max(0, 1 - epoch / (cfg.cosine_T_max * 0.8))`.

**References:**
- Welling & Teh (2011) — SGLD: Bayesian Learning via Stochastic Gradient Langevin Dynamics
- Chen et al. (2016) — Bridging the Gap between Stochastic Gradient MCMC and Stochastic Optimization

## Instructions

**Step 1: Add argparse flag and Config field:**
```python
parser.add_argument('--langevin_noise', type=float, default=0.0,
                    help='Langevin noise scale added to params after Lion step. 0 = disabled.')
```
And in the Config dataclass:
```python
langevin_noise: float = 0.0  # SGLD-style parameter noise after Lion step
```

**Step 2: Add noise injection after the optimizer step.** Find the line that calls `optimizer.step()` (~line 1700+ in train.py). Immediately after `optimizer.step()` and BEFORE the EMA update, add:
```python
# Langevin noise for SGLD-style exploration (anneals to 0 before EMA window)
if cfg.langevin_noise > 0.0:
    noise_scale = cfg.langevin_noise * max(0.0, 1.0 - epoch / (cfg.cosine_T_max * 0.8))
    if noise_scale > 0.0:
        with torch.no_grad():
            for p in model.parameters():
                if p.requires_grad:
                    p.data.add_(torch.randn_like(p.data) * noise_scale)
```

That is all — ~10 LoC. No other changes needed.

**Step 3: Run 6 experiments** (3 noise scales × 2 seeds). All runs must include `--aft_foil_srf` (baseline since PR #2104).

W&B group: `phase6/langevin-noise`

noise=5e-5 (very conservative):
```bash
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/langevin-5e5-s42" --wandb_group phase6/langevin-noise \
  --langevin_noise 5e-5 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf
```
Run seed 73 with the same flags (`--wandb_name "edward/langevin-5e5-s73" --seed 73`).

noise=1e-4 (primary test value):
Same flags with `--langevin_noise 1e-4`, names `edward/langevin-1e4-s42` and `edward/langevin-1e4-s73`.

noise=3e-4 (aggressive — monitor for instability):
Same flags with `--langevin_noise 3e-4`, names `edward/langevin-3e4-s42` and `edward/langevin-3e4-s73`.
If val/loss spikes above 0.41 during training, abort and skip the second seed for that value.

**Report all 6 runs** (or 5 if 3e-4 diverges): p_in, p_oodc, p_tan, p_re per run + W&B run IDs.

## Baseline

Current single-model baseline (PR #2104, 8-seed mean, seeds 42-49, +aft_foil_srf):

| Metric | 8-seed mean | Target to beat |
|--------|-------------|----------------|
| p_in   | **13.19 ± 0.33** | < 13.19 |
| p_oodc | **7.92 ± 0.17**  | < 7.92  |
| p_tan  | **30.05 ± 0.36** | < 30.05 |
| p_re   | **6.45 ± 0.07**  | < 6.45  |

Single-model seed references (no Langevin, with --aft_foil_srf):
- seed=42: p_in≈12.71, p_oodc≈8.13
- seed=73: p_in≈12.2, p_oodc≈7.59

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/baseline-s42" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf
```