### PR TITLE
Transolver++ Ada-Temp: per-point adaptive slice temperature + Rep-Slice

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 ada_temp=False, rep_slice=False):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -148,6 +149,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.softmax = nn.Softmax(dim=-1)
         self.dropout = nn.Dropout(dropout)
         self.temperature = nn.Parameter(torch.ones([1, heads, 1, 1]) * 0.5)
+        # Transolver++ Ada-Temp: per-point adaptive slice temperature
+        self.ada_temp_on = ada_temp
+        self.rep_slice_on = rep_slice
+        if self.ada_temp_on:
+            self.ada_temp_proj = nn.Linear(dim, heads)
+            nn.init.zeros_(self.ada_temp_proj.weight)
+            nn.init.zeros_(self.ada_temp_proj.bias)
         self.tandem_temp_offset = nn.Parameter(torch.zeros(1, heads, 1, 1))
         self.linear_no_attention = linear_no_attention
         self.learned_kernel = learned_kernel
@@ -209,6 +217,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if tandem_mask is not None:
             temp = (temp + self.tandem_temp_offset * tandem_mask).clamp(min=1e-4)
         temp = temp.clamp(min=1e-4)
+        if self.ada_temp_on:
+            # Per-point, per-head temperature offset from input features
+            ada_offset = self.ada_temp_proj(x)  # [B, N, heads]
+            ada_offset = ada_offset.permute(0, 2, 1).unsqueeze(-1)  # [B, heads, N, 1]
+            temp = (temp + ada_offset).clamp(min=0.01)  # now per-point
         if self.decouple_slice and tandem_mask is not None:
             std_logits = self.in_project_slice(x_mid) / temp
             tan_logits = self.in_project_slice_tandem(x_mid) / temp
@@ -221,6 +234,11 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if self.prog_slices:
             # Apply slice mask: 0 for active slices, -1e9 for inactive (updated each epoch)
             slice_logits = slice_logits + self.slice_mask
+        if self.rep_slice_on and self.training:
+            gumbel = -torch.log(-torch.log(
+                torch.empty_like(slice_logits).uniform_(1e-7, 1 - 1e-7)
+            ))
+            slice_logits = slice_logits + gumbel
         slice_weights = self.softmax(slice_logits)
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
@@ -283,6 +301,8 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        ada_temp=False,
+        rep_slice=False,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -308,6 +328,8 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            ada_temp=ada_temp,
+            rep_slice=rep_slice,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -700,6 +722,8 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        ada_temp=False,
+        rep_slice=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -772,6 +796,8 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    ada_temp=ada_temp,
+                    rep_slice=rep_slice,
                 )
                 for idx in range(n_layers)
             ]
@@ -1074,6 +1100,10 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    # Phase 6: Transolver++ Ada-Temp and Rep-Slice
+    ada_temp: bool = False                  # per-point adaptive slice temperature (Transolver++)
+    ada_temp_tau0: float = 0.5              # base temperature for Ada-Temp
+    rep_slice: bool = False                 # Gumbel-Softmax reparameterization for sharp slice routing
 
 
 cfg = sp.parse(Config)
@@ -1234,6 +1264,8 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    ada_temp=cfg.ada_temp,
+    rep_slice=cfg.rep_slice,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

The current Transolver uses a **global learnable temperature** (`self.temperature`, shape `[1, heads, 1, 1]`) shared across all N=120k mesh nodes for slice weight computation. Transolver++ (arXiv 2502.02414, ICML 2025) shows that replacing this with a **per-point adaptive temperature** (Ada-Temp) prevents slice-weight homogenization — where all nodes collapse to the same slice, erasing physics distinctions.

The paper reports **62% surface-error reduction from Ada-Temp alone on aircraft datasets** and 13% average improvement across 6 PDE benchmarks. For our tandem problem, homogenization is plausible on OOD NACA6416 inputs: the 96 slices are trained overwhelmingly on NACA0012 geometries, and OOD inputs may collapse to an "average" routing that fails to represent tandem wake coupling.

**Rep-Slice** (Gumbel-Softmax reparameterization) further encourages sparse, sharp slice assignments during training by adding Gumbel noise to slice logits before softmax.

