### PR TITLE
mHC Learnable Residual Mixing: per-sublayer alpha/beta scale in TransolverBlock

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -377,8 +377,10 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        mhc_residuals=False,
     ):
         super().__init__()
+        self.mhc_residuals = mhc_residuals
         self.last_layer = last_layer
         self.field_decoder = field_decoder
         self.domain_velhead = domain_velhead
@@ -435,6 +437,12 @@ class TransolverBlock(nn.Module):
         self.se_fc2 = nn.Linear(hidden_dim // 4, hidden_dim)
         nn.init.zeros_(self.se_fc2.weight)
         nn.init.zeros_(self.se_fc2.bias)
+        if mhc_residuals:
+            # Learnable residual mixing: x_out = alpha * x + beta * F(x)
+            self.attn_alpha = nn.Parameter(torch.ones(1))
+            self.attn_beta = nn.Parameter(torch.ones(1))
+            self.mlp_alpha = nn.Parameter(torch.ones(1))
+            self.mlp_beta = nn.Parameter(torch.ones(1))
         if self.last_layer:
             self.ln_3 = nn.LayerNorm(hidden_dim)
             if soft_moe:
@@ -498,12 +506,28 @@ class TransolverBlock(nn.Module):
             cond_out = self.adaln_net(condition)  # [B, H*4]
             s1, b1, s2, b2 = cond_out.chunk(4, dim=-1)  # each [B, H]
             fx_norm = _ln(self.ln_1, fx) * (1 + s1.unsqueeze(1)) + b1.unsqueeze(1)
-            fx = _ln(self.ln_1_post, self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
+            attn_out = self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features)
+            if self.mhc_residuals:
+                fx = _ln(self.ln_1_post, self.attn_alpha * fx + self.attn_beta * attn_out)
+            else:
+                fx = _ln(self.ln_1_post, attn_out + fx)
             fx_norm = _ln(self.ln_2, fx) * (1 + s2.unsqueeze(1)) + b2.unsqueeze(1)
-            fx = _ln(self.ln_2_post, self.mlp(fx_norm) + fx)
+            mlp_out = self.mlp(fx_norm)
+            if self.mhc_residuals:
+                fx = _ln(self.ln_2_post, self.mlp_alpha * fx + self.mlp_beta * mlp_out)
+            else:
+                fx = _ln(self.ln_2_post, mlp_out + fx)
         else:
-            fx = _ln(self.ln_1_post, self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
-            fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
+            attn_out = self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features)
+            if self.mhc_residuals:
+                fx = _ln(self.ln_1_post, self.attn_alpha * fx + self.attn_beta * attn_out)
+            else:
+                fx = _ln(self.ln_1_post, attn_out + fx)
+            mlp_out = self.mlp(_ln(self.ln_2, fx))
+            if self.mhc_residuals:
+                fx = _ln(self.ln_2_post, self.mlp_alpha * fx + self.mlp_beta * mlp_out)
+            else:
+                fx = _ln(self.ln_2_post, mlp_out + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
@@ -794,6 +818,7 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        mhc_residuals=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -866,6 +891,7 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    mhc_residuals=mhc_residuals,
                 )
                 for idx in range(n_layers)
             ]
@@ -1170,6 +1196,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    mhc_residuals: bool = False             # learnable alpha/beta residual weights per sublayer (hyper-connection mixing)
 
 
 cfg = sp.parse(Config)
@@ -1330,6 +1357,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    mhc_residuals=cfg.mhc_residuals,
 )
 
 model = Transolver(**model_config).to(device)
@@ -2767,6 +2795,13 @@ for epoch in range(MAX_EPOCHS):
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f
+    if cfg.mhc_residuals:
+        for i, block in enumerate(_base_model.blocks):
+            if hasattr(block, 'attn_alpha'):
+                metrics[f"block{i}/attn_alpha"] = block.attn_alpha.item()
+                metrics[f"block{i}/attn_beta"] = block.attn_beta.item()
+                metrics[f"block{i}/mlp_alpha"] = block.mlp_alpha.item()
+                metrics[f"block{i}/mlp_beta"] = block.mlp_beta.item()
     wandb.log(metrics)
 
     if torch.cuda.is_available():


### PR DESCRIPTION
## Hypothesis

