### PR TITLE
DSDF Test-Time Feature Alignment for OOD Tandem Generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1074,6 +1074,8 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 7: DSDF test-time feature alignment
+    dsdf_tta_align: bool = False            # align OOD tandem DSDF stats to training distribution at val time
 
 
 cfg = sp.parse(Config)
@@ -1178,6 +1180,27 @@ _pmean = (_phys_sum / _phys_n).float()
 _pstd = ((_phys_sq_sum / _phys_n - _pmean ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
 phys_stats = {"y_mean": _pmean, "y_std": _pstd}
 print(f"  Cp stats — mean: {_pmean.tolist()}, std: {_pstd.tolist()}")
+
+# --- DSDF training channel stats (for test-time alignment) ---
+DSDF_TRAIN_MEAN = None
+DSDF_TRAIN_STD = None
+if cfg.dsdf_tta_align:
+    print("Computing DSDF training channel statistics for TTA alignment...")
+    _dsdf_sum = torch.zeros(8, device=device)
+    _dsdf_sq_sum = torch.zeros(8, device=device)
+    _dsdf_n = 0.0
+    with torch.no_grad():
+        for _x, _y, _is_surf, _mask in tqdm(_stats_loader, desc="DSDF stats", leave=False):
+            _x, _mask = _x.to(device), _mask.to(device)
+            _dsdf = _x[:, :, 2:10]  # 8 DSDF channels (saf + dsdf)
+            _m = _mask.float().unsqueeze(-1)  # [B, N, 1]
+            _dsdf_sum += (_dsdf * _m).sum(dim=(0, 1))
+            _dsdf_sq_sum += (_dsdf ** 2 * _m).sum(dim=(0, 1))
+            _dsdf_n += _mask.float().sum().item()
+    DSDF_TRAIN_MEAN = (_dsdf_sum / _dsdf_n).float()
+    DSDF_TRAIN_STD = ((_dsdf_sq_sum / _dsdf_n - DSDF_TRAIN_MEAN ** 2).clamp(min=0.0).sqrt()).clamp(min=1e-6).float()
+    print(f"  DSDF train mean: {DSDF_TRAIN_MEAN.tolist()}")
+    print(f"  DSDF train std:  {DSDF_TRAIN_STD.tolist()}")
 
 if cfg.raw_targets or cfg.adaptive_norm:
     _label = "Adaptive norm" if cfg.adaptive_norm else "Raw"
@@ -2335,6 +2358,19 @@ for epoch in range(MAX_EPOCHS):
                 x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
                 is_surface = is_surface.to(device, non_blocking=True)
                 mask = mask.to(device, non_blocking=True)
+
+                # DSDF test-time alignment: shift OOD tandem sample DSDF stats → training distribution
+                if cfg.dsdf_tta_align and DSDF_TRAIN_MEAN is not None:
+                    _tta_is_tandem = (x[:, 0, 22].abs() > 0.01)
+                    if _tta_is_tandem.any():
+                        x = x.clone()
+                        for _b in range(x.shape[0]):
+                            if _tta_is_tandem[_b]:
+                                _valid = mask[_b]  # only align real (non-padded) nodes
+                                _dsdf = x[_b, _valid, 2:10]  # (N_valid, 8)
+                                _smean = _dsdf.mean(dim=0)
+                                _sstd = _dsdf.std(dim=0).clamp(min=1e-6)
+                                x[_b, _valid, 2:10] = (_dsdf - _smean) / _sstd * DSDF_TRAIN_STD + DSDF_TRAIN_MEAN
 
                 raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

The model's DSDF feature distribution for NACA6416 (OOD, heavily cambered) systematically differs from the training distribution (mostly NACA00XX symmetric foils). When the learned mapping `f(dsdf_features) → flow field` is evaluated on inputs from a low-density region of its training distribution, prediction accuracy degrades — this is the standard covariate shift problem, and it directly contributes to the p_tan gap (28.50 vs p_in 13.21, a 2.17x ratio).

**Key insight:** This is not a model capacity problem — it is an input distribution mismatch problem. If we align the per-sample DSDF channel statistics of OOD test samples to the training distribution before inference, we pull the model's inputs back into its trained domain without any change to model weights or training procedure.

This is the inference-time version of Domain Adaptation. Similar to test-time batch norm adaptation (Schneider et al., NeurIPS 2020) but applied to raw DSDF input features rather than batch norm statistics.

**Why this is different from SWD Domain Alignment (#2175, CLOSED):** SWD aligned internal slice token distributions during training via a loss — destroyed physically meaningful tandem-specific representations. This approach aligns raw input features at test time only (no training change) and only for OOD tandem samples. Cannot harm training-domain accuracy.

**Literature:**
- Schneider et al. (2020). "Improving robustness against common corruptions by covariate shift adaptation." NeurIPS 2020. Test-time BN adaptation → 5-10% improvement on distribution-shifted inputs.
- Wang et al. (2021). "Tent: Fully Test-Time Adaptation by Entropy Minimization." ICLR 2021. Canonical TTA paper.
- Sun & Saenko (2016). "Deep CORAL: Correlation Alignment for Deep Domain Adaptation." Second-order statistics alignment; we use simpler first-order only.

## Instructions

### Step 1: Compute training DSDF channel statistics

Compute per-channel mean and std for DSDF channels (x[:, :, 2:10], 8 channels) across all training samples. Hardcode as constants in train.py.

```python
# One-time scan of training set:
all_dsdf = []
for batch in train_dataloader:
    x = batch['x']  # (B, N, C)
    all_dsdf.append(x[:, :, 2:10].reshape(-1, 8))
all_dsdf = torch.cat(all_dsdf, dim=0)  # (N_total_nodes, 8)
train_dsdf_mean = all_dsdf.mean(dim=0)  # (8,)
train_dsdf_std = all_dsdf.std(dim=0)    # (8,)
# Print and hardcode these as DSDF_TRAIN_MEAN, DSDF_TRAIN_STD constants
```

Or compute lazily on first validation pass and cache.

### Step 2: Apply alignment during validation only

```python
def apply_dsdf_tta(x, train_dsdf_mean, train_dsdf_std, tandem_mask):
    """
    Align DSDF feature distribution of OOD samples to training distribution.
    Apply ONLY during validation, ONLY to tandem OOD samples.
    
    x: (B, N, C) full feature tensor
    tandem_mask: (B,) bool — True if this sample is an OOD tandem sample
    train_dsdf_mean: (8,) training distribution mean per channel
    train_dsdf_std: (8,) training distribution std per channel
    """
    if tandem_mask.sum() == 0:
        return x
    
    x = x.clone()
    dsdf_slice = slice(2, 10)
    train_dsdf_mean = train_dsdf_mean.to(x.device)
    train_dsdf_std = train_dsdf_std.to(x.device)
    
    for b in range(x.shape[0]):
        if tandem_mask[b]:
            dsdf = x[b, :, dsdf_slice]  # (N, 8)
            sample_mean = dsdf.mean(dim=0)           # (8,)
            sample_std = dsdf.std(dim=0).clamp(min=1e-6)  # (8,)
            dsdf_aligned = (dsdf - sample_mean) / sample_std * train_dsdf_std + train_dsdf_mean
            x[b, :, dsdf_slice] = dsdf_aligned
    return x
```

In the validation loop:
```python
if args.dsdf_tta_align and not model.training:
    x = apply_dsdf_tta(x, DSDF_TRAIN_MEAN, DSDF_TRAIN_STD, tandem_mask)
```

### Step 3: Flag

- `--dsdf_tta_align`: Enable DSDF test-time feature alignment (validation only)

### Step 4: Run experiments

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent tanjiro --seed 42 \
  --wandb_name "tanjiro/dsdf-tta-align-s42" \
  --wandb_group "tanjiro/dsdf-tta-align" \
  --dsdf_tta_align \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5

# Seed 73: same command, --seed 73, --wandb_name "tanjiro/dsdf-tta-align-s73"
```

### Key implementation notes

1. **Identifying OOD tandem samples:** Check how the dataset labels tandem vs single-foil samples. The OOD tandem val split (p_tan) contains NACA6416 samples. Use whatever flag/mask the dataset provides to identify these samples during validation.

2. **DSDF channel indices:** Verify channels 2:10 are the 8 DSDF channels. Print feature stats for one sample to confirm by magnitude range.

3. **Apply ONLY at validation:** The training pipeline uses DSDF magnitude aug (aug_dsdf2_sigma) which deliberately shifts training distributions. The TTA alignment must ONLY touch the validation forward pass.

4. **Sanity check:** Log pre/post alignment mean/std for one OOD sample in the first validation epoch. Should converge to training distribution values.

5. **Variant to try if Variant A fails:** Apply alignment to fore-foil DSDF (2:6) and aft-foil DSDF (6:10) separately — they may have different training distributions. Try separate alignment if global alignment fails.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.21** | < 13.21 |
| p_oodc | **7.82** | < 7.82 |
| **p_tan** | **28.50** | **< 28.50** |
| p_re | **6.45** | < 6.45 |

**Baseline W&B runs:** 6yfv5lio (s42, p_tan=28.432), etepxvjc (s73, p_tan=28.572) — PR #2184 (DCT Freq Loss w=0.05)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --wandb_name "tanjiro/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```