### PR TITLE
Manifold Mixup: feature-level interpolation for OOD generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1002,6 +1002,13 @@ class Transolver(nn.Module):
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
 
+        # Manifold Mixup: interpolate hidden features before last block (output head)
+        if isinstance(data, Mapping):
+            _mm_lam = data.get("manifold_mix_lam", None)
+            _mm_perm = data.get("manifold_mix_perm", None)
+            if _mm_lam is not None and _mm_perm is not None:
+                fx = _mm_lam * fx + (1.0 - _mm_lam) * fx[_mm_perm]
+
         # Last block: use adaln_all condition if enabled, else fallback to adaln_output
         last_condition = block_condition if use_cond else (x[:, 0, 13:15] if self.adaln_output else None)
 
@@ -1170,6 +1177,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    manifold_mixup: bool = False            # feature-level mixup: mix hidden state after backbone blocks
+    mixup_alpha: float = 0.2               # Beta(alpha, alpha) concentration — 0.2 = mild mixing
 
 
 cfg = sp.parse(Config)
@@ -1885,8 +1894,23 @@ for epoch in range(MAX_EPOCHS):
             else:
                 y_norm = y_norm / sample_stds
 
+        # Manifold Mixup: sample λ and permutation (training only, requires B > 1)
+        _mm_lam = None
+        _mm_perm = None
+        if cfg.manifold_mixup and model.training and B > 1:
+            _mm_lam = torch.distributions.Beta(
+                torch.tensor(cfg.mixup_alpha, device=device),
+                torch.tensor(cfg.mixup_alpha, device=device),
+            ).sample()
+            _mm_perm = torch.randperm(B, device=device)
+
+        _model_input = {"x": x}
+        if _mm_lam is not None:
+            _model_input["manifold_mix_lam"] = _mm_lam
+            _model_input["manifold_mix_perm"] = _mm_perm
+
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model(_model_input)
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -1896,10 +1920,15 @@ for epoch in range(MAX_EPOCHS):
         aoa_pred = aoa_pred.float()
         hidden = hidden.float()
         if model.training and not cfg.no_perstd and not cfg.raw_targets and not cfg.adaptive_norm:
+            # For Manifold Mixup, use interpolated sample_stds matching the mixed prediction scale
+            _stds_for_pred = (
+                (_mm_lam * sample_stds + (1.0 - _mm_lam) * sample_stds[_mm_perm])
+                if _mm_lam is not None else sample_stds
+            )
             if cfg.multiply_std:
-                pred = pred * sample_stds
+                pred = pred * _stds_for_pred
             else:
-                pred = pred / sample_stds
+                pred = pred / _stds_for_pred
 
         # Surface refinement head: additive correction on surface nodes
         if refine_head is not None and model.training:
@@ -1953,6 +1982,10 @@ for epoch in range(MAX_EPOCHS):
                     aft_correction = aft_srf_head(aft_hidden, aft_pred, _aft_cond).float()
                 pred = pred.clone()
                 pred[aft_idx[:, 0], aft_idx[:, 1]] = pred[aft_idx[:, 0], aft_idx[:, 1]] + aft_correction
+
+        # Manifold Mixup: mix normalized targets to match the mixed predictions
+        if _mm_lam is not None:
+            y_norm = _mm_lam * y_norm + (1.0 - _mm_lam) * y_norm[_mm_perm]
 
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()


### PR DESCRIPTION
## Hypothesis

The model overfits to the discrete distribution of training samples. At convergence, encoded feature representations cluster tightly around training examples, leaving gaps in the feature space that OOD samples fall into. **Manifold Mixup** (Verma et al., ICML 2019) addresses this by creating virtual training examples through interpolation of encoded features and targets.

During training, for each batch:
1. Sample λ ~ Beta(α, α) where α controls interpolation strength
2. Create shuffled batch indices
3. After the backbone encoding (preprocess MLP + TransolverBlocks), interpolate encoded features: `fx_mix = λ * fx + (1-λ) * fx[perm]`
4. Interpolate targets: `y_mix = λ * y + (1-λ) * y[perm]`
5. Compute loss on mixed features/targets

