### PR TITLE
Iterative SRF Heads (RAFT-style): N=3 correction passes on surface nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1071,6 +1071,7 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    srf_iterations: int = 1                  # number of SRF head passes (RAFT-style iterative refinement)
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
@@ -1798,14 +1799,15 @@ for epoch in range(MAX_EPOCHS):
                     ).float()
                     pred = pred + refine_correction
                 else:
-                    # Standard: extract surface nodes, apply MLP, scatter back
+                    # Standard: extract surface nodes, apply MLP iteratively, scatter back
                     surf_idx = is_surface.nonzero(as_tuple=False)  # [M, 2] (batch, node)
                     if surf_idx.numel() > 0:
                         surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
-                        surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
-                        correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
+                        current_surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]].clone()  # [M, 3]
+                        for _ in range(cfg.srf_iterations):
+                            current_surf_pred = current_surf_pred + refine_head(surf_hidden, current_surf_pred).float()
                         pred = pred.clone()
-                        pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
+                        pred[surf_idx[:, 0], surf_idx[:, 1]] = current_surf_pred
 
         # Aft-foil dedicated refinement head: additive correction on boundary ID=7 nodes only
         if aft_srf_ctx_head is not None and model.training and _aft_foil_mask is not None:
@@ -1831,15 +1833,16 @@ for epoch in range(MAX_EPOCHS):
             aft_idx = _aft_foil_mask.nonzero(as_tuple=False)  # [A, 2] (batch, node)
             if aft_idx.numel() > 0:
                 aft_hidden = hidden[aft_idx[:, 0], aft_idx[:, 1]]  # [A, n_hidden]
-                aft_pred = pred[aft_idx[:, 0], aft_idx[:, 1]]      # [A, 3]
-                # FiLM conditioning: expand gap/stagger per aft-foil node
+                current_aft_pred = pred[aft_idx[:, 0], aft_idx[:, 1]].clone()  # [A, 3]
                 _aft_cond = None
                 if cfg.aft_foil_srf_film:
                     _aft_cond = _raw_gap_stagger[aft_idx[:, 0]]  # [A, 2]
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    aft_correction = aft_srf_head(aft_hidden, aft_pred, _aft_cond).float()
+                for _ in range(cfg.srf_iterations):
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        aft_correction = aft_srf_head(aft_hidden, current_aft_pred, _aft_cond).float()
+                    current_aft_pred = current_aft_pred + aft_correction
                 pred = pred.clone()
-                pred[aft_idx[:, 0], aft_idx[:, 1]] = pred[aft_idx[:, 0], aft_idx[:, 1]] + aft_correction
+                pred[aft_idx[:, 0], aft_idx[:, 1]] = current_aft_pred
 
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
@@ -2451,10 +2454,11 @@ for epoch in range(MAX_EPOCHS):
                             surf_idx = is_surface.nonzero(as_tuple=False)
                             if surf_idx.numel() > 0:
                                 surf_hidden = _eval_hidden[surf_idx[:, 0], surf_idx[:, 1]]
-                                surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                                correction = eval_refine_head(surf_hidden, surf_pred).float()
+                                current_surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]].clone()
+                                for _ in range(cfg.srf_iterations):
+                                    current_surf_pred = current_surf_pred + eval_refine_head(surf_hidden, current_surf_pred).float()
                                 pred_loss = pred_loss.clone()
-                                pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
+                                pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = current_surf_pred
                     # Back-compute refined pred so denormalization (pred_orig) includes refinement
                     if cfg.multiply_std:
                         pred = pred_loss / sample_stds
@@ -2486,12 +2490,14 @@ for epoch in range(MAX_EPOCHS):
                     aft_idx = _eval_aft_mask.nonzero(as_tuple=False)
                     if aft_idx.numel() > 0:
                         _ah = _eval_hidden[aft_idx[:, 0], aft_idx[:, 1]]
