### PR TITLE
Fore-SRF Skip: inject fore-foil mean hidden into AftSRF input

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1117,6 +1117,7 @@ class Config:
     # Phase 6: Dedicated aft-foil surface refinement head (boundary ID=7 nodes only)
     aft_foil_srf: bool = False               # enable second SRF head for aft-foil (ID=7) nodes
     aft_foil_srf_film: bool = False          # FiLM conditioning on gap/stagger for aft-foil head
+    aft_srf_fore_skip: bool = False          # inject fore-foil mean surface hidden into AftSRF input (zero-init)
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
@@ -1347,10 +1348,20 @@ if cfg.aft_foil_srf:
               f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, "
               f"film={cfg.aft_foil_srf_film})")
 
+# Fore-to-aft surface context projection (zero-init — fore skip connection)
+fore_to_aft_proj = None
+if cfg.aft_srf_fore_skip and aft_srf_head is not None:
+    fore_to_aft_proj = nn.Linear(cfg.n_hidden, cfg.n_hidden, bias=False).to(device)
+    nn.init.zeros_(fore_to_aft_proj.weight)
+    fore_to_aft_proj = torch.compile(fore_to_aft_proj, mode=cfg.compile_mode)
+    _proj_n = sum(p.numel() for p in fore_to_aft_proj.parameters())
+    print(f"Fore-to-aft skip projection: {_proj_n:,} params (zero-init)")
+
 from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
 ema_aft_srf_head = None  # EMA copy of aft-foil SRF head
+ema_fore_to_aft_proj = None  # EMA copy of fore-to-aft projection
 swad_initial_val = None
 swad_prev_val = float("inf")
 swad_checkpoints: list = []
@@ -1506,6 +1517,8 @@ if refine_head is not None:
 # Add aft-foil SRF head params to optimizer if enabled
 if aft_srf_head is not None:
     _aft_params = list(aft_srf_head.parameters())
+    if fore_to_aft_proj is not None:
+        _aft_params.extend(list(fore_to_aft_proj.parameters()))
     base_opt.add_param_group({'params': _aft_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _aft_params):,} aft-foil SRF head params to optimizer")
 if aft_srf_ctx_head is not None:
@@ -1888,6 +1901,19 @@ for epoch in range(MAX_EPOCHS):
             if aft_idx.numel() > 0:
                 aft_hidden = hidden[aft_idx[:, 0], aft_idx[:, 1]]  # [A, n_hidden]
                 aft_pred = pred[aft_idx[:, 0], aft_idx[:, 1]]      # [A, 3]
+                # Fore-foil skip: inject fore-foil mean surface hidden into aft hidden
+                if fore_to_aft_proj is not None:
+                    _fore_foil_mask = is_surface & (_raw_saf_norm <= 0.005) & _is_tandem.unsqueeze(1)
+                    enriched = aft_hidden.clone()
+                    for b in aft_idx[:, 0].unique():
+                        fore_b = _fore_foil_mask[b].nonzero(as_tuple=True)[0]
+                        if fore_b.numel() > 0:
+                            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                                fore_mean = hidden[b, fore_b].detach().mean(dim=0)  # [n_hidden]
+                                fore_ctx = fore_to_aft_proj(fore_mean)              # [n_hidden]
+                            b_mask = (aft_idx[:, 0] == b)
+                            enriched[b_mask] = enriched[b_mask] + fore_ctx.float()
+                    aft_hidden = enriched
                 # FiLM conditioning: expand gap/stagger per aft-foil node
                 _aft_cond = None
                 if cfg.aft_foil_srf_film:
@@ -2244,6 +2270,14 @@ for epoch in range(MAX_EPOCHS):
                     with torch.no_grad():
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _aft_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+            if fore_to_aft_proj is not None:
+                _fwd_base = fore_to_aft_proj._orig_mod if hasattr(fore_to_aft_proj, '_orig_mod') else fore_to_aft_proj
+                if ema_fore_to_aft_proj is None:
+                    ema_fore_to_aft_proj = deepcopy(_fwd_base)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_fore_to_aft_proj.parameters(), _fwd_base.parameters()):
+                            ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
             if aft_srf_ctx_head is not None:
                 _ctx_base = aft_srf_ctx_head._orig_mod if hasattr(aft_srf_ctx_head, '_orig_mod') else aft_srf_ctx_head
                 if ema_aft_srf_head is None:
