### PR TITLE
Foil Shape Similarity Bias: Extend GSB with Inter-Foil Geometry

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -700,10 +700,12 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        gsb_shape_similarity=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.gsb_shape_similarity = gsb_shape_similarity
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -771,13 +773,13 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
-                    spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    spatial_bias_input_dim=7 if gsb_shape_similarity else (6 if gap_stagger_spatial_bias else 4),
                 )
                 for idx in range(n_layers)
             ]
         )
-        # Zero-init the 2 new input columns of spatial_bias so initial routing is unchanged
-        if gap_stagger_spatial_bias:
+        # Zero-init the new input columns of spatial_bias so initial routing is unchanged
+        if gap_stagger_spatial_bias or gsb_shape_similarity:
             with torch.no_grad():
                 for block in self.blocks:
                     block.spatial_bias[0].weight[:, 4:].zero_()
@@ -882,9 +884,20 @@ class Transolver(nn.Module):
             new_pos = self.get_grid(pos)
             x = torch.cat((x, new_pos), dim=-1)
 
+        # Compute inter-foil shape similarity before feature_cross modifies x
+        if self.gsb_shape_similarity:
+            # foil-1 DSDF: x[:,:,2:6], foil-2 DSDF: x[:,:,6:10] (standardized)
+            dsdf1_mean = x[:, :, 2:6].mean(dim=1)   # [B, 4]
+            dsdf2_mean = x[:, :, 6:10].mean(dim=1)   # [B, 4]
+            shape_sim = torch.nn.functional.cosine_similarity(dsdf1_mean, dsdf2_mean, dim=-1, eps=1e-8)  # [B]
+
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        if self.gap_stagger_spatial_bias:
+        if self.gsb_shape_similarity:
+            gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)  # [B, N, 2]
+            shape_sim_feat = shape_sim[:, None, None].expand(-1, x.shape[1], 1)  # [B, N, 1]
+            raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger, shape_sim_feat], dim=-1)  # [B, N, 7]
+        elif self.gap_stagger_spatial_bias:
             # Gap (idx 22) and stagger (idx 23) are global per-sample scalars; broadcast to all nodes
             gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)  # [B, N, 2]
             raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger], dim=-1)  # [B, N, 6]
@@ -1020,6 +1033,7 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    gsb_shape_similarity: bool = False     # extend GSB from 6D to 7D with inter-foil DSDF shape similarity
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1230,6 +1244,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    gsb_shape_similarity=cfg.gsb_shape_similarity,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

