### PR TITLE
Phase 6: Per-Foil Physics Normalization — Fix Aft-Foil Cp Denominator

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1052,6 +1052,7 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    per_foil_pnorm: bool = False             # per-foil Cp normalization: separate q for fore/aft in tandem
 
 
 cfg = sp.parse(Config)
@@ -1107,6 +1108,46 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-10, 10) * Umag
     y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-10, 10) * Umag
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
+    return y
+
+
+def _build_perfoil_q(y, mask, aft_foil_mask, is_tandem, q_global):
+    """Build per-node q map: aft-foil nodes get q_aft, everything else gets q_global.
+
+    Returns q_map [B, N, 1] suitable for element-wise pressure division.
+    """
+    B, N = mask.shape
+    q_map = q_global.expand(B, N, 1).clone()  # [B, N, 1] start with global q
+    for b in range(B):
+        if not is_tandem[b]:
+            continue
+        fore_mask_b = mask[b] & ~aft_foil_mask[b]  # fore-foil + volume nodes
+        aft_mask_b = mask[b] & aft_foil_mask[b]     # aft-foil nodes only
+        if not aft_mask_b.any() or not fore_mask_b.any():
+            continue
+        # Compute q_aft from aft-foil region nodes only
+        _, q_aft = _umag_q(y[b:b+1], aft_mask_b.unsqueeze(0))
+        # Clamp: q_aft >= 0.1 * q_global to prevent blow-up
+        q_aft = q_aft.clamp(min=0.1 * q_global[b].item())
+        q_map[b, aft_mask_b, :] = q_aft.squeeze()
+    return q_map
+
+
+def _phys_norm_perfoil(y, Umag, q_map):
+    """Like _phys_norm but with per-node q for pressure."""
+    y_p = y.clone()
+    y_p[:, :, 0:1] = y[:, :, 0:1] / Umag
+    y_p[:, :, 1:2] = y[:, :, 1:2] / Umag
+    y_p[:, :, 2:3] = y[:, :, 2:3] / q_map  # q_map is [B, N, 1]
+    return y_p
+
+
+def _phys_denorm_perfoil(y_p, Umag, q_map):
+    """Reverse per-foil normalization."""
+    y = y_p.clone()
+    y[:, :, 0:1] = y_p[:, :, 0:1].clamp(-10, 10) * Umag
+    y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-10, 10) * Umag
+    y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q_map
     return y
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=cfg.num_workers, pin_memory=True,
@@ -1642,7 +1683,8 @@ for epoch in range(MAX_EPOCHS):
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
-        if aft_srf_head is not None:
+        _is_tandem = None
+        if aft_srf_head is not None or cfg.per_foil_pnorm:
             _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
@@ -1669,6 +1711,15 @@ for epoch in range(MAX_EPOCHS):
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
+        # Per-foil q map for tandem samples (aft-foil gets local q)
+        _q_map = None
+        if cfg.per_foil_pnorm and _aft_foil_mask is not None and _is_tandem is not None:
+            _q_map = _build_perfoil_q(y, mask, _aft_foil_mask, _is_tandem, q)
+            if epoch == 0 and global_step == 0:
+                for _b in range(min(4, y.shape[0])):
+                    if _is_tandem[_b] and _aft_foil_mask[_b].any():
+                        _q_aft_b = _q_map[_b, _aft_foil_mask[_b], 0].mean()
+                        print(f"[per_foil_pnorm] b={_b}: q_global={q[_b].item():.4f}, q_aft={_q_aft_b.item():.4f}, ratio={_q_aft_b.item()/q[_b].item():.3f}")
         if cfg.raw_targets:
             y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
         elif cfg.adaptive_norm:
@@ -1677,7 +1728,10 @@ for epoch in range(MAX_EPOCHS):
                 y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
             y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
         else:
-            y_phys = _phys_norm(y, Umag, q)
+            if _q_map is not None:
+                y_phys = _phys_norm_perfoil(y, Umag, _q_map)
+            else:
+                y_phys = _phys_norm(y, Umag, q)
             if cfg.log_pressure:
                 y_phys = y_phys.clone()
                 y_phys[:, :, 2:3] = y_phys[:, :, 2:3].abs().add(1).log() * y_phys[:, :, 2:3].sign()
