### PR TITLE
Phase 6: Fore-Foil TE Relative Coords — Inter-Foil Jet Frame for AftSRF Context

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -553,11 +553,12 @@ class AftFoilRefinementContextHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 192,
-                 n_layers: int = 3, k_neighbors: int = 8):
+                 n_layers: int = 3, k_neighbors: int = 8, use_rel_coords: bool = False):
         super().__init__()
         self.k = k_neighbors
-        # Input: aft surface hidden + volume KNN context + base pred
-        in_dim = n_hidden + n_hidden + out_dim
+        self.use_rel_coords = use_rel_coords
+        # Input: aft surface hidden + volume KNN context + base pred (+ 2 rel coords if enabled)
+        in_dim = n_hidden + n_hidden + out_dim + (2 if use_rel_coords else 0)
         layers: list[nn.Module] = []
         for i in range(n_layers):
             layers.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
@@ -570,14 +571,16 @@ class AftFoilRefinementContextHead(nn.Module):
 
     def forward(self, aft_hidden: torch.Tensor, aft_positions: torch.Tensor,
                 vol_hidden: torch.Tensor, vol_positions: torch.Tensor,
-                aft_base_pred: torch.Tensor) -> torch.Tensor:
+                aft_base_pred: torch.Tensor,
+                fore_te_pos: torch.Tensor | None = None) -> torch.Tensor:
         """
         Args:
             aft_hidden: [A, n_hidden] — hidden features for aft-foil surface nodes
-            aft_positions: [A, 2] — xy coords of aft-foil surface nodes
+            aft_positions: [A, 2] — xy coords of aft-foil surface nodes (standardized)
             vol_hidden: [V, n_hidden] — hidden features of volume (non-surface) nodes
-            vol_positions: [V, 2] — xy coords of volume nodes
+            vol_positions: [V, 2] — xy coords of volume nodes (standardized)
             aft_base_pred: [A, out_dim] — base predictions for aft-foil nodes
+            fore_te_pos: [2] — standardized xy of fore-foil trailing edge node (optional)
         Returns:
             correction: [A, out_dim] — additive correction
         """
@@ -585,7 +588,11 @@ class AftFoilRefinementContextHead(nn.Module):
         dists = torch.cdist(aft_positions, vol_positions)  # [A, V]
         _, nn_idx = dists.topk(k, dim=-1, largest=False)  # [A, k]
         vol_context = vol_hidden[nn_idx].mean(dim=1)  # [A, n_hidden]
-        inp = torch.cat([aft_hidden, vol_context, aft_base_pred], dim=-1)
+        if self.use_rel_coords and fore_te_pos is not None:
+            rel_coords = aft_positions - fore_te_pos.unsqueeze(0)  # [A, 2]
+            inp = torch.cat([aft_hidden, vol_context, aft_base_pred, rel_coords], dim=-1)
+        else:
+            inp = torch.cat([aft_hidden, vol_context, aft_base_pred], dim=-1)
         return self.mlp(inp)
 
 
@@ -1052,6 +1059,7 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    aft_foil_srf_rel_coords: bool = False    # add (x_rel, y_rel) = node - fore-TE to context head input
 
 
 cfg = sp.parse(Config)
@@ -1255,6 +1263,7 @@ if cfg.aft_foil_srf:
             hidden_dim=cfg.aft_foil_srf_hidden,
             n_layers=cfg.aft_foil_srf_layers,
             k_neighbors=8,
+            use_rel_coords=cfg.aft_foil_srf_rel_coords,
         ).to(device)
         aft_srf_ctx_head = torch.compile(aft_srf_ctx_head, mode=cfg.compile_mode)
         _aft_n_params = sum(p.numel() for p in aft_srf_ctx_head.parameters())
@@ -1642,11 +1651,15 @@ for epoch in range(MAX_EPOCHS):
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
-        if aft_srf_head is not None:
+        _fore_foil_mask = None
+        if aft_srf_head is not None or aft_srf_ctx_head is not None:
             _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+            if cfg.aft_foil_srf_rel_coords:
+                # Fore-foil (foil-1) surface nodes: saf_norm ≈ 0 (secondary airfoil field only nonzero on foil-2)
+                _fore_foil_mask = is_surface & (_raw_saf_norm <= 0.005) & _is_tandem.unsqueeze(1)
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1792,6 +1805,14 @@ for epoch in range(MAX_EPOCHS):
                 _vol_b = _vol_mask[b].nonzero(as_tuple=True)[0]
                 if _aft_b.numel() == 0 or _vol_b.numel() == 0:
                     continue
