### PR TITLE
GeoTransolver GALE: geometry-latent cross-attention in TransolverBlock

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -332,6 +332,8 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        geotransolver_gale=False,
+        gale_latent_dim=32,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -390,6 +392,15 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        self.geotransolver_gale = geotransolver_gale
+        if geotransolver_gale:
+            gale_total_dim = gale_latent_dim * 2  # fore + aft foil latents concatenated
+            self.gale_q_proj = nn.Linear(hidden_dim, hidden_dim)
+            self.gale_k_proj = nn.Linear(gale_total_dim, hidden_dim)
+            self.gale_v_proj = nn.Linear(gale_total_dim, hidden_dim)
+            self.gale_out_proj = nn.Linear(hidden_dim, hidden_dim)
+            nn.init.zeros_(self.gale_out_proj.weight)
+            nn.init.zeros_(self.gale_out_proj.bias)
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             if soft_moe:
@@ -441,7 +452,7 @@ class TransolverBlock(nn.Module):
                     nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim)
                 )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None, zone_features=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None, zone_features=None, geom_latent=None):
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         # DomainLayerNorm helper: pass is_tandem when enabled, else plain call
         dln_it = (tandem_mask.view(-1) > 0.5) if (self.domain_layernorm and tandem_mask is not None) else None
@@ -454,10 +465,26 @@ class TransolverBlock(nn.Module):
             s1, b1, s2, b2 = cond_out.chunk(4, dim=-1)  # each [B, H]
             fx_norm = _ln(self.ln_1, fx) * (1 + s1.unsqueeze(1)) + b1.unsqueeze(1)
             fx = _ln(self.ln_1_post, self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
+            # GALE: geometry-latent cross-attention after physics attention, before FFN
+            if self.geotransolver_gale and geom_latent is not None:
+                gale_q = self.gale_q_proj(fx)          # [B, N, D]
+                gale_kv = geom_latent.unsqueeze(1)     # [B, 1, 2*latent_dim]
+                gale_k = self.gale_k_proj(gale_kv)    # [B, 1, D]
+                gale_v = self.gale_v_proj(gale_kv)    # [B, 1, D]
+                cross_out = F.scaled_dot_product_attention(gale_q, gale_k, gale_v)  # [B, N, D]
+                fx = fx + self.gale_out_proj(cross_out)
             fx_norm = _ln(self.ln_2, fx) * (1 + s2.unsqueeze(1)) + b2.unsqueeze(1)
             fx = _ln(self.ln_2_post, self.mlp(fx_norm) + fx)
         else:
             fx = _ln(self.ln_1_post, self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
+            # GALE: geometry-latent cross-attention after physics attention, before FFN
+            if self.geotransolver_gale and geom_latent is not None:
+                gale_q = self.gale_q_proj(fx)          # [B, N, D]
+                gale_kv = geom_latent.unsqueeze(1)     # [B, 1, 2*latent_dim]
+                gale_k = self.gale_k_proj(gale_kv)    # [B, 1, D]
+                gale_v = self.gale_v_proj(gale_kv)    # [B, 1, D]
+                cross_out = F.scaled_dot_product_attention(gale_q, gale_k, gale_v)  # [B, N, D]
+                fx = fx + self.gale_out_proj(cross_out)
             fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
@@ -712,6 +739,25 @@ class SurfaceRefinementContextHead(nn.Module):
         return correction
 
 
+class GeometryEncoder(nn.Module):
+    """Pool surface node features into a fixed-size geometry latent."""
+
+    def __init__(self, in_dim, latent_dim):
+        super().__init__()
+        self.proj = nn.Sequential(
+            nn.Linear(in_dim, latent_dim * 2),
+            nn.GELU(),
+            nn.Linear(latent_dim * 2, latent_dim),
+        )
+
+    def forward(self, surface_x, surface_mask):
+        # surface_x: [B, N, D], surface_mask: [B, N] bool
+        masked = surface_x * surface_mask.unsqueeze(-1).float()
+        count = surface_mask.float().sum(1, keepdim=True).clamp(min=1)
+        pooled = masked.sum(1) / count  # [B, D]
+        return self.proj(pooled)  # [B, latent_dim]
+
+
 class Transolver(nn.Module):
     def __init__(
         self,
@@ -749,10 +795,13 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        geotransolver_gale=False,
+        gale_latent_dim=32,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.geotransolver_gale = geotransolver_gale
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -821,6 +870,8 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    geotransolver_gale=geotransolver_gale,
+                    gale_latent_dim=gale_latent_dim,
                 )
                 for idx in range(n_layers)
             ]
@@ -830,6 +881,10 @@ class Transolver(nn.Module):
             with torch.no_grad():
                 for block in self.blocks:
                     block.spatial_bias[0].weight[:, 4:].zero_()
+        # GeoTransolver GALE: geometry-latent encoders (fore and aft foil)
+        if geotransolver_gale:
+            self.fore_geom_enc = GeometryEncoder(fun_dim + space_dim, gale_latent_dim)
+            self.aft_geom_enc = GeometryEncoder(fun_dim + space_dim, gale_latent_dim)
         # Separate pressure pathway (pressure_separate_last_block):
         # Independent MLP + pres_head that processes shared hidden features
         self._pressure_separate = False  # set from Config after construction
@@ -925,6 +980,19 @@ class Transolver(nn.Module):
         else:
             zone_features = None
 
+        # GeoTransolver GALE: compute geometry latent from raw input features
+        if self.geotransolver_gale:
+            fore_surf_mask = data.get("fore_surf_mask") if isinstance(data, Mapping) else None
+            aft_surf_mask = data.get("aft_surf_mask") if isinstance(data, Mapping) else None
+            if fore_surf_mask is not None and aft_surf_mask is not None:
+                fore_latent = self.fore_geom_enc(x, fore_surf_mask)   # [B, latent_dim]
+                aft_latent = self.aft_geom_enc(x, aft_surf_mask)      # [B, latent_dim]
+                geom_latent = torch.cat([fore_latent, aft_latent], dim=-1)  # [B, 2*latent_dim]
+            else:
+                geom_latent = None
+        else:
+            geom_latent = None
+
         if self.unified_pos:
             if pos is None:
                 raise ValueError("Missing required input tensor: pos")
@@ -948,7 +1016,7 @@ class Transolver(nn.Module):
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
         for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features, geom_latent=geom_latent)
 
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
@@ -965,11 +1033,11 @@ class Transolver(nn.Module):
             fx_for_pressure = fx  # save for separate pressure branch
             p_sep = self.pressure_sep_mlp(fx_for_pressure)  # [B, N, 1]
             # Main last block produces vel only (pressure_first still active but p comes from separate branch)