@@ -2205,7 +2259,8 @@ for epoch in range(MAX_EPOCHS):
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
                 # Aft-foil mask for eval (same logic as training)
                 _eval_aft_mask = None
-                if eval_aft_srf_head is not None:
+                _v_is_tandem = None
+                if eval_aft_srf_head is not None or cfg.per_foil_pnorm:
                     _v_saf_norm = x[:, :, 2:4].norm(dim=-1)
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
@@ -2229,6 +2284,9 @@ for epoch in range(MAX_EPOCHS):
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
+                _v_q_map = None
+                if cfg.per_foil_pnorm and _eval_aft_mask is not None and _v_is_tandem is not None:
+                    _v_q_map = _build_perfoil_q(y, mask, _eval_aft_mask, _v_is_tandem, q)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
                 elif cfg.adaptive_norm:
@@ -2237,7 +2295,10 @@ for epoch in range(MAX_EPOCHS):
                         y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
                     y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
                 else:
-                    y_phys = _phys_norm(y, Umag, q)
+                    if _v_q_map is not None:
+                        y_phys = _phys_norm_perfoil(y, Umag, _v_q_map)
+                    else:
+                        y_phys = _phys_norm(y, Umag, q)
                     if cfg.log_pressure:
                         y_phys = y_phys.clone()
                         y_phys[:, :, 2:3] = y_phys[:, :, 2:3].abs().add(1).log() * y_phys[:, :, 2:3].sign()
@@ -2398,14 +2459,18 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.asinh_pressure:
                         pred_phys = pred_phys.clone()
                         pred_phys[:, :, 2:3] = torch.sinh(pred_phys[:, :, 2:3]) / cfg.asinh_scale
+                    _denorm_q = _v_q_map if _v_q_map is not None else q
                     if cfg.tight_denorm_clamps:
                         _pd = pred_phys.clone()
                         _pd[:, :, 0:1] = pred_phys[:, :, 0:1].clamp(-5, 5) * Umag
                         _pd[:, :, 1:2] = pred_phys[:, :, 1:2].clamp(-5, 5) * Umag
-                        _pd[:, :, 2:3] = pred_phys[:, :, 2:3].clamp(-10, 10) * q
+                        _pd[:, :, 2:3] = pred_phys[:, :, 2:3].clamp(-10, 10) * _denorm_q
                         pred_orig = _pd
                     else:
-                        pred_orig = _phys_denorm(pred_phys, Umag, q)
+                        if _v_q_map is not None:
+                            pred_orig = _phys_denorm_perfoil(pred_phys, Umag, _v_q_map)
+                        else:
+                            pred_orig = _phys_denorm(pred_phys, Umag, q)
                 y_clamped = y.clamp(-1e6, 1e6)
                 err = (pred_orig - y_clamped).abs()
                 finite = err.isfinite()
@@ -2614,6 +2679,12 @@ if best_metrics:
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
+                    _vis_q_map = None
+                    if cfg.per_foil_pnorm:
+                        _vis_saf_norm = x_dev[:, :, 2:4].norm(dim=-1)
+                        _vis_is_tandem = (x_dev[:, 0, 22].abs() > 0.01)
+                        _vis_aft_mask = is_surf_dev & (_vis_saf_norm > 0.005) & _vis_is_tandem.unsqueeze(1)
+                        _vis_q_map = _build_perfoil_q(y_dev, mask, _vis_aft_mask, _vis_is_tandem, q)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
                     if cfg.raw_targets:
                         y_pred = (pred * raw_stats["y_std"] + raw_stats["y_mean"]).squeeze(0).cpu()
@@ -2631,14 +2702,18 @@ if best_metrics:
                         if cfg.asinh_pressure:
                             pred_phys = pred_phys.clone()
                             pred_phys[:, :, 2:3] = torch.sinh(pred_phys[:, :, 2:3]) / cfg.asinh_scale
