### PR TITLE
Add inter-foil distance feature to spatial bias routing

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -700,10 +700,12 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        interfoil_dist_feature=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.interfoil_dist_feature = interfoil_dist_feature
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -771,7 +773,7 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
-                    spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    spatial_bias_input_dim=(7 if interfoil_dist_feature and gap_stagger_spatial_bias else 6) if gap_stagger_spatial_bias else 4,
                 )
                 for idx in range(n_layers)
             ]
@@ -781,6 +783,11 @@ class Transolver(nn.Module):
             with torch.no_grad():
                 for block in self.blocks:
                     block.spatial_bias[0].weight[:, 4:].zero_()
+        # Zero-init the 7th column for inter-foil distance feature
+        if interfoil_dist_feature and gap_stagger_spatial_bias:
+            with torch.no_grad():
+                for block in self.blocks:
+                    block.spatial_bias[0].weight[:, 6:].zero_()
         # Separate pressure pathway (pressure_separate_last_block):
         # Independent MLP + pres_head that processes shared hidden features
         self._pressure_separate = False  # set from Config after construction
@@ -893,6 +900,19 @@ class Transolver(nn.Module):
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
+
+        # Inter-foil distance feature: log(1 + d_interfoil) for spatial bias routing
+        if self.interfoil_dist_feature and self.gap_stagger_spatial_bias:
+            foil2_center = x[:, 0:1, 22:24]  # [B, 1, 2]: (gap, stagger) ≈ foil-2 offset
+            node_xy = x[:, :, :2]  # [B, N, 2]
+            d_sq = ((node_xy - foil2_center) ** 2).sum(dim=-1, keepdim=True)  # [B, N, 1]
+            d_interfoil = torch.sqrt(d_sq + 1e-8)  # [B, N, 1]
+            # Single-foil: sentinel 10.0 so log1p(10)≈2.4 distinguishes from tandem
+            is_tandem_1d = (x[:, 0, 21].abs() > 0.01).float()  # [B]
+            mask = is_tandem_1d[:, None, None]  # [B, 1, 1]
+            d_interfoil = d_interfoil * mask + 10.0 * (1.0 - mask)
+            log_d = torch.log1p(d_interfoil)  # [B, N, 1]
+            raw_xy = torch.cat([raw_xy, log_d], dim=-1)  # [B, N, 7]
 
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
@@ -1020,6 +1040,7 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    interfoil_dist_feature: bool = False   # add log(1+d_interfoil) as 7th spatial_bias input channel
     dct_freq_loss: bool = False   # DCT frequency-weighted auxiliary loss on surface pressure
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
@@ -1234,6 +1255,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    interfoil_dist_feature=cfg.interfoil_dist_feature,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

The spatial_bias MLP currently routes slice attention based on (x, y, curvature, dist-to-surface, gap, stagger) — 6 scalars. These describe the **node's local geometry** and the **global tandem configuration**, but not the node's relationship to the *other* foil. We hypothesize that adding `log(1 + d_interfoil)` — the log-distance from each mesh node to foil-2's geometric center — as a 7th input to the spatial_bias MLP will allow the model to partition attention slices by proximity to foil-2, improving wake-interference predictions on tandem configurations.

Physical motivation: in tandem foils, pressure perturbations decay as ~1/r from the upstream foil. A node's log-distance to foil-2 is a meaningful geometric signal for distinguishing near-wake vs far-field regions, which the current 6-dim routing input cannot express. This is a purely structural enhancement — no feature distribution manipulation, no domain alignment.

The gap scalar (x[:, 0, 22]) and stagger scalar (x[:, 0, 23]) together define foil-2's approximate center offset relative to foil-1. The inter-foil distance for each node is then the Euclidean distance from (node_x, node_y) to (stagger, gap).

For **single-foil samples** (where gap≈0, stagger≈0), set d_interfoil = 10.0 (a large constant), so log1p(10) ≈ 2.4 is a stable sentinel that distinguishes single-foil from tandem samples without disrupting gradient flow.

## Instructions