-            fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features)
+            fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features, geom_latent=geom_latent)
             # Override: replace the pressure channel from the last block with the separate branch's output
             fx = torch.cat([fx[:, :, :2], p_sep], dim=-1)
         else:
-            fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features)
+            fx = self.blocks[-1](fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=last_condition, zone_features=zone_features, geom_latent=geom_latent)
 
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
@@ -1124,6 +1192,8 @@ class Config:
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
+    geotransolver_gale: bool = False  # Geometry-latent cross-attention conditioning
+    gale_latent_dim: int = 32         # Geometry latent dimension per foil
 
 
 cfg = sp.parse(Config)
@@ -1284,6 +1354,8 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    geotransolver_gale=cfg.geotransolver_gale,
+    gale_latent_dim=cfg.gale_latent_dim,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1726,6 +1798,13 @@ for epoch in range(MAX_EPOCHS):
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+        # GALE: fore/aft surface masks computed from raw saf_norm before normalization
+        _fore_surf_mask_gale = None
+        _aft_surf_mask_gale = None
+        if cfg.geotransolver_gale:
+            _raw_saf_norm_gale = x[:, :, 2:4].norm(dim=-1)  # [B, N]
+            _fore_surf_mask_gale = is_surface & (_raw_saf_norm_gale <= 0.005)
+            _aft_surf_mask_gale = is_surface & (_raw_saf_norm_gale > 0.005)
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -1829,7 +1908,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "fore_surf_mask": _fore_surf_mask_gale, "aft_surf_mask": _aft_surf_mask_gale})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -2057,7 +2136,7 @@ for epoch in range(MAX_EPOCHS):
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                rdrop_out = model({"x": x})
+                rdrop_out = model({"x": x, "fore_surf_mask": _fore_surf_mask_gale, "aft_surf_mask": _aft_surf_mask_gale})
                 rdrop_pred = rdrop_out["preds"].float() / sample_stds
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
@@ -2196,7 +2275,7 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
+                out2 = model({"x": x, "fore_surf_mask": _fore_surf_mask_gale, "aft_surf_mask": _aft_surf_mask_gale})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
@@ -2405,6 +2484,13 @@ for epoch in range(MAX_EPOCHS):
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
                     _v_gap_stagger = x[:, 0, 22:24]  # [B, 2]
