### PR TITLE
SWD Tandem Domain Alignment: Slice Token Distribution Matching

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -248,6 +248,9 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             out_slice_token = torch.matmul(attn_weights, v_slice_token)
             out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
 
+        # Store for SWD domain alignment (training only; accessed via _base_model.blocks[-1].attn)
+        if self.training:
+            self._last_slice_token = out_slice_token  # [B, H, G, D_head]
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
         out_x = rearrange(out_x, "b h n d -> b n (h d)")
         return self.to_out(out_x)
@@ -933,6 +936,28 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
+def sliced_wasserstein_distance(x: torch.Tensor, y: torch.Tensor, n_projections: int = 50) -> torch.Tensor:
+    """Sliced Wasserstein Distance between two point clouds via random projections.
+
+    x: [N_x, d] — slice tokens from tandem samples (flattened across heads and slices)
+    y: [N_y, d] — slice tokens from single-foil samples
+    Returns: scalar SWD loss (differentiable w.r.t. both x and y).
+
+    Reference: Lee et al. "Sliced Wasserstein Discrepancy for Unsupervised Domain Adaptation"
+    (CVPR 2019, arXiv:1904.11430).
+    """
+    d = x.shape[-1]
+    directions = F.normalize(torch.randn(n_projections, d, device=x.device), dim=-1)
+    x_proj = x @ directions.T   # [N_x, n_proj]
+    y_proj = y @ directions.T   # [N_y, n_proj]
+    x_sorted = x_proj.sort(dim=0).values
+    y_sorted = y_proj.sort(dim=0).values
+    n = min(x_sorted.shape[0], y_sorted.shape[0])
+    x_sorted = x_sorted[:n]
+    y_sorted = y_sorted[:n]
+    return ((x_sorted - y_sorted) ** 2).mean()
+
+
 MAX_TIMEOUT = 180.0  # minutes
 MAX_EPOCHS = 500
 
@@ -1070,6 +1095,11 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # SWD domain alignment: match slice token distributions between tandem and single-foil
+    swd_align: bool = False
+    swd_weight: float = 0.01
+    swd_n_proj: int = 50
+    swd_start_epoch: int = 20
 
 
 cfg = sp.parse(Config)
@@ -1963,6 +1993,28 @@ for epoch in range(MAX_EPOCHS):
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
             loss = loss + cfg.rdrop_alpha * rdrop_loss
 
+        # SWD domain alignment: pull tandem and single-foil slice token distributions together
+        swd_loss_tensor = None
+        swd_loss_val = 0.0
+        if cfg.swd_align and epoch >= cfg.swd_start_epoch:
+            _last_attn = _base_model.blocks[-1].attn
+            if hasattr(_last_attn, '_last_slice_token') and _last_attn._last_slice_token is not None:
+                _swd_tok = _last_attn._last_slice_token  # [B, H, G, D_head]
+                _is_tandem_swd = is_tandem_batch  # [B] bool
+                if _is_tandem_swd.any() and (~_is_tandem_swd).any():
+                    _Bs, _H, _G, _D = _swd_tok.shape
+                    # Flatten heads into feature dim: [B, G, H*D_head=n_hidden]
+                    _tokens_flat = _swd_tok.permute(0, 2, 1, 3).reshape(_Bs, _G, _H * _D).float()
+                    _tan_tok = _tokens_flat[_is_tandem_swd].reshape(-1, _H * _D)   # [Btan*G, n_hidden]
+                    _sin_tok = _tokens_flat[~_is_tandem_swd].reshape(-1, _H * _D)  # [Bsin*G, n_hidden]
+                    swd_loss_tensor = sliced_wasserstein_distance(_tan_tok, _sin_tok, cfg.swd_n_proj)
+                    swd_loss_val = swd_loss_tensor.item()
+                    loss = loss + cfg.swd_weight * swd_loss_tensor
+                    if global_step % 20 == 0:
+                        wandb.log({"train/swd_loss": swd_loss_val, "global_step": global_step})
+                elif global_step % 20 == 0:
+                    wandb.log({"train/swd_skip": 1, "global_step": global_step})
+
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
@@ -1981,6 +2033,10 @@ for epoch in range(MAX_EPOCHS):
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
             loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
             loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            if swd_loss_tensor is not None:
+                _swd_half = 0.5 * cfg.swd_weight * swd_loss_tensor
+                loss_a = loss_a + _swd_half
+                loss_b = loss_b + _swd_half
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2034,6 +2090,9 @@ for epoch in range(MAX_EPOCHS):
                 (_grp_loss(is_normal_tan), is_normal_tan),
                 (_grp_loss(is_extreme), is_extreme),
             ]
+            if swd_loss_tensor is not None:
+                _swd_per_task = (cfg.swd_weight / 3.0) * swd_loss_tensor
+                task_losses_with_masks = [(l + _swd_per_task, m) for l, m in task_losses_with_masks]
             task_losses = [l for l, m in task_losses_with_masks if m.any()]
             if len(task_losses) == 0:
                 task_losses = [loss_A]  # fallback
@@ -2119,6 +2178,10 @@ for epoch in range(MAX_EPOCHS):
                 scheduler.step()
             except ValueError:
                 pass
