### PR TITLE
Attention Register Tokens: learnable global slots in Physics-Attention to prevent OOD routing collapse

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 register_tokens=False, register_k=4):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -185,6 +186,15 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
                 nn.Linear(2 * dim_head, dim_head), nn.GELU(),
                 nn.Linear(dim_head, 1),
             )
+        # Register tokens: [heads, K, dim_head] — independent per-head, small random init
+        if register_tokens and not linear_no_attention:
+            self.register_tokens_param = nn.Parameter(
+                torch.randn(heads, register_k, dim_head) * 0.02
+            )
+            self._register_k = register_k
+        else:
+            self.register_tokens_param = None
+            self._register_k = 0
 
     def forward(self, x, spatial_bias=None, tandem_mask=None, zone_features=None):
         bsz, num_points, _ = x.shape
@@ -229,14 +239,23 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         if self.linear_no_attention:
             out_slice_token = slice_token
         else:
-            q_slice_token = self.to_q(slice_token)
-            slice_token_kv = slice_token.mean(dim=1, keepdim=True)
+            S = slice_token.size(2)  # number of physics slices
+            # Augment slice tokens with register tokens before self-attention
+            if self.register_tokens_param is not None:
+                B = slice_token.size(0)
+                regs = self.register_tokens_param.unsqueeze(0).expand(B, -1, -1, -1)  # [B, H, K, D]
+                slice_aug = torch.cat([slice_token, regs], dim=2)  # [B, H, S+K, D]
+            else:
+                slice_aug = slice_token
+
+            q_slice_token = self.to_q(slice_aug)
+            slice_token_kv = slice_aug.mean(dim=1, keepdim=True)
             k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
             v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
             if self.learned_kernel:
-                B, H, S, D = q_slice_token.shape
-                q_exp = q_slice_token.unsqueeze(-2).expand(B, H, S, S, D)
-                k_exp = k_slice_token.unsqueeze(-3).expand(B, H, S, S, D)
+                B, H, SK, D = q_slice_token.shape
+                q_exp = q_slice_token.unsqueeze(-2).expand(B, H, SK, SK, D)
+                k_exp = k_slice_token.unsqueeze(-3).expand(B, H, SK, SK, D)
                 qk_cat = torch.cat([q_exp, k_exp], dim=-1)
                 attn_logits = self.kernel_mlp(qk_cat).squeeze(-1)
                 attn_weights = F.softmax(attn_logits, dim=-1)
@@ -245,7 +264,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
                 k_norm = F.normalize(k_slice_token, dim=-1)
                 attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
                 attn_weights = F.softmax(attn_logits, dim=-1)
-            out_slice_token = torch.matmul(attn_weights, v_slice_token)
+            out_aug = torch.matmul(attn_weights, v_slice_token)
+            out_slice_token = out_aug[:, :, :S, :]  # discard register outputs [B, H, S, D]
             out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
 
         out_x = torch.einsum("bhgc,bhng->bhnc", out_slice_token, slice_weights)
@@ -283,6 +303,8 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        register_tokens=False,
+        register_k=4,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -308,6 +330,8 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            register_tokens=register_tokens,
+            register_k=register_k,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -700,6 +724,8 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        register_tokens=False,
+        register_k=4,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -772,6 +798,8 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    register_tokens=register_tokens,
+                    register_k=register_k,
                 )
                 for idx in range(n_layers)
             ]
@@ -1020,6 +1048,8 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    register_tokens: bool = False  # add learnable register tokens to Physics-Attention (prevent OOD attention sink)
+    register_k: int = 4            # number of register tokens per attention block
     dct_freq_loss: bool = False   # DCT frequency-weighted auxiliary loss on surface pressure
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
@@ -1234,6 +1264,8 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    register_tokens=cfg.register_tokens,
+    register_k=cfg.register_k,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

Transolver's Physics-Attention operates on slice tokens — soft aggregates over mesh nodes. For OOD inputs (NACA6416 tandem), some slice tokens likely become \"dump tokens\": they absorb signals that don't fit training distribution patterns without contributing useful predictions. This is the attention sink pathology documented in ViTs.

