### PR TITLE
DCT Frequency-Weighted Surface Pressure Loss

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1020,6 +1020,10 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    dct_freq_loss: bool = False   # DCT frequency-weighted auxiliary loss on surface pressure
+    dct_freq_weight: float = 0.05 # weight for DCT freq loss
+    dct_freq_gamma: float = 2.0   # frequency upweighting strength
+    dct_freq_alpha: float = 1.5   # frequency exponent
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1658,6 +1662,9 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
+        _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
+        _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
@@ -1952,6 +1959,43 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+
+        # DCT frequency-weighted auxiliary loss on surface pressure
+        if cfg.dct_freq_loss and model.training:
+            _dct_loss = torch.tensor(0.0, device=device)
+            _n_foils_dct = 0
+            for b in range(B):
+                surf_idx_b = is_surface[b].nonzero(as_tuple=True)[0]
+                if surf_idx_b.numel() < 8:
+                    continue
+                _is_tan_b = _raw_tandem_for_dct[b].item()
+                if _is_tan_b:
+                    saf_vals = _raw_saf_for_dct[b, surf_idx_b]
+                    foil_groups = [surf_idx_b[saf_vals <= 0.005], surf_idx_b[saf_vals > 0.005]]
+                else:
+                    foil_groups = [surf_idx_b]
+                for foil_surf in foil_groups:
+                    if foil_surf.numel() < 8:
+                        continue
+                    # Sort by raw x-coordinate for 1D signal ordering
+                    x_coords = _raw_x_for_dct[b, foil_surf]
+                    sort_order = x_coords.argsort()
+                    sorted_idx = foil_surf[sort_order]
+                    # Extract pressure channel (channel 2 in output)
+                    p_pred = pred[b, sorted_idx, 2]  # [M]
+                    p_gt = y_norm[b, sorted_idx, 2]  # [M]
+                    # FFT-based frequency loss
+                    M = p_pred.shape[0]
+                    pred_fft = torch.fft.rfft(p_pred).abs()  # [M//2+1]
+                    gt_fft = torch.fft.rfft(p_gt).abs()
+                    # Frequency weighting: w_k = 1 + gamma * (k/M)^alpha
+                    k = torch.arange(pred_fft.shape[0], device=device, dtype=pred_fft.dtype)
+                    w = 1.0 + cfg.dct_freq_gamma * (k / M) ** cfg.dct_freq_alpha
+                    _dct_loss = _dct_loss + (w * (pred_fft - gt_fft).abs()).mean()
+                    _n_foils_dct += 1
+            if _n_foils_dct > 0:
+                _dct_loss = _dct_loss / _n_foils_dct
+                loss = loss + cfg.dct_freq_weight * _dct_loss
 
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)

--- a/research/EXPERIMENT_NEZUKO_DCT_FREQ_LOSS.md
+++ b/research/EXPERIMENT_NEZUKO_DCT_FREQ_LOSS.md
@@ -1,0 +1,5 @@
+# Experiment: DCT Frequency-Weighted Surface Pressure Loss
+
+**Student:** nezuko
+**Branch:** nezuko/dct-freq-loss
+**Status:** WIP


### PR DESCRIPTION
## Hypothesis

Neural networks exhibit **spectral bias** — they learn low-frequency components first (Rahaman et al., 2019). The standard L1 surface loss weights all surface nodes equally, but the hardest-to-predict features are high-spatial-frequency: leading edge stagnation pressure peak, suction surface recovery, and trailing edge separation. A DCT-domain auxiliary loss with smooth frequency weighting forces the model to attend to these sharp features.

