### PR TITLE
Phase 6: Foil-2 Independent AoA Rotation Aug — Decoupled Tandem Geometry

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1005,6 +1005,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    aug_foil2_aoa_sigma: float = 0.0    # independent aft-foil AoA rotation sigma in radians (0=disabled, tandem only)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1634,6 +1635,41 @@ for epoch in range(MAX_EPOCHS):
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
+
+        # Foil-2 independent AoA rotation augmentation (tandem surface nodes only)
+        if model.training and cfg.aug_foil2_aoa_sigma > 0.0:
+            _saf_norm_rot = x[:, :, 2:4].norm(dim=-1)  # [B, N]
+            _is_tandem_rot = (x[:, 0, 22].abs() > 0.01)  # [B]
+            _aft_mask_rot = is_surface & (_saf_norm_rot > 0.005) & _is_tandem_rot.unsqueeze(1)  # [B, N]
+            if _is_tandem_rot.any():
+                _delta_aoa = torch.randn(x.size(0), device=x.device) * cfg.aug_foil2_aoa_sigma
+                _delta_aoa = _delta_aoa * _is_tandem_rot.float()  # zero for non-tandem
+                for b in range(x.size(0)):
+                    if _delta_aoa[b].abs() < 1e-8:
+                        continue
+                    aft_b = _aft_mask_rot[b]  # [N] bool
+                    if not aft_b.any():
+                        continue
+                    theta = _delta_aoa[b]
+                    cos_t, sin_t = torch.cos(theta), torch.sin(theta)
+                    # Rotate positions around aft-foil centroid
+                    aft_x = x[b, aft_b, 0]
+                    aft_y = x[b, aft_b, 1]
+                    cx, cy = aft_x.mean(), aft_y.mean()
+                    dx, dy = aft_x - cx, aft_y - cy
+                    x[b, aft_b, 0] = cos_t * dx - sin_t * dy + cx
+                    x[b, aft_b, 1] = sin_t * dx + cos_t * dy + cy
+                    # Rotate foil-2 DSDF gradient pairs (6,7) and (8,9)
+                    for ch_s in [6, 8]:
+                        gdx = x[b, aft_b, ch_s].clone()
+                        gdy = x[b, aft_b, ch_s + 1].clone()
+                        x[b, aft_b, ch_s] = cos_t * gdx - sin_t * gdy
+                        x[b, aft_b, ch_s + 1] = sin_t * gdx + cos_t * gdy
+                    # Rotate velocity targets (Ux=0, Uy=1); pressure is scalar, no rotation
+                    ux = y[b, aft_b, 0].clone()
+                    uy = y[b, aft_b, 1].clone()
+                    y[b, aft_b, 0] = cos_t * ux - sin_t * uy
+                    y[b, aft_b, 1] = sin_t * ux + cos_t * uy
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

In the training data, both foils in a tandem configuration share the same AoA — the aft-foil angle is mechanically linked to the fore-foil. The model never sees independent (fore_AoA, aft_AoA) combinations. During val_tandem_transfer with NACA6416, the effective incidence on the aft foil changes due to the different front-foil geometry, creating a distribution shift the model cannot handle.

**Fix:** For tandem samples only, independently rotate the aft-foil nodes by a small angle delta ~ N(0, sigma) around the aft-foil centroid. This creates novel (fore_AoA, aft_AoA) combinations, forcing the model to disentangle fore-foil and aft-foil flow features — a more general representation that should transfer better to unseen foil geometries.

The existing aoa_perturb augmentation rotates ALL nodes globally. This new augmentation is aft-foil-only and tandem-only — much more targeted.

**Expected impact:** -2% to -4% p_tan. Medium complexity (~35 LoC).

## Instructions

### Step 1: Add config flag

```python
# Config dataclass:
aug_foil2_aoa_sigma: float = 0.0   # Independent aft-foil AoA rotation sigma (radians, 0 = disabled)
```

### Step 2: Understand how aft-foil nodes are identified

Search for _aft_foil_mask in train.py. This mask identifies aft-foil nodes based on some criterion (likely foil_id or x-coordinate threshold). You need this mask to know which nodes to rotate.

Also find how the existing aoa_perturb augmentation works — search for aoa_perturb in the augmentation block. This gives you the rotation pattern to follow.

### Step 3: Implement aft-foil rotation augmentation

In the augmentation block (BEFORE standardization, after gap/stagger aug), add:

