### PR TITLE
Surface Curvature Feature: explicit local κ for surface nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,72 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_surface_curvature(raw_xy, is_surface, saf_norm):
+    """Compute dimensionless local curvature for fore- and aft-foil surface nodes.
+
+    Uses angle-sorted node ordering and finite differences of tangent angle.
+    Returns two channels: kappa_fore (foil-1) and kappa_aft (foil-2).
+    Volume nodes get 0. Aft-foil channels are 0 for single-foil samples.
+
+    Args:
+        raw_xy: [B, N, 2+] raw node features (x,y at indices 0,1) — BEFORE normalization
+        is_surface: [B, N] boolean surface mask
+        saf_norm: [B, N] SAF vector norm (>0.005 = aft-foil surface)
+
+    Returns:
+        [B, N, 2] tensor: (kappa_fore, kappa_aft) — dimensionless curvature × chord
+    """
+    B, N = is_surface.shape
+    device = raw_xy.device
+    kappa = torch.zeros(B, N, 2, device=device, dtype=raw_xy.dtype)
+
+    for b in range(B):
+        for foil_idx, foil_mask_fn in enumerate([
+            lambda: is_surface[b] & (saf_norm[b] <= 0.005),   # fore-foil
+            lambda: is_surface[b] & (saf_norm[b] > 0.005),    # aft-foil
+        ]):
+            fmask = foil_mask_fn()
+            n_nodes = fmask.sum().item()
+            if n_nodes < 3:
+                continue
+
+            xy = raw_xy[b, fmask, :2]  # [M, 2]
+
+            # Sort by angle from centroid for consistent ring ordering
+            centroid = xy.mean(dim=0, keepdim=True)
+            angles = torch.atan2(xy[:, 1] - centroid[0, 1],
+                                 xy[:, 0] - centroid[0, 0])
+            order = angles.argsort()
+            xy_sorted = xy[order]
+
+            # Tangent vectors between consecutive nodes
+            dx = xy_sorted[1:, 0] - xy_sorted[:-1, 0]
+            dy = xy_sorted[1:, 1] - xy_sorted[:-1, 1]
+            ds = torch.sqrt(dx ** 2 + dy ** 2 + 1e-8)
+
+            # Tangent angles and curvature via central difference
+            theta = torch.atan2(dy, dx)  # [M-1]
+            dtheta = theta[1:] - theta[:-1]  # [M-2]
+            dtheta = torch.atan2(torch.sin(dtheta), torch.cos(dtheta))  # unwrap
+            ds_mid = 0.5 * (ds[1:] + ds[:-1])  # [M-2]
+            kappa_raw = dtheta / (ds_mid + 1e-8)  # [M-2]
+
+            # Normalize by chord length for dimensionless curvature
+            chord = (xy[:, 0].max() - xy[:, 0].min()).clamp(min=1e-6)
+            kappa_norm = kappa_raw * chord
+
+            # Map back: interior sorted nodes are indices 1..M-2
+            mask_indices = fmask.nonzero(as_tuple=True)[0]
+            interior_orig = mask_indices[order[1:-1]]
+            kappa[b, interior_orig, foil_idx] = kappa_norm
+
+            # Extrapolate endpoints from nearest interior
+            kappa[b, mask_indices[order[0]], foil_idx] = kappa_norm[0]
+            kappa[b, mask_indices[order[-1]], foil_idx] = kappa_norm[-1]
+
+    return kappa  # [B, N, 2]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1170,6 +1236,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    surface_curvature_feature: bool = False  # explicit local curvature κ for surface nodes (+2 input channels)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1367,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (2 if cfg.surface_curvature_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+surface_kappa], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1761,8 +1828,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        # TE coordinate frame / wake deficit / surface curvature: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_curvature_feature
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1794,6 +1861,9 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        if cfg.surface_curvature_feature:
+            _kappa_feats = compute_surface_curvature(_raw_xy_te, is_surface, _raw_saf_norm_te)
+            x = torch.cat([x, _kappa_feats], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,7 +2523,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_curvature_feature
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2484,6 +2554,9 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                if cfg.surface_curvature_feature:
+                    _kappa_feats = compute_surface_curvature(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                    x = torch.cat([x, _kappa_feats], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2867,7 +2940,7 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
-                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_curvature_feature
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
                     _raw_gap_wake_vis = x_dev[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2888,6 +2961,9 @@ if best_metrics:
                             wake_feats_vis = compute_wake_deficit_features(
                                 _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis)
                             x_n = torch.cat([x_n, wake_feats_vis], dim=-1)
+                    if cfg.surface_curvature_feature:
+                        _kappa_feats_vis = compute_surface_curvature(_raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis)
+                        x_n = torch.cat([x_n, _kappa_feats_vis], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
@@ -2982,7 +3058,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_curvature_feature
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3006,6 +3082,9 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    if cfg.surface_curvature_feature:
+                        _kappa_feats_vv = compute_surface_curvature(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                        x = torch.cat([x, _kappa_feats_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

The model's input features (DSDF, TE coord frame, wake deficit) encode **position** relative to aerodynamic reference points, but carry no explicit information about **shape variation** along the foil surface. Local curvature κ = dθ/ds (rate of change of tangent angle with arc-length) directly determines the surface pressure distribution via the Euler equations — high curvature at the LE creates the suction peak, gentle curvature at mid-chord gives smooth pressure recovery, and TE curvature governs separation behavior.

Computing curvature from existing inputs requires second-order spatial derivatives of DSDF, which neural networks have strong spectral bias against learning. Providing κ explicitly as an input feature removes this hard learning task — the same reasoning that made TE coord frame (-5.4% p_in) and wake deficit (-4.1% p_in) work.

**Physical motivation:**
- Inviscid pressure: Cp ∝ local curvature (Euler equations on body-conforming coordinates)
- Boundary layer: separation onset correlates with adverse pressure gradient, which tracks curvature changes
- OOD generalization: dimensionless curvature (κ × chord) is shape-invariant — a NACA0012 and NACA6416 have different curvature distributions that directly explain their different Cp distributions

**Key distinction from in-flight experiments:**
- Surface normals (#2229 alphonse): encode **direction** the surface faces → (nx, ny)
- Surface curvature (this PR): encodes **rate of change** of direction → dθ/ds
- These are complementary: normals are first-order, curvature is second-order geometry

**Confidence:** Medium-high. Follows the proven feature engineering pattern. The only risk is that DSDF already partially encodes curvature information (level-set curvature = ∇²DSDF), but making it explicit should still help given the spectral bias argument.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flag

In the `Config` dataclass:
```python
surface_curvature_feature: bool = False   # local curvature κ for surface nodes
```

Add argparse: `--surface_curvature_feature` (store_true).

### Step 2: Implement curvature computation

Add a helper function (similar to the TE coord frame helper):

```python
def compute_surface_curvature(x_coords, boundary_id, n_input):
    """Compute dimensionless local curvature for surface nodes.
    
    Args:
        x_coords: [B, N, n_input] node features (x,y at indices 0,1)
        boundary_id: [B, N] integer boundary IDs
        n_input: number of input channels
    
    Returns:
        kappa_fore: [B, N, 1] curvature w.r.t fore-foil (0 for volume nodes)
        kappa_aft:  [B, N, 1] curvature w.r.t aft-foil (0 for volume/single-foil)
    """
    B, N, _ = x_coords.shape
    kappa_fore = torch.zeros(B, N, 1, device=x_coords.device)
    kappa_aft = torch.zeros(B, N, 1, device=x_coords.device)
    
    for foil_bid, kappa_out in [(6, kappa_fore), (7, kappa_aft)]:
        for b in range(B):
            mask = (boundary_id[b] == foil_bid)
            if mask.sum() < 3:
                continue  # need at least 3 nodes for curvature
            
            xy = x_coords[b, mask, :2]  # [M, 2]
            
            # Sort by angle from centroid (gives consistent ring ordering)
            centroid = xy.mean(dim=0, keepdim=True)
            angles = torch.atan2(xy[:, 1] - centroid[0, 1],
                                  xy[:, 0] - centroid[0, 0])
            order = angles.argsort()
            xy_sorted = xy[order]
            
            # Compute tangent vectors between consecutive nodes
            dx = xy_sorted[1:, 0] - xy_sorted[:-1, 0]
            dy = xy_sorted[1:, 1] - xy_sorted[:-1, 1]
            ds = torch.sqrt(dx**2 + dy**2 + 1e-8)
            
            # Tangent angles
            theta = torch.atan2(dy, dx)  # [M-1]
            
            # Curvature: dtheta/ds (central difference where possible)
            # For M surface nodes we get M-2 curvature values (interior nodes)
            dtheta = theta[1:] - theta[:-1]  # [M-2]
            # Handle angle wrapping
            dtheta = torch.atan2(torch.sin(dtheta), torch.cos(dtheta))
            ds_mid = 0.5 * (ds[1:] + ds[:-1])  # [M-2]
            kappa = dtheta / (ds_mid + 1e-8)  # [M-2]
            
            # Normalize by chord length (max_x - min_x) for dimensionless curvature
            chord = xy[:, 0].max() - xy[:, 0].min() + 1e-8
            kappa_norm = kappa * chord  # dimensionless
            
            # Assign back to original node positions
            # order gives sorted→original mapping. Interior sorted nodes are indices 1..M-2
            interior_sorted_idx = order[1:-1]  # indices in the original mask space
            # Map back to full [N] space
            mask_indices = mask.nonzero(as_tuple=True)[0]
            full_indices = mask_indices[interior_sorted_idx]
            kappa_out[b, full_indices, 0] = kappa_norm
            
            # Extrapolate endpoints: copy from nearest interior node
            kappa_out[b, mask_indices[order[0]], 0] = kappa_norm[0]
            kappa_out[b, mask_indices[order[-1]], 0] = kappa_norm[-1]
    
    return kappa_fore, kappa_aft
```

### Step 3: Integrate into the input pipeline

In the preprocessing section where TE coord frame and wake deficit features are computed:

```python
if cfg.surface_curvature_feature:
    kappa_fore, kappa_aft = compute_surface_curvature(x, boundary_id, n_input)
    x = torch.cat([x, kappa_fore, kappa_aft], dim=-1)
    # Update n_input accordingly (add 2 channels)
```

Make sure `n_input` is updated at model construction time too:
```python
if cfg.surface_curvature_feature:
    n_input += 2  # kappa_fore, kappa_aft
```

### Step 4: Handle all 4 loops

Apply the curvature computation in ALL loops: train, val, vis, and re-verification. The computation is per-sample and uses only mesh geometry, so it's deterministic and safe.

### Step 5: torch.compile compatibility

All operations (atan2, sort, indexing, finite differences) are compile-safe for fixed-size tensors. If the per-sample loop over `B` causes issues with torch.compile, move the computation to a pre-processing step before the training loop (compute once per sample and cache, since curvature depends only on mesh geometry, not on predictions).

**IMPORTANT optimization note:** Curvature depends only on the mesh geometry, which is FIXED per sample. You can precompute curvature for each sample once and cache it in the dataset/dataloader. This avoids recomputing every epoch. If caching is complex, the per-batch computation is acceptable since it's just finite differences on ~150 surface nodes.

### Step 6: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/surface-curvature-s42" \
  --wandb_group "round18/surface-curvature-feature" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --surface_curvature_feature

# Seed 73 — identical but --seed 73 --wandb_name "askeladd/surface-curvature-s73"
```

### Step 7: Report results

Add a **Results** comment to this PR with:
- Table: p_in, p_oodc, p_tan, p_re for seed 42, seed 73, and 2-seed average
- Comparison against baseline (deltas)
- W&B run IDs
- Note on where curvature values are largest (LE, TE, mid-chord) and if this correlates with prediction improvement regions

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd --wandb_name "askeladd/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```