### PR TITLE
Input Feature Noise Augmentation: Gaussian noise on all input channels

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    input_noise: bool = False               # Gaussian noise on all input features during training (regularization)
+    input_noise_sigma: float = 0.02         # std of noise (applied after normalization + feature assembly)
 
 
 cfg = sp.parse(Config)
@@ -1807,6 +1809,9 @@ for epoch in range(MAX_EPOCHS):
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+        # Input feature noise augmentation: isotropic Gaussian noise on ALL channels
+        if cfg.input_noise and model.training:
+            x = x + torch.randn_like(x) * cfg.input_noise_sigma
         Umag, q = _umag_q(y, mask)
         if cfg.raw_targets:
             y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]


### PR DESCRIPTION
## Hypothesis

After 5 consecutive failed feature additions this round (chord-camber, Re-walldist, surface normals, arc-length PE, domain-split SRF), evidence strongly suggests the feature engineering space is **saturated** — DSDF + TE coord frame + wake deficit already capture the geometric information the model can use.

The remaining performance gap is primarily in OOD metrics (p_oodc 7.64 vs ensemble 6.6, p_re 6.30 vs ensemble 5.8). This suggests the model **overfits to the exact distribution of input features** in the training set.

**Input Feature Noise Augmentation** adds small Gaussian noise to ALL input feature channels during training. This is a standard regularization technique (Sietsma & Dow 1991, Bishop 1995) that:
1. Smooths the learned function, preventing sharp decision boundaries that break OOD
2. Creates virtual training examples in the neighborhood of each real sample
3. Is equivalent to Tikhonov regularization (L2 penalty on the Jacobian) for small noise magnitudes

The noise is applied AFTER feature normalization so that all channels receive proportional perturbation regardless of their scale.

**Key distinction from other augmentations in baseline:**
- `--aug aoa_perturb`: perturbs ONE specific physical quantity (angle of attack)
- `--aug_dsdf2_sigma`: perturbs DSDF features specifically
- **This**: perturbs ALL input channels uniformly, creating isotropic regularization in feature space

**Key distinction from edward's Re augmentation (#2233):**
- Edward: targets ONE channel (log Re) with a specific physical motivation
- This: targets ALL channels as a general regularization technique

**Confidence:** Medium. Well-established ML technique, but the model already has augmentation on specific channels. The question is whether adding noise to the REMAINING channels (coordinates, boundary IDs, TE frame, wake deficit, etc.) provides additional regularization benefit.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
input_noise: bool = False        # Gaussian noise on all input features during training
input_noise_sigma: float = 0.02  # std of noise (applied after normalization)
```

### Step 2: Apply noise during training

In the **training loop only**, AFTER the input features are assembled and normalized (so all channels are on comparable scales), and BEFORE the forward pass through the model:

```python
if cfg.input_noise and model.training:
    # Add Gaussian noise to all input features
    noise = torch.randn_like(x) * cfg.input_noise_sigma
    x = x + noise
```

**CRITICAL requirements:**
- Apply ONLY during training (NOT during validation, visualization, or re-verification)
- Apply AFTER any input normalization (so noise is proportional to feature scale)
- Apply BEFORE the model forward pass
- The noise should be freshly sampled each batch (different noise per forward pass)

### Step 3: Verify no impact on validation

Double-check that the noise is only applied in the training branch. Validation metrics should be computed on clean (unperturbed) inputs.

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent alphonse --wandb_name "alphonse/input-noise-s42" \
  --wandb_group "round18/input-noise-augmentation" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --input_noise --input_noise_sigma 0.02

# Seed 73 — identical but --seed 73 --wandb_name "alphonse/input-noise-s73"
```

### Step 5: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, comparison to baseline, W&B run IDs.

Pay special attention to:
- **p_oodc and p_re**: these are OOD metrics — the target of this regularization
- **p_in**: if this degrades significantly (>3%), noise sigma is too large
- **Training loss curve**: check if the training loss is higher than baseline (expected — noise makes training harder) but validation loss is lower (the regularization signal)

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```