+        # Clear stored slice tokens before EMA deepcopy (non-leaf tensors break deepcopy)
+        if cfg.swd_align:
+            for _blk in _base_model.blocks:
+                _blk.attn._last_slice_token = None
         if epoch >= cfg.ema_start_epoch and not cfg.swad and not cfg.swa and not cfg.swa_cyclic and not cfg.snapshot_ensemble:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)

--- a/research/EXPERIMENT_ASKELADD_SWD_ALIGN.md
+++ b/research/EXPERIMENT_ASKELADD_SWD_ALIGN.md
@@ -1,0 +1,9 @@
+# Experiment: SWD Tandem Domain Alignment
+
+## Hypothesis
+Slice token distributions differ between tandem and single-foil samples. Aligning them via
+Sliced Wasserstein Distance forces domain-agnostic intermediate representations that generalize
+better to OOD NACA6416. Computationally cheap (50 random projections).
+
+## Expected impact
+-1 to -4% p_tan via domain-aligned representations.


### PR DESCRIPTION
## Hypothesis

The intermediate slice token distributions of tandem samples vs single-foil samples are misaligned — the model routes them through different feature pathways. This distributional mismatch hurts OOD NACA6416 generalization: the model has learned that "tandem-looking slice distributions" go one way, and NACA6416 in tandem looks different from all seen tandem configs.

**Proposed:** Add an auxiliary loss minimizing the Sliced Wasserstein Distance (SWD) between slice token distributions of tandem and single-foil samples. This forces domain-agnostic intermediate representations at the slice level.

SWD is computationally cheap: O(K × N log N) where K=50 random projections, N = number of slice tokens. Negligible overhead. No adversarial training needed — direct optimal transport distance.

Reference: Lee et al. "Sliced Wasserstein Discrepancy for Unsupervised Domain Adaptation" (CVPR 2019, arXiv:1904.11430).

## Instructions

**Step 1 — Add SWD function:**
```python
def sliced_wasserstein_distance(x, y, n_projections=50):
    """
    x: [N_x, d] — slice tokens from tandem samples
    y: [N_y, d] — slice tokens from single-foil samples
    Returns scalar SWD loss.
    """
    d = x.shape[-1]
    directions = F.normalize(torch.randn(n_projections, d, device=x.device), dim=-1)
    x_proj = x @ directions.T   # [N_x, n_proj]
    y_proj = y @ directions.T   # [N_y, n_proj]
    x_sorted = x_proj.sort(dim=0).values
    y_sorted = y_proj.sort(dim=0).values
    # Resample to same length
    n = min(x_sorted.shape[0], y_sorted.shape[0])
    x_sorted = x_sorted[:n]
    y_sorted = y_sorted[:n]
    return ((x_sorted - y_sorted) ** 2).mean()
```

**Step 2 — Add CLI flags:**
```python
parser.add_argument('--swd_align', action='store_true', help='Enable SWD domain alignment')
parser.add_argument('--swd_weight', type=float, default=0.01, help='SWD loss weight')
parser.add_argument('--swd_n_proj', type=int, default=50, help='Number of random projections')
parser.add_argument('--swd_start_epoch', type=int, default=20,
                    help='Delay SWD loss until primary features established')
```

**Step 3 — Apply in training loop.** After the final TransolverBlock, extract slice tokens and compute SWD:
```python
if args.swd_align and epoch >= args.swd_start_epoch:
    # Need access to slice tokens from the last TransolverBlock
    # These are the intermediate representations before the decoder
    tandem_mask = is_tandem.bool()  # identify tandem samples in batch
    if tandem_mask.any() and (~tandem_mask).any():
        tandem_tokens = slice_tokens[tandem_mask].reshape(-1, n_hidden)
        single_tokens = slice_tokens[~tandem_mask].reshape(-1, n_hidden)
        swd = sliced_wasserstein_distance(tandem_tokens, single_tokens, args.swd_n_proj)
        total_loss = total_loss + args.swd_weight * swd
```

**Important implementation notes:**
- You need to extract `slice_tokens` from the model's forward pass. Look at how `TransolverBlock.forward()` returns slice tokens (the attention-weighted features). You may need to add a hook or modify the forward to return them.
- The `is_tandem` flag should already exist in the training loop (used by tandem_ramp). Use the same mechanism.
- If both `tandem_mask.any()` and `(~tandem_mask).any()` aren't both True in a batch, skip SWD for that batch (log how often this happens).
- Log `swd_loss` value to W&B every 20 steps to monitor convergence.

**Step 4 — Run 2 configs, 2 seeds each** using `--wandb_group askeladd-swd-align`:

**Config A — weight=0.01, start_epoch=20:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd \
  --wandb_name "askeladd/swd-w0.01-e20" --wandb_group askeladd-swd-align \
  --swd_align --swd_weight 0.01 --swd_n_proj 50 --swd_start_epoch 20 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --seed 42
```
(repeat with `--seed 73`)

**Config B — stronger alignment, weight=0.05:**
Same command with `--swd_weight 0.05` and `--wandb_name "askeladd/swd-w0.05-e20"`. (Repeat with `--seed 73`.)

Run all 4 in parallel. Report p_in, p_oodc, p_tan, p_re per config (2-seed avg).

## Baseline

| Metric | Baseline (2-seed avg) |
|--------|----------------------|
| p_in | 13.05 |
| p_oodc | 7.70 |
| **p_tan** | **28.60** |
| p_re | 6.55 |

Baseline W&B runs: d7l91p0x (seed 42, p_tan=28.9), j9btfx09 (seed 73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```