### PR TITLE
GEPS Test-Time Low-Rank Adaptation for OOD Tandem

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -960,8 +960,8 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-MAX_TIMEOUT = 180.0  # minutes
-MAX_EPOCHS = 500
+MAX_TIMEOUT = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", 180.0))
+MAX_EPOCHS = int(os.environ.get("SENPAI_MAX_EPOCHS", 500))
 
 
 @dataclass
@@ -1102,6 +1102,7 @@ class Config:
     geps_tta_steps: int = 10               # number of TTA adaptation steps per batch
     geps_tta_lr: float = 1e-3              # learning rate for LoRA adaptation
     geps_tta_rank: int = 4                 # rank of LoRA context parameters
+    geps_tta_eval_every: int = 0          # apply TTA every N epochs (0 = only at last epoch/timeout)
 
 
 cfg = sp.parse(Config)
@@ -2473,9 +2474,16 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm / sample_stds
 
                 # GEPS test-time adaptation: adapt LoRA params via continuity residual
-                # Only for val_tandem_transfer where OOD generalization matters most
+                # Only for val_tandem_transfer where OOD generalization matters most.
+                # Only activate at the last epoch (or every geps_tta_eval_every epochs) to avoid
+                # making every training epoch slow (TTA adds ~12 min per validation pass).
+                _elapsed_now = (time.time() - train_start) / 60.0
+                _is_last_epoch = (epoch == MAX_EPOCHS - 1
+                                  or _elapsed_now >= MAX_TIMEOUT - 5.0
+                                  or (cfg.geps_tta_eval_every > 0 and (epoch + 1) % cfg.geps_tta_eval_every == 0))
                 _geps_active = (cfg.geps_tta and split_name == "val_tandem_transfer"
-                                and eval_model.lora_ctxs is not None)
+                                and eval_model.lora_ctxs is not None
+                                and _is_last_epoch)
                 if _geps_active:
                     # Reset LoRA params to zero before each batch
                     _lora_params = [p for n, p in eval_model.named_parameters() if 'lora' in n]

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -663,6 +663,23 @@ class SurfaceRefinementContextHead(nn.Module):
         return correction
 
 