This fills the feature space between training samples with plausible interpolations, creating a smoother loss landscape and better OOD generalization.

**Why it might work here:**
- The biggest performance gaps are on OOD metrics (p_oodc 7.64 vs ensemble 6.6, p_re 6.30 vs ensemble 5.8)
- Mixup is proven to improve OOD generalization in vision (ImageNet), NLP, and scientific ML
- Feature-level Mixup (manifold) is more effective than input-level Mixup because the encoded space is more linearly separable
- With α=0.2 (mild interpolation), most λ values are near 0 or 1, so the model mostly sees real samples with occasional mild interpolation

**Key distinction from input noise augmentation (#2235, alphonse):**
- Input noise: adds random perturbation to each sample independently
- Manifold Mixup: creates convex combinations of REAL encoded representations → explores the space BETWEEN real samples

**Confidence:** Medium-high. Well-established technique with strong theoretical backing (Verma et al., 2019; Mixup: Zhang et al., ICLR 2018). Main risk: pressure fields may not interpolate linearly in encoded space (physics is nonlinear). Using a small α (0.2) mitigates this.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
manifold_mixup: bool = False     # feature-level mixup for OOD generalization
mixup_alpha: float = 0.2         # Beta distribution parameter (small = mild mixing)
```

### Step 2: Implement Mixup in the training loop

In the **training loop only**, AFTER the backbone forward pass (all TransolverBlocks) but BEFORE the output heads (pressure decoder, velocity decoder, SRF heads):

```python
if cfg.manifold_mixup and model.training:
    # Sample mixing coefficient
    lam = torch.distributions.Beta(cfg.mixup_alpha, cfg.mixup_alpha).sample().to(device)
    
    # Random permutation for pairing
    perm = torch.randperm(fx.shape[0], device=device)
    
    # Mix encoded features
    fx = lam * fx + (1.0 - lam) * fx[perm]
    
    # Mix ALL targets correspondingly
    # Find where the target tensors are (pressure, velocity) and mix them:
    target_p = lam * target_p + (1.0 - lam) * target_p[perm]
    target_ux = lam * target_ux + (1.0 - lam) * target_ux[perm]
    target_uy = lam * target_uy + (1.0 - lam) * target_uy[perm]
    
    # Also mix any masks/weights that are per-sample
    # e.g., surface masks, boundary IDs for loss computation
    # IMPORTANT: binary masks should NOT be mixed — use the original sample's masks
    # Only continuous targets should be interpolated
```

**CRITICAL:** 
- Only mix in the training loop. Validation must use unmixed data.
- Mix features AND targets with the SAME λ and permutation.
- Do NOT mix binary masks (surface_mask, boundary_id). Use the original sample's masks for loss computation.
- Do NOT mix when batch_size=1 (need at least 2 samples to mix).

### Step 3: Handle SRF heads

The SRF heads (SurfaceRefinementHead, AftFoilRefinementHead) operate on subsets of nodes. After mixing encoded features `fx`, the SRF heads should process the mixed features normally. The mixed targets should be used for the SRF loss computation.

### Step 4: Handle PCGrad compatibility

PCGrad separates gradients by loss component. Mixup doesn't change which loss components exist — it only changes the features and targets. PCGrad should work normally with mixed inputs.

### Step 5: torch.compile compatibility

All operations (Beta sampling, indexing, linear interpolation) are compile-safe. The `torch.distributions.Beta` call might need to be outside the compiled region — sample λ before entering the compiled forward pass.

### Step 6: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent nezuko --wandb_name "nezuko/manifold-mixup-s42" \
  --wandb_group "round18/manifold-mixup" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --manifold_mixup --mixup_alpha 0.2

# Seed 73 — identical but --seed 73 --wandb_name "nezuko/manifold-mixup-s73"
```

### Step 7: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```