### PR TITLE
Pressure Laplacian Smoothness: topology-aware surface Cp regularization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,74 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_pressure_laplacian_loss(p_pred, xy_coords, is_surface, saf_norm, le_te_exclude=0.05):
+    """Graph-Laplacian smoothness loss on surface pressure predictions.
+
+    For each foil's surface nodes, sorted into a ring by angle from centroid,
+    computes the squared pressure spatial gradient between adjacent nodes.
+    Excludes nodes near LE (min-x) and TE (max-x) within le_te_exclude fraction
+    of chord, where sharp gradients are physically expected.
+
+    Args:
+        p_pred:      [B, N] predicted pressure (normalized space)
+        xy_coords:   [B, N, 2] raw node coordinates (pre-normalization)
+        is_surface:  [B, N] bool surface node mask
+        saf_norm:    [B, N] SAF channel norm (<=0.005 = fore foil, >0.005 = aft foil)
+        le_te_exclude: fraction of chord to exclude near LE and TE
+
+    Returns: scalar loss (mean squared pressure gradient over valid adjacent pairs)
+    """
+    B = p_pred.shape[0]
+    total_loss = torch.tensor(0.0, device=p_pred.device, dtype=p_pred.dtype)
+    count = 0
+
+    for foil_idx, foil_mask_fn in enumerate([
+        lambda sn: sn <= 0.005,   # fore-foil
+        lambda sn: sn > 0.005,    # aft-foil
+    ]):
+        for b in range(B):
+            mask = is_surface[b] & foil_mask_fn(saf_norm[b])
+            n_surf = mask.sum().item()
+            if n_surf < 5:
+                continue
+
+            xy = xy_coords[b, mask]  # [M, 2]
+            p = p_pred[b, mask]      # [M]
+
+            # Sort by angle from centroid (ring ordering for airfoil boundary)
+            centroid = xy.mean(dim=0)
+            angles = torch.atan2(xy[:, 1] - centroid[1], xy[:, 0] - centroid[0])
+            order = angles.argsort()
+            xy_sorted = xy[order]          # [M, 2]
+            p_sorted = p[order]            # [M]
+
+            # LE/TE exclusion zone by x-position
+            x_sorted = xy_sorted[:, 0]
+            x_min = x_sorted.min()
+            x_max = x_sorted.max()
+            chord = (x_max - x_min).clamp(min=1e-6)
+
+            not_le = (x_sorted - x_min) > le_te_exclude * chord
+            not_te = (x_max - x_sorted) > le_te_exclude * chord
+            valid = not_le & not_te  # [M]
+
+            # Adjacent pairs (ring: i, i+1 for i=0..M-2, plus wrap M-1→0)
+            dp = p_sorted[1:] - p_sorted[:-1]        # [M-1]
+            ds = (xy_sorted[1:] - xy_sorted[:-1]).norm(dim=-1).clamp(min=1e-6)  # [M-1]
+            pair_valid = valid[:-1] & valid[1:]       # [M-1]
+
+            if pair_valid.sum() < 3:
+                continue
+
+            grad_sq = (dp / ds) ** 2                  # [M-1]
+            total_loss = total_loss + (grad_sq * pair_valid.float()).sum()
+            count += int(pair_valid.sum().item())
+
+    if count > 0:
+        return total_loss / count
+    return total_loss
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1118,6 +1186,9 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    pressure_laplacian_loss: bool = False   # topology-aware surface pressure smoothness
+    laplacian_weight: float = 0.01          # weight for Laplacian smoothness loss
+    laplacian_le_te_exclude: float = 0.05   # exclude nodes within this fraction of chord from LE/TE
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1762,7 +1833,7 @@ for epoch in range(MAX_EPOCHS):
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
         # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.pressure_laplacian_loss
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -2110,6 +2181,14 @@ for epoch in range(MAX_EPOCHS):
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
 
