### PR TITLE
Phase 6: Tandem-Slice Carve-Out — Reserved Physics Slices for Tandem Samples

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 tandem_slice_carveout=0, tandem_carveout_bias=-100.0):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -154,6 +155,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.decouple_slice = decouple_slice
         self.zone_temp = zone_temp
         self.prog_slices = prog_slices
+        self.tandem_slice_carveout = tandem_slice_carveout
+        self.tandem_carveout_bias = tandem_carveout_bias
+        if tandem_slice_carveout > 0:
+            # Pre-compute carve-out bias mask: 0 for shared slices, bias for reserved slices
+            _co_bias = torch.zeros(slice_num)
+            _co_bias[-tandem_slice_carveout:] = tandem_carveout_bias
+            self.register_buffer('carveout_bias_mask', _co_bias)
         if prog_slices:
             # Buffer for masking inactive slices; updated per-epoch by training loop
             self.register_buffer('slice_mask', torch.zeros(slice_num))
@@ -221,6 +229,12 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if self.prog_slices:
             # Apply slice mask: 0 for active slices, -1e9 for inactive (updated each epoch)
             slice_logits = slice_logits + self.slice_mask
+        if self.tandem_slice_carveout > 0 and tandem_mask is not None:
+            # Reserve last K slices for tandem samples: apply large negative bias for non-tandem
+            is_nontandem = 1.0 - tandem_mask.float()  # [B, 1, 1, 1]
+            # carveout_bias_mask: [S] — 0 for shared, -100 for reserved
+            # Broadcast: [S] * [B, 1, 1, 1] → [B, 1, 1, S] + [B, H, N, S]
+            slice_logits = slice_logits + self.carveout_bias_mask * is_nontandem
         slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
@@ -283,6 +297,8 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        tandem_slice_carveout=0,
+        tandem_carveout_bias=-100.0,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -308,6 +324,8 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            tandem_slice_carveout=tandem_slice_carveout,
+            tandem_carveout_bias=tandem_carveout_bias,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -700,6 +718,8 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        tandem_slice_carveout=0,
+        tandem_carveout_bias=-100.0,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -772,6 +792,8 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    tandem_slice_carveout=tandem_slice_carveout,
+                    tandem_carveout_bias=tandem_carveout_bias,
                 )
                 for idx in range(n_layers)
             ]
@@ -1070,6 +1092,9 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Tandem slice carve-out — reserve slices exclusively for tandem samples
+    tandem_slice_carveout: int = 0           # number of slices to reserve for tandem; 0 = off
+    tandem_carveout_bias: float = -100.0     # logit bias applied to reserved slices for non-tandem
 
 
 cfg = sp.parse(Config)
@@ -1230,6 +1255,8 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    tandem_slice_carveout=cfg.tandem_slice_carveout,
+    tandem_carveout_bias=cfg.tandem_carveout_bias,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

The Transolver uses 96 physics slices (with `--slice_num 96`) to assign each mesh node to a soft mixture of learned physics representations. Currently, all slices are shared across single-foil and tandem samples. **The hypothesis:** single-foil samples are co-opting slice representations that would otherwise specialize for tandem inter-foil physics, diluting the dedicated capacity for tandem wake interactions.

**The fix:** Reserve K physics slices exclusively for tandem samples. For single-foil samples, apply a large negative bias to the reserved slice logits — effectively preventing single-foil nodes from routing through those slices. For tandem samples, no bias is applied (they can use all 96 slices). This carves out dedicated representational capacity for tandem-specific flow patterns (wake interaction, gap channel flow, fore-foil suction shielding) without harming single-foil capacity.

**Why we haven't tried this:** All prior slice-related experiments (#2106 Fourier PE, #2103 weight-tied iterative) changed the routing mechanism globally. This is the first experiment to partition the slice space by sample type.

**Expected impact:** -2 to -5% p_tan. Zero effect on single-foil metrics if bias is large enough (|-100| effectively excludes reserved slices). Memory overhead: zero (no new parameters; just an additive bias to existing logits).

## Instructions

### Step 1 — Add config flags

```python
# In Config dataclass:
tandem_slice_carveout: int = 0      # number of slices to reserve for tandem; 0 = off
tandem_carveout_bias: float = -100.0  # logit bias applied to reserved slices for non-tandem
```

### Step 2 — Compute tandem mask in Transolver.forward

