### PR TITLE
Phase 6: Foil-1 DSDF Magnitude Augmentation — Front Foil Shape Transfer

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -960,6 +960,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    aug_dsdf1_sigma: float = 0.0        # log-normal scale for foil-1 DSDF magnitude aug (0=disabled, tandem only)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1566,6 +1567,18 @@ for epoch in range(MAX_EPOCHS):
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
+
+        # Foil-1 DSDF magnitude augmentation (tandem samples only, training only)
+        # x layout: [pos(2), saf(2), dsdf(8), ...]; foil-1 DSDF = dsdf[0:4] = x[:, :, 4:8]
+        if model.training and cfg.aug_dsdf1_sigma > 0.0:
+            _is_tandem_aug1 = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero → tandem
+            if _is_tandem_aug1.any():
+                _dsdf1_scale = torch.exp(
+                    torch.randn(x.size(0), device=x.device) * cfg.aug_dsdf1_sigma
+                )
+                # Identity for non-tandem samples
+                _dsdf1_scale = _dsdf1_scale * _is_tandem_aug1.float() + (~_is_tandem_aug1).float()
+                x[:, :, 4:8] = x[:, :, 4:8] * _dsdf1_scale.view(-1, 1, 1)
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

PR #2126 (merged) applied log-normal magnitude augmentation to foil-2 DSDF channels (x[:,6:10]) and improved **p_tan by -1.4%** (30.53→30.11) by forcing shape-transfer generalization for the rear foil. The `val_tandem_transfer` evaluation uses **NACA6416 as the FRONT foil** (never seen in any training tandem data). The front foil's geometry is encoded in the **foil-1 DSDF channels** — the direct analogue of foil-2 DSDF for the other side.

If DSDF2 aug improved p_tan by reducing reliance on memorized rear-foil geometry, then DSDF1 aug should work even more directly: it targets the exact geometric encoding that val_tandem_transfer exercises. The training set has only NACA2412 and NACA9412 as front foils; augmenting the front-foil DSDF magnitude forces the model to generalize across front-foil shape families.

**Key constraint:** Scaling is purely multiplicative per sample (not per-node), log-normal, applied to tandem samples only — gradient directions are preserved, same design as DSDF2 aug.

## Instructions

### Step 0: Verify foil-1 DSDF channel indices

Before implementing, read `cfd_tandemfoil/data/prepare_multi.py` (read-only) and identify which global column indices in the raw 24-dim `x` tensor correspond to foil-1 DSDF features. Based on the confirmed feature layout:
```
[pos(2), saf(2), dsdf(8), is_surface(1), log_Re(1), AoA0_rad(1), NACA0(3), AoA1_rad(1), NACA1(3), gap(1), stagger(1)]
```
foil-2 DSDF was confirmed at `x[:, :, 6:10]` (PR #2126). Foil-1 DSDF is the first half of the 8-channel dsdf block. Check the code to confirm the exact indices (expected: `x[:, :, 4:8]` or similar). Document what you find in a code comment and in your results comment.

### Step 1: Add config flag

In `train.py`, add to `Config`:
```python
aug_dsdf1_sigma: float = 0.0   # log-normal scale for foil-1 DSDF magnitude aug (0 = disabled)
```

### Step 2: Implement the augmentation

In the augmentation block (near the DSDF2 aug code from PR #2126), **before** the standardization line, add:

```python
if cfg.aug_dsdf1_sigma > 0.0:
    _is_tandem_aug1 = (x[:, 0, 22].abs() > 0.01)   # tandem detection (same as gap/stagger aug)
    if _is_tandem_aug1.any():
        # Log-normal multiplicative scale per sample (preserves direction, adjusts magnitude)
        _scale1 = torch.exp(
            torch.randn(x.size(0), device=x.device) * cfg.aug_dsdf1_sigma
        )
        # Apply only to tandem samples (identity for non-tandem)
        _scale1 = _scale1 * _is_tandem_aug1.float() + (~_is_tandem_aug1).float()
        # Apply to foil-1 DSDF channels only — adjust slice if your index check differs
        x[:, :, 4:8] = x[:, :, 4:8] * _scale1.view(-1, 1, 1)
```

**Critical:** Adjust `x[:, :, 4:8]` to match the actual foil-1 DSDF indices you verify in Step 0.

**Note:** Both DSDF1 and DSDF2 aug flags are independent. You run with `--aug_dsdf2_sigma 0.05` (already in baseline) plus your new `--aug_dsdf1_sigma <value>`.

### Step 3: Run sweep

Use `--wandb_group phase6/dsdf1-mag-aug` for all runs. Run 2 seeds each for σ=0.05, 0.10, 0.15 (6 total runs):

```bash
BASE="--asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05"

# sigma = 0.05 (2 seeds)
python train.py --agent tanjiro --wandb_name "tanjiro/dsdf1-aug-s05-s42" \
  --wandb_group phase6/dsdf1-mag-aug --seed 42 --aug_dsdf1_sigma 0.05 $BASE

python train.py --agent tanjiro --wandb_name "tanjiro/dsdf1-aug-s05-s73" \
  --wandb_group phase6/dsdf1-mag-aug --seed 73 --aug_dsdf1_sigma 0.05 $BASE

# sigma = 0.10 (2 seeds)
python train.py --agent tanjiro --wandb_name "tanjiro/dsdf1-aug-s10-s42" \
  --wandb_group phase6/dsdf1-mag-aug --seed 42 --aug_dsdf1_sigma 0.10 $BASE

python train.py --agent tanjiro --wandb_name "tanjiro/dsdf1-aug-s10-s73" \
  --wandb_group phase6/dsdf1-mag-aug --seed 73 --aug_dsdf1_sigma 0.10 $BASE

# sigma = 0.15 (2 seeds)
python train.py --agent tanjiro --wandb_name "tanjiro/dsdf1-aug-s15-s42" \
  --wandb_group phase6/dsdf1-mag-aug --seed 42 --aug_dsdf1_sigma 0.15 $BASE

python train.py --agent tanjiro --wandb_name "tanjiro/dsdf1-aug-s15-s73" \
  --wandb_group phase6/dsdf1-mag-aug --seed 73 --aug_dsdf1_sigma 0.15 $BASE
```

### Step 4: Report results

Report all 6 runs in a table (p_in, p_oodc, p_tan, p_re, val/loss, W&B run ID) plus 2-seed averages per σ. Compare against baseline targets below.

**Early stopping signal:** If σ=0.05 shows p_tan worse than baseline on both seeds, discontinue σ=0.10 and σ=0.15 early and report.

## Baseline

Current single-model baseline (PR #2126 merged, 2-seed evidence):

| Metric | Current Baseline | Target |
|--------|-----------------|--------|
| p_in | 13.04 | < 13.04 |
| p_oodc | 7.66 | < 7.66 |
| **p_tan** | **30.11** | **< 30.11** |
| p_re | 6.52 | < 6.52 |

**Reproduce current baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dsdf2-aug" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05
```

**Merge bar:** 2-seed average p_tan < 30.11 (primary), without regressing p_oodc > 7.80 or p_in > 13.20.

**Prior context (PR #2126 — DSDF2 aug, merged):**
- DSDF2 aug σ=0.05 improved p_tan: 30.53→30.11 (-1.4%), p_in: 13.24→13.04 (-1.5%), p_oodc: 7.73→7.66 (-0.9%)
- σ=0.05 was the sweet spot — larger σ (0.10, 0.15) degraded p_tan
- Foil-2 DSDF channels confirmed at x[:,:,6:10]; foil-1 is the symmetric counterpart