### PR TITLE
SE(2) AoA-Aligned Spatial Bias: Chord-Frame Slice Routing

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -700,10 +700,18 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        se2_spatial_bias=False,
+        aoa_stats=None,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.se2_spatial_bias = se2_spatial_bias
+        if se2_spatial_bias:
+            if aoa_stats is None:
+                raise ValueError("se2_spatial_bias requires aoa_stats=(mean, std) for feature 14")
+            self.register_buffer("aoa_mean", torch.tensor(aoa_stats[0], dtype=torch.float32))
+            self.register_buffer("aoa_std", torch.tensor(aoa_stats[1], dtype=torch.float32))
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -884,7 +892,20 @@ class Transolver(nn.Module):
 
         x_cross = x * self.feature_cross(x)
         x = x + 0.1 * x_cross  # residual with small scale
-        if self.gap_stagger_spatial_bias:
+        if self.se2_spatial_bias:
+            # Rotate (x,y) into AoA-aligned (freestream-aligned) frame for spatial bias
+            # De-standardize feature 14 to recover raw AoA in radians
+            aoa = x[:, 0:1, 14:15] * self.aoa_std + self.aoa_mean  # [B, 1, 1] raw AoA radians
+            cos_a, sin_a = torch.cos(aoa), torch.sin(aoa)           # [B, 1, 1]
+            x_mesh, y_mesh = x[:, :, 0:1], x[:, :, 1:2]            # [B, N, 1] each
+            x_rot = x_mesh * cos_a + y_mesh * sin_a                 # along-freestream
+            y_rot = -x_mesh * sin_a + y_mesh * cos_a                # cross-freestream
+            if self.gap_stagger_spatial_bias:
+                gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)  # [B, N, 2]
+                raw_xy = torch.cat([x_rot, y_rot, x[:, :, 24:26], gap_stagger], dim=-1)  # [B, N, 6]
+            else:
+                raw_xy = torch.cat([x_rot, y_rot, x[:, :, 24:26]], dim=-1)  # [B, N, 4]
+        elif self.gap_stagger_spatial_bias:
             # Gap (idx 22) and stagger (idx 23) are global per-sample scalars; broadcast to all nodes
             gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)  # [B, N, 2]
             raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger], dim=-1)  # [B, N, 6]
@@ -1020,6 +1041,7 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    se2_spatial_bias: bool = False  # rotate (x,y) into AoA-aligned frame before spatial bias MLP
     dct_freq_loss: bool = False   # DCT frequency-weighted auxiliary loss on surface pressure
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
@@ -1234,6 +1256,8 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    se2_spatial_bias=cfg.se2_spatial_bias,
+    aoa_stats=(stats["x_mean"][14].item(), stats["x_std"][14].item()) if cfg.se2_spatial_bias else None,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1662,6 +1686,8 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        if cfg.se2_spatial_bias and epoch == 0 and batch_idx == 0:
+            print(f"AoA stats: mean={_raw_aoa.mean():.3f}, std={_raw_aoa.std():.3f}, range=[{_raw_aoa.min():.3f}, {_raw_aoa.max():.3f}]")
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None


### PR DESCRIPTION
## Hypothesis

