### PR TITLE
DSDF Spatial Dropout: Zero-Out Foil Shape Features for Random Nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1005,6 +1005,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    dsdf_spatial_dropout: float = 0.0   # probability of zeroing DSDF for each node during training
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1637,6 +1638,11 @@ for epoch in range(MAX_EPOCHS):
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
+
+        # DSDF spatial dropout: zero out DSDF channels for random nodes (training only)
+        if cfg.dsdf_spatial_dropout > 0.0 and model.training:
+            _dsdf_drop_mask = (torch.rand(x.shape[0], x.shape[1], 1, device=x.device) > cfg.dsdf_spatial_dropout).float()
+            x[:, :, 2:10] = x[:, :, 2:10] * _dsdf_drop_mask
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

The model's input features include 8 DSDF (signed distance function) channels at indices 2-9 that encode foil shape geometry. The val_tandem_transfer test evaluates on NACA6416 (unseen foil shape) — the model must generalize from training shapes (NACA0012, NACA2412, NACA9412).

**DSDF magnitude augmentation** (PR #2126, merged, p_tan -1.4%) showed that making the model less reliant on exact DSDF values improves geometric transfer. This experiment takes a more aggressive approach: **randomly zeroing out DSDF features for a fraction of mesh nodes during training.**

This forces the model to predict pressure for some nodes using ONLY position, curvature, and distance-to-surface features — without knowing the foil shape at those locations. The model must learn to infer local pressure from flow context and neighbor information rather than memorizing exact shape-to-pressure mappings. This is analogous to dropout applied to a specific feature group rather than hidden units.

**Physical motivation:** In real CFD, local pressure depends on both the local geometry AND the upstream flow state. A model that over-relies on local DSDF (geometry-only) at each node will fail when the geometry changes (NACA6416). Forcing the model to sometimes work without DSDF information pushes it toward using flow-context features that generalize across foil shapes.

**Distinction from DSDF magnitude aug:** Magnitude aug (σ=0.05) perturbs all nodes uniformly — the model always sees DSDF, just noisier. Spatial dropout completely removes DSDF for random nodes — a much stronger regularization signal. The two are complementary: mag aug prevents exact memorization, dropout prevents DSDF dependence entirely.

**Expected impact:** p_tan -1% to -3%. Zero computational overhead (dropout is just a multiplication by a binary mask).

## Instructions

### Step 1: Add config flag

```python
# Config dataclass:
dsdf_spatial_dropout: float = 0.0   # probability of zeroing DSDF for each node
```

```python
# argparse:
parser.add_argument('--dsdf_spatial_dropout', type=float, default=0.0,
                    help='Per-node probability of zeroing DSDF channels (2:10) during training')
```

### Step 2: Apply dropout in forward pass (training only)

In the training loop, AFTER the existing augmentations but BEFORE standardization (~line 1552-1568), add:

```python
if cfg.dsdf_spatial_dropout > 0.0 and model.training:
    _dsdf_drop_mask = (torch.rand(x.shape[0], x.shape[1], 1, device=x.device) > cfg.dsdf_spatial_dropout).float()
    x[:, :, 2:10] = x[:, :, 2:10] * _dsdf_drop_mask
```

That's it. ~3 lines of code. The mask is [B, N, 1] — same for all 8 DSDF channels per node, different across nodes.

**Important:**
- Apply BEFORE standardization (the standardization will still subtract mean and divide by std, giving non-zero values for dropped nodes. This is fine — the model learns that zero pre-std maps to a specific standardized value, similar to how dropout interacts with batch norm in vision models).
- Do NOT apply during validation/evaluation (the `model.training` guard handles this).
- Do NOT apply to the position channels (0:2) or any non-DSDF features — only channels 2:10.

### Step 3: Run 6 experiments (3 dropout rates × 2 seeds)

Sweep: p = {0.05, 0.10, 0.20}

```bash
# p=0.05, seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/dsdf-drop05-s42" --wandb_group phase6/dsdf-spatial-dropout \
  --dsdf_spatial_dropout 0.05 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15

# p=0.05, seed 73 (same, --seed 73, wandb_name "thorfinn/dsdf-drop05-s73")

# p=0.10, seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/dsdf-drop10-s42" --wandb_group phase6/dsdf-spatial-dropout \
  --dsdf_spatial_dropout 0.10 --seed 42 \
  [... same flags as above ...]

# p=0.10, seed 73 (same, --seed 73)

# p=0.20, seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/dsdf-drop20-s42" --wandb_group phase6/dsdf-spatial-dropout \
  --dsdf_spatial_dropout 0.20 --seed 42 \
  [... same flags as above ...]

# p=0.20, seed 73 (same, --seed 73)
```

**Notes:**
- Do NOT include `--aft_foil_srf_context` (confirmed harmful, removed from baseline).
- DO include `--pcgrad_3way --pcgrad_extreme_pct 0.15` and `--aug_dsdf2_sigma 0.05` (current baseline).
- If you only have 4 GPUs, prioritize p=0.10 and p=0.05 (2 seeds each). Add p=0.20 if time permits.

Report: 2-seed avg for each p value across all 4 metrics + W&B run IDs. Include the epoch-0 sanity check that dropout is actually zeroing DSDF channels (print a few dropped/non-dropped node values).

## Baseline

Current single-model baseline (PR #2119, PCGrad 2-way):

| Metric | 2-seed target |
|--------|--------------|
| p_in   | < 13.20      |
| p_oodc | < 7.91       |
| p_tan  | **< 29.48**  |
| p_re   | < 6.50       |

Baseline W&B: jpe1t13t (s42), cdccuyl7 (s73)

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15
```