+                # Fore-foil trailing edge: rightmost (max-x) fore-foil surface node
+                fore_te_pos = None
+                if cfg.aft_foil_srf_rel_coords and _fore_foil_mask is not None:
+                    _fore_b = _fore_foil_mask[b].nonzero(as_tuple=True)[0]
+                    if _fore_b.numel() > 0:
+                        _fore_coords = _coords[b, _fore_b]  # [N_fore, 2] standardized
+                        _te_idx = _fore_coords[:, 0].argmax()
+                        fore_te_pos = _fore_coords[_te_idx].detach()  # [2]
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     _corr = aft_srf_ctx_head(
                         hidden[b, _aft_b],     # aft surface hidden
@@ -1799,6 +1820,7 @@ for epoch in range(MAX_EPOCHS):
                         hidden[b, _vol_b],     # volume hidden
                         _coords[b, _vol_b],    # volume positions
                         pred[b, _aft_b],       # aft base prediction
+                        fore_te_pos,           # fore-foil trailing edge position (or None)
                     ).float()
                 pred[b, _aft_b] = pred[b, _aft_b] + _corr
         elif aft_srf_head is not None and model.training and _aft_foil_mask is not None:
@@ -2205,11 +2227,14 @@ for epoch in range(MAX_EPOCHS):
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
                 # Aft-foil mask for eval (same logic as training)
                 _eval_aft_mask = None
-                if eval_aft_srf_head is not None:
+                _eval_fore_foil_mask = None
+                if eval_aft_srf_head is not None or eval_aft_srf_ctx_head is not None:
                     _v_saf_norm = x[:, :, 2:4].norm(dim=-1)
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
                     _v_gap_stagger = x[:, 0, 22:24]  # [B, 2]
+                    if cfg.aft_foil_srf_rel_coords:
+                        _eval_fore_foil_mask = is_surface & (_v_saf_norm <= 0.005) & _v_is_tandem.unsqueeze(1)
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -2334,11 +2359,19 @@ for epoch in range(MAX_EPOCHS):
                         _vol_b = _vol_mask_v[b].nonzero(as_tuple=True)[0]
                         if _aft_b.numel() == 0 or _vol_b.numel() == 0:
                             continue
+                        fore_te_pos_v = None
+                        if cfg.aft_foil_srf_rel_coords and _eval_fore_foil_mask is not None:
+                            _fore_b_v = _eval_fore_foil_mask[b].nonzero(as_tuple=True)[0]
+                            if _fore_b_v.numel() > 0:
+                                _fore_coords_v = _coords_v[b, _fore_b_v]
+                                _te_idx_v = _fore_coords_v[:, 0].argmax()
+                                fore_te_pos_v = _fore_coords_v[_te_idx_v].detach()
                         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                             _corr = eval_aft_srf_ctx_head(
                                 _eval_hidden[b, _aft_b], _coords_v[b, _aft_b],
                                 _eval_hidden[b, _vol_b], _coords_v[b, _vol_b],
                                 pred_loss[b, _aft_b],
+                                fore_te_pos_v,
                             ).float()
                         pred_loss[b, _aft_b] += _corr
                     if cfg.multiply_std:


### PR DESCRIPTION
## Hypothesis