+                # GALE: fore/aft surface masks for eval (same logic as training)
+                _fore_surf_mask_gale_v = None
+                _aft_surf_mask_gale_v = None
+                if cfg.geotransolver_gale:
+                    _raw_saf_norm_gale_v = x[:, :, 2:4].norm(dim=-1)
+                    _fore_surf_mask_gale_v = is_surface & (_raw_saf_norm_gale_v <= 0.005)
+                    _aft_surf_mask_gale_v = is_surface & (_raw_saf_norm_gale_v > 0.005)
                 x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -2490,7 +2576,7 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    _eval_out = eval_model({"x": x})
+                    _eval_out = eval_model({"x": x, "fore_surf_mask": _fore_surf_mask_gale_v, "aft_surf_mask": _aft_surf_mask_gale_v})
                     pred = _eval_out["preds"]
                     _eval_hidden = _eval_out["hidden"]
                 pred = pred.float()
@@ -2768,6 +2854,18 @@ wandb.summary.update({"total_epochs": epoch + 1, "total_time_min": total_time})
 if best_metrics:
     wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})
 
+# GALE diagnostic: log gale_out_proj.weight Frobenius norms per block
+if cfg.geotransolver_gale:
+    _gale_norms = {}
+    _raw_model = _base_model._orig_mod if hasattr(_base_model, "_orig_mod") else _base_model
+    for _bi, _block in enumerate(_raw_model.blocks):
+        if hasattr(_block, "gale_out_proj"):
+            _norm = _block.gale_out_proj.weight.detach().float().norm().item()
+            _gale_norms[f"gale/block{_bi}_out_proj_norm_F"] = _norm
+            print(f"  GALE block {_bi}: ||gale_out_proj.weight||_F = {_norm:.4f}")
+    if _gale_norms:
+        wandb.summary.update(_gale_norms)
+
     print("\nGenerating flow field plots...")
     try:
         if cfg.swa_cyclic and swa_cyclic_model is not None:
@@ -2801,6 +2899,13 @@ if best_metrics:
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if cfg.te_coord_frame else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if cfg.te_coord_frame else None
+                    # GALE: fore/aft surface masks for visualization
+                    _fore_surf_mask_gale_vis = None
+                    _aft_surf_mask_gale_vis = None
+                    if cfg.geotransolver_gale:
+                        _raw_saf_norm_gale_vis = x_dev[:, :, 2:4].norm(dim=-1)
+                        _fore_surf_mask_gale_vis = is_surf_dev & (_raw_saf_norm_gale_vis <= 0.005)
+                        _aft_surf_mask_gale_vis = is_surf_dev & (_raw_saf_norm_gale_vis > 0.005)
                     x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                     curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                     if cfg.te_coord_frame:
@@ -2818,7 +2923,7 @@ if best_metrics:
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
-                    pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
+                    pred = vis_model({"x": x_n, "mask": mask, "fore_surf_mask": _fore_surf_mask_gale_vis, "aft_surf_mask": _aft_surf_mask_gale_vis})["preds"].float()
                     if cfg.raw_targets:
                         y_pred = (pred * raw_stats["y_std"] + raw_stats["y_mean"]).squeeze(0).cpu()
                     elif cfg.adaptive_norm:
@@ -2904,6 +3009,13 @@ if cfg.surface_refine and best_metrics:
                     _raw_aoa = x[:, 0, 14:15]
                     _raw_xy_te = x[:, :, :2].clone() if cfg.te_coord_frame else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if cfg.te_coord_frame else None
+                    # GALE: fore/aft surface masks for OOD-Re verify loop
+                    _fore_surf_mask_gale_r = None
+                    _aft_surf_mask_gale_r = None
+                    if cfg.geotransolver_gale:
+                        _raw_saf_norm_gale_r = x[:, :, 2:4].norm(dim=-1)
+                        _fore_surf_mask_gale_r = is_surface & (_raw_saf_norm_gale_r <= 0.005)
+                        _aft_surf_mask_gale_r = is_surface & (_raw_saf_norm_gale_r > 0.005)
                     x = (x - stats["x_mean"]) / stats["x_std"]
                     curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                     if cfg.foil2_dist:
@@ -2975,7 +3087,7 @@ if cfg.surface_refine and best_metrics:
 
                     # Model forward
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        out = verify_model({"x": x})
+                        out = verify_model({"x": x, "fore_surf_mask": _fore_surf_mask_gale_r, "aft_surf_mask": _aft_surf_mask_gale_r})
                         pred_raw = out["preds"].float()
                         hidden = out["hidden"].float()
 


### PR DESCRIPTION
## Hypothesis

The core OOD failure on p_tan is that NACA6416 (test) has different camber, chord and thickness distributions from NACA0012 (training). The backbone sees dsdf features that encode proximity to geometry, but no explicit geometric "shape identity" signal is injected into the global slice tokens. GeoTransolver (arXiv 2412.14171) showed that injecting a geometry latent into the Transolver attention blocks via cross-attention significantly improves OOD generalization on airfoil shape families.

**Mechanism:** Pool surface node features → fixed-size geometry latent vector (per foil) → cross-attend slice tokens against geometry latent at each TransolverBlock. The slice tokens now carry explicit shape conditioning, so the physics-attention routing adapts to the geometry being processed rather than relying solely on node-local dsdf features.

The TE coordinate frame (PR #2207, merged, -5.4% p_in) confirmed that adding explicit geometric reference signals helps OOD. This is the next level: instead of fixed geometric offsets, inject a **learned** geometric representation into the global routing mechanism.

**Source:** arXiv 2412.14171 (GeoTransolver), human team requested via issue #1926.

**Target:** p_tan primarily (NACA6416 OOD), secondarily p_oodc.

## Instructions

### Step 1: Add config flags

In the `Config` dataclass:
```python
geotransolver_gale: bool = False  # Geometry-latent cross-attention conditioning
gale_latent_dim: int = 32         # Geometry latent dimension per foil
```

### Step 2: Add the GeometryEncoder module

Add this new module near the other model classes:
```python
class GeometryEncoder(nn.Module):
    """Pool surface node features into a fixed-size geometry latent."""
    def __init__(self, in_dim, latent_dim):
        super().__init__()
        self.proj = nn.Sequential(
            nn.Linear(in_dim, latent_dim * 2),
            nn.GELU(),
            nn.Linear(latent_dim * 2, latent_dim),
        )
    def forward(self, surface_x, surface_mask):
        # surface_x: [B, N, D], surface_mask: [B, N] bool
        masked = surface_x * surface_mask.unsqueeze(-1).float()
        count = surface_mask.float().sum(1, keepdim=True).clamp(min=1)
        pooled = masked.sum(1) / count  # [B, D]
        return self.proj(pooled)  # [B, latent_dim]
```

Separately encode fore-foil and aft-foil surface nodes, concatenate → `geom_latent` of dim `2 * latent_dim`.

### Step 3: Add cross-attention to TransolverBlock

In `TransolverBlock.__init__`, add parameter `geotransolver_gale: bool = False` and `gale_latent_dim: int = 32`:
```python
self.geotransolver_gale = geotransolver_gale
if geotransolver_gale:
    gale_total_dim = gale_latent_dim * 2  # fore + aft foil latents concatenated
    self.gale_q_proj = nn.Linear(n_hidden, n_hidden)
    self.gale_k_proj = nn.Linear(gale_total_dim, n_hidden)
    self.gale_v_proj = nn.Linear(gale_total_dim, n_hidden)
    self.gale_out_proj = nn.Linear(n_hidden, n_hidden)
    # CRITICAL: Zero-init output projection so cross-attention starts as no-op
    nn.init.zeros_(self.gale_out_proj.weight)
    nn.init.zeros_(self.gale_out_proj.bias)
```

In `TransolverBlock.forward`, add a `geom_latent` parameter (default None). After the slice-attention (physics attention) step but BEFORE the FFN, apply geometry cross-attention:
```python
# After physics attention, before FFN:
if self.geotransolver_gale and geom_latent is not None:
    # geom_latent: [B, 2*latent_dim]
    # Apply cross-attention on the per-node hidden states fx directly:
    gale_q = self.gale_q_proj(fx)              # [B, N, D]
    gale_kv = geom_latent.unsqueeze(1)         # [B, 1, 2*latent_dim]
    gale_k = self.gale_k_proj(gale_kv)         # [B, 1, D]
    gale_v = self.gale_v_proj(gale_kv)         # [B, 1, D]
    cross_out = F.scaled_dot_product_attention(gale_q, gale_k, gale_v)  # [B, N, D]
    fx = fx + self.gale_out_proj(cross_out)    # additive, zero-init → no-op at start
```

**Important:** Cross-attention is between ALL node hidden states (queries) and a SINGLE geometry latent token (key/value). Computationally cheap — N×1 attention collapses to a linear projection scaled by attention weight.

**Also important:** The `adaln_all` code path (if present) also needs the same cross-attention insertion point. Check if there's a separate branch for `self.adaln_all` in the forward method and apply GALE there too.

### Step 4: Build geometry latent in the Transolver model

In `Transolver.__init__`, if `cfg.geotransolver_gale`:
```python
if cfg.geotransolver_gale:
    self.fore_geom_enc = GeometryEncoder(in_channels, cfg.gale_latent_dim)
    self.aft_geom_enc = GeometryEncoder(in_channels, cfg.gale_latent_dim)
```

In `Transolver.forward`, before the TransolverBlock loop, compute the geometry latent:
```python
if self.cfg.geotransolver_gale:
    # Use existing zone classification:
    # zone 1 = fore-foil surface, zone 2 = aft-foil surface
    fore_surf_mask = (zones == 1)  # [B, N]
    aft_surf_mask = (zones == 2)   # [B, N]
    
    fore_latent = self.fore_geom_enc(x, fore_surf_mask)  # [B, latent_dim]
    aft_latent = self.aft_geom_enc(x, aft_surf_mask)     # [B, latent_dim]
    geom_latent = torch.cat([fore_latent, aft_latent], dim=-1)  # [B, 2*latent_dim]
else:
    geom_latent = None
```

**For single-foil samples:** `aft_surf_mask` is all-False → aft encoder gets zero-pooled input → learns a "no aft foil" latent. This is correct — no special handling needed.

Pass `geom_latent` to each TransolverBlock:
```python
for block in self.blocks:
    fx = block(fx, ..., geom_latent=geom_latent)
```

### Step 5: Verify torch.compile compatibility

All ops (Linear, GELU, scaled_dot_product_attention, cat, masked sum) are torch.compile-safe. No dynamic shapes — geometry latent is always [B, 2*latent_dim]. Should compile cleanly.

### Step 6: Diagnostic logging

After training, log `||gale_out_proj.weight||_F` per block to W&B — reveals whether geometry conditioning learned to contribute or stayed near zero.

## Baseline

**Current single-model baseline (PR #2207, +TE Coordinate Frame, 2-seed avg):**

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **12.490** | < 12.49 |
| **p_oodc** | **7.618** | < 7.62 |
| **p_tan** | **28.521** | < 28.52 |
| **p_re** | **6.411** | < 6.41 |

W&B runs: obn1wfja (seed 42), 52irfwwg (seed 73).

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --wandb_name "thorfinn/baseline-te-coord" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame
```

## Experiment

**Run 1 — single seed validation:**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --wandb_name "thorfinn/geotransolver-gale-s42" \
  --wandb_group "geotransolver-gale" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame \
  --geotransolver_gale --gale_latent_dim 32 \
  --seed 42
```

**If seed 42 shows improvement, run seed 73:**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --wandb_name "thorfinn/geotransolver-gale-s73" \
  --wandb_group "geotransolver-gale" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame \
  --geotransolver_gale --gale_latent_dim 32 \
  --seed 73
```

## Implementation Notes

- **Zero-init is critical.** The `gale_out_proj` must be zero-initialized so the model starts exactly at baseline behavior. Without this, the random cross-attention output will break convergence.
- **Surface masks:** Use the existing zone classification (zone 1 = fore surface, zone 2 = aft surface). Check how `surface_mask` is constructed in the existing code — the SRF heads already separate fore vs aft foil nodes.
- **Single-foil samples:** The aft geometry encoder receives all-zero pooled input. This naturally produces a distinct "no aft foil" latent. No special handling needed.
- **VRAM:** Cross-attention adds ~75K parameters across 3 blocks. The N×1 attention pattern adds negligible compute. VRAM impact should be <1GB.
- **torch.compile:** All ops are compile-safe. No dynamic control flow, no variable-length sequences.
- **Diagnostic:** After training, report `||gale_out_proj.weight||_F` per block — reveals whether geometry conditioning learned to contribute.