### PR TITLE
Re Input Augmentation: Gaussian noise on log(Re) for OOD robustness

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    aug_re_noise: bool = False              # Gaussian noise on log(Re) input during training for OOD robustness
+    aug_re_sigma: float = 0.1              # std of noise in log(Re) space (~±10% Re)
 
 
 cfg = sp.parse(Config)
@@ -1753,6 +1755,11 @@ for epoch in range(MAX_EPOCHS):
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
+
+        # Re input noise augmentation (training only)
+        if model.training and cfg.aug_re_noise:
+            _re_noise = torch.randn(x.size(0), 1, 1, device=x.device) * cfg.aug_re_sigma
+            x[:, :, 13:14] = x[:, :, 13:14] + _re_noise  # log(Re) channel
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

The model receives Reynolds number as a log(Re) input channel. During training, the model sees a fixed distribution of Re values from the training set. At test time, p_re evaluates on OOD Reynolds numbers — the model must extrapolate its learned Re-pressure relationship to unseen values.

By adding Gaussian noise to the log(Re) input channel during training, we force the model to be **less sensitive to exact Re values** and instead learn pressure patterns that are robust across a range of Re. This is the standard "input noise regularization" technique adapted specifically for the Re channel.

**Physical motivation:** For most mesh nodes (volume nodes far from walls, mid-chord surface nodes), the pressure field changes slowly with Re. Only nodes in the boundary layer and separation region are highly Re-sensitive. Adding Re noise teaches the model to focus on geometry-driven pressure patterns rather than over-fitting to precise Re conditioning — a form of OOD robustness training.

**Analogy:** `--aug aoa_perturb` already adds noise to the AoA input, which has proven effective (part of the established baseline). This extends the same principle to Reynolds number.

**Key difference from failed Re-scaled walldist (#2228):** That PR added a redundant feature (product of existing inputs). This PR adds input NOISE during training — a regularization technique, not an input feature. No new parameters, no new channels. Just a training-time perturbation that widens the effective training distribution.

**Expected improvement:** -2 to -4% p_re (OOD Reynolds). Possible secondary benefit on p_oodc (OOD condition, which may include Re variation).

**Risk:** If the model needs precise Re information for in-distribution accuracy, adding noise could hurt p_in. We mitigate by using small sigma (0.1 in log space ≈ ±10% Re) and applying noise ONLY during training (not validation).

**Confidence:** Medium. Standard ML technique (input noise regularization), targeted at the weakest metric. Main uncertainty is optimal noise magnitude.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
aug_re_noise: bool = False     # Gaussian noise on log(Re) input during training
aug_re_sigma: float = 0.1     # std of noise in log(Re) space (~±10% Re)
```

### Step 2: Identify where log(Re) enters the input

Find where the Reynolds number is encoded into the input features. It's likely one of the input channels in `x[:, :, k]`. Check how `log_Re` or `re` is computed and added to the feature vector. Note the exact channel index.

### Step 3: Add noise during training

In the **training loop only** (NOT in val/vis/verify), after the input features are assembled but BEFORE normalization:

```python
if cfg.aug_re_noise and model.training:
    # Find the Re channel index — adjust based on your investigation in Step 2
    re_channel_idx = <discovered_index>
    
    # Add Gaussian noise to log(Re) in the training input
    re_noise = torch.randn(x.shape[0], 1, 1, device=x.device) * cfg.aug_re_sigma
    # Broadcast: same noise for all nodes in a sample (Re is global)
    x[:, :, re_channel_idx] = x[:, :, re_channel_idx] + re_noise.squeeze(-1)
```

**IMPORTANT:** The noise must be:
- Per-sample (same noise for all nodes in a batch element)
- Only during training (disabled during validation/visualization)
- Applied to the log(Re) channel specifically (not other inputs)

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent edward --wandb_name "edward/re-aug-s42" \
  --wandb_group "round18/re-input-augmentation" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --aug_re_noise --aug_re_sigma 0.1

# Seed 73 — identical but --seed 73 --wandb_name "edward/re-aug-s73"
```

### Step 5: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs. **Pay special attention to p_re** — that's the target metric. Also note if p_in degrades (would indicate noise is too large).

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```