### PR TITLE
Differential LR: Boost Specialized Heads (aft_srf, surface_refine, GSB)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1020,6 +1020,7 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    head_lr_mult: float = 1.0  # LR multiplier for specialized heads (aft_srf, surface_refine, GSB spatial_bias). 1.0=no change
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1424,20 +1425,24 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+_boost_keywords = ['spatial_bias']
+backbone_attn = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale']) and not any(k in n for k in _boost_keywords)]
+backbone_gsb  = [p for n, p in model.named_parameters() if 'spatial_bias' in n]
+other_params  = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
 _base_lr = cfg.two_phase_lr_1 if cfg.two_phase_lr else cfg.lr
+_head_lr = _base_lr * cfg.head_lr_mult
+_param_groups = [
+    {'params': backbone_attn, 'lr': _base_lr * 0.5},
+    {'params': other_params, 'lr': _base_lr},
+    {'params': backbone_gsb, 'lr': _head_lr},
+]
+if cfg.head_lr_mult != 1.0:
+    print(f"[Differential LR] backbone_attn: {_base_lr*0.5:.1e}, backbone_other: {_base_lr:.1e}, GSB spatial_bias: {_head_lr:.1e} (mult={cfg.head_lr_mult}x)")
 if cfg.use_lion:
-    base_opt = Lion([
-        {'params': attn_params, 'lr': _base_lr * 0.5},
-        {'params': other_params, 'lr': _base_lr}
-    ], weight_decay=cfg.weight_decay)
+    base_opt = Lion(_param_groups, weight_decay=cfg.weight_decay)
     optimizer = base_opt  # Lion has its own momentum; skip Lookahead
 else:
-    base_opt = torch.optim.AdamW([
-        {'params': attn_params, 'lr': _base_lr * 0.5},
-        {'params': other_params, 'lr': _base_lr}
-    ], weight_decay=cfg.weight_decay)
+    base_opt = torch.optim.AdamW(_param_groups, weight_decay=cfg.weight_decay)
     if cfg.use_lookahead:
         optimizer = Lookahead(base_opt, k=10, alpha=0.8)
     else:
@@ -1446,18 +1451,18 @@ else:
 # Add refinement head params to optimizer if enabled
 if refine_head is not None:
     _refine_params = list(refine_head.parameters())
-    base_opt.add_param_group({'params': _refine_params, 'lr': _base_lr})
-    print(f"Added {sum(p.numel() for p in _refine_params):,} refinement head params to optimizer")
+    base_opt.add_param_group({'params': _refine_params, 'lr': _head_lr})
+    print(f"Added {sum(p.numel() for p in _refine_params):,} refinement head params to optimizer (lr={_head_lr:.1e})")
 
 # Add aft-foil SRF head params to optimizer if enabled
 if aft_srf_head is not None:
     _aft_params = list(aft_srf_head.parameters())
-    base_opt.add_param_group({'params': _aft_params, 'lr': _base_lr})
-    print(f"Added {sum(p.numel() for p in _aft_params):,} aft-foil SRF head params to optimizer")
+    base_opt.add_param_group({'params': _aft_params, 'lr': _head_lr})
+    print(f"Added {sum(p.numel() for p in _aft_params):,} aft-foil SRF head params to optimizer (lr={_head_lr:.1e})")
 if aft_srf_ctx_head is not None:
     _ctx_params = list(aft_srf_ctx_head.parameters())
-    base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
-    print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
+    base_opt.add_param_group({'params': _ctx_params, 'lr': _head_lr})
+    print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer (lr={_head_lr:.1e})")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":

--- a/research/EXPERIMENT_NEZUKO_DIFF_LR.md
+++ b/research/EXPERIMENT_NEZUKO_DIFF_LR.md
@@ -1,0 +1,7 @@
+# Experiment: Differential Learning Rates for Specialized Heads
+
+Student: nezuko
+Branch: nezuko/differential-lr-specialized-heads
+Slug: differential-lr-specialized-heads
+
+See PR body for full hypothesis and instructions.


### PR DESCRIPTION
## Hypothesis

The specialized correction heads (aft-foil SRF, surface refinement, Gap-Stagger Spatial Bias MLP) were added to a baseline with globally tuned LR=2e-4. These heads are zero-initialized — they start inert and must "wake up" during training. With the default LR, they receive the same update magnitude as the backbone, but they are starting from zero while the backbone starts from a pre-converged state (from cosine warmup).