**Key difference from BSP Spectral Loss (#2172, FAILED):**
1. BSP used **DFT** with sharp bin-based weights → catastrophic instability at w=0.1 (relative spectral error amplified near-zero bins in asinh space)
2. This uses **DCT** (real-valued, no phase issues) with smooth polynomial weighting
3. BSP used **relative** spectral error → division by small values. This uses **absolute** DCT coefficient difference → numerically stable
4. BSP was the primary loss. This is a gentle **auxiliary** loss on top of standard L1

**Literature:** FreqINR (arXiv:2408.13716, 2024) demonstrated adaptive DCT-domain loss for INRs — assigning higher weights to high-frequency content improved reconstruction of sharp features.

## Instructions

### Step 1: Surface node ordering by arc-length

For each foil surface, order nodes by arc-length (angular position around foil center). This gives a 1D signal suitable for DCT:

```python
import numpy as np

def order_surface_nodes(coords_2d, zone_mask):
    """
    Order surface nodes by angle around their centroid.
    coords_2d: (N, 2) all node coordinates
    zone_mask: boolean (N,) True for surface nodes of this foil
    Returns: indices into the surface node array, sorted by arc-length angle
    """
    surf_coords = coords_2d[zone_mask]  # (M, 2)
    centroid = surf_coords.mean(axis=0)
    angles = np.arctan2(surf_coords[:, 1] - centroid[1],
                        surf_coords[:, 0] - centroid[0])
    order = np.argsort(angles)
    return order
```

**Surface node identification:** Surface nodes are identified by zone labels in the dataset. Check how `prepare_multi.py` assigns zones — typically zone 0 = volume, zone 1 = foil-1 surface, zone 2 = foil-2 surface (or similar). Use the zone labels to extract surface nodes per foil.

**Caching:** The ordering is geometry-dependent and fixed per sample. Cache it once during data loading.

### Step 2: DCT frequency-weighted loss

```python
import torch
import torch.fft

def dct_freq_loss(p_pred_surf, p_gt_surf, gamma=2.0, alpha=1.5):
    """
    DCT-domain frequency-weighted loss on ordered surface pressure.

    p_pred_surf: (B, M) predicted surface pressure, nodes ordered by arc-length
    p_gt_surf: (B, M) ground truth surface pressure, same ordering
    gamma: frequency upweighting strength
    alpha: frequency weighting exponent
    Returns: scalar loss
    """
    # Compute 1D DCT (Type II) via FFT trick
    # DCT-II of x can be computed as: real part of FFT of [x, x_reversed]
    # Or use torch.fft.dct if available, else:
    N = p_pred_surf.shape[-1]

    # Simple DCT via real FFT
    pred_dct = torch.fft.rfft(p_pred_surf, dim=-1).real  # (B, N//2+1)
    gt_dct = torch.fft.rfft(p_gt_surf, dim=-1).real

    # Frequency weighting: w_k = 1 + gamma * (k/N)^alpha
    k = torch.arange(pred_dct.shape[-1], device=p_pred_surf.device, dtype=p_pred_surf.dtype)
    w = 1.0 + gamma * (k / N) ** alpha  # (N//2+1,)

    # Weighted absolute difference of DCT coefficients
    loss = (w * (pred_dct - gt_dct).abs()).mean()
    return loss
```

**Note:** `torch.fft.rfft` computes the real FFT, which is close to DCT for real signals. For a true DCT-II, you can use `scipy.fftpack.dct` but this requires CPU. The rfft approximation should be sufficient and is fully GPU-compatible.

### Step 3: Integrate as auxiliary loss

```python
# In training loop, after computing standard loss:
if args.dct_freq_loss:
    for foil_idx in [1, 2]:  # both foil surfaces
        zone_mask = (zones == foil_idx)  # boolean mask for this foil
        if zone_mask.sum() == 0:
            continue

        # Extract and order surface pressure
        p_pred_surf = pred_pressure[zone_mask]  # ordered by arc-length (cached)
        p_gt_surf = gt_pressure[zone_mask]

        freq_loss += dct_freq_loss(p_pred_surf, p_gt_surf,
                                    gamma=args.dct_freq_gamma,
                                    alpha=args.dct_freq_alpha)

    total_loss = standard_loss + args.dct_freq_weight * freq_loss
```

### Step 4: Flags

- `--dct_freq_loss`: Enable DCT frequency-weighted auxiliary loss
- `--dct_freq_weight <float>`: Auxiliary loss weight. Try 0.05 and 0.1
- `--dct_freq_gamma <float>`: Frequency upweighting strength. Default 2.0
- `--dct_freq_alpha <float>`: Frequency exponent. Default 1.5

### Step 5: Run experiments

```bash
# Config A: weight=0.05 (gentle), seed 42
cd cfd_tandemfoil && python train.py --agent nezuko --seed 42 \
  --wandb_name "nezuko/dct-freq-w0.05-s42" \
  --wandb_group "nezuko/dct-freq-loss" \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias

# Config B: weight=0.1
# Seed 73: change --seed 73
```

### Key implementation notes

1. **Zone identification:** Check `prepare_multi.py` to find how surface nodes are labeled. The `saf` (surface assignment field) or zone labels distinguish foil-1, foil-2, and volume nodes. Surface nodes typically have a small DSDF value (<threshold).

2. **Variable surface node counts:** Different samples may have different numbers of surface nodes. Pad or truncate to a fixed length for batched DCT computation. Use the median surface node count as the fixed length.

3. **Asinh space:** The DCT operates on asinh-transformed pressure (same space as the L1 loss). This is correct — we want to upweight high-frequency components in the space where the model is trained.

4. **torch.compile:** `torch.fft.rfft` is compile-compatible. The frequency weighting is a simple tensor operation. Should compile fine.

5. **Why this is different from BSP (#2172):** BSP failed because (a) it used relative spectral error which amplified near-zero bins, and (b) the weight=0.1 caused catastrophic training collapse. Our approach uses absolute difference with smooth polynomial weighting — the loss is bounded and well-behaved. Start with the gentle weight=0.05.

6. **PCGrad interaction:** Include the DCT loss in the same backward pass as the standard loss. It's not a separate PCGrad group.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.05** | < 13.05 |
| p_oodc | **7.70** | < 7.70 |
| **p_tan** | **28.60** | **< 28.60** |
| p_re | **6.55** | < 6.55 |

**Baseline W&B runs:** d7l91p0x (s42, p_tan=28.9), j9btfx09 (s73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias
```