### PR TITLE
Tandem Cross-DSDF Features: Per-Node Inter-Foil Geometry

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1070,6 +1070,8 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Tandem Cross-DSDF features — per-node inter-foil geometry scalars
+    tandem_cross_dsdf: bool = False         # append dsdf_dist_ratio and dsdf_rel_angle as per-node features
 
 
 cfg = sp.parse(Config)
@@ -1200,7 +1202,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32 + (2 if cfg.tandem_cross_dsdf else 0),  # +curv, +dist, [+foil2dist], +32 fourier PE, [+2 cross-dsdf]
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1666,6 +1668,19 @@ for epoch in range(MAX_EPOCHS):
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+        # Cross-DSDF features: per-node inter-foil geometry (computed from raw x before standardization)
+        # foil-1 DSDF: x[:,:,2:6]; foil-2 DSDF: x[:,:,6:10]
+        if cfg.tandem_cross_dsdf:
+            _tandem_mask_f = (x[:, 0, 22].abs() > 0.01).float().view(-1, 1, 1)  # [B,1,1]
+            _dsdf1_min = x[:, :, 2:6].abs().min(dim=-1, keepdim=True).values  # [B,N,1]
+            _dsdf2_min = x[:, :, 6:10].abs().min(dim=-1, keepdim=True).values  # [B,N,1]
+            _dist_ratio = _dsdf2_min / (_dsdf1_min + _dsdf2_min + 1e-4)  # [B,N,1] in [0,1]
+            _dsdf1_angle = torch.atan2(x[:, :, 3:4], x[:, :, 2:3])  # foil-1 DSDF gradient angle
+            _dsdf2_angle = torch.atan2(x[:, :, 7:8], x[:, :, 6:7])  # foil-2 DSDF gradient angle
+            _rel_angle = _dsdf2_angle - _dsdf1_angle  # [B,N,1] in ~[-pi, pi]
+            # Zero out for non-tandem samples
+            _dist_ratio = _dist_ratio * _tandem_mask_f
+            _rel_angle = _rel_angle * _tandem_mask_f
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1674,6 +1689,8 @@ for epoch in range(MAX_EPOCHS):
             x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
         else:
             x = torch.cat([x, curv, dist_feat], dim=-1)
