### PR TITLE
TE Coordinate Frame: trailing-edge-relative input features for wake coupling

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -253,6 +253,55 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         return self.to_out(out_x)
 
 
+def compute_te_features(raw_xy, is_surface, saf_norm):
+    """Compute trailing-edge-relative coordinate features.
+
+    Finds the trailing edge (max x-coord among surface nodes) for each foil
+    and computes per-node offsets (dx, dy, radius) from each TE.
+
+    Args:
+        raw_xy:     [B, N, 2] raw (pre-standardization) x, y coordinates
+        is_surface: [B, N] bool
+        saf_norm:   [B, N] norm of raw saf channels (x[:,:,2:4] before normalization)
+                    ≤ 0.005 → foil-1 surface, > 0.005 → foil-2 surface
+
+    Returns: [B, N, 6] = [dx_fore, dy_fore, r_fore, dx_aft, dy_aft, r_aft]
+             aft features are zero for single-foil samples
+    """
+    x_coords = raw_xy[:, :, 0]  # [B, N]
+    y_coords = raw_xy[:, :, 1]  # [B, N]
+    INF = 1e6
+
+    # Fore-foil surface (foil-1): saf_norm <= 0.005
+    fore_surf = is_surface & (saf_norm <= 0.005)
+    fore_x_masked = x_coords * fore_surf.float() - INF * (~fore_surf).float()
+    fore_te_idx = fore_x_masked.topk(1, dim=1)[1].squeeze(1)      # [B]
+    fore_te_x = x_coords.gather(1, fore_te_idx.unsqueeze(1)).squeeze(1)  # [B]
+    fore_te_y = y_coords.gather(1, fore_te_idx.unsqueeze(1)).squeeze(1)  # [B]
+
+    # Aft-foil surface (foil-2): saf_norm > 0.005
+    aft_surf = is_surface & (saf_norm > 0.005)
+    is_tandem = aft_surf.any(dim=1).float()[:, None]               # [B, 1]
+    # Safe fallback: use fore_surf when no aft-foil nodes to avoid all-False topk
+    aft_surf_safe = aft_surf | (~aft_surf.any(dim=1, keepdim=True))
+    aft_x_masked = x_coords * aft_surf.float() - INF * (~aft_surf_safe).float()
+    aft_te_idx = aft_x_masked.topk(1, dim=1)[1].squeeze(1)
+    aft_te_x = x_coords.gather(1, aft_te_idx.unsqueeze(1)).squeeze(1) * is_tandem.squeeze(1)
+    aft_te_y = y_coords.gather(1, aft_te_idx.unsqueeze(1)).squeeze(1) * is_tandem.squeeze(1)
+
+    # Per-node offsets from fore TE
+    dx_fore = x_coords - fore_te_x[:, None]
+    dy_fore = y_coords - fore_te_y[:, None]
+    r_fore = (dx_fore ** 2 + dy_fore ** 2).sqrt().clamp(min=1e-6)
+
+    # Per-node offsets from aft TE (zero for single-foil)
+    dx_aft = (x_coords - aft_te_x[:, None]) * is_tandem
+    dy_aft = (y_coords - aft_te_y[:, None]) * is_tandem
+    r_aft = (dx_aft ** 2 + dy_aft ** 2).sqrt().clamp(min=1e-6) * is_tandem
+
+    return torch.stack([dx_fore, dy_fore, r_fore, dx_aft, dy_aft, r_aft], dim=-1)  # [B, N, 6]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1074,6 +1123,7 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
 
 
 cfg = sp.parse(Config)
@@ -1204,7 +1254,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + 32,  # +curv, +dist, [+foil2dist], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1665,6 +1715,9 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
+        # TE coordinate frame: save raw xy and saf_norm before normalization
+        _raw_xy_te = x[:, :, :2].clone() if cfg.te_coord_frame else None
+        _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if cfg.te_coord_frame else None
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
@@ -1679,6 +1732,9 @@ for epoch in range(MAX_EPOCHS):
         if cfg.foil2_dist:
             foil2_dist_feat = torch.log1p(raw_dsdf[:, :, 4:8].abs().min(dim=-1, keepdim=True).values * 10.0)
             x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
