### PR TITLE
Bernoulli Consistency Loss: physics coupling for p + 0.5|u|² = C

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    bernoulli_loss: bool = False            # soft Bernoulli consistency auxiliary loss on surface nodes
+    bernoulli_weight: float = 0.01         # weight for Bernoulli consistency loss
 
 
 cfg = sp.parse(Config)
@@ -1226,6 +1228,56 @@ def _phys_denorm(y_p, Umag, q):
     y[:, :, 1:2] = y_p[:, :, 1:2].clamp(-10, 10) * Umag
     y[:, :, 2:3] = y_p[:, :, 2:3].clamp(-20, 20) * q
     return y
+
+
+def bernoulli_consistency_loss_fn(pred, sample_stds, freestream, phys_y_mean, phys_y_std,
+                                   is_surface, asinh_scale, weight):
+    """Soft Bernoulli consistency loss: Cp + (Ux/Umag)^2 + (Uy/Umag)^2 ≈ 1.0 on surface nodes.
+
+    Inverts the normalization pipeline to recover Cp-space predictions, then penalizes
+    deviation from the inviscid Bernoulli relation. Serves as a soft physics prior
+    coupling the pressure and velocity heads via gradient.
+
+    Args:
+        pred: [B, N, 3] — model predictions in normalized residual/sample_std space
+        sample_stds: [B, 1, 3] — per-sample std normalization factors
+        freestream: [B, 1, 3] or None — freestream offset in normalized space
+        phys_y_mean: [3] — phys_stats channel means
+        phys_y_std: [3] — phys_stats channel stds
+        is_surface: [B, N] bool — surface node mask
+        asinh_scale: float — asinh transform scale
+        weight: float — loss weight
+    """
+    if not is_surface.any():
+        return torch.tensor(0.0, device=pred.device)
+
+    # Invert normalization pipeline:
+    #   pred = (phys_normed - freestream) / sample_stds
+    #   phys_normed = (asinh_space - phys_mean) / phys_std
+    #   asinh_space: [Ux/Umag, Uy/Umag, asinh(Cp * scale)]
+    pred_unnorm = pred * sample_stds          # undo per-sample std [B, N, 3]
+    if freestream is not None:
+        pred_unnorm = pred_unnorm + freestream  # add residual offset back [B, N, 3]
+    # Undo phys_stats standardization
+    pred_asinh = pred_unnorm * phys_y_std + phys_y_mean  # [B, N, 3]
+
+    ux_norm = pred_asinh[..., 0]   # Ux/Umag [B, N]
+    uy_norm = pred_asinh[..., 1]   # Uy/Umag [B, N]
+    asinh_cp = pred_asinh[..., 2]  # asinh(Cp * scale) [B, N]
+
+    # Invert asinh: asinh(Cp * scale) → Cp
+    cp = torch.sinh(asinh_cp) / asinh_scale  # Cp = p/(0.5*Umag^2) [B, N]
+
+    # Bernoulli in Cp-space: Cp + (Ux/Umag)^2 + (Uy/Umag)^2 = 1.0 (inviscid)
+    # At stagnation: Cp=1.0, Ux=Uy=0 → sum=1.0 ✓
+    # At far field: Cp=0, cos^2+sin^2=1 → sum=1.0 ✓
+    # At viscous wall: Ux≈Uy≈0, so Cp should approach stagnation value — soft prior only
+    bern_residual = cp + ux_norm ** 2 + uy_norm ** 2 - 1.0  # [B, N]
+
+    # Apply only on surface nodes
+    surf_residuals = bern_residual[is_surface]  # [M]
+    return weight * (surf_residuals ** 2).mean()
+
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=cfg.num_workers, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
@@ -2110,6 +2162,21 @@ for epoch in range(MAX_EPOCHS):
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
 