+        if cfg.tandem_cross_dsdf:
+            x = torch.cat([x, _dist_ratio, _rel_angle], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2153,7 +2170,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _wlog = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.tandem_cross_dsdf and global_step % 50 == 1 and is_tandem_batch.any():
+            _wlog["train/cross_dsdf_dist_ratio_mean"] = _dist_ratio[is_tandem_batch].mean().item()
+            _wlog["train/cross_dsdf_rel_angle_mean_abs"] = _rel_angle[is_tandem_batch].abs().mean().item()
+        wandb.log(_wlog)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -2303,6 +2324,14 @@ for epoch in range(MAX_EPOCHS):
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
                     _v_gap_stagger = x[:, 0, 22:24]  # [B, 2]
+                if cfg.tandem_cross_dsdf:
+                    _v_tandem_mask_f = (x[:, 0, 22].abs() > 0.01).float().view(-1, 1, 1)
+                    _v_dsdf1_min = x[:, :, 2:6].abs().min(dim=-1, keepdim=True).values
+                    _v_dsdf2_min = x[:, :, 6:10].abs().min(dim=-1, keepdim=True).values
+                    _v_dist_ratio = _v_dsdf2_min / (_v_dsdf1_min + _v_dsdf2_min + 1e-4) * _v_tandem_mask_f
+                    _v_dsdf1_angle = torch.atan2(x[:, :, 3:4], x[:, :, 2:3])
+                    _v_dsdf2_angle = torch.atan2(x[:, :, 7:8], x[:, :, 6:7])
+                    _v_rel_angle = ((_v_dsdf2_angle - _v_dsdf1_angle) * _v_tandem_mask_f)
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -2311,6 +2340,8 @@ for epoch in range(MAX_EPOCHS):
                     x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
                 else:
                     x = torch.cat([x, curv, dist_feat], dim=-1)
+                if cfg.tandem_cross_dsdf:
+                    x = torch.cat([x, _v_dist_ratio, _v_rel_angle], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2694,9 +2725,23 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
+                    if cfg.tandem_cross_dsdf:
+                        _vis_tandem_f = (x_dev[:, 0, 22].abs() > 0.01).float().view(-1, 1, 1)
+                        _vis_dsdf1_min = x_dev[:, :, 2:6].abs().min(dim=-1, keepdim=True).values
+                        _vis_dsdf2_min = x_dev[:, :, 6:10].abs().min(dim=-1, keepdim=True).values
+                        _vis_dist_ratio = _vis_dsdf2_min / (_vis_dsdf1_min + _vis_dsdf2_min + 1e-4) * _vis_tandem_f
+                        _vis_dsdf1_angle = torch.atan2(x_dev[:, :, 3:4], x_dev[:, :, 2:3])
+                        _vis_dsdf2_angle = torch.atan2(x_dev[:, :, 7:8], x_dev[:, :, 6:7])
+                        _vis_rel_angle = (_vis_dsdf2_angle - _vis_dsdf1_angle) * _vis_tandem_f
                     x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                     curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                    x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                    if cfg.foil2_dist:
+                        foil2_dist_feat = torch.log1p(raw_dsdf[:, :, 4:8].abs().min(dim=-1, keepdim=True).values * 10.0)
+                        x_n = torch.cat([x_n, curv, dist_feat, foil2_dist_feat], dim=-1)
+                    else:
+                        x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                    if cfg.tandem_cross_dsdf:
+                        x_n = torch.cat([x_n, _vis_dist_ratio, _vis_rel_angle], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
@@ -2791,6 +2836,14 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
+                    if cfg.tandem_cross_dsdf:
+                        _vr_tandem_f = (x[:, 0, 22].abs() > 0.01).float().view(-1, 1, 1)
+                        _vr_dsdf1_min = x[:, :, 2:6].abs().min(dim=-1, keepdim=True).values
+                        _vr_dsdf2_min = x[:, :, 6:10].abs().min(dim=-1, keepdim=True).values
+                        _vr_dist_ratio = _vr_dsdf2_min / (_vr_dsdf1_min + _vr_dsdf2_min + 1e-4) * _vr_tandem_f
+                        _vr_dsdf1_angle = torch.atan2(x[:, :, 3:4], x[:, :, 2:3])
+                        _vr_dsdf2_angle = torch.atan2(x[:, :, 7:8], x[:, :, 6:7])
+                        _vr_rel_angle = (_vr_dsdf2_angle - _vr_dsdf1_angle) * _vr_tandem_f
                     x = (x - stats["x_mean"]) / stats["x_std"]
                     curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                     if cfg.foil2_dist:
@@ -2798,6 +2851,8 @@ if cfg.surface_refine and best_metrics:
                         x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
                     else:
                         x = torch.cat([x, curv, dist_feat], dim=-1)
+                    if cfg.tandem_cross_dsdf:
+                        x = torch.cat([x, _vr_dist_ratio, _vr_rel_angle], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)

--- a/research/EXPERIMENT_ASKELADD_CROSS_DSDF.md
+++ b/research/EXPERIMENT_ASKELADD_CROSS_DSDF.md
@@ -1,0 +1,7 @@
+# Experiment: Tandem Cross-DSDF Features
+
+Student: askeladd
+Branch: askeladd/tandem-cross-dsdf-features
+Slug: tandem-cross-dsdf-features
+
+See PR body for full hypothesis and instructions.


### PR DESCRIPTION
## Hypothesis

The Gap-Stagger Spatial Bias (PR #2130, -3.0% p_tan) injects gap and stagger as **global** scalars into slice routing. But these describe the tandem configuration globally — not the **per-node** relationship of each mesh point to each foil.

Adding two explicit per-node inter-foil geometry features lets every node know its local position relative to both foils:
1. **dsdf_dist_ratio** = `dsdf2_min / (dsdf1_min + dsdf2_min + ε)` — ranges [0,1], encodes how much a node is in foil-2's neighborhood vs foil-1's. Nodes in the inter-foil channel will have intermediate values; nodes near aft-foil surface will approach 1.
2. **dsdf_rel_angle** = `atan2(dsdf2_gy, dsdf2_gx) - atan2(dsdf1_gy, dsdf1_gx)` — angular difference between the SDF gradient directions of the two foils, encoding their local geometric relationship.

These features are zero for non-tandem (single-foil) samples. They are physically motivated: pressure in the inter-foil channel depends on how close each point is to each foil and how their surfaces align — exactly what these features encode.

## Instructions

### Step 1: Add feature computation before standardization

In the training loop, just after extracting `_raw_gap_stagger` and BEFORE the `x = (x - stats["x_mean"]) / stats["x_std"]` standardization line, add:

```python
if cfg.tandem_cross_dsdf:
    # DSDF minimum magnitudes per foil: channels 2:6 (foil-1), 6:10 (foil-2)
    _dsdf1_min = x[:, :, 2:6].abs().min(dim=-1, keepdim=True).values   # [B, N, 1]
    _dsdf2_min = x[:, :, 6:10].abs().min(dim=-1, keepdim=True).values  # [B, N, 1]
    
    # dist_ratio: relative proximity to foil-2 vs foil-1 (0=near foil-1, 1=near foil-2)
    _dist_ratio = _dsdf2_min / (_dsdf1_min + _dsdf2_min + 1e-4)  # [B, N, 1]
    
    # Gradient direction difference: atan2(dsdf_y, dsdf_x) for each foil
    # Using first two gradient channels: col 2,3 for foil-1; col 6,7 for foil-2
    _dsdf1_angle = torch.atan2(x[:, :, 3:4], x[:, :, 2:3])  # [B, N, 1]
    _dsdf2_angle = torch.atan2(x[:, :, 7:8], x[:, :, 6:7])  # [B, N, 1]
    _rel_angle = _dsdf2_angle - _dsdf1_angle                 # [B, N, 1], range ≈[-pi, pi]
    
    # Zero out for non-tandem samples (gap=stagger=0)
    _tandem_mask = (x[:, 0, 22].abs() > 0.01).float().view(-1, 1, 1)  # [B, 1, 1]
    _dist_ratio = _dist_ratio * _tandem_mask
    _rel_angle  = _rel_angle  * _tandem_mask
    
    # Append to x — increases X_DIM from 24 to 26
    x = torch.cat([x, _dist_ratio, _rel_angle], dim=-1)  # [B, N, 26]
```

### Step 2: Handle input dimension change for the model

The model is constructed from `x.shape[-1]` (the `fun_dim`). Since this is computed at runtime, you need to ensure the model sees X_DIM=26 when `--tandem_cross_dsdf` is set.

**Option A (simpler):** Move the feature computation to BEFORE model construction, so when `fun_dim = x.shape[-1]` is computed, it already sees 26 dims. Compute on the first batch at model construction time.

**Option B:** Hard-code the dim offset: if `cfg.tandem_cross_dsdf`, `fun_dim += 2`.

Also update `stats["x_mean"]` and `stats["x_std"]` to accommodate the new channels. Append zeros to `x_mean` and ones to `x_std` for the 2 new channels so they pass through standardization unchanged (already in [0,1] and [-pi,pi] respectively).

```python
if cfg.tandem_cross_dsdf:
    stats["x_mean"] = torch.cat([stats["x_mean"], torch.zeros(2, device=device)])
    stats["x_std"]  = torch.cat([stats["x_std"],  torch.ones(2, device=device)])
```

### Step 3: Add config flag

```python
# Config dataclass:
tandem_cross_dsdf: bool = False

# argparse:
parser.add_argument('--tandem_cross_dsdf', action='store_true',
                    help='Add per-node dist_ratio and rel_angle cross-DSDF features for tandem.')
```

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent askeladd \
  --wandb_name "askeladd/cross-dsdf-s42" --wandb_group phase6/tandem-cross-dsdf \
  --tandem_cross_dsdf --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73: same flags, --seed 73, wandb_name "askeladd/cross-dsdf-s73"
```

Also log `_dist_ratio.mean()` and `_rel_angle.mean()` at epoch 1 to confirm features are non-zero on tandem samples.

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | W&B |
|--------|------|------|--------|-------|------|-----|
| cross-dsdf | 42 | | | | | |
| cross-dsdf | 73 | | | | | |
| **avg** | — | | | | | |
| **Baseline** | — | 13.05 | 7.70 | 28.60 | 6.55 | d7l91p0x, j9btfx09 |

## Baseline

| Metric | Target |
|--------|--------|
| p_in   | < 13.05 |
| p_oodc | < 7.70  |
| **p_tan** | **< 28.60** |
| p_re   | < 6.55  |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```