### PR TITLE
Normal-Velocity Hard Constraint: No-Penetration BC Projection

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -134,6 +134,125 @@ class DomainLayerNorm(nn.Module):
         return torch.where(mask_t, self.ln_tandem(x), self.ln_single(x))
 
 
+def compute_surface_normals_batch(positions, is_surface):
+    """Compute outward unit normals at surface nodes using the tangent method.
+
+    For each sample, surface nodes are sorted by angle around their centroid.
+    Tangents are computed from adjacent sorted nodes; normals are the perpendicular,
+    oriented outward (away from centroid).
+
+    Args:
+        positions:   (B, N, 2) float — x, y mesh coordinates in physical space
+        is_surface:  (B, N)    bool  — True at airfoil surface nodes
+
+    Returns:
+        normals:     (B, N, 2) float — unit outward normal at surface nodes,
+                     zero vector at non-surface nodes
+    """
+    B, N, _ = positions.shape
+    normals = torch.zeros_like(positions)  # (B, N, 2)
+
+    for b in range(B):
+        surf_idx = is_surface[b].nonzero(as_tuple=True)[0]  # (M,)
+        if surf_idx.numel() < 3:
+            continue
+
+        surf_pos = positions[b, surf_idx]  # (M, 2)
+        centroid = surf_pos.mean(dim=0)    # (2,)
+
+        # Sort surface nodes by angle around centroid
+        delta = surf_pos - centroid        # (M, 2)
+        angles = torch.atan2(delta[:, 1], delta[:, 0])  # (M,)
+        order = angles.argsort()
+        sorted_pos = surf_pos[order]       # (M, 2)
+
+        # Compute tangent from neighboring sorted nodes (circular)
+        M = sorted_pos.shape[0]
+        prev_idx = (torch.arange(M, device=positions.device) - 1) % M
+        next_idx = (torch.arange(M, device=positions.device) + 1) % M
+        tangent = sorted_pos[next_idx] - sorted_pos[prev_idx]  # (M, 2)
+
+        # Normal = 90-degree rotation of tangent
+        n = torch.stack([-tangent[:, 1], tangent[:, 0]], dim=-1)  # (M, 2)
+
+        # Normalize
+        nlen = n.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+        n = n / nlen
+
+        # Ensure outward direction (dot product with centroid-to-node should be positive)
+        outward = (sorted_pos - centroid)  # (M, 2)
+        flip = (n * outward).sum(dim=-1) < 0  # (M,) bool
+        n[flip] = -n[flip]
+
+        # Scatter back to original (unsorted) surface node order
+        inv_order = order.argsort()
+        n_unsorted = n[inv_order]
+
+        normals[b, surf_idx] = n_unsorted
+
+    return normals
+
+
+def _project_no_penetration(pred, surf_normals, is_surface, sample_stds,
+                             phys_stats, freestream, multiply_std):
+    """Project out surface-normal velocity to enforce no-penetration BC.
+
+    Works in Cp-normalized velocity space (Ux/Umag, Uy/Umag) where both
+    components share the same Umag scale, making physical-space unit normals valid.
+    Only modifies velocity channels (0, 1); pressure (channel 2) is unchanged.
+
+    Args:
+        pred:         [B, N, 3]  predictions in loss scale
+        surf_normals: [B, N, 2]  outward unit normals in physical position space
+        is_surface:   [B, N]     bool mask for surface nodes
+        sample_stds:  [B, 1, 3]  per-sample std used for loss scaling
+        phys_stats:   dict with "y_mean" [3] and "y_std" [3] (Cp-normalized stats)
+        freestream:   [B, 1, 3] or None — freestream offset in phys_stats-norm space
+        multiply_std: bool — True: loss = phys_norm * std; False: loss = phys_norm / std
+
+    Returns:
+        pred with u·n̂ = 0 enforced at all surface nodes (differentiable).
+    """
+    # Undo sample_stds → phys_stats-normalized residual space
+    if multiply_std:
+        pred_psnorm = pred / sample_stds
+    else:
+        pred_psnorm = pred * sample_stds
+
+    # Add freestream back → full phys_stats-normalized space
+    if freestream is not None:
+        pred_psnorm = pred_psnorm + freestream
+
+    # Undo phys_stats normalization for velocity → Cp-normalized space (Ux/Umag, Uy/Umag)
+    pstd = phys_stats["y_std"].to(pred.device)   # [3]
+    pmean = phys_stats["y_mean"].to(pred.device)  # [3]
+    u_cp = pred_psnorm[:, :, :2] * pstd[:2] + pmean[:2]  # [B, N, 2]
+
+    # Project out normal component u·n̂ at surface nodes (Gram-Schmidt)
+    surf_idx = is_surface.nonzero(as_tuple=False)  # [M, 2]
+    if surf_idx.numel() > 0:
+        b_idx, n_idx = surf_idx[:, 0], surf_idx[:, 1]
+        u_surf = u_cp[b_idx, n_idx]           # [M, 2]
+        n_hat = surf_normals[b_idx, n_idx]     # [M, 2]
+        u_dot_n = (u_surf * n_hat).sum(dim=-1, keepdim=True)  # [M, 1]
+        u_cp = u_cp.clone()
+        u_cp[b_idx, n_idx] = u_surf - u_dot_n * n_hat
+
+    # Re-apply phys_stats normalization for velocity
+    pred_psnorm_corrected = pred_psnorm.clone()
+    pred_psnorm_corrected[:, :, :2] = (u_cp - pmean[:2]) / pstd[:2]
+
+    # Subtract freestream back
+    if freestream is not None:
+        pred_psnorm_corrected = pred_psnorm_corrected - freestream
+
+    # Re-apply sample_stds → loss scale
+    if multiply_std:
+        return pred_psnorm_corrected * sample_stds
+    else:
+        return pred_psnorm_corrected / sample_stds
+
+
 class Physics_Attention_Irregular_Mesh(nn.Module):
     """Physics attention for irregular meshes in 1D/2D/3D space."""
 
