### PR TITLE
Augmentation Annealing: Linearly Decay Aug Strengths During Training

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1019,6 +1019,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    aug_anneal: float = 1.0             # final aug strength multiplier (1.0=no annealing, 0.0=full decay to zero)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
@@ -1544,6 +1545,15 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
+    # Augmentation annealing: linear decay from 1.0 to cfg.aug_anneal over training
+    if cfg.aug_anneal < 1.0:
+        _aug_scale = 1.0 - (1.0 - cfg.aug_anneal) * (epoch / cfg.cosine_T_max)
+        _aug_scale = max(_aug_scale, cfg.aug_anneal)
+    else:
+        _aug_scale = 1.0
+    if cfg.aug_anneal < 1.0 and epoch in (0, 50, 100, 140, 155):
+        print(f"[Aug anneal] epoch={epoch}, _aug_scale={_aug_scale:.4f}")
+
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
@@ -1632,8 +1642,9 @@ for epoch in range(MAX_EPOCHS):
                 if _is_tandem_aug.any():
                     _B = x.size(0)
                     # Per-sample Gaussian noise, broadcast to all N nodes
-                    _gap_noise  = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma
-                    _stag_noise = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma
+                    _gs_sigma = cfg.aug_gap_stagger_sigma * _aug_scale
+                    _gap_noise  = torch.randn(_B, device=x.device) * _gs_sigma
+                    _stag_noise = torch.randn(_B, device=x.device) * _gs_sigma
                     # Zero out noise for non-tandem samples (preserve single-foil sentinel exactly)
                     _gap_noise  = _gap_noise  * _is_tandem_aug.float()
                     _stag_noise = _stag_noise * _is_tandem_aug.float()
@@ -1647,8 +1658,9 @@ for epoch in range(MAX_EPOCHS):
         if model.training and cfg.aug_dsdf2_sigma > 0.0:
             _is_tandem_aug2 = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero → tandem
             if _is_tandem_aug2.any():
+                _dsdf2_sig = cfg.aug_dsdf2_sigma * _aug_scale
                 _dsdf2_scale = torch.exp(
-                    torch.randn(x.size(0), device=x.device) * cfg.aug_dsdf2_sigma
+                    torch.randn(x.size(0), device=x.device) * _dsdf2_sig
                 )
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()


### PR DESCRIPTION
## Hypothesis

Standard competition ML practice: apply full augmentation early in training for diversity, then reduce augmentation strength in the final phase for fine-tuning on clean data. The model first learns robust features from augmented samples, then refines on the true data distribution.

Currently, augmentation strengths are constant throughout training:
- `--aug_gap_stagger_sigma 0.02` (constant)
- `--aug_dsdf2_sigma 0.05` (constant)
- `--aug aoa_perturb` (constant perturbation)

Late in training (epochs 140-155), the cosine LR is near zero and the EMA is accumulating. At this point, augmentation noise may be HURTING rather than helping — the model is trying to fine-tune but sees noisy data.

**Proposed:** Linearly decay the multiplicative sigma values from 100% at epoch 0 to some fraction at the final epoch. Test two decay targets:
- Config A: decay to 50% (final σ_gs=0.01, σ_dsdf2=0.025)
- Config B: decay to 0% (final σ_gs=0, σ_dsdf2=0) — full annealing

**Expected impact:** p_tan -0.5% to -2%. The model gets both diversity (early) and precision (late).

## Instructions

### Step 1: Add augmentation annealing

In Config:
```python
aug_anneal: float = 1.0  # Final augmentation multiplier (1.0 = no annealing, 0.0 = full decay)
```

In argparse:
```python
parser.add_argument('--aug_anneal', type=float, default=1.0,
                    help='Final aug strength multiplier. Linear decay from 1.0 to this value over training.')
```

### Step 2: Compute annealing factor each epoch

At the start of each training epoch (inside the epoch loop):
```python
if cfg.aug_anneal < 1.0:
    # Linear decay from 1.0 at epoch 0 to cfg.aug_anneal at max_epoch
    _aug_scale = 1.0 - (1.0 - cfg.aug_anneal) * (epoch / cfg.cosine_T_max)
    _aug_scale = max(_aug_scale, cfg.aug_anneal)  # clamp at target
else:
    _aug_scale = 1.0
```

### Step 3: Apply scaling to sigma-based augmentations

In the augmentation block (around line 1542), scale the sigmas:
```python
# Gap/stagger aug
_gs_sigma = cfg.aug_gap_stagger_sigma * _aug_scale
# ... use _gs_sigma instead of cfg.aug_gap_stagger_sigma

# DSDF2 aug
_dsdf2_sigma = cfg.aug_dsdf2_sigma * _aug_scale
# ... use _dsdf2_sigma instead of cfg.aug_dsdf2_sigma
```

**Note:** The `aoa_perturb` augmentation may also benefit from annealing, but start with just the sigma-based augs.

### Step 4: Run experiments — 2 configs × 2 seeds = 4 runs

**Config A: Anneal to 50%** (σ decays from full to half)
```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/aug-anneal50-s42" --wandb_group phase6/aug-annealing \
  --aug_anneal 0.5 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73 (same, --seed 73, wandb_name "nezuko/aug-anneal50-s73")
```

**Config B: Anneal to 0%** (σ decays from full to zero)
```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/aug-anneal0-s42" --wandb_group phase6/aug-annealing \
  --aug_anneal 0.0 --seed 42 \
  [... same baseline flags as above ...]

# Seed 73 (same, --seed 73, wandb_name "nezuko/aug-anneal0-s73")
```

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | W&B |
|--------|------|------|--------|-------|------|-----|
| anneal→50% | 42 | | | | | |
| anneal→50% | 73 | | | | | |
| **anneal→50% avg** | — | | | | | |
| anneal→0% | 42 | | | | | |
| anneal→0% | 73 | | | | | |
| **anneal→0% avg** | — | | | | | |
| **Baseline (no anneal)** | — | 13.05 | 7.70 | 28.60 | 6.55 | d7l91p0x, j9btfx09 |

Also print `_aug_scale` at key epochs (0, 50, 100, 140, 155) to verify annealing is working.

## Baseline

| Metric | 2-seed target |
|--------|--------------|
| p_in   | < 13.05      |
| p_oodc | < 7.70       |
| p_tan  | **< 28.60**  |
| p_re   | < 6.55       |

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```