### PR TITLE
Tandem Feature Cross: config-aware sigmoid gate on encoded features

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1114,6 +1114,7 @@ class Config:
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
+    tandem_feature_cross: bool = False   # config-aware sigmoid gate on encoded features (conditioned on gap/stagger/Re/AoA)
     dct_freq_loss: bool = False   # DCT frequency-weighted auxiliary loss on surface pressure
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
@@ -1338,6 +1339,21 @@ torch._functorch.config.donated_buffer = False  # required for retain_graph=True
 model = torch.compile(model, mode=cfg.compile_mode)
 _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 
+# Tandem feature cross gate: sigmoid gate on encoded features conditioned on (gap, stagger, Re, AoA)
+tandem_gate = None
+if cfg.tandem_feature_cross:
+    _gate_output_dim = _base_model.feature_cross.in_features  # fun_dim + space_dim
+    tandem_gate = nn.Sequential(
+        nn.Linear(4, 32),
+        nn.GELU(),
+        nn.Linear(32, _gate_output_dim),
+    ).to(device)
+    nn.init.zeros_(tandem_gate[-1].weight)
+    nn.init.constant_(tandem_gate[-1].bias, 5.0)  # sigmoid(5) ≈ 0.993 → near-identity gate
+    tandem_gate = torch.compile(tandem_gate, mode=cfg.compile_mode)
+    _gate_n = sum(p.numel() for p in tandem_gate.parameters())
+    print(f"Tandem feature cross gate: {_gate_n:,} params (out_dim={_gate_output_dim}, sigmoid(5) init)")
+
 # Surface refinement head (separate module, not compiled with main model)
 refine_head = None
 if cfg.surface_refine:
@@ -1397,6 +1413,7 @@ from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
 ema_aft_srf_head = None  # EMA copy of aft-foil SRF head
+ema_tandem_gate = None  # EMA copy of tandem feature cross gate
 swad_initial_val = None
 swad_prev_val = float("inf")
 swad_checkpoints: list = []
@@ -1558,6 +1575,10 @@ if aft_srf_ctx_head is not None:
     _ctx_params = list(aft_srf_ctx_head.parameters())
     base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
+if tandem_gate is not None:
+    _gate_params = list(tandem_gate.parameters())
+    base_opt.add_param_group({'params': _gate_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _gate_params):,} tandem gate params to optimizer")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
@@ -1758,6 +1779,15 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        # Tandem gate: save raw config scalars before normalization
+        _raw_gate_scalars = None
+        if tandem_gate is not None:
+            _raw_gate_scalars = torch.stack([
+                x[:, 0, 22].float(),  # gap (raw)
+                x[:, 0, 23].float(),  # stagger (raw)
+                x[:, 0, 13].float(),  # log(Re) (raw)
+                x[:, 0, 14].float(),  # AoA (raw)
+            ], dim=-1)  # [B, 4]
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
@@ -1804,6 +1834,11 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
+        # Tandem feature cross: apply sigmoid gate conditioned on (gap, stagger, Re, AoA)
+        if tandem_gate is not None and _raw_gate_scalars is not None:
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                gate_vals = torch.sigmoid(tandem_gate(_raw_gate_scalars.to(device)))  # [B, D]
+            x = x * gate_vals[:, None, :].float()
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -2309,6 +2344,14 @@ for epoch in range(MAX_EPOCHS):
                     with torch.no_grad():
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+            if tandem_gate is not None:
+                _gate_base = tandem_gate._orig_mod if hasattr(tandem_gate, '_orig_mod') else tandem_gate
+                if ema_tandem_gate is None:
+                    ema_tandem_gate = deepcopy(_gate_base)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_tandem_gate.parameters(), _gate_base.parameters()):
+                            ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 
@@ -2429,6 +2472,13 @@ for epoch in range(MAX_EPOCHS):
             eval_aft_srf_ctx_head.eval()
         else:
             aft_srf_ctx_head.eval()
+    eval_tandem_gate = tandem_gate
+    if tandem_gate is not None:
+        if ema_tandem_gate is not None and ema_model is not None and eval_model is ema_model:
+            eval_tandem_gate = ema_tandem_gate
+            eval_tandem_gate.eval()
+        else:
+            tandem_gate.eval()
     val_metrics_per_split: dict[str, dict] = {}
     val_loss_sum = 0.0
 
@@ -2453,6 +2503,15 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
+                # Tandem gate: save raw config scalars before normalization
+                _v_raw_gate_scalars = None
+                if eval_tandem_gate is not None:
+                    _v_raw_gate_scalars = torch.stack([
+                        x[:, 0, 22].float(),  # gap (raw)
+                        x[:, 0, 23].float(),  # stagger (raw)
+                        x[:, 0, 13].float(),  # log(Re) (raw)
+                        x[:, 0, 14].float(),  # AoA (raw)
+                    ], dim=-1)  # [B, 4]
                 _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
@@ -2494,6 +2553,11 @@ for epoch in range(MAX_EPOCHS):
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
+                # Tandem gate: apply sigmoid gate conditioned on (gap, stagger, Re, AoA)
+                if eval_tandem_gate is not None and _v_raw_gate_scalars is not None:
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        gate_vals = torch.sigmoid(eval_tandem_gate(_v_raw_gate_scalars.to(device)))
+                    x = x * gate_vals[:, None, :].float()
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]


