### PR TITLE
SAM: Sharpness-Aware Minimization for flat minima

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1079,6 +1079,8 @@ class Config:
     adaln_decouple: bool = False       # decoupled slice assignment for tandem
     adaln_nozero: bool = False         # ablation: no zero-init on adaln projection
     adaln_sam: bool = False            # SAM optimizer in last 25% of training
+    sam: bool = False                  # SAM optimizer for all training epochs
+    sam_rho: float = 0.05              # SAM perturbation radius
     film_cond: bool = False            # FiLM conditioning (simpler alternative to AdaLN)
     adaln_zone_temp: bool = False      # zone-aware temperature modulation
     # Phase 2 R5: tandem warm-in combinations
@@ -1559,7 +1561,7 @@ if aft_srf_ctx_head is not None:
     base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
 
-sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
+sam_optimizer = SAM(base_opt, rho=cfg.sam_rho if cfg.sam else 0.05) if (cfg.adaln_sam or cfg.sam) else None
 if cfg.scheduler_type == "warm_restarts":
     _warmup = torch.optim.lr_scheduler.LinearLR(base_opt, start_factor=0.1, total_iters=10)
     _restarts = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
@@ -2243,7 +2245,7 @@ for epoch in range(MAX_EPOCHS):
             loss.backward()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
-        sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * 0.75)
+        sam_active = sam_optimizer is not None and (cfg.sam or epoch >= int(MAX_EPOCHS * 0.75))
         _should_step = (cfg.grad_accum_steps <= 1 or
                         (batch_idx + 1) % cfg.grad_accum_steps == 0 or
                         batch_idx == len(train_loader) - 1)
@@ -2252,17 +2254,21 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.perturb()
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
+            x_d = x.detach()  # detach to avoid double-backward through shared x graph
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
+                out2 = model({"x": x_d})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
-            abs_err2 = (pred2 - y_norm).abs()
+            y_norm_d = y_norm.detach()  # detach to avoid double-backward through y_norm graph
+            abs_err2 = (pred2 - y_norm_d).abs()
             vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
             surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
             surf_loss2 = (surf_ps2 * tandem_boost).mean()
-            re_loss2 = F.mse_loss(re_pred2, log_re_target)
-            aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)
+            log_re_target_d = x[:, 0, 13:14].detach()
+            aoa_target_d = x[:, 0, 14:15].detach()
+            re_loss2 = F.mse_loss(re_pred2, log_re_target_d)
+            aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target_d)
             loss2 = vol_loss2 + surf_weight * surf_loss2 + 0.01 * re_loss2 + 0.01 * aoa_loss2
             loss2.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)


### PR DESCRIPTION
## Hypothesis

The model converges to sharp minima that perform well in-distribution but poorly on OOD inputs (p_oodc gap of 1.04 vs ensemble, p_re gap of 0.50). **Sharpness-Aware Minimization (SAM)** (Foret et al., ICLR 2021) explicitly seeks flat minima by optimizing for the worst-case loss in a neighborhood of the current weights.

SAM's update rule:
1. Compute gradient: g = nabla L(w)
2. Compute adversarial perturbation: epsilon = rho * g / ||g||
3. Compute gradient at perturbed point: g' = nabla L(w + epsilon)
4. Update: w = w - lr * g'

This forces the optimizer to find parameters where the loss is low AND the loss surface is flat (robust to perturbation). Flat minima generalize better because small input distribution shifts don't dramatically change the output.

