### PR TITLE
Huber Surface Loss: smooth L1 for finer pressure gradient signal

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    huber_surface_loss: bool = False        # use smooth L1 (Huber) instead of L1 for surface pressure
+    huber_delta: float = 0.5               # Huber transition threshold in normalized pressure space
 
 
 cfg = sp.parse(Config)
@@ -2001,14 +2003,21 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Surface pressure error: Huber (smooth L1) or standard L1
+        if cfg.huber_surface_loss:
+            _p_diff = pred[:, :, 2:3] - y_norm[:, :, 2:3]
+            _surf_pres_err = torch.nn.functional.smooth_l1_loss(
+                _p_diff, torch.zeros_like(_p_diff), beta=cfg.huber_delta, reduction='none')
+        else:
+            _surf_pres_err = abs_err[:, :, 2:3]
+        surf_per_sample = (_surf_pres_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+            surf_pres = _surf_pres_err  # pressure errors [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]


### PR DESCRIPTION
## Hypothesis

The baseline uses L1 (MAE) loss for surface pressure. L1 gives **constant gradient magnitude (±1) regardless of error size**. At convergence, most surface nodes have small errors, but L1's constant gradient creates noisy optimization — every node pushes the weights equally hard whether its error is 0.01 or 10.0.

**Huber loss (smooth L1)** transitions from **L2 (quadratic) for small errors** to **L1 (linear) for large errors**:
- Small errors (< δ): gradient ∝ error → smoother, more precise fine-tuning
- Large errors (> δ): gradient = ±1 → robust to outliers (same as current L1)

This gives the optimizer a **finer gradient signal** at convergence while maintaining robustness to extreme values. The transition threshold δ controls the boundary.

**Why this might help:**
1. **Better convergence quality:** At epoch 140+, most surface pressure errors are small. L2-like gradients for small errors enable more precise weight updates, potentially pushing metrics down by 1-3%.
2. **Natural hard-example emphasis:** L2 gives LARGER gradients for larger errors. Nodes near the LE suction peak and separation region (where errors are largest) automatically get stronger gradient signal — a physics-aligned form of hard example mining.
3. **Complementary to existing losses:** The DCT freq loss handles frequency-domain smoothness. `--high_p_clamp` handles extreme outliers. Huber handles the gradient magnitude distribution — a different axis entirely.

**Physical motivation:** Surface pressure distributions have a few high-gradient regions (LE, TE, separation) and large smooth regions (mid-chord). L1 treats them all equally. Huber naturally concentrates optimization effort on the challenging regions.

**Confidence:** Medium. Well-established loss function (Huber 1964, widely used in detection: Faster R-CNN, SSD). The key uncertainty is whether δ is well-tuned — too small → L2 everywhere (sensitive to outliers), too large → L1 everywhere (no benefit).

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
huber_surface_loss: bool = False    # use smooth L1 (Huber) instead of L1 for surface pressure
huber_delta: float = 0.5            # transition threshold (in asinh-normalized pressure space)
```

### Step 2: Modify the surface pressure loss computation

Find where the surface pressure MAE loss is computed. It should look something like:
```python
surf_p_loss = F.l1_loss(pred_p[surf_mask], target_p[surf_mask])
# or equivalent using torch.abs(pred - target).mean()
```

Replace with:
```python
if cfg.huber_surface_loss:
    surf_p_loss = F.smooth_l1_loss(
        pred_p[surf_mask], target_p[surf_mask], 
        beta=cfg.huber_delta  # PyTorch uses 'beta' for the Huber threshold
    )
else:
    surf_p_loss = F.l1_loss(pred_p[surf_mask], target_p[surf_mask])
```

**IMPORTANT:** Only change the **surface pressure** loss, NOT:
- Volume losses (keep as-is)
- Velocity losses (keep as-is)
- DCT frequency loss (keep as-is)
- Any other auxiliary losses

The validation metrics should still be computed with L1 (MAE) for fair comparison against baseline.

### Step 3: Choosing delta

The `--huber_delta 0.5` default is calibrated for asinh-normalized pressure space:
- Typical asinh pressure values range from -3 to +3
- Surface MAE ≈ 0.03-0.05 in normalized space for well-predicted nodes
- δ = 0.5 means: errors < 0.5 get L2 treatment, errors > 0.5 get L1 treatment
- This puts most nodes in the L2 regime (fine-tuning) while keeping outlier robustness

If the default doesn't work, try δ = 0.1 (more L2, more aggressive fine-tuning) or δ = 1.0 (more L1, closer to baseline).

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/huber-surface-s42" \
  --wandb_group "round18/huber-surface-loss" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --huber_surface_loss --huber_delta 0.5

# Seed 73 — identical but --seed 73 --wandb_name "askeladd/huber-surface-s73"
```

### Step 5: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

**Also report:** 
- Training loss curve shape (should be lower than baseline L1 since Huber < L1 for small errors)
- Whether the validation MAE (still computed as L1) improves even though training uses Huber

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd --wandb_name "askeladd/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```