### PR TITLE
dp/dn=0 Physics Loss: Surface Normal Pressure Gradient Constraint

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1070,6 +1070,8 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: dp/dn=0 physics loss — surface normal pressure gradient constraint
+    pde_surf_normal_weight: float = 0.0     # weight for dp/dn=0 auxiliary loss (0 = disabled)
 
 
 cfg = sp.parse(Config)
@@ -1953,6 +1955,55 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
+        # dp/dn=0 physics loss: penalize pressure differences between nearby surface nodes
+        # in the wall-normal direction. Fully vectorized, no per-sample loop.
+        _pde_loss = torch.tensor(0.0, device=device)
+        if cfg.pde_surf_normal_weight > 0.0 and model.training:
+            _s_flat = surf_mask.nonzero(as_tuple=False)  # [M, 2] — (batch_idx, node_idx)
+            _M = _s_flat.shape[0]
+            if _M >= 2:
+                _K = min(16, _M) * B
+                _idx_i = torch.randint(_M, (_K,), device=device)
+                _idx_j = torch.randint(_M, (_K,), device=device)
+                # Keep only pairs from same batch element and not identical
+                _bi = _s_flat[_idx_i, 0]
+                _bj = _s_flat[_idx_j, 0]
+                _same = (_bi == _bj) & (_idx_i != _idx_j)
+                if _same.any():
+                    _idx_i = _idx_i[_same]
+                    _idx_j = _idx_j[_same]
+                    _bi = _s_flat[_idx_i, 0]
+                    _ni_idx = _s_flat[_idx_i, 1]
+                    _nj_idx = _s_flat[_idx_j, 1]
+                    # Spatial displacement
+                    _xi = x[_bi, _ni_idx, :2]
+                    _xj = x[_bi, _nj_idx, :2]
+                    _dx = _xj - _xi
+                    _dist = _dx.norm(dim=-1).clamp(min=0.01)  # clamp at 0.01 in standardized space
+                    # Filter: only keep pairs with moderate distance (avoid near-duplicates and far pairs)
+                    _dist_ok = (_dist > 0.02) & (_dist < 1.0)
+                    if _dist_ok.any():
+                        _bi = _bi[_dist_ok]
+                        _ni_idx = _ni_idx[_dist_ok]
+                        _nj_idx = _nj_idx[_dist_ok]
+                        _dx = _dx[_dist_ok]
+                        _dist = _dist[_dist_ok]
+                        # Wall normal from DSDF gradient (channels 2:4)
+                        _n_i = x[_bi, _ni_idx, 2:4]
+                        _n_j = x[_bi, _nj_idx, 2:4]
+                        _sum_n = _n_i + _n_j
+                        _n_norm = _sum_n.norm(dim=-1).clamp(min=1e-4)
+                        _avg_n = _sum_n / _n_norm.unsqueeze(-1)
+                        # Normal component of displacement direction
+                        _dir = _dx / _dist.unsqueeze(-1)
+                        _normal_proj = (_dir * _avg_n).sum(dim=-1).abs()
+                        # Pressure difference (no division by distance — just penalize dp along normal)
+                        _dp = pred[_bi, _nj_idx, 2] - pred[_bi, _ni_idx, 2]
+                        _pde_loss = (_dp * _normal_proj).pow(2).mean()
+            loss = loss + cfg.pde_surf_normal_weight * _pde_loss
+            if batch_idx % 100 == 0:
+                wandb.log({"train/pde_dpdn_loss": _pde_loss.item(), "global_step": global_step})
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -1979,8 +2030,9 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            _pde_shared = cfg.pde_surf_normal_weight * _pde_loss * 0.5 if cfg.pde_surf_normal_weight > 0.0 else 0.0
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + _pde_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + _pde_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2025,7 +2077,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                _pde_shared = cfg.pde_surf_normal_weight * _pde_loss / 3.0 if cfg.pde_surf_normal_weight > 0.0 else 0.0
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + _pde_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors

--- a/research/EXPERIMENT_ALPHONSE_DPDN.md
+++ b/research/EXPERIMENT_ALPHONSE_DPDN.md
@@ -1,0 +1,7 @@
+# Experiment: dp/dn=0 Surface Normal Pressure Gradient Loss
+
+Student: alphonse
+Branch: alphonse/dpdn-physics-loss
+Slug: dpdn-physics-loss
+
+See PR body for full hypothesis and instructions.


### PR DESCRIPTION
## Hypothesis

At a solid airfoil wall, the inviscid Euler momentum equation in the wall-normal direction gives **dp/dn ≈ 0** — pressure gradients normal to the surface should be near-zero. The model currently has no explicit incentive to enforce this physical constraint. If the predicted pressure field violates dp/dn=0 at surface nodes, it is physically wrong — and these are exactly the nodes where Surface MAE is evaluated.

**This is a zero-parameter approach** — pure auxiliary loss modification, no model changes. It adds a physics-informed regularizer that penalizes non-physical pressure gradients at the surface, complementing the data-driven MSE loss with domain knowledge.

The SAF (Signed Arc-length Field) gradient vectors already in the input features (`x[:,:,2:4]` for foil-1, `x[:,:,6:8]` for foil-2) provide a proxy for the wall-normal direction: `n ≈ normalize(grad_SAF)`. These are readily available.

**Key insight:** The dp/dn=0 constraint is STRONGER at the surface (where we evaluate) and naturally relaxes away from the wall. By penalizing only surface-node pressure gradients in the normal direction, we focus the regularizer exactly where it matters for the metric.

## Instructions

### Step 1: Add config flags

```python
# Config dataclass:
pde_surf_normal_weight: float = 0.0  # 0 = disabled

# argparse:
parser.add_argument('--pde_surf_normal_weight', type=float, default=0.0,
                    help='Weight for dp/dn=0 surface normal pressure gradient auxiliary loss.')
```

