### PR TITLE
Asymmetric PCGrad: Protect In-Dist Gradients, Project OOD Only

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1070,6 +1070,7 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    pcgrad_asymmetric: bool = False         # asymmetric projection: only project OOD grad, preserve in-dist
 
 
 cfg = sp.parse(Config)
@@ -2003,7 +2004,11 @@ for epoch in range(MAX_EPOCHS):
                 elif gb is None:
                     p.grad = ga
                 elif dot_ab < 0:
-                    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
+                    if cfg.pcgrad_asymmetric:
+                        gb_proj = gb - (dot_ab / ga_ns) * ga
+                        p.grad = (ga + gb_proj) * 0.5
+                    else:
+                        p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
                 else:
                     p.grad = (ga + gb) * 0.5
         elif cfg.pcgrad_3way and is_tandem_batch.any() and (~is_tandem_batch).any():


### PR DESCRIPTION
## Hypothesis

The current 2-way PCGrad baseline (PR #2130) uses **symmetric** gradient surgery: when in-dist gradients (g_A) and OOD gradients (g_B) conflict, BOTH are projected to remove the conflicting component. This means even the in-dist gradient gets modified when it conflicts with OOD — sacrificing in-dist accuracy for the sake of balance.

**Asymmetric PCGrad** inverts this: only project g_B (OOD) onto the normal plane of g_A (in-dist). The in-dist gradient is never touched. This matches our actual problem structure: in-dist (p_in, p_oodc, p_re) is the anchor task; OOD tandem transfer (p_tan) is the adapting task that should learn without destabilizing the anchor.

**Expected impact:** -1% to -3% across OOD metrics (p_oodc, p_tan, p_re) while holding or improving p_in. The symmetry change is a 3-line code modification inside the existing PCGrad block.

**Why not tried before:** Previous PCGrad experiments (#2147) changed the task grouping (3-way vs 2-way). This changes the *projection direction* within the existing 2-way setup — a fundamentally different axis.

## Instructions

### Code change: `cfd_tandemfoil/train.py`

**Step 1: Add config flag** (~line 950 in the config dataclass):
```python
pcgrad_asymmetric: bool = False
```

**Step 2: Modify the PCGrad projection block** (~lines 1996-2010, inside the per-parameter loop where `dot_ab < 0`).

Find the current symmetric block:
```python
elif dot_ab < 0:
    p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
else:
    p.grad = (ga + gb) * 0.5
```

Change it to:
```python
elif dot_ab < 0:
    if cfg.pcgrad_asymmetric:
        # ASYMMETRIC: only project g_B (OOD) onto normal plane of g_A (in-dist)
        # g_A is preserved; g_B has its g_A-conflicting component removed
        gb_proj = gb - (dot_ab / ga_ns) * ga
        p.grad = (ga + gb_proj) * 0.5
    else:
        # SYMMETRIC (original): both gradients projected
        p.grad = ((ga - (dot_ab / gb_ns) * gb) + (gb - (dot_ab / ga_ns) * ga)) * 0.5
else:
    p.grad = (ga + gb) * 0.5
```

**Step 3: Wire the flag** — Add `--pcgrad_asymmetric` as a `store_true` argparse flag and pass it through to cfg.

**Step 4: Run 2 seeds:**

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/asymmetric-pcgrad-s42" --wandb_group phase6/asymmetric-pcgrad \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --pcgrad_asymmetric

# Seed 73 (same flags, --seed 73, --wandb_name "edward/asymmetric-pcgrad-s73")
```

### Important implementation note

The `ga_ns = (ga_flat @ ga_flat).item()` in the current code is the GLOBAL gradient norm squared (computed once outside the per-parameter loop). The asymmetric formula uses `ga_ns` as the denominator — use the same pre-computed value.

For single-foil samples where only one task gradient exists (g_B is zero), the `dot_ab < 0` branch will not fire — behavior is identical to the symmetric baseline for single-foil batches.

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | W&B |
|--------|------|------|--------|-------|------|-----|
| asymmetric-pcgrad | 42 | | | | | |
| asymmetric-pcgrad | 73 | | | | | |
| **avg** | — | | | | | |
| **Baseline (symmetric, lr=2e-4)** | — | 13.05 | 7.70 | 28.60 | 6.55 | d7l91p0x, j9btfx09 |

Also report: did p_in hold steady or improve vs baseline? (key signal that asymmetric projection is working correctly)

## Baseline

Current baseline (PR #2130, GSB + PCGrad symmetric, lr=2e-4, 2-seed avg):

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| p_in   | 13.05     | < 13.05 |
| p_oodc | 7.70      | < 7.70  |
| **p_tan** | **28.60** | **< 28.60** |
| p_re   | 6.55      | < 6.55  |

W&B: d7l91p0x (seed 42), j9btfx09 (seed 73)

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```