### PR TITLE
Iterative 2-Pass Refinement: Self-Conditioning (AlphaFold2 Recycling)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -700,9 +700,12 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        iterative_refinement=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
+        self.iterative_refinement = iterative_refinement
+        self._refinement_active = False  # set externally when epoch >= warmup
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
         self.pressure_first = pressure_first
         self.ref = ref
@@ -802,6 +805,10 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        # Iterative refinement: project pass-1 predictions back into hidden space
+        if self.iterative_refinement:
+            self.correction_proj = nn.Linear(out_dim, n_hidden, bias=False)
+            nn.init.zeros_(self.correction_proj.weight)  # zero-init: pass-2 starts identical to pass-1
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -894,6 +901,56 @@ class Transolver(nn.Module):
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
 
+        # Last block condition (computed once, used in all passes)
+        last_condition = block_condition if use_cond else (x[:, 0, 13:15] if self.adaln_output else None)
+
+        # --- Iterative refinement: 2-pass forward ---
+        if self._refinement_active:
+            # Pass 1: standard forward, no gradients (saves ~50% memory)
+            with torch.no_grad():
+                fx_p1 = self.preprocess(x)
+                fx_pre_p1 = fx_p1
+                fx_p1 = fx_p1 * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+                for block in self.blocks[:-1]:
+                    fx_p1 = block(fx_p1, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+                if self._pressure_separate and self.pressure_first:
+                    p_sep_p1 = self.pressure_sep_mlp(fx_p1)
+                    fx_p1 = self.blocks[-1](fx_p1, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features)
+                    fx_p1 = torch.cat([fx_p1[:, :, :2], p_sep_p1], dim=-1)
+                else:
+                    fx_p1 = self.blocks[-1](fx_p1, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features)
+                gate_p1 = self.skip_gate(fx_pre_p1)
+                pass1_pred = fx_p1 + gate_p1 * self.out_skip(fx_pre_p1)  # [B, N, out_dim]
+
+            # Pass 2: preprocess + correction from pass-1 predictions
+            fx = self.preprocess(x)
+            fx_pre = fx  # save for skip
+            fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+            # Add correction signal: correction_proj is zero-init so pass-2 starts ≡ pass-1
+            correction = self.correction_proj(pass1_pred)  # [B, N, n_hidden]
+            fx = fx + correction
+
+            for block in self.blocks[:-1]:
+                fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+
+            fx_deep = fx
+            re_pred = self.re_head(fx.mean(dim=1))
+            aoa_pred = self.aoa_head(fx.mean(dim=1))
+
+            if self._pressure_separate and self.pressure_first:
+                fx_for_pressure = fx
+                p_sep = self.pressure_sep_mlp(fx_for_pressure)
+                fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features)
+                fx = torch.cat([fx[:, :, :2], p_sep], dim=-1)
+            else:
+                fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features)
+
+            gate = self.skip_gate(fx_pre)
+            fx = fx + gate * self.out_skip(fx_pre)
+            self._validate_output_dims(fx)
+            return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "hidden": fx_deep}
+
+        # --- Standard single-pass forward ---
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
@@ -907,9 +964,6 @@ class Transolver(nn.Module):
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
-
-        # Last block: use adaln_all condition if enabled, else fallback to adaln_output
-        last_condition = block_condition if use_cond else (x[:, 0, 13:15] if self.adaln_output else None)
 
         if self._pressure_separate and self.pressure_first:
             # Separate pressure pathway: independent MLP processes pre-last features
@@ -1070,6 +1124,9 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Iterative 2-pass refinement (AlphaFold2-style recycling)
+    iterative_refinement: bool = False       # run model twice: pass-1 → correction → pass-2
+    iterative_warmup_epoch: int = 60         # use single-pass before this epoch (garbage pass-1 predictions)
 
 
 cfg = sp.parse(Config)
@@ -1230,6 +1287,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    iterative_refinement=cfg.iterative_refinement,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1549,6 +1607,9 @@ for epoch in range(MAX_EPOCHS):
 
     # --- Train ---
     model.train()
