### PR TITLE
Multi-Resolution Hash Grid Encoding of Mesh Coordinates

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -134,6 +134,82 @@ class DomainLayerNorm(nn.Module):
         return torch.where(mask_t, self.ln_tandem(x), self.ln_single(x))
 
 
+class HashGrid2D(nn.Module):
+    """Multi-resolution 2D hash grid encoding (Instant-NGP style).
+
+    Expects per-sample normalized coordinates in [0, 1]^2.
+    Output dim = n_levels * features_per_level.
+    """
+    def __init__(self, n_levels=8, features_per_level=4, base_resolution=16,
+                 max_resolution=2048, hash_table_size=2**16):
+        super().__init__()
+        self.n_levels = n_levels
+        self.features_per_level = features_per_level
+        self.output_dim = n_levels * features_per_level  # 32
+
+        # Compute resolution at each level (geometric progression)
+        b = (max_resolution / base_resolution) ** (1.0 / (n_levels - 1))
+        self.resolutions = [int(base_resolution * b**i) for i in range(n_levels)]
+
+        # Hash tables: one embedding table per level
+        self.hash_tables = nn.ModuleList([
+            nn.Embedding(min(res * res, hash_table_size), features_per_level)
+            for res in self.resolutions
+        ])
+
+        # Initialize small so it starts near-zero (doesn't disrupt baseline)
+        for table in self.hash_tables:
+            nn.init.uniform_(table.weight, -1e-4, 1e-4)
+
+    def forward(self, xy_norm):
+        """
+        xy_norm: (B, N, 2) — per-sample normalized mesh coordinates in [0, 1].
+        Returns: (B, N, output_dim) hash grid features.
+        """
+        xy_norm = xy_norm.clamp(0.0, 1.0)
+        features = []
+        for level_idx, res in enumerate(self.resolutions):
+            # Scale to grid resolution
+            xy_scaled = xy_norm * (res - 1)  # (B, N, 2)
+
+            # Floor and ceil for bilinear interpolation
+            xy_floor = xy_scaled.long().clamp(0, res - 2)
+            xy_ceil = xy_floor + 1
+            frac = xy_scaled - xy_floor.float()  # fractional part
+
+            # 4 corner indices for bilinear interp (XOR spatial hash)
+            hash_size = self.hash_tables[level_idx].num_embeddings
+            ix0, iy0 = xy_floor[..., 0], xy_floor[..., 1]
+            ix1, iy1 = xy_ceil[..., 0], xy_ceil[..., 1]
+
+            def _hash(ix, iy):
+                return ((ix * 2654435761) ^ (iy * 805459861)) % hash_size
+
+            idx_00 = _hash(ix0, iy0)
+            idx_01 = _hash(ix0, iy1)
+            idx_10 = _hash(ix1, iy0)
+            idx_11 = _hash(ix1, iy1)
+
+            # Look up features
+            table = self.hash_tables[level_idx]
+            f00 = table(idx_00)  # (B, N, F)
+            f01 = table(idx_01)
+            f10 = table(idx_10)
+            f11 = table(idx_11)
+
+            # Bilinear interpolation
+            fx = frac[..., 0:1]  # (B, N, 1)
+            fy = frac[..., 1:2]
+            f = (f00 * (1 - fx) * (1 - fy) +
+                 f01 * (1 - fx) * fy +
+                 f10 * fx * (1 - fy) +
+                 f11 * fx * fy)
+
+            features.append(f)
+
+        return torch.cat(features, dim=-1)  # (B, N, n_levels * features_per_level)
+
+
 class Physics_Attention_Irregular_Mesh(nn.Module):
     """Physics attention for irregular meshes in 1D/2D/3D space."""
 
@@ -700,6 +776,7 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        hash_grid_encoding=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -802,6 +879,13 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        # Hash grid encoding — instantiated after initialize_weights() to preserve small init
+        if hash_grid_encoding:
+            self.hash_grid = HashGrid2D(
+                n_levels=8, features_per_level=4,
+                base_resolution=16, max_resolution=2048,
+                hash_table_size=2**16,
+            )
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -1070,6 +1154,8 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Multi-resolution hash grid encoding of mesh coordinates
+    hash_grid_encoding: bool = False         # enable Instant-NGP-style hash grid spatial encoding
 
 
 cfg = sp.parse(Config)
