### PR TITLE
Phase 6: Tandem DSDF Channel Mixup — Synthetic Foil-Shape Interpolation

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -959,6 +959,8 @@ class Config:
     aug_start_epoch: int = 0        # delay augmentation onset until this epoch
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
+    aug_tandem_dsdf_mixup: bool = False       # mix DSDF channels between tandem samples
+    aug_tandem_dsdf_mixup_alpha: float = 0.7  # Beta distribution alpha parameter
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1552,6 +1554,23 @@ for epoch in range(MAX_EPOCHS):
                     # Apply: broadcast [B] → [B, 1] → adds to [B, N]
                     x[:, :, 22] = x[:, :, 22] + _gap_noise.unsqueeze(1)
                     x[:, :, 23] = x[:, :, 23] + _stag_noise.unsqueeze(1)
+
+        # Tandem DSDF Channel Mixup (tandem-only)
+        if cfg.aug_tandem_dsdf_mixup:
+            _is_tan_mixup = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero -> tandem
+            if _is_tan_mixup.sum() >= 2:
+                _tan_idx = _is_tan_mixup.nonzero(as_tuple=False).squeeze(1)
+                _perm = _tan_idx[torch.randperm(len(_tan_idx), device=x.device)]
+                _beta_dist = torch.distributions.Beta(
+                    torch.tensor(cfg.aug_tandem_dsdf_mixup_alpha, device=x.device),
+                    torch.tensor(0.4, device=x.device),
+                )
+                _lam = _beta_dist.sample((_tan_idx.shape[0],)).view(-1, 1, 1)
+                # Mix ONLY DSDF channels (indices 2:10) — positions, scalars, targets unchanged
+                x[_tan_idx, :, 2:10] = (
+                    _lam * x[_tan_idx, :, 2:10]
+                    + (1 - _lam) * x[_perm, :, 2:10]
+                )
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

The primary bottleneck is **p_tan = 30.53** (surface MAE on NACA6416 tandem transfer). NACA6416 is an unseen foil geometry during training — the training set contains NACA0012 and similar profiles. The model has to generalize its tandem pressure predictions to an out-of-distribution foil shape.

Our data augmentation strategy (gap/stagger aug, DSDF magnitude aug) has proven effective at improving tandem generalization. This experiment extends that principle to **foil-shape space**: by interpolating the DSDF feature channels between two tandem samples, we create synthetic training samples with intermediate foil geometries that span the space between the known training shapes.

The key insight: DSDF channels encode the geometry of each foil (signed distance function gradients = surface normal directions and curvature). A linear interpolation of these channels creates a plausible intermediate geometry that doesn't correspond to any real sample in the training set, but sits between the known training shapes in feature space. NACA6416 sits in the same shape space — this augmentation increases the probability that the model has seen something similar during training.

**Why this won't corrupt the physics:**
- We only mix DSDF channels (x[:,:,2:10]) — the geometric encoding
- Position coordinates, Re/AoA scalars, gap/stagger, and ALL targets are kept fixed
- The physical targets (velocity field, pressure) remain consistent with the base sample's geometry
- This is a well-known technique in computer vision (Cutmix/Mixup) adapted to physics-informed feature spaces

**Expected impact:** -1% to -3% p_tan. Low risk — worst case is the model ignores the augmentation.

## Instructions

In `cfd_tandemfoil/train.py`, add the Tandem DSDF Channel Mixup augmentation.

**1. Add config fields** (near line ~961, after `aug_gap_stagger_sigma`):
```python
aug_tandem_dsdf_mixup: bool = False
aug_tandem_dsdf_mixup_alpha: float = 0.7  # Beta distribution alpha
```

**2. Add augmentation block** in the training loop, immediately after the gap/stagger aug block (~line 1554), BEFORE `x = (x - stats["x_mean"]) / stats["x_std"]`:

```python
# Tandem DSDF Channel Mixup (tandem-only)
if cfg.aug_tandem_dsdf_mixup:
    _is_tan_mixup = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero -> tandem
    if _is_tan_mixup.sum() >= 2:
        _tan_idx = _is_tan_mixup.nonzero(as_tuple=False).squeeze(1)
        _perm = _tan_idx[torch.randperm(len(_tan_idx), device=x.device)]
        _beta_dist = torch.distributions.Beta(
            torch.tensor(cfg.aug_tandem_dsdf_mixup_alpha, device=x.device),
            torch.tensor(0.4, device=x.device)
        )
        _lam = _beta_dist.sample((_tan_idx.shape[0],)).view(-1, 1, 1)
        # Mix ONLY DSDF channels (indices 2:10) — positions, scalars, targets unchanged
        x[_tan_idx, :, 2:10] = (
            _lam * x[_tan_idx, :, 2:10] +
            (1 - _lam) * x[_perm, :, 2:10]
        )
```

**3. Verify channel indices**: Confirm in `data/prepare_multi.py` that indices 2:10 in raw x are the full DSDF block (foil-1 and foil-2 signed distance channels). The comment at train.py line 1556 (`raw_dsdf = x[:, :, 2:10]`) strongly suggests this is correct.

**Implementation notes:**
- Apply BEFORE standardization — operating in raw feature space
- Apply to ALL tandem samples in the batch (not a subset)
- `_perm` is a random permutation of tandem indices — each tandem sample mixed with a different partner
- Beta(0.7, 0.4): asymmetric, ~70% of samples get lambda > 0.5 (subtle perturbations most of time)
- Training only — no change to eval/validation code
- Single-foil samples (gap=0) completely unaffected

**Experiment sweep — 4 runs total (2 alpha values x 2 seeds):**

```bash
# Alpha=0.7 — seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/dsdf-mixup-a07-s42" --wandb_group phase6/tandem-dsdf-mixup \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 \
  --aug_tandem_dsdf_mixup --aug_tandem_dsdf_mixup_alpha 0.7

# Alpha=0.7 — seed 43
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/dsdf-mixup-a07-s43" --wandb_group phase6/tandem-dsdf-mixup \
  --seed 43 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 \
  --aug_tandem_dsdf_mixup --aug_tandem_dsdf_mixup_alpha 0.7

# Alpha=0.5 — seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/dsdf-mixup-a05-s42" --wandb_group phase6/tandem-dsdf-mixup \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 \
  --aug_tandem_dsdf_mixup --aug_tandem_dsdf_mixup_alpha 0.5

# Alpha=0.5 — seed 43
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/dsdf-mixup-a05-s43" --wandb_group phase6/tandem-dsdf-mixup \
  --seed 43 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 \
  --aug_tandem_dsdf_mixup --aug_tandem_dsdf_mixup_alpha 0.5
```

**Decision rule:** Report results for both alpha values. If alpha=0.7 2-seed avg gives p_tan < 30.53, that's a win. If alpha=0.7 regresses p_tan by >0.3 vs baseline after 100 epochs, abort those runs and focus on alpha=0.5 only.

## Baseline

Current 8-seed combined baseline (PR #2123):

| Metric | Baseline (8-seed mean) |
|--------|----------------------|
| p_in   | 13.24 ± 0.33         |
| p_oodc | 7.73 ± 0.22          |
| **p_tan** | **30.53 ± 0.50**  |
| p_re   | 6.50 ± 0.07          |

**Target: p_tan < 30.53 (primary), p_oodc < 7.73 (secondary).**

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```