The Transolver uses fixed residual connections `x_out = x + F(x)` in each block, with a fixed `skip_gate` that is initialized to approximate identity. This leaves no freedom for the optimizer to calibrate the **relative contribution of the skip path vs. the transformation path** on a per-block, per-sublayer basis.

Replacing fixed residuals with learnable scalar weights `x_out = alpha * x + beta * F(x)` (initialized at alpha=1, beta=1) gives 12 additional parameters (4 per block × 3 blocks) that the optimizer can use to:
1. Learn that early blocks (geometry encoding) need high skip weight (alpha near 1)
2. Learn that later blocks (global physics) may benefit from lower skip weight (alpha < 1, more transformation)
3. Enable per-block calibration for OOD generalization (NACA6416 vs NACA0012 may require different depth dynamics)

This is the **hyper-connection / learnable residual mixing** concept, explicitly requested by the human research team (GitHub Issue #1926). The safe (1, 1) initialization means epoch 0 is **identical to baseline** — zero regression risk.

**Expected improvement:** -1 to -3% p_oodc (OOD condition target), with possible p_tan improvement from better block depth calibration.

## Instructions

### 1. Add argparse flag

```python
parser.add_argument('--mhc_residuals', action='store_true', default=False,
                    help='Learnable alpha/beta residual weights per sublayer (hyper-connection mixing)')
```

### 2. Modify TransolverBlock

In `TransolverBlock.__init__`, add after the existing skip_gate:

```python
if getattr(cfg, 'mhc_residuals', False):
    # 4 learnable scalars per block: attn skip/transform + MLP skip/transform
    self.attn_alpha = nn.Parameter(torch.ones(1))   # attn sublayer: skip weight
    self.attn_beta  = nn.Parameter(torch.ones(1))   # attn sublayer: transform weight
    self.mlp_alpha  = nn.Parameter(torch.ones(1))   # MLP sublayer: skip weight
    self.mlp_beta   = nn.Parameter(torch.ones(1))   # MLP sublayer: transform weight
```

In `TransolverBlock.forward`, find the two residual additions (attention sublayer and MLP sublayer). Replace:

```python
# BEFORE (approximate identity via biased sigmoid skip_gate):
# fx = skip_gate(fx) * fx + attn_out

# AFTER:
if cfg.mhc_residuals:
    fx = self.attn_alpha * fx + self.attn_beta * attn_out
else:
    fx = skip_gate(fx) * fx + attn_out  # original

# Similarly for the MLP sublayer:
if cfg.mhc_residuals:
    fx = self.mlp_alpha * fx + self.mlp_beta * mlp_out
else:
    fx = skip_gate(fx) * fx + mlp_out  # original
```

**Implementation note:** Look at the actual `TransolverBlock.forward` code carefully — the exact variable names (`fx`, `attn_out`, `mlp_out`) may differ. The pattern to identify is the two `+` operations that add the sublayer output back to the running representation. Replace each with the alpha/beta version.

### 3. Monitor in W&B

Log the alpha/beta values for each block so we can see what the optimizer learns:
```python
# In training loop, log periodically:
for i, block in enumerate(model.blocks):
    if cfg.mhc_residuals:
        wandb.log({
            f'block{i}/attn_alpha': block.attn_alpha.item(),
            f'block{i}/attn_beta': block.attn_beta.item(),
            f'block{i}/mlp_alpha': block.mlp_alpha.item(),
            f'block{i}/mlp_beta': block.mlp_beta.item(),
        })
```

### 4. Run commands (2 seeds)

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/mhc-residuals-s42" --wandb_group "edward/mhc-residuals" \
  --mhc_residuals \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature

# Seed 73: same with --seed 73 --wandb_name "edward/mhc-residuals-s73"
```

**Watch for:** If alpha or beta → 0 (one path killed), that is valid and interpretable. If val/loss diverges in epochs 1-3, try init alpha=1.0, beta=0.5 as a conservative alternative.

## Baseline

**Current best (PR #2213 — Wake Deficit Feature, 2-seed avg):**

| Metric | Value | Merge threshold |
|--------|-------|-----------------|
| p_in | **11.979** | < 11.98 |
| p_oodc | **7.643** | < 7.65 |
| p_tan | **28.341** | < 28.34 |
| p_re | **6.300** | < 6.30 |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```