### PR TITLE
Re-Scaled WallDist: boundary layer thickness proxy via Re^(-1/2) scaling

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    re_scaled_walldist: bool = False        # Re^(-1/2) scaled wall distance for BL thickness proxy (+1 channel)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1301,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.re_scaled_walldist else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+re_scaled_wdist], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1758,6 +1759,7 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        _raw_log_re = x[:, 0, 13].clone() if cfg.re_scaled_walldist else None  # log(Re) before normalization
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
@@ -1794,6 +1796,11 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        if cfg.re_scaled_walldist:
+            # BL thickness proxy: wall_dist * Re^(-0.5) — encodes node position relative to BL
+            _re_factor = torch.exp(_raw_log_re * (-0.5)).clamp(max=1.0)[:, None, None]  # [B, 1, 1]
+            _bl_scaled = dist_surf * _re_factor  # [B, N, 1]
+            x = torch.cat([x, _bl_scaled], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,6 +2460,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
+                _raw_log_re_v = x[:, 0, 13].clone() if cfg.re_scaled_walldist else None
                 _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
@@ -2484,6 +2492,9 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                if cfg.re_scaled_walldist:
+                    _re_factor_v = torch.exp(_raw_log_re_v * (-0.5)).clamp(max=1.0)[:, None, None]
+                    x = torch.cat([x, dist_surf * _re_factor_v], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2867,6 +2878,7 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
+                    _raw_log_re_vis = x_dev[:, 0, 13].clone() if cfg.re_scaled_walldist else None
                     _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
@@ -2888,6 +2900,9 @@ if best_metrics:
                             wake_feats_vis = compute_wake_deficit_features(
                                 _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis)
                             x_n = torch.cat([x_n, wake_feats_vis], dim=-1)
+                    if cfg.re_scaled_walldist:
+                        _re_factor_vis = torch.exp(_raw_log_re_vis * (-0.5)).clamp(max=1.0)[:, None, None]
+                        x_n = torch.cat([x_n, dist_surf * _re_factor_vis], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
@@ -2982,6 +2997,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
+                    _raw_log_re_vv = x[:, 0, 13].clone() if cfg.re_scaled_walldist else None
                     _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
@@ -3006,6 +3022,9 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    if cfg.re_scaled_walldist:
+                        _re_factor_vv = torch.exp(_raw_log_re_vv * (-0.5)).clamp(max=1.0)[:, None, None]
+                        x = torch.cat([x, dist_surf * _re_factor_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

The model currently receives wall distance (`foil2_dist`) as a raw input channel, but has **no explicit encoding of the boundary layer thickness** at the given Reynolds number. In aerodynamics, the laminar boundary layer thickness scales as `δ ~ x / sqrt(Re)` (Blasius solution). For turbulent flow, `δ ~ x / Re^(1/5)`.

By multiplying the wall distance by `Re^(-1/2)` (or equivalently, dividing by `sqrt(Re)`), we create a **dimensionless boundary layer coordinate** `y/δ` that tells the model "is this node inside or outside the boundary layer?" This is Reynolds-number-invariant:
- At high Re (thinner BL): nodes at the same physical distance are relatively FURTHER from the wall in BL units
- At low Re (thicker BL): same nodes are relatively CLOSER in BL units

This directly targets **p_re** (OOD Reynolds number) — the model currently must infer BL scaling implicitly from the Re scalar and raw wall distance separately. Explicit BL-scaled distance removes this inference step.

**Physical motivation:** The pressure distribution depends on whether a node is inside the boundary layer (viscous-dominated), in the wake (velocity deficit), or in the freestream (inviscid). The Re-scaled wall distance makes this classification explicit. It's the standard non-dimensionalization in boundary layer theory (y+ = y·u_τ/ν, but our simplified version y/δ captures the same physics without needing friction velocity).

**Expected improvement:** -2 to -5% p_re (OOD Reynolds), possible p_oodc improvement (OOD condition).

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flag

```python
re_scaled_walldist: bool = False   # Re^(-1/2) scaled wall distance for BL thickness proxy (+1 channel)
```

### Step 2: Compute Re-scaled wall distance

Find where the `foil2_dist` feature is computed or used. The Reynolds number should be available as a sample-level scalar (check the data loading — it may be in the input features or metadata).

```python
if cfg.re_scaled_walldist:
    # Get wall distance and Re for each sample
    # wall_dist: [B, N] — distance from nearest surface (foil2_dist or similar)
    # re_scalar: [B] — Reynolds number for each sample
    
    # Compute BL-scaled distance: wall_dist * Re^(-0.5)
    # This gives approximately y/δ (node position relative to BL thickness)
    re_factor = (re_scalar.clamp(min=1e3) ** (-0.5))[:, None]  # [B, 1]
    bl_scaled_dist = wall_dist * re_factor  # [B, N]
    
    # Append as new channel
    bl_feat = bl_scaled_dist.unsqueeze(-1)  # [B, N, 1]
```

**Finding Re:** Search for where Reynolds number is loaded. It may be:
- A raw input channel (check `x[:, :, k]` for Re)
- Part of `sample_metadata`
- Computed from flow conditions

If Re is not readily available as a scalar, you can compute it from the input features. Check `prepare_multi.py` or the data loading code for how Re is encoded.

**Finding wall distance:** The `--foil2_dist` flag adds a wall-distance channel. If that flag is enabled, the wall distance is already computed. You can re-use it, or compute a fresh one from the surface node positions.

### Step 3: Update input dimension

Add `+ (1 if cfg.re_scaled_walldist else 0)` to `fun_dim` or `n_x`.

### Step 4: Append in all loops

After existing feature concatenation, add the BL-scaled distance channel. Apply in all 4 loops.

### Step 5: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent edward --wandb_name "edward/re-scaled-walldist-s42" \
  --wandb_group "round17/re-scaled-walldist" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_scaled_walldist

# Seed 73 — identical but --seed 73 --wandb_name "edward/re-scaled-walldist-s73"
```

### Step 6: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, comparison to baseline, W&B run IDs. Pay special attention to p_re — that's the target metric.

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: hgml7i2r (seed 42), qic03vrg (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```