### PR TITLE
Phase 6: Tandem Self-Distillation — EMA Teacher for Tandem Samples

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1052,6 +1052,8 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    tandem_selfdistill: bool = False         # EMA self-distillation on tandem samples
+    tandem_selfdistill_weight: float = 0.1   # KD loss weight
 
 
 cfg = sp.parse(Config)
@@ -1944,6 +1946,22 @@ for epoch in range(MAX_EPOCHS):
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
             loss = loss + cfg.rdrop_alpha * rdrop_loss
 
+        # Tandem self-distillation: use EMA model as soft teacher on tandem samples
+        kd_loss = torch.tensor(0.0, device=device)
+        if cfg.tandem_selfdistill and ema_model is not None and is_tandem_batch.any():
+            with torch.no_grad():
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    ema_kd_out = ema_model({"x": x[is_tandem_batch]})
+                ema_kd_pred = ema_kd_out["preds"].float()
+            # Online backbone predictions for tandem samples (with grad)
+            online_kd_pred = out["preds"][is_tandem_batch].float()
+            # KD loss: MSE on surface pressure (channel 2) for tandem surface nodes
+            kd_surf_mask = (mask & is_surface)[is_tandem_batch]  # [N_tan, N_nodes]
+            n_surf_kd = kd_surf_mask.sum().clamp(min=1)
+            kd_diff_sq = (online_kd_pred[:, :, 2:3] - ema_kd_pred[:, :, 2:3]) ** 2
+            kd_loss = (kd_diff_sq * kd_surf_mask.unsqueeze(-1).float()).sum() / n_surf_kd
+            loss = loss + cfg.tandem_selfdistill_weight * kd_loss
+
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
@@ -2060,7 +2078,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _train_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.tandem_selfdistill:
+            _train_log["train/kd_loss"] = kd_loss.item()
+        wandb.log(_train_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The EMA model is already being maintained throughout training and is the checkpoint used for evaluation. It is a smoother, higher-quality version of the online model. Currently it is used **only at evaluation time**. But since it lives on-device and is updated every step, we can also use it as a **soft teacher** during training.

**Hypothesis:** After EMA begins accumulating (epoch ≥ `ema_start_epoch`), apply a self-distillation KD loss on **tandem samples only**: the EMA model's predictions on tandem nodes serve as soft targets that the online model must also predict. This gives the online model a second, smoother training signal on the hardest OOD split — val_tandem_transfer — at near-zero additional cost (EMA is already computed; we just run a second forward pass on the tandem subset with no_grad).

**Why tandem-only?** Tandem samples are the primary bottleneck (p_tan is our hardest metric). The EMA model has already seen more data per parameter update, is more stable on these samples, and provides a denoised supervision signal. KD on single-foil samples would have lower marginal value since the model already generalizes well there.

**Why this is different from auxiliary losses (dead end #2097):** Deep supervision added auxiliary prediction heads at intermediate layers — a gradient signal that interfered with learning. Self-distillation here is output-level only, after the full forward pass, and uses a soft/smooth target (EMA output) rather than ground truth. The EMA target smooths over noise in the ground truth labels for tandem samples.

**Expected impact:** p_tan −2% to −5%. ~25 LoC. Fully orthogonal to coordinate-based and augmentation changes.

## Instructions

### Step 1: Add config flags

```python
# argparse:
parser.add_argument('--tandem_selfdistill', action='store_true')
parser.add_argument('--tandem_selfdistill_weight', type=float, default=0.1)

# Config dataclass:
tandem_selfdistill: bool = False
tandem_selfdistill_weight: float = 0.1
```

### Step 2: Understand the EMA model in the training loop

Find where the EMA model is defined and updated. Search for:
```bash
grep -n "ema\|EMA\|_base_model\|ema_model" cfd_tandemfoil/train.py | head -40
```

The EMA model is `ema_model` (or similar). It is updated each step after the optimizer step, and used during validation. Note `ema_start_epoch` — EMA only accumulates after this epoch (default 100 in current baseline; may be different in train.py default, check with `grep ema_start_epoch train.py`).

### Step 3: Add the tandem self-distillation loss

In the training loop, AFTER computing the standard loss and AFTER the EMA model update, add:

```python
# Self-distillation KD loss on tandem samples
if cfg.tandem_selfdistill and epoch >= cfg.ema_start_epoch:
    # Identify tandem samples in the batch
    # tandem_mask is already computed earlier in the loop — reuse it
    # tandem_mask: [B] boolean, True for tandem samples
    
    if tandem_mask.any():
        # Get EMA predictions on tandem nodes (no_grad, no gradient through EMA)
        with torch.no_grad():
            ema_out = ema_model(x[tandem_mask], ...)   # same forward args as online model
            # NOTE: ema_model takes the same input signature — copy the forward call
            # from the online model forward pass, substituting ema_model
        
        # Online predictions on tandem nodes (already computed as `out`)
        online_tandem = out[tandem_mask]   # [N_tan, out_dim] — adjust for your tensor shape
        ema_tandem = ema_out               # [N_tan, out_dim]
        
        # KD loss: MSE between online and EMA outputs (on surface nodes only for efficiency)
        # Surface nodes only: use the same surf_mask you apply for surface MAE computation
        kd_loss = F.mse_loss(online_tandem, ema_tandem.detach())
        loss = loss + cfg.tandem_selfdistill_weight * kd_loss
```

**Key implementation detail:** The forward pass signature for `ema_model` is identical to the online model. You do NOT need to recompute anything — just run `ema_model(x[tandem_mask], ...)` with the same arguments used for the online model. Use `torch.no_grad()` to avoid gradients through the EMA model.

**Important:** The KD loss must be added BEFORE `loss.backward()`. If the EMA model update happens after `loss.backward()` in your training loop, compute the EMA forward pass BEFORE the optimizer step but AFTER the online forward pass. Check the exact order in the training loop with:
```bash
grep -n "ema\|backward\|optimizer.step\|loss" cfd_tandemfoil/train.py | grep -A2 -B2 "backward"
```

**Memory:** The EMA model forward pass on tandem-only samples (typically 30-50% of batch) costs ~1/3 extra compute. If you see OOM, filter to surface nodes only before computing KD loss, or reduce batch size by 10%.

### Step 4: Sweep over distillation weight

Run 3 seeds: w=0.05, w=0.10, w=0.20:

```bash
# w=0.10, seed 42 (primary)
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/tandem-selfdistill-w0.10-s42" \
  --wandb_group phase6/tandem-selfdistill --seed 42 \
  --tandem_selfdistill --tandem_selfdistill_weight 0.10 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context

# w=0.05, seed 42: same but --tandem_selfdistill_weight 0.05
# w=0.20, seed 42: same but --tandem_selfdistill_weight 0.20

# Control seed 42: same WITHOUT --tandem_selfdistill
```

**W&B group:** `phase6/tandem-selfdistill`

Report p_in, p_oodc, p_tan, p_re + W&B run IDs for all 4 runs. If w=0.10 seed 42 shows clear improvement, run a second seed (73) on the best weight for 2-seed averaging.

**Watch for:** If p_tan degrades monotonically as w increases, the KD loss is over-constraining the online model. If p_oodc degrades with no p_tan improvement, the KD loss is hurting generalization elsewhere — try restricting to surface pressure nodes only (not velocity/pressure volume nodes).

## Baseline

Current single-model baseline (PR #2127, AftSRF KNN context K=8, 2-seed mean):

| Metric | 2-seed mean | Target |
|--------|-------------|--------|
| p_in | **13.02** | < 13.02 |
| p_oodc | **7.62** | < 7.62 |
| **p_tan** | **29.91** | **< 29.91** ← primary |
| p_re | **6.47** | < 6.47 |

W&B: `zosxwjmm` (s42), `twilqf1x` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/baseline-aft-srf-ctx" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context
```