### PR TITLE
Phase 6: Reynolds-Conditional SRF — FiLM on (Re, AoA) for Surface Refinement Head

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -454,12 +454,15 @@ class SurfaceRefinementHead(nn.Module):
     Takes the Transolver hidden features (and optionally the base predictions)
     for surface nodes only, and outputs a residual correction that is added
     to the main model's predictions at surface locations.
+
+    Optionally applies FiLM conditioning on (Re, AoA) after the first hidden layer.
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
-                 n_layers: int = 2, p_only: bool = False):
+                 n_layers: int = 2, p_only: bool = False, film: bool = False):
         super().__init__()
         self.p_only = p_only
+        self.film = film
         actual_out = 1 if p_only else out_dim  # 1 for pressure-only, 3 for all fields
         layers: list[nn.Module] = []
         # Input: hidden features (n_hidden) + base predictions (out_dim)
@@ -473,17 +476,34 @@ class SurfaceRefinementHead(nn.Module):
         nn.init.zeros_(layers[-1].weight)
         nn.init.zeros_(layers[-1].bias)
         self.mlp = nn.Sequential(*layers)
+        # FiLM modulation from (Re, AoA) — 2-dim condition, zero-initialized
+        if film:
+            self.film_scale = nn.Linear(2, hidden_dim, bias=False)
+            self.film_shift = nn.Linear(2, hidden_dim)
+            nn.init.zeros_(self.film_scale.weight)
+            nn.init.zeros_(self.film_shift.weight)
+            nn.init.zeros_(self.film_shift.bias)
 
-    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor,
+                cond: torch.Tensor | None = None) -> torch.Tensor:
         """
         Args:
             hidden: [M, n_hidden] — hidden features for surface nodes only
             base_pred: [M, out_dim] — base predictions for surface nodes only
+            cond: [M, 2] — per-node (Re, AoA) condition (only used if film=True)
         Returns:
             correction: [M, out_dim] — additive correction (zero-padded for p_only)
         """
         inp = torch.cat([hidden, base_pred], dim=-1)
-        correction = self.mlp(inp)
+        # Run through layers, applying FiLM after first hidden activation (index 2)
+        x = inp
+        for i, layer in enumerate(self.mlp):
+            x = layer(x)
+            if self.film and cond is not None and i == 2:
+                gamma = self.film_scale(cond)   # [M, hidden_dim]
+                beta = self.film_shift(cond)    # [M, hidden_dim]
+                x = x * (1.0 + gamma) + beta
+        correction = x
         if self.p_only:
             # Pad with zeros for velocity channels: [M, 1] → [M, 3]
             zeros = torch.zeros(correction.shape[0], base_pred.shape[-1] - 1,
@@ -995,6 +1015,7 @@ class Config:
     surface_refine_layers: int = 2            # number of hidden layers in refinement MLP
     surface_refine_p_only: bool = False       # only refine pressure channel (not velocity)
     surface_refine_context: bool = False      # use surface + nearest-volume context features
+    surface_refine_film: bool = False         # FiLM conditioning on (Re, AoA) for SRF head
     # Phase 6: Asinh pressure transform
     asinh_pressure: bool = False             # transform pressure targets with asinh for dynamic range compression
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
@@ -1190,6 +1211,7 @@ if cfg.surface_refine:
             hidden_dim=cfg.surface_refine_hidden,
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
+            film=cfg.surface_refine_film,
         ).to(device)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())
@@ -1695,7 +1717,11 @@ for epoch in range(MAX_EPOCHS):
                     if surf_idx.numel() > 0:
                         surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
                         surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
-                        correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
+                        # FiLM condition: (Re, AoA) per surface node — from x[:, 0, 13:15]
+                        _srf_cond = None
+                        if cfg.surface_refine_film:
+                            _srf_cond = x[surf_idx[:, 0], 0, 13:15]  # [M, 2]
+                        correction = refine_head(surf_hidden, surf_pred, _srf_cond).float()  # [M, 3]
                         pred = pred.clone()
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
 
@@ -2199,7 +2225,10 @@ for epoch in range(MAX_EPOCHS):
                             if surf_idx.numel() > 0:
                                 surf_hidden = _eval_hidden[surf_idx[:, 0], surf_idx[:, 1]]
                                 surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                                correction = eval_refine_head(surf_hidden, surf_pred).float()
+                                _srf_cond_val = None
+                                if cfg.surface_refine_film:
+                                    _srf_cond_val = x[surf_idx[:, 0], 0, 13:15]  # [M, 2]
+                                correction = eval_refine_head(surf_hidden, surf_pred, _srf_cond_val).float()
                                 pred_loss = pred_loss.clone()
                                 pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
                     # Back-compute refined pred so denormalization (pred_orig) includes refinement


### PR DESCRIPTION
## Hypothesis

The shared `surface_refine` head (`--surface_refine`, merged Phase 5, the single biggest win at -72.7% p_re) currently applies the same MLP correction regardless of flow regime. It has no awareness of Reynolds number or angle of attack — the same weights correct predictions at Re=1e5 and Re=4e6, even though the error character differs dramatically:

