### PR TITLE
Phase 6: Fore-Foil Loss Upweighting (ID=6) — Symmetric to Aft-Foil Weight

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1005,6 +1005,8 @@ class Config:
     aft_foil_srf_film: bool = False          # FiLM conditioning on gap/stagger for aft-foil head
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
+    # Phase 6: Fore-foil loss upweighting
+    fore_foil_loss_weight: float = 1.0       # loss weight multiplier for fore-foil (ID=6) surface nodes (1.0=baseline)
 
 
 cfg = sp.parse(Config)
@@ -1557,14 +1559,20 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
-        # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
+        # SAF norm and tandem detection (needed for aft-foil SRF and fore-foil loss weight)
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
+        _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
+        _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
         _aft_foil_mask = None
         if aft_srf_head is not None:
-            _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
-            _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+        # Fore-foil mask: tandem surface nodes that are NOT aft-foil (SAF norm <= 0.005)
+        node_w = None
+        if cfg.fore_foil_loss_weight != 1.0:
+            _fore_foil_mask = is_surface & (_raw_saf_norm <= 0.005) & _is_tandem.unsqueeze(1)
+            node_w = torch.ones(x.size(0), x.size(1), device=x.device)
+            node_w[_fore_foil_mask] = cfg.fore_foil_loss_weight
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1761,7 +1769,12 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Weighted surface loss (fore-foil nodes get extra weight when enabled)
+        if node_w is not None:
+            _wt_surf = surf_mask.float() * node_w  # [B, N]
+            surf_per_sample = (abs_err[:, :, 2:3] * _wt_surf.unsqueeze(-1)).sum(dim=(1, 2)) / _wt_surf.sum(dim=1).clamp(min=1).float()
+        else:
+            surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -1774,8 +1787,12 @@ for epoch in range(MAX_EPOCHS):
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
-            hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            hard_w = (hard_mask.float() * 0.5 + 1.0)  # [B, N] — 1.5 hard, 1.0 else
+            if node_w is not None:
+                combined_w = hard_w * node_w  # [B, N]
+                surf_per_sample = (surf_pres * combined_w.unsqueeze(-1) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / (surf_mask.float() * combined_w).sum(dim=1).clamp(min=1).float()
+            else:
+                surf_per_sample = (surf_pres * hard_w.unsqueeze(-1) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))


### PR DESCRIPTION
## Hypothesis

