### PR TITLE
Phase 6: EMA Stochastic Weight Perturbation — Flat Minima Seeking

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -942,6 +942,7 @@ class Config:
     cosine_eta_min: float = 1e-5
     ema_start_epoch: int = 140
     ema_decay: float = 0.998
+    ema_perturb_sigma: float = 0.0  # One-time weight perturbation magnitude at EMA start (0 = disabled)
     temp_anneal_epoch: int = 50
     vol_ramp_epochs: int = 40
     tandem_curriculum_epochs: int = 10
@@ -2028,6 +2029,29 @@ for epoch in range(MAX_EPOCHS):
                 pass
         if epoch >= cfg.ema_start_epoch and not cfg.swad and not cfg.swa and not cfg.swa_cyclic and not cfg.snapshot_ensemble:
             if ema_model is None:
+                # One-time weight perturbation to explore flat minima
+                if cfg.ema_perturb_sigma > 0.0:
+                    with torch.no_grad():
+                        for p in _base_model.parameters():
+                            if p.requires_grad:
+                                p.data.add_(torch.randn_like(p.data) * cfg.ema_perturb_sigma)
+                        if refine_head is not None:
+                            _rh = refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head
+                            for p in _rh.parameters():
+                                if p.requires_grad:
+                                    p.data.add_(torch.randn_like(p.data) * cfg.ema_perturb_sigma)
+                        if aft_srf_head is not None:
+                            _ah = aft_srf_head._orig_mod if hasattr(aft_srf_head, '_orig_mod') else aft_srf_head
+                            for p in _ah.parameters():
+                                if p.requires_grad:
+                                    p.data.add_(torch.randn_like(p.data) * cfg.ema_perturb_sigma)
+                        if aft_srf_ctx_head is not None:
+                            _ch = aft_srf_ctx_head._orig_mod if hasattr(aft_srf_ctx_head, '_orig_mod') else aft_srf_ctx_head
+                            for p in _ch.parameters():
+                                if p.requires_grad:
+                                    p.data.add_(torch.randn_like(p.data) * cfg.ema_perturb_sigma)
+                    print(f"[ema_perturb] Applied sigma={cfg.ema_perturb_sigma} perturbation at epoch {epoch}")
+                    wandb.log({"ema_perturb/applied_epoch": epoch, "ema_perturb/sigma": cfg.ema_perturb_sigma, "global_step": global_step})
                 ema_model = deepcopy(_base_model)
             else:
                 with torch.no_grad():


### PR DESCRIPTION
## Hypothesis

Models in flatter loss basins generalize better to distribution shifts. p_tan tests on NACA6416 (unseen foil) — the sharpest OOD challenge. The current EMA (decay=0.999, starting at epoch ~140) averages the training trajectory but doesn't explicitly encourage flat-basin convergence.

**Idea:** At the moment EMA starts accumulating, inject a one-time Gaussian perturbation into the live model weights. The model then recovers from this perturbation over subsequent training steps, and the EMA averages the recovery trajectory. If the loss basin is flat (good for generalization), the recovery is smooth and the EMA captures a broader region of the flat manifold. If the basin is sharp, recovery is rocky and EMA captures worse models.