-                        _ap = pred_loss[aft_idx[:, 0], aft_idx[:, 1]]
+                        _current_ap = pred_loss[aft_idx[:, 0], aft_idx[:, 1]].clone()
                         _ac = _v_gap_stagger[aft_idx[:, 0]] if cfg.aft_foil_srf_film else None
-                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                            _aft_corr = eval_aft_srf_head(_ah, _ap, _ac).float()
+                        for _ in range(cfg.srf_iterations):
+                            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                                _aft_corr = eval_aft_srf_head(_ah, _current_ap, _ac).float()
+                            _current_ap = _current_ap + _aft_corr
                         pred_loss = pred_loss.clone()
-                        pred_loss[aft_idx[:, 0], aft_idx[:, 1]] += _aft_corr
+                        pred_loss[aft_idx[:, 0], aft_idx[:, 1]] = _current_ap
                         # Back-compute pred for denormalization
                         if cfg.multiply_std:
                             pred = pred_loss / sample_stds


### PR DESCRIPTION
## Hypothesis

The SurfaceRefinementHead and AftFoilRefinementHead each run a single forward pass to produce an additive correction. We hypothesize that **iterating these heads N=3 times** — feeding the current prediction back as input each pass — allows progressive residual refinement analogous to RAFT (optical flow) and AlphaFold recycling.

