### PR TITLE
Phase 6: Context-Aware AftSRF — KNN Volume Context for Wake Pressure

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -544,6 +544,51 @@ class AftFoilRefinementHead(nn.Module):
         return x
 
 
+class AftFoilRefinementContextHead(nn.Module):
+    """Aft-foil refinement head with KNN volume context for wake pressure recovery.
+
+    For each aft-foil surface node, aggregates hidden states from K nearest
+    volume neighbors, giving the correction head access to upstream wake
+    information. Zero-initialized output for safe initialization.
+    """
+
+    def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 192,
+                 n_layers: int = 3, k_neighbors: int = 8):
+        super().__init__()
+        self.k = k_neighbors
+        # Input: aft surface hidden + volume KNN context + base pred
+        in_dim = n_hidden + n_hidden + out_dim
+        layers: list[nn.Module] = []
+        for i in range(n_layers):
+            layers.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
+            layers.append(nn.LayerNorm(hidden_dim))
+            layers.append(nn.GELU())
+        layers.append(nn.Linear(hidden_dim, out_dim))
+        nn.init.zeros_(layers[-1].weight)
+        nn.init.zeros_(layers[-1].bias)
+        self.mlp = nn.Sequential(*layers)
+
+    def forward(self, aft_hidden: torch.Tensor, aft_positions: torch.Tensor,
+                vol_hidden: torch.Tensor, vol_positions: torch.Tensor,
+                aft_base_pred: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            aft_hidden: [A, n_hidden] — hidden features for aft-foil surface nodes
+            aft_positions: [A, 2] — xy coords of aft-foil surface nodes
+            vol_hidden: [V, n_hidden] — hidden features of volume (non-surface) nodes
+            vol_positions: [V, 2] — xy coords of volume nodes
+            aft_base_pred: [A, out_dim] — base predictions for aft-foil nodes
+        Returns:
+            correction: [A, out_dim] — additive correction
+        """
+        k = min(self.k, vol_hidden.shape[0])
+        dists = torch.cdist(aft_positions, vol_positions)  # [A, V]
+        _, nn_idx = dists.topk(k, dim=-1, largest=False)  # [A, k]
+        vol_context = vol_hidden[nn_idx].mean(dim=1)  # [A, n_hidden]
+        inp = torch.cat([aft_hidden, vol_context, aft_base_pred], dim=-1)
+        return self.mlp(inp)
+
+
 class SurfaceRefinementContextHead(nn.Module):
     """Surface refinement head that incorporates nearest-volume context.
 
@@ -1005,6 +1050,7 @@ class Config:
     aft_foil_srf_film: bool = False          # FiLM conditioning on gap/stagger for aft-foil head
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
+    aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
 
 
 cfg = sp.parse(Config)
@@ -1199,19 +1245,33 @@ if cfg.surface_refine:
 
 # Aft-foil (boundary ID=7) dedicated refinement head
 aft_srf_head = None
+aft_srf_ctx_head = None
 if cfg.aft_foil_srf:
-    aft_srf_head = AftFoilRefinementHead(
-        n_hidden=cfg.n_hidden,
-        out_dim=3,
-        hidden_dim=cfg.aft_foil_srf_hidden,
-        n_layers=cfg.aft_foil_srf_layers,
-        film=cfg.aft_foil_srf_film,
-    ).to(device)
-    aft_srf_head = torch.compile(aft_srf_head, mode=cfg.compile_mode)
-    _aft_n_params = sum(p.numel() for p in aft_srf_head.parameters())
-    print(f"Aft-foil SRF head: {_aft_n_params:,} params "
-          f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, "
-          f"film={cfg.aft_foil_srf_film})")
+    if cfg.aft_foil_srf_context:
+        aft_srf_ctx_head = AftFoilRefinementContextHead(
+            n_hidden=cfg.n_hidden,
+            out_dim=3,
+            hidden_dim=cfg.aft_foil_srf_hidden,
+            n_layers=cfg.aft_foil_srf_layers,
+            k_neighbors=8,
+        ).to(device)
+        aft_srf_ctx_head = torch.compile(aft_srf_ctx_head, mode=cfg.compile_mode)
+        _aft_n_params = sum(p.numel() for p in aft_srf_ctx_head.parameters())
+        print(f"Aft-foil SRF context head: {_aft_n_params:,} params "
+              f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, k=8)")
+    else:
+        aft_srf_head = AftFoilRefinementHead(
+            n_hidden=cfg.n_hidden,
+            out_dim=3,
+            hidden_dim=cfg.aft_foil_srf_hidden,
+            n_layers=cfg.aft_foil_srf_layers,
+            film=cfg.aft_foil_srf_film,
+        ).to(device)
+        aft_srf_head = torch.compile(aft_srf_head, mode=cfg.compile_mode)
+        _aft_n_params = sum(p.numel() for p in aft_srf_head.parameters())
+        print(f"Aft-foil SRF head: {_aft_n_params:,} params "
+              f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, "
+              f"film={cfg.aft_foil_srf_film})")
 
 from copy import deepcopy
 ema_model = None
@@ -1236,6 +1296,8 @@ if refine_head is not None:
     n_params += sum(p.numel() for p in refine_head.parameters())
 if aft_srf_head is not None:
     n_params += sum(p.numel() for p in aft_srf_head.parameters())
+if aft_srf_ctx_head is not None:
+    n_params += sum(p.numel() for p in aft_srf_ctx_head.parameters())
 
 
 class SAM:
@@ -1372,6 +1434,10 @@ if aft_srf_head is not None:
     _aft_params = list(aft_srf_head.parameters())
     base_opt.add_param_group({'params': _aft_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _aft_params):,} aft-foil SRF head params to optimizer")
+if aft_srf_ctx_head is not None:
+    _ctx_params = list(aft_srf_ctx_head.parameters())
+    base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
@@ -1467,6 +1533,8 @@ for epoch in range(MAX_EPOCHS):
         refine_head.train()
     if aft_srf_head is not None:
         aft_srf_head.train()
+    if aft_srf_ctx_head is not None:
+        aft_srf_ctx_head.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
@@ -1700,7 +1768,26 @@ for epoch in range(MAX_EPOCHS):
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
 
         # Aft-foil dedicated refinement head: additive correction on boundary ID=7 nodes only
-        if aft_srf_head is not None and model.training and _aft_foil_mask is not None:
+        if aft_srf_ctx_head is not None and model.training and _aft_foil_mask is not None:
+            # Context-aware version: KNN volume context for wake pressure
+            _vol_mask = mask & ~is_surface  # [B, N] — volume (non-surface) nodes
+            _coords = x[:, :, :2]  # standardized (x, y) positions
+            pred = pred.clone()
+            for b in range(x.shape[0]):
+                _aft_b = _aft_foil_mask[b].nonzero(as_tuple=True)[0]
+                _vol_b = _vol_mask[b].nonzero(as_tuple=True)[0]
+                if _aft_b.numel() == 0 or _vol_b.numel() == 0:
+                    continue
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    _corr = aft_srf_ctx_head(
+                        hidden[b, _aft_b],     # aft surface hidden
+                        _coords[b, _aft_b],    # aft surface positions
+                        hidden[b, _vol_b],     # volume hidden
+                        _coords[b, _vol_b],    # volume positions
+                        pred[b, _aft_b],       # aft base prediction
+                    ).float()
+                pred[b, _aft_b] = pred[b, _aft_b] + _corr
+        elif aft_srf_head is not None and model.training and _aft_foil_mask is not None:
             aft_idx = _aft_foil_mask.nonzero(as_tuple=False)  # [A, 2] (batch, node)
             if aft_idx.numel() > 0:
                 aft_hidden = hidden[aft_idx[:, 0], aft_idx[:, 1]]  # [A, n_hidden]
@@ -1950,6 +2037,14 @@ for epoch in range(MAX_EPOCHS):
                     with torch.no_grad():
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _aft_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+            if aft_srf_ctx_head is not None:
+                _ctx_base = aft_srf_ctx_head._orig_mod if hasattr(aft_srf_ctx_head, '_orig_mod') else aft_srf_ctx_head
+                if ema_aft_srf_head is None:
+                    ema_aft_srf_head = deepcopy(_ctx_base)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
+                            ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -2057,12 +2152,19 @@ for epoch in range(MAX_EPOCHS):
             refine_head.eval()
     # Select aft-foil SRF head for eval (EMA if available)
     eval_aft_srf_head = aft_srf_head
+    eval_aft_srf_ctx_head = aft_srf_ctx_head
     if aft_srf_head is not None:
         if ema_aft_srf_head is not None and ema_model is not None and eval_model is ema_model:
             eval_aft_srf_head = ema_aft_srf_head
             eval_aft_srf_head.eval()
         elif aft_srf_head is not None:
             aft_srf_head.eval()
+    if aft_srf_ctx_head is not None:
+        if ema_aft_srf_head is not None and ema_model is not None and eval_model is ema_model:
+            eval_aft_srf_ctx_head = ema_aft_srf_head
+            eval_aft_srf_ctx_head.eval()
+        else:
+            aft_srf_ctx_head.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -2209,7 +2311,27 @@ for epoch in range(MAX_EPOCHS):
                         pred = pred_loss * sample_stds
 
                 # Apply aft-foil SRF head during validation
-                if eval_aft_srf_head is not None and _eval_aft_mask is not None:
+                if eval_aft_srf_ctx_head is not None and _eval_aft_mask is not None:
+                    _vol_mask_v = mask & ~is_surface
+                    _coords_v = x[:, :, :2]
+                    pred_loss = pred_loss.clone()
+                    for b in range(x.shape[0]):
+                        _aft_b = _eval_aft_mask[b].nonzero(as_tuple=True)[0]
+                        _vol_b = _vol_mask_v[b].nonzero(as_tuple=True)[0]
+                        if _aft_b.numel() == 0 or _vol_b.numel() == 0:
+                            continue
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            _corr = eval_aft_srf_ctx_head(
+                                _eval_hidden[b, _aft_b], _coords_v[b, _aft_b],
+                                _eval_hidden[b, _vol_b], _coords_v[b, _vol_b],
+                                pred_loss[b, _aft_b],
+                            ).float()
+                        pred_loss[b, _aft_b] += _corr
+                    if cfg.multiply_std:
+                        pred = pred_loss / sample_stds
+                    else:
+                        pred = pred_loss * sample_stds
+                elif eval_aft_srf_head is not None and _eval_aft_mask is not None:
                     aft_idx = _eval_aft_mask.nonzero(as_tuple=False)
                     if aft_idx.numel() > 0:
                         _ah = _eval_hidden[aft_idx[:, 0], aft_idx[:, 1]]
@@ -2397,6 +2519,11 @@ for epoch in range(MAX_EPOCHS):
                 aft_srf_head._orig_mod if hasattr(aft_srf_head, '_orig_mod') else aft_srf_head
             )
             torch.save(_aft_save.state_dict(), model_dir / "aft_srf_head.pt")