+        # Bernoulli consistency auxiliary loss on surface nodes
+        _bern_loss = torch.tensor(0.0, device=device)
+        if cfg.bernoulli_loss and model.training and cfg.asinh_pressure and not cfg.adaptive_norm and not cfg.raw_targets:
+            _bern_loss = bernoulli_consistency_loss_fn(
+                pred=pred,
+                sample_stds=sample_stds,
+                freestream=_freestream,
+                phys_y_mean=phys_stats["y_mean"].unsqueeze(0).unsqueeze(0),
+                phys_y_std=phys_stats["y_std"].unsqueeze(0).unsqueeze(0),
+                is_surface=surf_mask,
+                asinh_scale=cfg.asinh_scale,
+                weight=cfg.bernoulli_weight,
+            )
+            loss = loss + _bern_loss
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -2136,8 +2203,9 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            bern_shared = _bern_loss * 0.5 if _bern_loss.item() > 0 else 0.0
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + bern_shared
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + bern_shared
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2182,7 +2250,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                bern_shared = _bern_loss * 0.5 if _bern_loss.item() > 0 else 0.0
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + bern_shared
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2310,7 +2379,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _wandb_step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.bernoulli_loss:
+            _wandb_step_log["train/bernoulli_loss"] = _bern_loss.item()
+        wandb.log(_wandb_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The model predicts pressure (p) and velocity (Ux, Uy) as separate outputs with no explicit coupling between them. But for incompressible steady flow, these are coupled by the Bernoulli equation along a streamline:

```
p + 0.5 * (Ux² + Uy²) = p_total  (constant along streamline)
```

At the airfoil surface, the no-penetration condition reduces this to a relationship between wall pressure and tangential velocity. The current architecture uses a pressure-first sequential decoder (`--pressure_first --pressure_deep`) that conditions velocity on pressure predictions — but this coupling only exists in the forward pass, not in the loss. Adding a soft Bernoulli consistency auxiliary loss on surface nodes would make the p→u coupling explicit at the gradient level, providing physically-grounded signal that couples the two heads.

This is distinct from the failed Normal-Velocity Hard Constraint (PR #2187, hard-enforce u_n=0). A **soft** auxiliary loss is far less likely to destabilize training.

**Expected gains:** -1% to -3% p_in and surface velocity. The coupling may also improve p_tan if TE velocity prediction becomes more consistent with TE pressure.

## Instructions

Add a Bernoulli consistency auxiliary loss on surface nodes. The loss penalizes deviation of the model's own (p, Ux, Uy) predictions from the Bernoulli equation — no ground-truth labels needed.

### Step 1: Implement the Bernoulli loss

The pressure is predicted in asinh-transformed space (`--asinh_pressure --asinh_scale 0.75`). Invert the transform to get physical pressure before applying Bernoulli. Velocity predictions are in linear (un-transformed) space.

```python
def bernoulli_consistency_loss(pred_uvp, is_surface, Umag, asinh_scale, weight):
    """
    pred_uvp: [B, N, 3] — predicted (Ux, Uy, p) in model space
    is_surface: [B, N] bool — surface node mask
    Umag: [B] — freestream velocity magnitude per sample
    asinh_scale: float — the asinh transform scale factor
    weight: float — loss weight
    """
    if not is_surface.any():
        return torch.tensor(0.0, device=pred_uvp.device)

    ux = pred_uvp[..., 0]  # [B, N] — linear space
    uy = pred_uvp[..., 1]  # [B, N] — linear space
    p_transformed = pred_uvp[..., 2]  # [B, N] — asinh space

    # Invert asinh transform to physical pressure
    p_phys = torch.sinh(p_transformed / asinh_scale) * asinh_scale

    # Stagnation pressure: p_total = 0.5 * Umag^2 (inlet dynamic pressure, normalized)
    p_total = 0.5 * (Umag ** 2).unsqueeze(-1)  # [B, 1]

    # Bernoulli residual on surface nodes only
    q = 0.5 * (ux ** 2 + uy ** 2)
    bern_residual = (p_phys + q - p_total)[is_surface]  # should be ~0
    return weight * (bern_residual ** 2).mean()
```

### Step 2: Add CLI flags

```python
parser.add_argument('--bernoulli_loss', action='store_true')
parser.add_argument('--bernoulli_weight', type=float, default=0.01)
```

### Step 3: Call in training loop

After `pred_uvp` is computed in `train_step`, add:

```python
if cfg.bernoulli_loss:
    bern_l = bernoulli_consistency_loss(
        pred_uvp, is_surface, batch_Umag, cfg.asinh_scale, cfg.bernoulli_weight
    )
    loss = loss + bern_l
    # Log: metrics['train/bernoulli_loss'] = bern_l.item()
```

**Check how Umag is available per-sample.** It may be stored in the batch dict (e.g. `batch['Umag']`, `batch['vel_mag']`) or derivable from the boundary conditions. If not directly available, approximate from the inlet velocity features or from the AoA + freestream scalar. Inspect the batch structure in `train.py` to find it — it must exist since the model uses freestream conditions.

Ensure `pred_uvp` is the **non-EMA** model's output (not the EMA snapshot), so gradients flow through the Bernoulli loss.

### Step 4: Run experiments

```bash
# Primary run — bernoulli_weight=0.01, seed 42
cd cfd_tandemfoil && python train.py \
  --agent thorfinn --wandb_name "thorfinn/bernoulli-w0.01-s42" \
  --wandb_group bernoulli-consistency-loss \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --bernoulli_loss --bernoulli_weight 0.01 \
  --seed 42

# Run seed 73 with identical flags (change seed and wandb_name)
```

If seed 42 shows improvement, run weight=0.001 and weight=0.05 under the same `--wandb_group` to assess sensitivity. The `train/bernoulli_loss` should stay below ~10% of the main surface loss — if it dominates, reduce weight.

### Monitoring in W&B

Log `train/bernoulli_loss` every step. Key checks:
- Is the Bernoulli loss decreasing over training? (Model becoming more physically consistent)
- Does high Bernoulli loss correlate with high surface MAE samples?
- At convergence, what is the typical residual magnitude?

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed avg):

| Metric | Value | Merge threshold |
|--------|-------|-----------------|
| **p_in** | **11.979** | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| **p_tan** | **28.341** | < 28.34 |
| **p_re** | **6.300** | < 6.30 |

W&B: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

Reproduce baseline:
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```