Make the following changes to `cfd_tandemfoil/train.py`:

### Step 1: Add `--interfoil_dist_feature` flag

In the argparse section, add:
```python
parser.add_argument("--interfoil_dist_feature", action="store_true",
                    help="Add log(1+d_interfoil) as 7th spatial_bias input channel")
```

### Step 2: Pass flag through to `TransolverModel` / `Physics_Attention_Irregular_Mesh`

Thread `interfoil_dist_feature=args.interfoil_dist_feature` through the model constructor call and store as `self.interfoil_dist_feature`.

### Step 3: Extend spatial_bias input dim from 6→7

In the block/layer init, wherever `spatial_bias_input_dim` is set:
```python
spatial_bias_input_dim = 6 if gap_stagger_spatial_bias else 4
if interfoil_dist_feature and gap_stagger_spatial_bias:
    spatial_bias_input_dim = 7
```

### Step 4: Zero-init the new 7th input column

After the existing zero-init block for the `gap_stagger_spatial_bias` extra columns, add:
```python
if interfoil_dist_feature and gap_stagger_spatial_bias:
    with torch.no_grad():
        for block in self.blocks:
            block.spatial_bias[0].weight[:, 6:].zero_()
```
This ensures that at epoch 0, the new feature contributes zero, preserving the trained routing from the baseline.

### Step 5: Compute and append d_interfoil in the forward pass

In the forward pass, right after `raw_xy` is constructed (currently lines ~887-892), append the inter-foil distance:

```python
if self.interfoil_dist_feature and self.gap_stagger_spatial_bias:
    # gap_stagger: [B, N, 2] already computed above as x[:,0:1,22:24].expand(...)
    # gap = stagger scalar (index 22), stagger = stagger scalar (index 23)
    foil2_center = x[:, 0:1, 22:24]  # [B, 1, 2]: (gap, stagger) = approx foil-2 offset
    node_xy = x[:, :, :2]  # [B, N, 2]
    # For single-foil samples, gap≈0 and stagger≈0, so distance ≈ ||(node_x, node_y)||
    # Use is_tandem mask to replace with sentinel 10.0 for single-foil
    is_tandem_1d = (x[:, 0, 21].abs() > 0.01).float()  # [B]
    d_sq = ((node_xy - foil2_center) ** 2).sum(dim=-1, keepdim=True)  # [B, N, 1]
    d_interfoil = torch.sqrt(d_sq + 1e-8)  # [B, N, 1]
    # Replace single-foil distances with sentinel 10.0
    sentinel = torch.full_like(d_interfoil, 10.0)
    mask = is_tandem_1d[:, None, None]  # [B, 1, 1]
    d_interfoil = d_interfoil * mask + sentinel * (1.0 - mask)
    log_d = torch.log1p(d_interfoil)  # [B, N, 1]
    raw_xy = torch.cat([raw_xy, log_d], dim=-1)  # [B, N, 7]
```

### Step 6: Run with `--interfoil_dist_feature` alongside all baseline flags

Use `--wandb_group round7/interfoil-dist-feature` and run 2 seeds (42 and 73):

**Seed 42:**
```bash
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/interfoil-dist-seed42" \
  --wandb_group round7/interfoil-dist-feature \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --interfoil_dist_feature
```

**Seed 73:**
```bash
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/interfoil-dist-seed73" \
  --wandb_group round7/interfoil-dist-feature \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --interfoil_dist_feature
```

### Step 7: Report results

When both seeds are done, add a **Results** comment to this PR with:
- 2-seed average of: p_in, p_oodc, p_tan, p_re
- Individual per-seed values
- W&B run IDs and links
- Whether any seeds diverged

## Baseline

Current best (PR #2184, DCT Freq Loss, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 13.205 | < 13.21 |
| p_oodc | 7.816 | < 7.82 |
| **p_tan** | **28.502** | **< 28.50** |
| p_re | 6.453 | < 6.45 |

W&B runs: 6yfv5lio (seed 42, p_tan=28.432), etepxvjc (seed 73, p_tan=28.572)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```