The `is_tandem` scalar is already computed in `Transolver.forward` (look for `is_tandem = ...` or the `tandem_ramp` block). This value is already passed to TransolverBlocks as `tandem_mask`. Verify exactly where this is done.

### Step 3 — Apply carve-out bias in TransolverBlock.forward (or Physics_Attention.forward)

Find where `slice_logits` are computed. The Transolver computes softmax-based routing logits for each node. Add the carve-out bias AFTER the logits are computed but BEFORE the softmax:

```python
# In Physics_Attention_Irregular_Mesh.forward (or TransolverBlock.forward),
# after computing slice_logits [B, N, num_slices]:
if cfg.tandem_slice_carveout > 0:
    n_reserved = cfg.tandem_slice_carveout
    # is_nontandem: [B] bool or float; 1.0 for single-foil, 0.0 for tandem
    # tandem_mask is already available (check how it's passed to Physics_Attention)
    is_nontandem = 1.0 - tandem_mask.float()  # [B], 1.0 for non-tandem
    # Apply large negative bias to last n_reserved slices for non-tandem samples
    # Shape: carveout_bias should broadcast to [B, N, n_reserved]
    carveout = is_nontandem[:, None, None] * cfg.tandem_carveout_bias  # [B, 1, 1]
    slice_logits[:, :, -n_reserved:] = slice_logits[:, :, -n_reserved:] + carveout
```

**Important:** Check how `tandem_mask` is currently passed to `Physics_Attention_Irregular_Mesh`. It may already be available as a parameter to the attention forward; if not, add it. The `is_tandem` value computed in `Transolver.forward` is the source of truth.

### Step 4 — Verify torch.compile safety

The slice operation `slice_logits[:, :, -n_reserved:]` is torch.compile-safe as long as `n_reserved` is a Python int (config value, resolved at trace time). The `is_nontandem` multiplication must not introduce dynamic shapes — verify the broadcast works statically.

### Step 5 — Run 6 experiments with `--wandb_group phase6/tandem-slice-carveout`

All runs include `--aft_foil_srf --aug_gap_stagger_sigma 0.02` (current baseline).

| GPU | Config | wandb_name | Seed |
|-----|--------|-----------|------|
| 0 | Baseline (no carveout, control) | alphonse/tsc-control-s42 | 42 |
| 1 | Baseline (no carveout, control) | alphonse/tsc-control-s43 | 43 |
| 2 | `--tandem_slice_carveout 4` | alphonse/tsc-k4-s42 | 42 |
| 3 | `--tandem_slice_carveout 4` | alphonse/tsc-k4-s43 | 43 |
| 4 | `--tandem_slice_carveout 8` | alphonse/tsc-k8-s42 | 42 |
| 5 | `--tandem_slice_carveout 8` | alphonse/tsc-k8-s43 | 43 |

Full base command:
```bash
cd cfd_tandemfoil && nohup env PYTHONUNBUFFERED=1 CUDA_VISIBLE_DEVICES=<gpu> python train.py \
  --agent alphonse --wandb_name "alphonse/<name>" --wandb_group phase6/tandem-slice-carveout \
  --seed <seed> \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 \
  [--tandem_slice_carveout 4|8] \
  > logs/<name>.log 2>&1 &
```

**Do NOT override SENPAI_MAX_EPOCHS or SENPAI_TIMEOUT_MINUTES.**

## What to report

- Surface MAE for all 6 configs: p_in, p_oodc, p_tan, p_re (and W&B run IDs)
- Does carveout improve p_tan vs control? Is k=4 or k=8 better?
- Does p_in/p_oodc degrade? (Should not — single-foil samples are unaffected if bias is -100)
- VRAM: should be identical to baseline (~38GB; no new parameters)
- Does the carveout interact with torch.compile? Check for recompilation warnings.
- What fraction of training steps have tandem vs non-tandem samples? (Sanity check that the mask works correctly)

## Baseline

Current combined 8-seed mean (seeds 42-49, +aft_foil_srf +aug_gap_stagger_sigma 0.02):

| Metric | 8-seed mean | Target to beat |
|--------|-------------|----------------|
| p_in | 13.24 ± 0.33 | < 13.24 |
| p_oodc | 7.73 ± 0.22 | < 7.73 |
| **p_tan** | **30.53 ± 0.50** | **< 30.53** |
| p_re | 6.50 ± 0.07 | < 6.50 |

```bash
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/combined-baseline" --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```