@@ -1070,6 +1189,8 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Hard no-penetration boundary condition: project out surface-normal velocity after prediction
+    normal_vel_projection: bool = False      # enforce u·n̂=0 at surface nodes via Gram-Schmidt projection
 
 
 cfg = sp.parse(Config)
@@ -1666,6 +1787,10 @@ for epoch in range(MAX_EPOCHS):
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+        # Surface normals (computed in physical space before normalization, after augmentation)
+        _surf_normals = None
+        if cfg.normal_vel_projection:
+            _surf_normals = compute_surface_normals_batch(x[:, :, :2], is_surface)
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1833,6 +1958,14 @@ for epoch in range(MAX_EPOCHS):
                     aft_correction = aft_srf_head(aft_hidden, aft_pred, _aft_cond).float()
                 pred = pred.clone()
                 pred[aft_idx[:, 0], aft_idx[:, 1]] = pred[aft_idx[:, 0], aft_idx[:, 1]] + aft_correction
+
+        # Hard no-penetration BC: project out u·n̂ at surface nodes (training)
+        if cfg.normal_vel_projection and _surf_normals is not None:
+            if not cfg.raw_targets and not cfg.adaptive_norm:
+                pred = _project_no_penetration(
+                    pred, _surf_normals, is_surface, sample_stds,
+                    phys_stats, _freestream, cfg.multiply_std,
+                )
 
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
@@ -2303,6 +2436,10 @@ for epoch in range(MAX_EPOCHS):
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
                     _v_gap_stagger = x[:, 0, 22:24]  # [B, 2]
+                # Surface normals (computed in physical space before normalization)
+                _v_surf_normals = None
+                if cfg.normal_vel_projection:
+                    _v_surf_normals = compute_surface_normals_batch(x[:, :, :2], is_surface)
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -2453,6 +2590,14 @@ for epoch in range(MAX_EPOCHS):
                             pred = pred_loss / sample_stds
                         else:
                             pred = pred_loss * sample_stds
