### PR TITLE
Attention Temperature Curriculum: Broad→Sharp Slice Routing

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1070,6 +1070,11 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Attention temperature curriculum: broad→sharp slice routing schedule
+    temp_curriculum: bool = False           # enable attention temperature annealing schedule
+    temp_init: float = 2.0                  # starting temperature (high = broad softmax)
+    temp_floor: float = 0.3                 # ending temperature before free learning
+    temp_anneal_epochs: int = 80            # epochs over which to anneal temp_init → temp_floor
 
 
 cfg = sp.parse(Config)
@@ -1546,6 +1551,25 @@ for epoch in range(MAX_EPOCHS):
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
+
+    # Attention temperature curriculum: broad→sharp slice routing
+    if cfg.temp_curriculum:
+        with torch.no_grad():
+            if epoch < cfg.temp_anneal_epochs:
+                frac = epoch / cfg.temp_anneal_epochs
+                scheduled_temp = cfg.temp_init * (1 - frac) + cfg.temp_floor * frac
+                for module in _base_model.modules():
+                    if hasattr(module, 'temperature') and isinstance(module.temperature, nn.Parameter):
+                        module.temperature.data.fill_(scheduled_temp)
+                        module.temperature.requires_grad_(False)
+            elif epoch == cfg.temp_anneal_epochs:
+                # Release: unfreeze temperature parameters for free learning
+                for module in _base_model.modules():
+                    if hasattr(module, 'temperature') and isinstance(module.temperature, nn.Parameter):
+                        module.temperature.requires_grad_(True)
+        # Log current temperature value
+        _cur_temp = _base_model.blocks[0].attn.temperature.mean().item() if hasattr(_base_model.blocks[0].attn, 'temperature') else float('nan')
+        wandb.log({"train/attn_temperature": _cur_temp, "global_step": global_step})
 
     # --- Train ---
     model.train()

--- a/research/EXPERIMENT_FERN_TEMP_CURRICULUM.md
+++ b/research/EXPERIMENT_FERN_TEMP_CURRICULUM.md
@@ -1,0 +1,9 @@
+# Experiment: Attention Temperature Curriculum
+
+## Hypothesis
+The slice attention temperature is initialized at 0.5 and learns freely. High temp = broad routing
+(many slices get signal), low temp = sharp specialized routing. Scheduling from high→low forces
+broad exploration early, specialized exploitation late. Zero new parameters.
+
+## Expected impact
+-1 to -3% p_tan via better attention routing dynamics.


### PR DESCRIPTION
## Hypothesis

The `temperature` parameter in `Physics_Attention_Irregular_Mesh` is initialized at 0.5 and left to learn freely. It controls how broadly/sharply the slice attention distributes point features:
- **High temperature** → broad softmax, many slices get signal (exploration)
- **Low temperature** → sharp softmax, each point commits to few slices (specialization)

The model currently finds its own temperature from random init, which may converge to a local optimum where tandem points — which need broader context about the paired foil — are over-committed too early in training.

**Proposed:** Externally schedule temperature from high (2.0) → low (0.3) over the first 80 epochs, then release to free learning. This mirrors "warm exploration then exploit" from simulated annealing. Early broad routing helps NACA6416 geometry share signal with seen geometries.

This is orthogonal to GSB (which changes *where* routing happens) — this changes *how broadly* routing happens during training. **Zero new parameters.**

## Instructions

**Step 1 — Add CLI flags:**
```python
parser.add_argument('--temp_curriculum', action='store_true',
                    help='Enable attention temperature scheduling')
parser.add_argument('--temp_init', type=float, default=2.0,
                    help='Starting temperature (high = broad)')
parser.add_argument('--temp_floor', type=float, default=0.3,
                    help='Ending temperature before release')
parser.add_argument('--temp_anneal_epochs', type=int, default=80,
                    help='Epochs over which to anneal')
```

**Step 2 — Add temperature scheduling in the training loop.** At the start of each epoch (after the epoch counter increments), inject the scheduled temperature into all attention modules:

```python
if args.temp_curriculum:
    if epoch < args.temp_anneal_epochs:
        frac = epoch / args.temp_anneal_epochs
        scheduled_temp = args.temp_init * (1 - frac) + args.temp_floor * frac
        for module in model.modules():
            if hasattr(module, 'temperature') and isinstance(module.temperature, nn.Parameter):
                module.temperature.data.fill_(scheduled_temp)
                module.temperature.requires_grad_(False)  # freeze during schedule
    elif epoch == args.temp_anneal_epochs:
        # Release: unfreeze temperature parameters
        for module in model.modules():
            if hasattr(module, 'temperature') and isinstance(module.temperature, nn.Parameter):
                module.temperature.requires_grad_(True)
    # After release, temperature learns freely (no intervention)
```

**Important:** The EMA model's temperature should NOT be externally set — let it accumulate naturally from the training model's updates. Only modify the training model's `temperature` parameter.

**Step 3 — Run 2 configs, 2 seeds each** using `--wandb_group fern-temp-curriculum`:

**Config A — standard anneal (init=2.0, floor=0.3, anneal_epochs=80):**
```bash
cd cfd_tandemfoil && python train.py --agent fern \
  --wandb_name "fern/temp-curr-2.0-0.3-80" --wandb_group fern-temp-curriculum \
  --temp_curriculum --temp_init 2.0 --temp_floor 0.3 --temp_anneal_epochs 80 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --seed 42
```
(repeat with `--seed 73`)

**Config B — shorter anneal (init=1.5, floor=0.5, anneal_epochs=60):**
```bash
cd cfd_tandemfoil && python train.py --agent fern \
  --wandb_name "fern/temp-curr-1.5-0.5-60" --wandb_group fern-temp-curriculum \
  --temp_curriculum --temp_init 1.5 --temp_floor 0.5 --temp_anneal_epochs 60 \
  ... (same baseline flags) \
  --seed 42
```
(repeat with `--seed 73`)

Run all 4 in parallel. Report p_in, p_oodc, p_tan, p_re per config (2-seed avg).

**Diagnostic:** Log the temperature value every 10 epochs to W&B (both during schedule and after release) so we can see where it converges.

## Baseline

| Metric | Baseline (2-seed avg) |
|--------|----------------------|
| p_in | 13.05 |
| p_oodc | 7.70 |
| **p_tan** | **28.60** |
| p_re | 6.55 |

Baseline W&B runs: d7l91p0x (seed 42, p_tan=28.9), j9btfx09 (seed 73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```