The Gap/Stagger Spatial Bias (GSB, PR #2130) conditions slice routing on (gap, stagger) scalars — tandem **arrangement** geometry. But it knows nothing about **foil shape similarity**. When two foils are geometrically similar (both NACA0012-like), tandem wake interaction differs fundamentally from a dissimilar pair (NACA0012 fore + NACA6416 aft). The val_tandem_transfer split specifically tests this dissimilar-geometry case.

**The fix:** Extend the GSB's `raw_xy` tensor from 6D to 7D by appending a scalar measuring the shape similarity between foil-1 and foil-2 DSDF representations. This scalar tells the spatial_bias MLP: "these two foils are [similar / different]," enabling geometry-type-conditioned slice routing.

**Why this helps p_tan specifically:** p_tan = val_tandem_transfer = NACA6416 aft foil with unseen shape. With shape-similarity conditioning, the routing network can learn: "low similarity → activate tandem-specialization slices more aggressively; high similarity → rely on standard wake physics." This is exactly the discrimination needed.

**Why it won't hurt:** Zero-initialization of the new input column's weights ensures training starts from the IDENTICAL baseline as the current model. No regression risk on p_in, p_oodc.

**Implementation cost:** ~30 lines. Pure additive.

## Instructions

### Step 1 — Compute inter-foil shape similarity scalar

In the dataset or feature construction code, compute a scalar measuring how similar foil-1 and foil-2 DSDF vectors are. Two options (pick whichever is simpler given the code structure):

**Option A — per-sample cosine similarity of DSDF means:**
```python
# Assume foil-1 DSDF channels: x[:, 2:6], foil-2 DSDF channels: x[:, 6:10]
# x shape: [B, N, F] or [N, F] depending on batching

# Mean over nodes for each DSDF channel
dsdf1_mean = x[..., 2:6].mean(dim=-2)   # [B, 4] or [4]
dsdf2_mean = x[..., 6:10].mean(dim=-2)  # [B, 4] or [4]

# Cosine similarity between the two DSDF vectors
cos_sim = F.cosine_similarity(dsdf1_mean, dsdf2_mean, dim=-1, eps=1e-8)  # [B] or scalar
```

**Option B — L2 distance between DSDF magnitude means (simpler):**
```python
dsdf1_mag = x[..., 2:6].norm(dim=-1).mean(dim=-2)  # [B] or scalar
dsdf2_mag = x[..., 6:10].norm(dim=-1).mean(dim=-2)
shape_diff = (dsdf1_mag - dsdf2_mag).abs()  # absolute difference in mean DSDF magnitude
```

Use whichever approach integrates cleanly with the existing feature pipeline. The key requirement: it's a scalar (or [B, 1]) that can be appended to the existing GSB raw_xy vector.

### Step 2 — Extend GSB raw_xy

Find where `gap_stagger_spatial_bias` builds its `raw_xy` tensor. Currently it constructs a 6D vector from existing spatial coordinates + (gap, stagger). Append the shape similarity scalar:

```python
# Before (6D):
raw_xy = torch.cat([..., gap_scalar, stagger_scalar], dim=-1)  # [B, N, 6]

# After (7D):
shape_sim = cos_sim[:, None, None].expand_as(raw_xy[..., :1])  # broadcast to [B, N, 1]
raw_xy = torch.cat([..., gap_scalar, stagger_scalar, shape_sim], dim=-1)  # [B, N, 7]
```

### Step 3 — Zero-init the new weight column

The GSB spatial_bias MLP takes `raw_xy` as input (6D currently). After extending to 7D, the new weight column must be zero-initialized to preserve training start from baseline:

```python
# Find the first linear layer of the spatial_bias MLP
# Extend its weight matrix: [out_features, 6] → [out_features, 7]
# with the new column initialized to zeros

old_weight = spatial_bias_mlp.fc1.weight.data  # [out_features, 6]
new_col = torch.zeros(old_weight.shape[0], 1, device=old_weight.device)
spatial_bias_mlp.fc1.weight.data = torch.cat([old_weight, new_col], dim=1)

# Similarly extend input_size in the MLP definition from 6 to 7
```

Add a config flag:
```python
gsb_shape_similarity: bool = False   # extend GSB from 6D to 7D with inter-foil shape sim
```

### Step 4 — Run 2 seeds

Use `--wandb_group phase6/foil-shape-similarity-bias`.

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/fssb-s42" --wandb_group phase6/foil-shape-similarity-bias \
  --gsb_shape_similarity --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/fssb-s73" --wandb_group phase6/foil-shape-similarity-bias \
  --gsb_shape_similarity --seed 73 \
  [same flags as above]
```

**Do NOT override SENPAI_MAX_EPOCHS or SENPAI_TIMEOUT_MINUTES.**

## What to Report

- Surface MAE: p_in, p_oodc, p_tan, p_re for both seeds + 2-seed mean, with W&B run IDs
- Which similarity metric did you use (cosine similarity or L2 distance)?
- Does the shape_sim scalar vary meaningfully across the dataset? (Log the range/distribution for a few batches)
- Any training instability at epoch 0? (Should be zero if zero-init is correct)

## Baseline

Current single-model baseline (PR #2130, GSB + PCGrad, 2-seed avg):

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in   | 13.05     | < 13.05        |
| p_oodc | 7.70      | < 7.70         |
| **p_tan** | **28.60** | **< 28.60** |
| p_re   | 6.55      | < 6.55         |

W&B baseline runs: `d7l91p0x` (seed 42, p_tan=28.9), `j9btfx09` (seed 73, p_tan=28.3)

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```