### PR TITLE
NOBLE Nonlinear Low-Rank Branches in TransolverBlock FFN (Retry)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -90,8 +90,29 @@ class GatedMLP2(nn.Module):
         return self.down(h)
 
 
+class NOBLELinear(nn.Module):
+    """Linear + low-rank nonlinear branch (NOBLE, arXiv 2603.06492).
+    y = xW + cos(omega * xW_down + phi) * W_up
+    CosNet activation with learnable frequency omega and phase phi per channel.
+    W_up zero-initialized so correction=0 at step 0 (baseline-equivalent start).
+    """
+    def __init__(self, in_f, out_f, rank=16, bias=True):
+        super().__init__()
+        self.linear = nn.Linear(in_f, out_f, bias=bias)
+        self.down = nn.Linear(in_f, rank, bias=False)
+        self.up = nn.Linear(rank, out_f, bias=False)
+        self.omega = nn.Parameter(torch.ones(rank))   # CosNet frequency
+        self.phi = nn.Parameter(torch.zeros(rank))    # CosNet phase
+        nn.init.zeros_(self.up.weight)                # zero-init: correction starts at 0
+
+    def forward(self, x):
+        h = self.down(x)
+        h = torch.cos(self.omega * h + self.phi)      # CosNet periodic activation
+        return self.linear(x) + self.up(h)
+
+
 class MLP(nn.Module):
-    def __init__(self, n_input, n_hidden, n_output, n_layers=1, act="gelu", res=True):
+    def __init__(self, n_input, n_hidden, n_output, n_layers=1, act="gelu", res=True, noble_rank=0):
         super().__init__()
         if act not in ACTIVATION:
             raise NotImplementedError
@@ -101,9 +122,10 @@ class MLP(nn.Module):
         self.n_output = n_output
         self.n_layers = n_layers
         self.res = res
-        self.linear_pre = nn.Sequential(nn.Linear(n_input, n_hidden), act_fn())
-        self.linear_post = nn.Linear(n_hidden, n_output)
-        self.linears = nn.ModuleList([nn.Sequential(nn.Linear(n_hidden, n_hidden), act_fn()) for _ in range(n_layers)])
+        _Lin = (lambda i, o, **kw: NOBLELinear(i, o, rank=noble_rank, **kw)) if noble_rank > 0 else nn.Linear
+        self.linear_pre = nn.Sequential(_Lin(n_input, n_hidden), act_fn())
+        self.linear_post = _Lin(n_hidden, n_output)
+        self.linears = nn.ModuleList([nn.Sequential(_Lin(n_hidden, n_hidden), act_fn()) for _ in range(n_layers)])
 
     def forward(self, x):
         x = self.linear_pre(x)
@@ -283,6 +305,7 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        noble_rank=0,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -327,7 +350,7 @@ class TransolverBlock(nn.Module):
             nn.init.zeros_(self.film_net[-1].weight)
             nn.init.zeros_(self.film_net[-1].bias)
         self.ln_2 = _LN(hidden_dim)
-        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act, noble_rank=noble_rank)
         self.spatial_bias = nn.Sequential(
             nn.Linear(spatial_bias_input_dim, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
@@ -700,6 +723,7 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        noble_rank=0,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -772,6 +796,7 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    noble_rank=noble_rank,
                 )
                 for idx in range(n_layers)
             ]
