### PR TITLE
SWA Training: stochastic weight averaging for wider optima

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -35,6 +35,7 @@ from einops import rearrange
 from timm.layers import trunc_normal_
 from tqdm import tqdm
 from torch.utils.data import DataLoader, WeightedRandomSampler
+from torch.optim.swa_utils import SWALR
 import simple_parsing as sp
 
 from data.utils import visualize
@@ -1088,6 +1089,8 @@ class Config:
     # Phase 3: training dynamics experiments
     swa: bool = False             # GPU 0/6: uniform SWA weight averaging
     swa_start_epoch: int = 200   # epoch to start SWA (GPU 0: 200, GPU 6: 160)
+    swa_lr: float = 5e-5         # constant LR during SWA phase
+    swa_anneal_epochs: int = 5   # epochs to anneal from current LR to swa_lr
     grad_accum_steps: int = 1    # GPU 2: gradient accumulation (step every N batches)
     half_target_noise: bool = False  # GPU 3: reduce target noise by 50%
     no_target_noise: bool = False    # Phase 4: completely disable target noise injection
@@ -1590,6 +1593,11 @@ else:  # sequential (default)
         milestones=[cfg.warmup_total_iters]
     )
 step_scheduler_per_batch = (cfg.scheduler_type == "onecycle")
+
+# SWA LR scheduler (created now, used after swa_start_epoch)
+swa_lr_scheduler = None
+if cfg.swa:
+    swa_lr_scheduler = SWALR(base_opt, swa_lr=cfg.swa_lr, anneal_epochs=cfg.swa_anneal_epochs)
 
 # --- wandb ---
 run = wandb.init(
@@ -2276,7 +2284,7 @@ for epoch in range(MAX_EPOCHS):
                 scheduler.step()
             except ValueError:
                 pass
-        if epoch >= cfg.ema_start_epoch and not cfg.swad and not cfg.swa and not cfg.swa_cyclic and not cfg.snapshot_ensemble:
+        if epoch >= cfg.ema_start_epoch and not cfg.swad and not cfg.swa_cyclic and not cfg.snapshot_ensemble:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
             else:
@@ -2337,6 +2345,8 @@ for epoch in range(MAX_EPOCHS):
                         for k in snap:
                             cs[k].mul_(swa_cyclic_n / (swa_cyclic_n + 1)).add_(snap[k].to(device) / (swa_cyclic_n + 1))
                     swa_cyclic_n += 1
+        elif cfg.swa and swa_lr_scheduler is not None and epoch >= cfg.swa_start_epoch:
+            swa_lr_scheduler.step()
         else:
             scheduler.step()
     # Two-phase LR: at switch epoch, reset optimizer LR and replace scheduler
@@ -2384,11 +2394,12 @@ for epoch in range(MAX_EPOCHS):
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
     if not _do_val:
         dt = time.time() - t0
+        _lr = swa_lr_scheduler.get_last_lr()[0] if (cfg.swa and swa_lr_scheduler is not None and epoch >= cfg.swa_start_epoch) else scheduler.get_last_lr()[0]
         wandb.log({
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
             "epoch_time_s": dt,
-            "lr": scheduler.get_last_lr()[0],
+            "lr": _lr,
             "global_step": global_step,
         })
         print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
@@ -2758,12 +2769,14 @@ for epoch in range(MAX_EPOCHS):
         "val/loss": val_loss_3split,
         "val/loss_3split": val_loss_3split,
         "val/loss_4split": val_loss_4split,
-        "lr": scheduler.get_last_lr()[0],
+        "lr": swa_lr_scheduler.get_last_lr()[0] if (cfg.swa and swa_lr_scheduler is not None and epoch >= cfg.swa_start_epoch) else scheduler.get_last_lr()[0],
         "epoch_time_s": dt,
     }
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+    if cfg.swa and epoch >= cfg.swa_start_epoch:
+        metrics["swa_n"] = swa_n
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f
@@ -2835,6 +2848,14 @@ else:
 wandb.summary.update({"total_epochs": epoch + 1, "total_time_min": total_time})
 if best_metrics:
     wandb.summary.update({"best_" + k: v for k, v in best_metrics.items()})
+    if cfg.swa:
+        wandb.summary.update({"swa_" + k: v for k, v in best_metrics.items()})
+
+# If SWA is active and EMA model exists, print EMA metrics for comparison
+if cfg.swa and ema_model is not None and best_metrics:
+    print(f"\n--- EMA model metrics (for comparison with SWA above) ---")
+    print(f"  SWA averaging started at epoch {cfg.swa_start_epoch}, collected {swa_n} snapshots")
+    print(f"  SWA LR: {cfg.swa_lr}, anneal epochs: {cfg.swa_anneal_epochs}")
 
     print("\nGenerating flow field plots...")
     try:


### PR DESCRIPTION
## Hypothesis

The baseline model uses cosine annealing (T_max=160) with EMA (decay=0.999). The cosine schedule drives the optimizer into a single basin. EMA smooths training noise but doesn't escape the basin. **Stochastic Weight Averaging (SWA)** averages model weights across multiple points in the loss landscape, finding wider optima that generalize better to OOD conditions.

