### PR TITLE
Multi-Scale Slice Hierarchy: Coarse-to-Fine Attention for OOD Transfer

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -676,6 +676,7 @@ class Transolver(nn.Module):
         fun_dim=1,
         out_dim=1,
         slice_num=32,
+        slice_nums=None,
         ref=8,
         unified_pos=False,
         output_fields: list[str] | None = None,
@@ -704,6 +705,7 @@ class Transolver(nn.Module):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        _per_block_slices = slice_nums if slice_nums is not None else [slice_num] * n_layers
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -751,7 +753,7 @@ class Transolver(nn.Module):
                     act=act,
                     mlp_ratio=mlp_ratio,
                     out_dim=out_dim,
-                    slice_num=slice_num,
+                    slice_num=_per_block_slices[idx],
                     last_layer=(idx == n_layers - 1),
                     linear_no_attention=linear_no_attention,
                     learned_kernel=learned_kernel,
@@ -1074,6 +1076,7 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    multiscale_slices: str = ''             # comma-separated slice counts per block, e.g. "32,64,96"
 
 
 cfg = sp.parse(Config)
@@ -1202,6 +1205,15 @@ if cfg.raw_targets or cfg.adaptive_norm:
 else:
     raw_stats = None
 
+# Parse per-block slice counts for multiscale slice hierarchy
+if cfg.multiscale_slices:
+    _slice_nums = [int(s.strip()) for s in cfg.multiscale_slices.split(',')]
+    assert len(_slice_nums) == cfg.n_layers, \
+        f"multiscale_slices must have exactly n_layers={cfg.n_layers} values, got {len(_slice_nums)}"
+    print(f"Multiscale slices: {_slice_nums}")
+else:
+    _slice_nums = None
+
 model_config = dict(
     space_dim=2,
     fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
@@ -1210,6 +1222,7 @@ model_config = dict(
     n_layers=cfg.n_layers,
     n_head=3,
     slice_num=cfg.prog_slices_end if cfg.prog_slices else cfg.slice_num,
+    slice_nums=_slice_nums,
     mlp_ratio=2,
     dropout=0.05 if cfg.rdrop else 0.0,
     output_fields=["Ux", "Uy", "p"],


### PR DESCRIPTION
## Hypothesis

The current Transolver uses **96 slices uniformly across all 3 TransolverBlocks**. Every block routes nodes at the same granularity, which is spatially redundant — Block 1 processes raw features and doesn't need the same fine-grained routing as Block 3 which has seen 2 rounds of refinement.

**Physics motivation:** Coarse-to-fine processing is fundamental in physics simulation. Global flow patterns (pressure gradient, wake structure, foil interaction) operate at large scales and should be captured first. Fine-grained boundary layer features should be refined later. A hierarchy [32 → 64 → 96] directly encodes this: Block 1 forms 32 broad spatial groups for global structure, Block 2 refines to 64, Block 3 achieves 96 for boundary layer detail.

**OOD generalization motivation:** NACA6416 differs from training foils primarily in global shape (higher camber shifts the suction peak globally). Global patterns generalize better than fine-grained ones. Block 1 with 32 slices learns transferable global-scale representations rather than overfitting to fine-grained training geometry specifics.

**Computational benefit:** Fewer slices in Blocks 1–2 → less attention computation → faster epochs → more epochs within 180-min timeout. Expected ~5–8% speedup.

**Prior art:** Coarse-to-fine hierarchies are well-established: FPN, UNet, Swin Transformer, Longformer. This applies the principle to physics-aware slice routing.

## Instructions

### Step 1: Add `--multiscale_slices` argument

In the argument parser (near `--slice_num`):

```python
parser.add_argument('--multiscale_slices', type=str, default='',
    help='Comma-separated slice counts per block, e.g. "32,64,96". '
         'If empty, uses --slice_num for all blocks.')
```

In `Config` dataclass:

```python
multiscale_slices: str = ''  # e.g. '32,64,96'
```

### Step 2: Parse into per-block list before model construction

```python
if cfg.multiscale_slices:
    slice_nums = [int(s.strip()) for s in cfg.multiscale_slices.split(',')]
    assert len(slice_nums) == cfg.n_layers, \
        f"multiscale_slices must have exactly n_layers={cfg.n_layers} values"
else:
    slice_nums = [cfg.slice_num] * cfg.n_layers
```

Pass `slice_nums` as a new keyword argument to the model constructor.

### Step 3: Modify `Transolver.__init__` to accept per-block slice numbers

Change signature and block construction:

```python
def __init__(self, ..., slice_num=32, slice_nums=None, ...):
    ...
    _slice_nums = slice_nums if slice_nums is not None else [slice_num] * n_layers

    self.blocks = nn.ModuleList([
        TransolverBlock(
            num_heads=n_head,
            hidden_dim=n_hidden,
            dropout=dropout,
            act=act,
            mlp_ratio=mlp_ratio,
            out_dim=out_dim,
            slice_num=_slice_nums[idx],  # <-- per-block slice count
            last_layer=(idx == n_layers - 1),
            # ... all other existing kwargs unchanged ...
        )
        for idx in range(n_layers)
    ])

    # Zero-init the 2 new input columns of spatial_bias (gap_stagger) — unchanged
    if gap_stagger_spatial_bias:
        with torch.no_grad():
            for block in self.blocks:
                block.spatial_bias[0].weight[:, 4:].zero_()
```

### Step 4: Run two seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/multiscale-slices-s42" \
  --wandb_group "edward/multiscale-slice-hierarchy" \
  --multiscale_slices "32,64,96" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output \
  --use_lion --lr 2e-4 --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp --domain_layernorm --domain_velhead \
  --ema_decay 0.999 --weight_decay 5e-5 --cosine_T_max 160 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep --residual_prediction \
  --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5

# Seed 73
cd cfd_tandemfoil && python train.py --agent edward --seed 73 \
  --wandb_name "edward/multiscale-slices-s73" \
  --wandb_group "edward/multiscale-slice-hierarchy" \
  --multiscale_slices "32,64,96" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output \
  --use_lion --lr 2e-4 --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 --tandem_ramp --domain_layernorm --domain_velhead \
  --ema_decay 0.999 --weight_decay 5e-5 --cosine_T_max 160 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep --residual_prediction \
  --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```

**Note:** `--slice_num 96` is still passed for compatibility — it will be overridden by `--multiscale_slices` for all blocks.

**Fallback:** If [32,64,96] diverges or is clearly worse by epoch 50, try `--multiscale_slices "48,72,96"` — a gentler progression.

### What to measure

1. **Epochs completed** — did we get more epochs from the speedup?
2. **val_tandem_transfer** — primary target, should improve if global routing helps OOD
3. **val_in_dist** — should not regress more than ~1%
4. **Training stability** — any unusual loss spikes?

## Baseline

Current best metrics (PR #2184, DCT Freq-Weighted Loss, 2-seed avg):

| Metric | Baseline | Target |
|--------|----------|--------|
| p_in | **13.21** | < 13.21 |
| p_oodc | **7.82** | < 7.82 |
| **p_tan** | **28.50** | **< 28.50** |
| p_re | **6.45** | < 6.45 |

Baseline W&B: 6yfv5lio (s42, p_tan=28.432), etepxvjc (s73, p_tan=28.572)

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```