This is inspired by Stochastic Weight Averaging (Izmailov et al., 2018) and the "perturbation → recovery → average" principle, but simpler than full SAM (which is incompatible with Lion, PR #2086).

**Key difference from prior failed methods:**
- SAM (#2086): per-step perturbation, incompatible with Lion's sign operation
- SGLD (#2120): per-step noise, overwhelmed by Lion's implicit gradient noise
- SWAD (#2094): dense trajectory averaging over many checkpoints, catastrophic
- **This:** ONE perturbation at EMA start, then normal training + EMA. No per-step overhead. No interaction with Lion optimizer.

**Expected impact:** -1% to -3% p_tan. Low risk — worst case the perturbation is too small to matter.

## Instructions

### Step 1: Add config flag

In `Config` dataclass:
```python
ema_perturb_sigma: float = 0.0   # One-time weight perturbation magnitude at EMA start (0 = disabled)
```

In argparse:
```python
parser.add_argument('--ema_perturb_sigma', type=float, default=0.0,
                    help='Gaussian perturbation sigma applied to model weights at EMA start epoch')
```

### Step 2: Add perturbation at EMA initialization

Find the EMA initialization point in the training loop (search for `ema_model is None` or `deepcopy`, around line 1928-1931). It looks like:

```python
if epoch >= cfg.ema_start_epoch and not cfg.swad and ...:
    if ema_model is None:
        ema_model = deepcopy(_base_model)
    else:
        # existing EMA update ...
```

Add the perturbation BEFORE the deepcopy:

```python
if epoch >= cfg.ema_start_epoch and not cfg.swad and ...:
    if ema_model is None:
        # One-time weight perturbation to explore flat minima
        if cfg.ema_perturb_sigma > 0.0:
            with torch.no_grad():
                for p in _base_model.parameters():
                    if p.requires_grad:
                        p.data.add_(torch.randn_like(p.data) * cfg.ema_perturb_sigma)
            print(f"[ema_perturb] Applied sigma={cfg.ema_perturb_sigma} perturbation at epoch {epoch}")
        ema_model = deepcopy(_base_model)
    else:
        # existing EMA update ...
```

**Important:** The perturbation modifies the LIVE model, not the EMA. The EMA starts from the perturbed model and then averages the recovery trajectory.

### Step 3: Run sweep — 3 sigma values × 2 seeds = 6 runs

```bash
BASE="--asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context"

# sigma=5e-4, seeds 42/73
python train.py --agent tanjiro --wandb_name "tanjiro/ema-perturb-5e4-s42" \
  --wandb_group phase6/ema-perturb --seed 42 --ema_perturb_sigma 5e-4 $BASE
python train.py --agent tanjiro --wandb_name "tanjiro/ema-perturb-5e4-s73" \
  --wandb_group phase6/ema-perturb --seed 73 --ema_perturb_sigma 5e-4 $BASE

# sigma=1e-3, seeds 42/73
python train.py --agent tanjiro --wandb_name "tanjiro/ema-perturb-1e3-s42" \
  --wandb_group phase6/ema-perturb --seed 42 --ema_perturb_sigma 1e-3 $BASE
python train.py --agent tanjiro --wandb_name "tanjiro/ema-perturb-1e3-s73" \
  --wandb_group phase6/ema-perturb --seed 73 --ema_perturb_sigma 1e-3 $BASE

# sigma=3e-3, seeds 42/73
python train.py --agent tanjiro --wandb_name "tanjiro/ema-perturb-3e3-s42" \
  --wandb_group phase6/ema-perturb --seed 42 --ema_perturb_sigma 3e-3 $BASE
python train.py --agent tanjiro --wandb_name "tanjiro/ema-perturb-3e3-s73" \
  --wandb_group phase6/ema-perturb --seed 73 --ema_perturb_sigma 3e-3 $BASE
```

Run all 6 in parallel. W&B group: `phase6/ema-perturb`.

### What to report

1. Confirm the perturbation print fired at the expected epoch
2. Surface MAE table (p_in, p_oodc, p_tan, p_re) for all 6 runs + W&B run IDs
3. 2-seed means per sigma vs baseline
4. val/loss comparison — did the perturbation cause a visible spike followed by recovery?

## Baseline

Current single-model baseline (PR #2127 — AftSRF KNN Context K=8):

| Metric | 2-seed avg | Target |
|--------|------------|--------|
| p_in | **13.02** | < 13.02 |
| p_oodc | **7.62** | < 7.62 |
| **p_tan** | **29.91** | **< 29.91** |
| p_re | **6.47** | < 6.47 |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-aft-srf-ctx" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aft_foil_srf_context
```