### PR TITLE
Phase 6: Aft-Foil Loss Upweighting — Stronger Gradient for Wake Nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1004,6 +1004,8 @@ class Config:
     aft_foil_srf_film: bool = False          # FiLM conditioning on gap/stagger for aft-foil head
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
+    # Phase 6: Aft-foil loss upweighting
+    aft_foil_loss_weight: float = 1.0        # loss weight multiplier for aft-foil (ID=7) surface nodes (1.0=baseline)
 
 
 cfg = sp.parse(Config)
@@ -1544,7 +1546,7 @@ for epoch in range(MAX_EPOCHS):
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
-        if aft_srf_head is not None:
+        if aft_srf_head is not None or cfg.aft_foil_loss_weight != 1.0:
             _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
@@ -1750,6 +1752,12 @@ for epoch in range(MAX_EPOCHS):
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
+        # Build aft-foil per-node weight tensor for loss (1.0 for all non-aft nodes)
+        if cfg.aft_foil_loss_weight != 1.0 and _aft_foil_mask is not None and _aft_foil_mask.any():
+            _aft_w = torch.ones_like(surf_mask, dtype=torch.float32).unsqueeze(-1)  # [B, N, 1]
+            _aft_w[_aft_foil_mask] = cfg.aft_foil_loss_weight
+        else:
+            _aft_w = None
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
             surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
@@ -1759,7 +1767,15 @@ for epoch in range(MAX_EPOCHS):
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            # Combine hard-node weights with aft-foil upweighting if enabled
+            combined_w = hard_weights * _aft_w if _aft_w is not None else hard_weights
+            surf_per_sample = (surf_pres * combined_w * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / \
+                              (combined_w.squeeze(-1) * surf_mask.float()).sum(dim=1).clamp(min=1)
+        elif _aft_w is not None:
+            # Aft-foil upweighting without hard-node mining
+            surf_pres = abs_err[:, :, 2:3]
+            surf_per_sample = (surf_pres * _aft_w * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / \
+                              (_aft_w.squeeze(-1) * surf_mask.float()).sum(dim=1).clamp(min=1)
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))


### PR DESCRIPTION
## Hypothesis

The dedicated aft-foil SRF head (PR #2104, merged) provides a learned correction for ID=7 surface nodes **after** the Transolver trunk. However, the trunk itself is still trained with equal loss weight for all surface nodes. The aft foil lives in the wake of the fore foil — its pressure distribution is harder to predict and more sensitive to gap/stagger geometry.

**Idea:** Upweight aft-foil (ID=7) nodes in the main surface L1 loss by a factor of 1.5–2.0×. This forces the trunk's attention mechanism to develop richer, more discriminative representations for aft-foil nodes, directly improving the inputs that flow into the SRF head. The mechanism is complementary to (not redundant with) the dedicated SRF head:

- SRF head: post-hoc residual correction  
- Loss upweighting: changes what the trunk optimizes for

**Why this targets p_tan:** The p_tan gap (30.05 single-model vs 29.1 ensemble) is primarily an aft-foil prediction problem. Extra gradient pressure on aft-foil nodes should close this gap. Low risk — the weight is a continuous dial; at 1.0× it recovers the exact baseline.

**Note:** Prior PR #1893 (Foil-2 Loss Upweighting) was tried before the dedicated SRF head existed — this tests the interaction term: loss upweighting WITH the aft-foil SRF head already in baseline.

## Instructions

**Step 1: Add flag to argparse and Config:**
```python
parser.add_argument('--aft_foil_loss_weight', type=float, default=1.0,
                    help='Loss weight multiplier for aft-foil (ID=7) surface nodes (1.0=baseline)')
```
Add `aft_foil_loss_weight: float = 1.0` to the Config dataclass.

**Step 2: Build the aft-foil node mask.**
The same SAF-based proxy used by `--aft_foil_srf` already exists in the training loop. Find where `_aft_foil_mask` is computed (grep for `aft_foil_mask` in train.py) and reuse it. If the mask isn't available at loss-computation time, reconstruct using the same threshold (SAF distance > 0.005, is_tandem, is_surface).

**Step 3: Apply weighted mean in the surface loss computation.**
Find where `surf_loss` is computed (grep for `surf_loss` or surface loss in the training loop). Modify:

```python
if cfg.aft_foil_loss_weight != 1.0 and _aft_foil_mask is not None:
    node_weights = torch.ones(B, N, device=device)
    node_weights[_aft_foil_mask] = cfg.aft_foil_loss_weight
    # Weighted mean: divide by sum of weights, not node count
    weighted_errs = abs_err * node_weights.unsqueeze(-1)  # [B, N, C]
    surf_loss = weighted_errs[surface_mask].sum() / node_weights.unsqueeze(-1)[surface_mask].sum()
else:
    surf_loss = abs_err[surface_mask].mean()
```

**Note:** Use weighted mean (not weighted sum) to keep the loss scale comparable to baseline. This prevents the optimizer from seeing an artificially inflated loss scale.

**Step 4: Run sweep across 2 weights × 2 seeds:**

```bash
# Weight 1.5, seed 42 (run this first)
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/aft-foil-lw-1.5-s42" \
  --wandb_group phase6/aft-foil-loss-weight \
  --aft_foil_loss_weight 1.5 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf

# Weight 1.5, seed 73
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/aft-foil-lw-1.5-s73" \
  --wandb_group phase6/aft-foil-loss-weight \
  --aft_foil_loss_weight 1.5 --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf

# If weight=1.5 looks promising, also run weight=2.0 on both seeds
# (same flags, --aft_foil_loss_weight 2.0, --wandb_name "tanjiro/aft-foil-lw-2.0-s42/73")
```

Report all 4 surface MAE metrics plus val/loss for each run. Include the W&B run IDs.

## Baseline

**Current single-model baseline (PR #2104, +aft_foil_srf, 8-seed mean, seeds 42-49):**

| Metric | Baseline mean | Std | Target to beat |
|--------|--------------|-----|----------------|
| p_in   | 13.19        | 0.33 | < 13.19       |
| p_oodc | 7.92         | 0.17 | < 7.92        |
| p_tan  | 30.05        | 0.36 | < 30.05       |
| p_re   | 6.45         | 0.07 | < 6.45        |

**Merge criterion:** 2-seed average must beat the baseline targets on p_tan (primary) and not regress on p_in/p_oodc/p_re.

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --wandb_name "tanjiro/baseline-check" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf
```