### PR TITLE
Ensemble Distillation: Soft Targets from 16-Seed Ensemble

### DIFF
--- a/cfd_tandemfoil/precompute_ensemble.py
+++ b/cfd_tandemfoil/precompute_ensemble.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Pre-compute ensemble soft targets for knowledge distillation.
+
+Loads model checkpoints one at a time, runs inference on the training set,
+and averages predictions in physical space. Saves per-sample soft targets
+indexed by train_ds Subset position.
+
+Usage:
+    cd cfd_tandemfoil
+    python precompute_ensemble.py \
+        --run_ids j9w7d1r7 mc4jvgqj cbbvhl62 bigqfn3k bqhg6lq8 5ukk7wv6 xlnhwuqc ii1tz4vv \
+        --output ensemble_soft_targets.pt
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+sys.path.insert(0, str(Path(__file__).parent))
+from data.prepare_multi import load_data, pad_collate
+from eval_ensemble import load_model_and_refine, _umag_q, _phys_norm, _phys_denorm
+
+
+def precompute_soft_targets(run_ids, output_path, asinh_scale=0.75, batch_size=4):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}, Models: {len(run_ids)}")
+
+    # Load training data
+    print("Loading data...")
+    train_ds, _, stats, _ = load_data("data/split_manifest.json", "data/split_stats.json")
+    x_stats = {k: stats[k].to(device) for k in ["x_mean", "x_std"]}
+
+    # Compute physics normalization stats (same as training)
+    print("Computing physics normalization stats...")
+    stats_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False,
+                              collate_fn=pad_collate, num_workers=4, pin_memory=True)
+    phys_sum = torch.zeros(3, device=device, dtype=torch.float64)
+    phys_sq_sum = torch.zeros(3, device=device, dtype=torch.float64)
+    phys_n = 0.0
+    with torch.no_grad():
+        for x, y, is_surface, mask in tqdm(stats_loader, desc="Phys stats"):
+            y, mask = y.to(device), mask.to(device)
+            Um, q = _umag_q(y, mask)
+            yp = _phys_norm(y, Um, q)
+            yp = yp.clone()
+            yp[:, :, 2:3] = torch.asinh(yp[:, :, 2:3] * asinh_scale)
+            m = mask.float().unsqueeze(-1)
+            phys_sum += (yp * m).sum(dim=(0, 1))
+            phys_sq_sum += (yp ** 2 * m).sum(dim=(0, 1))
+            phys_n += mask.float().sum().item()
+    phys_mean = (phys_sum / phys_n).float()
+    phys_std = ((phys_sq_sum / phys_n - phys_mean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
+    phys_stats = {"y_mean": phys_mean, "y_std": phys_std}
+
+    # Sequential inference: one model at a time to save VRAM
+    n_models = len(run_ids)
+    # We'll accumulate predictions in physical space per sample
+    # Store as list of (N_i, 3) tensors
+    n_train = len(train_ds)
+    pred_sums = [None] * n_train  # Will be populated on first model
+
+    for model_idx, run_id in enumerate(run_ids):
+        print(f"\n[{model_idx+1}/{n_models}] Loading model {run_id}...")
+        model, refine_head = load_model_and_refine(run_id, device)
+
+        # Run inference on training set in order
+        loader = DataLoader(train_ds, batch_size=batch_size, shuffle=False,
+                            collate_fn=pad_collate, num_workers=4, pin_memory=True)
+
+        sample_offset = 0
+        with torch.no_grad():
+            for x_raw, y, is_surface, mask in tqdm(loader, desc=f"Inference {run_id}", leave=False):
+                x_raw = x_raw.to(device)
+                y = y.to(device)
+                is_surface = is_surface.to(device)
+                mask = mask.to(device)
+                B, N = mask.shape
+                Umag, q_val = _umag_q(y, mask)
+
+                # Preprocessing (exact copy from eval_ensemble.py)
+                raw_dsdf = x_raw[:, :, 2:10]
+                dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
+                dist_feat = torch.log1p(dist_surf * 10.0)
+                _raw_aoa = x_raw[:, 0, 14:15]
+
+                x = (x_raw - x_stats["x_mean"]) / x_stats["x_std"]
+                curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
+                x = torch.cat([x, curv, dist_feat], dim=-1)
+
+                # Target normalization
+                y_phys = _phys_norm(y, Umag, q_val)
+                y_phys = y_phys.clone()
+                y_phys[:, :, 2:3] = torch.asinh(y_phys[:, :, 2:3] * asinh_scale)
+                y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+
+                # Residual prediction
+                _aoa = _raw_aoa
+                _fs_phys = torch.zeros(B, 1, 3, device=device)
+                _fs_phys[:, 0, 0] = torch.cos(_aoa.squeeze(-1))
+                _fs_phys[:, 0, 1] = torch.sin(_aoa.squeeze(-1))
+                _v_freestream = (_fs_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+                y_norm = y_norm - _v_freestream
+
+                # Per-sample std
+                raw_gap = x[:, 0, 21]
+                is_tandem = raw_gap.abs() > 0.5
+                sample_stds = torch.ones(B, 1, 3, device=device)
+                channel_clamps = torch.tensor([0.1, 0.1, 2.0], device=device)
+                tandem_clamps = torch.tensor([0.3, 0.3, 2.0], device=device)
+                for b in range(B):
+                    valid = mask[b]
+                    if is_tandem[b]:
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=tandem_clamps)
+                    else:
+                        sample_stds[b, 0] = y_norm[b, valid].std(dim=0).clamp(min=channel_clamps)
+
+                # Model forward pass
+                raw_xy = x[:, :, :2]
+                xy_min = raw_xy.amin(dim=1, keepdim=True)
+                xy_max = raw_xy.amax(dim=1, keepdim=True)
+                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                freqs = torch.cat([model.fourier_freqs_fixed.to(device),
+                                   model.fourier_freqs_learned.abs()])
+                xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2),
+                                        xy_scaled.cos().flatten(-2)], dim=-1)
+                x_aug = torch.cat([x, fourier_pe], dim=-1)
+
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    out = model({"x": x_aug})
+                    pred = out["preds"].float()
+                    hidden = out["hidden"].float()
+
+                # Undo per-sample std
+                pred_loss = pred / sample_stds
+
+                # Surface refinement
+                if refine_head is not None:
+                    surf_idx = is_surface.nonzero(as_tuple=False)
+                    if surf_idx.numel() > 0:
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]
+                            surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
+                            correction = refine_head(surf_hidden, surf_pred).float()
+                        pred_loss = pred_loss.clone()
+                        pred_loss[surf_idx[:, 0], surf_idx[:, 1]] += correction
+                    pred = pred_loss * sample_stds
+
+                # Add freestream back
+                pred = pred + _v_freestream
+
+                # Denormalize to physical space
+                pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
+                pred_phys = pred_phys.clone()
+                pred_phys[:, :, 2:3] = torch.sinh(pred_phys[:, :, 2:3]) / asinh_scale
+                pred_orig = _phys_denorm(pred_phys, Umag, q_val)
+
+                # Accumulate per-sample predictions
+                for b in range(B):
+                    idx = sample_offset + b
+                    if idx >= n_train:
+                        break
+                    n_valid = mask[b].sum().item()
+                    pred_sample = pred_orig[b, :n_valid].cpu()
+                    if pred_sums[idx] is None:
+                        pred_sums[idx] = pred_sample
+                    else:
+                        pred_sums[idx] = pred_sums[idx] + pred_sample
+                sample_offset += B
+
+        # Free model memory
+        del model, refine_head
+        torch.cuda.empty_cache()
+        print(f"  Model {run_id} done. Processed {sample_offset} samples.")
+
+    # Average predictions
+    print(f"\nAveraging {n_models} model predictions...")
+    soft_targets = {}
+    for i in range(n_train):
+        if pred_sums[i] is not None:
+            soft_targets[i] = pred_sums[i] / n_models
+        else:
+            print(f"  WARNING: sample {i} has no predictions!")
+
+    print(f"Saving {len(soft_targets)} soft targets to {output_path}")
+    torch.save(soft_targets, output_path)
+    print("Done!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run_ids", nargs="+", required=True)
+    parser.add_argument("--output", type=str, default="ensemble_soft_targets.pt")
+    parser.add_argument("--asinh_scale", type=float, default=0.75)
+    parser.add_argument("--batch_size", type=int, default=4)
+    args = parser.parse_args()
+    precompute_soft_targets(args.run_ids, args.output, args.asinh_scale, args.batch_size)

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, asdict
 from einops import rearrange
 from timm.layers import trunc_normal_
 from tqdm import tqdm
