### PR TITLE
Phase 6: Reynolds Number Perturbation Augmentation — OOD-Re Robustness

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -959,6 +959,7 @@ class Config:
     aug_start_epoch: int = 0        # delay augmentation onset until this epoch
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
+    aug_re_sigma: float = 0.0           # std of Gaussian noise on log_Re feature (index 13) during training
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1553,6 +1554,12 @@ for epoch in range(MAX_EPOCHS):
                     x[:, :, 22] = x[:, :, 22] + _gap_noise.unsqueeze(1)
                     x[:, :, 23] = x[:, :, 23] + _stag_noise.unsqueeze(1)
 
+        # Reynolds number perturbation augmentation (all samples, training only)
+        if cfg.aug_re_sigma > 0.0:
+            _B = x.size(0)
+            _re_noise = torch.randn(_B, device=x.device) * cfg.aug_re_sigma  # [B]
+            x[:, :, 13] = x[:, :, 13] + _re_noise.unsqueeze(1)  # broadcast to all N nodes
+
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
@@ -1951,7 +1958,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _aft_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.aug_re_sigma > 0.0:
+            _step_log["aug/re_sigma"] = cfg.aug_re_sigma
+        wandb.log(_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The gap/stagger perturbation augmentation (PR #2115, σ=0.02) was our biggest recent win: **p_oodc -4.9%, p_re -1.5%**. The mechanism is domain randomization — training with slightly perturbed geometry features teaches the model to be robust to OOD geometry.

We apply the exact same paradigm to Reynolds number. The `val_ood_re` split tests at **Re=4.445M (fully OOD)**. By adding small Gaussian noise to `log_Re` (feature index 13 in the 24-dim input) during training, we teach the model that flows at slightly different Re values should yield smoothly-varying predictions — directly targeting p_re robustness.

**Why this should work:**
- CFD flows vary smoothly with Re (Navier-Stokes equations are smooth in Re)
- Adding noise σ on log_Re = training on a distribution of Re values within ~e^σ of the true Re, giving implicit coverage of nearby Re values
- Gap/stagger aug proves domain randomization works for geometry parameters; Re is the natural next axis to regularize
- The log_Re feature is global (same value for all N nodes per sample), making implementation trivial: perturb `x[:, :, 13]` once per batch

**Primary target: p_re < 6.45. Secondary: p_oodc < 7.92.**

## Instructions

In `cfd_tandemfoil/train.py`, add a new config flag and augmentation block following the exact same pattern as `aug_gap_stagger_sigma`:

**1. Add config field** (near line ~961, after `aug_gap_stagger_sigma`):
```python
aug_re_sigma: float = 0.0  # std of Gaussian noise on log_Re feature (index 13) during training
```

**2. Add augmentation block** in the training loop, immediately after the gap/stagger aug block (~line 1555), and BEFORE the standardization call `x = (x - stats["x_mean"]) / stats["x_std"]`:
```python
# Reynolds number perturbation augmentation (all samples)
if cfg.aug_re_sigma > 0.0:
    _B = x.size(0)
    _re_noise = torch.randn(_B, device=x.device) * cfg.aug_re_sigma  # [B]
    x[:, :, 13] = x[:, :, 13] + _re_noise.unsqueeze(1)  # broadcast to all N nodes
```

**Implementation notes:**
- Apply BEFORE `x = (x - stats["x_mean"]) / stats["x_std"]` — noise is in raw feature space, same as gap/stagger aug
- Apply to ALL samples (not tandem-only) — Re is a universal feature
- No clamping needed — small Gaussian perturbation on log_Re is always physically valid
- Training-only (no change to eval/validation code)
- Optional sanity metric: log `aug/re_noise_std` as the actual std of Re noise per epoch

**Experiment sweep — run 2 seeds for each sigma value:**

```bash
# σ=0.05 (start here — analogous scale to gap/stagger σ=0.02 on log_Re range)
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/re-aug-s05-s42" --wandb_group phase6/re-perturb-aug \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 \
  --aug_re_sigma 0.05
```

Run seeds 42 and 43 for σ=0.05 first. If both look promising (p_re improves), also run σ=0.10 and σ=0.20 with the same wandb_group. If σ=0.05 degrades p_tan by >2%, stop and report.

## Baseline

Current single-model baseline (PR #2104 + PR #2115 merged, 8-seed mean, seeds 42-49):

| Metric | 8-seed mean | Target to beat |
|--------|-------------|----------------|
| p_in   | 13.19 ± 0.33 | < 13.19 |
| p_oodc | 7.92 ± 0.17  | < 7.92  |
| p_tan  | 30.05 ± 0.36 | < 30.05 |
| p_re   | **6.45 ± 0.07** | **< 6.45** |

Per-seed baselines for direct 2-seed comparison:
- Seed 42: p_in≈13.4, p_oodc≈7.7, p_tan≈29.8, p_re≈6.4
- Seed 43: p_in≈13.2, p_oodc≈7.8, p_tan≈29.3, p_re≈6.4