+        # Graph-Laplacian smoothness loss on surface pressure (training only)
+        _lap_loss = torch.tensor(0.0, device=device)
+        if cfg.pressure_laplacian_loss and model.training and _raw_xy_te is not None:
+            _lap_loss = compute_pressure_laplacian_loss(
+                pred[:, :, 2], _raw_xy_te, is_surface, _raw_saf_norm_te,
+                le_te_exclude=cfg.laplacian_le_te_exclude)
+            loss = loss + cfg.laplacian_weight * _lap_loss
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -2310,7 +2389,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _wandb_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.pressure_laplacian_loss:
+            _wandb_log["train/laplacian_loss"] = _lap_loss.item()
+        wandb.log(_wandb_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Surface pressure distributions are physically smooth everywhere except at the stagnation point and separation region. The model has no explicit smoothness constraint — the existing DCT frequency loss (PR #2184, merged) penalizes high-frequency content but operates in sorted-node space with arbitrary LE/TE ordering issues. A **graph-Laplacian smoothness loss** operating on actual mesh adjacency is topology-aware and avoids the ordering ambiguity.

For each pair of adjacent surface nodes (i, j) on the same foil, penalize `(p_pred_i - p_pred_j)^2 / dist(i,j)^2` — the squared spatial gradient of predicted pressure. This enforces that surface Cp varies smoothly along the airfoil, which is a physically correct constraint everywhere except at stagnation and separation.

**Physical motivation:** Inviscid pressure distributions satisfy the Laplace equation (harmonic functions). Even in viscous flows at Re=1-5M, surface pressure is smooth between the stagnation point and separation. The mesh has ~150 surface nodes per airfoil — the Laplacian reduces to a finite difference on a 1D ring topology.

**Key distinction from failed loss modifications:**
- Bernoulli loss (#2224): imposed WRONG physics (Bernoulli invalid at viscous walls) → catastrophic
- Arc-length surface loss (#2210): conflicted with hard-node mining, used arbitrary ordering → p_in +14.2%
- DCT freq loss (#2184, merged): works in FREQUENCY domain with sorted-node ordering issues
- **This (Laplacian):** enforces TOPOLOGICAL smoothness in SPATIAL domain using actual mesh adjacency — physically correct, complementary to DCT

**Critical safeguard vs #2210 failure:** The arc-length loss failed because it interfered with the model's ability to produce sharp pressure gradients at LE and TE. This loss addresses that by **excluding high-curvature regions** (LE and TE vicinity) from the penalty. Nodes within 5% chord of LE or TE are exempt from the smoothness penalty, allowing sharp gradients where physics demands them.

**Confidence:** Medium. Physically motivated, topology-aware, complementary to DCT. Main risk: may be redundant with DCT freq loss if DCT already captures sufficient smoothness signal. The LE/TE exclusion zone addresses the #2210 failure mode.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
pressure_laplacian_loss: bool = False    # topology-aware surface pressure smoothness
laplacian_weight: float = 0.01           # weight for Laplacian smoothness loss
laplacian_le_te_exclude: float = 0.05    # exclude nodes within this fraction of chord from LE/TE
```

### Step 2: Implement Laplacian smoothness computation

Add a helper function:

```python
def compute_pressure_laplacian_loss(p_pred, xy_coords, boundary_id, le_te_exclude=0.05):
    """Graph-Laplacian smoothness loss on surface pressure predictions.
    
    For each foil's surface nodes, sorted into a ring by angle from centroid,
    computes the squared pressure gradient between adjacent nodes.
    Excludes nodes near LE/TE (within le_te_exclude fraction of chord).
    
    Args:
        p_pred: [B, N] predicted pressure (or [B, N, 1])
        xy_coords: [B, N, 2] node coordinates
        boundary_id: [B, N] integer boundary IDs (6=fore surface, 7=aft surface)
        le_te_exclude: fraction of chord to exclude near LE and TE
    
    Returns: scalar loss (mean squared pressure gradient over all valid adjacent pairs)
    """
    if p_pred.dim() == 3:
        p_pred = p_pred.squeeze(-1)
    
    B = p_pred.shape[0]
    total_loss = torch.tensor(0.0, device=p_pred.device)
    count = 0
    
    for foil_bid in [6, 7]:
        for b in range(B):
            mask = (boundary_id[b] == foil_bid)
            if mask.sum() < 5:  # need enough nodes for meaningful smoothness
                continue
            
            xy = xy_coords[b, mask, :2]  # [M, 2]
            p = p_pred[b, mask]           # [M]
            
            # Sort by angle from centroid (ring ordering)
            centroid = xy.mean(dim=0, keepdim=True)
            angles = torch.atan2(xy[:, 1] - centroid[0, 1],
                                  xy[:, 0] - centroid[0, 0])
            order = angles.argsort()
            xy_sorted = xy[order]
            p_sorted = p[order]
            
            # Identify LE (min-x) and TE (max-x) positions
            x_min = xy[:, 0].min()
            x_max = xy[:, 0].max()
            chord = x_max - x_min + 1e-8
            
            # Create exclusion mask: exclude nodes near LE and TE
            x_sorted = xy_sorted[:, 0]
            not_le = (x_sorted - x_min) > le_te_exclude * chord
            not_te = (x_max - x_sorted) > le_te_exclude * chord
            valid = not_le & not_te  # [M]
            
            # Both node i and i+1 must be valid for the pair to count
            pair_valid = valid[:-1] & valid[1:]  # [M-1]
            
            if pair_valid.sum() < 3:
                continue
            
            # Squared pressure gradient between adjacent nodes
            dp = p_sorted[1:] - p_sorted[:-1]  # [M-1]
            ds = (xy_sorted[1:] - xy_sorted[:-1]).norm(dim=-1).clamp(min=1e-6)  # [M-1]
            grad_sq = (dp / ds) ** 2  # [M-1]
            
            # Only count valid pairs
            total_loss = total_loss + (grad_sq * pair_valid.float()).sum()
            count += pair_valid.sum().item()
    
    if count > 0:
        return total_loss / count
    return total_loss
```

### Step 3: Integrate into training loss

In the training step, after the main loss computation and before backward():

```python
if cfg.pressure_laplacian_loss:
    # Use the surface pressure predictions from the model
    # p_pred should be the predicted pressure for surface nodes
    lap_loss = compute_pressure_laplacian_loss(
        p_pred_surface, xy_coords, boundary_id, 
        le_te_exclude=cfg.laplacian_le_te_exclude
    )
    loss = loss + cfg.laplacian_weight * lap_loss
    
    # Log to W&B
    if wandb_log:
        log_dict['train/laplacian_loss'] = lap_loss.item()
```

**IMPORTANT:** Apply only in the training loop, not in validation/viz. The loss is a regularizer.

### Step 4: torch.compile compatibility

All operations (sort, indexing, norm, arithmetic) are compile-safe for fixed-shape tensors. The per-sample loop over `B` should be fine since B is small (typically 1-4). If torch.compile struggles with the variable `count`, move the normalization outside the compiled region.

### Step 5: Run 2 seeds with default weight

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent frieren --wandb_name "frieren/pressure-laplacian-s42" \
  --wandb_group "round18/pressure-laplacian-smooth" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --pressure_laplacian_loss --laplacian_weight 0.01

# Seed 73 — identical but --seed 73 --wandb_name "frieren/pressure-laplacian-s73"
```

### Step 6: Report results

Add a **Results** comment with:
- Table: p_in, p_oodc, p_tan, p_re for seed 42, seed 73, 2-seed avg
- Comparison against baseline
- W&B run IDs
- Log the `train/laplacian_loss` curve — note whether it decreases during training (model is learning to be smooth) or stays flat (already smooth, feature is redundant)
- If laplacian_loss is >5x the surface MAE loss magnitude, note this — may need to reduce weight

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent frieren --wandb_name "frieren/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```