+                        _vis_denorm_q = _vis_q_map if _vis_q_map is not None else q
                         if cfg.tight_denorm_clamps:
                             _pd = pred_phys.clone()
                             _pd[:, :, 0:1] = pred_phys[:, :, 0:1].clamp(-5, 5) * Umag
                             _pd[:, :, 1:2] = pred_phys[:, :, 1:2].clamp(-5, 5) * Umag
-                            _pd[:, :, 2:3] = pred_phys[:, :, 2:3].clamp(-10, 10) * q
+                            _pd[:, :, 2:3] = pred_phys[:, :, 2:3].clamp(-10, 10) * _vis_denorm_q
                             y_pred = _pd.squeeze(0).cpu()
                         else:
-                            y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
+                            if _vis_q_map is not None:
+                                y_pred = _phys_denorm_perfoil(pred_phys, Umag, _vis_q_map).squeeze(0).cpu()
+                            else:
+                                y_pred = _phys_denorm(pred_phys, Umag, q).squeeze(0).cpu()
                 samples.append((x[:, :2], y_true, y_pred, is_surface))
             images = visualize(samples, out_dir=plot_dir / split_name)
             if images:
@@ -2716,6 +2791,12 @@ if cfg.surface_refine and best_metrics:
 
                     # Ground truth denormalization reference
                     Umag, q = _umag_q(y, mask)
+                    _ver_q_map = None
+                    if cfg.per_foil_pnorm:
+                        _ver_saf_norm = raw_dsdf[:, :, :2].norm(dim=-1)  # saf channels
+                        _ver_is_tandem = (_re_raw.to(device).abs() > 0)  # placeholder; OOD-Re is typically single-foil
+                        # For verification: compute aft mask from raw x (already consumed by standardization)
+                        # OOD-Re split is single-foil so per-foil q degenerates to global q
                     if cfg.adaptive_norm:
                         y_adapt = y.clone()
                         if cfg.asinh_pressure:


### PR DESCRIPTION
## Hypothesis

The current `_umag_q` function computes a **single** domain-mean Umag from ALL mesh nodes (fore + aft + wake). For tandem samples, the aft foil sits deep in the fore-foil's wake where local velocities are significantly lower than freestream. This means the `q = 0.5 * Umag²` denominator used for aft-foil Cp is **physically incorrect** — it uses the global (inflated) dynamic pressure instead of the local aft-foil reference.

The consequence: aft-foil Cp values in the training targets are systematically inflated relative to what local physics implies. The model must implicitly learn to undo this normalization artifact, wasting representational capacity. Single-foil samples are completely unaffected (no wake interference).

**Fix:** For tandem samples, split the normalization so:
- **Fore-foil nodes** use `q_fore` (computed from fore-foil nodes only)
- **Aft-foil nodes** use `q_aft` (computed from aft-foil nodes only)

This is a physically motivated bias correction applied consistently to both training and validation. No new hyperparameters.

**Expected impact:** -2% to -5% p_tan. The model has been fighting an incorrect normalization for aft-foil nodes from day one.

**Risk:** MEDIUM-LOW. If `Umag_aft ≈ Umag_fore` (wide gap, weak wake), the split degenerates cleanly to current behavior. Edge case: very tight gap → very low `q_aft` → need a minimum clamp (see Step 4).

## Instructions

### Step 1: Add config flag

In `Config` dataclass (~line 950):
```python
per_foil_pnorm: bool = False
```

In argparse:
```python
parser.add_argument('--per_foil_pnorm', action='store_true',
                    help='Per-foil Cp normalization: separate q for fore/aft nodes in tandem')
```

### Step 2: Add helper function (after `_umag_q`, ~line 1030)

```python
def _umag_q_perfoil(y, fore_mask, aft_mask):
    """Separate q normalization for fore and aft foil nodes in tandem samples."""
    Umag_fore, q_fore = _umag_q(y, fore_mask)
    Umag_aft, q_aft = _umag_q(y, aft_mask)
    # Clamp aft q to avoid blow-up in deep-wake scenarios
    q_aft = q_aft.clamp(min=0.1 * q_fore)
    return Umag_fore, q_fore, Umag_aft, q_aft
```

