### PR TITLE
Surface Pressure Gradient Loss: penalize dp/ds mismatch along surface

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1024,6 +1024,8 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    dp_ds_loss: bool = False      # auxiliary loss on surface pressure gradients (dp/ds)
+    dp_ds_weight: float = 0.05    # weight for dp/ds gradient loss
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1662,9 +1664,10 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
-        _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
-        _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
-        _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
+        _need_raw_dct = cfg.dct_freq_loss or cfg.dp_ds_loss
+        _raw_x_for_dct = x[:, :, 0].clone() if _need_raw_dct else None  # save raw x before normalization
+        _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if _need_raw_dct else None
+        _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if _need_raw_dct else None
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
@@ -1996,6 +1999,36 @@ for epoch in range(MAX_EPOCHS):
             if _n_foils_dct > 0:
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
+
+        # Surface pressure gradient (dp/ds) auxiliary loss
+        if cfg.dp_ds_loss and model.training:
+            _dp_loss = torch.tensor(0.0, device=device)
+            _n_foils_dp = 0
+            for b in range(B):
+                surf_idx_b = is_surface[b].nonzero(as_tuple=True)[0]
+                if surf_idx_b.numel() < 4:
+                    continue
+                _is_tan_b = _raw_tandem_for_dct[b].item()
+                if _is_tan_b:
+                    saf_vals = _raw_saf_for_dct[b, surf_idx_b]
+                    foil_groups = [surf_idx_b[saf_vals <= 0.005], surf_idx_b[saf_vals > 0.005]]
+                else:
+                    foil_groups = [surf_idx_b]
+                for foil_surf in foil_groups:
+                    if foil_surf.numel() < 4:
+                        continue
+                    x_coords = _raw_x_for_dct[b, foil_surf]
+                    sort_order = x_coords.argsort()
+                    sorted_idx = foil_surf[sort_order]
+                    p_pred = pred[b, sorted_idx, 2]
+                    p_gt = y_norm[b, sorted_idx, 2]
+                    dp_pred = p_pred[1:] - p_pred[:-1]
+                    dp_gt = p_gt[1:] - p_gt[:-1]
+                    _dp_loss = _dp_loss + (dp_pred - dp_gt).abs().mean()
+                    _n_foils_dp += 1
+            if _n_foils_dp > 0:
+                _dp_loss = _dp_loss / _n_foils_dp
+                loss = loss + cfg.dp_ds_weight * _dp_loss
 
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)


### PR DESCRIPTION
## Hypothesis

The current training loss (MAE + DCT freq) optimizes **point-wise** pressure accuracy and **spectral amplitude** fidelity, but never directly penalizes errors in the **spatial gradient of pressure along the surface** (dp/ds). Since:

1. **Pressure gradient drives lift and separation** — the Kutta-Joukowski theorem and boundary layer equations show that dp/ds determines where flow separates and how much lift is generated. Matching Cp values but not dCp/ds can still produce wrong aerodynamic forces.

2. **The aft foil in tandem configurations has the steepest pressure gradients** — wake impingement from the fore foil creates sharp pressure jumps on the aft leading edge. These are exactly where our p_tan errors concentrate.

3. **DCT freq loss catches global spectral content; gradient loss catches local spatial structure** — they are complementary. DCT penalizes wrong *amplitudes* at each frequency; gradient loss penalizes wrong *transitions* between adjacent nodes.

The hypothesis: adding an auxiliary loss on consecutive surface node pressure differences will explicitly force the model to match the **shape** of the pressure distribution, not just its point values and spectral content, improving p_tan on the OOD NACA6416 aft foil.

**Relationship to in-flight experiments:**
- `#2210` (arc-length surface loss reweighting): reweights existing MAE loss by arc-length spacing — not gradient matching
- `#2197` (curvature loss weighting): reweights by geometric curvature — not actual pressure gradient
- `#2184` (DCT freq loss, merged): penalizes spectral mismatch in frequency domain — complementary, not overlapping

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags (near the `dct_freq_loss` flags, around line 1023)

