### PR TITLE
Binned Spectral Power Loss: Frequency-Weighted Surface Pressure Loss

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1070,6 +1070,11 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Binned Spectral Power (BSP) loss — frequency-weighted surface pressure loss
+    bsp_loss: bool = False                   # enable BSP spectral loss on fore-foil surface pressure
+    bsp_loss_weight: float = 0.1             # weight of BSP loss term
+    bsp_num_bins: int = 3                    # number of frequency bins (low/mid/high)
+    bsp_bin_weights_str: str = "1.0,2.0,3.0" # comma-sep weights per bin (low to high freq)
 
 
 cfg = sp.parse(Config)
@@ -1117,6 +1122,50 @@ def _phys_norm(y, Umag, q):
     y_p[:, :, 1:2] = y[:, :, 1:2] / Umag
     y_p[:, :, 2:3] = y[:, :, 2:3] / q
     return y_p
+
+
+def bsp_loss_fn(pred_surf, target_surf, num_bins=3, bin_weights=(1.0, 2.0, 3.0)):
+    """Binned Spectral Power loss on arc-length-sorted surface pressure.
+
+    Uses RELATIVE spectral error (per Chakraborty et al. 2026, arXiv:2502.00472):
+    loss = mean((1 - pred_spec / tgt_spec)^2) per bin, weighted by bin_weights.
+    Relative error ensures high-frequency bins (small absolute magnitudes) are
+    penalized proportionally, counteracting neural network spectral bias.
+
+    Args:
+        pred_surf: [N_surf] predicted pressure along arc-length
+        target_surf: [N_surf] target pressure along arc-length
+        num_bins: number of frequency bins
+        bin_weights: tuple of per-bin weights (low→high freq)
+    Returns:
+        Scalar loss value.
+    """
+    N = pred_surf.shape[0]
+    if N < 4:
+        return torch.tensor(0.0, device=pred_surf.device)
+    # Resample to next power of 2 via linear interpolation (avoids NN artifacts)
+    N_fft = 2 ** int(torch.tensor(float(N)).log2().ceil().item())
+    N_fft = max(N_fft, 4)
+    p = F.interpolate(pred_surf.unsqueeze(0).unsqueeze(0), size=N_fft,
+                       mode='linear', align_corners=True).squeeze()
+    t = F.interpolate(target_surf.unsqueeze(0).unsqueeze(0), size=N_fft,
+                       mode='linear', align_corners=True).squeeze()
+    # Compute FFT magnitude spectra, drop Nyquist bin (unreliable)
+    pred_fft = torch.fft.rfft(p).abs()[:-1]
+    tgt_fft = torch.fft.rfft(t).abs()[:-1]
+    n_freq = pred_fft.shape[0]
+    bin_size = max(1, n_freq // num_bins)
+    eps = 1e-7
+    loss = torch.tensor(0.0, device=pred_surf.device)
+    for b_idx in range(num_bins):
+        w = bin_weights[b_idx] if b_idx < len(bin_weights) else bin_weights[-1]
+        lo = b_idx * bin_size
+        hi = (b_idx + 1) * bin_size if b_idx < num_bins - 1 else n_freq
+        if lo < n_freq:
+            # Relative spectral error: penalizes fractional mismatch per frequency
+            ratio = (pred_fft[lo:hi] + eps) / (tgt_fft[lo:hi] + eps)
+            loss = loss + w * torch.mean((1.0 - ratio) ** 2)
+    return loss
 
 
 def _phys_denorm(y_p, Umag, q):
@@ -1953,6 +2002,35 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
+        # BSP spectral loss on fore-foil surface pressure (tandem samples only)
+        _bsp_loss_val = torch.tensor(0.0, device=device)
+        if cfg.bsp_loss and is_tandem_batch.any():
+            bsp_bin_weights = [float(w) for w in cfg.bsp_bin_weights_str.split(',')]
+            _raw_saf_norm_bsp = x[:, :, 2:4].norm(dim=-1)  # [B, N]
+            # Fore-foil surface = surface nodes with saf_norm ≈ 0 (not aft-foil)
+            fore_foil_mask = is_surface & (_raw_saf_norm_bsp <= 0.005)  # [B, N]
+            bsp_accum = torch.tensor(0.0, device=device)
+            bsp_count = 0
+            for b in range(B):
+                if not is_tandem_batch[b]:
+                    continue
+                fore_idx = fore_foil_mask[b].nonzero(as_tuple=True)[0]
+                if fore_idx.numel() < 8:
+                    continue
+                # Sort fore-foil nodes by angle from centroid for arc-length ordering
+                xy = x[b, fore_idx, :2]  # [M, 2]
+                cx, cy = xy[:, 0].mean(), xy[:, 1].mean()
+                angles = torch.atan2(xy[:, 1] - cy, xy[:, 0] - cx)
+                sort_order = angles.argsort()
+                # Extract pressure predictions and targets in arc-length order
+                pred_p = pred[b, fore_idx[sort_order], 2]   # [M] pressure channel
+                tgt_p = y_norm[b, fore_idx[sort_order], 2]  # [M]
+                bsp_accum = bsp_accum + bsp_loss_fn(pred_p, tgt_p, cfg.bsp_num_bins, bsp_bin_weights)
+                bsp_count += 1
+            if bsp_count > 0:
+                _bsp_loss_val = bsp_accum / bsp_count
+                loss = loss + cfg.bsp_loss_weight * _bsp_loss_val
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -1979,8 +2057,9 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
+            bsp_shared = cfg.bsp_loss_weight * _bsp_loss_val if cfg.bsp_loss else 0.0
             loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + bsp_shared
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2028,11 +2107,12 @@ for epoch in range(MAX_EPOCHS):
                 return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             loss_A = _grp_loss(~is_tandem_batch)
+            bsp_tandem = cfg.bsp_loss_weight * _bsp_loss_val * 0.5 if cfg.bsp_loss else 0.0
             # Only include non-empty groups to avoid backward() on no-grad tensors
             task_losses_with_masks = [
                 (loss_A, (~is_tandem_batch)),
-                (_grp_loss(is_normal_tan), is_normal_tan),
-                (_grp_loss(is_extreme), is_extreme),
+                (_grp_loss(is_normal_tan) + bsp_tandem, is_normal_tan),
+                (_grp_loss(is_extreme) + bsp_tandem, is_extreme),
             ]
             task_losses = [l for l, m in task_losses_with_masks if m.any()]
             if len(task_losses) == 0:
@@ -2153,7 +2233,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.bsp_loss:
+            log_dict["train/bsp_loss"] = _bsp_loss_val.item()
+        wandb.log(log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()

--- a/research/EXPERIMENT_THORFINN_BSP_LOSS.md
+++ b/research/EXPERIMENT_THORFINN_BSP_LOSS.md
@@ -1,0 +1,13 @@
+# Experiment: Binned Spectral Power (BSP) Loss on Arc-Length Surface Pressure
+
+## Hypothesis
+Neural networks exhibit spectral bias — they learn low-frequency components faster and
+more accurately than high-frequency ones (Rahaman et al. ICML 2019). Surface pressure on
+the NACA6416 fore-foil has high-frequency components at leading edge stagnation and wake
+interaction zones — exactly the features that dominate p_tan error.
+
+Apply 1D DFT along arc-length surface coordinate, bin frequency coefficients,
+and apply higher loss weights to mid/high frequency bins.
+
+## Expected impact
+-2 to -5% p_tan. Inspired by Koh & Kim JCP 2026 (arXiv:2502.00472).


### PR DESCRIPTION
## Hypothesis

Neural networks exhibit **spectral bias** — they learn low-frequency components of the target function faster and more accurately than high-frequency ones (Rahaman et al., ICML 2019). Surface pressure on the tandem fore-foil (NACA6416) has significant high-frequency components at:
- The leading edge stagnation point (sharp pressure peak)
- The wake interaction zone downstream of the aft-foil gap

These high-frequency features are exactly what drives p_tan error — the MAE loss weights all spatial locations equally, so the optimizer spends most gradient signal on smooth/low-frequency regions and under-fits the sharp features.

**Proposed fix:** Sort surface nodes by arc-length coordinate, compute a 1D DFT along arc-length, group the Fourier coefficients into 3 frequency bins (low/mid/high), and apply progressively higher loss weights to mid and high frequency bins. This directly increases gradient signal on the features that dominate p_tan error.

Reference: Koh & Kim (JCP 2026, arXiv:2502.00472) — BSP loss showed 10–30% improvement on chaotic fluid system surrogates via this mechanism.

## Instructions

Implement the BSP loss as a new auxiliary loss term in `train.py`. Add the following:

**Step 1 — Add BSP loss function** (add near other loss helper functions):
```python
def bsp_loss(pred_surf, target_surf, num_bins=3, bin_weights=(1.0, 2.0, 3.0)):
    """Binned Spectral Power loss on arc-length sorted surface pressure.
    pred_surf, target_surf: [N_surf] tensors (1D along arc-length)
    """
    N = pred_surf.shape[0]
    # Resample to next power of 2 for efficient FFT
    N_fft = 2 ** int(torch.tensor(N).float().log2().ceil().item())
    idx = torch.linspace(0, N-1, N_fft, device=pred_surf.device).long().clamp(0, N-1)
    p = pred_surf[idx]
    t = target_surf[idx]
    # Compute FFT magnitude spectra
    pred_fft = torch.fft.rfft(p).abs()
    tgt_fft  = torch.fft.rfft(t).abs()
    n_freq = pred_fft.shape[0]
    bin_size = max(1, n_freq // num_bins)
    loss = 0.0
    for b, w in enumerate(bin_weights):
        lo = b * bin_size
        hi = (b+1) * bin_size if b < num_bins - 1 else n_freq
        loss = loss + w * F.mse_loss(pred_fft[lo:hi], tgt_fft[lo:hi])
    return loss
```

**Step 2 — Add CLI flags** (with `argparse`):
```python
parser.add_argument('--bsp_loss', action='store_true', help='Enable BSP spectral loss')
parser.add_argument('--bsp_loss_weight', type=float, default=0.1, help='Weight of BSP loss')
parser.add_argument('--bsp_num_bins', type=int, default=3, help='Number of frequency bins')
parser.add_argument('--bsp_bin_weights', type=str, default='1.0,2.0,3.0',
                    help='Comma-sep weights per bin (low to high freq)')
```

**Step 3 — Apply loss on surface nodes during training**. In the loss computation loop (where surface MAE is computed), after computing the main pressure loss, add:
```python
if args.bsp_loss and is_tandem_sample:
    bw = [float(x) for x in args.bsp_bin_weights.split(',')]
    # Apply to fore-foil surface nodes (boundary_id == 6) sorted by arc-length
    # Use existing surface node masks; sort nodes by their arc-length coordinate
    # (use x/y position as proxy if arc-length not precomputed: cumsum of distances)
    fore_mask = (boundary_ids == 6)  # adjust to actual boundary ID for fore-foil
    if fore_mask.sum() > 4:
        fore_pred = pred_pressure[fore_mask]
        fore_tgt  = target_pressure[fore_mask]
        # Sort by arc-length (approximate via node index or x-coordinate if ordered)
        bsp = bsp_loss(fore_pred, fore_tgt, args.bsp_num_bins, bw)
        total_loss = total_loss + args.bsp_loss_weight * bsp
```

**Important implementation notes:**
- First, identify how surface nodes are indexed in the dataset. Look for `boundary_id`, `surface_mask`, or similar fields in the data loader. The fore-foil nodes need to be identifiable and sortable by arc-length.
- If node ordering already follows arc-length (common in structured mesh data), no re-sorting needed.
- Apply BSP loss **only to tandem samples** (where p_tan matters). Single-foil samples don't need spectral supervision.
- Apply BSP loss **only to fore-foil** (NACA6416) surface nodes, not aft-foil — the aft-foil already has `aft_foil_srf` head.
- Start `bsp_loss_weight=0.1`. If training is unstable, reduce to 0.05.

**Run 2 configs, 2 seeds each** using `--wandb_group thorfinn-bsp-loss`:

**Config A — BSP weight=0.1, bins=(1.0, 2.0, 3.0):**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/bsp-w0.1" --wandb_group thorfinn-bsp-loss \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --bsp_loss --bsp_loss_weight 0.1 --bsp_num_bins 3 --bsp_bin_weights "1.0,2.0,3.0" \
  --seed 42
```
(repeat with `--seed 73`)

**Config B — BSP weight=0.05 (conservative):**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn \
  --wandb_name "thorfinn/bsp-w0.05" --wandb_group thorfinn-bsp-loss \
  ... (same flags except) --bsp_loss_weight 0.05 \
  --seed 42
```
(repeat with `--seed 73`)

Run all 4 in parallel. Report p_in, p_oodc, p_tan, p_re per config (2-seed avg).

**If the BSP loss causes NaN or loss explosion**, reduce `--bsp_loss_weight` to 0.01 and report.

## Baseline

| Metric | Baseline (2-seed avg) |
|--------|----------------------|
| p_in | 13.05 |
| p_oodc | 7.70 |
| **p_tan** | **28.60** |
| p_re | 6.55 |

Baseline W&B runs: d7l91p0x (seed 42, p_tan=28.9), j9btfx09 (seed 73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```