+class LoRAContext(nn.Module):
+    """Low-rank context adaptation parameters (GEPS-style).
+
+    Applied after each TransolverBlock. Initialized to zero so the model
+    behaves identically at init. Only adapted during test-time adaptation (TTA).
+    """
+
+    def __init__(self, hidden_dim: int, rank: int = 4):
+        super().__init__()
+        self.lora_A = nn.Parameter(torch.zeros(hidden_dim, rank))
+        self.lora_B = nn.Parameter(torch.zeros(rank, hidden_dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [B, N, D] — low-rank residual: x + x @ A @ B
+        return x + x @ self.lora_A @ self.lora_B
+
+
 class Transolver(nn.Module):
     def __init__(
         self,
@@ -700,10 +717,12 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        geps_lora_rank=0,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.geps_lora_rank = geps_lora_rank
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -781,6 +800,11 @@ class Transolver(nn.Module):
             with torch.no_grad():
                 for block in self.blocks:
                     block.spatial_bias[0].weight[:, 4:].zero_()
+        # GEPS LoRA context: low-rank adaptation parameters for test-time adaptation
+        # Only applied to non-last blocks (last block outputs predictions, not hidden features)
+        self.lora_ctxs = None
+        if geps_lora_rank > 0:
+            self.lora_ctxs = nn.ModuleList([LoRAContext(n_hidden, geps_lora_rank) for _ in range(n_layers - 1)])
         # Separate pressure pathway (pressure_separate_last_block):
         # Independent MLP + pres_head that processes shared hidden features
         self._pressure_separate = False  # set from Config after construction
@@ -898,8 +922,10 @@ class Transolver(nn.Module):
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
-        for block in self.blocks[:-1]:
+        for i, block in enumerate(self.blocks[:-1]):
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+            if self.lora_ctxs is not None:
+                fx = self.lora_ctxs[i](fx)
 
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
@@ -921,6 +947,7 @@ class Transolver(nn.Module):
             fx = torch.cat([fx[:, :, :2], p_sep], dim=-1)
         else:
             fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features)
+        # Note: no LoRAContext after last block (it outputs predictions, not hidden features)
 
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
@@ -1070,6 +1097,11 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: GEPS test-time adaptation — low-rank LoRA context adaptation at inference
+    geps_tta: bool = False                  # enable GEPS test-time adaptation during validation
+    geps_tta_steps: int = 10               # number of TTA adaptation steps per batch
+    geps_tta_lr: float = 1e-3              # learning rate for LoRA adaptation
+    geps_tta_rank: int = 4                 # rank of LoRA context parameters
 
 
 cfg = sp.parse(Config)
@@ -1108,6 +1140,59 @@ def _umag_q(y, mask):
     Umag = (Ux_mean ** 2 + Uy_mean ** 2).sqrt().clamp(min=1.0).unsqueeze(-1)  # [B, 1, 1]
     q = 0.5 * Umag ** 2
     return Umag, q
+
+
+def _compute_continuity_residual(coords_t: torch.Tensor, Ux: torch.Tensor, Uy: torch.Tensor,
+                                  mask: torch.Tensor, K: int = 8,
+                                  max_nodes: int = 4096) -> torch.Tensor:
+    """Compute mean |div(U)|^2 using vectorized KNN least-squares gradient estimation.
+
+    Args:
+        coords_t:  [N, 2] float32 — node (x, y) positions (physical, not normalized)
+        Ux, Uy:   [N] float32 — predicted velocity components (must have grad)
+        mask:     [N] bool — valid node mask (e.g. non-padding interior nodes)
+        K:        number of nearest neighbors for local gradient estimation
+        max_nodes: subsample to this many nodes if M > max_nodes (avoids O(M^2) OOM)
+    Returns:
+        scalar — mean continuity residual over sampled valid nodes
+    """
+    coords_v = coords_t[mask]  # [M, 2]
+    Ux_v = Ux[mask]            # [M]
+    Uy_v = Uy[mask]            # [M]
+    M = coords_v.shape[0]
+    if M < K + 1:
+        return torch.tensor(0.0, device=Ux.device, requires_grad=True)
+
+    # Subsample to avoid O(M^2) OOM for large meshes
+    if M > max_nodes:
+        perm = torch.randperm(M, device=coords_v.device)[:max_nodes]
+        coords_v = coords_v[perm]
+        Ux_v = Ux_v[perm]
+        Uy_v = Uy_v[perm]
+        M = max_nodes
+
+    # Pairwise distances — cdist on subsampled set (max_nodes × max_nodes)
+    dists = torch.cdist(coords_v, coords_v)  # [M, M]
+    dists.fill_diagonal_(float('inf'))
+    k = min(K, M - 1)
+    _, nbr_idx = dists.topk(k, dim=-1, largest=False)  # [M, k]
+
+    # Delta coordinates and velocity differences
+    delta = coords_v[nbr_idx] - coords_v.unsqueeze(1)   # [M, k, 2]
+    dUx = Ux_v[nbr_idx] - Ux_v.unsqueeze(1)             # [M, k]
+    dUy = Uy_v[nbr_idx] - Uy_v.unsqueeze(1)             # [M, k]
+
+    # Batch normal equations: (A^T A)^{-1} A^T dU, where A = delta [M, k, 2]
+    ATA = torch.bmm(delta.transpose(1, 2), delta)  # [M, 2, 2]
+    ATA = ATA + 1e-8 * torch.eye(2, device=ATA.device).unsqueeze(0)
+    ATdUx = torch.bmm(delta.transpose(1, 2), dUx.unsqueeze(2)).squeeze(2)  # [M, 2]
+    ATdUy = torch.bmm(delta.transpose(1, 2), dUy.unsqueeze(2)).squeeze(2)  # [M, 2]
+
+    grad_Ux = torch.linalg.solve(ATA, ATdUx.unsqueeze(2)).squeeze(2)  # [M, 2]
+    grad_Uy = torch.linalg.solve(ATA, ATdUy.unsqueeze(2)).squeeze(2)  # [M, 2]
+
+    div_U = grad_Ux[:, 0] + grad_Uy[:, 1]  # ∂Ux/∂x + ∂Uy/∂y
+    return (div_U ** 2).mean()
 
 
 def _phys_norm(y, Umag, q):
@@ -1230,6 +1315,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    geps_lora_rank=cfg.geps_tta_rank if cfg.geps_tta else 0,
 )
 
 model = Transolver(**model_config).to(device)
@@ -2296,6 +2382,8 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
+                # Save raw physical coordinates for GEPS TTA continuity residual
+                _raw_pos_v = x[:, :, :2].clone()  # [B, N, 2] — physical (x, y) before normalization
                 # Aft-foil mask for eval (same logic as training)
                 _eval_aft_mask = None
                 if eval_aft_srf_head is not None:
@@ -2383,6 +2471,49 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm * sample_stds
                 else:
                     y_norm_scaled = y_norm / sample_stds
+
+                # GEPS test-time adaptation: adapt LoRA params via continuity residual
+                # Only for val_tandem_transfer where OOD generalization matters most
+                _geps_active = (cfg.geps_tta and split_name == "val_tandem_transfer"
+                                and eval_model.lora_ctxs is not None)
+                if _geps_active:
+                    # Reset LoRA params to zero before each batch
+                    _lora_params = [p for n, p in eval_model.named_parameters() if 'lora' in n]
+                    with torch.no_grad():
+                        for p in _lora_params:
+                            p.zero_()
+                    # Run TTA: adapt LoRA using continuity residual (no ground truth needed)
+                    # torch.enable_grad() needed because the outer val loop runs under torch.no_grad()
+                    _tta_opt = torch.optim.Adam(_lora_params, lr=cfg.geps_tta_lr)
+                    eval_model.train()
+                    with torch.enable_grad():
+                        for _tta_step in range(cfg.geps_tta_steps):
+                            _tta_opt.zero_grad()
+                            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                                _tta_out = eval_model({"x": x})
+                            _tta_pred = _tta_out["preds"].float()  # [B, N, 3] — [Ux, Uy, p]
+                            # Add freestream back if residual prediction mode
+                            if cfg.residual_prediction and _v_freestream is not None:
+                                _tta_pred_phys = _tta_pred + _v_freestream
+                            else:
+                                _tta_pred_phys = _tta_pred
+                            # Compute continuity residual per batch item
+                            _cont_loss = torch.tensor(0.0, device=device)
+                            for _b in range(x.shape[0]):
+                                _bmask = mask[_b]
+                                _Ux_b = _tta_pred_phys[_b, :, 0]
+                                _Uy_b = _tta_pred_phys[_b, :, 1]
+                                _coords_b = _raw_pos_v[_b]  # [N, 2]
+                                _cont_loss = _cont_loss + _compute_continuity_residual(
+                                    _coords_b, _Ux_b, _Uy_b, _bmask, K=8
+                                )
+                            _cont_loss = _cont_loss / x.shape[0]
+                            _cont_loss.backward()
+                            _tta_opt.step()
+                    eval_model.eval()
+                    if n_vbatches == 0:
+                        wandb.log({"val_tandem_transfer/tta_cont_loss": _cont_loss.item(),
+                                   "global_step": global_step})
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     _eval_out = eval_model({"x": x})

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -960,8 +960,8 @@ class Transolver(nn.Module):
 # ---------------------------------------------------------------------------
 
 
-MAX_TIMEOUT = float(os.environ.get("SENPAI_TIMEOUT_MINUTES", 180.0))
-MAX_EPOCHS = int(os.environ.get("SENPAI_MAX_EPOCHS", 500))
+MAX_TIMEOUT = 180.0  # minutes (wall-clock limit per run)
+MAX_EPOCHS = 500
 
 
 @dataclass

--- a/research/EXPERIMENT_FERN_GEPS_TTA.md
+++ b/research/EXPERIMENT_FERN_GEPS_TTA.md
@@ -1,0 +1,5 @@
+# Experiment: GEPS Test-Time Low-Rank Adaptation
+
+**Student:** fern
+**Branch:** fern/geps-tta
+**Status:** WIP


### PR DESCRIPTION
## Hypothesis

The NACA6416 fore-foil is OOD — it is unlike anything in the training distribution. Standard inference cannot generalize across this gap. **GEPS** (Generalization of PDE Surrogates via Context Adaptation, arXiv:2410.23889, NeurIPS 2024) showed that low-rank context adaptation at test time — using a physics-based self-supervised signal with no ground truth — generalizes PDE surrogates to unseen PDE parameters and geometries. The key: only a small set of low-rank context parameters are adapted, while large pretrained weights stay frozen, preventing overfitting to noise.

**The physics signal:** For incompressible flow, the continuity equation ∂Ux/∂x + ∂Uy/∂y = 0 must hold everywhere. The model predicts both pressure and velocity. At test time, we adapt context parameters to minimize the continuity residual of the velocity predictions. This signal requires NO ground truth — only the model's own predictions and the mesh coordinates.

**Expected benefit:** GEPS showed 10-40% OOD error reduction on Navier-Stokes-adjacent problems. Our p_tan gap is the classic OOD scenario GEPS was designed for.

## Instructions

### Step 1: Add low-rank context parameters to attention layers

Add LoRA-style context parameters to each TransolverBlock's attention mechanism. These are small, low-rank matrices that modulate the attention output:

```python
class LoRAContext(nn.Module):
    """Low-rank context adaptation parameters (GEPS-style)."""
    def __init__(self, hidden_dim, rank=4):
        super().__init__()
        self.lora_A = nn.Parameter(torch.zeros(hidden_dim, rank))
        self.lora_B = nn.Parameter(torch.zeros(rank, hidden_dim))
        # Initialize to zero so model behaves identically without adaptation

    def forward(self, x):
        # x: (B, N, D) or (N, D)
        return x + x @ self.lora_A @ self.lora_B  # low-rank residual
```

Add one `LoRAContext` per TransolverBlock, applied after the attention output (before the residual connection). Total new params: `n_layers * 2 * rank * hidden_dim` = 3 * 2 * 4 * 192 = ~4600 params.

**IMPORTANT:** The LoRA parameters are initialized to ZERO. During standard training, they contribute nothing. They ONLY activate during test-time adaptation.

### Step 2: Implement KNN-based continuity residual

The continuity equation for 2D incompressible flow: div(U) = ∂Ux/∂x + ∂Uy/∂y = 0.

To compute this from unstructured node predictions, use K-nearest-neighbor finite differences:

```python
from scipy.spatial import cKDTree
import torch

def compute_continuity_residual(coords, Ux_pred, Uy_pred, K=8):
    """
    Compute |div(U)|^2 at each node using KNN-based finite differences.

    coords: (N, 2) numpy array of (x, y) positions
    Ux_pred, Uy_pred: (N,) tensors of predicted velocity components
    K: number of nearest neighbors for gradient estimation
    Returns: scalar continuity residual (mean |div(U)|^2)
    """
    # Build KD-tree (do this ONCE per batch, cache if possible)
    tree = cKDTree(coords)
    dists, indices = tree.query(coords, k=K+1)  # +1 to include self
    indices = indices[:, 1:]  # exclude self
    dists = dists[:, 1:]

    N = coords.shape[0]
    div_U = torch.zeros(N, device=Ux_pred.device)

    for i in range(N):
        nbr_idx = indices[i]
        dx = torch.tensor(coords[nbr_idx, 0] - coords[i, 0], device=Ux_pred.device)
        dy = torch.tensor(coords[nbr_idx, 1] - coords[i, 1], device=Ux_pred.device)
        dUx = Ux_pred[nbr_idx] - Ux_pred[i]
        dUy = Uy_pred[nbr_idx] - Uy_pred[i]

        # Least-squares gradient: solve [dx dy] @ [grad_x, grad_y]^T = dU
        A = torch.stack([dx, dy], dim=1)  # (K, 2)
        # dUx/dx via least squares
        ATA = A.T @ A + 1e-8 * torch.eye(2, device=A.device)
        grad_Ux = torch.linalg.solve(ATA, A.T @ dUx)  # (2,)
        grad_Uy = torch.linalg.solve(ATA, A.T @ dUy)

        div_U[i] = grad_Ux[0] + grad_Uy[1]  # ∂Ux/∂x + ∂Uy/∂y

    return (div_U ** 2).mean()
```

**Performance note:** The per-node loop is slow. Vectorize it:

```python
def compute_continuity_residual_vectorized(coords_np, Ux_pred, Uy_pred, K=8):
    """Vectorized version — much faster."""
    tree = cKDTree(coords_np)
    _, indices = tree.query(coords_np, k=K+1)
    indices = indices[:, 1:]  # (N, K)

    coords_t = torch.tensor(coords_np, device=Ux_pred.device, dtype=Ux_pred.dtype)

    # Neighbor coordinates and values
    nbr_coords = coords_t[indices]  # (N, K, 2)
    center_coords = coords_t.unsqueeze(1)  # (N, 1, 2)
    delta = nbr_coords - center_coords  # (N, K, 2)

    dUx = Ux_pred[indices] - Ux_pred.unsqueeze(1)  # (N, K)
    dUy = Uy_pred[indices] - Uy_pred.unsqueeze(1)  # (N, K)

    # Batch least-squares: (N, 2, K) @ (N, K, 1) via normal equations
    # A = delta (N, K, 2), solve A^T A g = A^T dU
    ATA = torch.bmm(delta.transpose(1, 2), delta)  # (N, 2, 2)
    ATA += 1e-8 * torch.eye(2, device=ATA.device).unsqueeze(0)

    ATdUx = torch.bmm(delta.transpose(1, 2), dUx.unsqueeze(2))  # (N, 2, 1)
    ATdUy = torch.bmm(delta.transpose(1, 2), dUy.unsqueeze(2))

    grad_Ux = torch.linalg.solve(ATA, ATdUx).squeeze(-1)  # (N, 2)
    grad_Uy = torch.linalg.solve(ATA, ATdUy).squeeze(-1)

    div_U = grad_Ux[:, 0] + grad_Uy[:, 1]  # ∂Ux/∂x + ∂Uy/∂y
    return (div_U ** 2).mean()
```

### Step 3: Implement test-time adaptation loop

During validation (NOT training), adapt the LoRA context parameters:

```python
def test_time_adapt(model, batch, n_steps=10, lr=1e-3):
    """Adapt LoRA context parameters using continuity residual."""
    # Collect only LoRA parameters
    lora_params = [p for name, p in model.named_parameters() if 'lora' in name]

    # Reset LoRA to zero before each test batch
    for p in lora_params:
        p.data.zero_()

    # Create optimizer for LoRA params only
    tta_optimizer = torch.optim.Adam(lora_params, lr=lr)

    # Extract coordinates (first 2 channels)
    coords_np = batch['x'][:, :, :2].cpu().numpy()  # adjust indexing as needed

    model.train()  # enable gradients
    for step in range(n_steps):
        tta_optimizer.zero_grad()
        pred = model(batch)  # forward pass
        Ux_pred = pred[..., 1]  # velocity x (adjust index)
        Uy_pred = pred[..., 2]  # velocity y (adjust index)

        # Compute continuity residual (per sample in batch)
        loss = 0
        B = Ux_pred.shape[0]
        for b in range(B):
            loss += compute_continuity_residual_vectorized(
                coords_np[b], Ux_pred[b], Uy_pred[b], K=8
            )
        loss = loss / B
        loss.backward()
        tta_optimizer.step()

    model.eval()
    # Now run final prediction with adapted parameters
    with torch.no_grad():
        final_pred = model(batch)

    # Reset LoRA params to zero for next batch
    for p in lora_params:
        p.data.zero_()

    return final_pred
```

### Step 4: Integration and flags

Add these flags:
- `--geps_tta`: Enable test-time adaptation during validation
- `--geps_tta_steps 10`: Number of adaptation steps (try 10 and 20)
- `--geps_tta_lr 1e-3`: Learning rate for LoRA adaptation
- `--geps_tta_rank 4`: Rank of LoRA context parameters

**Training is completely unchanged.** The LoRA params are zero during training. TTA only runs during validation on `val_ood_tandem` (and optionally other val splits).

### Step 5: Run experiments

Run **2 seeds** per config. Since training is unchanged, the only variable is the TTA settings at eval time:

```bash
# Config A: 10 TTA steps (seed 42)
cd cfd_tandemfoil && python train.py --agent fern --seed 42 \
  --wandb_name "fern/geps-tta-10step-s42" \
  --wandb_group "fern/geps-tta" \
  --geps_tta --geps_tta_steps 10 --geps_tta_rank 4 --geps_tta_lr 1e-3 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias

# Config B: 20 TTA steps (same flags but --geps_tta_steps 20)
# Seed 73: change --seed 73
```

### Key implementation notes

1. **torch.compile compatibility:** The TTA inner loop uses `model.train()` and gradient computation, which may conflict with torch.compile. If compile fails, wrap the TTA function with `@torch.compiler.disable` or run validation without compile.

2. **Coordinate extraction:** The (x, y) coordinates are in `x[:, :, :2]` (first two input channels). Verify this by printing shapes.

3. **Prediction channel ordering:** Check which output channels correspond to p, Ux, Uy. The continuity residual uses Ux and Uy only.

4. **KD-tree caching:** Build the KD-tree ONCE per validation sample (coordinates don't change across TTA steps). Cache it.

5. **VRAM:** The LoRA params add ~4600 * 4 bytes = ~18KB. Negligible. The TTA gradient computation adds a forward+backward pass per step, but only during validation.

6. **Evaluation timing:** TTA adds 10-20 forward+backward passes per validation batch. This may slow validation by 10-20x. Apply TTA ONLY to the `val_ood_tandem` split (where OOD matters most). Skip TTA for in-distribution validation.

7. **Report BOTH metrics:** Report val metrics WITH and WITHOUT TTA so we can see the pure adaptation effect.

8. **EMA model:** Apply TTA to the EMA model at validation time (the one used for reporting metrics), not the training model.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.05** | < 13.05 |
| p_oodc | **7.70** | < 7.70 |
| **p_tan** | **28.60** | **< 28.60** |
| p_re | **6.55** | < 6.55 |

**Baseline W&B runs:** d7l91p0x (s42, p_tan=28.9), j9btfx09 (s73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent fern --wandb_name "fern/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias
```