The dedicated aft-foil SRF head (PR #2104) and gap/stagger augmentation (PR #2115) both improved p_oodc. However, the trunk is still trained with **equal loss weight for all surface nodes**. The fore-foil (boundary ID=6) is the upstream foil in tandem configurations — its pressure field drives the entire wake interaction. Better fore-foil predictions should propagate downstream.

**Idea:** Upweight fore-foil (ID=6) surface nodes in the main surface pressure L1 loss by 1.5–2.0×. This forces the trunk's attention to develop richer representations for fore-foil nodes, complementing the aft-foil work already in baseline.

**Why this is different from fern's fore-foil SRF head (#2117):**
- SRF head (fern): post-hoc residual correction network on top of trunk output
- Loss upweighting (this PR): changes what the trunk optimizes for during training
- These are **orthogonal** — both can be merged without conflict

**Why this should work:** Tanjiro is testing the exact same logic for aft-foil (#2121). If it works there, the symmetric fore-foil version should help too. Low risk — at weight=1.0 it exactly recovers baseline.

## Instructions

### Step 1: Add config flag

In the `Config` dataclass (near other loss weight flags):
```python
fore_foil_loss_weight: float = 1.0  # loss weight multiplier for fore-foil (ID=6) surface nodes (1.0=baseline)
```

Add to argparse:
```python
parser.add_argument('--fore_foil_loss_weight', type=float, default=1.0,
                    help='Loss weight multiplier for fore-foil (ID=6) surface nodes')
```

### Step 2: Compute fore-foil mask before x normalization

Find the aft-foil mask block (~line 1562). Currently `_raw_saf_norm` is only computed when `aft_srf_head is not None`. Refactor to compute it unconditionally before `x = (x - stats["x_mean"]) / stats["x_std"]`:

```python
# Compute SAF norm unconditionally (needed for both aft-foil SRF and fore-foil loss)
_raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N] — raw x before normalization
_is_tandem = (x[:, 0, 22].abs() > 0.01)    # [B] — gap feature nonzero
_aft_foil_mask = None
if aft_srf_head is not None:
    _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
    _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2]

# Fore-foil mask: tandem surface nodes that are NOT aft-foil (SAF norm <= 0.005)
node_w = None
if cfg.fore_foil_loss_weight != 1.0:
    _fore_foil_mask = is_surface & (_raw_saf_norm <= 0.005) & _is_tandem.unsqueeze(1)
    node_w = torch.ones(x.size(0), x.size(1), device=x.device)
    node_w[_fore_foil_mask] = cfg.fore_foil_loss_weight
    # Sanity check — should have fore-foil nodes for tandem samples
    assert _fore_foil_mask.sum() > 0, "No fore-foil nodes found — check SAF index or tandem detection"
```

### Step 3: Apply node weights in surface loss computation

Find `surf_per_sample` at ~line 1764. Replace the initial computation:

```python
# Weighted surface loss (fore-foil nodes get extra weight)
if node_w is not None:
    wt_surf = surf_mask.float() * node_w  # [B, N]
    surf_per_sample = (abs_err[:, :, 2:3] * wt_surf.unsqueeze(-1)).sum(dim=(1, 2)) / \
                      wt_surf.sum(dim=1).clamp(min=1).float()
else:
    surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / \
                      surf_mask.sum(dim=1).clamp(min=1).float()
```

Also update the hard-node mining path (~line 1778, inside `if epoch >= 30:`). Find where `surf_per_sample` is overwritten with `hard_weights` and combine node_w:

```python
# Existing: hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)
# Replace the surf_per_sample line with:
hard_w = (hard_mask.float() * 0.5 + 1.0)  # [B, N] — keep 2D for combining
if node_w is not None:
    combined_w = hard_w * node_w  # [B, N]
    surf_per_sample = (surf_pres * combined_w.unsqueeze(-1) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / \
                      (surf_mask.float() * combined_w).sum(dim=1).clamp(min=1).float()
else:
    surf_per_sample = (surf_pres * hard_w.unsqueeze(-1) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / \
                      surf_mask.sum(dim=1).clamp(min=1).float()
```

### Step 4: Experiment runs — 2 weights × 2 seeds = 4 runs

W&B group: `phase6/fore-foil-loss-weight`

```bash
cd cfd_tandemfoil

# Weight 1.5, seed 42
python train.py --agent nezuko \
  --wandb_name "nezuko/fore-foil-lw-1.5-s42" --wandb_group phase6/fore-foil-loss-weight \
  --fore_foil_loss_weight 1.5 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02

# Weight 1.5, seed 73
python train.py --agent nezuko \
  --wandb_name "nezuko/fore-foil-lw-1.5-s73" --wandb_group phase6/fore-foil-loss-weight \
  --fore_foil_loss_weight 1.5 --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02

# Weight 2.0, seed 42
python train.py --agent nezuko \
  --wandb_name "nezuko/fore-foil-lw-2.0-s42" --wandb_group phase6/fore-foil-loss-weight \
  --fore_foil_loss_weight 2.0 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02

# Weight 2.0, seed 73
python train.py --agent nezuko \
  --wandb_name "nezuko/fore-foil-lw-2.0-s73" --wandb_group phase6/fore-foil-loss-weight \
  --fore_foil_loss_weight 2.0 --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```

**If both weights regress on all metrics:** try weight=3.0 with 2 seeds — fore-foil has more nodes than aft-foil and may need stronger upweighting to have the same gradient effect.

### What to report

- Surface MAE table (p_in, p_oodc, p_tan, p_re) for all 4 runs with W&B run IDs
- 2-seed means for weight=1.5 and weight=2.0 vs baseline
- Which weight performs best — is there a quality/tradeoff?
- Sanity check: how many fore-foil nodes vs aft-foil nodes per typical tandem sample? (print from the mask sums)

## Baseline

Current single-model baseline (PRs #2104 + #2115 merged, 8-seed mean):

| Metric | 8-seed mean | Target to beat |
|--------|-------------|----------------|
| p_in   | **13.19 ± 0.33** | < 13.19 |
| p_oodc | **7.92 ± 0.17**  | < 7.92  |
| p_tan  | **30.05 ± 0.36** | **< 30.05** |
| p_re   | **6.45 ± 0.07**  | < 6.45  |

Baseline reproduce (all new flags included):
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```