### PR TITLE
Online Hard Node Mining: error-weighted surface loss

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1118,6 +1118,8 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    ohnm: bool = False            # online hard node mining: weight surface nodes by current error
+    ohnm_gamma: float = 1.0       # error exponent (1.0=linear focus, 2.0=quadratic focus)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -2001,14 +2003,24 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # OHNM: compute per-node weights based on current prediction error (detached)
+        if cfg.ohnm:
+            with torch.no_grad():
+                node_mean_err = abs_err.detach().mean(dim=-1)  # [B, N] mean across Ux,Uy,p channels
+                raw_w = (node_mean_err ** cfg.ohnm_gamma) * surf_mask.float()  # [B, N]
+                w_mean = (raw_w * surf_mask.float()).sum(dim=1, keepdim=True) / surf_mask.sum(dim=1, keepdim=True).clamp(min=1)
+                ohnm_w = raw_w / (w_mean + 1e-8)  # normalize so mean surface weight = 1
+            _surf_pres_base = abs_err[:, :, 2:3] * ohnm_w.unsqueeze(-1)  # OHNM-weighted pressure error
+        else:
+            _surf_pres_base = abs_err[:, :, 2:3]
+        surf_per_sample = (_surf_pres_base * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+            surf_pres = _surf_pres_base  # use OHNM-weighted pressure errors if enabled
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
@@ -2310,7 +2322,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.ohnm:
+            _log_dict["train/ohnm_w_max"] = ohnm_w.max().item()
+            _log_dict["train/ohnm_w_std"] = (ohnm_w * surf_mask.float()).sum(dim=1).std().item() if B > 1 else 0.0
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis
Surface MAE is dominated by a minority of hard-to-predict nodes (suction peaks, stagnation points, TE pressure recovery). Currently, all surface nodes contribute equally to the loss. By weighting each node's loss contribution by its current prediction error (detached), we focus gradient signal on the nodes that matter most for MAE reduction. This is analogous to focal loss for detection (Lin et al. 2017) adapted for regression, and online hard example mining (OHEM, Shrivastava et al. 2016) applied at the node level.

**Key insight:** The nodes with the largest absolute errors dominate the MAE metric. Training the model to prioritize these nodes should reduce MAE more efficiently than uniform weighting.

## Instructions

### 1. Add CLI flags to `Config` dataclass (near other loss flags around line 1100):
```python
ohnm: bool = False                  # online hard node mining for surface loss
ohnm_gamma: float = 1.0             # error exponent (1.0=linear, 2.0=quadratic focus)
```

### 2. Modify the surface loss computation
Find the surface MAE loss calculation in the training loop (where per-node `|pred - target|` is computed for surface nodes). Modify it as follows:

```python
if cfg.ohnm:
    # Compute per-node errors (detached — no gradient through weights)
    with torch.no_grad():
        node_errors = (pred_surface - gt_surface).abs().mean(dim=-1)  # [M] per-node error across channels
        weights = node_errors ** cfg.ohnm_gamma  # [M] focus on hard nodes
        weights = weights / (weights.mean() + 1e-8)  # normalize so mean weight = 1
    # Apply weights to the loss (weights are detached, loss still gets gradients)
    weighted_surface_loss = (weights.unsqueeze(-1) * (pred_surface - gt_surface).abs()).mean()
else:
    weighted_surface_loss = (pred_surface - gt_surface).abs().mean()  # original uniform MAE
```

**Important details:**
- `weights` must be **detached** (no gradient) — they guide the loss but don't participate in backprop
- Only apply OHNM to the **surface MAE loss**, NOT to DCT freq loss, volume loss, or SRF loss
- Apply OHNM to **both** the main surface loss and the aft-foil surface loss (if `--aft_foil_srf` is active)
- The normalization `weights / weights.mean()` ensures the total loss magnitude stays comparable to baseline
- gamma=1.0 means a node with 2x error gets 2x weight; gamma=2.0 means 4x weight
- Apply this BEFORE any per-sample-std normalization to avoid interfering with the existing normalization pipeline

### 3. Run configuration
```bash
cd cfd_tandemfoil && python train.py --agent frieren --wandb_name "frieren/ohnm-gamma1" \
  --wandb_group "ohnm" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --ohnm --ohnm_gamma 1.0 \
  --seed 42
```
Run with seeds 42 and 73.

## Baseline (PR #2213, 2-seed avg)
| Metric | Value | Target to beat |
|--------|-------|---------------|
| p_in | 11.979 | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| p_tan | 28.341 | < 28.34 |
| p_re | 6.300 | < 6.30 |

Baseline W&B runs: hgml7i2r (s42), qic03vrg (s73)

Reproduce baseline:
```bash
cd cfd_tandemfoil && python train.py --agent frieren --wandb_name "frieren/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```