```python
dp_ds_loss: bool = False      # auxiliary loss on surface pressure gradients (dp/ds)
dp_ds_weight: float = 0.05    # weight for dp/ds gradient loss
```

### Step 2: Extend the raw-coordinate save block (around line 1665) to also trigger on dp_ds_loss

```python
_raw_x_for_dct = x[:, :, 0].clone() if (cfg.dct_freq_loss or cfg.dp_ds_loss) else None
_raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if (cfg.dct_freq_loss or cfg.dp_ds_loss) else None
_raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if (cfg.dct_freq_loss or cfg.dp_ds_loss) else None
```

### Step 3: Add the gradient loss block immediately after the DCT loss block (around line 1999)

```python
# Surface pressure gradient (dp/ds) auxiliary loss
if cfg.dp_ds_loss and model.training:
    _dp_loss = torch.tensor(0.0, device=device)
    _n_foils_dp = 0
    for b in range(B):
        surf_idx_b = is_surface[b].nonzero(as_tuple=True)[0]
        if surf_idx_b.numel() < 4:
            continue
        _is_tan_b = _raw_tandem_for_dct[b].item()
        if _is_tan_b:
            saf_vals = _raw_saf_for_dct[b, surf_idx_b]
            foil_groups = [surf_idx_b[saf_vals <= 0.005], surf_idx_b[saf_vals > 0.005]]
        else:
            foil_groups = [surf_idx_b]
        for foil_surf in foil_groups:
            if foil_surf.numel() < 4:
                continue
            # Sort by raw x-coordinate (consistent with DCT ordering)
            x_coords = _raw_x_for_dct[b, foil_surf]
            sort_order = x_coords.argsort()
            sorted_idx = foil_surf[sort_order]
            # Extract pressure channel (channel 2)
            p_pred = pred[b, sorted_idx, 2]  # [M]
            p_gt = y_norm[b, sorted_idx, 2]  # [M]
            # Finite differences: adjacent pressure differences (dp/ds proxy)
            dp_pred = p_pred[1:] - p_pred[:-1]  # [M-1]
            dp_gt = p_gt[1:] - p_gt[:-1]        # [M-1]
            _dp_loss = _dp_loss + (dp_pred - dp_gt).abs().mean()
            _n_foils_dp += 1
    if _n_foils_dp > 0:
        _dp_loss = _dp_loss / _n_foils_dp
        loss = loss + cfg.dp_ds_weight * _dp_loss
```

### Step 4: Training runs

Run 2 seeds. Report W&B run IDs and final surface MAE metrics in a PR comment.

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent alphonse --wandb_name "alphonse/dp-ds-w005-s42" \
  --wandb_group "round12/surface-dp-ds" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --dp_ds_loss --dp_ds_weight 0.05 \
  --seed 42

# Seed 73
cd cfd_tandemfoil && python train.py \
  --agent alphonse --wandb_name "alphonse/dp-ds-w005-s73" \
  --wandb_group "round12/surface-dp-ds" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --dp_ds_loss --dp_ds_weight 0.05 \
  --seed 73
```

If both seeds beat baseline, optionally test `--dp_ds_weight 0.02` as a 3rd run.

## Baseline

Current best metrics (PR #2184, DCT Frequency-Weighted Loss, 2-seed avg):

| Metric | Baseline | Target |
|--------|----------|--------|
| p_in   | 13.205   | < 13.205 |
| p_oodc | 7.816    | < 7.816  |
| **p_tan** | **28.502** | **< 28.502** |
| p_re   | 6.453    | < 6.453  |

W&B baseline: `6yfv5lio` (seed 42, p_tan=28.432), `etepxvjc` (seed 73, p_tan=28.572)

```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-dct-freq" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5
```