### PR TITLE
SRF Dropout: regularize surface refinement heads for OOD

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -552,7 +552,7 @@ class SurfaceRefinementHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
-                 n_layers: int = 2, p_only: bool = False):
+                 n_layers: int = 2, p_only: bool = False, dropout: float = 0.0):
         super().__init__()
         self.p_only = p_only
         actual_out = 1 if p_only else out_dim  # 1 for pressure-only, 3 for all fields
@@ -563,6 +563,8 @@ class SurfaceRefinementHead(nn.Module):
             layers.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
             layers.append(nn.LayerNorm(hidden_dim))
             layers.append(nn.GELU())
+            if dropout > 0.0:
+                layers.append(nn.Dropout(dropout))
         layers.append(nn.Linear(hidden_dim, actual_out))
         # Zero-init last layer so refinement starts as identity
         nn.init.zeros_(layers[-1].weight)
@@ -595,7 +597,7 @@ class AftFoilRefinementHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 192,
-                 n_layers: int = 3, film: bool = False):
+                 n_layers: int = 3, film: bool = False, dropout: float = 0.0):
         super().__init__()
         self.film = film
         in_dim = n_hidden + out_dim
@@ -604,11 +606,15 @@ class AftFoilRefinementHead(nn.Module):
             layers.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
             layers.append(nn.LayerNorm(hidden_dim))
             layers.append(nn.GELU())
+            if dropout > 0.0:
+                layers.append(nn.Dropout(dropout))
         layers.append(nn.Linear(hidden_dim, out_dim))
         nn.init.zeros_(layers[-1].weight)
         nn.init.zeros_(layers[-1].bias)
         self.mlp = nn.Sequential(*layers)
         # FiLM modulation from gap/stagger (2-dim condition)
+        # film_apply_idx: index of layer after which FiLM is applied (end of first block)
+        self.film_apply_idx = 3 if dropout > 0.0 else 2  # Linear(0), LN(1), GELU(2), [Dropout(3)]
         if film:
             self.film_scale = nn.Linear(2, hidden_dim, bias=False)
             self.film_shift = nn.Linear(2, hidden_dim)
@@ -627,12 +633,11 @@ class AftFoilRefinementHead(nn.Module):
             correction: [A, out_dim] — additive correction
         """
         inp = torch.cat([hidden, base_pred], dim=-1)
-        # Run through layers, applying FiLM after first hidden activation
+        # Run through layers, applying FiLM after first hidden activation block
         x = inp
         for i, layer in enumerate(self.mlp):
             x = layer(x)
-            # Apply FiLM after first LayerNorm+GELU (i.e., after index 2)
-            if self.film and cond is not None and i == 2:
+            if self.film and cond is not None and i == self.film_apply_idx:
                 gamma = self.film_scale(cond)   # [A, hidden_dim]
                 beta = self.film_shift(cond)    # [A, hidden_dim]
                 x = x * (1.0 + gamma) + beta
@@ -1170,6 +1175,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    srf_dropout: float = 0.0               # dropout probability in SRF MLP hidden layers (0 = disabled)
 
 
 cfg = sp.parse(Config)
@@ -1356,6 +1362,7 @@ if cfg.surface_refine:
             hidden_dim=cfg.surface_refine_hidden,
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
+            dropout=cfg.srf_dropout,
         ).to(device)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())
@@ -1386,6 +1393,7 @@ if cfg.aft_foil_srf:
             hidden_dim=cfg.aft_foil_srf_hidden,
             n_layers=cfg.aft_foil_srf_layers,
             film=cfg.aft_foil_srf_film,
+            dropout=cfg.srf_dropout,
         ).to(device)
         aft_srf_head = torch.compile(aft_srf_head, mode=cfg.compile_mode)
         _aft_n_params = sum(p.numel() for p in aft_srf_head.parameters())


### PR DESCRIPTION
## Hypothesis

The model currently has **zero dropout anywhere** in the architecture. The Surface Refinement (SRF) heads are the final output layers — they take backbone hidden states and produce pressure corrections on the surface. If these heads overfit to the exact training distribution, they'll produce inaccurate corrections for OOD inputs.

**Adding dropout (p=0.1) to the SRF MLP layers** provides stochastic regularization during training, forcing the SRF heads to be robust to feature dropout. At inference, dropout is disabled (deterministic predictions).

**Why SRF heads specifically (not backbone):**
1. The backbone needs full capacity to learn physics-attention routing. Backbone dropout would interfere with the slice mechanism.
2. SRF heads are 3-layer MLPs (192-dim) that produce the final surface correction. This is where output overfitting happens — the heads memorize exact pressure corrections for training configurations.
3. Selective dropout on output heads is standard in multi-task learning (e.g., detection heads in YOLO, classification heads in ViT). It regularizes the prediction without constraining feature learning.

**Physical motivation:** For OOD inputs (NACA6416 tandem), the backbone produces slightly different hidden states than for training geometries. The SRF heads need to generalize their correction function to these unseen states. Dropout forces the heads to not rely on any single feature dimension, making the correction more robust.

**Confidence:** Medium. Dropout is well-established but has been less effective on physics models than on classification. The key question is whether p=0.1 is enough (or too much) for these small MLPs.

## Instructions

All changes in `cfd_tandemfoil/train.py`.

### Step 1: Add config flag

```python
srf_dropout: float = 0.0    # dropout probability in SRF MLP layers (0 = disabled)
```

### Step 2: Add dropout layers to SRF heads

Find where the Surface Refinement MLP layers are constructed. They should be sequential Linear → Activation → Linear chains. Add `nn.Dropout(cfg.srf_dropout)` after each activation:

```python
# In the SRF head construction (adjust based on actual code structure):
if cfg.srf_dropout > 0:
    layers = []
    for i in range(n_layers):
        layers.append(nn.Linear(in_dim, out_dim))
        layers.append(nn.GELU())  # or whatever activation
        layers.append(nn.Dropout(cfg.srf_dropout))
    layers.append(nn.Linear(out_dim, output_dim))  # final projection, no dropout
    srf_mlp = nn.Sequential(*layers)
```

**IMPORTANT:** Do NOT add dropout after the final Linear layer — only between hidden layers. The output projection should be deterministic.

Apply to BOTH the fore-foil SRF head and the aft-foil SRF head (if separate).

### Step 3: Verify dropout is training-only

`nn.Dropout` automatically disables during `model.eval()`. Verify that validation/visualization code calls `model.eval()` (or `ema_model.eval()`). No manual handling needed.

### Step 4: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent alphonse --wandb_name "alphonse/srf-dropout-s42" \
  --wandb_group "round19/srf-dropout" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --srf_dropout 0.1

# Seed 73 — identical but --seed 73 --wandb_name "alphonse/srf-dropout-s73"
```

### Step 5: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

Focus on OOD metrics (p_oodc, p_re) — these are the expected beneficiaries of regularization.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| p_tan  | **28.341** | < 28.34 |
| p_re   | **6.300**  | < 6.30  |

W&B: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```