### PR TITLE
Tandem Surface Mixup: Between-Sample Aft-Foil Geometry Augmentation

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1070,6 +1070,9 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Tandem surface mixup — swap aft-foil surface nodes between tandem samples (CutMix for mesh data)
+    tandem_surface_mixup: bool = False       # enable between-sample aft-foil node swapping
+    tandem_surface_mixup_prob: float = 0.3   # probability of applying mixup per eligible pair
 
 
 cfg = sp.parse(Config)
@@ -1666,6 +1669,15 @@ for epoch in range(MAX_EPOCHS):
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+        # Tandem surface mixup: precompute aft-foil masks (needs raw features before standardization)
+        _tmix_aft_masks = None
+        if cfg.tandem_surface_mixup and model.training:
+            if _aft_foil_mask is not None:
+                _tmix_aft_masks = _aft_foil_mask  # reuse existing aft-foil mask
+            else:
+                _tmix_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
+                _tmix_is_tandem = (x[:, 0, 22].abs() > 0.01)
+                _tmix_aft_masks = is_surface & (_tmix_saf_norm > 0.005) & _tmix_is_tandem.unsqueeze(1)
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1733,6 +1745,63 @@ for epoch in range(MAX_EPOCHS):
                 p_noise = 0.008 * (1 - noise_progress) + 0.001 * noise_progress
             noise_scale = torch.tensor([vel_noise, vel_noise, p_noise], device=device)
             y_norm = y_norm + noise_scale * torch.randn_like(y_norm)
+
+        # Tandem surface mixup: swap aft-foil surface nodes between tandem sample pairs
+        if cfg.tandem_surface_mixup and model.training and _tmix_aft_masks is not None:
+            # Find tandem samples that have aft-foil nodes
+            _tmix_tandem_idx = _tmix_aft_masks.any(dim=1).nonzero(as_tuple=True)[0]
+
+            if len(_tmix_tandem_idx) >= 2:
+                _tmix_perm = _tmix_tandem_idx[torch.randperm(len(_tmix_tandem_idx), device=device)]
+                _tmix_n_pairs = len(_tmix_tandem_idx) // 2
+
+                _tmix_swap_count = 0
+                _tmix_skip_count = 0
+                for _si in range(_tmix_n_pairs):
+                    _a = _tmix_tandem_idx[_si * 2]
+                    _b = _tmix_perm[_si * 2]
+                    if _a == _b:
+                        _b = _tmix_perm[_si * 2 + 1] if _si * 2 + 1 < len(_tmix_perm) else _tmix_perm[0]
+                    if _a == _b:
+                        continue
+
+                    # Apply with probability
+                    if torch.rand(1, device=device).item() > cfg.tandem_surface_mixup_prob:
+                        continue
+
+                    # Aft-foil surface masks for both samples
+                    _aft_a = _tmix_aft_masks[_a]  # [N] bool
+                    _aft_b = _tmix_aft_masks[_b]  # [N] bool
+
+                    _na = _aft_a.sum().item()
+                    _nb = _aft_b.sum().item()
+                    if _na == 0 or _nb == 0:
+                        _tmix_skip_count += 1
+                        continue
+
+                    # Subsample to min count when node counts differ (variable mesh topologies)
+                    _n_swap = min(_na, _nb)
+                    _idx_a = _aft_a.nonzero(as_tuple=True)[0]
+                    _idx_b = _aft_b.nonzero(as_tuple=True)[0]
+                    _sel_a = _idx_a[torch.randperm(len(_idx_a), device=device)[:_n_swap]]
+                    _sel_b = _idx_b[torch.randperm(len(_idx_b), device=device)[:_n_swap]]
+
+                    # Swap x features AND y_norm targets for selected aft-foil surface nodes
+                    _xa_aft = x[_a, _sel_a].clone()
+                    _ya_aft = y_norm[_a, _sel_a].clone()
+                    x[_a, _sel_a] = x[_b, _sel_b]
+                    y_norm[_a, _sel_a] = y_norm[_b, _sel_b]
+                    x[_b, _sel_b] = _xa_aft
+                    y_norm[_b, _sel_b] = _ya_aft
+                    _tmix_swap_count += 1
+
+                # Diagnostic logging at epoch 1
+                if epoch == 1 and batch_idx == 0:
+                    _aft_counts = [_tmix_aft_masks[i].sum().item() for i in _tmix_tandem_idx.tolist()[:10]]
+                    print(f"[tandem_surface_mixup] {_tmix_swap_count}/{_tmix_n_pairs} pairs swapped "
+                          f"(prob={cfg.tandem_surface_mixup_prob}), "
+                          f"{_tmix_skip_count} skipped (no aft nodes), "
+                          f"aft-foil node counts (first 10 tandem): {_aft_counts}")
 
         # Per-sample std normalization: skip tandem samples (gap feature index 21)
         raw_gap = x[:, 0, 21]