**Why this should help:**
- RAFT (Teed & Deng, ECCV 2020) applies a lightweight GRU update iteratively — each pass sees the same features but refines the estimate, achieving SOTA with 12+ iterations
- AlphaFold2 uses 3 recycling passes; each pass produces cleaner input for the next
- Our SRF heads are tiny (~150K params). Running them 3× adds **<1% epoch overhead** — negligible vs the 1.3x overhead of the failed full-model iteration (PR #2165)
- Zero-initialized output ensures the first pass is identical to baseline; passes 2-3 learn to add incremental corrections from scratch
- The backbone hidden states (which don't change between iterations) provide stable context; only the current prediction updates — a clean, lightweight recurrence

**Why this differs from the failed PR #2165 (Iterative 2-Pass Refinement, p_tan +6.6%):**
- #2165 ran the **entire backbone** twice (1.3x overhead → only 131 epochs → undertrained)
- This runs only the **SRF heads** (tiny MLPs on ~300 surface nodes per batch)
- Full epoch budget preserved (~148-155 epochs)

## Instructions

Make the following changes to `cfd_tandemfoil/train.py`:

### Step 1: Add config flag (~line 1062, near other `surface_refine` flags)

```python
srf_iterations: int = 1  # number of SRF head passes (RAFT-style iterative refinement)
```

### Step 2: Add argparse argument (near other `--surface_refine*` args)

```python
parser.add_argument("--srf_iterations", type=int, default=1,
                    help="Number of SRF head passes (RAFT-style). 1=standard, 3=3-pass.")
```

### Step 3: Modify standard SRF in training loop (~line 1801-1808)

Find:
```python
surf_idx = is_surface.nonzero(as_tuple=False)  # [M, 2] (batch, node)
if surf_idx.numel() > 0:
    surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
    surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
    correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
    pred = pred.clone()
    pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
```

Replace with:
```python
surf_idx = is_surface.nonzero(as_tuple=False)  # [M, 2] (batch, node)
if surf_idx.numel() > 0:
    surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
    current_surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]].clone()  # [M, 3]
    for _ in range(cfg.srf_iterations):
        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
            correction = refine_head(surf_hidden, current_surf_pred).float()
        current_surf_pred = current_surf_pred + correction
    pred = pred.clone()
    pred[surf_idx[:, 0], surf_idx[:, 1]] = current_surf_pred
```

Note: The existing `torch.amp.autocast` context wraps the whole block; move it into the loop as shown.

### Step 4: Modify aft-foil SRF in training loop (~line 1830-1842)

Find the `elif aft_srf_head is not None and model.training` block. Replace the correction application with:
```python
aft_hidden = hidden[aft_idx[:, 0], aft_idx[:, 1]]  # [A, n_hidden]
current_aft_pred = pred[aft_idx[:, 0], aft_idx[:, 1]].clone()  # [A, 3]
_aft_cond = None
if cfg.aft_foil_srf_film:
    _aft_cond = _raw_gap_stagger[aft_idx[:, 0]]  # [A, 2]
for _ in range(cfg.srf_iterations):
    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
        aft_correction = aft_srf_head(aft_hidden, current_aft_pred, _aft_cond).float()
    current_aft_pred = current_aft_pred + aft_correction
pred = pred.clone()
pred[aft_idx[:, 0], aft_idx[:, 1]] = current_aft_pred
```

### Step 5: Modify standard SRF in eval loop (~line 2450-2457)

Find:
```python
surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
correction = eval_refine_head(surf_hidden, surf_pred).float()
pred_loss = pred_loss.clone()
pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
```

Replace with:
```python
current_surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]].clone()
for _ in range(cfg.srf_iterations):
    correction = eval_refine_head(surf_hidden, current_surf_pred).float()
    current_surf_pred = current_surf_pred + correction
pred_loss = pred_loss.clone()
pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = current_surf_pred
```

### Step 6: Modify aft-foil SRF in eval loop (~line 2485-2499)

Find:
```python
_ah = _eval_hidden[aft_idx[:, 0], aft_idx[:, 1]]
_ap = pred_loss[aft_idx[:, 0], aft_idx[:, 1]]
_ac = _v_gap_stagger[aft_idx[:, 0]] if cfg.aft_foil_srf_film else None
with torch.amp.autocast("cuda", dtype=torch.bfloat16):
    _aft_corr = eval_aft_srf_head(_ah, _ap, _ac).float()
pred_loss = pred_loss.clone()
pred_loss[aft_idx[:, 0], aft_idx[:, 1]] += _aft_corr
```

Replace with:
```python
_ah = _eval_hidden[aft_idx[:, 0], aft_idx[:, 1]]
_current_ap = pred_loss[aft_idx[:, 0], aft_idx[:, 1]].clone()
_ac = _v_gap_stagger[aft_idx[:, 0]] if cfg.aft_foil_srf_film else None
for _ in range(cfg.srf_iterations):
    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
        _aft_corr = eval_aft_srf_head(_ah, _current_ap, _ac).float()
    _current_ap = _current_ap + _aft_corr
pred_loss = pred_loss.clone()
pred_loss[aft_idx[:, 0], aft_idx[:, 1]] = _current_ap
```

The `if cfg.multiply_std` back-compute block immediately after remains unchanged.

### Step 7: Run 2 seeds with N=3 iterations

**Seed 42:**
```bash
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/iterative-srf-n3-seed42" \
  --wandb_group round11/iterative-srf \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --srf_iterations 3
```

**Seed 73:**
```bash
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/iterative-srf-n3-seed73" \
  --wandb_group round11/iterative-srf \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --srf_iterations 3
```

### Step 8: Report results

Add a **Results** comment with:
- 2-seed average of: p_in, p_oodc, p_tan, p_re
- Individual per-seed values and best epoch
- W&B run IDs and links
- Per-epoch timing vs baseline to confirm <1% overhead
- Qualitative: do later iterations produce smaller corrections? (Optional: log `correction.abs().mean()` per iteration for a few epochs)

## Baseline

Current best (PR #2184, DCT Freq Loss, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 13.205 | < 13.21 |
| p_oodc | 7.816 | < 7.82 |
| **p_tan** | **28.502** | **< 28.50** |
| p_re | 6.453 | < 6.45 |

W&B runs: `6yfv5lio` (seed 42, p_tan=28.432), `etepxvjc` (seed 73, p_tan=28.572)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```