+        if aft_srf_ctx_head is not None:
+            _ctx_save = ema_aft_srf_head if ema_aft_srf_head is not None else (
+                aft_srf_ctx_head._orig_mod if hasattr(aft_srf_ctx_head, '_orig_mod') else aft_srf_ctx_head
+            )
+            torch.save(_ctx_save.state_dict(), model_dir / "aft_srf_ctx_head.pt")
         tag = f" * -> {model_path}"
 
     split_summary = "  ".join(


### PR DESCRIPTION
## Hypothesis

The `--aft_foil_srf` head (PR #2104, merged, -0.8% p_tan) corrects aft-foil surface predictions using only the surface node's own hidden representation. But aft-foil pressure is strongly influenced by the wake flow arriving from the fore-foil — a **non-local** physical dependency. The correction head has no access to what the volume nodes immediately upstream of the aft-foil look like.

By augmenting each aft-foil surface node's hidden representation with the **averaged hidden states of its K=8 nearest volume neighbors** (restricted to the aft-foil refinement zone, zone_id=2), we give the correction head direct access to wake-state information. This is physically motivated: the pressure recovery on the aft-foil suction surface depends on the velocity deficit and turbulence level arriving from the fore-foil wake — information carried in the volume nodes just upstream.

The existing `SurfaceRefinementContextHead` class already implements KNN-context refinement for all surface nodes globally. This experiment applies the same mechanism targeted specifically to aft-foil nodes, keeping the global SRF head unchanged.

## Instructions

### Step 1: Understand the existing architecture

Read the `AftFoilRefinementHead` class and its usage in `train.py`. Note:
- Input: `aft_hidden` [N_aft, n_hidden], `aft_base_pred` [N_aft, out_dim]
- Output: correction delta [N_aft, out_dim]
- The in_features of the MLP is `n_hidden * 2 + out_dim` (hidden + base_pred concatenated twice)

Also check if `SurfaceRefinementContextHead` exists and read its implementation — it already does KNN context gathering and you can borrow the logic directly.

### Step 2: Modify AftFoilRefinementHead to accept volume context

Create a new variant `AftFoilRefinementContextHead` (or add a `use_context` flag to the existing head):

```python
class AftFoilRefinementContextHead(nn.Module):
    def __init__(self, n_hidden, out_dim, hidden_size=192, n_layers=3, k_neighbors=8):
        super().__init__()
        self.k = k_neighbors
        # Input: aft_hidden + vol_context_avg + base_pred
        in_features = n_hidden + n_hidden + out_dim  # (surface hidden + volume context avg + base pred)
        layers = [nn.Linear(in_features, hidden_size), nn.GELU()]
        for _ in range(n_layers - 2):
            layers += [nn.Linear(hidden_size, hidden_size), nn.GELU()]
        layers.append(nn.Linear(hidden_size, out_dim))
        self.net = nn.Sequential(*layers)

    def forward(self, aft_hidden, aft_positions, vol_hidden, vol_positions, aft_base_pred):
        # aft_hidden: [N_aft, n_hidden]
        # aft_positions: [N_aft, 2]  (x, y coordinates of aft-foil surface nodes)
        # vol_hidden: [N_vol, n_hidden]  (hidden states of zone_id=2 volume nodes)
        # vol_positions: [N_vol, 2]  (x, y coordinates of zone_id=2 volume nodes)
        # aft_base_pred: [N_aft, out_dim]

        # KNN: for each aft-foil surface node, find K nearest volume neighbors
        dists = torch.cdist(aft_positions, vol_positions)  # [N_aft, N_vol]
        _, nn_idx = dists.topk(self.k, dim=-1, largest=False)  # [N_aft, K]
        vol_context = vol_hidden[nn_idx].mean(dim=1)  # [N_aft, n_hidden]

        inp = torch.cat([aft_hidden, vol_context, aft_base_pred], dim=-1)
        return self.net(inp)
```

### Step 3: Wire it up in the forward pass

Add config flag:
```python
aft_foil_srf_context: bool = False  # Enable KNN volume context for aft-foil SRF
```

In the forward pass, when `cfg.aft_foil_srf` is True and `cfg.aft_foil_srf_context` is True:

1. Extract volume nodes in the aft-foil zone (zone_id=2) from the full hidden tensor:
   ```python
   # zone_id is available as a feature in x (check prepare_multi.py for exact index)
   # zone2_mask: [B, N] boolean mask for zone_id=2 volume (non-surface) nodes
   zone2_mask = (zone_id_feature == 2) & ~surface_mask  # adjust indices as needed
   ```

2. For each sample in the batch, gather zone-2 volume positions and hidden states, then call the context head:
   ```python
   # Process per sample (zone-2 node counts may vary per sample)
   corrections = []
   for b in range(B):
       aft_idx_b = aft_foil_mask[b].nonzero().squeeze(-1)
       z2_idx_b = zone2_mask[b].nonzero().squeeze(-1)
       
       correction_b = aft_srf_context_head(
           fx[b, aft_idx_b],           # aft surface hidden
           x[b, aft_idx_b, :2],        # aft surface positions (standardized)
           fx[b, z2_idx_b],            # zone-2 volume hidden
           x[b, z2_idx_b, :2],         # zone-2 volume positions (standardized)
           out[b, aft_idx_b],          # aft base prediction
       )
       corrections.append((aft_idx_b, correction_b))
   ```

3. Apply corrections and zero out for non-tandem samples (same as existing aft_foil_srf logic).

**Memory note:** `torch.cdist` on [N_aft, N_vol] should be cheap — N_aft is small (~50-100 aft surface nodes) and N_vol for zone_id=2 is also bounded. If you see OOM, reduce K from 8 to 4.

### Step 4: Run validation

Use `--wandb_group phase6/aft-srf-knn-context`. Run 2 seeds:

```bash
python train.py --agent frieren --wandb_name "frieren/aft-srf-ctx-s42" \
  --wandb_group phase6/aft-srf-knn-context --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context

python train.py --agent frieren --wandb_name "frieren/aft-srf-ctx-s73" \
  --wandb_group phase6/aft-srf-knn-context --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context
```

**Report** p_in, p_oodc, p_tan, p_re, val/loss, W&B run ID for each seed, plus 2-seed average. Also report VRAM usage (should be ~38GB with the KNN computation; flag if it exceeds 45GB).

## Baseline

Current single-model baseline (PR #2104 + PR #2115, 8-seed mean, seeds 42-49):

| Metric | Baseline | Target |
|--------|----------|--------|
| p_in | 13.19 ± 0.33 | < 13.19 |
| p_oodc | 7.92 ± 0.17 | < 7.92 |
| **p_tan** | **30.05 ± 0.36** | **< 30.05** |
| p_re | 6.45 ± 0.07 | < 6.45 |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-aft-srf-aug" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```

**Merge bar:** 2-seed average p_tan < 30.05 (primary), without regressing p_in > 13.5 or p_oodc > 8.0.