**Theoretical motivation:** Standard transfer learning / fine-tuning practice applies higher LR to newly added layers vs frozen backbone. Here the backbone isn't frozen, but the specialized heads are at a structural disadvantage: they need to learn task-specific patterns (fore/aft surface corrections, geometry routing) on top of an already-tuned backbone. A 2x-3x LR boost gives them the gradient signal needed to converge faster within the 160-epoch budget.

**Specific mechanism:** The GSB spatial bias MLP currently lives in the `attn_params` group (LR = 1e-4 = base_lr * 0.5 for the attention group). This is HALF the effective LR vs the backbone — the GSB params are being under-trained. Raising GSB params to `base_lr * 2.0` = 4e-4 may unlock further gains from the mechanism that just delivered -3.0% p_tan.

## Instructions

### Step 1: Restructure optimizer parameter groups

Locate the optimizer setup in train.py (search for `attn_params`, `Lion([`). The current structure uses two groups: `attn_params` (lr * 0.5) and `other_params` (lr * 1.0).

**Change 1:** Extract `spatial_bias` params from `attn_params` into a new boosted group.
**Change 2:** Add surface_refine and aft_srf head params into the same boosted group.

```python
# Current (approximate):
attn_params  = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
other_params = [p for n, p in model.named_parameters() if p not in set(attn_params)]

# NEW:
_boost_keywords = ['spatial_bias']  # GSB MLP params get boosted LR
backbone_attn  = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale']) and not any(k in n for k in _boost_keywords)]
backbone_other = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
backbone_gsb   = [p for n, p in model.named_parameters() if 'spatial_bias' in n]

_head_lr_mult = cfg.head_lr_mult  # new config flag, default=2.0

base_opt = Lion([
    {'params': backbone_attn,  'lr': _base_lr * 0.5},
    {'params': backbone_other, 'lr': _base_lr},
    {'params': backbone_gsb,   'lr': _base_lr * _head_lr_mult},  # boosted
], weight_decay=cfg.weight_decay)
```

**Change 3:** When adding surface_refine and aft_srf head params to the optimizer (search for `add_param_group`), use the boosted LR:

```python
# For surface_refine head:
base_opt.add_param_group({'params': list(surface_refine_head.parameters()), 'lr': _base_lr * _head_lr_mult})

# For aft_srf head:
base_opt.add_param_group({'params': list(aft_srf_head.parameters()), 'lr': _base_lr * _head_lr_mult})
```

### Step 2: Add config flag

```python
# Config dataclass:
head_lr_mult: float = 1.0  # default 1.0 = no change

# argparse:
parser.add_argument('--head_lr_mult', type=float, default=1.0,
                    help='LR multiplier for specialized heads (aft_srf, surface_refine, GSB). Default=1.0 (no change).')
```

### Step 3: Run 3 configs × 1-2 seeds

Test two multiplier values to find the sweet spot:

```bash
# Config A: head_lr_mult=2.0, seed 42
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/head-lr2-s42" --wandb_group phase6/differential-lr \
  --head_lr_mult 2.0 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Config A: seed 73 (same, --seed 73, wandb_name "nezuko/head-lr2-s73")

# Config B: head_lr_mult=3.0, seed 42
# (same flags, --head_lr_mult 3.0, wandb_name "nezuko/head-lr3-s42")

# Config B: seed 73 (same, --seed 73, wandb_name "nezuko/head-lr3-s73")
```

If head_lr_mult=2.0 shows clear improvement, that's the winner; if it also helps at 3.0, report both. If 2.0 regresses, try 1.5 as a fallback.

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | W&B |
|--------|------|------|--------|-------|------|-----|
| mult=2.0 | 42 | | | | | |
| mult=2.0 | 73 | | | | | |
| **mult=2.0 avg** | — | | | | | |
| mult=3.0 | 42 | | | | | |
| mult=3.0 | 73 | | | | | |
| **mult=3.0 avg** | — | | | | | |
| **Baseline** | — | 13.05 | 7.70 | 28.60 | 6.55 | d7l91p0x, j9btfx09 |

Also confirm the parameter groups are set up correctly by logging the LR for each group at epoch 1.

## Baseline

| Metric | Target |
|--------|--------|
| p_in   | < 13.05 |
| p_oodc | < 7.70  |
| **p_tan** | **< 28.60** |
| p_re   | < 6.55  |

W&B baseline: d7l91p0x (s42), j9btfx09 (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```