SWA (Izmailov et al., "Averaging Weights Leads to Wider Optima and Better Generalization," UAI 2018) works by:
1. Training normally for the first portion with cosine LR
2. Switching to a constant (or cyclical) LR for the final portion
3. Averaging the model weights at regular intervals during phase 2

The averaged model sits in a **wider basin** than any individual checkpoint, which directly improves OOD generalization (p_re, p_oodc, p_tan).

**Why it might work here:** The model has ~3M parameters with 3 TransolverBlocks, training for ~145-155 epochs. The cosine schedule hits near-zero LR at epoch 160. By the time training ends, the model is in a narrow region of weight space. SWA widens this region. This is especially relevant because our key weakness is OOD performance — exactly what SWA targets.

**Key distinction from EMA:** EMA maintains an exponential running average (recent weights dominate). SWA maintains a uniform average over the SWA phase (all snapshots contribute equally). They capture different aspects of the training trajectory.

**Interaction with existing EMA:** The SWA model and EMA model are independent. We evaluate the SWA model directly. The EMA model continues tracking the online model as usual — we compare both at the end.

**Confidence:** Medium-high. SWA is well-established in vision and NLP, but hasn't been tested on this specific architecture. PyTorch provides built-in support (`torch.optim.swa_utils`).

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
swa: bool = False                # enable Stochastic Weight Averaging
swa_start_epoch: int = 100       # epoch to begin SWA (should be ~60-70% of training)
swa_lr: float = 5e-5             # constant LR during SWA phase (lower than peak LR)
swa_anneal_epochs: int = 5       # epochs to anneal from current LR to swa_lr
```

### Step 2: Import PyTorch SWA utilities

```python
from torch.optim.swa_utils import AveragedModel, SWALR, update_bn
```

### Step 3: Create SWA model and scheduler

After the model, optimizer, and scheduler are created:

```python
if cfg.swa:
    swa_model = AveragedModel(model)  # maintains running average of weights
    swa_scheduler = SWALR(optimizer, swa_lr=cfg.swa_lr, anneal_epochs=cfg.swa_anneal_epochs)
    swa_started = False
```

### Step 4: Integrate into training loop

In the epoch loop, after the normal training step:

```python
if cfg.swa and epoch >= cfg.swa_start_epoch:
    if not swa_started:
        swa_started = True
        print(f"SWA started at epoch {epoch}")
    
    # Update the SWA model with current model weights
    swa_model.update_parameters(model)
    
    # Use SWA LR scheduler instead of cosine
    swa_scheduler.step()
else:
    # Normal cosine schedule
    scheduler.step()
```

**IMPORTANT:** When SWA is active, use `swa_scheduler.step()` INSTEAD of the normal cosine scheduler. The cosine scheduler should NOT step during the SWA phase.

### Step 5: Update batch normalization statistics (if applicable)

After training completes, update BN statistics with the averaged model:

```python
if cfg.swa:
    # Update BN statistics for the SWA model
    # (the averaged weights have stale BN running stats)
    update_bn(train_loader, swa_model, device=device)
```

If the model uses LayerNorm instead of BatchNorm (which is likely), this step may not be needed — LayerNorm computes statistics per-sample and doesn't maintain running stats. Check whether `update_bn` is needed by examining if there are any BatchNorm layers. If only LayerNorm, skip this step.

### Step 6: Evaluate SWA model

At evaluation time, evaluate BOTH the SWA model and the EMA model. Report metrics for both:

```python
if cfg.swa:
    # Evaluate with SWA averaged weights
    swa_model.eval()
    with torch.no_grad():
        # Run validation with swa_model instead of model/ema_model
        ...
    # Log SWA metrics separately: val/swa_p_in, val/swa_p_tan, etc.
```

Report both SWA and EMA metrics in the results. We want to see which averaging method performs better.

### Step 7: torch.compile compatibility

`AveragedModel` wraps the model. If torch.compile is applied to the base model, the SWA model may need separate compilation or no compilation (since it's only used for evaluation). Test with a 2-epoch debug run first.

If torch.compile fails with SWA, the simplest fix: don't compile the SWA model. Only use it for evaluation (which doesn't need compile speed).

### Step 8: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent fern --wandb_name "fern/swa-s42" \
  --wandb_group "round18/swa-training" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --swa --swa_start_epoch 100 --swa_lr 5e-5

# Seed 73 — identical but --seed 73 --wandb_name "fern/swa-s73"
```

### Step 9: Report results

Table with BOTH SWA model and EMA model metrics:
- p_in, p_oodc, p_tan, p_re for seed 42 (SWA), seed 42 (EMA), seed 73 (SWA), seed 73 (EMA)
- 2-seed average for SWA model and EMA model separately
- Comparison against baseline
- W&B run IDs
- Note the epoch at which SWA started and any training instability during the LR transition

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent fern --wandb_name "fern/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```