### PR TITLE
Phase 6: Foil-2 DSDF Magnitude Augmentation — Tandem Shape Transfer

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -959,6 +959,7 @@ class Config:
     aug_start_epoch: int = 0        # delay augmentation onset until this epoch
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
+    aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1552,6 +1553,19 @@ for epoch in range(MAX_EPOCHS):
                     # Apply: broadcast [B] → [B, 1] → adds to [B, N]
                     x[:, :, 22] = x[:, :, 22] + _gap_noise.unsqueeze(1)
                     x[:, :, 23] = x[:, :, 23] + _stag_noise.unsqueeze(1)
+
+        # Foil-2 DSDF magnitude augmentation (tandem samples only, training only)
+        # x layout: [pos(2), saf(2), dsdf(8), ...]; foil-2 SDF = dsdf[4:8] = x[:, :, 6:10]
+        # Scaling is log-normal (preserves gradient directions, adjusts magnitude only)
+        if model.training and cfg.aug_dsdf2_sigma > 0.0:
+            _is_tandem_aug2 = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero → tandem
+            if _is_tandem_aug2.any():
+                _dsdf2_scale = torch.exp(
+                    torch.randn(x.size(0), device=x.device) * cfg.aug_dsdf2_sigma
+                )
+                # Identity for non-tandem samples
+                _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
+                x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

Gap/stagger perturbation augmentation (#2115, merged) improved p_oodc by **-4.9%** by domain-randomizing the scalar tandem geometry descriptors (gap, stagger) during training. The `val_tandem_transfer` evaluation (NACA6416 as the front foil, absent from all training tandem data) drives p_tan, and its failure mode is **geometric**: the model has only seen NACA2412 and NACA9412 as front foils, and must generalize to a different camber/thickness profile.

The foil-2 DSDF channels (signed distance function gradients for the secondary foil) are the **per-node geometric encoding** of the front foil shape. By randomly scaling the foil-2 DSDF magnitude during training (log-normal, applied to tandem samples only), we force the model to be less reliant on memorizing exact DSDF patterns for seen foil shapes — directly targeting the geometric transfer gap that val_tandem_transfer probes. This is the geometric analog of gap/stagger aug.

**Key constraint:** Scaling is purely multiplicative and applied uniformly per sample (not per-node), so gradient directions are preserved and sign flips cannot occur.

## Instructions

### Step 0: Verify foil-2 DSDF channel indices

Before implementing, read `cfd_tandemfoil/data/prepare_multi.py` (read-only) and confirm which column indices in the raw 24-dim `x` tensor correspond to foil-2 DSDF features. The working assumption is that raw x indices **6–9** (0-indexed) are the foil-2 DSDF channels (4 channels: sdf value + gradient in x/y + second foil distance). Document what you find in a comment in your code and in your results comment.

### Step 1: Add config flag

In `train.py`, add to `Config`:
```python
aug_dsdf2_sigma: float = 0.0   # log-normal scale for foil-2 DSDF magnitude aug (0 = disabled)
```

### Step 2: Implement the augmentation

In the augmentation block (near the gap/stagger aug code), **before** the standardization line (`x = (x - stats["x_mean"]) / stats["x_std"]`), add:

```python
if cfg.aug_dsdf2_sigma > 0.0:
    _is_tandem_aug = (x[:, 0, 22].abs() > 0.01)   # tandem detection (same as gap/stagger aug)
    if _is_tandem_aug.any():
        # Log-normal multiplicative scale per sample (preserves direction, adjusts magnitude)
        _scale = torch.exp(
            torch.randn(x.size(0), device=x.device) * cfg.aug_dsdf2_sigma
        )
        # Apply only to tandem samples (identity for non-tandem)
        _scale = _scale * _is_tandem_aug.float() + (~_is_tandem_aug).float()
        # Apply to foil-2 DSDF channels only — adjust slice [6:10] if your index check differs
        x[:, :, 6:10] = x[:, :, 6:10] * _scale.view(-1, 1, 1)
```

**Critical:** Adjust `x[:, :, 6:10]` to match the actual foil-2 DSDF indices you find in Step 0.

### Step 3: Run sweep

Use `--wandb_group phase6/dsdf2-mag-aug` for all runs. Run 2 seeds each for σ=0.05, 0.10, 0.15 (6 total runs):

```bash
BASE="--asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02"

# sigma = 0.05 (2 seeds)
python train.py --agent tanjiro --wandb_name "tanjiro/dsdf2-aug-s05-s42" \
  --wandb_group phase6/dsdf2-mag-aug --seed 42 --aug_dsdf2_sigma 0.05 $BASE

python train.py --agent tanjiro --wandb_name "tanjiro/dsdf2-aug-s05-s73" \
  --wandb_group phase6/dsdf2-mag-aug --seed 73 --aug_dsdf2_sigma 0.05 $BASE

# sigma = 0.10 (2 seeds)
python train.py --agent tanjiro --wandb_name "tanjiro/dsdf2-aug-s10-s42" \
  --wandb_group phase6/dsdf2-mag-aug --seed 42 --aug_dsdf2_sigma 0.10 $BASE

python train.py --agent tanjiro --wandb_name "tanjiro/dsdf2-aug-s10-s73" \
  --wandb_group phase6/dsdf2-mag-aug --seed 73 --aug_dsdf2_sigma 0.10 $BASE

# sigma = 0.15 (2 seeds)
python train.py --agent tanjiro --wandb_name "tanjiro/dsdf2-aug-s15-s42" \
  --wandb_group phase6/dsdf2-mag-aug --seed 42 --aug_dsdf2_sigma 0.15 $BASE

python train.py --agent tanjiro --wandb_name "tanjiro/dsdf2-aug-s15-s73" \
  --wandb_group phase6/dsdf2-mag-aug --seed 73 --aug_dsdf2_sigma 0.15 $BASE
```

### Step 4: Report results

Report all 6 runs in a table (p_in, p_oodc, p_tan, p_re, val/loss, W&B run ID) plus 2-seed averages per σ value. Compare against baseline targets below.

**Early stopping signal:** If σ=0.05 shows p_tan worse than baseline on both seeds, discontinue σ=0.10 and σ=0.15 early and report.

## Baseline

Current single-model baseline (PR #2104 + PR #2115, 8-seed mean, seeds 42-49):

| Metric | Baseline | Target |
|--------|----------|--------|
| p_in | 13.19 ± 0.33 | < 13.19 |
| p_oodc | 7.92 ± 0.17 | < 7.92 |
| **p_tan** | **30.05 ± 0.36** | **< 30.05** |
| p_re | 6.45 ± 0.07 | < 6.45 |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-aft-srf-aug" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```

**Merge bar:** 2-seed average p_tan < 30.05 (primary), without regressing p_oodc > 8.0 or p_in > 13.5.