+    # Iterative refinement: activate 2-pass after warmup epoch
+    if cfg.iterative_refinement:
+        _base_model._refinement_active = (epoch >= cfg.iterative_warmup_epoch)
     if refine_head is not None:
         refine_head.train()
     if aft_srf_head is not None:
@@ -2249,6 +2310,10 @@ for epoch in range(MAX_EPOCHS):
         eval_model = model
     eval_model.eval()
     model.eval()
+    # Iterative refinement: set on eval model too
+    if cfg.iterative_refinement:
+        _eval_base = eval_model._orig_mod if hasattr(eval_model, '_orig_mod') else eval_model
+        _eval_base._refinement_active = (epoch >= cfg.iterative_warmup_epoch)
     # Select the right refinement head for validation (EMA if available)
     eval_refine_head = refine_head  # default: use training head
     if refine_head is not None:
@@ -2680,6 +2745,8 @@ if best_metrics:
         _sd = {k.removeprefix("_orig_mod."): v for k, v in _sd.items()}
         vis_model.load_state_dict(_sd)
         vis_model.eval()
+        if cfg.iterative_refinement:
+            vis_model._refinement_active = True  # always use 2-pass at visualization time
         plot_dir = Path("plots") / run.id
         n = 1 if cfg.debug else 4
         for split_name, split_ds in val_splits.items():
@@ -2757,6 +2824,8 @@ if cfg.surface_refine and best_metrics:
         _verify_sd = {k.removeprefix("_orig_mod."): v for k, v in _verify_sd.items()}
         verify_model.load_state_dict(_verify_sd)
         verify_model.eval()
