### PR TITLE
EMA Self-Distillation: use EMA predictions as soft targets

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,10 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Phase 7: EMA self-distillation
+    ema_self_distill: bool = False          # distill online model from EMA predictions (soft target regularizer)
+    distill_weight: float = 0.1            # weight for EMA distillation loss
+    distill_start_epoch: int = 20          # delay distillation until EMA has stabilized
 
 
 cfg = sp.parse(Config)
@@ -2120,6 +2124,19 @@ for epoch in range(MAX_EPOCHS):
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
             loss = loss + cfg.rdrop_alpha * rdrop_loss
 
+        # EMA self-distillation: push online model predictions toward EMA's stable predictions
+        _distill_loss = None
+        if cfg.ema_self_distill and model.training and ema_model is not None and epoch >= cfg.distill_start_epoch:
+            with torch.no_grad():
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    _ema_out = ema_model({"x": x})
+                _ema_pred_p = (_ema_out["preds"].float() / sample_stds)[:, :, 2]  # surface pressure channel
+            _online_pred_p = pred[:, :, 2]  # same channel from online model (already float, /sample_stds applied)
+            _surf_valid = surf_mask  # [B, N] bool: surface nodes with valid labels
+            if _surf_valid.any():
+                _distill_loss = F.mse_loss(_online_pred_p[_surf_valid], _ema_pred_p[_surf_valid])
+                loss = loss + cfg.distill_weight * _distill_loss
+
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
@@ -2136,8 +2153,9 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            distill_shared = cfg.distill_weight * _distill_loss if _distill_loss is not None else 0.0
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + distill_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + distill_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2182,7 +2200,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                distill_shared = cfg.distill_weight * _distill_loss if _distill_loss is not None else 0.0
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + distill_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2310,7 +2329,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if _distill_loss is not None:
+            _step_log["train/distill_loss"] = _distill_loss.item()
+        wandb.log(_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The baseline uses EMA (decay=0.999) to maintain a smoothed copy of the model for evaluation. The EMA model's predictions are typically more stable and better-generalized than the online model's, because exponential averaging smooths out training noise.

**Self-distillation** adds a secondary loss that pushes the online model's predictions toward the EMA model's predictions. This creates a feedback loop:
- EMA model: slow-moving, stable, provides "consensus" predictions
- Online model: learns from both ground truth AND EMA's smoothed predictions
- The distillation loss acts as a **confidence regularizer** — it penalizes the online model when its predictions diverge significantly from the EMA's stable predictions

**Why it might work here:**
1. **Implicit ensemble effect:** The EMA model averages over many training steps. Distilling from it is like distilling from a temporal ensemble.
2. **OOD regularization:** On OOD samples, the online model may produce noisy predictions that the EMA has smoothed over many steps. The distillation loss keeps the online model from making wild OOD predictions.
3. **Gradient smoothing:** The MSE distillation loss provides a SMOOTH gradient signal (unlike L1 which has discontinuous gradients). This complements the L1 primary loss.
4. **Zero extra compute:** The EMA model is already maintained in the baseline. We just need one extra forward pass (which is fast since it's in `torch.no_grad()`).

**Related work:** Born Again Networks (Furlanello et al., ICML 2018), Mean Teacher (Tarvainen & Valpola, NeurIPS 2017). In those works, using a teacher that tracks the student significantly improves generalization.

**Confidence:** Medium. Novel application to CFD surrogate training. The circular dependency (EMA tracks online, online distills from EMA) is stable at low weights. Main risk: if EMA and online model agree closely (which they should by late training), the distillation loss provides negligible signal.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
ema_self_distill: bool = False      # distill online model from EMA predictions
distill_weight: float = 0.1         # weight for distillation loss
distill_start_epoch: int = 20       # don't distill in very early training (EMA is not yet stable)
```

### Step 2: Add distillation loss in training loop

In the training step, AFTER the online model's forward pass and BEFORE the backward pass:

```python
if cfg.ema_self_distill and epoch >= cfg.distill_start_epoch:
    with torch.no_grad():
        # Forward pass through EMA model (no gradients needed)
        ema_pred = ema_model(x_input)  # same input as online model
        # ema_pred should have the same structure as online model output
        # (pressure predictions, velocity predictions, etc.)
    
    # MSE distillation loss on surface pressure predictions
    distill_loss = F.mse_loss(pred_p[surf_mask], ema_pred_p[surf_mask])
    loss = loss + cfg.distill_weight * distill_loss
    
    # Log to W&B
    if wandb_log:
        log_dict['train/distill_loss'] = distill_loss.item()
```

**IMPORTANT details:**
- Use `torch.no_grad()` for the EMA forward pass — we don't want gradients flowing through the EMA model
- Only distill the SURFACE PRESSURE predictions (not volume, not velocity) — surface pressure is what we optimize for
- Start distillation after epoch 20 — the EMA model needs time to accumulate meaningful averages before being used as a teacher
- Use MSE (not L1) for the distillation loss — MSE provides smoother gradients for matching predictions

### Step 3: Handle EMA forward pass

The EMA model should already be available (it's maintained for evaluation). You'll need to run a forward pass through it during training. This is straightforward since the EMA model has the same architecture as the online model.

If the EMA model is wrapped differently (e.g., not compiled, different module structure), ensure the forward pass produces compatible output tensors.

### Step 4: torch.compile compatibility

The EMA forward pass is in `torch.no_grad()` context and doesn't participate in the backward graph. It should be compile-safe. If the compiled model has issues with the EMA call, run the EMA forward outside the compiled region.

### Step 5: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent thorfinn --wandb_name "thorfinn/ema-distill-s42" \
  --wandb_group "round19/ema-self-distillation" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --ema_self_distill --distill_weight 0.1 --distill_start_epoch 20

# Seed 73 — identical but --seed 73 --wandb_name "thorfinn/ema-distill-s73"
```

### Step 6: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

Also report:
- `train/distill_loss` curve — does the online model converge toward the EMA? (loss should decrease over training)
- Comparison of EMA model vs online model metrics at final epoch
- Any impact on training speed (the extra EMA forward pass should be minimal)

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --wandb_name "thorfinn/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```