- **Low Re:** boundary layer separation → large Cp plateaus, smooth gradients
- **High Re:** attached flow → sharp leading-edge gradients, pressure recovery

**Hypothesis:** Conditioning the SRF head on (Re, AoA) via FiLM modulation allows the correction MLP to adapt its strategy to the flow regime, directly targeting `p_re` and `p_oodc`.

**Why this is different from the dead-end `aft_foil_srf_film` (+41.6% p_oodc regression, #2104):** That FiLM used configurational features (gap, stagger) that vary per-sample dynamically. Re and AoA are the *primary flow condition descriptors* — they are already used by AdaLN in every Transolver block. FiLM on Re/AoA for the SRF head is the same mechanism as AdaLN, applied to the post-processing correction step.

**Expected impact:** -2 to -4% p_re, -1 to -2% p_oodc. ~18 LoC change. No memory overhead.

## Instructions

### Step 1: Locate the key classes

```bash
grep -n "class SurfaceRefinementHead\|class AftFoilRefinementHead\|film" cfd_tandemfoil/train.py | head -30
```

Find `SurfaceRefinementHead.__init__` and `SurfaceRefinementHead.forward`. Also look at `AftFoilRefinementHead` — it already has `film=True` FiLM support; mirror that exact pattern.

### Step 2: Add FiLM to SurfaceRefinementHead

In `SurfaceRefinementHead.__init__`, add optional `film: bool = False` parameter and FiLM layers:

```python
self.film = film
if film:
    self.film_scale = nn.Linear(2, hidden_dim, bias=False)
    self.film_shift = nn.Linear(2, hidden_dim)
    nn.init.zeros_(self.film_scale.weight)
    nn.init.zeros_(self.film_shift.weight)
    nn.init.zeros_(self.film_shift.bias)
```

In `SurfaceRefinementHead.forward`, add a `cond` argument and apply FiLM after the first hidden activation:

```python
def forward(self, h_surf, base_surf, cond=None):
    x = torch.cat([h_surf, base_surf], dim=-1)
    x = self.act(self.fc1(x))
    if self.film and cond is not None:
        scale = self.film_scale(cond)
        shift = self.film_shift(cond)
        x = x * (1 + scale) + shift
    x = self.fc2(x)
    return x
```

### Step 3: Verify the Re and AoA feature indices

```bash
grep -n "adaln\|cond_dim\|cond_feat\|cond\[:, 0\]\|x\[:, 0,\|condition" cfd_tandemfoil/train.py | head -40
```

The condition input should be `x[:, 0, 13:15]` — Re and AoA as the first 2 scalar condition features (same as what AdaLN uses). Verify by printing at training start:

```python
print(f"[DEBUG] cond sample: feat13={x[0,0,13]:.4f}, feat14={x[0,0,14]:.4f}")
```

These should be normalized values in roughly [-3, 3]. If they look like zeros, find the right indices via `prepare_multi.py` or the stats dict.

### Step 4: Pass condition to the SRF head

Find where `refine_head(` is called. Add condition extraction and pass it:

```python
# Extract per-sample condition [B, 2]
cond_global = x[:, 0, 13:15]

# Expand to surface nodes using surf_idx (surf_idx[:, 0] = batch index per node)
cond_surf = cond_global[surf_idx[:, 0]]   # [N_surf_nodes, 2]

# Call with condition:
surf_pred = refine_head(h_surf, base_surf, cond=cond_surf)
```

### Step 5: Add config flags

```python
# argparse:
parser.add_argument('--surface_refine_film', action='store_true')
# Config dataclass:
surface_refine_film: bool = False
```

Pass `film=cfg.surface_refine_film` when constructing `SurfaceRefinementHead`.

### Step 6: Run experiments

Run 2 film seeds + 2 control seeds (identical config, no `--surface_refine_film`) for a clean comparison:

```bash
# Film, seed 42
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/re-srf-film-s42" \
  --wandb_group phase6/re-conditional-srf \
  --surface_refine --surface_refine_film --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02

# Film, seed 73 — same + --seed 73
# Control, seed 42 — same without --surface_refine_film
# Control, seed 73 — same without --surface_refine_film + --seed 73
```

**Note:** Use `--surface_refine` (not `--surface_refine_hidden`/`--surface_refine_layers` alone) — the `--surface_refine` flag enables the head.

**W&B group:** `phase6/re-conditional-srf`

Report surface MAE metrics (p_in, p_oodc, p_tan, p_re) for all 4 runs. If both film seeds beat both control seeds on p_re, strong candidate for 8-seed validation.

## Baseline

Current single-model baseline (PR #2104 + #2115, +aft_foil_srf +aug_gap_stagger_sigma=0.02, 8-seed mean, seeds 42-49):

| Metric | 8-seed mean | Target to beat |
|--------|-------------|----------------|
| p_in   | **13.19 ± 0.33** | < 13.19 |
| p_oodc | **7.92 ± 0.17**  | < 7.92  |
| p_tan  | **30.05 ± 0.36** | < 30.05 |
| p_re   | **6.45 ± 0.07**  | **< 6.45** ← primary target |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/baseline-s42" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```