### PR TITLE
Surface Arc-Length PE: curvilinear position encoding for surface nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,53 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_surface_arc_length(raw_xy, is_surface, saf_norm):
+    """Compute normalized arc-length from LE for surface nodes.
+
+    For each foil (fore/aft), sorts surface nodes by angle from centroid to get
+    a consistent LE-to-TE ordering, then computes cumulative arc-length normalized
+    to [0, 1]. Volume nodes get 0.
+
+    Args:
+        raw_xy:     [B, N, 2] raw (pre-standardization) x, y coordinates
+        is_surface: [B, N] bool
+        saf_norm:   [B, N] norm of raw saf channels
+
+    Returns: [B, N, 1] arc-length feature
+    """
+    B, N, _ = raw_xy.shape
+    arc = torch.zeros(B, N, device=raw_xy.device)
+
+    fore_surf = is_surface & (saf_norm <= 0.005)
+    aft_surf = is_surface & (saf_norm > 0.005)
+
+    for foil_mask in [fore_surf, aft_surf]:
+        for b in range(B):
+            idx = foil_mask[b].nonzero(as_tuple=True)[0]
+            if len(idx) < 3:
+                continue
+            pts = raw_xy[b, idx, :]  # [K, 2]
+
+            # Sort by angle from centroid for consistent ordering
+            centroid = pts.mean(0)
+            angles = torch.atan2(pts[:, 1] - centroid[1], pts[:, 0] - centroid[0])
+            order = angles.argsort()
+            pts_sorted = pts[order]
+
+            # Cumulative arc-length (include wrap-around from last to first)
+            diffs = pts_sorted[1:] - pts_sorted[:-1]
+            seg_len = diffs.norm(dim=-1)
+            cumlen = torch.cat([torch.zeros(1, device=raw_xy.device), seg_len.cumsum(0)])
+            total = cumlen[-1].clamp(min=1e-6)
+            s = cumlen / total  # [K] in [0, 1]
+
+            # Un-sort and assign
+            unsort = order.argsort()
+            arc[b, idx] = s[unsort]
+
+    return arc.unsqueeze(-1)  # [B, N, 1]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1170,6 +1217,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    surface_arc_length_pe: bool = False     # arc-length from LE (normalized by chord) for surface nodes (+1 input channel)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1348,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.surface_arc_length_pe else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+arc_pe], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1761,8 +1809,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        # TE coordinate frame / wake deficit / arc-length PE: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_arc_length_pe
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1794,6 +1842,9 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        if cfg.surface_arc_length_pe:
+            arc_pe = compute_surface_arc_length(_raw_xy_te, is_surface, _raw_saf_norm_te)
+            x = torch.cat([x, arc_pe], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,7 +2504,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_arc_length_pe
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2484,6 +2535,9 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                if cfg.surface_arc_length_pe:
+                    arc_pe = compute_surface_arc_length(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                    x = torch.cat([x, arc_pe], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2867,7 +2921,7 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
-                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_arc_length_pe
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
                     _raw_gap_wake_vis = x_dev[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2888,6 +2942,9 @@ if best_metrics:
                             wake_feats_vis = compute_wake_deficit_features(
                                 _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis)
                             x_n = torch.cat([x_n, wake_feats_vis], dim=-1)
+                    if cfg.surface_arc_length_pe:
+                        arc_pe_vis = compute_surface_arc_length(_raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis)
+                        x_n = torch.cat([x_n, arc_pe_vis], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
@@ -2982,7 +3039,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_arc_length_pe
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3006,6 +3063,9 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    if cfg.surface_arc_length_pe:
+                        arc_pe_vv = compute_surface_arc_length(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                        x = torch.cat([x, arc_pe_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

The TE coordinate frame (PR #2207, -5.4% p_in) proved that explicit geometric reference frame features dramatically improve predictions. That feature provides **radial information** (how far from the TE, in x and y). 

The orthogonal question is: **where along the airfoil surface is this node?** Arc-length from the leading edge, normalized by chord, provides the curvilinear surface coordinate `s ∈ [0, 1]` — the canonical parameterization aerodynamicists use for Cp curves. This is NOT inferrable from DSDF features (which encode distance TO the surface, not ALONG it).

**Physical motivation:**
- For NACA6416 OOD: the leading-edge suction peak occurs at a different chordwise position than NACA0012 due to camber. Arc-length PE (s ∈ [0,1] normalized by chord) is **invariant to chord scale differences** between the two airfoil families.
- The DSDF features (channels 2-5) encode shortest distance to the surface but do not encode where on the surface the nearest point is. Arc-length fills this gap.
- Following TE coord frame success: the model now knows "how far from the TE" (radial). Arc-length PE tells it "how far along the surface from the LE" (curvilinear). Together they triangulate surface location precisely.

**Expected improvement:** -1 to -3% p_oodc (OOD Cp distribution), -0.5 to -2% p_tan.

## Instructions

### 1. Add argparse flag

```python
parser.add_argument('--surface_arc_length_pe', action='store_true', default=False,
                    help='Add arc-length from LE (normalized by chord) as input feature for surface nodes')
```

### 2. Implement in `Transolver.forward` (after the wake_deficit_feature block, before `preprocess` GatedMLP2)

```python
if cfg.surface_arc_length_pe:
    # Surface node masks (boundary_id 5/6 = fore-foil, 7 = aft-foil)
    fore_surf = (boundary_id == 5) | (boundary_id == 6)  # [B, N]
    aft_surf = (boundary_id == 7)  # [B, N]

    xy = x[:, :, 0:2]  # [B, N, 2] node coordinates

    def compute_arc_length(surf_mask):
        """Compute normalized arc-length for surface nodes.
        Returns [B, N] with arc-length in [0,1] for surface nodes, 0 for volume nodes."""
        B, N = surf_mask.shape
        arc = torch.zeros(B, N, device=x.device)

        for b in range(B):
            idx = surf_mask[b].nonzero(as_tuple=True)[0]  # surface node indices
            if len(idx) == 0:
                continue
            pts = xy[b, idx, :]  # [K, 2]

            # Sort by angle from centroid (robust LE-to-TE ordering)
            centroid = pts.mean(0)
            angles = torch.atan2(pts[:, 1] - centroid[1], pts[:, 0] - centroid[0])
            order = angles.argsort()
            pts_sorted = pts[order]

            # Cumulative arc-length
            diffs = pts_sorted[1:] - pts_sorted[:-1]
            seg_len = diffs.norm(dim=-1)
            cumlen = torch.cat([torch.zeros(1, device=x.device), seg_len.cumsum(0)])
            total = cumlen[-1].clamp(min=1e-6)
            s = cumlen / total  # [K] in [0, 1]

            # Un-sort and assign
            unsort = order.argsort()
            arc[b, idx] = s[unsort]
        return arc

    arc_fore = compute_arc_length(fore_surf)  # [B, N]
    arc_aft = compute_arc_length(aft_surf)    # [B, N]
    arc_total = arc_fore + arc_aft  # non-overlapping masks, so sum is correct
    x = torch.cat([x, arc_total.unsqueeze(-1)], dim=-1)  # [B, N, D+1]
```

**Implementation note on n_x:** The `n_x` variable controls the input dimension for `preprocess` Linear. Add `n_x += 1` when `--surface_arc_length_pe` is enabled, alongside the existing `te_coord_frame` and `wake_deficit_feature` adjustments.

**Performance note:** The per-sample loop above is correct but slow for large batches. Vectorize if possible, but correctness is more important than speed for the first run. The loop processes ~batch_size=4 samples, each with ~150 surface nodes — overhead should be manageable.

**Alternative faster implementation:** Sort surface nodes by x-coordinate (instead of angle from centroid) as a simpler proxy for LE-to-TE ordering. This works for NACA airfoils where LE is at x_min and TE is at x_max. Upper and lower surfaces can be separated by sign of y:

```python
# Simpler alternative: x-coord based sorting for NACA foils
for b in range(B):
    idx = surf_mask[b].nonzero(as_tuple=True)[0]
    if len(idx) == 0:
        continue
    pts = xy[b, idx, :]
    # Sort by x (LE to TE)
    order = pts[:, 0].argsort()
    pts_sorted = pts[order]
    diffs = pts_sorted[1:] - pts_sorted[:-1]
    seg_len = diffs.norm(dim=-1)
    cumlen = torch.cat([torch.zeros(1, device=x.device), seg_len.cumsum(0)])
    s = cumlen / cumlen[-1].clamp(min=1e-6)
    unsort = order.argsort()
    arc[b, idx] = s[unsort]
```

Use whichever approach produces sensible arc-length values. Check that s values are in [0,1] and vary smoothly along the surface.

### 3. Run commands (2 seeds)

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent fern --seed 42 \
  --wandb_name "fern/surface-arc-pe-s42" --wandb_group "fern/surface-arc-length-pe" \
  --surface_arc_length_pe \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature

# Seed 73: same with --seed 73 --wandb_name "fern/surface-arc-pe-s73"
```

## Baseline

**Current best (PR #2213 — Wake Deficit Feature, 2-seed avg):**

| Metric | Value | Merge threshold |
|--------|-------|-----------------|
| p_in | **11.979** | < 11.98 |
| p_oodc | **7.643** | < 7.65 |
| p_tan | **28.341** | < 28.34 |
| p_re | **6.300** | < 6.30 |

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```