### PR TITLE
Geometry-adaptive curvature loss weighting on surface nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1020,6 +1020,8 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    curvature_loss_weight: bool = False  # weight surface loss by per-node curvature magnitude
+    curvature_alpha: float = 1.0         # strength: w_i = 1 + alpha * normalize(|kappa_i|)
     dct_freq_loss: bool = False   # DCT frequency-weighted auxiliary loss on surface pressure
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
@@ -1888,7 +1890,18 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Curvature-weighted surface loss: per-node weights based on curvature magnitude
+        _curv_node_weights = None
+        if cfg.curvature_loss_weight:
+            _kappa = x[:, :, 24].abs()  # curvature proxy, [B, N]
+            _kappa_surf = _kappa * surf_mask.float()  # zero off-surface
+            _kappa_max = _kappa_surf.max(dim=1, keepdim=True).values.clamp(min=1e-6)  # [B, 1]
+            _kappa_norm = _kappa_surf / _kappa_max  # [B, N], in [0, 1]
+            _curv_node_weights = (1.0 + cfg.curvature_alpha * _kappa_norm) * surf_mask.float()  # [B, N]
+        if _curv_node_weights is not None:
+            surf_per_sample = (abs_err[:, :, 2:3].squeeze(-1) * _curv_node_weights).sum(dim=1) / _curv_node_weights.sum(dim=1).clamp(min=1e-6)
+        else:
+            surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -1902,7 +1915,10 @@ for epoch in range(MAX_EPOCHS):
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            if _curv_node_weights is not None:
+                surf_per_sample = (surf_pres.squeeze(-1) * hard_weights.squeeze(-1) * _curv_node_weights).sum(dim=1) / _curv_node_weights.sum(dim=1).clamp(min=1e-6)
+            else:
+                surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))


### PR DESCRIPTION
## Hypothesis

The current surface loss weights all surface nodes equally: `surf_per_sample = (abs_err[:, :, 2:3] * surf_mask).sum(...) / surf_mask.sum(...)`. But aerodynamic accuracy matters most at **high-curvature regions**: leading edges, trailing edges, and suction-side shoulders — where pressure gradients are steepest and CFD engineers care most. These are exactly the regions where uniform weighting under-prioritizes relative to their engineering importance.

We hypothesize that **per-node curvature-weighted surface loss** — giving higher weight to high-curvature nodes — will force the model to improve predictions at the aerodynamically critical locations where errors are hardest to drive down, ultimately improving surface MAE on all validation tracks.

The curvature signal is already available as `x[:, :, 24]` (from `prepare_multi.py`), computed as Menger curvature. We normalize it to [0, 1] per sample and compute per-node weights:

```
w_i = 1 + alpha * normalize(|kappa_i|)
```

where `alpha` controls the strength of curvature emphasis. alpha=1.0 means a node at peak curvature gets 2x weight vs a flat-wall node. We try alpha in {0.5, 1.0, 2.0}.

This is a **loss reformulation only** — no architectural change, no feature distribution manipulation. The curvature channel already exists; we are simply using it as a loss weighting signal rather than (only) as an input feature.

## Instructions

Make the following changes to `cfd_tandemfoil/train.py`:

### Step 1: Add argument flags

In the argparse section, add:
```python
parser.add_argument("--curvature_loss_weight", action="store_true",
                    help="Weight surface loss by per-node curvature magnitude")
parser.add_argument("--curvature_alpha", type=float, default=1.0,
                    help="Strength of curvature weighting: w_i = 1 + alpha * normalize(|kappa_i|)")
```

### Step 2: Pass flags through to the training loss computation

Store `args.curvature_loss_weight` and `args.curvature_alpha` as accessible variables in the training loop.

### Step 3: Modify the surface pressure loss computation

Find where `surf_per_sample` is computed (approximately):
```python
surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1,2)) / surf_mask.sum(dim=1).clamp(min=1).float()
```

Replace with:
```python
if curvature_loss_weight:
    # x[:, :, 24] is Menger curvature, per-node
    kappa = x[:, :, 24].abs()  # [B, N]
    # Normalize per sample to [0, 1] (only over surface nodes)
    kappa_surf = kappa * surf_mask.float()  # [B, N], zero off-surface
    kappa_max = kappa_surf.max(dim=1, keepdim=True).values.clamp(min=1e-6)  # [B, 1]
    kappa_norm = kappa_surf / kappa_max  # [B, N], in [0, 1]
    # Per-node weight: 1 + alpha * normalized_curvature
    node_weights = (1.0 + curvature_alpha * kappa_norm) * surf_mask.float()  # [B, N]
    # Weighted surface pressure MAE
    surf_per_sample = (abs_err[:, :, 2:3].squeeze(-1) * node_weights).sum(dim=1) / node_weights.sum(dim=1).clamp(min=1e-6)
else:
    surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1,2)) / surf_mask.sum(dim=1).clamp(min=1).float()
```

**Important:** This changes the **loss** used during training, but the **validation surface MAE metric** should remain unchanged (uniform weighting) so metrics are comparable across experiments. Confirm that the `val/surface_mae` metric computation path is NOT modified — only the training loss.

### Step 4: Run 3 alpha values, 1 seed each (seed 42)

Use `--wandb_group round7/curvature-loss-weight` for all runs.

**Alpha 0.5:**
```bash
cd cfd_tandemfoil && python train.py \
  --agent tanjiro --wandb_name "tanjiro/curvature-loss-alpha0.5" \
  --wandb_group round7/curvature-loss-weight \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --curvature_loss_weight --curvature_alpha 0.5
```

**Alpha 1.0:**
```bash
cd cfd_tandemfoil && python train.py \
  --agent tanjiro --wandb_name "tanjiro/curvature-loss-alpha1.0" \
  --wandb_group round7/curvature-loss-weight \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --curvature_loss_weight --curvature_alpha 1.0
```

**Alpha 2.0:**
```bash
cd cfd_tandemfoil && python train.py \
  --agent tanjiro --wandb_name "tanjiro/curvature-loss-alpha2.0" \
  --wandb_group round7/curvature-loss-weight \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --curvature_loss_weight --curvature_alpha 2.0
```

### Step 5: If one alpha value clearly wins, run a second seed (73) to confirm

Pick the best alpha (lowest p_tan) and run seed 73 to get a 2-seed average for comparison against baseline.

### Step 6: Report results

Add a **Results** comment to this PR with:
- Per-alpha results table: p_in, p_oodc, p_tan, p_re for each alpha (seed 42)
- 2-seed average for the winning alpha (if you ran seed 73)
- W&B run IDs and links
- Whether any training loss changes affected metric computation (sanity check: baseline run metrics should be unaffected)

## Baseline

Current best (PR #2184, DCT Freq Loss, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 13.205 | < 13.21 |
| p_oodc | 7.816 | < 7.82 |
| **p_tan** | **28.502** | **< 28.50** |
| p_re | 6.453 | < 6.45 |

W&B runs: 6yfv5lio (seed 42, p_tan=28.432), etepxvjc (seed 73, p_tan=28.572)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```