### PR TITLE
Coordinated Tandem Ramp: Sigma Decay Synced With Loss Ramp

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -989,6 +989,9 @@ class Config:
     adaln_zone_temp: bool = False      # zone-aware temperature modulation
     # Phase 2 R5: tandem warm-in combinations
     tandem_ramp: bool = False          # gradual tandem surface loss warm-in (0→1 over epochs 10-50)
+    coordinated_ramp: bool = False     # coordinate gap/stagger sigma with tandem_ramp (high→low sigma as ramp rises)
+    ramp_sigma_start: float = 0.06     # starting sigma when coordinated_ramp (high diversity early)
+    ramp_sigma_end: float = 0.02       # ending sigma when coordinated_ramp (precise late)
     foil2_dist: bool = False           # explicit foil-2 distance feature (from secondary dsdf)
     slice_num: int = 48                # slice count (default 48, GPU6: 96)
     # Phase 3: training dynamics experiments
@@ -1627,13 +1630,21 @@ for epoch in range(MAX_EPOCHS):
                     is_surface[_b, _in_region] = is_surface[_cut_idx[_b], _in_region]
 
             # Gap/stagger perturbation augmentation (tandem samples only)
-            if cfg.aug_gap_stagger_sigma > 0.0:
+            # Compute dynamic sigma: coordinated ramp decays sigma as tandem_ramp rises
+            if cfg.coordinated_ramp:
+                _ramp_frac = min(1.0, max(0.0, (epoch - 10) / 40.0))
+                _dynamic_sigma = cfg.ramp_sigma_start * (1.0 - _ramp_frac) + cfg.ramp_sigma_end * _ramp_frac
+                if batch_idx == 0 and epoch in (0, 10, 25, 50, 100):
+                    print(f"[Coord ramp] epoch={epoch}, ramp_frac={_ramp_frac:.3f}, sigma={_dynamic_sigma:.4f}")
+            else:
+                _dynamic_sigma = cfg.aug_gap_stagger_sigma
+            if _dynamic_sigma > 0.0:
                 _is_tandem_aug = (x[:, 0, 21].abs() > 0.01)  # [B] — matches existing tandem detection
                 if _is_tandem_aug.any():
                     _B = x.size(0)
                     # Per-sample Gaussian noise, broadcast to all N nodes
-                    _gap_noise  = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma
-                    _stag_noise = torch.randn(_B, device=x.device) * cfg.aug_gap_stagger_sigma
+                    _gap_noise  = torch.randn(_B, device=x.device) * _dynamic_sigma
+                    _stag_noise = torch.randn(_B, device=x.device) * _dynamic_sigma
                     # Zero out noise for non-tandem samples (preserve single-foil sentinel exactly)
                     _gap_noise  = _gap_noise  * _is_tandem_aug.float()
                     _stag_noise = _stag_noise * _is_tandem_aug.float()
@@ -2153,7 +2164,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.coordinated_ramp:
+            _step_log["train/dynamic_sigma"] = _dynamic_sigma
+        wandb.log(_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()

--- a/research/EXPERIMENT_NEZUKO_COORD_RAMP.md
+++ b/research/EXPERIMENT_NEZUKO_COORD_RAMP.md
@@ -1,0 +1,9 @@
+# Experiment: Coordinated Tandem Ramp Curriculum
+
+## Hypothesis
+tandem_ramp and aug_gap_stagger_sigma are uncoordinated. Ramp sigma from 0.06 down to 0.02 as
+tandem_ramp rises from 0 to 1. High geometric diversity early (broad priors), precise targeting late.
+Critical distinction from aug annealing dead end: changes sigma magnitude, not aug probability.
+
+## Expected impact
+-0.5 to -2% p_tan via better curriculum alignment.


### PR DESCRIPTION
## Hypothesis

The current --tandem_ramp ramps the tandem OOD loss weight from 0→1 over training. The --aug_gap_stagger_sigma=0.02 is applied constantly. These two training dynamics are uncoordinated: the model receives constant geometric diversity from epoch 1, but zero tandem gradient signal early on.

**Proposed:** Coordinate them in opposite directions. Start with HIGH gap/stagger sigma (0.06) while tandem loss weight is LOW, then as tandem_ramp rises, simultaneously ramp sigma DOWN to 0.02. Intuition: broad geometric diversity early (helps learn general tandem priors), precise OOD-focused supervision late.

**Critical distinction from augmentation annealing dead end (#2152):** That experiment annealed augmentation PROBABILITY (turning augs off). This experiment changes sigma MAGNITUDE (maintaining constant probability but narrowing the perturbation range). Augmentation never turns off — it just focuses from broad to precise.

## Instructions

**Step 1 — Add CLI flags:**
```python
parser.add_argument('--coordinated_ramp', action='store_true',
                    help='Coordinate gap/stagger sigma with tandem_ramp')
parser.add_argument('--ramp_sigma_start', type=float, default=0.06,
                    help='Starting sigma (high diversity)')
parser.add_argument('--ramp_sigma_end', type=float, default=0.02,
                    help='Ending sigma (precise targeting)')
```

**Step 2 — In training loop, compute dynamic sigma each epoch.** Find where `aug_gap_stagger_sigma` is used to generate augmentation noise. Replace the fixed sigma with a dynamic one:

```python
if args.coordinated_ramp:
    # Get the tandem ramp fraction (same schedule that ramps tandem loss weight)
    # Look for where tandem_ramp_weight is computed — it goes from 0 to 1
    ramp_frac = tandem_ramp_weight  # 0 early, 1 late
    dynamic_sigma = args.ramp_sigma_start * (1 - ramp_frac) + args.ramp_sigma_end * ramp_frac
else:
    dynamic_sigma = args.aug_gap_stagger_sigma
```

Then use `dynamic_sigma` wherever `args.aug_gap_stagger_sigma` is used for noise generation.

**Important:** The tandem_ramp schedule is already in train.py — find how tandem_ramp_weight is computed per epoch and reuse the same fraction. The sigma should track it inversely: when tandem_ramp_weight is 0 (early), sigma is 0.06; when tandem_ramp_weight is 1 (late), sigma is 0.02.

**Step 3 — Run 2 configs, 2 seeds each** using `--wandb_group nezuko-coord-ramp`:

**Config A — sigma 0.06→0.02:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/coord-ramp-0.06" --wandb_group nezuko-coord-ramp \
  --coordinated_ramp --ramp_sigma_start 0.06 --ramp_sigma_end 0.02 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --seed 42
```
(repeat with `--seed 73`)

**Config B — sigma 0.04→0.02 (narrower range):**
Same command with `--ramp_sigma_start 0.04` and `--wandb_name "nezuko/coord-ramp-0.04"`. (Repeat with `--seed 73`.)

Run all 4 in parallel. Report p_in, p_oodc, p_tan, p_re per config (2-seed avg).

**Note:** Log the dynamic_sigma value to W&B every epoch so we can see the decay curve.

## Baseline

| Metric | Baseline (2-seed avg) |
|--------|----------------------|
| p_in | 13.05 |
| p_oodc | 7.70 |
| **p_tan** | **28.60** |
| p_re | 6.55 |

Baseline W&B runs: d7l91p0x (seed 42), j9btfx09 (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```