### PR TITLE
Backbone Gap/Stagger AdaLN: Thread Tandem Geometry Into All Blocks

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -858,10 +858,9 @@ class Transolver(nn.Module):
         if use_cond:
             cond_2 = x[:, 0, 13:15]  # Re, AoA [B, 2]
             if self.adaln_4cond:
-                gap_feat = x[:, 0, 21:22]  # gap feature [B, 1]
-                # surf_frac: fraction of nodes near a surface (curvature at index 24)
-                surf_frac = (x[:, :, 24].abs() > 0.01).float().mean(dim=1, keepdim=True)  # [B, 1]
-                block_condition = torch.cat([cond_2, gap_feat, surf_frac], dim=-1)  # [B, 4]
+                # Use gap and stagger (indices 22:24) — same global tandem-geometry scalars used by GSB
+                gap_stagger = x[:, 0, 22:24]  # [B, 2] — gap and stagger; both 0 for single-foil
+                block_condition = torch.cat([cond_2, gap_stagger], dim=-1)  # [B, 4] = (Re, AoA, gap, stagger)
             else:
                 block_condition = cond_2  # [B, 2]
         else:
@@ -981,7 +980,7 @@ class Config:
     # Phase 2 R4: AdaLN-Zero all blocks
     n_hidden: int = 192                # model width (override default)
     adaln_all_blocks: bool = False     # AdaLN-Zero on ALL TransolverBlocks
-    adaln_4cond: bool = False          # use 4-dim condition (Re, AoA, gap, surf_frac)
+    adaln_4cond: bool = False          # use 4-dim condition (Re, AoA, gap, stagger)
     adaln_decouple: bool = False       # decoupled slice assignment for tandem
     adaln_nozero: bool = False         # ablation: no zero-init on adaln projection
     adaln_sam: bool = False            # SAM optimizer in last 25% of training

--- a/research/EXPERIMENT_FRIEREN_BACKBONE_GS_ADALN.md
+++ b/research/EXPERIMENT_FRIEREN_BACKBONE_GS_ADALN.md
@@ -1,0 +1,7 @@
+# Experiment: Backbone-Wide Gap/Stagger AdaLN Conditioning
+
+Student: frieren
+Branch: frieren/backbone-gs-adaln
+Slug: backbone-gs-adaln
+
+See PR body for full hypothesis and instructions.


### PR DESCRIPTION
## Hypothesis

The gap and stagger scalars (tandem foil spacing and offset) are currently only available to the LAST TransolverBlock via `adaln_output` conditioning with (Re, AoA). **None of the backbone TransolverBlocks know they are processing a tandem configuration or what the gap/stagger is.** The slice assignment (which mesh nodes get grouped into which physics slice) is the core computational primitive — and for tandem foils, the inter-foil gap changes the pressure coupling length scale. Nodes near the gap should attend to different neighbors depending on gap width.

The infrastructure for conditioning ALL blocks already exists via `adaln_all_blocks=True`, which creates an `adaln_net` in every TransolverBlock that modulates both pre-attention and pre-MLP LayerNorm via AdaLN-Zero (scale+bias, zero-initialized so training starts as the unconditioned baseline). Currently this path uses only (Re, AoA) as condition. By changing the condition to include gap and stagger, every block's attention routing becomes tandem-geometry-aware from layer 1.

**Why this is different from GSB (PR #2130):** GSB injects gap/stagger into the `spatial_bias` MLP that feeds the attention scores. This gives the attention *keys* access to geometry, but not the *queries* or *values*, and only through a single scalar bias per head. AdaLN-All conditions the ENTIRE residual stream (both attention and FFN sublayers) by modulating the LayerNorm, which affects all dimensions of all attention heads simultaneously. The two mechanisms are complementary — GSB does per-head routing adjustment, AdaLN does global representation modulation.

**This is a bold structural change** — it adds new trainable parameters to all 3 backbone blocks and fundamentally changes how information flows through the model for tandem vs single-foil samples.

## Instructions

### Step 1: Enable `adaln_all_blocks` with gap/stagger condition

The code at lines ~857-868 in `Transolver.forward` builds `block_condition`. Currently with `adaln_4cond=True` it uses `(Re, AoA, gap_feat, surf_frac)`. We want `(Re, AoA, gap, stagger)` — using the same gap/stagger features that GSB and aft-foil SRF use.

**Modify the condition construction** (search for `if self.adaln_4cond:` in `Transolver.forward`):

```python
if self.adaln_4cond:
    # CHANGE: use gap and stagger (indices 22:24) instead of gap_feat and surf_frac
    gap_stagger = x[:, 0, 22:24]  # [B, 2] — gap and stagger from raw input
    block_condition = torch.cat([cond_2, gap_stagger], dim=-1)  # [B, 4] = (Re, AoA, gap, stagger)
```

This replaces the old `gap_feat` (index 21) and `surf_frac` (computed boolean) with the actual gap/stagger scalars that have proven informative throughout Phase 6.

**For single-foil samples**, gap=0 and stagger=0 in the data, so the condition naturally becomes (Re, AoA, 0, 0) — no special masking needed.

### Step 2: No changes to TransolverBlock needed

The `adaln_net` in each block already handles 4-dim input when `adaln_cond_dim=4`. The `adaln_all` codepath (lines 403-409) modulates `ln_1` and `ln_2` via the standard AdaLN-Zero pattern. Zero-init ensures the model starts as if unconditioned.

### Step 3: Run 2 configs

**Config A: adaln_all + adaln_4cond with gap/stagger** (the main hypothesis)
```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/backbone-gs-adaln-s42" --wandb_group phase6/backbone-gs-adaln \
  --adaln_all_blocks --adaln_4cond --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73: same flags, --seed 73, wandb_name "frieren/backbone-gs-adaln-s73"
```

**Config B (control): adaln_all WITHOUT 4cond — just Re/AoA in all blocks**
```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/backbone-adaln-reao-s42" --wandb_group phase6/backbone-gs-adaln \
  --adaln_all_blocks --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73: same flags, --seed 73, wandb_name "frieren/backbone-adaln-reao-s73"
```

Config B (Re/AoA only) isolates whether conditioning all blocks helps at all, vs Config A which tests the gap/stagger addition specifically.

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | W&B |
|--------|------|------|--------|-------|------|-----|
| adaln_all + gs 4cond | 42 | | | | | |
| adaln_all + gs 4cond | 73 | | | | | |
| **gs 4cond avg** | — | | | | | |
| adaln_all Re/AoA only | 42 | | | | | |
| adaln_all Re/AoA only | 73 | | | | | |
| **Re/AoA only avg** | — | | | | | |
| **Baseline** | — | 13.05 | 7.70 | 28.60 | 6.55 | d7l91p0x, j9btfx09 |

Also log VRAM usage for each config (the adaln_net adds parameters to all 3 blocks — expect a small increase).

## Baseline

| Metric | Target |
|--------|--------|
| p_in   | < 13.05 |
| p_oodc | < 7.70  |
| **p_tan** | **< 28.60** |
| p_re   | < 6.55  |

W&B baseline: d7l91p0x (s42), j9btfx09 (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```