+        if cfg.iterative_refinement:
+            verify_model._refinement_active = True  # always use 2-pass at verification time
 
         # Use EMA refinement head if available, else training head
         verify_refine = ema_refine_head if ema_refine_head is not None else (

--- a/research/EXPERIMENT_THORFINN_ITERATIVE_REFINE.md
+++ b/research/EXPERIMENT_THORFINN_ITERATIVE_REFINE.md
@@ -1,0 +1,7 @@
+# Experiment: Iterative 2-Pass Refinement (AlphaFold2-style Recycling)
+
+Student: thorfinn
+Branch: thorfinn/iterative-refinement
+Slug: iterative-refinement
+
+See PR body for full hypothesis and instructions.


### PR DESCRIPTION
## Hypothesis

Run the Transolver model TWICE on each input — pass-1 produces a standard prediction, then pass-2 receives the pass-1 output as additional input conditioning and produces a refined prediction. **Same model weights for both passes (no extra parameters).** The loss is computed only on pass-2 output.

**Why this should work:** The model's own first-pass predictions carry information about its uncertainty and systematic biases that is not present in the input geometry alone. In the inter-foil gap region (the primary source of p_tan failures), pass-1 will have structured errors. Pass-2, conditioned on these errors, can learn a correction function `f(geometry, pass1_prediction) → refined_prediction`.

**Prior art:**
- **AlphaFold2 recycling** (3 passes, shared weights, structure→structure): The most successful example of iterative refinement in scientific ML. Recycling improved pLDDT by ~5 points.
- **Diffusion self-conditioning** (Chen et al. 2022, "Analog Bits"): Conditioning generation on the model's own prior estimate improves quality at zero cost during generation.
- **Iterative error correction** in PDE solvers: Classical multigrid methods refine coarse solutions.

**This is a bold architectural change** — it doubles training compute but adds zero parameters.

## Instructions

### Step 1: Add a correction projection to the Transolver

The pass-1 output is 3-dim (Ux, Uy, p) or 4-dim depending on output channels. We need a way to feed this back into the model. Add a small linear layer that projects the pass-1 prediction into the hidden space and ADDS it to the standard input features.

In `Transolver.__init__`, after the main `preprocess` layers:

```python
self.iterative_refinement = cfg.iterative_refinement
self.iterative_warmup_epoch = cfg.iterative_warmup_epoch  # default: 60
if self.iterative_refinement:
    self.correction_proj = nn.Linear(self.out_dim, self.hidden_dim, bias=False)
    nn.init.zeros_(self.correction_proj.weight)  # Zero-init: starts as identity
```

### Step 2: Modify the forward pass

In `Transolver.forward()`, split the forward logic so it can be called twice. The simplest approach: extract the core forward computation into a helper method `_forward_core(fx, ...)` if not already factored. Otherwise, wrap the forward in a 2-pass loop:

```python
def forward(self, x, fx, ..., epoch=0):
    # Standard feature preprocessing (DSDF, normalization, etc.)
    fx = self.preprocess(fx)  # [B, N, H]
    
    if self.iterative_refinement and epoch >= self.iterative_warmup_epoch:
        # Pass 1: standard forward (detached to save memory)
        with torch.no_grad():
            pass1_fx = fx  # save input features
            for block in self.blocks:
                fx = block(fx, ...)
            pass1_pred = self.output_head(fx)  # [B, N, out_dim]
        
        # Pass 2: add correction signal from pass-1 predictions
        fx = pass1_fx  # reset to original features
        correction = self.correction_proj(pass1_pred.detach())  # [B, N, H]
        fx = fx + correction  # condition on pass-1 output
        
        for block in self.blocks:
            fx = block(fx, ...)
        pred = self.output_head(fx)
        return pred  # train on pass-2 output
    else:
        # Standard single-pass forward (before warmup or at inference without refinement)
        for block in self.blocks:
            fx = block(fx, ...)
        return self.output_head(fx)
```

**IMPORTANT implementation notes:**
1. `torch.no_grad()` on pass-1 saves ~50% memory — gradients only flow through pass-2. This is critical to fit in 96GB VRAM.
2. The `correction_proj` is zero-initialized, so at the start of warmup (epoch 60), the correction signal is zero and pass-2 ≡ pass-1 — no discontinuity.
3. Before `iterative_warmup_epoch`, use standard single-pass to avoid wasting compute on garbage pass-1 predictions.
4. The existing `_forward_core` structure in `Transolver.forward` may not be cleanly separable — adapt to the actual code structure. The key is: run the transformer blocks twice, with correction added before the second run.

### Step 3: Handle EMA and validation

At **validation/inference time**, always use 2-pass if `iterative_refinement=True` and epoch >= warmup. The EMA model should also use 2-pass refinement.

### Step 4: Add config flags

```python
# Config dataclass:
iterative_refinement: bool = False
iterative_warmup_epoch: int = 60

# argparse:
parser.add_argument('--iterative_refinement', action='store_true')
parser.add_argument('--iterative_warmup_epoch', type=int, default=60)
```

### Step 5: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/iter-refine-s42" --wandb_group phase6/iterative-refinement \
  --iterative_refinement --iterative_warmup_epoch 60 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73: same flags, --seed 73, wandb_name "thorfinn/iter-refine-s73"
```

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | VRAM | W&B |
|--------|------|------|--------|-------|------|------|-----|
| iterative 2-pass | 42 | | | | | | |
| iterative 2-pass | 73 | | | | | | |
| **iter avg** | — | | | | | | |
| **Baseline** | — | 13.05 | 7.70 | 28.60 | 6.55 | ~46GB | d7l91p0x, j9btfx09 |

Also log:
1. **VRAM usage** — expect ~60-70GB with no_grad pass-1 (vs 46GB baseline). Report if it OOMs.
2. **Training time** — expect ~1.5-1.8x baseline per epoch after warmup.
3. **Validation loss at epoch 59 (pre-warmup) vs epoch 61 (post-warmup)** — should be continuous (no discontinuity from zero-init correction).
4. If the 2-pass approach OOMs, try reducing batch size as a fallback, or report and we'll adjust.

## Baseline

| Metric | Target |
|--------|--------|
| p_in   | < 13.05 |
| p_oodc | < 7.70  |
| **p_tan** | **< 28.60** |
| p_re   | < 6.55  |

W&B baseline: d7l91p0x (s42), j9btfx09 (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```