--- a/research/EXPERIMENT_EDWARD_TANDEM_MIXUP.md
+++ b/research/EXPERIMENT_EDWARD_TANDEM_MIXUP.md
@@ -1,0 +1,7 @@
+# Experiment: Tandem Surface Mixup
+
+Student: edward
+Branch: edward/tandem-surface-mixup
+Slug: tandem-surface-mixup
+
+See PR body for full hypothesis and instructions.


### PR DESCRIPTION
## Hypothesis

Swap aft-foil surface nodes (both features and targets) between two tandem samples in the same batch. This creates synthetic "chimeric" tandem configurations where aft-foil geometry from one sample is embedded in another sample's flow field — configurations the model has never seen.

**Why this should work for p_tan:** The p_tan bottleneck is NACA6416 aft-foil prediction — the model sees NACA6416 only in tandem OOD. By swapping aft-foil surface nodes between samples, the model encounters novel (fore-foil, aft-foil, gap, stagger) combinations. It must learn the inter-foil coupling MECHANISM rather than memorizing specific configuration pairings. This is conceptually CutMix for mesh data — cut out the aft-foil node set and paste in a different one.

**Why this differs from the dead-end DSDF Channel Mixup (#2132):** That experiment mixed DSDF channel values within a single sample — a non-physical operation. This swaps entire surface node sets between samples, which corresponds to a physically plausible chimeric geometry. The difference is geometric coherence.

**Key guard:** Only swap when both samples have the SAME number of aft-foil surface nodes. If node counts differ (variable mesh topologies), skip the swap.

## Instructions

### Step 1: Add config flags

```python
# Config dataclass:
tandem_surface_mixup: bool = False
tandem_surface_mixup_prob: float = 0.3  # probability of applying mixup per eligible pair

# argparse:
parser.add_argument('--tandem_surface_mixup', action='store_true')
parser.add_argument('--tandem_surface_mixup_prob', type=float, default=0.3)
```

### Step 2: Implement the surface swap

In the training loop augmentation block (AFTER standardization and AFTER any existing augmentations), add:

```python
if cfg.tandem_surface_mixup and model.training:
    # Find tandem sample indices in the batch
    _tandem_idx = is_tandem_batch.nonzero(as_tuple=True)[0]  # indices of tandem samples
    
    if len(_tandem_idx) >= 2:
        # Create random pairs from tandem samples
        _perm = _tandem_idx[torch.randperm(len(_tandem_idx), device=device)]
        _n_pairs = len(_tandem_idx) // 2
        
        _swap_count = 0
        for _si in range(_n_pairs):
            _a = _tandem_idx[_si * 2]
            _b = _perm[_si * 2]
            if _a == _b:
                _b = _perm[_si * 2 + 1] if _si * 2 + 1 < len(_perm) else _perm[0]
            if _a == _b:
                continue
            
            # Apply with probability
            if torch.rand(1, device=device).item() > cfg.tandem_surface_mixup_prob:
                continue
            
            # Identify aft-foil surface nodes for both samples
            # Aft-foil = surface nodes where SAF norm > threshold (far from fore-foil)
            # Use the same proxy as _aft_foil_mask: surface nodes with DSDF1 magnitude > threshold
            _is_surf_a = is_surface[_a]  # [N] bool
            _is_surf_b = is_surface[_b]
            
            # SAF norm from raw DSDF1 channels — nodes with high SAF norm are on the aft foil
            # Use standardized x, so threshold needs adjustment
            # Simplest: use DSDF2 channels (6:10) — nodes with small DSDF2 norm are near aft-foil
            _dsdf2_a = x[_a, :, 6:10].norm(dim=-1)  # [N]
            _dsdf2_b = x[_b, :, 6:10].norm(dim=-1)
            
            # Aft-foil surface: surface nodes with DSDF2 magnitude BELOW threshold
            # (near the aft foil in tandem configs)
            _thresh = 0.5  # In standardized space — tune if needed
            _aft_a = _is_surf_a & (_dsdf2_a < _thresh)
            _aft_b = _is_surf_b & (_dsdf2_b < _thresh)
            
            # Only swap if node counts match exactly
            if _aft_a.sum() != _aft_b.sum() or _aft_a.sum() == 0:
                continue
            
            # Swap x features AND y_norm targets for aft-foil surface nodes
            _xa_aft = x[_a, _aft_a].clone()
            _ya_aft = y_norm[_a, _aft_a].clone()
            x[_a, _aft_a] = x[_b, _aft_b]
            y_norm[_a, _aft_a] = y_norm[_b, _aft_b]
            x[_b, _aft_b] = _xa_aft
            y_norm[_b, _aft_b] = _ya_aft
            _swap_count += 1
        
        # Log swap count at epoch 1 for debugging
        if epoch == 1:
            print(f"[tandem_surface_mixup] {_swap_count}/{_n_pairs} pairs swapped")
```

**IMPORTANT:** The `_thresh` for aft-foil identification needs calibration. Before the full run, add a debug print at epoch 1 that logs `_aft_a.sum()` and `_aft_b.sum()` for each pair to confirm:
1. Non-zero aft-foil nodes are found
2. Matching node counts allow swaps to happen

If very few swaps fire (< 10% of pairs), the threshold needs tuning. The augmentation's effectiveness depends on a reasonable swap frequency.

### Step 3: Run 2 configs

**Config A: mixup_prob=0.3** (moderate swap frequency)
```bash
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/tanmix-p03-s42" --wandb_group phase6/tandem-surface-mixup \
  --tandem_surface_mixup --tandem_surface_mixup_prob 0.3 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73: same, --seed 73, wandb_name "edward/tanmix-p03-s73"
```

**Config B: mixup_prob=0.5** (higher swap frequency)
```bash
# Same but --tandem_surface_mixup_prob 0.5, wandb_name "edward/tanmix-p05-s42" and s73
```

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | swaps/batch | W&B |
|--------|------|------|--------|-------|------|-------------|-----|
| prob=0.3 | 42 | | | | | | |
| prob=0.3 | 73 | | | | | | |
| **prob=0.3 avg** | — | | | | | | |
| prob=0.5 | 42 | | | | | | |
| prob=0.5 | 73 | | | | | | |
| **prob=0.5 avg** | — | | | | | | |
| **Baseline** | — | 13.05 | 7.70 | 28.60 | 6.55 | 0 | d7l91p0x, j9btfx09 |

**Critical diagnostics (epoch 1 logs):**
1. How many aft-foil surface nodes found per sample?
2. What % of tandem pairs have matching node counts?
3. How many swaps actually fired?

If zero swaps fire, the aft-foil detection threshold needs tuning — report the threshold issue and I'll provide guidance.

## Baseline

| Metric | Target |
|--------|--------|
| p_in   | < 13.05 |
| p_oodc | < 7.70  |
| **p_tan** | **< 28.60** |
| p_re   | < 6.55  |

W&B baseline: d7l91p0x (s42), j9btfx09 (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```