### PR TITLE
MAE Pretraining: Self-Supervised Geometry Encoder Initialization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -663,6 +663,20 @@ class SurfaceRefinementContextHead(nn.Module):
         return correction
 
 
+class MAEDecoder(nn.Module):
+    """Lightweight decoder for masked autoencoder pretraining."""
+    def __init__(self, hidden_dim=192, output_dim=24):
+        super().__init__()
+        self.decoder = nn.Sequential(
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+
+    def forward(self, h):
+        return self.decoder(h)
+
+
 class Transolver(nn.Module):
     def __init__(
         self,
@@ -1070,6 +1084,10 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: MAE pretraining — self-supervised geometry encoder initialization
+    mae_pretrain: bool = False              # enable MAE pretraining phase before supervised training
+    mae_pretrain_epochs: int = 20           # number of MAE pretraining epochs
+    mae_mask_ratio: float = 0.25            # fraction of nodes to mask during pretraining
 
 
 cfg = sp.parse(Config)
@@ -1524,6 +1542,113 @@ model_dir.mkdir(parents=True)
 model_path = model_dir / "checkpoint.pt"
 with open(model_dir / "config.yaml", "w") as f:
     yaml.dump(model_config, f)
+
+# --- MAE Pretraining Phase ---
+if cfg.mae_pretrain:
+    print(f"\n=== Phase 1: MAE Pretraining ({cfg.mae_pretrain_epochs} epochs, mask_ratio={cfg.mae_mask_ratio}) ===")
+    _mae_start = time.time()
+    # Get the uncompiled model for pretraining (compile after pretrain)
+    _mae_model = model._orig_mod if hasattr(model, '_orig_mod') else model
+    mae_decoder = MAEDecoder(hidden_dim=cfg.n_hidden, output_dim=X_DIM).to(device)
+    # Learned mask token: replaces masked node features (raw 24-dim, before normalization)
+    mae_mask_token = nn.Parameter(torch.zeros(1, 1, X_DIM, device=device))
+    mae_opt = Lion(
+        list(_mae_model.parameters()) + list(mae_decoder.parameters()) + [mae_mask_token],
+        lr=2e-4, weight_decay=5e-5,
+    )
+    for mae_epoch in range(cfg.mae_pretrain_epochs):
+        _mae_model.train()
+        mae_decoder.train()
+        _mae_epoch_loss = 0.0
+        _mae_n_batches = 0
+        for x_mae, y_mae, is_surface_mae, mask_mae in train_loader:
+            x_mae = x_mae.to(device, non_blocking=True)
+            mask_mae = mask_mae.to(device, non_blocking=True)
+            is_surface_mae = is_surface_mae.to(device, non_blocking=True)
+            B_mae, N_mae, _ = x_mae.shape
+            # Save raw features as reconstruction targets (pre-normalization)
+            x_raw_target = x_mae[:, :, :X_DIM].clone()
+            # Random node mask: True = masked
+            node_mask = torch.rand(B_mae, N_mae, device=device) < cfg.mae_mask_ratio
+            node_mask = node_mask & mask_mae  # only mask valid (non-padded) nodes
+            # Replace masked node features with learned mask token
+            x_masked = x_mae.clone()
+            x_masked[:, :, :X_DIM] = torch.where(
+                node_mask.unsqueeze(-1).expand(-1, -1, X_DIM),
+                mae_mask_token.expand(B_mae, N_mae, -1),
+                x_mae[:, :, :X_DIM],
+            )
+            # Standardize (same as training loop)
+            raw_dsdf_mae = x_masked[:, :, 2:10]
+            dist_surf_mae = raw_dsdf_mae.abs().min(dim=-1, keepdim=True).values
+            dist_feat_mae = torch.log1p(dist_surf_mae * 10.0)
+            x_masked = (x_masked - stats["x_mean"]) / stats["x_std"]
+            curv_mae = x_masked[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface_mae.float().unsqueeze(-1)
+            x_masked = torch.cat([x_masked, curv_mae, dist_feat_mae], dim=-1)
+            # Fourier PE
+            raw_xy_mae = x_masked[:, :, :2]
+            xy_min_mae = raw_xy_mae.amin(dim=1, keepdim=True)
+            xy_max_mae = raw_xy_mae.amax(dim=1, keepdim=True)
+            xy_norm_mae = (raw_xy_mae - xy_min_mae) / (xy_max_mae - xy_min_mae + 1e-8)
+            freqs_mae = torch.cat([_mae_model.fourier_freqs_fixed.to(device), _mae_model.fourier_freqs_learned.abs()])
+            xy_scaled_mae = xy_norm_mae.unsqueeze(-1) * freqs_mae
+            fourier_pe_mae = torch.cat([xy_scaled_mae.sin().flatten(-2), xy_scaled_mae.cos().flatten(-2)], dim=-1)
+            x_masked = torch.cat([x_masked, fourier_pe_mae], dim=-1)
+            # Forward through encoder (no compile during pretrain)
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                out_mae = _mae_model({"x": x_masked})
+                hidden_mae = out_mae["hidden"]  # [B, N, n_hidden]
+            hidden_mae = hidden_mae.float()
+            # Decode masked positions only
+            masked_hidden = hidden_mae[node_mask]  # [M, n_hidden]
+            x_recon = mae_decoder(masked_hidden)  # [M, X_DIM]
+            # Standardize targets too for consistent loss
+            x_raw_normed = (x_raw_target - stats["x_mean"][:X_DIM]) / stats["x_std"][:X_DIM]
+            masked_target = x_raw_normed[node_mask]  # [M, X_DIM]
+            mae_loss = F.l1_loss(x_recon, masked_target)
+            mae_opt.zero_grad()
+            mae_loss.backward()
+            torch.nn.utils.clip_grad_norm_(
+                list(_mae_model.parameters()) + list(mae_decoder.parameters()) + [mae_mask_token],
+                max_norm=1.0,
+            )
+            mae_opt.step()
+            _mae_epoch_loss += mae_loss.item()
+            _mae_n_batches += 1
+        _avg_mae_loss = _mae_epoch_loss / max(_mae_n_batches, 1)
+        _mae_elapsed = (time.time() - _mae_start) / 60.0
+        print(f"  MAE epoch {mae_epoch+1}/{cfg.mae_pretrain_epochs} — loss: {_avg_mae_loss:.4f} ({_mae_elapsed:.1f} min)")
+        wandb.log({"mae_pretrain/loss": _avg_mae_loss, "mae_pretrain/epoch": mae_epoch})
+    # Cleanup: discard MAE decoder and optimizer, keep pretrained encoder weights
+    del mae_decoder, mae_opt, mae_mask_token
+    torch.cuda.empty_cache()
+    _mae_total = (time.time() - _mae_start) / 60.0
+    print(f"=== MAE Pretraining complete ({_mae_total:.1f} min). Starting supervised training. ===\n")
+    # Re-create optimizer and scheduler for supervised training
+    attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+    other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+    base_opt = Lion([
+        {'params': attn_params, 'lr': cfg.lr * 0.5},
+        {'params': other_params, 'lr': cfg.lr}
+    ], weight_decay=cfg.weight_decay)
+    optimizer = base_opt
+    if refine_head is not None:
+        base_opt.add_param_group({'params': list(refine_head.parameters()), 'lr': cfg.lr})
+    if aft_srf_head is not None:
+        base_opt.add_param_group({'params': list(aft_srf_head.parameters()), 'lr': cfg.lr})
+    if aft_srf_ctx_head is not None:
+        base_opt.add_param_group({'params': list(aft_srf_ctx_head.parameters()), 'lr': cfg.lr})
+    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+        base_opt, start_factor=cfg.warmup_start_factor, total_iters=cfg.warmup_total_iters
+    )
+    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        base_opt, T_max=cfg.cosine_T_max, eta_min=cfg.cosine_eta_min
+    )
+    scheduler = torch.optim.lr_scheduler.SequentialLR(
+        base_opt, schedulers=[warmup_scheduler, cosine_scheduler],
+        milestones=[cfg.warmup_total_iters]
+    )
+    sam_optimizer = None
 
 best_val = float("inf")
 ema_val_loss = float("inf")

--- a/research/EXPERIMENT_ALPHONSE_MAE_PRETRAIN.md
+++ b/research/EXPERIMENT_ALPHONSE_MAE_PRETRAIN.md
@@ -1,0 +1,5 @@
+# Experiment: MAE Pretraining on Mesh Geometry
+
+**Student:** alphonse
+**Branch:** alphonse/mae-pretrain
+**Status:** WIP


### PR DESCRIPTION
## Hypothesis

The Transolver encoder currently learns two things simultaneously: (1) spatial reasoning about mesh structure and foil geometry, and (2) flow physics prediction. Pretraining the encoder using Masked Autoencoder (MAE) self-supervision on mesh geometry only — before supervised training — separates these objectives. For the OOD NACA6416 tandem case, a geometry-pretrained encoder may generalize better because it has learned a richer geometric representation covering ALL available geometries.

**GeoMAE (arXiv:2304.06911, CVPR 2023)** applied masked geometric reconstruction (surface normals, curvatures, centroids) to point cloud pretraining and showed significant improvements on downstream tasks. The Transolver's slice-attention mechanism is structurally similar to set-abstraction in point cloud networks.

**Key insight:** The model struggles on NACA6416 because it's geometrically OOD. If the encoder has already learned to represent diverse foil geometries through self-supervised pretraining, the supervised training can focus on learning flow physics rather than geometric structure. This decoupling should reduce the OOD gap.

## Instructions

### Step 1: MAE pretraining mode

Add a `--mae_pretrain` mode that runs before supervised training. The pretraining loop:

1. For each training batch, randomly mask 25% of nodes (replace their input features with a learned `[MASK]` token)
2. Run the Transolver encoder to get node embeddings for ALL nodes (including masked)
3. Run a lightweight decoder MLP (2 layers) to reconstruct the ORIGINAL input features at masked positions only
4. Loss: L1 reconstruction on masked node features

```python
class MAEDecoder(nn.Module):
    """Lightweight decoder for masked autoencoder pretraining."""
    def __init__(self, hidden_dim=192, output_dim=24):
        super().__init__()
        self.decoder = nn.Sequential(
            nn.Linear(hidden_dim, hidden_dim),
            nn.GELU(),
            nn.Linear(hidden_dim, output_dim)
        )

    def forward(self, h, mask):
        """
        h: (B, N, D) encoder hidden states
        mask: (B, N) boolean mask (True = masked nodes)
        Returns: reconstructed features at masked positions
        """
        masked_h = h[mask]  # (M, D)
        return self.decoder(masked_h)  # (M, output_dim)
```

**Masking strategy:**
```python
def random_mask(B, N, mask_ratio=0.25, device='cuda'):
    """Random node masking. Returns boolean mask."""
    mask = torch.rand(B, N, device=device) < mask_ratio
    return mask

# In pretraining forward pass:
mask = random_mask(B, N, mask_ratio=0.25)
# Replace masked node features with learned mask token
mask_token = nn.Parameter(torch.zeros(1, 1, input_dim))  # learned
x_masked = x.clone()
x_masked[mask] = mask_token.expand(mask.sum(), -1)
# Run encoder
h = encoder(x_masked)
# Reconstruct
x_recon = mae_decoder(h, mask)
# Loss: only on masked nodes
mae_loss = F.l1_loss(x_recon, x[mask][:, :output_dim])
```

### Step 2: Pretraining schedule

Run MAE pretraining for **20 epochs** before supervised training. This costs ~25 minutes (at ~70s/epoch), leaving ~155 minutes for supervised training (~130 epochs).

**IMPORTANT:** Use the SAME data loader as supervised training (including augmentation). The pretraining sees the same data distribution.

**Optimizer for pretraining:** Use the same Lion optimizer with lr=2e-4, but NO cosine annealing during pretraining (use constant LR). Reset the optimizer and scheduler for supervised training.

### Step 3: Supervised training with pretrained weights

After pretraining:
1. Save the encoder weights
2. Discard the MAE decoder (not needed for supervised training)
3. Initialize the full model with pretrained encoder weights
4. Run normal supervised training from epoch 0 with cosine annealing T_max=160
5. The pretrained weights are fine-tuned, not frozen

```python
if args.mae_pretrain:
    # Phase 1: MAE pretraining
    print("Phase 1: MAE pretraining...")
    mae_decoder = MAEDecoder(hidden_dim=192, output_dim=24).to(device)
    mae_optimizer = Lion(
        list(model.parameters()) + list(mae_decoder.parameters()),
        lr=2e-4, weight_decay=5e-5
    )
    for epoch in range(args.mae_pretrain_epochs):
        for batch in train_loader:
            mae_optimizer.zero_grad()
            mask = random_mask(B, N, 0.25)
            # ... forward pass with masking ...
            mae_loss.backward()
            mae_optimizer.step()

    # Discard MAE decoder and optimizer
    del mae_decoder, mae_optimizer

    # Phase 2: Normal supervised training
    print("Phase 2: Supervised training with pretrained encoder...")
    # Re-create optimizer and scheduler from scratch
    optimizer = Lion(model.parameters(), lr=2e-4, weight_decay=5e-5)
    scheduler = CosineAnnealingLR(optimizer, T_max=160)
    # ... proceed with normal training loop ...
```

### Step 4: Flags

- `--mae_pretrain`: Enable MAE pretraining phase before supervised training
- `--mae_pretrain_epochs 20`: Number of MAE pretraining epochs (default 20)
- `--mae_mask_ratio 0.25`: Fraction of nodes to mask (default 0.25)

### Step 5: Run experiments

```bash
# Config A: 20 pretrain epochs, seed 42
cd cfd_tandemfoil && python train.py --agent alphonse --seed 42 \
  --wandb_name "alphonse/mae-pretrain-20ep-s42" \
  --wandb_group "alphonse/mae-pretrain" \
  --mae_pretrain --mae_pretrain_epochs 20 --mae_mask_ratio 0.25 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias

# Config B: 10 pretrain epochs (faster, more supervised epochs)
# Same but --mae_pretrain_epochs 10
# Seed 73: change --seed 73
```

### Key implementation notes

1. **Mask token:** A single learned vector (24-dim) that replaces masked node features. Initialize to zero. This tells the encoder "this node's features are unknown — reconstruct from context."

2. **Reconstruction targets:** Reconstruct all 24 input channels at masked positions. The encoder must learn to infer geometric features (coordinates, DSDF, zone) from surrounding context — exactly the spatial reasoning needed for OOD generalization.

3. **torch.compile:** The masking operation (boolean indexing) may not be compile-friendly. If compile fails, run pretraining without compile and enable compile for supervised training only.

4. **VRAM:** The MAE decoder adds ~37K params (~150KB). The masking reduces the effective sequence length by 25%, so pretraining may actually use LESS VRAM than supervised training.

5. **Logging:** Log `mae_pretrain/loss` to W&B during pretraining. This helps verify the encoder is learning meaningful representations.

6. **Encoder includes SRF head:** The pretrained weights include the backbone BUT NOT the SRF head or prediction heads (those are task-specific). Only pretrain the TransolverBlock layers and the input projection.

7. **Epoch counting:** The pretraining epochs are separate from supervised epochs. Log them as `mae_epoch` in W&B. The supervised training starts at epoch 0 with a fresh optimizer and cosine schedule.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.05** | < 13.05 |
| p_oodc | **7.70** | < 7.70 |
| **p_tan** | **28.60** | **< 28.60** |
| p_re | **6.55** | < 6.55 |

**Baseline W&B runs:** d7l91p0x (s42, p_tan=28.9), j9btfx09 (s73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias
```