### PR TITLE
Cosine Warm Restarts: SGDR cyclical LR for multi-basin exploration

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1057,6 +1057,7 @@ class Config:
     scheduler_type: str = "sequential"  # "sequential", "warm_restarts", "onecycle"
     cosine_T_0: int = 50       # warm_restarts only
     cosine_T_mult: int = 2     # warm_restarts only
+    cosine_warm_restarts: bool = False   # SGDR: cosine annealing with warm restarts (overrides scheduler_type)
     onecycle_max_lr: float = 3e-3        # onecycle only
     onecycle_epochs: int = 200           # onecycle only
     onecycle_pct_start: float = 0.15    # onecycle only
@@ -1560,7 +1561,11 @@ if aft_srf_ctx_head is not None:
     print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
-if cfg.scheduler_type == "warm_restarts":
+if cfg.cosine_warm_restarts:
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+        base_opt, T_0=cfg.cosine_T_0, T_mult=cfg.cosine_T_mult, eta_min=cfg.cosine_eta_min
+    )
+elif cfg.scheduler_type == "warm_restarts":
     _warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
     _restarts = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
         base_opt, T_0=cfg.cosine_T_0, T_mult=cfg.cosine_T_mult, eta_min=cfg.cosine_eta_min


### PR DESCRIPTION
## Hypothesis

The baseline uses `CosineAnnealingLR(T_max=160)` — a single cosine decay from peak LR to near-zero. The model converges into ONE basin and stays there. **Cosine Annealing with Warm Restarts (SGDR)** (Loshchilov & Hutter, ICLR 2017) periodically resets the LR to its peak value, giving the optimizer multiple chances to escape the current basin and explore different regions of the loss landscape.

The schedule: `T_0=40, T_mult=2` creates cycles of length 40, 80, 160 epochs:
- Epochs 0-40: first exploration cycle
- Epoch 40: LR resets to peak → escape current basin
- Epochs 40-120: second exploration cycle (80 epochs, deeper convergence)
- Epoch 120: LR resets → final exploration
- Epochs 120-280: third cycle (but training ends at ~150 epochs due to timeout)

The EMA model (decay=0.999) continuously averages across all cycles, effectively creating an implicit ensemble across multiple basins.

**Why it might work here:**
1. With only ~145-155 epochs before timeout, the single cosine decay barely reaches near-zero LR. Warm restarts give more time at high LR (exploration) in the early cycles.
2. The EMA model benefits from weight diversity across cycles — different basins contribute different strengths (some better for p_in, some for p_oodc).
3. OOD generalization often improves with flatter optima. Warm restarts prevent the optimizer from settling into a sharp minimum.

**Key distinction from SWA (#2234, fern's other experiment):**
- SWA: switches to constant LR + uniform weight averaging in the last 20%
- Warm restarts: cyclical LR throughout training + EMA averaging
- These are complementary approaches to the same goal (wider optima)

**Confidence:** Medium. SGDR is well-established in vision (DeiT, ViT). The risk is that the first cycle (40 epochs) is too short for this dataset, and restarts may undo useful learned representations.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
cosine_warm_restarts: bool = False   # SGDR: cosine annealing with warm restarts
cosine_T_0: int = 40                 # first cycle length in epochs
cosine_T_mult: int = 2              # cycle length multiplier (T_0, T_0*T_mult, T_0*T_mult^2, ...)
```

### Step 2: Replace scheduler

Find where `CosineAnnealingLR` is created. When `--cosine_warm_restarts` is enabled, use `CosineAnnealingWarmRestarts` instead:

```python
if cfg.cosine_warm_restarts:
    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
        optimizer, 
        T_0=cfg.cosine_T_0,      # 40 epochs first cycle
        T_mult=cfg.cosine_T_mult,  # 2x each subsequent cycle
        eta_min=1e-6              # minimum LR (same as baseline)
    )
else:
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
        optimizer, T_max=cfg.cosine_T_max, eta_min=1e-6
    )
```

**IMPORTANT:** `CosineAnnealingWarmRestarts` steps per EPOCH (same as the baseline scheduler). Make sure `scheduler.step()` is called once per epoch, not per batch.

### Step 3: No other changes needed

The rest of the training pipeline (EMA, PCGrad, loss computation, etc.) stays exactly the same. Only the LR schedule changes.

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent frieren --wandb_name "frieren/warm-restarts-s42" \
  --wandb_group "round19/cosine-warm-restarts" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --cosine_warm_restarts --cosine_T_0 40 --cosine_T_mult 2

# Seed 73 — identical but --seed 73 --wandb_name "frieren/warm-restarts-s73"
```

**NOTE:** Do NOT include `--cosine_T_max 160` — the warm restarts scheduler uses `T_0` and `T_mult` instead. Including both flags may cause a conflict — make sure the code handles this correctly (use warm restarts scheduler when `--cosine_warm_restarts` is set, regardless of `--cosine_T_max`).

### Step 5: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

Also report:
- The LR curve shape — verify warm restarts are working (LR should spike at epochs ~40 and ~120)
- Which epoch achieved the best validation metrics (before or after a restart?)
- Whether the EMA model or the online model performs better

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent frieren --wandb_name "frieren/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```