### PR TITLE
Phase 6: Gap/Stagger-Conditioned Spatial Bias — Tandem-Geometry-Aware Slice Routing

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -282,6 +282,7 @@ class TransolverBlock(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        spatial_bias_input_dim=4,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -328,7 +329,7 @@ class TransolverBlock(nn.Module):
         self.ln_2 = _LN(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
-            nn.Linear(4, 64), nn.GELU(),
+            nn.Linear(spatial_bias_input_dim, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
             nn.Linear(64, slice_num),
         )
@@ -698,9 +699,11 @@ class Transolver(nn.Module):
         pressure_first=False,
         pressure_no_detach=False,
         pressure_deep=False,
+        gap_stagger_spatial_bias=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
+        self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -768,10 +771,16 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
+                    spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
                 )
                 for idx in range(n_layers)
             ]
         )
+        # Zero-init the 2 new input columns of spatial_bias so initial routing is unchanged
+        if gap_stagger_spatial_bias:
+            with torch.no_grad():
+                for block in self.blocks:
+                    block.spatial_bias[0].weight[:, 4:].zero_()
         # Separate pressure pathway (pressure_separate_last_block):
         # Independent MLP + pres_head that processes shared hidden features
         self._pressure_separate = False  # set from Config after construction
@@ -875,7 +884,12 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        if self.gap_stagger_spatial_bias:
+            # Gap (idx 22) and stagger (idx 23) are global per-sample scalars; broadcast to all nodes
+            gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)  # [B, N, 2]
+            raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger], dim=-1)  # [B, N, 6]
+        else:
+            raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
@@ -1005,6 +1019,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1214,6 +1229,7 @@ model_config = dict(
     pressure_first=cfg.pressure_first,
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
+    gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

Transolver's slice routing assigns each mesh node to a soft mixture of physics slices via \`slice_logits = ... + 0.1 * spatial_bias(raw_xy)\`. Currently, \`raw_xy\` is purely local: (x_coord, y_coord, curvature, dist-to-surface). The spatial_bias MLP has **zero knowledge of the inter-foil tandem geometry**.

For single-foil samples, gap=0 and stagger=0 — so extending raw_xy with these features adds **no information for single-foil samples** (zero input → zero effect). For tandem samples, different gap/stagger values fundamentally change the flow topology (wake interaction, channel flow, suction-side shielding), but all tandem configurations currently route through identical slice assignment logic regardless of inter-foil separation.

This experiment conditions Transolver's core slice routing on global tandem geometry. PR #2115 (merged) showed that gap/stagger perturbation during training improves p_oodc. This experiment is the **complementary mechanism**: making slice routing explicitly *aware* of which inter-foil geometry it's processing — not just robust to variation in it. The two mechanisms are orthogonal.

**Important new finding:** PR #2123 (combined baseline validation) showed that gap/stagger augmentation helps p_oodc (-2.4%) but slightly regresses p_tan (+1.6%). The spatial-bias approach operates through a completely different channel (slice routing, not augmentation) and is expected to help p_tan by giving the trunk genuine geometric awareness.

**Expected impact:** -3 to -7% p_tan. Negligible parameter overhead (384 extra scalars across 3 blocks). Zero effect on single-foil samples by design.

## Instructions

### Step 1 — Add config flag

```python
# In Config dataclass:
gap_stagger_spatial_bias: bool = False
```

### Step 2 — Modify TransolverBlock.__init__ to accept spatial_bias_input_dim

```python
# In TransolverBlock.__init__, change spatial_bias construction to accept input_dim param:
# Add spatial_bias_input_dim=4 to __init__ signature
def __init__(self, ..., spatial_bias_input_dim=4):
    ...
    self.spatial_bias = nn.Sequential(
        nn.Linear(spatial_bias_input_dim, 64), nn.GELU(),
        nn.Linear(64, 64), nn.GELU(),
        nn.Linear(64, slice_num),
    )
    nn.init.zeros_(self.spatial_bias[-1].weight)
    nn.init.zeros_(self.spatial_bias[-1].bias)
```

### Step 3 — Pass spatial_bias_input_dim when constructing blocks in Transolver.__init__

```python
for i in range(n_layers):
    block = TransolverBlock(
        ...,
        spatial_bias_input_dim=6 if cfg.gap_stagger_spatial_bias else 4,
    )
    self.blocks.append(block)
```

### Step 4 — Zero-init the 2 new input columns (critical for stability)

```python
# After constructing all TransolverBlock instances:
if cfg.gap_stagger_spatial_bias:
    with torch.no_grad():
        for block in self.blocks:
            # spatial_bias[0] is nn.Linear(6, 64)
            block.spatial_bias[0].weight[:, 4:].zero_()  # zero the 2 new input cols
```

This ensures gap/stagger start with exactly zero contribution. Training turns on the signal gradually via gradient descent.

### Step 5 — Extend raw_xy in Transolver.forward

```python
# Find raw_xy construction (look for x[:, :, :2] and x[:, :, 24:26]):
# CURRENT:
raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # [B, N, 4]

# PROPOSED:
if cfg.gap_stagger_spatial_bias:
    # gap = feature index 21, stagger = feature index 22 (global per sample, broadcast)
    gap_stagger = x[:, 0:1, 21:23].expand(-1, x.shape[1], -1)  # [B, N, 2]
    raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger], dim=-1)  # [B, N, 6]
else:
    raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # [B, N, 4]
```

**Notes:**
- Indices 21 (gap) and 22 (stagger) are global per-sample scalars, same for all N nodes. `x[:, 0:1, 21:23].expand(...)` is correct and torch.compile-safe (static shape).
- This `x` is post-standardization inside Transolver.forward. Standardized gap/stagger are in range ~[-2, 2].
- **Verify indices first:** Check `data/prepare_multi.py` to confirm that feature index 21 is gap and 22 is stagger. Print `x[:, 0, 21:23]` for a tandem sample and a single-foil sample to verify.

### Step 6 — Run 4 experiments with `--wandb_group phase6/gap-stagger-spatial-bias`

All runs include `--aft_foil_srf --aug_gap_stagger_sigma 0.02` (current baseline).

| GPU | Config | wandb_name | Seed |
|-----|--------|-----------|------|
| 0 | Baseline (no spatial bias, control) | fern/gsb-control-s42 | 42 |
| 1 | Baseline (no spatial bias, control) | fern/gsb-control-s43 | 43 |
| 2 | `--gap_stagger_spatial_bias` | fern/gsb-s42 | 42 |
| 3 | `--gap_stagger_spatial_bias` | fern/gsb-s43 | 43 |

Full base command:
```bash
cd cfd_tandemfoil && nohup env PYTHONUNBUFFERED=1 CUDA_VISIBLE_DEVICES=<gpu> python train.py \
  --agent fern --wandb_name "fern/<name>" --wandb_group phase6/gap-stagger-spatial-bias \
  --seed <seed> \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 \
  [--gap_stagger_spatial_bias] \
  > logs/<name>.log 2>&1 &
```

**Do NOT override SENPAI_MAX_EPOCHS or SENPAI_TIMEOUT_MINUTES.**

## What to report

- Surface MAE for all 4 configs: p_in, p_oodc, p_tan, p_re (and W&B run IDs)
- Does `--gap_stagger_spatial_bias` improve p_tan vs control?
- VRAM usage (should be ~38GB — negligible parameter overhead)
- Feature index verification: confirm that x[:, 0, 21] and x[:, 0, 22] are gap and stagger respectively (single-foil should be ~0, tandem should vary)
- Confirm zero-init check: that initial routing is identical with and without the flag at epoch 0

## Baseline

Current combined 8-seed mean (seeds 42-49, +aft_foil_srf +aug_gap_stagger_sigma 0.02):

| Metric | 8-seed mean | Target to beat |
|--------|-------------|----------------|
| p_in | 13.24 ± 0.33 | < 13.24 |
| p_oodc | 7.73 ± 0.22 | < 7.73 |
| **p_tan** | **30.53 ± 0.50** | **< 30.53** |
| p_re | 6.50 ± 0.07 | < 6.50 |

**Note:** For merge decisions, compare your 2-seed avg against these combined 8-seed means. The aft_foil_srf-only baseline (without gap_stagger aug) had p_tan=30.05 — your control runs will confirm the local baseline with both flags.

```bash
cd cfd_tandemfoil && python train.py --agent fern \
  --wandb_name "fern/combined-baseline" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```