\"Vision Transformers Need Registers\" (arXiv 2309.16588, NeurIPS 2023) showed that adding K learnable **register tokens** — global memory slots appended to the attention sequence and discarded after — eliminates pathological attention patterns and **significantly improves OOD generalization**. The mechanism: without registers, information that doesn't belong to any position creates high-norm dump tokens; registers provide explicit allocation for this global state, keeping physics slice tokens clean and specialized.

In Transolver, slice tokens are [B, 96, 192]. With K=4 registers, the self-attention in each Physics-Attention block operates over [B, 100, 192] — negligible overhead (4×192 = 768 extra params per block, 2304 total for 3 blocks). Registers are discarded before deslice — only the original 96 slice outputs are used.

This targets the p_tan OOD gap specifically: NACA6416 wake patterns are out-of-distribution → slice tokens for tandem samples may collapse into generic dump states → register tokens give those dumps an explicit home, freeing physics slices to specialize.

**Source:** arXiv 2309.16588 — Vision Transformers Need Registers (FAIR, NeurIPS 2023). Novel application to Transolver slice-token attention; not tried in any prior round.

## Instructions

### Step 1: Add config flags

```python
register_tokens: bool = False   # Add learnable global register tokens to Physics-Attention
register_k: int = 4             # Number of register tokens per block
```

### Step 2: In Physics_Attention_Irregular_Mesh.__init__, add register params

```python
if cfg.register_tokens:
    self.register_tokens = nn.Parameter(
        torch.randn(cfg.register_k, n_hidden) * 0.02
    )  # [K, n_hidden] — small random init, NOT zeros
else:
    self.register_tokens = None
```

### Step 3: In Physics_Attention_Irregular_Mesh.forward, extend slice sequence for attention

Find where slice_token is computed and self-attention applied over [B, S, n_hidden]. Replace the self-attention call with:

```python
if self.register_tokens is not None:
    B, S, H = slice_token.shape
    regs = self.register_tokens.unsqueeze(0).expand(B, -1, -1)  # [B, K, H]
    augmented = torch.cat([slice_token, regs], dim=1)             # [B, S+K, H]
    attended = self_attn_fn(augmented)                            # [B, S+K, H]
    slice_token = attended[:, :S, :]                              # [B, S, H] — discard registers
else:
    slice_token = self_attn_fn(slice_token)
```

Where self_attn_fn is the existing slice self-attention (may use torch.einsum for multi-head). Check the actual code and adapt accordingly — the key is that S+K goes into attention, only :S comes out for deslice.

**Critical notes:**
- Do NOT use zero initialization — zero-init registers get zero gradient at step 0.
- All 3 Physics_Attention_Irregular_Mesh blocks get their own independent register params.
- After attention, discard K register outputs ([:, :S, :]) before deslice einsum.
- torch.compile: cat, einsum, expand are all compile-compatible.
- The existing multi-head attention einsum handles arbitrary S dimension — verify the pattern works for S+K.

### Step 4: Run 2 seeds

```bash
# Seed 42 (GPU 0)
cd cfd_tandemfoil && CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent thorfinn --seed 42 \
  --wandb_name "thorfinn/register-tokens-k4-s42" \
  --wandb_group "round10/attention-register-tokens" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output \
  --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp \
  --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead \
  --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction \
  --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --register_tokens --register_k 4

# Seed 73 (GPU 1) — same flags, --seed 73 --wandb_name "thorfinn/register-tokens-k4-s73"
```

### Step 5 (optional follow-up if K=4 improves p_tan at epoch 80): try K=8

```bash
--register_tokens --register_k 8
```

## Baseline

**Current best single-model (PR #2184, DCT Freq-Weighted Loss w=0.05, 2-seed)**

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| p_in | **13.21** | < 13.21 |
| p_oodc | **7.82** | < 7.82 |
| **p_tan** | **28.50** | **< 28.50** (PRIMARY TARGET) |
| p_re | **6.45** | < 6.45 |

W&B runs: `6yfv5lio` (seed 42, p_tan=28.432), `etepxvjc` (seed 73, p_tan=28.572)

Reproduce:
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```