### PR TITLE
Spectral Norm SRF: constrain Lipschitz constant for OOD robustness

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    spectral_norm_srf: bool = False         # spectral normalization on SRF MLP hidden layers for Lipschitz control
 
 
 cfg = sp.parse(Config)
@@ -1357,6 +1358,13 @@ if cfg.surface_refine:
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
         ).to(device)
+    if cfg.spectral_norm_srf:
+        # Use parametrizations.spectral_norm (deepcopy-compatible) instead of hook-based spectral_norm.
+        # Skip output layer (zero-init, σ₁≈0 would cause division issues).
+        mlp_layers = list(refine_head.mlp)
+        for i, m in enumerate(mlp_layers[:-1]):  # exclude last (output) layer
+            if isinstance(m, nn.Linear):
+                torch.nn.utils.parametrizations.spectral_norm(m)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())
     print(f"Surface refinement head: {_refine_n_params:,} params "
@@ -1387,6 +1395,13 @@ if cfg.aft_foil_srf:
             n_layers=cfg.aft_foil_srf_layers,
             film=cfg.aft_foil_srf_film,
         ).to(device)
+        if cfg.spectral_norm_srf:
+            # Use parametrizations.spectral_norm (deepcopy-compatible) instead of hook-based spectral_norm.
+            # Skip output layer (zero-init, σ₁≈0 would cause division issues).
+            mlp_layers = list(aft_srf_head.mlp)
+            for i, m in enumerate(mlp_layers[:-1]):  # exclude last (output) layer
+                if isinstance(m, nn.Linear):
+                    torch.nn.utils.parametrizations.spectral_norm(m)
         aft_srf_head = torch.compile(aft_srf_head, mode=cfg.compile_mode)
         _aft_n_params = sum(p.numel() for p in aft_srf_head.parameters())
         print(f"Aft-foil SRF head: {_aft_n_params:,} params "


### PR DESCRIPTION
## Hypothesis

The Surface Refinement (SRF) heads are the final output layer — they take backbone hidden states and produce the surface pressure correction. If the SRF MLPs have unconstrained Lipschitz constants, small changes in the backbone's hidden representation (caused by OOD inputs) can produce large, erratic output changes. This is a core mechanism of OOD failure.

**Spectral Normalization** (Miyato et al., ICLR 2018) constrains each linear layer's spectral norm (largest singular value) to be ≤ 1, bounding the layer's Lipschitz constant. Composing spectrally-normalized layers bounds the entire network's Lipschitz constant, ensuring predictions change smoothly with inputs.

**Why apply to SRF specifically (not the backbone):**
1. The backbone (TransolverBlocks) needs high expressiveness to capture complex physics. Constraining it may hurt in-distribution performance.
2. The SRF heads are the LAST layers before output — they're where unconstrained Lipschitz causes the most OOD damage.
3. SRF heads have 3 layers of hidden_dim=192. Spectral norm on these 3 layers constrains output smoothness while preserving backbone freedom.
4. This is analogous to spectral normalization in GANs (applied to the discriminator/critic, not the generator).

**Expected effect:** Improved p_oodc and p_re (OOD metrics) by constraining output variability on unseen inputs. p_in may be unchanged or slightly worse (constraint reduces expressiveness). p_tan may improve if tandem transfer benefits from smoother aft-foil predictions.

**Confidence:** Medium. Spectral normalization is well-established for Lipschitz control. The uncertainty is whether the SRF heads are actually the bottleneck for OOD performance, or whether the issue lies deeper in the backbone.

**Reference:** Miyato et al., "Spectral Normalization for GANs," ICLR 2018. Also used in physics-informed neural operators for stability.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flag

```python
spectral_norm_srf: bool = False   # apply spectral normalization to SRF MLP layers
```

### Step 2: Apply spectral normalization to SRF heads

Find where the Surface Refinement heads are created. There should be a `SurfaceRefineHead` or similar class with MLP layers. Apply `torch.nn.utils.spectral_norm` to each Linear layer:

```python
if cfg.spectral_norm_srf:
    for module in [fore_srf_head, aft_srf_head]:  # adjust names as needed
        for name, layer in module.named_modules():
            if isinstance(layer, nn.Linear):
                nn.utils.spectral_norm(layer)
```

**IMPORTANT:** Apply spectral norm AFTER the SRF heads are constructed (after `__init__`), not during. `spectral_norm` is a module wrapper that replaces the weight parameter.

**Alternative approach** if the SRF head is constructed inline:
```python
# When building SRF MLP layers:
layers = []
for i in range(n_layers):
    linear = nn.Linear(in_dim, out_dim)
    if cfg.spectral_norm_srf:
        linear = nn.utils.spectral_norm(linear)
    layers.append(linear)
    layers.append(nn.GELU())  # or whatever activation
```

### Step 3: Verify torch.compile compatibility

`torch.nn.utils.spectral_norm` uses hooks that may conflict with `torch.compile`. If compilation fails:
- Try wrapping with `torch.no_grad()` around the spectral norm computation
- Or use the manual implementation: compute SVD of weight matrix, divide by largest singular value
- If all else fails, disable `torch.compile` for this run (add `--no_compile` if available)

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent edward --wandb_name "edward/specnorm-srf-s42" \
  --wandb_group "round19/spectral-norm-srf" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --spectral_norm_srf

# Seed 73 — identical but --seed 73 --wandb_name "edward/specnorm-srf-s73"
```

### Step 5: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

Focus on:
- **p_oodc and p_re**: These are the OOD metrics that spectral norm should help.
- **p_in**: If this degrades significantly, the constraint is too tight (SRF needs more expressiveness).
- **Training loss vs val loss gap**: If spectral norm reduces the generalization gap (train-val difference), it's working as intended even if absolute metrics don't improve.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| p_tan  | **28.341** | < 28.34 |
| p_re   | **6.300**  | < 6.30  |

W&B: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```