### PR TITLE
Spectral Shaping: Depthwise Conv Filter on GatedMLP Activations

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -60,6 +60,27 @@ ACTIVATION = {
 }
 
 
+class SpectralShaping(nn.Module):
+    """Learnable 1D filter along feature dimension, initialized to Gaussian blur.
+
+    Equivalent to a 1D conv with kernel_size=3 along the feature axis,
+    implemented as shifted-tensor weighted sum for torch.compile efficiency.
+    """
+    def __init__(self, kernel_size=3):
+        super().__init__()
+        assert kernel_size == 3, "Only kernel_size=3 supported"
+        self.w = nn.Parameter(torch.tensor([0.25, 0.50, 0.25]))
+
+    def forward(self, x):
+        # x: [B, N, D] — filter along D using learned 3-tap kernel
+        w0, w1, w2 = self.w[0], self.w[1], self.w[2]
+        # Pad by replicating edge features
+        left = x[..., :1]   # [B, N, 1]
+        right = x[..., -1:]  # [B, N, 1]
+        padded = torch.cat([left, x, right], dim=-1)  # [B, N, D+2]
+        return w0 * padded[..., :-2] + w1 * padded[..., 1:-1] + w2 * padded[..., 2:]
+
+
 class GatedMLP(nn.Module):
     def __init__(self, n_input, n_hidden, n_output, act='gelu'):
         super().__init__()
