### PR TITLE
MixStyle Tandem Feature Regularization for OOD Generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -846,6 +846,34 @@ class Transolver(nn.Module):
         if sum(self.output_dims) != preds.shape[-1]:
             raise ValueError("Sum of output_dims must match preds last dimension")
 
+    @torch.compiler.disable
+    def _apply_mixstyle(self, fx, is_tandem):
+        """MixStyle: mix feature statistics between tandem samples (Zhou et al., ICLR 2021)."""
+        import random as _rand
+        if _rand.random() < getattr(self, '_mixstyle_prob', 0.5):
+            tandem_mask_flat = (is_tandem.view(-1) > 0.5)  # [B]
+            n_tandem = tandem_mask_flat.sum().item()
+            if n_tandem >= 2:
+                tandem_idx = tandem_mask_flat.nonzero(as_tuple=True)[0]
+                perm = tandem_idx[torch.randperm(n_tandem, device=fx.device)]
+
+                eps = 1e-6
+                # Detach stats per reference impl — prevents model from "undoing" mixing via gradients
+                mu = fx[tandem_idx].mean(dim=1, keepdim=True).detach()          # [n_tandem, 1, H]
+                sigma = (fx[tandem_idx].var(dim=1, keepdim=True) + eps).sqrt().detach()  # [n_tandem, 1, H]
+                mu_perm = fx[perm].mean(dim=1, keepdim=True).detach()
+                sigma_perm = (fx[perm].var(dim=1, keepdim=True) + eps).sqrt().detach()
+
+                _ms_alpha = getattr(self, '_mixstyle_alpha', 0.3)
+                lam = torch.distributions.Beta(_ms_alpha, _ms_alpha).sample().item()
+
+                fx_normed = (fx[tandem_idx] - mu) / sigma
+                mu_mix = lam * mu + (1 - lam) * mu_perm
+                sigma_mix = lam * sigma + (1 - lam) * sigma_perm
+                fx = fx.clone()
+                fx[tandem_idx] = fx_normed * sigma_mix + mu_mix
+        return fx
+
     def forward(self, data, pos=None, condition=None):
         x, pos, condition = self._unpack_inputs(data, pos=pos, condition=condition)
         if x is None:
@@ -900,6 +928,10 @@ class Transolver(nn.Module):
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+
+        # MixStyle: mix feature statistics between tandem samples for OOD regularization
+        if self.training and getattr(self, '_mixstyle', False) and is_tandem is not None:
+            fx = self._apply_mixstyle(fx, is_tandem)
 
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
@@ -1070,6 +1102,10 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # MixStyle: feature-space style regularization for tandem OOD generalization
+    mixstyle: bool = False
+    mixstyle_alpha: float = 0.3              # Beta distribution alpha for mixing coefficient
+    mixstyle_prob: float = 0.5               # probability of applying MixStyle per forward pass
 
 
 cfg = sp.parse(Config)
@@ -1237,6 +1273,11 @@ model._pressure_separate = cfg.pressure_separate_last_block
 torch._functorch.config.donated_buffer = False  # required for retain_graph=True in PCGrad
 model = torch.compile(model, mode=cfg.compile_mode)
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
+
+# MixStyle attributes (set on uncompiled model so forward() can access them)
+_base_model._mixstyle = cfg.mixstyle
+_base_model._mixstyle_alpha = cfg.mixstyle_alpha
+_base_model._mixstyle_prob = cfg.mixstyle_prob
 
 # Surface refinement head (separate module, not compiled with main model)
 refine_head = None
@@ -1518,6 +1559,7 @@ for _sname in VAL_SPLIT_NAMES:
 wandb.define_metric("lr", step_metric="global_step")
 wandb.define_metric("epoch_time_s", step_metric="global_step")
 wandb.define_metric("val_predictions", step_metric="global_step")
+wandb.define_metric("mixstyle/*", step_metric="global_step")
 
 model_dir = Path(f"models/model-{run.id}")
 model_dir.mkdir(parents=True)
@@ -2153,7 +2195,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.mixstyle and global_step % 20 == 0:
+            _log_dict["mixstyle/enabled"] = 1
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The model's tandem OOD performance (p_tan) is bottlenecked by **overfitting to the feature statistics of training-distribution tandem shapes**. When NACA6416 appears in tandem at test time, its intermediate features have different mean/variance from training tandem features, causing degraded predictions.

**MixStyle** (Zhou et al., ICLR 2021) addresses this by mixing feature statistics (mean + std) between different samples during training, creating "virtual" samples with novel statistical profiles. Applied selectively to tandem samples, this forces the model to handle a broader range of tandem feature distributions — including distributions closer to what NACA6416 tandem produces at test time.