@@ -2360,12 +2394,19 @@ for epoch in range(MAX_EPOCHS):
     # Select aft-foil SRF head for eval (EMA if available)
     eval_aft_srf_head = aft_srf_head
     eval_aft_srf_ctx_head = aft_srf_ctx_head
+    eval_fore_to_aft_proj = fore_to_aft_proj
     if aft_srf_head is not None:
         if ema_aft_srf_head is not None and ema_model is not None and eval_model is ema_model:
             eval_aft_srf_head = ema_aft_srf_head
             eval_aft_srf_head.eval()
         elif aft_srf_head is not None:
             aft_srf_head.eval()
+    if fore_to_aft_proj is not None:
+        if ema_fore_to_aft_proj is not None and ema_model is not None and eval_model is ema_model:
+            eval_fore_to_aft_proj = ema_fore_to_aft_proj
+            eval_fore_to_aft_proj.eval()
+        else:
+            fore_to_aft_proj.eval()
     if aft_srf_ctx_head is not None:
         if ema_aft_srf_head is not None and ema_model is not None and eval_model is ema_model:
             eval_aft_srf_ctx_head = ema_aft_srf_head
@@ -2547,6 +2588,19 @@ for epoch in range(MAX_EPOCHS):
                     aft_idx = _eval_aft_mask.nonzero(as_tuple=False)
                     if aft_idx.numel() > 0:
                         _ah = _eval_hidden[aft_idx[:, 0], aft_idx[:, 1]]
+                        # Fore-foil skip: inject fore-foil mean surface hidden into aft hidden
+                        if eval_fore_to_aft_proj is not None:
+                            _v_fore_mask = is_surface & (_v_saf_norm <= 0.005) & _v_is_tandem.unsqueeze(1)
+                            _ah_enriched = _ah.clone()
+                            for b in aft_idx[:, 0].unique():
+                                fore_b = _v_fore_mask[b].nonzero(as_tuple=True)[0]
+                                if fore_b.numel() > 0:
+                                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                                        fore_mean = _eval_hidden[b, fore_b].mean(dim=0)
+                                        fore_ctx = eval_fore_to_aft_proj(fore_mean)
+                                    b_mask = (aft_idx[:, 0] == b)
+                                    _ah_enriched[b_mask] = _ah_enriched[b_mask] + fore_ctx.float()
+                            _ah = _ah_enriched
                         _ap = pred_loss[aft_idx[:, 0], aft_idx[:, 1]]
                         _ac = _v_gap_stagger[aft_idx[:, 0]] if cfg.aft_foil_srf_film else None
                         with torch.amp.autocast("cuda", dtype=torch.bfloat16):


### PR DESCRIPTION
## Hypothesis

The **AftFoilRefinementHead** currently receives only aft-foil surface hidden states + base predictions as input. It has **no explicit access to the fore-foil's internal representation**, yet the aft-foil pressure (p_tan, p_oodc) is physically determined by the fore-foil's wake — its circulation, separation, and boundary layer state.

We hypothesize that injecting a **zero-init projection of the fore-foil mean surface hidden state** into the aft-foil hidden features before passing to AftSRF will let the correction head learn to condition on upstream wake conditions. This gives the head "upstream awareness" that it currently infers only indirectly through the Transolver backbone's attention mechanism.

**Physical motivation:** The aft-foil pressure distribution is a nonlinear function of the fore-foil's circulation (Kutta-Joukowski) and wake deficit (velocity defect at aft-foil leading edge). These are encoded in the fore-foil surface hidden states. The AftSRF correction — which specializes in wake-induced pressure anomalies — should benefit from direct access to these upstream signals.

**Why zero-init is safe:** The projection weight `W_fore` is initialized to zeros, so `fore_ctx = W_fore @ fore_mean = 0` at step 0. The enriched aft-foil hidden `aft_hidden + fore_ctx = aft_hidden` exactly. Training begins from baseline-equivalent behavior.

**Implementation is minimal:** No changes to `AftFoilRefinementHead` class architecture. A single `nn.Linear(n_hidden, n_hidden, bias=False)` projection (zero-init) is applied before passing to the existing head. Total new parameters: 384×384 = ~147K.

## Instructions

### Step 1: Add config flag

Add to the config dataclass (near `aft_foil_srf_film`):

```python
aft_srf_fore_skip: bool = False  # inject fore-foil mean surface hidden into AftSRF
```

### Step 2: Create and register the projection module

