### PR TITLE
Slice Diversity Reg: Gram matrix orthogonality on slice attention

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -185,6 +185,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
                 nn.Linear(2 * dim_head, dim_head), nn.GELU(),
                 nn.Linear(dim_head, 1),
             )
+        self._div_loss = torch.tensor(0.0)  # slice diversity loss (populated in forward)
 
     def forward(self, x, spatial_bias=None, tandem_mask=None, zone_features=None):
         bsz, num_points, _ = x.shape
@@ -222,6 +223,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             # Apply slice mask: 0 for active slices, -1e9 for inactive (updated each epoch)
             slice_logits = slice_logits + self.slice_mask
         slice_weights = self.softmax(slice_logits)
+        # Slice diversity: Gram matrix orthogonality loss on slice profiles
+        # slice_weights: [B, H, N, S] — average over heads → [B, N, S]
+        w = slice_weights.mean(dim=1)  # [B, N, S]
+        w_norm = w / (w.norm(dim=1, keepdim=True) + 1e-6)  # L2-normalize over nodes
+        G = torch.bmm(w_norm.transpose(1, 2), w_norm)  # [B, S, S] cosine sim
+        eye = torch.eye(G.shape[-1], device=G.device, dtype=G.dtype).unsqueeze(0)
+        self._div_loss = ((G - eye) ** 2).mean()
         slice_norm = slice_weights.sum(2)
         slice_token = torch.einsum("bhnc,bhng->bhgc", fx_mid, slice_weights)
         slice_token = slice_token / ((slice_norm + 1e-5)[:, :, :, None].repeat(1, 1, 1, self.dim_head))
@@ -1124,6 +1132,8 @@ class Config:
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
+    slice_diversity_reg: bool = False       # Gram matrix orthogonality penalty on slice attention weights
+    slice_diversity_weight: float = 0.005   # weight for slice diversity regularization loss
 
 
 cfg = sp.parse(Config)
@@ -2052,6 +2062,20 @@ for epoch in range(MAX_EPOCHS):
             if _n_foils_dct > 0:
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
+
+        # Slice diversity regularization: penalize cosine similarity between slice profiles
+        if cfg.slice_diversity_reg and model.training:
+            _div_total = torch.tensor(0.0, device=device)
+            _n_blocks = 0
+            _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
+            for _blk in _base_model.blocks:
+                _div_total = _div_total + _blk.attn._div_loss.to(device)
+                _n_blocks += 1
+            if _n_blocks > 0:
+                _div_loss_avg = _div_total / _n_blocks
+                loss = loss + cfg.slice_diversity_weight * _div_loss_avg
+                if global_step % 50 == 0:
+                    wandb.log({"train/div_loss": _div_loss_avg.item(), "global_step": global_step})
 
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)


### PR DESCRIPTION
## Hypothesis

The Transolver physics-attention mechanism assigns each mesh node to slices via learned soft weights. If multiple slices converge to attend to the same spatial regions (slice collapse), the model wastes representational capacity. By penalizing the cosine similarity between different slice profiles using a Gram matrix orthogonality loss, we force each slice to specialize in a distinct spatial region — boundary layer, wake, freestream, suction peak, etc.

This is a pure loss-side change: **zero architecture modification, zero inference cost.** The penalty encourages diverse spatial decomposition during training, which should improve OOD generalization because each distinct physical phenomenon gets its own dedicated slice budget.

Related to multi-head attention diversity regularization (Li et al., 2018; "Improving Multi-Head Attention with Disagreement Regularization"), adapted for Transolver's slice-assignment attention.

**Confidence:** MEDIUM. Loss-side changes have a mixed track record, but the mechanism is orthogonal to all in-flight experiments and targets a structural capacity issue.

## Instructions

### Step 1: Add config flags

```python
# In Config dataclass in train.py:
slice_diversity_reg: bool = False
slice_diversity_weight: float = 0.005
```

### Step 2: Modify Physics_Attention_Irregular_Mesh.forward() to return diversity loss

The slice attention weights are computed in the Physics_Attention block as:
```python
slice_weights = self.slice_softmax(self.slice_linear(x_mid) / self.slice_temp)
# Shape: [B, H, N, slice_num]
```

After this line, compute diversity loss when enabled. Add a helper or inline the calculation:

```python
# Compute diversity loss from slice attention weights
# slice_weights: [B, H, N, S]
div_loss = torch.tensor(0.0, device=slice_weights.device)
if cfg.slice_diversity_reg:
    # Average over heads: [B, N, S]
    w = slice_weights.mean(dim=1)
    # L2-normalize each slice profile over nodes: [B, N, S]
    w_norm = w / (w.norm(dim=1, keepdim=True) + 1e-6)
    # Gram matrix of cosine similarities: [B, S, S]
    G = torch.bmm(w_norm.transpose(1, 2), w_norm)
    # Penalize off-diagonal entries (cosine sim between different slices should be 0)
    eye = torch.eye(G.shape[-1], device=G.device, dtype=G.dtype).unsqueeze(0)
    div_loss = ((G - eye) ** 2).mean()

# Modify the return of the attention block to include div_loss alongside the output
```

Pass `cfg` (or a boolean flag) into `Physics_Attention_Irregular_Mesh` so it can access `slice_diversity_reg`.

### Step 3: Accumulate diversity loss in TransolverIrregularMesh.forward()

In the block loop, accumulate losses:
```python
total_div_loss = 0.0
for block in self.blocks:
    fx, fx_deep, div_loss = block(fx, x, ...)  # unpack div_loss
    total_div_loss = total_div_loss + div_loss
```

After the block loop, add to total loss:
```python
if cfg.slice_diversity_reg:
    loss = loss + cfg.slice_diversity_weight * (total_div_loss / cfg.n_layers)
```

**torch.compile:** `bmm`, `norm`, `eye` are all compile-safe. No dynamic shapes or conditional tensor ops.

**VRAM impact:** Negligible — Gram matrix is [B=4, 96, 96] = 144KB per block.

### Step 4: Diagnostic check (2 epochs)

```bash
cd cfd_tandemfoil && python train.py --agent askeladd --debug \
  --slice_diversity_reg --slice_diversity_weight 0.005 \
  --wandb_name "askeladd/div-debug" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame
```

Verify: (1) No NaN/Inf, (2) div_loss logs cleanly to W&B, (3) torch.compile passes.

### Step 5: Run 2 seeds

```bash
cd cfd_tandemfoil && python train.py --agent askeladd --seed 42 \
  --wandb_name "askeladd/slice-diversity-reg-s42" --wandb_group "askeladd/slice-diversity-reg" \
  --slice_diversity_reg --slice_diversity_weight 0.005 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame
```

Seed 73: identical but `--seed 73 --wandb_name "askeladd/slice-diversity-reg-s73"`.

### Step 6: Optional variation (if time permits)

If both seeds finish, try λ=0.01 with seed 42:
```bash
--wandb_name "askeladd/slice-diversity-reg-w01-s42" --wandb_group "askeladd/slice-diversity-reg" \
--slice_diversity_reg --slice_diversity_weight 0.01
```

## Baseline

Current best (PR #2207, TE Coordinate Frame, 2-seed avg):

| Metric | Baseline | Target |
|--------|----------|--------|
| p_in   | 12.490   | < 12.490 |
| p_tan  | **28.521** | **< 28.521** |
| p_oodc | 7.618    | < 7.618 |
| p_re   | 6.411    | < 6.411 |

W&B runs: obn1wfja (seed 42, p_tan=28.641), 52irfwwg (seed 73, p_tan=28.400).

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd --wandb_name "askeladd/baseline-te-coord" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame
```