@@ -1200,7 +1286,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32 + (32 if cfg.hash_grid_encoding else 0),  # +curv, +dist, [+foil2dist], +32 fourier PE, [+32 hash grid]
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1230,6 +1316,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    hash_grid_encoding=cfg.hash_grid_encoding,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1424,20 +1511,25 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+_hash_grid_names = {'hash_grid'}
+_attn_keys = ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias']
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in _attn_keys) and not any(h in n for h in _hash_grid_names)]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in _attn_keys) and not any(h in n for h in _hash_grid_names)]
 _base_lr = cfg.two_phase_lr_1 if cfg.two_phase_lr else cfg.lr
+_param_groups = [
+    {'params': attn_params, 'lr': _base_lr * 0.5},
+    {'params': other_params, 'lr': _base_lr},
+]
+# Hash grid params get 5x higher LR for faster spatial feature learning
+if cfg.hash_grid_encoding:
+    _hash_params = [p for n, p in model.named_parameters() if any(h in n for h in _hash_grid_names)]
+    _param_groups.append({'params': _hash_params, 'lr': _base_lr * 5.0})
+    print(f"Hash grid: {sum(p.numel() for p in _hash_params):,} params at lr={_base_lr * 5.0:.1e}")
 if cfg.use_lion:
-    base_opt = Lion([
-        {'params': attn_params, 'lr': _base_lr * 0.5},
-        {'params': other_params, 'lr': _base_lr}
-    ], weight_decay=cfg.weight_decay)
+    base_opt = Lion(_param_groups, weight_decay=cfg.weight_decay)
     optimizer = base_opt  # Lion has its own momentum; skip Lookahead
 else:
-    base_opt = torch.optim.AdamW([
-        {'params': attn_params, 'lr': _base_lr * 0.5},
-        {'params': other_params, 'lr': _base_lr}
-    ], weight_decay=cfg.weight_decay)
+    base_opt = torch.optim.AdamW(_param_groups, weight_decay=cfg.weight_decay)
     if cfg.use_lookahead:
         optimizer = Lookahead(base_opt, k=10, alpha=0.8)
     else:
@@ -1684,6 +1776,9 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
+        if hasattr(_base_model, 'hash_grid'):
+            hash_feat = _base_model.hash_grid(xy_norm)
+            x = torch.cat([x, hash_feat], dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -2321,6 +2416,9 @@ for epoch in range(MAX_EPOCHS):
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
+                if hasattr(eval_model, 'hash_grid'):
+                    hash_feat = eval_model.hash_grid(xy_norm)
+                    x = torch.cat([x, hash_feat], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
@@ -2706,6 +2804,9 @@ if best_metrics:
                     xy_scaled = xy_norm.unsqueeze(-1) * freqs
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
+                    if hasattr(vis_model, 'hash_grid'):
+                        hash_feat = vis_model.hash_grid(xy_norm)
+                        x_n = torch.cat([x_n, hash_feat], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
                     if cfg.raw_targets:
@@ -2806,6 +2907,9 @@ if cfg.surface_refine and best_metrics:
                     xy_scaled = xy_norm.unsqueeze(-1) * freqs
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x = torch.cat([x, fourier_pe], dim=-1)
+                    if hasattr(verify_model, 'hash_grid'):
+                        hash_feat = verify_model.hash_grid(xy_norm)
+                        x = torch.cat([x, hash_feat], dim=-1)
 
                     # Ground truth denormalization reference
                     Umag, q = _umag_q(y, mask)

--- a/research/EXPERIMENT_EDWARD_HASH_GRID.md
+++ b/research/EXPERIMENT_EDWARD_HASH_GRID.md
@@ -1,0 +1,5 @@
+# Experiment: Multi-Resolution Hash Grid Encoding of Mesh Coordinates
+
+**Student:** edward
+**Branch:** edward/hash-grid-encoding
+**Status:** WIP


### PR DESCRIPTION
## Hypothesis

The Transolver's DSDF features encode distance/direction to foil surfaces at a fixed resolution. The network must learn to map this low-frequency input to high-frequency pressure gradients (leading edge stagnation, suction peaks, trailing edge separation) through all its layers. Neural networks exhibit **spectral bias** — they preferentially learn low-frequency components first (Rahaman et al., 2019). A multi-resolution hash grid encoding of (x, y) mesh coordinates provides explicit high-frequency spatial features that the backbone can access directly, breaking the spectral bias bottleneck.

**Evidence:** "Parametric hash encoding for physics surrogates" (arXiv:2403.15652, UC Irvine, 2024) showed that hash grid encodings applied to mesh coordinates for PDE surrogates reduce error by **30-50%** on problems with fine spatial structure. Hash grids are trained end-to-end alongside the network.

**Key difference from Fourier PE:** Fourier features are fixed-frequency; hash grid features are learned and can represent arbitrary spatial frequencies by discovering which grid cells matter for pressure prediction.

## Instructions

### Step 1: Implement `HashGrid2D` module

Add a new `HashGrid2D` class in `train.py` (near the other model components). This implements a 2D multi-resolution hash grid:

```python
class HashGrid2D(nn.Module):
    """Multi-resolution 2D hash grid encoding (Instant-NGP style)."""
    def __init__(self, n_levels=8, features_per_level=4, base_resolution=16,
                 max_resolution=2048, hash_table_size=2**16,
                 x_range=(-0.5, 2.5), y_range=(-1.0, 1.0)):
        super().__init__()
        self.n_levels = n_levels
        self.features_per_level = features_per_level
        self.output_dim = n_levels * features_per_level  # 32

        # Compute resolution at each level (geometric progression)
        resolutions = []
        b = (max_resolution / base_resolution) ** (1.0 / (n_levels - 1))
        for i in range(n_levels):
            resolutions.append(int(base_resolution * b**i))
        self.resolutions = resolutions

        # Hash tables: one embedding table per level
        self.hash_tables = nn.ModuleList([
            nn.Embedding(min(res * res, hash_table_size), features_per_level)
            for res in resolutions
        ])

        # Initialize small
        for table in self.hash_tables:
            nn.init.uniform_(table.weight, -1e-4, 1e-4)

        # Spatial range for normalization
        self.register_buffer('x_min', torch.tensor([x_range[0], y_range[0]]))
        self.register_buffer('x_max', torch.tensor([x_range[1], y_range[1]]))

    def forward(self, xy):
        """
        xy: (B, N, 2) or (N, 2) — mesh (x, y) coordinates
        Returns: (B, N, output_dim) or (N, output_dim) hash grid features
        """
        squeeze = False
        if xy.dim() == 2:
            xy = xy.unsqueeze(0)
            squeeze = True

        B, N, _ = xy.shape
        # Normalize to [0, 1]
        xy_norm = (xy - self.x_min) / (self.x_max - self.x_min + 1e-8)
        xy_norm = xy_norm.clamp(0, 1)

        features = []
        for level_idx, res in enumerate(self.resolutions):
            # Scale to grid resolution
            xy_scaled = xy_norm * (res - 1)  # (B, N, 2)

            # Floor and ceil for bilinear interpolation
            xy_floor = xy_scaled.long().clamp(0, res - 2)
            xy_ceil = xy_floor + 1
            frac = xy_scaled - xy_floor.float()  # fractional part

            # 4 corner indices for bilinear interp
            hash_size = self.hash_tables[level_idx].num_embeddings
            def hash_idx(ix, iy):
                # Simple spatial hash
                return ((ix * 2654435761) ^ (iy * 805459861)) % hash_size

            idx_00 = hash_idx(xy_floor[..., 0], xy_floor[..., 1])  # (B, N)
            idx_01 = hash_idx(xy_floor[..., 0], xy_ceil[..., 1])
            idx_10 = hash_idx(xy_ceil[..., 0], xy_floor[..., 1])
            idx_11 = hash_idx(xy_ceil[..., 0], xy_ceil[..., 1])

            # Look up features
            f00 = self.hash_tables[level_idx](idx_00)  # (B, N, F)
            f01 = self.hash_tables[level_idx](idx_01)
            f10 = self.hash_tables[level_idx](idx_10)
            f11 = self.hash_tables[level_idx](idx_11)

            # Bilinear interpolation
            fx = frac[..., 0:1]  # (B, N, 1)
            fy = frac[..., 1:2]
            f = (f00 * (1-fx) * (1-fy) +
                 f01 * (1-fx) * fy +
                 f10 * fx * (1-fy) +
                 f11 * fx * fy)

            features.append(f)

        out = torch.cat(features, dim=-1)  # (B, N, n_levels * features_per_level)
        if squeeze:
            out = out.squeeze(0)
        return out
```

**IMPORTANT:** Check what the actual coordinate range is in the dataset. Read a few batches and print `x[:, :, 0].min(), x[:, :, 0].max()` and `x[:, :, 1].min(), x[:, :, 1].max()` to set `x_range` and `y_range` correctly. The defaults above are guesses.

### Step 2: Integrate into the forward pass

Add `--hash_grid_encoding` flag. When enabled:

1. Instantiate `HashGrid2D` as `self.hash_grid` in the model `__init__`
2. In the forward pass, extract (x, y) coordinates from the input: `xy = x[:, :, :2]` (first two channels are x, y coordinates)
3. Compute hash features: `hash_feat = self.hash_grid(xy)` → shape (B, N, 32)
4. Concatenate to existing features: `x = torch.cat([x, hash_feat], dim=-1)` → input dim becomes 24 + 32 = 56
5. Update the first linear layer input dimension accordingly (you'll need to make this conditional on the flag)

### Step 3: Separate learning rate for hash grid parameters

The hash grid parameters benefit from a higher learning rate than the backbone. Create two parameter groups:

```python
hash_params = list(model.hash_grid.parameters())
other_params = [p for name, p in model.named_parameters() if 'hash_grid' not in name]

optimizer = Lion([
    {'params': other_params, 'lr': 2e-4},
    {'params': hash_params, 'lr': 1e-3},  # 5x higher for hash grid
], weight_decay=5e-5)
```

Both groups still use cosine annealing with T_max=160.

### Step 4: Run experiments

Run **2 seeds** with the W&B group:

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/hash-grid-encoding-s42" \
  --wandb_group "edward/hash-grid-encoding" \
  --hash_grid_encoding \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias

# Seed 73
cd cfd_tandemfoil && python train.py --agent edward --seed 73 \
  --wandb_name "edward/hash-grid-encoding-s73" \
  --wandb_group "edward/hash-grid-encoding" \
  --hash_grid_encoding \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias
```

### Key implementation notes

1. **Coordinate range:** MUST check actual data range before hardcoding. Print min/max of x[:,:,0] and x[:,:,1] from a few training batches.
2. **torch.compile compatibility:** The hash grid uses standard nn.Embedding + basic tensor ops, so it should be compile-friendly. Test with `torch.compile` before the full run.
3. **VRAM:** The hash tables add ~8 * min(res^2, 65536) * 4 * 4 bytes ≈ ~8MB total. Negligible VRAM impact.
4. **Hash function:** The XOR-based spatial hash above is the standard Instant-NGP hash. Ensure the hash indices are computed with `long()` tensors to avoid overflow.
5. **Gradient flow:** The hash grid learns through bilinear interpolation gradients. This is standard and well-tested in NeRF/Instant-NGP implementations.
6. **DSDF channel indices reminder:** Foil-1 DSDF channels are at `x[:,4:8]` NOT `x[:,2:6]`. Foil-2 at `x[:,6:10]`. XY coordinates are `x[:,:,:2]`.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.05** | < 13.05 |
| p_oodc | **7.70** | < 7.70 |
| **p_tan** | **28.60** | **< 28.60** |
| p_re | **6.55** | < 6.55 |

**Baseline W&B runs:** d7l91p0x (s42, p_tan=28.9), j9btfx09 (s73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias
```