-from torch.utils.data import DataLoader, WeightedRandomSampler
+from torch.utils.data import DataLoader, Dataset, WeightedRandomSampler
 import simple_parsing as sp
 
 from data.utils import visualize
@@ -1070,6 +1070,9 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Ensemble distillation
+    ensemble_distill_path: str = ""         # path to pre-computed ensemble soft targets .pt file (empty = disabled)
+    ensemble_distill_alpha: float = 0.3     # weight for soft target loss (0 = GT only, 1 = soft only)
 
 
 cfg = sp.parse(Config)
@@ -1127,21 +1130,64 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
-loader_kwargs = dict(collate_fn=pad_collate, num_workers=cfg.num_workers, pin_memory=True,
-                     persistent_workers=True, prefetch_factor=2)
+# Load ensemble soft targets for distillation (if enabled)
+_distill_targets = None
+if cfg.ensemble_distill_path:
+    print(f"Loading ensemble soft targets from {cfg.ensemble_distill_path}...")
+    _distill_targets = torch.load(cfg.ensemble_distill_path, map_location="cpu", weights_only=False)
+    print(f"  Loaded {len(_distill_targets)} soft targets (alpha={cfg.ensemble_distill_alpha})")
+
+def _distill_collate(batch):
+    """Collate that handles optional 4th element (soft target) from distillation wrapper."""
+    if len(batch[0]) == 4:
+        xs, ys, surfs, softs = zip(*batch)
+        x_pad, y_pad, surf_pad, mask = pad_collate(list(zip(xs, ys, surfs)))
+        # Pad soft targets the same way
+        max_n = x_pad.shape[1]
+        B = len(softs)
+        soft_pad = torch.zeros(B, max_n, 3)
+        for i, s in enumerate(softs):
+            if s is not None:
+                n = min(s.shape[0], max_n)
+                soft_pad[i, :n] = s[:n]
+        return x_pad, y_pad, surf_pad, mask, soft_pad
+    else:
+        return pad_collate(batch) + (None,)
+
+if _distill_targets is not None:
+    class _DistillWrapper(Dataset):
+        def __init__(self, ds, targets):
+            self.ds = ds
+            self.targets = targets
+        def __len__(self):
+            return len(self.ds)
+        def __getitem__(self, idx):
+            x, y, is_surf = self.ds[idx]
+            soft = self.targets.get(idx)
+            return x, y, is_surf, soft
+    _train_ds_for_loader = _DistillWrapper(train_ds, _distill_targets)
+    _collate_fn = _distill_collate
+else:
+    _train_ds_for_loader = train_ds
+    _collate_fn = pad_collate
+
+_base_loader_kwargs = dict(num_workers=cfg.num_workers, pin_memory=True,
+                           persistent_workers=True, prefetch_factor=2)
+loader_kwargs = dict(collate_fn=pad_collate, **_base_loader_kwargs)
+_train_loader_kwargs = dict(collate_fn=_collate_fn, **_base_loader_kwargs)
 
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
-                              shuffle=True, **loader_kwargs)
+    train_loader = DataLoader(_train_ds_for_loader, batch_size=cfg.batch_size,
+                              shuffle=True, **_train_loader_kwargs)
 else:
     sampler = WeightedRandomSampler(
         weights=sample_weights,
         num_samples=len(train_ds),
         replacement=True,
     )
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
-                              sampler=sampler, **loader_kwargs)
+    train_loader = DataLoader(_train_ds_for_loader, batch_size=cfg.batch_size,
+                              sampler=sampler, **_train_loader_kwargs)
 
 val_loaders = {
     name: DataLoader(subset, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
@@ -1562,7 +1608,13 @@ for epoch in range(MAX_EPOCHS):
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     if cfg.grad_accum_steps > 1:
         optimizer.zero_grad()
-    for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
+    for batch_idx, batch_data in enumerate(pbar):
+        if len(batch_data) == 5:
+            x, y, is_surface, mask, soft_y = batch_data
+            soft_y = soft_y.to(device, non_blocking=True) if soft_y is not None else None
+        else:
+            x, y, is_surface, mask = batch_data
+            soft_y = None
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -1916,6 +1968,22 @@ for epoch in range(MAX_EPOCHS):
                     surf_p_loss  * torch.exp(-2 * bm.log_sigma_surf_p)  / 2 + bm.log_sigma_surf_p)
         else:
             loss = vol_loss + surf_weight * surf_loss
+
+        # Ensemble distillation loss (pressure only, surface nodes)
+        if soft_y is not None and cfg.ensemble_distill_alpha > 0.0:
+            # Normalize soft_y through the same pipeline as GT
+            _sy_phys = _phys_norm(soft_y, Umag, q)
+            _sy_phys = _sy_phys.clone()
+            _sy_phys[:, :, 2:3] = torch.asinh(_sy_phys[:, :, 2:3] * cfg.asinh_scale)
+            _sy_norm = (_sy_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
+            if _freestream is not None:
+                _sy_norm = _sy_norm - _freestream
+            if not cfg.no_perstd and not cfg.raw_targets and not cfg.adaptive_norm:
+                _sy_norm = _sy_norm / sample_stds
+            # L1 on pressure channel only, surface nodes only
+            _distill_err = (pred[:, :, 2:3] - _sy_norm[:, :, 2:3]).abs()
+            _distill_loss = (_distill_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = (1 - cfg.ensemble_distill_alpha) * loss + cfg.ensemble_distill_alpha * _distill_loss
 
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None

--- a/research/EXPERIMENT_TANJIRO_ENSEMBLE_DISTILL.md
+++ b/research/EXPERIMENT_TANJIRO_ENSEMBLE_DISTILL.md
@@ -1,0 +1,5 @@
+# Experiment: Ensemble Distillation
+
+**Student:** tanjiro
+**Branch:** tanjiro/ensemble-distill
+**Status:** WIP


### PR DESCRIPTION
## Hypothesis

We have 45+ trained model checkpoints. Rather than using them only as a post-hoc ensemble, we can use their averaged predictions as soft training targets for a fresh single model. This is knowledge distillation where the teacher is the ensemble.

**Key insight from DEGU** (npj Computational Materials, 2025): students trained on ensemble soft targets can **outperform** the ensemble itself by exploiting the ensemble's variance-reduced signal without inheriting its biases.

**Why it might work here:** The 16-seed ensemble reaches p_tan=29.1 while our best single model hits 28.60. The ensemble predictions have lower per-sample variance than any individual model, providing a smoother training signal. A distilled student trained on `(1-alpha)*L1(pred, GT) + alpha*L1(pred, ensemble_mean)` gets the benefit of variance reduction while still learning from ground truth.

**Important caveat:** The ensemble was trained with the pre-GSB/PCGrad config, so ensemble mean may be weaker per-model than our current baseline. The distillation value comes from variance reduction, not individual model quality.

## Instructions

### Step 1: Pre-compute ensemble soft targets

Write a preprocessing script that generates the averaged ensemble predictions for the training set. This runs ONCE before training.

**Ensemble model run IDs (16-seed, seeds 42-49 + 66-73):**
```
f59v5aul 0yurebjv rdezx8es ds12ug79 yu1x0dy0 y147zvh1 lc5cbt4l 7cxu38oh
j9w7d1r7 mc4jvgqj cbbvhl62 bigqfn3k bqhg6lq8 5ukk7wv6 xlnhwuqc ii1tz4vv
```

**Approach — sequential single-model inference:**
```python
import wandb
import torch
import numpy as np

# For each model checkpoint:
# 1. Download from W&B artifacts or load from local cache
# 2. Run inference on the full training set
# 3. Accumulate predictions

# Pseudo-code:
all_preds = None
n_models = 0
for run_id in ensemble_run_ids:
    # Load model checkpoint from W&B
    api = wandb.Api()
    run = api.run(f"<entity>/<project>/{run_id}")
    # Download best checkpoint...
    model = load_checkpoint(checkpoint_path)
    model.eval()

    with torch.no_grad():
        preds = []
        for batch in train_dataloader:
            pred = model(batch)
            preds.append(pred.cpu())
        preds = torch.cat(preds, dim=0)  # (N_train, N_nodes, C)

    if all_preds is None:
        all_preds = preds
    else:
        all_preds += preds
    n_models += 1

ensemble_mean = all_preds / n_models
torch.save(ensemble_mean, "ensemble_soft_targets.pt")
```

**IMPORTANT practical simplification:** If downloading all 16 checkpoints is too complex, use just the **8 seeds 66-73** (run IDs: j9w7d1r7, mc4jvgqj, cbbvhl62, bigqfn3k, bqhg6lq8, 5ukk7wv6, xlnhwuqc, ii1tz4vv). These are the most recent ensemble seeds and should be sufficient.

**Memory management:** Load ONE model at a time, run inference, accumulate into running mean, then delete the model before loading the next. Peak VRAM should be ~40GB (single model).

**Alternative if checkpoint download is difficult:** Add a `--precompute_ensemble` flag that runs the pre-computation as part of the training script. The first run generates and caches soft targets; subsequent runs load from cache.

### Step 2: Modify training loop for distillation

Add a distillation loss term:

```python
def distillation_loss(pred, gt, soft_target, alpha):
    """Combined GT + soft target loss."""
    l_gt = F.l1_loss(pred, gt)
    l_soft = F.l1_loss(pred, soft_target)
    return (1 - alpha) * l_gt + alpha * l_soft
```

**Integration:**
1. Load `ensemble_soft_targets.pt` at training start
2. Index soft targets by sample index (must match dataset ordering!)
3. In the training loop: replace the standard L1 loss with the distillation loss
4. The soft targets should be on the same device as the model (move to GPU at batch time)

### Step 3: Flags

- `--ensemble_distill_path <path>`: Path to cached ensemble soft targets .pt file
- `--ensemble_distill_alpha <float>`: Weight for soft target loss. Default 0.3.

### Step 4: Run experiments

**Config A: alpha=0.3** (2 seeds)
```bash
# First: pre-compute soft targets (run once)
cd cfd_tandemfoil && python precompute_ensemble.py \
  --run_ids j9w7d1r7 mc4jvgqj cbbvhl62 bigqfn3k bqhg6lq8 5ukk7wv6 xlnhwuqc ii1tz4vv \
  --output ensemble_soft_targets.pt

# Seed 42
python train.py --agent tanjiro --seed 42 \
  --wandb_name "tanjiro/ensemble-distill-a0.3-s42" \
  --wandb_group "tanjiro/ensemble-distill" \
  --ensemble_distill_path ensemble_soft_targets.pt \
  --ensemble_distill_alpha 0.3 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias

# Seed 73: change --seed 73, update wandb_name
```

**Config B: alpha=0.5** (same flags but `--ensemble_distill_alpha 0.5`)

### Key implementation notes

1. **Dataset ordering must match:** The soft targets are indexed by sample position. Ensure the training dataloader uses the same sample ordering (or index by sample ID). If you shuffle the dataloader, you need to look up the correct soft target for each sample.

2. **Soft targets are in asinh space:** The ensemble models were trained with `--asinh_pressure --asinh_scale 0.75`. Their predictions are in asinh-transformed space. The soft targets should match the same transform as the ground truth.

3. **Only distill pressure (not velocity):** The primary metric is surface pressure. Apply distillation loss only to the pressure channel. Velocity channels use standard GT loss. This focuses the distillation signal on the metric we care about.

4. **Augmentation interaction:** When data augmentation modifies the input (AoA perturbation, DSDF perturbation), the soft targets are for the UN-augmented input. Two options: (a) apply distillation loss only on un-augmented batches, or (b) apply augmentation to both input and soft target consistently. Option (a) is simpler — just skip the distillation term for augmented samples.

5. **Pre-computation budget:** Loading 8 models and running inference should take ~30-40 minutes. If this exceeds the 180-min timeout, reduce to 4 models (j9w7d1r7, mc4jvgqj, cbbvhl62, bigqfn3k). A 4-model ensemble still provides meaningful variance reduction.

6. **W&B project/entity:** The run IDs above are from the `wandb/senpai` project. Use `wandb.Api()` to download model artifacts.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.05** | < 13.05 |
| p_oodc | **7.70** | < 7.70 |
| **p_tan** | **28.60** | **< 28.60** |
| p_re | **6.55** | < 6.55 |

**Baseline W&B runs:** d7l91p0x (s42, p_tan=28.9), j9btfx09 (s73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --wandb_name "tanjiro/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias
```