### PR TITLE
DSDF-1 Channel Dropout: Force Shape-Invariant Tandem Prediction

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1019,6 +1019,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    dsdf1_channel_dropout: float = 0.0  # p(zero out foil-1 DSDF channels) per tandem sample; 0 = off
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
@@ -1653,6 +1654,16 @@ for epoch in range(MAX_EPOCHS):
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
+
+        # Foil-1 DSDF channel dropout (tandem samples only, training only)
+        # Zeros out foil-1 shape channels x[:,:,2:6] to force shape-invariant wake prediction
+        if model.training and cfg.dsdf1_channel_dropout > 0.0:
+            _is_tandem_d1 = (x[:, 0, 22].abs() > 0.01)
+            _drop_mask = torch.rand(x.size(0), device=x.device) < cfg.dsdf1_channel_dropout
+            _tandem_and_drop = _is_tandem_d1 & _drop_mask
+            if _tandem_and_drop.any():
+                x = x.clone()
+                x[_tandem_and_drop, :, 2:6] = 0.0
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

The model currently sees all DSDF channels for both foils during every training step. For tandem samples, foil-1 DSDF channels (x[:,2:6]) encode the exact shape of the fore-foil — giving the model a shortcut: memorize fore-foil shape → predict downstream pressure. This shortcut works well for seen geometries (NACA0012-series) but degrades for unseen ones (NACA6416 in val_tandem_transfer).

**The fix:** During training, randomly zero out the foil-1 DSDF channels (x[:,2:6]) with probability p (applied per-sample, tandem samples only). This forces the model to predict aft-foil pressure even when fore-foil shape info is partially absent — building shape-invariant wake representations grounded in flow physics rather than geometry memorization.

This is inspired by:
1. The success of `--aug_dsdf2_sigma 0.05` (foil-2 DSDF magnitude augmentation, PR #2126) which improved p_tan by corrupting shape info
2. Dropout's proven effectiveness as a regularizer for forcing distributed representations
3. The NACA6416 representation gap: p_tan is the hardest metric because the aft-foil's unseen shape interacts with an equally-unseen fore-foil combination

**Key difference from aug_dsdf2_sigma:** σ scaling corrupts magnitude but preserves direction; channel dropout forces complete zero-shot shape generalization for random training steps. The model must predict aft-foil pressure with zero fore-foil shape information for those samples.

**Expected impact:** -2% to -5% p_tan. Single-foil samples completely unaffected (dropout is tandem-only).

## Instructions

### Step 1 — Add config flag

In `Config` dataclass:
```python
dsdf1_channel_dropout: float = 0.0   # p(zero out foil-1 DSDF channels) per tandem sample; 0 = off
```

### Step 2 — Verify foil-1 DSDF channel indices

Look at the dataset/feature construction code to confirm which feature indices correspond to foil-1 DSDF. Based on PR #2126 (foil-2 DSDF at x[:,6:10]), foil-1 DSDF is likely x[:,2:6]. Confirm before hardcoding.

### Step 3 — Apply dropout in training loop

In the training loop, after the batch is loaded and **before** passing to the model, apply the dropout. Add a `if model.training:` guard so validation is clean:

```python
if cfg.dsdf1_channel_dropout > 0 and model.training:
    # is_tandem: [B] bool tensor (already computed in batch loading)
    drop_mask = torch.rand(x.shape[0], device=x.device) < cfg.dsdf1_channel_dropout
    tandem_and_drop = is_tandem.bool() & drop_mask
    if tandem_and_drop.any():
        x = x.clone()  # avoid in-place modification of the original tensor
        x[tandem_and_drop, 2:6] = 0.0  # adjust indices if needed
```

### Step 4 — Run 3 experiments

Use `--wandb_group phase6/dsdf1-channel-dropout`.

| GPU | Config | wandb_name | Seed |
|-----|--------|-----------|------|
| 0 | p=0.2 | tanjiro/dsdf1-drop-p02-s42 | 42 |
| 1 | p=0.2 | tanjiro/dsdf1-drop-p02-s73 | 73 |
| 2 | p=0.3 | tanjiro/dsdf1-drop-p03-s42 | 42 |

Full command (p=0.2, seed 42):
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/dsdf1-drop-p02-s42" --wandb_group phase6/dsdf1-channel-dropout \
  --dsdf1_channel_dropout 0.2 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```

Repeat with `--seed 73` and `--dsdf1_channel_dropout 0.3 --seed 42`.

**Do NOT override SENPAI_MAX_EPOCHS or SENPAI_TIMEOUT_MINUTES.**

## What to Report

- Surface MAE for all runs: p_in, p_oodc, p_tan, p_re with W&B run IDs
- 2-seed avg for p=0.2 vs baseline
- Does p_in regress? (Should not — single-foil samples unaffected)
- Which foil-1 DSDF indices did you use? (confirm from code inspection)

## Baseline

Current single-model baseline (PR #2130, GSB + PCGrad, 2-seed avg):

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in   | 13.05     | < 13.05        |
| p_oodc | 7.70      | < 7.70         |
| **p_tan** | **28.60** | **< 28.60** |
| p_re   | 6.55      | < 6.55         |

W&B baseline runs: `d7l91p0x` (seed 42, p_tan=28.9), `j9btfx09` (seed 73, p_tan=28.3)

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```