@@ -283,6 +304,8 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        spectral_shaping=False,
+        spectral_shaping_kernel=3,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -328,6 +351,7 @@ class TransolverBlock(nn.Module):
             nn.init.zeros_(self.film_net[-1].bias)
         self.ln_2 = _LN(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.spec_shape = SpectralShaping(kernel_size=spectral_shaping_kernel) if spectral_shaping else None
         self.spatial_bias = nn.Sequential(
             nn.Linear(spatial_bias_input_dim, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
@@ -400,16 +424,21 @@ class TransolverBlock(nn.Module):
             def _ln(m, x): return m(x, is_tandem=dln_it)
         else:
             def _ln(m, x): return m(x)
+        def _mlp_fwd(x):
+            h = self.mlp(x)
+            if self.spec_shape is not None:
+                h = self.spec_shape(h)
+            return h
         if self.adaln_all and condition is not None:
             cond_out = self.adaln_net(condition)  # [B, H*4]
             s1, b1, s2, b2 = cond_out.chunk(4, dim=-1)  # each [B, H]
             fx_norm = _ln(self.ln_1, fx) * (1 + s1.unsqueeze(1)) + b1.unsqueeze(1)
             fx = _ln(self.ln_1_post, self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
             fx_norm = _ln(self.ln_2, fx) * (1 + s2.unsqueeze(1)) + b2.unsqueeze(1)
-            fx = _ln(self.ln_2_post, self.mlp(fx_norm) + fx)
+            fx = _ln(self.ln_2_post, _mlp_fwd(fx_norm) + fx)
         else:
             fx = _ln(self.ln_1_post, self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
-            fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
+            fx = _ln(self.ln_2_post, _mlp_fwd(_ln(self.ln_2, fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
@@ -700,6 +729,8 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        spectral_shaping=False,
+        spectral_shaping_kernel=3,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -772,6 +803,8 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    spectral_shaping=spectral_shaping,
+                    spectral_shaping_kernel=spectral_shaping_kernel,
                 )
                 for idx in range(n_layers)
             ]
@@ -1070,6 +1103,9 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Spectral shaping — depthwise conv filter on MLP activations
+    spectral_shaping: bool = False           # add spectral shaping conv after MLP in TransolverBlocks
+    spectral_shaping_kernel: int = 3         # kernel size for spectral shaping conv
 
 
 cfg = sp.parse(Config)
@@ -1230,6 +1266,8 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    spectral_shaping=cfg.spectral_shaping,
+    spectral_shaping_kernel=cfg.spectral_shaping_kernel,
 )
 
 model = Transolver(**model_config).to(device)

--- a/research/EXPERIMENT_FRIEREN_SPECTRAL_SHAPING.md
+++ b/research/EXPERIMENT_FRIEREN_SPECTRAL_SHAPING.md
@@ -1,0 +1,9 @@
+# Experiment: Spectral Shaping of GatedMLP Activations
+
+## Hypothesis
+Depthwise 1D conv (kernel=3) in feature dim after GatedMLP gate, initialized to Gaussian blur.
+Filters spectral junk from activations before slice scatter — the most info-dense bottleneck.
+576 extra params per TransolverBlock. Inspired by Fanaskov & Oseledets ICLR 2025.
+
+## Expected impact
+-1 to -3% p_tan via cleaner feature aggregation.


### PR DESCRIPTION
## Hypothesis

The GatedMLP modules in each TransolverBlock apply: x_out = gate(x) * value(x). After this nonlinearity, features can develop high-frequency "spectral junk" in the feature dimension that competes with the physics signal. "Spectral Shaping" (Fanaskov & Oseledets, ICLR 2025) showed that a learned depthwise 1D conv after nonlinearities — acting as a trainable low-pass/bandpass filter — significantly improves surrogate stability on fluid simulation tasks (40-60% spectral leakage reduction on Navier-Stokes).

**Proposed:** Add a depthwise 1D conv (kernel_size=3) in the feature dimension after each GatedMLP gate operation, initialized to a Gaussian blur kernel. This filters spectral artifacts before the slice-scatter step — the most information-dense bottleneck in the architecture.

Very lightweight: 576 extra parameters per TransolverBlock (1,728 total for 3 blocks).

## Instructions

**Step 1 — Add SpectralShaping module:**
```python
class SpectralShaping(nn.Module):
    """Depthwise 1D conv in feature dimension, initialized to Gaussian blur."""
    def __init__(self, n_features, kernel_size=3):
        super().__init__()
        self.conv = nn.Conv1d(n_features, n_features, kernel_size,
                              padding=kernel_size // 2, groups=n_features, bias=False)
        # Initialize to Gaussian blur: [0.25, 0.5, 0.25] for k=3
        with torch.no_grad():
            if kernel_size == 3:
                self.conv.weight.data.fill_(0)
                self.conv.weight.data[:, 0, 0] = 0.25
                self.conv.weight.data[:, 0, 1] = 0.50
                self.conv.weight.data[:, 0, 2] = 0.25

    def forward(self, x):
        # x: [B*N, D] or [B, N, D] — apply conv along feature dim
        if x.dim() == 2:
            return self.conv(x.unsqueeze(-1)).squeeze(-1)
        else:  # [B, N, D]
            B, N, D = x.shape
            x = x.reshape(B * N, D).unsqueeze(-1)  # [BN, D, 1]
            x = self.conv(x).squeeze(-1)  # [BN, D]
            return x.reshape(B, N, D)
```

**Wait — correction.** The conv should operate along the feature dimension. Since features are in the last dim, we need to transpose:
```python
def forward(self, x):
    # x: [B, N, D]
    # Conv1d expects [batch, channels, length]
    # We want to filter along D (feature dim) treating each spatial point independently
    B, N, D = x.shape
    x = x.reshape(B * N, 1, D)    # [BN, 1, D]
    # Use a regular Conv1d with 1 in-channel, 1 out-channel
    x = self.conv(x)               # [BN, 1, D]
    return x.reshape(B, N, D)
```

Actually, simplest approach — use a 1D Conv with groups=1, in_channels=1, out_channels=1:
```python
class SpectralShaping(nn.Module):
    def __init__(self, kernel_size=3):
        super().__init__()
        self.conv = nn.Conv1d(1, 1, kernel_size, padding=kernel_size // 2, bias=False)
        with torch.no_grad():
            if kernel_size == 3:
                self.conv.weight.data[0, 0] = torch.tensor([0.25, 0.50, 0.25])

    def forward(self, x):
        shape = x.shape
        x = x.reshape(-1, 1, shape[-1])  # [B*N, 1, D]
        x = self.conv(x)                  # [B*N, 1, D]
        return x.reshape(shape)
```

**Step 2 — Add CLI flags:**
```python
parser.add_argument('--spectral_shaping', action='store_true',
                    help='Add spectral shaping conv after GatedMLP')
parser.add_argument('--spectral_shaping_kernel', type=int, default=3,
                    help='Kernel size for spectral shaping conv')
```

**Step 3 — Integrate into GatedMLP or TransolverBlock.** After the `gate(x) * value(x)` operation in each GatedMLP, apply spectral shaping:
```python
if args.spectral_shaping:
    self.spec_shape = SpectralShaping(kernel_size=args.spectral_shaping_kernel)

# In forward:
x = gate * value
if hasattr(self, 'spec_shape'):
    x = self.spec_shape(x)
```

**Step 4 — Run 2 seeds** using `--wandb_group frieren-spectral-shaping`:

```bash
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/spec-shape-k3" --wandb_group frieren-spectral-shaping \
  --spectral_shaping --spectral_shaping_kernel 3 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --seed 42
```
(repeat with `--seed 73`)

Report p_in, p_oodc, p_tan, p_re (2-seed avg).

## Baseline

| Metric | Baseline (2-seed avg) |
|--------|----------------------|
| p_in | 13.05 |
| p_oodc | 7.70 |
| **p_tan** | **28.60** |
| p_re | 6.55 |

Baseline W&B runs: d7l91p0x (seed 42), j9btfx09 (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```