**Why this is NOT the same as SWD (#2175):** SWD tried to ALIGN tandem and single-foil distributions (forcing them to be the same). That destroyed the tandem-specific signal. MixStyle does the opposite — it creates DIVERSITY within the tandem domain by interpolating feature statistics between different tandem samples. The tandem signal is preserved; only the statistical "style" changes.

**Key difference from input-level augmentation** (aug_dsdf2, aug_gap_stagger): Those augmentations perturb the INPUT space. MixStyle operates in the FEATURE space after the Transolver blocks have processed the input. Feature-space regularization affects how the model generalizes to ALL unseen inputs (including far-OOD), not just inputs near the training distribution.

**Reference:** Zhou et al. "Domain Generalization with MixStyle" (ICLR 2021, arXiv:2104.02008)

## Instructions

### Step 1 — Add CLI flags

```python
parser.add_argument('--mixstyle', action='store_true', help='Enable MixStyle feature regularization')
parser.add_argument('--mixstyle_alpha', type=float, default=0.3, help='Beta distribution alpha for MixStyle mixing coefficient')
parser.add_argument('--mixstyle_prob', type=float, default=0.5, help='Probability of applying MixStyle per forward pass')
```

### Step 2 — Add MixStyle logic in `Transolver.forward()`

Insert the following **after the non-last blocks loop** (after `for block in self.blocks[:-1]: ...`, around line ~902) and **before** `fx_deep = fx`:

```python
# MixStyle: mix feature statistics between tandem samples for OOD regularization
if self.training and getattr(self, '_mixstyle', False) and is_tandem is not None:
    import random as _rand
    if _rand.random() < self._mixstyle_prob:
        tandem_mask_flat = (is_tandem.view(-1) > 0.5)  # [B]
        n_tandem = tandem_mask_flat.sum().item()
        if n_tandem >= 2:
            tandem_idx = tandem_mask_flat.nonzero(as_tuple=True)[0]
            perm = tandem_idx[torch.randperm(n_tandem, device=fx.device)]

            eps = 1e-6
            # Per-sample statistics over spatial dimension
            mu = fx[tandem_idx].mean(dim=1, keepdim=True)          # [n_tandem, 1, H]
            sigma = fx[tandem_idx].std(dim=1, keepdim=True) + eps  # [n_tandem, 1, H]
            mu_perm = fx[perm].mean(dim=1, keepdim=True)
            sigma_perm = fx[perm].std(dim=1, keepdim=True) + eps

            lam = torch.distributions.Beta(
                self._mixstyle_alpha, self._mixstyle_alpha
            ).sample().item()

            # Normalize → mix statistics → denormalize
            fx_normed = (fx[tandem_idx] - mu) / sigma
            mu_mix = lam * mu + (1 - lam) * mu_perm
            sigma_mix = lam * sigma + (1 - lam) * sigma_perm
            fx = fx.clone()  # avoid in-place modification issues with autograd
            fx[tandem_idx] = fx_normed * sigma_mix + mu_mix
```

**Also set the attributes on the model after construction (in the training setup):**
```python
if args.mixstyle:
    model._mixstyle = True
    model._mixstyle_alpha = args.mixstyle_alpha
    model._mixstyle_prob = args.mixstyle_prob
else:
    model._mixstyle = False
```

### Step 3 — Log MixStyle activation

Every 20 steps, log whether MixStyle was applied (for debugging):
```python
if args.mixstyle and step % 20 == 0:
    wandb.log({"mixstyle/applied": 1 if mixstyle_was_applied else 0}, step=global_step)
```

### Step 4 — Run 2 configs, 2 seeds each

Use `--wandb_group askeladd-mixstyle`.

**Config A — moderate mixing (alpha=0.3, prob=0.5):**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd \
  --wandb_name "askeladd/mixstyle-a03-p05" --wandb_group askeladd-mixstyle \
  --mixstyle --mixstyle_alpha 0.3 --mixstyle_prob 0.5 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --seed 42
```
(Repeat with `--seed 73`)

**Config B — stronger mixing (alpha=0.5, prob=1.0):**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd \
  --wandb_name "askeladd/mixstyle-a05-p10" --wandb_group askeladd-mixstyle \
  --mixstyle --mixstyle_alpha 0.5 --mixstyle_prob 1.0 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias \
  --seed 42
```
(Repeat with `--seed 73`)

Run all 4 in parallel. Report p_in, p_oodc, p_tan, p_re per config (2-seed avg).

### Implementation notes

- **Only mix tandem samples** — single-foil samples must NOT be touched by MixStyle. Use `is_tandem` to identify tandem samples in the batch.
- **Only during training** — MixStyle is disabled at eval/test time (`self.training` guard).
- **No label mixing** — MixStyle only changes feature statistics. Targets/labels remain unchanged. This is the key difference from Manifold Mixup.
- **The `fx.clone()` is essential** — without it, in-place modification of `fx[tandem_idx]` will break autograd.
- **If `torch.compile` issues arise**: wrap the MixStyle block in `if not torch.compiler.is_compiling():` as a fallback.
- **Expected VRAM**: identical to baseline (~43 GB). MixStyle adds negligible compute.

### Diagnostics

- If p_tan gets WORSE with Config B but not Config A → alpha=0.5 too aggressive, try alpha=0.1.
- If BOTH configs show no change → feature statistics already well-regularized by existing augmentation. Clean negative.
- Log `lam` values in a few batches to verify Beta distribution sampling.

## Baseline

| Metric | Baseline (2-seed avg) |
|--------|----------------------|
| p_in | 13.05 |
| p_oodc | 7.70 |
| **p_tan** | **28.60** |
| p_re | 6.55 |

Baseline W&B runs: d7l91p0x (seed 42, p_tan=28.9), j9btfx09 (seed 73, p_tan=28.3)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-gsb-pcgrad" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 --gap_stagger_spatial_bias
```