### PR DESCRIPTION
## Hypothesis

Gap and stagger scalars currently feed only into `--gap_stagger_spatial_bias` (slice routing). This helps routing but doesn't affect the **INPUT feature encoding**. For OOD NACA6416: the DSDF camber features signal a different geometric prior, but the model has no mechanism to upweight these features when it detects an OOD configuration.

A **sigmoid gate parameterized by (gap, stagger, Re, AoA)** can learn "for this tandem gap/stagger, amplify/suppress specific encoded feature channels." The gate is a global vector (same for all N nodes in a sample) conditioned on 4 flow configuration scalars. Near-identity initialization (`sigmoid(5) ≈ 0.99`) ensures first pass is baseline-equivalent.

This is distinct from the failed `feature_cross` from earlier phases (PR #1436) which was a learned node-to-node interaction matrix. This is a **GLOBAL gate** (same vector broadcast over all N nodes) conditioned on 4 scalars — much lower risk of overfitting.

**Physical motivation:** Different tandem configurations create qualitatively different flow physics. At small gaps, wake impingement dominates; at large gaps, the foils are nearly independent. The model should modulate which encoded features are emphasized based on the configuration — this gate provides that mechanism.

**Confidence:** Medium. The mechanism is physically motivated. Gap and stagger as input-gate conditioning is novel in this codebase (previously only used in routing). Near-identity init is safe. Main risk: redundancy with `--gap_stagger_spatial_bias` (routing vs feature modulation are mechanistically different, so orthogonality is plausible).

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flag

In the `Config` dataclass:
```python
tandem_feature_cross: bool = False   # config-aware sigmoid gate on encoded features
```

### Step 2: Create the gate module

In the model initialization section (near where `gap_stagger_spatial_bias` components are created), add:

```python
tandem_gate = None
if cfg.tandem_feature_cross:
    tandem_gate = nn.Sequential(
        nn.Linear(4, 32),
        nn.GELU(),
        nn.Linear(32, cfg.n_hidden),
    ).to(device)
    # Near-identity init: sigmoid(5) ≈ 0.993 → gate ≈ 1 (near-passthrough)
    nn.init.zeros_(tandem_gate[-1].weight)
    nn.init.constant_(tandem_gate[-1].bias, 5.0)
    tandem_gate = torch.compile(tandem_gate, mode=cfg.compile_mode)
    _gate_n = sum(p.numel() for p in tandem_gate.parameters())
    print(f"Tandem feature cross gate: {_gate_n:,} params (sigmoid(5) init)")
```

### Step 3: Add to optimizer

Add `tandem_gate` parameters to the optimizer. Match the LR of the main model:
```python
if tandem_gate is not None:
    param_groups[0]['params'].extend(list(tandem_gate.parameters()))
```

### Step 4: EMA tracking

Declare `ema_tandem_gate = None` alongside other EMA modules. In the EMA update loop, mirror the tandem_gate → ema_tandem_gate tracking.

### Step 5: Apply gate in training forward pass

After the input encoding (`preprocess` or equivalent), before the TransolverBlocks:

```python
if tandem_gate is not None:
    # Extract config scalars — these should be available from the data
    # gap: inter-foil gap, stagger: vertical offset, re: Reynolds number, aoa: angle of attack
    # You'll need to find where these scalars are available in the data pipeline
    # They may be in the raw input features or computed from the mesh geometry
    config_vec = torch.stack([gap, stagger, re_scalar, aoa_scalar], dim=-1)  # [B, 4]
    gate = torch.sigmoid(tandem_gate(config_vec))  # [B, n_hidden]
    fx = fx * gate[:, None, :]  # [B, N, n_hidden] element-wise
```

**Important:** For non-tandem samples (gap=0, stagger=0), the gate should be near-identity (sigmoid(bias=5)≈0.993). Verify this is the case.

**Finding the 4 config scalars:** Search the training loop for where gap, stagger, Re, AoA are available. They may be stored as part of the sample metadata or computed from `x`. Look for variables like `_gap`, `_stagger`, `_re`, `_aoa` or similar. If Re and AoA are not readily available as scalars, use 0.0 as placeholder and just condition on (gap, stagger, 0, 0) — even 2 scalars provide useful configuration context.

### Step 6: Apply gate in validation/eval loops

Mirror the gate application using `ema_tandem_gate` in all eval loops.

### Step 7: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent nezuko --wandb_name "nezuko/tandem-feat-cross-s42" \
  --wandb_group "round17/tandem-feature-cross" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --tandem_feature_cross

# Seed 73 — identical but --seed 73 --wandb_name "nezuko/tandem-feat-cross-s73"
```

### Step 8: Report results

Add a **Results** comment to this PR with:
- Table: p_in, p_oodc, p_tan, p_re for seed 42, seed 73, and 2-seed average
- Comparison against baseline
- W&B run IDs
- What gate values the model converged to (log gate statistics if possible)

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```