```python
if cfg.aug_foil2_aoa_sigma > 0.0 and _aft_foil_mask is not None:
    _is_tandem_rot = (x[:, 0, 22].abs() > 0.01)  # gap > 0 = tandem
    if _is_tandem_rot.any():
        _delta_aoa = torch.randn(x.size(0), device=x.device) * cfg.aug_foil2_aoa_sigma
        _delta_aoa = _delta_aoa * _is_tandem_rot.float()  # zero for non-tandem
        
        for b in range(x.size(0)):
            if _delta_aoa[b].abs() < 1e-8:
                continue
            aft_mask_b = _aft_foil_mask[b]  # [N] bool
            if not aft_mask_b.any():
                continue
            
            theta = _delta_aoa[b]
            cos_t, sin_t = torch.cos(theta), torch.sin(theta)
            
            # Compute aft-foil centroid
            aft_x = x[b, aft_mask_b, 0]
            aft_y = x[b, aft_mask_b, 1]
            cx, cy = aft_x.mean(), aft_y.mean()
            
            # Rotate (x, y) positions around centroid
            dx = aft_x - cx
            dy = aft_y - cy
            x[b, aft_mask_b, 0] = cos_t * dx - sin_t * dy + cx
            x[b, aft_mask_b, 1] = sin_t * dx + cos_t * dy + cy
            
            # Rotate DSDF gradient channels for aft-foil
            # DSDF channels come in (dx, dy) pairs — rotate each pair
            # Foil-2 DSDF is at x[:,:,6:10] (4 channels = 2 pairs of gradients)
            for ch_start in [6, 8]:  # Two (dx, dy) pairs
                gdx = x[b, aft_mask_b, ch_start].clone()
                gdy = x[b, aft_mask_b, ch_start + 1].clone()
                x[b, aft_mask_b, ch_start] = cos_t * gdx - sin_t * gdy
                x[b, aft_mask_b, ch_start + 1] = sin_t * gdx + cos_t * gdy
            
            # Rotate velocity targets (Ux, Uy) for aft-foil nodes
            # Check which channels in y are Ux, Uy — likely channels 0, 1
            ux = y[b, aft_mask_b, 0].clone()
            uy = y[b, aft_mask_b, 1].clone()
            y[b, aft_mask_b, 0] = cos_t * ux - sin_t * uy
            y[b, aft_mask_b, 1] = sin_t * ux + cos_t * uy
```

**CRITICAL CHECKS before running:**
1. Verify DSDF channel indices — confirm x[:,:,6:10] is foil-2 DSDF and that the (dx, dy) pairs are at (6,7) and (8,9)
2. Verify velocity channel indices in y — confirm y[:,:,0] and y[:,:,1] are Ux, Uy
3. Check if pressure (y[:,:,2]) needs rotation — pressure is a scalar, so NO rotation needed
4. Check if gap/stagger scalars (x[:,:,22:24]) need adjustment — small rotations change the effective gap/stagger slightly, but for sigma < 0.05 rad (~3 deg) this is negligible
5. Make sure the rotation is applied BEFORE standardization

### Step 4: Run sweep — 3 sigma values x 2 seeds = 6 runs

```bash
BASE="--asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02"

# sigma=0.02 (~1.1 deg), seeds 42/73
python train.py --agent edward --wandb_name "edward/f2aoa-s002-s42" \
  --wandb_group phase6/foil2-aoa-rot --seed 42 --aug_foil2_aoa_sigma 0.02 $BASE
python train.py --agent edward --wandb_name "edward/f2aoa-s002-s73" \
  --wandb_group phase6/foil2-aoa-rot --seed 73 --aug_foil2_aoa_sigma 0.02 $BASE

# sigma=0.05 (~2.9 deg), seeds 42/73
python train.py --agent edward --wandb_name "edward/f2aoa-s005-s42" \
  --wandb_group phase6/foil2-aoa-rot --seed 42 --aug_foil2_aoa_sigma 0.05 $BASE
python train.py --agent edward --wandb_name "edward/f2aoa-s005-s73" \
  --wandb_group phase6/foil2-aoa-rot --seed 73 --aug_foil2_aoa_sigma 0.05 $BASE

# sigma=0.10 (~5.7 deg), seeds 42/73
python train.py --agent edward --wandb_name "edward/f2aoa-s010-s42" \
  --wandb_group phase6/foil2-aoa-rot --seed 42 --aug_foil2_aoa_sigma 0.10 $BASE
python train.py --agent edward --wandb_name "edward/f2aoa-s010-s73" \
  --wandb_group phase6/foil2-aoa-rot --seed 73 --aug_foil2_aoa_sigma 0.10 $BASE
```

Run all 6 in parallel. W&B group: phase6/foil2-aoa-rot.

**NOTE:** Do NOT include --aft_foil_srf_context — it has a known bug (#2134) and is currently a no-op.

### What to report
1. Surface MAE (p_in, p_oodc, p_tan, p_re) for all 6 runs + W&B run IDs
2. 2-seed means per sigma vs baseline
3. Sanity check: print the aft-foil centroid and delta_aoa for a few samples at epoch 0

## Baseline

True current baseline (PR #2126 — DSDF2 aug, context head was bugged/no-op):

| Metric | 2-seed avg | Target |
|--------|------------|--------|
| p_in | **13.04** | < 13.04 |
| p_oodc | **7.66** | < 7.66 |
| **p_tan** | **30.11** | **< 30.11** |
| p_re | **6.52** | < 6.52 |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --disable_pcgrad --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02
```