### PR TITLE
Stochastic Depth Curriculum: progressive block dropping during early training

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -486,7 +486,11 @@ class TransolverBlock(nn.Module):
                     nn.Linear(hidden_dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, out_dim)
                 )
 
-    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None, zone_features=None):
+    def forward(self, fx, raw_xy=None, tandem_mask=None, condition=None, zone_features=None, drop_prob=0.0):
+        # Stochastic depth: skip entire block with probability drop_prob (non-last blocks only)
+        if self.training and not self.last_layer and drop_prob > 0.0:
+            if torch.rand(1, device=fx.device).item() < drop_prob:
+                return fx  # pass through unchanged (identity skip)
         sb = self.spatial_bias(raw_xy) if raw_xy is not None else None
         # DomainLayerNorm helper: pass is_tandem when enabled, else plain call
         dln_it = (tandem_mask.view(-1) > 0.5) if (self.domain_layernorm and tandem_mask is not None) else None
@@ -992,8 +996,13 @@ class Transolver(nn.Module):
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
-        for block in self.blocks[:-1]:
-            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+        # Stochastic depth: per-block drop probabilities passed via data dict
+        drop_probs = data.get("drop_probs") if isinstance(data, Mapping) else None
+        if drop_probs is None:
+            drop_probs = [0.0] * len(self.blocks)
+
+        for i, block in enumerate(self.blocks[:-1]):
+            fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features, drop_prob=drop_probs[i])
 
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
@@ -1170,6 +1179,9 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    stochastic_depth: bool = False          # curriculum stochastic depth: progressive block dropping
+    stochastic_depth_max_drop: float = 0.3  # max drop prob for last non-output block at epoch 0 (decays to 0)
+    stochastic_depth_warmup: int = 80       # epochs until drop prob reaches 0
 
 
 cfg = sp.parse(Config)
@@ -1647,6 +1659,19 @@ for epoch in range(MAX_EPOCHS):
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
+    # Stochastic depth: compute per-block drop probabilities (decay to 0 over warmup epochs)
+    if cfg.stochastic_depth and epoch < cfg.stochastic_depth_warmup:
+        decay_factor = 1.0 - (epoch / cfg.stochastic_depth_warmup)
+        n_blocks = cfg.n_layers
+        # Linear scaling: block 0 = 0, last non-output block = max_drop
+        # Note: last block (output block) always has drop_prob=0 (it's excluded in forward)
+        _sd_drop_probs = [
+            cfg.stochastic_depth_max_drop * (i / max(n_blocks - 1, 1)) * decay_factor
+            for i in range(n_blocks)
+        ]
+    else:
+        _sd_drop_probs = [0.0] * cfg.n_layers
+
     # --- Train ---
     model.train()
     if refine_head is not None:
@@ -1886,7 +1911,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "drop_probs": _sd_drop_probs})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -2114,7 +2139,7 @@ for epoch in range(MAX_EPOCHS):
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                rdrop_out = model({"x": x})
+                rdrop_out = model({"x": x, "drop_probs": _sd_drop_probs})
                 rdrop_pred = rdrop_out["preds"].float() / sample_stds
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
@@ -2253,7 +2278,7 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
+                out2 = model({"x": x, "drop_probs": _sd_drop_probs})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
@@ -2310,7 +2335,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.stochastic_depth and global_step % 50 == 0:
+            for _i, _dp in enumerate(_sd_drop_probs):
+                _step_log[f"stochastic_depth/drop_prob_block{_i}"] = _dp
+        wandb.log(_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The 3-layer Transolver trains all blocks simultaneously from epoch 0. If later blocks produce noisy gradients early in training (before they learn useful transformations), they corrupt the representations that earlier blocks are trying to learn. This is the **early-layer bottleneck** problem in deep networks.

**Stochastic depth** (Huang et al., ECCV 2016) randomly drops entire blocks during training with a per-block probability. The **curriculum** variant decays the drop probability to 0 over the first half of training:
- Epochs 0-80: block 2 has drop probability decaying from 0.3→0, block 1 from 0.15→0
- Epochs 80+: all blocks always active (standard inference behavior)
- Block 0 (first): never dropped

This forces blocks 0-1 to develop **independently robust representations** before block 2 is reliably active. It's a structural regularizer — much stronger than activation dropout.

**Why it might help OOD:** The model's failure to generalize tandem pressure to NACA6416 likely originates in the early blocks where geometry features are extracted. Stochastic depth pressure-tests these blocks to be self-sufficient, which regularizes against late-block overfitting to in-distribution patterns.

**Zero inference cost.** Drop probability is 0 after epoch 80 and always 0 at eval time. torch.compile compatible (the conditional skip is a simple if statement).

**Expected improvement:** -1 to -3% across all metrics from better regularization. Largest expected gains on OOD splits (p_oodc, p_tan, p_re).

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
stochastic_depth: bool = False       # progressive block dropping during training
stochastic_depth_max_drop: float = 0.3  # max drop prob for the last block (decays to 0)
stochastic_depth_warmup: int = 80    # epochs until drop prob reaches 0
```

### Step 2: Modify TransolverBlock to accept drop probability

In `TransolverBlock.forward`, add a `drop_prob` parameter:

```python
def forward(self, fx, x, T, B, N, ..., drop_prob=0.0):
    # Stochastic depth: skip entire block with probability drop_prob
    if self.training and drop_prob > 0.0:
        if torch.rand(1, device=fx.device).item() < drop_prob:
            return fx, fx_deep if ... else fx  # pass through unchanged
    
    # ... normal forward pass ...
```

**Important:** When the block is dropped, return `fx` unchanged (identity). The `fx_deep` output (for pressure_deep) should also be `fx` unchanged.

### Step 3: Compute per-block drop probabilities in training loop

At the start of each epoch:
```python
if cfg.stochastic_depth and epoch < cfg.stochastic_depth_warmup:
    # Linear decay from max_drop to 0 over warmup epochs
    decay_factor = 1.0 - (epoch / cfg.stochastic_depth_warmup)
    # Per-block drop prob: linear scaling, block 0 = 0, last block = max
    n_blocks = cfg.n_layers
    drop_probs = [
        cfg.stochastic_depth_max_drop * (i / (n_blocks - 1)) * decay_factor
        for i in range(n_blocks)
    ]
    # drop_probs for 3 blocks: [0.0, 0.15*decay, 0.30*decay]
else:
    drop_probs = [0.0] * cfg.n_layers
```

Pass `drop_probs[i]` to each block's forward call.

### Step 4: Log drop statistics

```python
if cfg.stochastic_depth and step % 50 == 0:
    wandb.log({f'stochastic_depth/drop_prob_block{i}': dp for i, dp in enumerate(drop_probs)})
```

### Step 5: Ensure eval loops DON'T drop

In all validation/eval loops, pass `drop_prob=0.0` to all blocks (or simply don't pass the parameter — default is 0.0).

### Step 6: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent thorfinn --wandb_name "thorfinn/stochastic-depth-s42" \
  --wandb_group "round17/stochastic-depth-curriculum" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --stochastic_depth --stochastic_depth_max_drop 0.3 --stochastic_depth_warmup 80

# Seed 73 — identical but --seed 73 --wandb_name "thorfinn/stochastic-depth-s73"
```

### Step 7: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, comparison to baseline, W&B run IDs. Report what epochs the drop probs reached 0 and whether training dynamics differed from baseline.

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: hgml7i2r (seed 42), qic03vrg (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --wandb_name "thorfinn/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```