+
+                # Hard no-penetration BC: project out u·n̂ at surface nodes (val)
+                if cfg.normal_vel_projection and _v_surf_normals is not None:
+                    if not cfg.raw_targets and not cfg.adaptive_norm:
+                        pred_loss = _project_no_penetration(
+                            pred_loss, _v_surf_normals, is_surface, sample_stds,
+                            phys_stats, _v_freestream, cfg.multiply_std,
+                        )
 
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()

--- a/research/EXPERIMENT_EDWARD_NORMAL_VEL.md
+++ b/research/EXPERIMENT_EDWARD_NORMAL_VEL.md
@@ -1,0 +1,5 @@
+# Experiment: Normal-Velocity Hard Constraint
+
+**Student:** edward
+**Branch:** edward/normal-vel-constraint
+**Status:** WIP


### PR DESCRIPTION
## Hypothesis

On any airfoil surface, the velocity normal to the surface must be zero (no-penetration BC). Currently, the model learns this implicitly — but for OOD geometries like NACA6416, it can and does predict nonzero normal velocity at surface nodes. This violates fundamental physics and contaminates the pressure prediction.

**The fix:** After the model predicts (Ux, Uy) at surface nodes, apply a differentiable projection that removes the normal component: `u_corrected = u_pred - (u_pred · n_hat) * n_hat`. This makes the no-penetration condition **structurally impossible to violate**, regardless of geometry.

This is a **geometric bias** — it holds for ANY airfoil shape (seen or unseen). By baking it in as a hard constraint rather than a soft loss, we improve OOD generalization for free.

**Key literature:**
- Beucler et al. (2021) "Enforcing Analytic Constraints in Neural Networks" — hard constraints beat soft constraints for physical systems
- Holzschuh et al. (2023) "Solving Navier-Stokes with Constrained GNNs" — direct application of hard BCs in mesh-based flow prediction

## Instructions

### Step 1: Compute surface normals from DSDF gradients

The outward surface normal at a surface node can be approximated from the DSDF gradient. For a surface node where DSDF ≈ 0, the gradient of the signed distance field gives the normal direction:

```python
def compute_surface_normals(coords, dsdf_values, surface_mask, K=6):
    """
    Compute outward surface normals at surface nodes using DSDF gradient.
    
    coords: (N, 2) node positions
    dsdf_values: (N,) signed distance to the nearest foil surface
    surface_mask: (N,) boolean — True for surface nodes
    K: neighbors for gradient estimation
    Returns: normals (M, 2) unit normal vectors at M surface nodes
    """
    from scipy.spatial import cKDTree
    import numpy as np
    
    surf_idx = np.where(surface_mask)[0]
    surf_coords = coords[surf_idx]
    
    # For each surface node, compute DSDF gradient using KNN
    tree = cKDTree(coords)
    _, nbr_indices = tree.query(surf_coords, k=K+1)
    nbr_indices = nbr_indices[:, 1:]  # exclude self
    
    M = len(surf_idx)
    normals = np.zeros((M, 2))
    
    for i in range(M):
        nbrs = nbr_indices[i]
        dx = coords[nbrs, 0] - surf_coords[i, 0]
        dy = coords[nbrs, 1] - surf_coords[i, 1]
        d_dsdf = dsdf_values[nbrs] - dsdf_values[surf_idx[i]]
        
        # Least-squares gradient
        A = np.column_stack([dx, dy])
        ATA = A.T @ A + 1e-10 * np.eye(2)
        grad = np.linalg.solve(ATA, A.T @ d_dsdf)
        
        norm = np.linalg.norm(grad)
        if norm > 1e-8:
            normals[i] = grad / norm
        else:
            normals[i] = [0, 1]  # fallback
    
    return normals
```

**SIMPLER ALTERNATIVE** — use the foil geometry directly:

For each surface node, compute the tangent direction from adjacent surface nodes (sorted by arc-length). The normal is the 90° rotation of the tangent:
```python
tangent = next_node - prev_node
tangent /= np.linalg.norm(tangent)
normal = np.array([-tangent[1], tangent[0]])  # 90° rotation
```

This is more accurate and doesn't require KNN. Use whichever approach is simpler to implement.