### Step 2: Implement the auxiliary loss

In the training loop, AFTER computing the main loss and AFTER the model forward pass produces `pred`, add the physics loss. This should use the PREDICTED pressure (not target), since we want to regularize the model's output.

```python
if cfg.pde_surf_normal_weight > 0.0 and model.training:
    K_PAIRS = 16  # random pairs per batch element
    _pde_loss = torch.tensor(0.0, device=device)
    _pde_count = 0
    
    for b_idx in range(x.shape[0]):
        # Get surface node indices for this sample
        _s_idx = is_surface[b_idx].nonzero(as_tuple=True)[0]
        if len(_s_idx) < 2:
            continue
        
        # Sample K random pairs of surface nodes
        _pi = torch.randint(len(_s_idx), (K_PAIRS,), device=device)
        _pj = torch.randint(len(_s_idx), (K_PAIRS,), device=device)
        _valid = _pi != _pj
        _pi, _pj = _pi[_valid], _pj[_valid]
        if len(_pi) == 0:
            continue
        
        _i_idx, _j_idx = _s_idx[_pi], _s_idx[_pj]
        
        # Spatial coordinates
        _xi = x[b_idx, _i_idx, :2]  # [K, 2] — (x, y) coordinates
        _xj = x[b_idx, _j_idx, :2]
        _dx = _xj - _xi
        _dist = _dx.norm(dim=-1, keepdim=True).clamp(min=1e-6)
        
        # Wall normal from SAF gradient (use foil-1 DSDF gradient channels 2:4)
        # For nodes near foil-2, use channels 6:8 instead
        # Simple approach: use whichever DSDF has smaller magnitude (= closer foil)
        _dsdf1_mag_i = x[b_idx, _i_idx, 2:6].norm(dim=-1)
        _dsdf2_mag_i = x[b_idx, _i_idx, 6:10].norm(dim=-1)
        _dsdf1_mag_j = x[b_idx, _j_idx, 2:6].norm(dim=-1)
        _dsdf2_mag_j = x[b_idx, _j_idx, 6:10].norm(dim=-1)
        
        # Use foil-1 gradient for nodes closer to foil-1, else foil-2
        _use_foil2_i = (_dsdf2_mag_i < _dsdf1_mag_i).unsqueeze(-1)
        _ni = torch.where(_use_foil2_i, x[b_idx, _i_idx, 6:8], x[b_idx, _i_idx, 2:4])
        _nj = torch.where(_use_foil2_i[:len(_pj)], x[b_idx, _j_idx, 6:8], x[b_idx, _j_idx, 2:4])
        
        # Normalize to unit vectors
        _ni = torch.nn.functional.normalize(_ni, dim=-1)
        _nj = torch.nn.functional.normalize(_nj, dim=-1)
        _avg_n = torch.nn.functional.normalize(_ni + _nj, dim=-1)
        
        # Normal component of displacement direction
        _dir = _dx / _dist
        _normal_proj = (_dir * _avg_n).sum(dim=-1).abs()  # |cos(angle)|
        
        # Finite-difference pressure gradient in normal direction
        # pred[:,:,2] is pressure channel (after asinh transform)
        _pi_pred = pred[b_idx, _i_idx, 2:3]  # [K, 1]
        _pj_pred = pred[b_idx, _j_idx, 2:3]
        _dp_dn = ((_pj_pred - _pi_pred).squeeze(-1) / _dist.squeeze(-1)) * _normal_proj
        
        _pde_loss = _pde_loss + (_dp_dn ** 2).mean()
        _pde_count += 1
    
    if _pde_count > 0:
        _pde_loss = _pde_loss / _pde_count
        loss = loss + cfg.pde_surf_normal_weight * _pde_loss
```

**Note on the `is_surface` mask:** Use the same surface mask that's used for surface MAE evaluation. If there's a boolean tensor identifying surface nodes, use that directly.

### Step 3: Run 2 weight values × 2 seeds = 4 runs

The weight needs calibration. Start with two values bracketing reasonable range:

```bash
# Weight=0.01, Seed 42
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/dpdn-w001-s42" --wandb_group phase6/dpdn-physics-loss \
  --pde_surf_normal_weight 0.01 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Weight=0.01, Seed 73: same, --seed 73, wandb_name "alphonse/dpdn-w001-s73"

# Weight=0.1, Seed 42: same but --pde_surf_normal_weight 0.1, wandb_name "alphonse/dpdn-w01-s42"
# Weight=0.1, Seed 73: same, --seed 73, wandb_name "alphonse/dpdn-w01-s73"
```

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | pde_loss (epoch 1) | pde_loss (final) | W&B |
|--------|------|------|--------|-------|------|-------------------|-----------------|-----|
| w=0.01 | 42 | | | | | | | |
| w=0.01 | 73 | | | | | | | |
| **w=0.01 avg** | — | | | | | | | |
| w=0.1 | 42 | | | | | | | |
| w=0.1 | 73 | | | | | | | |
| **w=0.1 avg** | — | | | | | | | |
| **Baseline** | — | 13.05 | 7.70 | 28.60 | 6.55 | — | — | d7l91p0x, j9btfx09 |

**Critical:** Log the `_pde_loss` value at epoch 1, 50, and final epoch to verify the physics loss is meaningful (non-zero, decreasing). If it's always near-zero, the model already satisfies dp/dn≈0 and the loss adds no information.

## Baseline

| Metric | Target |
|--------|--------|
| p_in   | < 13.05 |
| p_oodc | < 7.70  |
| **p_tan** | **< 28.60** |
| p_re   | < 6.55  |

W&B baseline: d7l91p0x (s42), j9btfx09 (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```