After the `aft_srf_head` creation block (around the `torch.compile(aft_srf_head, ...)` line), add:

```python
# Fore-to-aft surface context projection (zero-init — fore skip connection)
fore_to_aft_proj = None
if cfg.aft_srf_fore_skip and aft_srf_head is not None:
    fore_to_aft_proj = nn.Linear(cfg.n_hidden, cfg.n_hidden, bias=False).to(device)
    nn.init.zeros_(fore_to_aft_proj.weight)
    fore_to_aft_proj = torch.compile(fore_to_aft_proj, mode=cfg.compile_mode)
    _proj_n = sum(p.numel() for p in fore_to_aft_proj.parameters())
    print(f"Fore-to-aft skip projection: {_proj_n:,} params (zero-init)")
```

### Step 3: Add to optimizer parameter groups

Find where aft_srf_head parameters are added to the optimizer. Extend the same parameter list:

```python
if fore_to_aft_proj is not None:
    _aft_params.extend(list(fore_to_aft_proj.parameters()))
```

(If the optimizer uses a separate `add_param_group` call for aft_srf, add `fore_to_aft_proj` there. Match the LR of aft_srf_head.)

### Step 4: EMA tracking

Near `ema_aft_srf_head = None` (initialization), declare:

```python
ema_fore_to_aft_proj = None
```

In the EMA update loop (wherever `ema_aft_srf_head` is created/updated from `aft_srf_head`), add analogous lines for `fore_to_aft_proj` → `ema_fore_to_aft_proj`.

### Step 5: Enrich aft-foil hidden features in training forward pass

Find the training forward pass block that applies `aft_srf_head` (the `elif aft_srf_head is not None and model.training and _aft_foil_mask is not None:` block). After extracting `aft_hidden`:

```python
# Before the existing:
#   _aft_cond = None
#   if cfg.aft_foil_srf_film: ...
# Add:
if fore_to_aft_proj is not None:
    # Fore-foil surface = is_surface & saf_norm <= 0.005 (foil-1 nodes in tandem)
    _fore_foil_mask = is_surface & (_raw_saf_norm <= 0.005) & _is_tandem.unsqueeze(1)
    batch_ids = aft_idx[:, 0]
    enriched = aft_hidden.clone()
    for b in batch_ids.unique():
        fore_b = _fore_foil_mask[b].nonzero(as_tuple=True)[0]
        if fore_b.numel() > 0:
            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                fore_mean = hidden[b, fore_b].detach().mean(dim=0)  # [n_hidden]
                fore_ctx = fore_to_aft_proj(fore_mean)              # [n_hidden]
            b_mask = (batch_ids == b)
            enriched[b_mask] = enriched[b_mask] + fore_ctx.float()
    aft_hidden = enriched
```

**Important:** Use `.detach()` on the fore hidden to prevent gradient flow back into the backbone through this skip path. The projection itself receives gradients; the backbone does not get additional gradient signal via this path.

### Step 6: Apply the same enrichment in the validation/eval forward pass

Find where `ema_aft_srf_head` is used for validation predictions. Apply the same fore-foil enrichment using `ema_fore_to_aft_proj` instead of `fore_to_aft_proj`.

### Step 7: Add argparse flag

```python
parser.add_argument("--aft_srf_fore_skip", action="store_true",
                    help="Inject fore-foil mean surface hidden into AftSRF input (zero-init)")
```

### Step 8: Run experiments

**Trial A — seed 42:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/fore-srf-skip-s42" \
  --wandb_group "nezuko/fore-srf-additive-skip" \
  --aft_srf_fore_skip \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame \
  --seed 42
```

**Trial B — seed 73:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/fore-srf-skip-s73" \
  --wandb_group "nezuko/fore-srf-additive-skip" \
  --aft_srf_fore_skip \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame \
  --seed 73
```

Report W&B run IDs and final surface MAE for both seeds in a PR comment.

## Baseline

**Current baseline (PR #2207 — TE Coordinate Frame, 2-seed avg):**

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | 12.490   | < 12.49        |
| p_oodc | 7.618    | < 7.62         |
| p_tan  | 28.521   | < 28.52        |
| p_re   | 6.411    | < 6.41         |

W&B runs: obn1wfja (seed 42, p_tan=28.641, p_in=12.708), 52irfwwg (seed 73, p_tan=28.400, p_in=12.271)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-te-coord" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame
```