### PR TITLE
Surface Normal Features: outward normal direction per surface node (+2 channels)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,71 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_surface_normals(raw_xy: torch.Tensor, is_surface: torch.Tensor,
+                            saf_norm: torch.Tensor, k: int = 5) -> torch.Tensor:
+    """Compute outward-pointing surface normal (nx, ny) for each surface node.
+
+    For each surface node: find k nearest surface neighbors on the same foil,
+    estimate local tangent from neighbor displacements, rotate 90° for the normal,
+    then orient outward (away from foil centroid).
+
+    Vectorized over nodes within each (batch, foil) group for efficiency.
+    Computed from raw pre-normalization coordinates for geometric accuracy.
+
+    Args:
+        raw_xy:     [B, N, 2] raw x, y coordinates (before normalization)
+        is_surface: [B, N] bool surface mask
+        saf_norm:   [B, N] norm of saf channels (<=0.005 = fore-foil, >0.005 = aft-foil)
+        k: number of nearest neighbors for local tangent estimation
+    Returns:
+        [B, N, 2] (nx, ny) unit outward normal. Zero for volume nodes.
+    """
+    B, N = raw_xy.shape[:2]
+    result = torch.zeros(B, N, 2, device=raw_xy.device, dtype=raw_xy.dtype)
+
+    fore_threshold = lambda sn: sn <= 0.005
+    aft_threshold = lambda sn: sn > 0.005
+
+    for b in range(B):
+        for threshold_fn in (fore_threshold, aft_threshold):
+            mask = is_surface[b] & threshold_fn(saf_norm[b])
+            M = mask.sum().item()
+            if M < 3:
+                continue
+
+            indices = mask.nonzero(as_tuple=True)[0]  # [M]
+            xy = raw_xy[b, indices]                    # [M, 2]
+            centroid = xy.mean(dim=0)                  # [2]
+
+            # Pairwise distances → kNN indices (exclude self, column 0)
+            k_eff = min(k, M - 1)
+            dists = torch.cdist(xy.unsqueeze(0), xy.unsqueeze(0)).squeeze(0)  # [M, M]
+            _, knn_idx = dists.topk(k_eff + 1, dim=1, largest=False)          # [M, k+1]
+            knn_idx = knn_idx[:, 1:]                                           # [M, k]
+
+            # Neighbor displacements and tangent estimation (vectorized over nodes)
+            neighbors_xy = xy[knn_idx]                 # [M, k, 2]
+            displacements = neighbors_xy - xy.unsqueeze(1)  # [M, k, 2]
+            d_norms = displacements.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+            d_unit = displacements / d_norms           # [M, k, 2] unit directions
+            tangent = d_unit.mean(dim=1)               # [M, 2] average tangent direction
+            t_norms = tangent.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+            tangent = tangent / t_norms                # [M, 2] unit tangent
+
+            # Normal = rotate tangent 90° CCW: (tx, ty) → (-ty, tx)
+            normals = torch.stack([-tangent[:, 1], tangent[:, 0]], dim=-1)  # [M, 2]
+
+            # Orient outward: flip normals pointing toward centroid
+            to_centroid = centroid.unsqueeze(0) - xy   # [M, 2]
+            dot = (normals * to_centroid).sum(dim=-1)  # [M] positive = points toward centroid
+            flip = (dot > 0).float().unsqueeze(-1) * 2 - 1  # +1 or -1
+            normals = normals * (-flip)                # flip inward-pointing normals
+
+            result[b, indices] = normals
+
+    return result  # [B, N, 2]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1170,6 +1235,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    surface_normal_features: bool = False   # outward surface normal (nx, ny) per surface node (+2 channels)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1366,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (2 if cfg.surface_normal_features else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+normals], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1761,8 +1827,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        # TE coordinate frame / wake deficit / surface normals: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_normal_features
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1794,6 +1860,9 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        if cfg.surface_normal_features:
+            surf_normals = compute_surface_normals(_raw_xy_te, is_surface, _raw_saf_norm_te)
+            x = torch.cat([x, surf_normals], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,7 +2522,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_normal_features
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2484,6 +2553,9 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                if cfg.surface_normal_features:
+                    surf_normals = compute_surface_normals(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                    x = torch.cat([x, surf_normals], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2867,7 +2939,7 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
-                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_normal_features
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
                     _raw_gap_wake_vis = x_dev[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2888,6 +2960,9 @@ if best_metrics:
                             wake_feats_vis = compute_wake_deficit_features(
                                 _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis)
                             x_n = torch.cat([x_n, wake_feats_vis], dim=-1)
+                    if cfg.surface_normal_features:
+                        surf_normals_vis = compute_surface_normals(_raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis)
+                        x_n = torch.cat([x_n, surf_normals_vis], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
@@ -2982,7 +3057,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_normal_features
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3006,6 +3081,9 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    if cfg.surface_normal_features:
+                        surf_normals_vv = compute_surface_normals(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                        x = torch.cat([x, surf_normals_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

The model currently has no explicit encoding of the **local surface orientation** at each surface node. It has curvature (scalar) and DSDF (distance to surface), but not the direction the surface is FACING at each point.

Surface normal direction (nx, ny) directly determines the local pressure: in inviscid flow, `p = p_stagnation - 0.5*rho*(V·n)^2` at the surface. The normal tells the model **which direction the surface faces relative to the freestream** — this is the primary geometric quantity that determines pressure.

For OOD generalization (NACA0012 → NACA6416):
- NACA0012 (symmetric): normals are symmetric about the chord line
- NACA6416 (cambered): normals are **asymmetric** — upper surface normals tilt differently from lower surface due to 6% camber and 16% thickness distribution
- The surface normal captures this camber asymmetry in a direct, geometry-invariant way

This is NOT derivable from existing features:
- **DSDF** encodes distance TO the surface, not the surface's own orientation
- **Curvature** is the RATE of change of the normal (d²y/ds²), not the normal itself
- **TE/LE coord frames** encode distance FROM reference points, not local geometry

**Physical motivation:** Every panel method and BEM solver uses surface normals as fundamental inputs. They determine pressure loading, force decomposition, and wake boundary conditions. Adding normals as input features aligns the model's representation with how aerodynamicists parameterize surface pressure.

**Expected improvement:** -1 to -3% p_tan (OOD camber), -1 to -2% p_in (better pressure loading). Zero architecture change, +2 input channels.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flag

```python
surface_normal_features: bool = False   # outward surface normal (nx, ny) per surface node (+2 channels)
```

### Step 2: Implement `compute_surface_normals`

```python
def compute_surface_normals(raw_xy, is_surface, saf_norm, k=5):
    """Compute outward-pointing surface normal for each surface node.
    
    For each surface node: find k nearest surface neighbors ON THE SAME FOIL,
    fit a local tangent direction from the neighbor displacements,
    rotate 90° to get the normal, then orient outward (away from foil centroid).
    
    Args:
        raw_xy:     [B, N, 2] raw x, y coordinates
        is_surface: [B, N] bool
        saf_norm:   [B, N] saf channel norm (<=0.005 = foil-1, >0.005 = foil-2)
        k: number of nearest neighbors for tangent estimation
    
    Returns: [B, N, 2] (nx, ny) unit normal. Zero for volume nodes.
    """
    B, N = raw_xy.shape[:2]
    result = torch.zeros(B, N, 2, device=raw_xy.device, dtype=raw_xy.dtype)
    
    for b in range(B):
        for foil_idx, threshold_fn in enumerate([
            lambda sn: sn <= 0.005,   # fore-foil
            lambda sn: sn > 0.005,    # aft-foil
        ]):
            mask = is_surface[b] & threshold_fn(saf_norm[b])
            if mask.sum() < 3:
                continue
            
            indices = mask.nonzero(as_tuple=True)[0]  # surface node indices
            xy = raw_xy[b, indices]  # [M, 2]
            centroid = xy.mean(dim=0)  # foil centroid
            
            # For each surface node, find k nearest neighbors
            # Use pairwise distances
            dists = torch.cdist(xy.unsqueeze(0), xy.unsqueeze(0)).squeeze(0)  # [M, M]
            _, knn_idx = dists.topk(min(k+1, len(indices)), dim=1, largest=False)  # [M, k+1]
            knn_idx = knn_idx[:, 1:]  # exclude self
            
            # Local tangent from neighbor displacements
            for i in range(len(indices)):
                neighbors = xy[knn_idx[i]]  # [k, 2]
                displacements = neighbors - xy[i]  # [k, 2]
                # Tangent = principal direction of displacements (SVD or simple average)
                # Simple: weighted average of displacement directions
                d_norms = displacements.norm(dim=1, keepdim=True).clamp(min=1e-8)
                d_unit = displacements / d_norms
                tangent = d_unit.mean(dim=0)  # average direction
                tangent = tangent / tangent.norm().clamp(min=1e-8)
                
                # Normal = rotate tangent 90° CCW
                nx = -tangent[1]
                ny = tangent[0]
                
                # Orient outward: normal should point AWAY from centroid
                to_centroid = centroid - xy[i]
                if (nx * to_centroid[0] + ny * to_centroid[1]) > 0:
                    nx, ny = -nx, -ny  # flip to point outward
                
                result[b, indices[i], 0] = nx
                result[b, indices[i], 1] = ny
    
    return result
```

**IMPORTANT: torch.compile compatibility.** The nested loops above are NOT compile-friendly. You have two options:
1. **Precompute before compile**: compute normals once per batch OUTSIDE the compiled model forward, then pass as additional input features.
2. **Vectorize**: replace the per-node loop with batched operations (cdist + topk are already vectorized; the tangent computation can be vectorized over all nodes simultaneously).

Option 1 is simpler and safer. Compute the normals in the training loop before calling the model, then concatenate them to the input features.

### Step 3: Update input dimension

Add `+ (2 if cfg.surface_normal_features else 0)` to `fun_dim` or `n_x`.

### Step 4: Compute and append in training/eval loops

Before normalization, compute normals from raw coordinates. Then after feature concatenation:
```python
if cfg.surface_normal_features:
    normals = compute_surface_normals(_raw_xy, is_surface, _raw_saf_norm)
    x = torch.cat([x, normals], dim=-1)
```

Apply in **all 4 loops**.

### Step 5: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent alphonse --wandb_name "alphonse/surface-normals-s42" \
  --wandb_group "round17/surface-normal-features" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --surface_normal_features

# Seed 73 — identical but --seed 73 --wandb_name "alphonse/surface-normals-s73"
```

### Step 6: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, comparison to baseline, W&B run IDs.

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: hgml7i2r (seed 42), qic03vrg (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```