### PR TITLE
Lookahead Optimizer: slow-weight averaging wrapper for Lion

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1063,6 +1063,9 @@ class Config:
     onecycle_div_factor: float = 10.0   # onecycle only
     onecycle_final_div_factor: float = 100.0  # onecycle only
     use_lookahead: bool = True
+    lookahead: bool = False              # wrap Lion optimizer with Lookahead (default only wraps AdamW)
+    lookahead_k: int = 5                 # inner loop steps before slow weight update
+    lookahead_alpha: float = 0.5         # interpolation coefficient toward fast weights
     # Architecture flags (one per GPU)
     linear_no_attention: bool = False  # GPU0: skip Q/K/V in slice attention
     field_decoder: bool = False        # GPU1: separate vel/pres output heads
@@ -1558,6 +1561,11 @@ if aft_srf_ctx_head is not None:
     _ctx_params = list(aft_srf_ctx_head.parameters())
     base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
+
+# Wrap optimizer with Lookahead (after all param groups are added)
+if cfg.lookahead:
+    optimizer = Lookahead(base_opt, k=cfg.lookahead_k, alpha=cfg.lookahead_alpha)
+    print(f"Lookahead wrapper: k={cfg.lookahead_k}, alpha={cfg.lookahead_alpha}")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":


### PR DESCRIPTION
## Hypothesis

The current optimizer (Lion, lr=2e-4, cosine annealing) finds good local minima but may settle in sharp valleys that don't generalize well to OOD inputs. **Lookahead** (Zhang et al., 2019) wraps any base optimizer with a slow-weight interpolation mechanism:

1. Maintain two copies of weights: **fast weights** (updated by Lion every step) and **slow weights** (updated every K steps)
2. Every K steps: `slow_weights = slow_weights + alpha * (fast_weights - slow_weights)`
3. Reset fast weights to slow weights
4. At inference, use slow weights

**Why this should help:**
- **Flat minima**: Lookahead's slow weights average over K steps of Lion updates, biasing toward flatter regions of the loss landscape. Flatter minima generalize better to OOD inputs (p_oodc, p_re).
- **Reduced variance**: The slow-weight update smooths out the noisy trajectory of the fast optimizer, reducing the seed-to-seed variance we've seen in many experiments.
- **Proven in competition ML**: Lookahead has been a staple in Kaggle winning solutions since 2019. It consistently provides +0.5-2% improvement at zero cost in training time or VRAM.
- **Complementary to EMA**: The baseline uses `--ema_decay 0.999` for evaluation. Lookahead is different — it modifies the TRAINING trajectory, not just the evaluation weights. EMA smooths the output; Lookahead smooths the optimization path.

**Key distinction from SWA (fern #2234):** SWA averages weights in the FINAL phase of training (last N epochs). Lookahead averages THROUGHOUT training (every K steps). SWA finds a flat region by averaging final iterates; Lookahead constrains the optimizer to stay near a running center throughout.

**Confidence:** Medium-High. Lookahead is one of the simplest optimizer modifications with the most consistent empirical benefit. The only risk is that Lion (which already uses momentum/EMA internally) might already provide some of the stabilization that Lookahead offers — potentially redundant.

**Reference:** Zhang et al., "Lookahead Optimizer: k steps forward, 1 step back," NeurIPS 2019. https://arxiv.org/abs/1907.08610

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Implement Lookahead wrapper class

Add this class BEFORE the main training function. It's a standard optimizer wrapper that works with any base optimizer:

```python
class Lookahead(torch.optim.Optimizer):
    """Lookahead optimizer wrapper (Zhang et al., NeurIPS 2019)."""
    
    def __init__(self, base_optimizer, k=5, alpha=0.5):
        self.base_optimizer = base_optimizer
        self.k = k
        self.alpha = alpha
        self._step_count = 0
        
        # Store slow weights
        self.slow_weights = []
        for group in base_optimizer.param_groups:
            slow = []
            for p in group['params']:
                slow.append(p.data.clone())
            self.slow_weights.append(slow)
        
        # Expose param_groups for scheduler compatibility
        self.param_groups = base_optimizer.param_groups
        self.state = base_optimizer.state
    
    @property
    def defaults(self):
        return self.base_optimizer.defaults
    
    def step(self, closure=None):
        loss = self.base_optimizer.step(closure)
        self._step_count += 1
        
        if self._step_count % self.k == 0:
            for group_idx, group in enumerate(self.base_optimizer.param_groups):
                for p_idx, p in enumerate(group['params']):
                    slow = self.slow_weights[group_idx][p_idx]
                    slow.add_(self.alpha * (p.data - slow))
                    p.data.copy_(slow)
        
        return loss
    
    def zero_grad(self, set_to_none=True):
        self.base_optimizer.zero_grad(set_to_none=set_to_none)
    
    def state_dict(self):
        return self.base_optimizer.state_dict()
    
    def load_state_dict(self, state_dict):
        self.base_optimizer.load_state_dict(state_dict)
```

### Step 2: Add config flags

```python
lookahead: bool = False      # wrap optimizer with Lookahead
lookahead_k: int = 5         # inner loop steps before slow weight update
lookahead_alpha: float = 0.5 # interpolation coefficient toward fast weights
```

### Step 3: Wrap the optimizer

After the Lion optimizer is created (look for the line that creates the optimizer), wrap it:

```python
if cfg.lookahead:
    optimizer = Lookahead(optimizer, k=cfg.lookahead_k, alpha=cfg.lookahead_alpha)
```

**CRITICAL:** The Lookahead wrapper must be applied AFTER the optimizer is created but BEFORE the learning rate scheduler is attached. The scheduler should reference `optimizer.param_groups` which Lookahead proxies correctly.

### Step 4: Verify compatibility

Check that:
- `torch.compile` still works (Lookahead doesn't touch the forward pass)
- The cosine scheduler still updates the LR correctly via `optimizer.param_groups`
- EMA still works (EMA reads model parameters, which Lookahead modifies in-place)
- PCGrad still works (it calls `optimizer.step()` which Lookahead wraps)
- Gradient clipping still works (applied before `optimizer.step()`)

### Step 5: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/lookahead-s42" \
  --wandb_group "round19/lookahead-optimizer" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --lookahead --lookahead_k 5 --lookahead_alpha 0.5

# Seed 73 — identical but --seed 73 --wandb_name "askeladd/lookahead-s73"
```

### Step 6: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, comparison to baseline, W&B run IDs.

Pay special attention to:
- **Seed variance**: If s42-s73 spread is smaller than baseline (1.0-1.5 on p_in), Lookahead is stabilizing training as expected.
- **OOD metrics (p_oodc, p_re)**: These should benefit most from flatter minima.
- **Training curve**: The loss should be smoother (less noisy) than baseline.
- **Epoch count**: Lookahead adds negligible overhead (one weight copy every 5 steps). Epoch count should match baseline (~145-150).

## Baseline

Current best (PR #2213, Wake Deficit Feature, 2-seed average):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| **p_tan** | **28.341** | **< 28.34** |
| p_re   | **6.300**  | < 6.30  |

W&B runs: `hgml7i2r` (seed 42), `qic03vrg` (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd --wandb_name "askeladd/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```