+        elif cfg.te_coord_frame:
+            te_feats = compute_te_features(_raw_xy_te, is_surface, _raw_saf_norm_te)
+            x = torch.cat([x, curv, dist_feat, te_feats], dim=-1)
         else:
             x = torch.cat([x, curv, dist_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
@@ -2340,6 +2396,8 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
+                _raw_xy_te = x[:, :, :2].clone() if cfg.te_coord_frame else None
+                _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if cfg.te_coord_frame else None
                 # Aft-foil mask for eval (same logic as training)
                 _eval_aft_mask = None
                 if eval_aft_srf_head is not None:
@@ -2353,6 +2411,9 @@ for epoch in range(MAX_EPOCHS):
                 if cfg.foil2_dist:
                     foil2_dist_feat = torch.log1p(raw_dsdf[:, :, 4:8].abs().min(dim=-1, keepdim=True).values * 10.0)
                     x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
+                elif cfg.te_coord_frame:
+                    te_feats = compute_te_features(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                    x = torch.cat([x, curv, dist_feat, te_feats], dim=-1)
                 else:
                     x = torch.cat([x, curv, dist_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
@@ -2738,9 +2799,15 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
+                    _raw_xy_te_vis = x_dev[:, :, :2].clone() if cfg.te_coord_frame else None
+                    _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if cfg.te_coord_frame else None
                     x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                     curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
-                    x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
+                    if cfg.te_coord_frame:
+                        te_feats_vis = compute_te_features(_raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis)
+                        x_n = torch.cat([x_n, curv, dist_feat, te_feats_vis], dim=-1)
+                    else:
+                        x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
@@ -2835,11 +2902,16 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
+                    _raw_xy_te = x[:, :, :2].clone() if cfg.te_coord_frame else None
+                    _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if cfg.te_coord_frame else None
                     x = (x - stats["x_mean"]) / stats["x_std"]
                     curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                     if cfg.foil2_dist:
                         foil2_dist_feat = torch.log1p(raw_dsdf[:, :, 4:8].abs().min(dim=-1, keepdim=True).values * 10.0)
                         x = torch.cat([x, curv, dist_feat, foil2_dist_feat], dim=-1)
+                    elif cfg.te_coord_frame:
+                        te_feats = compute_te_features(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                        x = torch.cat([x, curv, dist_feat, te_feats], dim=-1)
                     else:
                         x = torch.cat([x, curv, dist_feat], dim=-1)
                     raw_xy = x[:, :, :2]


### PR DESCRIPTION
## Hypothesis

The current input features use raw (x, y) Cartesian coordinates plus DSDF distances. For aerodynamic pressure prediction, the **trailing edge** is the most critical geometric reference point: it is where the Kutta condition is enforced, pressure recovery terminates, and wake formation begins.

GeoMPNN (arXiv 2412.09399, NeurIPS 2024 ML4CFD Best Student Paper) uses trailing-edge-relative coordinate frames as input features, showing **+3–5 OOD score points from the TE frame alone** (Table 2 ablation). The key insight: representing each node's position relative to the trailing edge captures the aerodynamic coupling between a node and the wake origin in a **geometry-invariant** way — the distance from a node to the TE encodes "how far into the recovery region am I?" regardless of absolute foil shape.

For NACA6416 OOD generalization specifically: the TE location and shape differ significantly from training foils (NACA0012/2412/4412), yet the model's spatial coordinate frame takes no special account of the TE. Giving the model explicit TE-relative features should help it generalize the pressure recovery pattern to the new foil shape.

**This is distinct from:**
- Inter-foil distance feature (DEAD, #2195): added distance to foil-2 *center*, overfits tandem patterns. This uses distance to *own foil TE* — geometry-intrinsic.
- Chord-normalized coords: normalizes by chord length globally. TE-relative coords use the TE as a local origin.

**Source:** GeoMPNN, arXiv 2412.09399, NeurIPS 2024 ML4CFD Best Student Paper. Confidence: MEDIUM-HIGH.

## Instructions

Add 6 new input channels: trailing-edge-relative coordinates for fore-foil TE and aft-foil TE.

In `Transolver.forward`, before the `preprocess` GatedMLP2, add:

```python
if cfg.te_coord_frame:
    # Find trailing edge = node with max x-coordinate among surface nodes
    fore_surf = (boundary_id == 5) | (boundary_id == 6)   # [B, N] bool
    aft_surf  = (boundary_id == 7)                         # [B, N] bool
    x_coords  = x[:, :, 0]                                 # [B, N]
    INF = 1e6

    # Fore-foil TE position
    fore_x_masked = x_coords * fore_surf.float() - INF * (~fore_surf).float()
    fore_te_x_idx = fore_x_masked.topk(1, dim=1)[1].squeeze(1)       # [B]
    fore_te_x = x_coords.gather(1, fore_te_x_idx.unsqueeze(1)).squeeze(1)
    fore_te_y = x[:, :, 1].gather(1, fore_te_x_idx.unsqueeze(1)).squeeze(1)

    # Aft-foil TE position (zero for single-foil samples)
    is_tandem = (aft_surf.any(dim=1)).float()[:, None]                # [B, 1]
    aft_surf_safe = aft_surf | (~aft_surf.any(dim=1, keepdim=True))   # avoid all-False topk crash
    aft_x_masked = x_coords * aft_surf.float() - INF * (~aft_surf_safe).float()
    aft_te_x_idx = aft_x_masked.topk(1, dim=1)[1].squeeze(1)
    aft_te_x = x_coords.gather(1, aft_te_x_idx.unsqueeze(1)).squeeze(1) * is_tandem.squeeze(1)
    aft_te_y = x[:, :, 1].gather(1, aft_te_x_idx.unsqueeze(1)).squeeze(1) * is_tandem.squeeze(1)

    # Per-node signed offsets from each TE
    dx_fore = x_coords - fore_te_x[:, None]
    dy_fore = x[:, :, 1] - fore_te_y[:, None]
    r_fore  = (dx_fore**2 + dy_fore**2).sqrt().clamp(min=1e-6)

    dx_aft  = (x_coords - aft_te_x[:, None]) * is_tandem
    dy_aft  = (x[:, :, 1] - aft_te_y[:, None]) * is_tandem
    r_aft   = (dx_aft**2 + dy_aft**2).sqrt().clamp(min=1e-6) * is_tandem

    te_feats = torch.stack([dx_fore, dy_fore, r_fore,
                             dx_aft,  dy_aft,  r_aft], dim=-1)  # [B, N, 6]
    x = torch.cat([x, te_feats], dim=-1)                        # X_DIM += 6
```

Add config flag:
```python
te_coord_frame: bool = False   # TE-relative coordinate frame as additional input features
```

Update `fun_dim` (input dimension of `preprocess` GatedMLP2): add 6 when `cfg.te_coord_frame` is True.

**Run 2 seeds:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/te-coord-frame-s42" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --seed 42
```

Run seed 73 with identical flags but `--seed 73 --wandb_name "edward/te-coord-frame-s73"`.

**Implementation notes:**
- Use `topk(1)` not `argmax` — safer for torch.compile.
- `aft_surf_safe` guard prevents crash when `aft_surf` is all-False (single-foil samples).
- `is_tandem` mask zeroes aft-foil TE features for non-tandem samples (p_in, p_oodc, p_re tracks).
- Try unnormalized coordinates first — TE offsets are in the same coordinate space as (x, y).
- All ops (topk, gather, sqrt, clamp, stack, cat) are torch.compile-compatible.

## Baseline

Current best (PR #2184, DCT Freq-Weighted Loss, 2-seed avg):

| Metric | Baseline | Target |
|--------|----------|--------|
| p_in   | 13.205   | < 13.205 |
| p_tan  | **28.502** | **< 28.502** |
| p_oodc | 7.816    | < 7.816 |
| p_re   | 6.453    | < 6.453 |

W&B runs: 6yfv5lio (seed 42, p_tan=28.432), etepxvjc (seed 73, p_tan=28.572).

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```