### PR TITLE
Laplacian Eigenvector Mesh Positional Encoding for OOD Geometry Transfer

### DIFF
--- a/cfd_tandemfoil/precompute_lap_pe.py
+++ b/cfd_tandemfoil/precompute_lap_pe.py
@@ -1,0 +1,105 @@
+"""Pre-compute Laplacian eigenvector positional encodings for all mesh samples."""
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as spla
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent))
+from data.prepare_multi import load_pickle
+
+
+def compute_laplacian_pe(edge_index: np.ndarray, n_nodes: int, k: int = 16) -> np.ndarray:
+    """Compute k smallest non-trivial Laplacian eigenvectors.
+
+    Args:
+        edge_index: (2, E) array of [src, dst] pairs
+        n_nodes: total number of nodes
+        k: number of eigenvectors to compute
+    Returns:
+        (n_nodes, k) array of eigenvectors (absolute value for sign invariance)
+    """
+    row = edge_index[0]
+    col = edge_index[1]
+    data = np.ones(len(row), dtype=np.float64)
+    A = sp.csr_matrix((data, (row, col)), shape=(n_nodes, n_nodes))
+    A = A + A.T
+    A.data = np.minimum(A.data, 1.0)  # binarize
+    degrees = np.array(A.sum(axis=1)).flatten()
+    D = sp.diags(degrees)
+    L = D - A
+
+    try:
+        # Shift-invert mode (sigma=0) is much faster for smallest eigenvalues
+        eigenvalues, eigenvectors = spla.eigsh(L, k=k + 1, sigma=1e-5, which='LM', tol=1e-3)
+        idx = np.argsort(eigenvalues)
+        eigenvectors = eigenvectors[:, idx[1:k + 1]]  # skip trivial
+        eigenvectors = np.abs(eigenvectors)  # sign invariance
+    except Exception as e:
+        print(f"  eigsh failed ({e}), returning zeros")
+        eigenvectors = np.zeros((n_nodes, k), dtype=np.float32)
+
+    return eigenvectors.astype(np.float32)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--k', type=int, default=16, help='Number of eigenvectors')
+    parser.add_argument('--cache_dir', type=str, default='cache/lap_pe/', help='Output directory')
+    parser.add_argument('--manifest', type=str, default='data/split_manifest.json')
+    args = parser.parse_args()
+
+    cache_dir = Path(args.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    # Build global index mapping (file_idx, local_idx) → global_idx
+    global_idx = 0
+    total_samples = 0
+    t_start = time.time()
+
+    for fi, pkl_path in enumerate(manifest['pickle_paths']):
+        print(f"\nLoading {pkl_path}...")
+        data = load_pickle(Path(pkl_path))
+        print(f"  {len(data)} samples")
+
+        for si, sample in enumerate(data):
+            out_path = cache_dir / f"lap_pe_{global_idx:05d}.pt"
+            if out_path.exists():
+                global_idx += 1
+                total_samples += 1
+                continue
+
+            n_nodes = sample.pos.shape[0]
+            edge_index = sample.edge_index.numpy()
+
+            t0 = time.time()
+            lap_pe = compute_laplacian_pe(edge_index, n_nodes, k=args.k)
+            dt = time.time() - t0
+
+            torch.save(torch.from_numpy(lap_pe), out_path)
+            total_samples += 1
+
+            if total_samples % 50 == 0 or total_samples <= 5:
+                elapsed = time.time() - t_start
+                rate = total_samples / elapsed
+                print(f"  [{total_samples}] nodes={n_nodes}, k={args.k}, time={dt:.2f}s, rate={rate:.1f} samples/s")
+
+            global_idx += 1
+
+        del data
+
+    elapsed = time.time() - t_start
+    print(f"\nDone: {total_samples} samples in {elapsed:.0f}s ({total_samples/elapsed:.1f} samples/s)")
+    print(f"Cached to: {cache_dir}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, asdict
 from einops import rearrange
 from timm.layers import trunc_normal_
 from tqdm import tqdm
-from torch.utils.data import DataLoader, WeightedRandomSampler
+from torch.utils.data import DataLoader, Subset, WeightedRandomSampler
 import simple_parsing as sp
 
 from data.utils import visualize
@@ -1024,6 +1024,9 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    laplacian_pe: bool = False    # replace Fourier PE with Laplacian eigenvector PE
+    laplacian_pe_k: int = 16      # number of Laplacian eigenvectors
+    lap_pe_cache_dir: str = "cache/lap_pe/"  # path to cached PE files
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1093,6 +1096,26 @@ train_ds, val_splits, stats, sample_weights = load_data(
 )
 stats = {k: v.to(device) for k, v in stats.items()}
 
+# Load Laplacian PE cache if enabled
+_lap_pe_all = {}  # global_idx -> (N, k) tensor
+if cfg.laplacian_pe:
+    from pathlib import Path as _Path
+    _lap_dir = _Path(cfg.lap_pe_cache_dir)
+    for _f in sorted(_lap_dir.glob("lap_pe_*.pt")):
+        _idx = int(_f.stem.split("_")[-1])
+        _lap_pe_all[_idx] = torch.load(_f, map_location="cpu", weights_only=True)[:, :cfg.laplacian_pe_k]
+    print(f"Loaded {len(_lap_pe_all)} Laplacian PE files from {_lap_dir} (k={cfg.laplacian_pe_k})")
+
+    # Create index-returning wrapper for Subset
+    class _IndexedSubset(Subset):
+        __getitems__ = None  # disable batch fetching so __getitem__ is always used
+        def __getitem__(self, idx):
+            glob_idx = self.indices[idx]
+            return (*self.dataset[glob_idx], glob_idx)
+    # Replace train_ds and val_splits with indexed versions
+    train_ds = _IndexedSubset(train_ds.dataset, train_ds.indices)
+    val_splits = {k: _IndexedSubset(v.dataset, v.indices) for k, v in val_splits.items()}
+
 
 def _umag_q(y, mask):
     """Per-sample reference velocity and dynamic pressure from mean velocity.
@@ -1131,7 +1154,30 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
 
-loader_kwargs = dict(collate_fn=pad_collate, num_workers=cfg.num_workers, pin_memory=True,
+def _collate_with_lap_pe(batch):
+    """Collate that handles (x, y, surf, glob_idx) tuples and constructs lap_pe batch."""
+    xs, ys, surfs, idxs = zip(*batch)
+    max_n = max(x.shape[0] for x in xs)
+    B = len(xs)
+    x_pad = torch.zeros(B, max_n, xs[0].shape[1])
+    y_pad = torch.zeros(B, max_n, ys[0].shape[1])
+    surf_pad = torch.zeros(B, max_n, dtype=torch.bool)
+    mask_pad = torch.zeros(B, max_n, dtype=torch.bool)
+    pe_pad = torch.zeros(B, max_n, cfg.laplacian_pe_k)
+    for i, (x, y, sf, gi) in enumerate(zip(xs, ys, surfs, idxs)):
+        n = x.shape[0]
+        x_pad[i, :n] = x
+        y_pad[i, :n] = y
+        surf_pad[i, :n] = sf
+        mask_pad[i, :n] = True
+        pe = _lap_pe_all.get(gi)
+        if pe is not None:
+            _m = min(n, pe.shape[0])
+            pe_pad[i, :_m] = pe[:_m]
+    return x_pad, y_pad, surf_pad, mask_pad, pe_pad
+
+_collate_fn = _collate_with_lap_pe if cfg.laplacian_pe else pad_collate
+loader_kwargs = dict(collate_fn=_collate_fn, num_workers=cfg.num_workers, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
 
 if cfg.debug:
@@ -1160,7 +1206,8 @@ _phys_sq_sum = torch.zeros(3, device=device)
 _phys_n = 0.0
 _stats_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
 with torch.no_grad():
-    for _x, _y, _is_surf, _mask in tqdm(_stats_loader, desc="Phys stats", leave=False):
+    for _stat_batch in tqdm(_stats_loader, desc="Phys stats", leave=False):
+        _x, _y, _is_surf, _mask = _stat_batch[0], _stat_batch[1], _stat_batch[2], _stat_batch[3]
         _y, _mask = _y.to(device), _mask.to(device)
         _Um, _q = _umag_q(_y, _mask)
         _yp = _phys_norm(_y, _Um, _q)
@@ -1186,7 +1233,8 @@ if cfg.raw_targets or cfg.adaptive_norm:
     _raw_sq_sum = torch.zeros(3, device=device)
     _raw_n = 0.0
     with torch.no_grad():
-        for _x, _y, _is_surf, _mask in tqdm(_stats_loader, desc=f"{_label} stats", leave=False):
+        for _stat_batch in tqdm(_stats_loader, desc=f"{_label} stats", leave=False):
+            _x, _y, _is_surf, _mask = _stat_batch[0], _stat_batch[1], _stat_batch[2], _stat_batch[3]
             _y, _mask = _y.to(device), _mask.to(device)
             _yt = _y.clone()
             if cfg.adaptive_norm and cfg.asinh_pressure:
@@ -1204,7 +1252,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (cfg.laplacian_pe_k if cfg.laplacian_pe else 32),  # +curv, +dist, [+foil2dist], +PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1566,7 +1614,12 @@ for epoch in range(MAX_EPOCHS):
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     if cfg.grad_accum_steps > 1:
         optimizer.zero_grad()
-    for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
+    for batch_idx, _batch in enumerate(pbar):
+        if cfg.laplacian_pe:
+            x, y, is_surface, mask, _batch_lap_pe = _batch
+            _batch_lap_pe = _batch_lap_pe.to(device, non_blocking=True)
+        else:
+            x, y, is_surface, mask = _batch
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -1681,16 +1734,18 @@ for epoch in range(MAX_EPOCHS):
             x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
         else:
             x = torch.cat([x, curv, dist_feat], dim=-1)
-        # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
-        raw_xy = x[:, :, :2]
-        # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-        xy_min = raw_xy.amin(dim=1, keepdim=True)
-        xy_max = raw_xy.amax(dim=1, keepdim=True)
-        xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-        freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-        xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
-        x = torch.cat([x, fourier_pe], dim=-1)
+        # Positional encoding: Laplacian eigenvectors OR Fourier PE
+        if cfg.laplacian_pe:
+            x = torch.cat([x, _batch_lap_pe], dim=-1)
+        else:
+            raw_xy = x[:, :, :2]
+            xy_min = raw_xy.amin(dim=1, keepdim=True)
+            xy_max = raw_xy.amax(dim=1, keepdim=True)
+            xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+            freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+            xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+            fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+            x = torch.cat([x, fourier_pe], dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -2329,9 +2384,14 @@ for epoch in range(MAX_EPOCHS):
         n_vbatches = 0
 
         with torch.no_grad():
-            for x, y, is_surface, mask in tqdm(
+            for _vbatch in tqdm(
                 vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
             ):
+                if cfg.laplacian_pe:
+                    x, y, is_surface, mask, _batch_lap_pe = _vbatch
+                    _batch_lap_pe = _batch_lap_pe.to(device, non_blocking=True)
+                else:
+                    x, y, is_surface, mask = _vbatch
                 x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
                 is_surface = is_surface.to(device, non_blocking=True)
                 mask = mask.to(device, non_blocking=True)
@@ -2355,16 +2415,18 @@ for epoch in range(MAX_EPOCHS):
                     x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
                 else:
                     x = torch.cat([x, curv, dist_feat], dim=-1)
-                # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
-                raw_xy = x[:, :, :2]
-                # Normalize xy to [0,1] per-sample for consistent Fourier encoding
-                xy_min = raw_xy.amin(dim=1, keepdim=True)
-                xy_max = raw_xy.amax(dim=1, keepdim=True)
-                xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
-                xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
-                fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
-                x = torch.cat([x, fourier_pe], dim=-1)
+                # Positional encoding: Laplacian eigenvectors OR Fourier PE
+                if cfg.laplacian_pe:
+                    x = torch.cat([x, _batch_lap_pe], dim=-1)
+                else:
+                    raw_xy = x[:, :, :2]
+                    xy_min = raw_xy.amin(dim=1, keepdim=True)
+                    xy_max = raw_xy.amax(dim=1, keepdim=True)
+                    xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                    freqs = torch.cat([model.fourier_freqs_fixed.to(device), model.fourier_freqs_learned.abs()])
+                    xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
+                    fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
+                    x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
@@ -2729,7 +2791,11 @@ if best_metrics:
         for split_name, split_ds in val_splits.items():
             samples = []
             for i in range(min(n, len(split_ds))):
-                x, y_true, is_surface = split_ds[i]
+                _vis_sample = split_ds[i]
+                if cfg.laplacian_pe:
+                    x, y_true, is_surface, _vis_glob_idx = _vis_sample
+                else:
+                    x, y_true, is_surface = _vis_sample
                 with torch.no_grad():
                     x_dev = x.unsqueeze(0).to(device)
                     y_dev = y_true.unsqueeze(0).to(device)
@@ -2741,15 +2807,23 @@ if best_metrics:
                     x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                     curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                     x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
-                    # Fourier PE (must match training loop)
-                    raw_xy = x_n[:, :, :2]
-                    xy_min = raw_xy.amin(dim=1, keepdim=True)
-                    xy_max = raw_xy.amax(dim=1, keepdim=True)
-                    xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                    freqs = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
-                    xy_scaled = xy_norm.unsqueeze(-1) * freqs
-                    fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
-                    x_n = torch.cat([x_n, fourier_pe], dim=-1)
+                    # Positional encoding (must match training loop)
+                    if cfg.laplacian_pe:
+                        _vis_pe = _lap_pe_all.get(_vis_glob_idx)
+                        if _vis_pe is not None:
+                            _vis_pe_dev = _vis_pe[:x_dev.shape[1]].unsqueeze(0).to(device)
+                        else:
+                            _vis_pe_dev = torch.zeros(1, x_dev.shape[1], cfg.laplacian_pe_k, device=device)
+                        x_n = torch.cat([x_n, _vis_pe_dev], dim=-1)
+                    else:
+                        raw_xy = x_n[:, :, :2]
+                        xy_min = raw_xy.amin(dim=1, keepdim=True)
+                        xy_max = raw_xy.amax(dim=1, keepdim=True)
+                        xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                        freqs = torch.cat([vis_model.fourier_freqs_fixed.to(device), vis_model.fourier_freqs_learned.abs()])
+                        xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                        x_n = torch.cat([x_n, fourier_pe], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
                     if cfg.raw_targets:
@@ -2820,7 +2894,12 @@ if cfg.surface_refine and best_metrics:
             all_re_values = []  # Reynolds numbers for correlation check
 
             with torch.no_grad():
-                for x, y, is_surface, mask in tqdm(_ood_re_loader, desc="Verify OOD-Re", leave=False):
+                for _ver_batch in tqdm(_ood_re_loader, desc="Verify OOD-Re", leave=False):
+                    if cfg.laplacian_pe:
+                        x, y, is_surface, mask, _batch_lap_pe = _ver_batch
+                        _batch_lap_pe = _batch_lap_pe.to(device, non_blocking=True)
+                    else:
+                        x, y, is_surface, mask = _ver_batch
                     x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
                     is_surface = is_surface.to(device, non_blocking=True)
                     mask = mask.to(device, non_blocking=True)
@@ -2842,14 +2921,17 @@ if cfg.surface_refine and best_metrics:
                         x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
                     else:
                         x = torch.cat([x, curv, dist_feat], dim=-1)
-                    raw_xy = x[:, :, :2]
-                    xy_min = raw_xy.amin(dim=1, keepdim=True)
-                    xy_max = raw_xy.amax(dim=1, keepdim=True)
-                    xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
-                    freqs = torch.cat([verify_model.fourier_freqs_fixed.to(device), verify_model.fourier_freqs_learned.abs()])
-                    xy_scaled = xy_norm.unsqueeze(-1) * freqs
-                    fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
-                    x = torch.cat([x, fourier_pe], dim=-1)
+                    if cfg.laplacian_pe:
+                        x = torch.cat([x, _batch_lap_pe], dim=-1)
+                    else:
+                        raw_xy = x[:, :, :2]
+                        xy_min = raw_xy.amin(dim=1, keepdim=True)
+                        xy_max = raw_xy.amax(dim=1, keepdim=True)
+                        xy_norm = (raw_xy - xy_min) / (xy_max - xy_min + 1e-8)
+                        freqs = torch.cat([verify_model.fourier_freqs_fixed.to(device), verify_model.fourier_freqs_learned.abs()])
+                        xy_scaled = xy_norm.unsqueeze(-1) * freqs
+                        fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
+                        x = torch.cat([x, fourier_pe], dim=-1)
 
                     # Ground truth denormalization reference
                     Umag, q = _umag_q(y, mask)


### PR DESCRIPTION
## Hypothesis

The current 16-dim Fourier PE encodes raw (x,y) coordinates via fixed sine/cosine frequencies — it tells the model *where* a node sits in 2D space, but not *what topological role* it plays in the flow domain. For NACA6416 (OOD), nodes have different x,y distributions than training shapes, so the Fourier PE assigns unfamiliar encodings to topologically similar locations (leading edge, pressure side, trailing edge, wake region). This hurts OOD generalization.

**The fix:** Replace the 16-dim Fourier PE (x[:, :, 26:42]) with the 16 smallest eigenvectors of the mesh graph Laplacian. Laplacian eigenvectors encode the **intrinsic topology** of the mesh — the connectivity structure of the flow domain — rather than the extrinsic 2D embedding. A NACA6416 leading edge and a NACA0012 leading edge have similar topological roles (high curvature, stagnation region) that Laplacian eigenvectors can identify, while Fourier PE cannot.

**The deeper insight (Schmidhuber-style):** The right representation makes the task trivially easy. Laplacian eigenvectors are the canonical spectral decomposition of the graph structure — they directly encode the eigenmodes of heat diffusion on the mesh, which correspond to physically meaningful flow modes. This is not a random architecture search — it is the natural PE for graph-structured physical domains.

**Literature:**
- Belkin & Niyogi (2003). "Laplacian Eigenmaps for Dimensionality Reduction and Data Representation." Neural Computation. The mathematical foundation. https://cs.uchicago.edu/~niyogi/papersps/LapMapNeurComp.pdf
- Dwivedi & Bresson (2020). "A Generalization of Transformer Networks to Graphs." Introduces Laplacian eigenvectors as PE for graph transformers. Direct predecessor. https://arxiv.org/abs/2012.09699
- Rampasek et al. (2022). "Recipe for a General, Powerful, Scalable Graph Transformer (GPS)." NeurIPS 2022. SOTA graph transformer using LapPE. https://arxiv.org/abs/2205.12454
- Lim et al. (2022). "Sign and Basis Invariant Networks for Spectral GNNs (SignNet)." ICML 2022. Solves the sign ambiguity problem — critical for correctness. https://arxiv.org/abs/2202.13013

## Instructions

### Step 1: Build the mesh adjacency matrix

For each sample, the CFD mesh has edge connectivity information (faces/cells define which nodes are neighbors). Extract this as a sparse adjacency matrix:

```python
import scipy.sparse as sp
import scipy.sparse.linalg as spla
import numpy as np

def build_laplacian(edge_index, n_nodes):
    """
    Build normalized graph Laplacian from edge list.
    edge_index: (2, E) array of [src, dst] pairs (undirected)
    n_nodes: total number of nodes
    Returns: scipy sparse Laplacian L = D - A (unnormalized)
    """
    row = edge_index[0]
    col = edge_index[1]
    data = np.ones(len(row))
    A = sp.csr_matrix((data, (row, col)), shape=(n_nodes, n_nodes))
    A = A + A.T  # ensure symmetric (undirected)
    A.data = np.ones_like(A.data)  # binarize (remove duplicates)
    D = sp.diags(np.array(A.sum(axis=1)).flatten())
    L = D - A
    return L

def compute_laplacian_pe(edge_index, n_nodes, k=16):
    """
    Compute k smallest non-trivial Laplacian eigenvectors.
    Returns: (n_nodes, k) array of eigenvectors (absolute value for sign invariance)
    """
    L = build_laplacian(edge_index, n_nodes)
    # k+1 because the smallest eigenvector (eigenvalue 0) is constant — skip it
    eigenvalues, eigenvectors = spla.eigsh(L, k=k+1, which='SM')
    # Sort by eigenvalue, skip the first (trivial eigenvector)
    idx = np.argsort(eigenvalues)
    eigenvectors = eigenvectors[:, idx[1:k+1]]  # (n_nodes, k)
    # Sign invariance: take absolute value (simple, no SignNet needed for first test)
    eigenvectors = np.abs(eigenvectors)
    return eigenvectors.astype(np.float32)
```

### Step 2: Cache Laplacian PE per sample

The adjacency structure depends on mesh topology (same per sample if meshes are fixed). Compute and cache during data loading. Add a `--laplacian_pe` flag that triggers this computation.

```python
# In the dataset __getitem__ or a pre-processing step:
if args.laplacian_pe:
    # Get edge connectivity from mesh (check prepare_multi.py for how edges are stored)
    # The mesh faces/cells define the edge connectivity
    lap_pe = compute_laplacian_pe(edge_index, n_nodes, k=16)  # (N, 16)
    # Cache to disk: torch.save(lap_pe, f"cache/lap_pe_{sample_id}.pt")
```

**Caching is essential:** The eigsh computation takes ~0.1-0.5s per 20K-node mesh. Pre-compute for all training and validation samples and cache as .pt files. Load from cache during training.

### Step 3: Replace Fourier PE in the feature vector

In train.py, identify where Fourier PE is constructed (channels 26:42 of the input feature tensor x). Replace with the precomputed Laplacian PE:

```python
# Current (Fourier PE at channels 26:42):
# x[:, :, 26:42] = fourier_pe(coords_xy)  # 16-dim

# New (Laplacian PE):
if args.laplacian_pe:
    lap_pe_tensor = batch['lap_pe']  # (B, N, 16) — preloaded from cache
    x[:, :, 26:42] = lap_pe_tensor
```

The rest of the model is unchanged. This is a drop-in replacement — no architecture changes needed.

### Step 4: Run experiments

```bash
# First: pre-compute and cache Laplacian PEs for all samples
cd cfd_tandemfoil && python precompute_lap_pe.py --k 16 --cache_dir cache/lap_pe/

# Config A: k=16 (matching current Fourier PE dims), absolute-value sign invariance
# Seed 42
python train.py --agent nezuko --seed 42 \
  --wandb_name "nezuko/laplacian-pe-k16-s42" \
  --wandb_group "nezuko/laplacian-pe" \
  --laplacian_pe --laplacian_pe_k 16 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5

# Seed 73: same command, --seed 73, --wandb_name "nezuko/laplacian-pe-k16-s73"
```

### Key implementation notes

1. **Edge connectivity:** Check `prepare_multi.py` to find how mesh faces/cells are stored. CFD meshes typically have triangular or quad cells — each cell defines edges between its vertices. Extract all unique undirected edges from the face list.

2. **Sign ambiguity:** Both v and -v are valid eigenvectors. We use absolute value |v| for simplicity — this loses sign information but is sign-invariant without any extra network. If this works, a follow-up can try proper SignNet (small 2-layer MLP applied per eigenvector independently).

3. **Eigenvector ordering:** Laplacian eigenvectors are sorted by increasing eigenvalue. Eigenvalue 0 corresponds to the constant eigenvector (trivial) — always skip the first one. Use eigenvectors 1 through k (k=16 non-trivial eigenvectors).

4. **Memory/compute:** For a 20K-node mesh, eigsh with k=17 (SM, sparse) takes ~0.1-0.5s on CPU. Pre-compute and cache ALL training + validation samples before training starts. Estimated storage: 16 floats × 20K nodes × 1322 samples ≈ 1.7GB.

5. **Degenerate case:** Some meshes may have duplicate/zero eigenvalues, making eigenvectors non-unique. Protect with a try/except around eigsh and fall back to zero PE if it fails.

6. **Verification:** Plot the first 4 Laplacian eigenvectors on a sample mesh. They should look like smooth spatial modes (low-freq oscillations across the mesh) — if they look random, something is wrong with the adjacency construction.

7. **Flags:**
   - `--laplacian_pe`: Enable Laplacian PE (replaces Fourier PE at channels 26:42)
   - `--laplacian_pe_k <int>`: Number of eigenvectors (default 16)
   - `--lap_pe_cache_dir <path>`: Path to cached PE files

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.21** | < 13.21 |
| p_oodc | **7.82** | < 7.82 |
| **p_tan** | **28.50** | **< 28.50** |
| p_re | **6.45** | < 6.45 |

**Baseline W&B runs:** 6yfv5lio (s42, p_tan=28.432), etepxvjc (s73, p_tan=28.572) — PR #2184 (DCT Freq Loss w=0.05)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```