This is **distinct from WIP SCA** (frieren #2199): SCA adds a learnable diagonal scale to attention *logits after* slice tokens are computed. Ada-Temp acts *before* slice aggregation, sharpening node-to-slice routing. Complementary mechanisms.

**Source:** Transolver++, arXiv 2502.02414, ICML 2025 (same Transolver backbone as ours).

---

## Instructions

All changes are in `cfd_tandemfoil/train.py`.

### Step 1: Add argparse flags

```python
parser.add_argument('--ada_temp', action='store_true',
    help='Transolver++ per-point adaptive slice temperature')
parser.add_argument('--ada_temp_tau0', type=float, default=0.5,
    help='Base temperature for Ada-Temp (matches existing temperature init of 0.5)')
parser.add_argument('--rep_slice', action='store_true',
    help='Transolver++ Gumbel-Softmax reparameterization for sharp slice routing')
```

### Step 2: Modify `Physics_Attention_Irregular_Mesh.__init__`

This class (line ~137) takes `dim, heads, dim_head, dropout, slice_num, ...` as args. It is instantiated in `TransolverBlock`. Follow the same pattern used for `zone_temp`, `decouple_slice` — add the new booleans as constructor params and pass them through from `TransolverBlock` (which gets them from `cfg`/`args`).

In `__init__`, add:
```python
self.ada_temp_on = ada_temp        # new bool param, default False
self.rep_slice_on = rep_slice      # new bool param, default False
if self.ada_temp_on:
    # Per-point, per-head temperature offset
    # Zero-initialized so model starts IDENTICAL to baseline (offset=0)
    self.ada_temp_proj = nn.Linear(dim, heads)
    nn.init.zeros_(self.ada_temp_proj.weight)
    nn.init.zeros_(self.ada_temp_proj.bias)
```

### Step 3: Modify `Physics_Attention_Irregular_Mesh.forward`

The forward signature is `forward(self, x, spatial_bias=None, tandem_mask=None, zone_features=None)` where `x` is `[B, N, dim]`.

The existing temperature block (lines ~204–218) computes a global `temp` and uses it:
```python
temp = self.temperature            # [1, heads, 1, 1], value=0.5
# ... zone_temp and tandem_temp_offset adjustments ...
temp = temp.clamp(min=1e-4)
slice_logits = self.in_project_slice(x_mid) / temp   # [B, heads, N, slice_num]
```

**Add immediately after `temp = temp.clamp(min=1e-4)`, before the slice_logits line:**
```python
if self.ada_temp_on:
    # x is [B, N, dim]; project to per-point per-head offset
    ada_offset = self.ada_temp_proj(x)               # [B, N, heads]
    ada_offset = ada_offset.permute(0, 2, 1).unsqueeze(-1)  # [B, heads, N, 1]
    temp = (temp + ada_offset).clamp(min=0.01)       # [B, heads, N, 1] — now per-point
    # This broadcasts correctly: in_project_slice(x_mid) is [B, heads, N, slice_num]
```

**Add Rep-Slice after spatial_bias and prog_slices are applied, immediately before `slice_weights = self.softmax(slice_logits)`:**
```python
if self.rep_slice_on and self.training:
    gumbel = -torch.log(-torch.log(
        torch.empty_like(slice_logits).uniform_(1e-7, 1 - 1e-7)
    ))
    slice_logits = slice_logits + gumbel
slice_weights = self.softmax(slice_logits)
```

### Step 4: Wire up in `TransolverBlock`

Pass `ada_temp` and `rep_slice` (both default `False`) through `TransolverBlock.__init__` to the `Physics_Attention_Irregular_Mesh` constructor, following the same pattern as `zone_temp` and `decouple_slice`.

In `TransolverBlock.__init__`, read from `args`:
```python
ada_temp = getattr(args, 'ada_temp', False)
rep_slice = getattr(args, 'rep_slice', False)
```

### Step 5: Run experiments

Run 2 seeds with `--ada_temp --rep_slice`:

**Seed 42:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/ada-temp-rep-s42" \
  --wandb_group alphonse-ada-temp \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --ada_temp --ada_temp_tau0 0.5 --rep_slice \
  --seed 42
```

**Seed 73:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/ada-temp-rep-s73" \
  --wandb_group alphonse-ada-temp \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --ada_temp --ada_temp_tau0 0.5 --rep_slice \
  --seed 73
```

### Implementation notes

- **Zero-init is critical.** `ada_temp_proj` initialized to zeros so `ada_offset=0` at epoch 0 — model starts identical to baseline. Temperature only deviates as it trains.
- **VRAM impact:** One additional `[B, N, heads]` tensor per forward pass — ~7MB for B=4, N=120k, heads=8. Negligible.
- **torch.compile:** `torch.empty_like(...).uniform_()` is compile-safe.
- **Rep-Slice is training-only.** The `self.training` check skips Gumbel noise during eval and EMA passes.
- **If first run shows improvement:** Try a follow-up without `--rep_slice` (Ada-Temp only) to isolate which component drives the gain.

## Baseline (PR #2184 — DCT Freq Loss w=0.05, 2-seed avg)

| Metric | 2-seed avg | Beat threshold |
|--------|-----------|----------------|
| p_in   | 13.205    | < 13.21        |
| p_oodc | 7.816     | < 7.82         |
| **p_tan** | **28.502** | **< 28.50** |
| p_re   | 6.453     | < 6.45         |

W&B baseline runs: `6yfv5lio` (seed 42), `etepxvjc` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```