### PR TITLE
Input Feature Noise Augmentation — Gaussian Noise on All Input Channels

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1005,6 +1005,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    input_noise_sigma: float = 0.0      # std of Gaussian noise added to standardized input features (0=disabled)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1651,6 +1652,8 @@ for epoch in range(MAX_EPOCHS):
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
         x = (x - stats["x_mean"]) / stats["x_std"]
+        if cfg.input_noise_sigma > 0.0 and model.training:
+            x = x + torch.randn_like(x) * cfg.input_noise_sigma
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         if cfg.foil2_dist:


### PR DESCRIPTION
## Hypothesis

The model processes ~26 input features per mesh node (positions, DSDF channels, curvature, distance-to-surface, etc.). The val_tandem_transfer test evaluates on NACA6416 — an unseen foil shape that produces slightly different feature distributions than the training shapes. Even small distribution shifts in input features can cause disproportionate prediction errors in a well-optimized model.

**Input noise augmentation** adds small Gaussian noise to ALL input features AFTER standardization during training. This is a standard regularization technique (similar to how image models use pixel noise) that:
1. Prevents overfitting to the exact feature values in the training set
2. Smooths the loss landscape in feature space → better generalization
3. Makes the model robust to small distribution shifts in any feature → directly targets the OOD failure mode

This is fundamentally different from DSDF-specific augmentations (which target geometry features only) — it regularizes the ENTIRE input representation. It's also extremely cheap (~2 LoC, zero computational overhead).

**Expected impact:** p_tan -0.5% to -2%. Strongest effect expected on OOD metrics (p_oodc, p_re, p_tan) where input distribution shift is the bottleneck.

## Instructions

### Step 1: Add config flag

```python
# Config dataclass:
input_noise_sigma: float = 0.0  # std of Gaussian noise added to standardized input features
```

```python
# argparse:
parser.add_argument('--input_noise_sigma', type=float, default=0.0,
                    help='Gaussian noise std added to standardized input features during training')
```

### Step 2: Apply noise AFTER standardization

Find the standardization line: `x = (x - stats["x_mean"]) / stats["x_std"]` (~line 1568).

IMMEDIATELY AFTER it, add:

```python
if cfg.input_noise_sigma > 0.0 and model.training:
    x = x + torch.randn_like(x) * cfg.input_noise_sigma
```

That's it. 2 lines of code.

**Important:**
- Apply AFTER standardization — noise magnitude is relative to the standardized features (unit-ish scale)
- The `model.training` guard ensures NO noise during validation/evaluation
- σ=0.01 means ~1% perturbation of each standardized feature per node per sample

### Step 3: Run 6 experiments (3 noise levels × 2 seeds)

Sweep: σ = {0.01, 0.03, 0.05}

```bash
# σ=0.01, seed 42
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/innoise01-s42" --wandb_group phase6/input-noise-aug \
  --input_noise_sigma 0.01 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15

# σ=0.01, seed 73 (same, --seed 73, wandb_name "edward/innoise01-s73")

# σ=0.03, seed 42 (same, --input_noise_sigma 0.03, wandb_name "edward/innoise03-s42")
# σ=0.03, seed 73 (same, --seed 73, wandb_name "edward/innoise03-s73")

# σ=0.05, seed 42 (same, --input_noise_sigma 0.05, wandb_name "edward/innoise05-s42")
# σ=0.05, seed 73 (same, --seed 73, wandb_name "edward/innoise05-s73")
```

**Notes:**
- Do NOT include `--aft_foil_srf_context` (confirmed harmful, removed from baseline)
- DO include `--pcgrad_3way --pcgrad_extreme_pct 0.15` and `--aug_dsdf2_sigma 0.05` (current baseline)
- If limited to 4 GPUs, prioritize σ=0.01 and σ=0.03 (2 seeds each), add σ=0.05 if time permits.

Report: 2-seed avg for each σ value across all 4 metrics + W&B run IDs.

## Baseline

Current single-model baseline (PR #2119, PCGrad 2-way):

| Metric | 2-seed target |
|--------|--------------|
| p_in   | < 13.20      |
| p_oodc | < 7.91       |
| p_tan  | **< 29.48**  |
| p_re   | < 6.50       |

Baseline W&B: jpe1t13t (s42), cdccuyl7 (s73)

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15
```