### Step 3: Locate `_aft_foil_mask` in the training loop

Search for `_aft_foil_mask` in `train.py` — it should be computed around line 1562-1566 from raw (pre-standardization) x. Confirm this mask correctly identifies aft-foil nodes for tandem samples.

Also find the `is_tandem` indicator — look for `x[:, 0, 21]` (gap feature, nonzero for tandem) or `_is_tandem_batch`.

### Step 4: Apply per-foil normalization in training and validation loops

Find where `Umag, q = _umag_q(y, mask)` is called in the training loop, then add AFTER it:

```python
if cfg.per_foil_pnorm and _aft_foil_mask is not None:
    _fore_mask = mask & ~_aft_foil_mask           # [B, N] fore-foil + non-tandem nodes
    _aft_mask_valid = mask & _aft_foil_mask       # [B, N] aft-foil nodes
    _is_tandem_b = (x[:, 0, 21].abs() > 0.01)    # [B] tandem indicator (pre-standardization)
    
    # For each tandem sample, override q with per-foil values
    # Build per-sample q tensors [B, 1, 1] for use in _phys_norm
    q_effective = q.clone()   # start with global q
    Umag_effective = Umag.clone()
    
    for b in range(y.shape[0]):
        if _is_tandem_b[b] and _fore_mask[b].any() and _aft_mask_valid[b].any():
            _, q_f, _, q_a = _umag_q_perfoil(
                y[b:b+1], _fore_mask[b:b+1], _aft_mask_valid[b:b+1]
            )
            # Apply split: fore nodes use q_fore, aft nodes use q_aft
            # You'll need to adapt _phys_norm to accept per-node q, OR
            # apply it block by block:
            # e.g. y_norm[b, _fore_mask[b]] = _phys_norm(y[b:b+1, _fore_mask[b]], ..., q_f)
            # e.g. y_norm[b, _aft_mask_valid[b]] = _phys_norm(y[b:b+1, _aft_mask_valid[b]], ..., q_a)
```

**Study `_phys_norm` and `_umag_q` carefully before implementing** — the exact API depends on their signature. The key invariant: fore-foil pressure nodes normalized with `q_fore`, aft-foil pressure nodes with `q_aft`.

**CRITICAL:** Apply the same split in the **validation loop** (find the second `_umag_q` / `_phys_norm` call, ~line 2090-2095). Train/val normalization must match.

### Step 5: Sanity check at epoch 0

```python
if cfg.per_foil_pnorm and epoch == 0 and step == 0:
    for b in range(min(4, y.shape[0])):
        if _is_tandem_b[b] and _fore_mask[b].any() and _aft_mask_valid[b].any():
            _, q_f, _, q_a = _umag_q_perfoil(y[b:b+1], _fore_mask[b:b+1], _aft_mask_valid[b:b+1])
            print(f"[per_foil_pnorm] b={b}: q_fore={q_f.item():.4f}, q_aft={q_a.item():.4f}, ratio={q_a.item()/q_f.item():.3f}")
```

Expected: `q_aft / q_fore` typically 0.4-0.8 for tandem samples. If ratio ≈ 1.0, the mask may be wrong.

### Step 6: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/per-foil-pnorm-s42" --wandb_group phase6/per-foil-pnorm \
  --per_foil_pnorm --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context

# Seed 73
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/per-foil-pnorm-s73" --wandb_group phase6/per-foil-pnorm \
  --per_foil_pnorm --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context
```

Run both in parallel. Report W&B run IDs. 

## Baseline

Current single-model baseline (PR #2127 — AftSRF KNN Context K=8):

| Metric | 2-seed avg | Target to beat |
|--------|------------|----------------|
| p_in | **13.02** | < 13.02 |
| p_oodc | **7.62** | < 7.62 |
| **p_tan** | **29.91** | **< 29.91** |
| p_re | **6.47** | < 6.47 |

W&B: zosxwjmm (seed 42, p_tan=29.96), twilqf1x (seed 73, p_tan=29.87)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-aft-srf-ctx" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context
```