@@ -1024,6 +1049,8 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    noble_branches: bool = False  # NOBLE: nonlinear low-rank branches in TransolverBlock FFN
+    noble_rank: int = 16          # rank of NOBLE low-rank correction branch
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1234,6 +1261,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    noble_rank=cfg.noble_rank if cfg.noble_branches else 0,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1428,8 +1456,9 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+_attn_keys = ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias', 'omega', 'phi']
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in _attn_keys)]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in _attn_keys)]
 _base_lr = cfg.two_phase_lr_1 if cfg.two_phase_lr else cfg.lr
 if cfg.use_lion:
     base_opt = Lion([


### PR DESCRIPTION
## Hypothesis

**NOBLE** (arXiv 2603.06492 — \"Nonlinear Low-Rank Branches\") adds a residual branch `σ(x·W_down)·W_up` alongside each existing linear layer in TransolverBlock FFN MLPs, where `W_down` projects to rank r=16 and `W_up` projects back. The activation `σ` is **CosNet**: `cos(ω·x + φ)` with learnable frequency `ω` and phase `φ` per channel. This makes each FFN layer a sum of its original linear map plus a nonlinear low-rank correction — initialized to zero so training starts from baseline-equivalent behavior.

**Why this should improve p_tan:** The tandem pressure distribution has sharp nonlinear dependencies on wake interaction geometry (inter-foil pressure channel, gap/stagger coupling) that a purely linear projection cannot represent efficiently. NOBLE adds dedicated nonlinear capacity to each FFN layer without disrupting the well-conditioned linear path. CosNet's periodic activation is physically motivated: pressure fluctuations in the inter-foil channel are quasi-periodic functions of gap/stagger geometry. Paper reports 1.47x step speedup and 32% fewer steps to convergence at equivalent parameter count.

**Zero-init safety:** W_up is initialized to zeros so the correction branch outputs exactly zero at initialization, training starts from baseline-equivalent behavior.

This idea comes directly from the human research team directives (issue #1926). Note: PR #2204 was assigned previously but the student branch had no commits — this is the true first run.

## Instructions

### Step 1: Add NOBLELinear wrapper class

Add this class near the top of train.py (after imports, before model classes):

```python
class NOBLELinear(nn.Module):
    """Linear layer + low-rank nonlinear branch: y = xW + sigma(xW_down)W_up.
    CosNet activation: sigma(h) = cos(omega*h + phi) with learnable freq/phase.
    Zero-init on W_up ensures correction=0 at step 0 (baseline-equivalent start).
    """
    def __init__(self, in_f, out_f, rank=16, bias=True):
        super().__init__()
        self.linear = nn.Linear(in_f, out_f, bias=bias)
        self.down = nn.Linear(in_f, rank, bias=False)
        self.up = nn.Linear(rank, out_f, bias=False)
        self.omega = nn.Parameter(torch.ones(rank))   # CosNet frequency
        self.phi = nn.Parameter(torch.zeros(rank))    # CosNet phase
        nn.init.zeros_(self.up.weight)                # zero-init: correction starts at 0

    def forward(self, x):
        h = self.down(x)
        h = torch.cos(self.omega * h + self.phi)      # CosNet periodic activation
        return self.linear(x) + self.up(h)
```

### Step 2: Add config flags

Add to the config dataclass:

```python
noble_branches: bool = False   # Enable NOBLE nonlinear low-rank branches in FFN layers
noble_rank: int = 16           # Rank of the low-rank correction branch
```

### Step 3: Replace FFN nn.Linear layers in Physics_Attention_Irregular_Mesh

Find the FFN definition inside Physics_Attention_Irregular_Mesh.__init__ -- it's an nn.Sequential with two nn.Linear layers (the feed-forward after slice attention). When cfg.noble_branches is True, replace each nn.Linear with NOBLELinear:

```python
if cfg.noble_branches:
    self.ffn = nn.Sequential(
        NOBLELinear(n_hidden, n_hidden, rank=cfg.noble_rank),
        nn.GELU(),
        NOBLELinear(n_hidden, n_hidden, rank=cfg.noble_rank),
    )
else:
    # existing FFN definition unchanged
    self.ffn = nn.Sequential(
        nn.Linear(n_hidden, n_hidden),
        nn.GELU(),
        nn.Linear(n_hidden, n_hidden),
    )
```

This applies to ALL 3 TransolverBlocks since each creates its own Physics_Attention_Irregular_Mesh.

### Step 4: LR group for CosNet params (recommended)

The omega and phi parameters benefit from lower LR to prevent divergence. Find where optimizer parameter groups are built and add CosNet params to the attention group (lower LR multiplier):

```python
noble_cosnet_params = [p for n, p in model.named_parameters()
                       if ('omega' in n or 'phi' in n)]
# Add to attention param group (typically 0.1x base LR):
# {'params': noble_cosnet_params, 'lr': cfg.lr * 0.1}
```

If param group code is complex, base LR 2e-4 is also acceptable for CosNet params.

### Step 5: Parse flags in argparse

Add --noble_branches (store_true) and --noble_rank (int, default 16).

### Step 6: Run experiments

**Trial A - rank=16, seed 42:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/noble-r16-s42" \
  --wandb_group "nezuko/noble-branches-v2" \
  --noble_branches --noble_rank 16 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --seed 42
```

**Trial B - rank=16, seed 73:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/noble-r16-s73" \
  --wandb_group "nezuko/noble-branches-v2" \
  --noble_branches --noble_rank 16 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --seed 73
```

Report W&B run IDs and final surface MAE for both seeds in a PR comment.
If p_tan < 28.50 for both seeds, also run rank=8 and rank=32 trials to characterize rank sensitivity.

## Baseline

**Current baseline (PR #2184 — DCT Frequency-Weighted Loss, 2-seed avg):**

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | 13.205   | < 13.21        |
| p_oodc | 7.816    | < 7.82         |
| p_tan  | 28.502   | < 28.50        |
| p_re   | 6.453    | < 6.45         |

W&B runs: 6yfv5lio (seed 42, p_tan=28.432), etepxvjc (seed 73, p_tan=28.572)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```