The **gap-stagger spatial bias (GSB, PR #2130)** was the single biggest improvement in Phase 6 (-3.0% p_tan). It routes attention slices based on (x, y, sdf, tandem_flag, gap, stagger) coordinates. But there is a subtle flaw: the (x, y) coordinates are in the **absolute mesh frame** — meaning the routing changes as AoA changes. For OOD geometries like NACA6416 (different camber, different AoA distribution), the learned routing cues may fire incorrectly because the spatial_bias MLP has implicitly tied routing to the training coordinate distribution.

**The fix:** Before feeding (x, y) into the spatial_bias MLP, rotate them into the **AoA-aligned (freestream-aligned) frame**:
- `x' = x*cos(α) + y*sin(α)` — along-freestream coordinate
- `y' = -x*sin(α) + y*cos(α)` — cross-freestream coordinate

This makes the routing see **distance along and across the chord**, which is invariant to AoA changes. The model routes slices by aerodynamically meaningful coordinates rather than mesh coordinates that shift with AoA.

Motivated by Bånkestad et al. (arXiv:2405.20287, 2024): aligning to the principal axis before graph attention gives significant OOD generalization improvements for fluid flow surrogates.

**Expected impact:** -1 to -2% p_tan. The p_tan gap is exactly the AoA-sensitive OOD setting where coordinate-frame invariance matters most.

---

## Instructions

### The change in one sentence
In `train.py`, rotate (x, y) by the freestream AoA before building `raw_xy` for the `spatial_bias` MLP.

### Key implementation facts (already verified)
- AoA (foil 1, radians) is at feature index **14** in the augmented `x` tensor
- `raw_xy` is built in `UniPDE_3D.forward` at lines ~887-892
- spatial_bias MLP stays **6-dim** — no architecture change needed
- `--aug_full_dsdf_rot` already updates index 14 in-place → rotation is consistent with augmentation

### Exact code change

Find `UniPDE_3D.forward` around lines 887-892, where `raw_xy` is constructed:

**Current code:**
```python
if self.gap_stagger_spatial_bias:
    gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)  # [B, N, 2]
    raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger], dim=-1)  # [B, N, 6]
else:
    raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # [B, N, 4]
```

**Replace with:**
```python
if self.se2_spatial_bias:
    aoa = x[:, 0:1, 14:15]                                  # [B, 1, 1] AoA radians
    cos_a, sin_a = torch.cos(aoa), torch.sin(aoa)            # [B, 1, 1]
    x_mesh, y_mesh = x[:, :, 0:1], x[:, :, 1:2]             # [B, N, 1] each
    x_rot = x_mesh * cos_a + y_mesh * sin_a                  # along-freestream
    y_rot = -x_mesh * sin_a + y_mesh * cos_a                 # cross-freestream
    if self.gap_stagger_spatial_bias:
        gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)
        raw_xy = torch.cat([x_rot, y_rot, x[:, :, 24:26], gap_stagger], dim=-1)
    else:
        raw_xy = torch.cat([x_rot, y_rot, x[:, :, 24:26]], dim=-1)
else:
    if self.gap_stagger_spatial_bias:
        gap_stagger = x[:, 0:1, 22:24].expand(-1, x.shape[1], -1)
        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger], dim=-1)
    else:
        raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)
```

### Config plumbing (3 places)
1. `TrainConfig` dataclass: add `se2_spatial_bias: bool = False`
2. `UniPDE_3D.__init__`: accept `se2_spatial_bias=False` kwarg, store `self.se2_spatial_bias = se2_spatial_bias`
3. `UniPDE_3D` construction call: pass `se2_spatial_bias=args.se2_spatial_bias`

### Verify AoA index before training
Add this print in forward (remove after confirming):
```python
print(f"AoA stats: mean={x[:,0,14].mean():.3f}, std={x[:,0,14].std():.3f}, range=[{x[:,0,14].min():.3f}, {x[:,0,14].max():.3f}]")
```
Expected: values in radians, range roughly [-0.3, 0.3].

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent thorfinn --seed 42 \
  --wandb_name "thorfinn/se2-chord-routing-s42" \
  --wandb_group "thorfinn/se2-chord-routing" \
  --se2_spatial_bias \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5

# Seed 73: same command with --seed 73 and --wandb_name "thorfinn/se2-chord-routing-s73"
```

Keep `--gap_stagger_spatial_bias` active — the two mechanisms are complementary. GSB adds (gap, stagger) global tandem info; SE(2) fixes the local (x, y) frame. Both should be on.

### Report in PR comment

Please post results as a PR comment with:
- 2-seed average surface MAE: p_in, p_oodc, p_tan, p_re
- W&B run IDs for both seeds
- AoA range from the sanity check print (to confirm correct feature index)
- Any unexpected training behavior

---

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in | **13.21** | < 13.21 |
| p_oodc | **7.82** | < 7.82 |
| **p_tan** | **28.50** | **< 28.50** |
| p_re | **6.45** | < 6.45 |

**Baseline W&B runs:** 6yfv5lio (seed 42, p_tan=28.432), etepxvjc (seed 73, p_tan=28.572)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```