### PR TITLE
Online Hard Example Mining: Adaptive Per-Sample Loss Upweighting

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1020,6 +1020,7 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    ohem_top_k: float = 0.0  # fraction of hardest samples to upweight per batch (0=disabled, 0.3=top 30%)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1904,6 +1905,20 @@ for epoch in range(MAX_EPOCHS):
                                        torch.ones(B, device=device))
         else:
             tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
+        # OHEM: upweight hardest samples adaptively
+        if cfg.ohem_top_k > 0.0 and model.training:
+            _ohem_loss = surf_per_sample.detach()
+            _k = max(1, int(cfg.ohem_top_k * _ohem_loss.shape[0]))
+            _ohem_thresh = _ohem_loss.topk(_k).values[-1]
+            _ohem_w = torch.where(_ohem_loss >= _ohem_thresh,
+                                  torch.tensor(2.0, device=device),
+                                  torch.tensor(1.0, device=device))
+            _ohem_w = _ohem_w / _ohem_w.mean()  # normalize to preserve gradient magnitude
+            if epoch in (0, 1, 80) and batch_idx == 0:
+                _n_hard = (_ohem_loss >= _ohem_thresh).sum().item()
+                _n_hard_tandem = ((_ohem_loss >= _ohem_thresh) & is_tandem_batch).sum().item()
+                print(f"[OHEM] epoch={epoch}, hard={_n_hard}/{_ohem_loss.shape[0]}, tandem_in_hard={_n_hard_tandem}/{_n_hard}")
+            surf_per_sample = surf_per_sample * _ohem_w
         surf_loss = (surf_per_sample * tandem_boost).mean()
         if cfg.uncertainty_loss:
             bm = _base_model

--- a/research/EXPERIMENT_NEZUKO_OHEM.md
+++ b/research/EXPERIMENT_NEZUKO_OHEM.md
@@ -1,0 +1,7 @@
+# Experiment: Online Hard Example Mining for Surface Pressure
+
+Student: nezuko
+Branch: nezuko/hard-sample-mining
+Slug: hard-sample-mining
+
+See PR body for full hypothesis and instructions.


### PR DESCRIPTION
## Hypothesis

The model treats all training samples equally, but some samples are much harder to predict than others. By computing per-sample loss BEFORE reduction and upweighting the hardest K% of samples in each batch, we force the model to allocate capacity to its worst-case predictions — which are likely the tandem configurations that drive p_tan error.

**Why this differs from fixed loss upweighting (#2121, #2122, dead ends):** Those experiments upweighted ALL tandem or ALL foil-specific samples by a fixed factor. OHEM is ADAPTIVE — it identifies whichever samples the model is currently worst at, regardless of whether they're tandem/single-foil. This means the model's attention shifts dynamically: early in training it might focus on difficult tandem configs, later it might focus on edge cases within in-dist data. The upweighting follows the model's current error landscape, not a fixed prior.

**Prior art:** OHEM (Shrivastava et al. 2016) is standard in object detection for handling class imbalance. Focal Loss (Lin et al. 2017) is the smooth variant. Both are proven to improve worst-case performance at minimal cost to average performance.

## Instructions

### Step 1: Add config flags

```python
# Config dataclass:
ohem_top_k: float = 0.0  # 0 = disabled. 0.3 = upweight top 30% hardest samples

# argparse:
parser.add_argument('--ohem_top_k', type=float, default=0.0,
                    help='Fraction of hardest samples to upweight per batch (0=disabled, 0.3=top 30%)')
```

### Step 2: Implement per-sample loss weighting

Find where the loss is computed (search for the main MSE/MAE loss). The current code likely computes loss over all nodes and reduces to a scalar. Instead:

```python
if cfg.ohem_top_k > 0.0 and model.training:
    # Compute per-sample loss BEFORE mean reduction
    # loss_per_node: [B, N, C] where C = number of output channels
    # Reduce over nodes and channels to get per-sample loss: [B]
    _per_sample_loss = loss_per_node.mean(dim=(1, 2))  # [B]
    
    # Compute adaptive weights: upweight the top-K% hardest samples
    _k = max(1, int(cfg.ohem_top_k * _per_sample_loss.shape[0]))
    _threshold = _per_sample_loss.topk(_k).values[-1]  # threshold for top-K
    
    # Soft upweighting: hard samples get weight=2.0, easy samples get weight=1.0
    _weights = torch.where(_per_sample_loss >= _threshold, 
                           torch.tensor(2.0, device=device),
                           torch.tensor(1.0, device=device))  # [B]
    
    # Normalize to preserve expected gradient magnitude
    _weights = _weights / _weights.mean()
    
    # Apply weights to per-sample loss
    loss = (_per_sample_loss * _weights).mean()
else:
    loss = loss_per_node.mean()  # standard reduction
```

**IMPORTANT implementation detail:** The existing loss computation may already reduce to a scalar. You need to intercept it BEFORE the final `.mean()` to get per-sample losses. Look at how `loss` is computed — you may need to modify it to compute `loss_per_node` first, then apply OHEM weighting, then reduce.

If the loss is computed as `loss = F.mse_loss(pred, target)` (which auto-reduces), change to:
```python
loss_per_node = F.mse_loss(pred, target, reduction='none')  # [B, N, C]
# ... apply OHEM weighting ...
```

### Step 3: Run 2 configs × 2 seeds

**Config A: ohem_top_k=0.25** (upweight top 25% hardest samples)
```bash
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/ohem-025-s42" --wandb_group phase6/hard-sample-mining \
  --ohem_top_k 0.25 --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias

# Seed 73: same, --seed 73, wandb_name "nezuko/ohem-025-s73"
```

**Config B: ohem_top_k=0.5** (upweight top 50% hardest samples)
```bash
# Same but --ohem_top_k 0.5, wandb_name "nezuko/ohem-050-s42" and s73
```

### What to report

| Config | Seed | p_in | p_oodc | p_tan | p_re | W&B |
|--------|------|------|--------|-------|------|-----|
| ohem=0.25 | 42 | | | | | |
| ohem=0.25 | 73 | | | | | |
| **ohem=0.25 avg** | — | | | | | |
| ohem=0.50 | 42 | | | | | |
| ohem=0.50 | 73 | | | | | |
| **ohem=0.50 avg** | — | | | | | |
| **Baseline** | — | 13.05 | 7.70 | 28.60 | 6.55 | d7l91p0x, j9btfx09 |

Also log at epoch 1 and epoch 80: what fraction of hard samples are tandem vs single-foil? This reveals whether OHEM is implicitly upweighting tandem samples (expected).

## Baseline

| Metric | Target |
|--------|--------|
| p_in   | < 13.05 |
| p_oodc | < 7.70  |
| **p_tan** | **< 28.60** |
| p_re   | < 6.55  |

W&B baseline: d7l91p0x (s42), j9btfx09 (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```