The KNN volume context head (PR #2127, just merged) gives the aft-foil SRF head access to *what the wake looks like* upstream. But the aft-foil nodes' input positions are in the **global mesh frame** — the head has no explicit sense of *where the aft-foil sits relative to the fore-foil*. This matters: a node at (x=1.6, y=0.0) has a fundamentally different aerodynamic role depending on whether the fore-foil trailing edge is at x=1.0 (gap=0.6) or x=1.4 (gap=0.2).

**Hypothesis:** Adding 2 extra features to the `AftFoilRefinementContextHead` input — (x_rel, y_rel) = (x_node − x_te_fore, y_node − y_te_fore) — provides the inter-foil jet coordinate frame that physically governs wake-surface interaction. KNN context tells the head *what* the wake carries; relative coords tell the head *where in the wake* each surface node sits. These two pieces of information are complementary and together should unlock stronger aft-foil pressure predictions.

**Physical motivation:** Aft-foil Cp recovery depends strongly on the node's position relative to the inter-foil jet stagnation line. A node that sits directly in the jet core vs. at the jet boundary experiences very different pressure recovery, even if the upstream hidden states look similar. Relative coordinates make this geometry explicit.

**Expected impact:** p_tan −3% to −7%. Synergistic with `--aft_foil_srf_context`.

## Instructions

### Step 0: Understand the existing AftFoilRefinementContextHead

Read `AftFoilRefinementContextHead.__init__` and `.forward` in `train.py`. It currently:
- Takes `aft_hidden` [N_aft, n_hidden], `aft_positions` [N_aft, 2], `vol_hidden` [N_vol, n_hidden], `vol_positions` [N_vol, 2], `aft_base_pred` [N_aft, out_dim]
- Computes KNN context from vol_hidden
- Concatenates `[aft_hidden, vol_context, aft_base_pred]` → MLP

Find the `in_features` line in `__init__` — it is `n_hidden + n_hidden + out_dim`.

### Step 1: Add flag and modify the head

```python
# argparse:
parser.add_argument('--aft_foil_srf_rel_coords', action='store_true')
# Config dataclass:
aft_foil_srf_rel_coords: bool = False
```

Modify `AftFoilRefinementContextHead.__init__`:
```python
self.use_rel_coords = use_rel_coords
in_features = n_hidden + n_hidden + out_dim + (2 if use_rel_coords else 0)
```

Pass `use_rel_coords=cfg.aft_foil_srf_rel_coords` when constructing the head.

### Step 2: Modify forward to accept and use fore_te_pos

```python
def forward(self, aft_hidden, aft_positions, vol_hidden, vol_positions, aft_base_pred, fore_te_pos=None):
    # KNN context (existing — keep unchanged)
    dists = torch.cdist(aft_positions, vol_positions)
    _, nn_idx = dists.topk(self.k, dim=-1, largest=False)
    vol_context = vol_hidden[nn_idx].mean(dim=1)  # [N_aft, n_hidden]

    # Relative coordinates
    if self.use_rel_coords and fore_te_pos is not None:
        rel_coords = aft_positions - fore_te_pos.unsqueeze(0)  # [N_aft, 2]
        inp = torch.cat([aft_hidden, vol_context, aft_base_pred, rel_coords], dim=-1)
    else:
        inp = torch.cat([aft_hidden, vol_context, aft_base_pred], dim=-1)
    return self.net(inp)
```

### Step 3: Compute fore-foil trailing edge per sample in the forward loop

In the same per-sample loop you wrote for PR #2127 (the KNN context loop), add:

```python
for b in range(B):
    aft_idx_b = aft_foil_mask[b].nonzero().squeeze(-1)
    z2_idx_b = zone2_mask[b].nonzero().squeeze(-1)

    # NEW: fore-foil trailing edge
    fore_te_pos = None
    if cfg.aft_foil_srf_rel_coords:
        # Use zone_id==1 surface nodes (same pattern as zone_id==2 you already wrote)
        fore_surf_mask_b = (zone_id_b[b] == 1) & is_surf_b[b]  # adjust tensor names to match yours
        fore_idx_b = fore_surf_mask_b.nonzero().squeeze(-1)
        if fore_idx_b.numel() > 0:
            fore_positions = x[b, fore_idx_b, :2]          # [N_fore, 2]
            te_idx = fore_positions[:, 0].argmax()
            fore_te_pos = fore_positions[te_idx].detach()   # [2]

    correction_b = aft_srf_context_head(
        fx[b, aft_idx_b],
        x[b, aft_idx_b, :2],
        fx[b, z2_idx_b],
        x[b, z2_idx_b, :2],
        out[b, aft_idx_b],
        fore_te_pos,   # NEW arg
    )
```

**Zone ID:** Reuse the exact same zone_id tensor and surface mask you already defined for PR #2127 — just change `== 2` to `== 1` to get fore-foil nodes.

**Single-foil samples:** If `fore_idx_b.numel() == 0`, `fore_te_pos = None` → head falls back to non-relative path. Safe.

**Sanity check (add at training start, remove before final run):**
```python
if fore_te_pos is not None:
    rel0 = x[b, aft_idx_b[0], :2] - fore_te_pos
    print(f"[DEBUG] fore_te=({fore_te_pos[0]:.3f},{fore_te_pos[1]:.3f}) aft[0]=({x[b,aft_idx_b[0],0]:.3f},{x[b,aft_idx_b[0],1]:.3f}) rel=({rel0[0]:.3f},{rel0[1]:.3f})")
```
Expected: x_rel ~ [0.0, 0.8], y_rel ~ [−0.3, 0.3]. If you see values > 5 or < −5 the coords are in standardized space — verify you are using x[:,:,:2] BEFORE standardization (same as your KNN context positions).

### Step 4: Run experiments

2 seeds with rel_coords + 2 control seeds (same config but WITHOUT `--aft_foil_srf_rel_coords`):

```bash
# Rel coords, seed 42
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/aft-srf-relcoords-s42" \
  --wandb_group phase6/foil1-relative-coords --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context --aft_foil_srf_rel_coords

# Rel coords, seed 73: same + --seed 73
# Control seed 42: same WITHOUT --aft_foil_srf_rel_coords
# Control seed 73: same WITHOUT --aft_foil_srf_rel_coords --seed 73
```

**W&B group:** `phase6/foil1-relative-coords`

Report p_in, p_oodc, p_tan, p_re + W&B run IDs for all 4 runs, plus 2-seed averages for rel_coords and control.

## Baseline

Current single-model baseline (PR #2127, AftSRF KNN context K=8, 2-seed mean):

| Metric | 2-seed mean | Target |
|--------|-------------|--------|
| p_in | **13.02** | < 13.02 |
| p_oodc | **7.62** | < 7.62 |
| **p_tan** | **29.91** | **< 29.91** ← primary |
| p_re | **6.47** | < 6.47 |

W&B: `zosxwjmm` (s42), `twilqf1x` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent frieren --seed 42 \
  --wandb_name "frieren/baseline-aft-srf-ctx" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context
```