**IMPORTANT: Cache the normals.** Surface normals are geometry-dependent and fixed per sample. Compute once during data loading and store as part of the batch.

### Step 2: Apply normal-velocity projection

In the forward pass, after the model produces velocity predictions at surface nodes:

```python
def project_normal_velocity(u_pred, normals, surface_mask):
    """
    Project out normal component of velocity at surface nodes.
    
    u_pred: (B, N, 2) predicted (Ux, Uy) — in PHYSICAL space (denormalized)
    normals: (B, M, 2) unit surface normals at M surface nodes
    surface_mask: (B, N) boolean mask for surface nodes
    Returns: corrected u_pred with zero normal velocity at surfaces
    """
    u_corrected = u_pred.clone()
    for b in range(u_pred.shape[0]):
        mask = surface_mask[b]
        u_surf = u_pred[b, mask, :]  # (M, 2)
        n = normals[b]  # (M, 2)
        
        # Dot product: normal component of velocity
        u_dot_n = (u_surf * n).sum(dim=-1, keepdim=True)  # (M, 1)
        
        # Project out normal component
        u_surf_corrected = u_surf - u_dot_n * n  # (M, 2)
        u_corrected[b, mask, :] = u_surf_corrected
    
    return u_corrected
```

**Where to apply:** After the SRF head and any post-processing, but BEFORE the loss computation. This ensures:
1. The loss sees only tangential velocity at surfaces
2. Gradients backpropagate through the projection (it's differentiable)
3. The model learns to predict velocities that are already nearly tangential

### Step 3: Apply during BOTH training and inference

This is critical — the projection should be applied during:
- **Training:** So the model learns from the corrected predictions and receives gradients through the projection
- **Validation:** So the reported metrics reflect the constrained predictions

The projection is a simple linear operation — no additional VRAM, negligible compute cost.

### Step 4: Handle the normalization pipeline

The model works in normalized/asinh space. The projection must be applied in **physical velocity space**:

1. Model predicts normalized (Ux_norm, Uy_norm)
2. Denormalize to physical space: (Ux_phys, Uy_phys)
3. Apply projection: remove normal component
4. Re-normalize back to model space
5. Compute loss in model space

If the denormalization is complex, a simpler approach: apply the projection in the normalized space directly. Since the projection `u - (u·n)n` is a linear operation, it works in any coordinate system as long as the normal vectors are in the same space. Compute normals in the model's normalized coordinate system.

### Step 5: Flags and experiments

- `--normal_vel_projection`: Enable hard no-penetration constraint

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/normal-vel-proj-s42" \
  --wandb_group "edward/normal-vel-constraint" \
  --normal_vel_projection \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias

# Seed 73: change --seed 73
```

### Key implementation notes

1. **Surface node identification:** Check how `prepare_multi.py` identifies surface nodes. Look for zone labels, boundary IDs, or the `saf` (surface assignment field). Surface nodes typically have `boundary_id == 4` (foil-1) or `boundary_id == 7` (foil-2), or similar.

2. **Normal sign convention:** The normals should point OUTWARD from the foil surface. Verify by checking that `dot(normal, surface_to_centroid) < 0` for a test sample.

3. **torch.compile compatibility:** The projection is a simple tensor operation (dot product + subtraction). Fully compile-friendly.

4. **DSDF channel indices reminder:** Foil-1 DSDF at `x[:,4:8]`, Foil-2 at `x[:,6:10]`. XY coordinates at `x[:,:,:2]`.

5. **Augmentation interaction:** When AoA augmentation rotates the mesh, the surface normals must be rotated by the same angle. If normals are pre-computed, they need to be recomputed or rotated after augmentation.

6. **Zero extra parameters.** This adds no learnable parameters — it's a pure geometric constraint.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.05** | < 13.05 |
| p_oodc | **7.70** | < 7.70 |
| **p_tan** | **28.60** | **< 28.60** |
| p_re | **6.55** | < 6.55 |

**Baseline W&B runs:** d7l91p0x (s42, p_tan=28.9), j9btfx09 (s73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias
```