**Why SAM specifically for this problem:**
1. **OOD gap is our main weakness.** p_oodc (7.643) and p_re (6.300) have the biggest gaps vs the 16-seed ensemble. SAM's flat minima directly target OOD robustness.
2. **Warm restarts just failed (#2238)** trying to find better basins by re-exploring. SAM takes the opposite approach: don't escape the current basin, but find the FLATTEST point within it.
3. **Proven in vision transformers.** SAM improves ViT generalization by 1-3% on ImageNet. Our Transolver is architecturally similar (attention-based, similar depth).
4. **Compatible with Lion.** SAM wraps the existing optimizer — it uses Lion for the actual weight update, just with a perturbed gradient.

**Trade-off:** SAM requires 2 forward+backward passes per step (~2x compute). With ~150 epochs normally, expect ~75-80 epochs. Adjust cosine_T_max to 80 to complete the schedule.

**Confidence:** Medium-High. SAM is one of the most well-validated generalization techniques in modern ML. Main risk: 2x compute reduces epoch count, and the model may need the full 150 epochs to converge.

**Reference:** Foret et al., "Sharpness-Aware Minimization for Efficiently Improving Generalization," ICLR 2021. https://arxiv.org/abs/2010.01412

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flags

```python
sam: bool = False          # Sharpness-Aware Minimization
sam_rho: float = 0.05      # perturbation radius (neighborhood size)
```

### Step 2: Implement SAM step

The SAM step replaces the standard `optimizer.step()`. Implement it as a function:

```python
def sam_step(model, optimizer, loss_fn, batch, cfg):
    """One SAM optimization step: ascend then descend."""
    # Step 1: Compute gradient at current point
    loss = loss_fn(model, batch)
    loss.backward()
    
    # Step 2: Save current parameters and compute perturbation
    old_params = {}
    with torch.no_grad():
        grad_norm = 0.0
        for name, p in model.named_parameters():
            if p.grad is not None:
                grad_norm += p.grad.data.norm(2).item() ** 2
            old_params[name] = p.data.clone()
        grad_norm = grad_norm ** 0.5
        
        # Perturb: w + rho * grad / ||grad||
        for name, p in model.named_parameters():
            if p.grad is not None:
                eps = cfg.sam_rho * p.grad.data / (grad_norm + 1e-12)
                p.data.add_(eps)
    
    # Step 3: Compute gradient at perturbed point
    optimizer.zero_grad()
    loss_sam = loss_fn(model, batch)
    loss_sam.backward()
    
    # Step 4: Restore original parameters and apply the perturbed gradient
    with torch.no_grad():
        for name, p in model.named_parameters():
            p.data.copy_(old_params[name])
    
    # Step 5: Standard optimizer step with the perturbed gradient
    optimizer.step()
    
    return loss.item()
```

**IMPORTANT implementation notes:**
- The `loss_fn(model, batch)` function should encapsulate the FULL training loss (surface pressure + volume + velocity + PCGrad + DCT freq — everything).
- You need to refactor the existing training step into a callable `loss_fn` that takes the model and batch and returns the scalar loss. This may require extracting the loss computation into a separate function.
- If this refactoring is too complex, a simpler approach: just double the forward/backward pass inline in the training loop with the perturbation logic between them.

### Step 3: Integrate into training loop

Replace the standard training step with the SAM step when `cfg.sam` is enabled. The key change is that each training step now does TWO forward+backward passes instead of one.

**If refactoring loss_fn is too complex**, use this inline approach:
```python
if cfg.sam:
    # First forward+backward (compute gradient at current point)
    loss = <existing loss computation>
    loss.backward()
    
    # Compute perturbation
    with torch.no_grad():
        grad_norm = sum(p.grad.data.norm(2)**2 for p in model.parameters() if p.grad is not None) ** 0.5
        old_params = {n: p.data.clone() for n, p in model.named_parameters()}
        for p in model.parameters():
            if p.grad is not None:
                p.data.add_(cfg.sam_rho * p.grad.data / (grad_norm + 1e-12))
    
    # Second forward+backward (gradient at perturbed point)
    optimizer.zero_grad()
    loss_sam = <same loss computation again>
    loss_sam.backward()
    
    # Restore and step
    with torch.no_grad():
        for n, p in model.named_parameters():
            p.data.copy_(old_params[n])
    optimizer.step()
else:
    # Standard step (existing code)
    loss.backward()
    optimizer.step()
```

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent frieren --wandb_name "frieren/sam-s42" \
  --wandb_group "round19/sam-optimizer" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 80 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --sam --sam_rho 0.05

# Seed 73 — identical but --seed 73 --wandb_name "frieren/sam-s73"
```

Key changes: `--sam --sam_rho 0.05 --cosine_T_max 80`

### Step 5: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

Report:
- **Epoch count**: Should be ~70-80 (half of baseline due to 2x compute). If much less, SAM overhead is higher than expected.
- **OOD metrics**: p_oodc and p_re are the targets — SAM should help these most.
- **Training curve**: Should be smoother than baseline.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| p_tan  | **28.341** | < 28.34 |
| p_re   | **6.300**  | < 6.30  |

W&B: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent frieren --wandb_name "frieren/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```