### PR TITLE
Blended L1+L2 Surface Loss: MSE auxiliary for large-error penalty

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    l2_surface_weight: float = 0.0          # auxiliary L2 (MSE) surface loss weight added on top of L1; 0=disabled
 
 
 cfg = sp.parse(Config)
@@ -1657,6 +1658,7 @@ for epoch in range(MAX_EPOCHS):
         aft_srf_ctx_head.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
+    epoch_surf_l2 = 0.0
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
@@ -2025,6 +2027,12 @@ for epoch in range(MAX_EPOCHS):
         else:
             tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
+        # Auxiliary L2 surface loss: adds MSE penalty for large errors on top of L1
+        _surf_l2_item = 0.0
+        if cfg.l2_surface_weight > 0.0:
+            surf_l2 = (sq_err * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            _surf_l2_item = surf_l2.item()
+            surf_loss = surf_loss + cfg.l2_surface_weight * surf_l2
         if cfg.uncertainty_loss:
             bm = _base_model
             surf_ux_loss = (abs_err[:, :, 0:1] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
@@ -2314,6 +2322,7 @@ for epoch in range(MAX_EPOCHS):
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
+        epoch_surf_l2 += _surf_l2_item
         n_batches += 1
         pbar.set_postfix(vol=f"{vol_loss.item():.3f}", surf=f"{surf_loss.item():.3f}")
 
@@ -2387,6 +2396,7 @@ for epoch in range(MAX_EPOCHS):
         wandb.log({
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
+            **({"train/surf_l2_loss": epoch_surf_l2} if cfg.l2_surface_weight > 0.0 else {}),
             "epoch_time_s": dt,
             "lr": scheduler.get_last_lr()[0],
             "global_step": global_step,
@@ -2755,6 +2765,7 @@ for epoch in range(MAX_EPOCHS):
     metrics = {
         "train/vol_loss": epoch_vol,
         "train/surf_loss": epoch_surf,
+        **({"train/surf_l2_loss": epoch_surf_l2} if cfg.l2_surface_weight > 0.0 else {}),
         "val/loss": val_loss_3split,
         "val/loss_3split": val_loss_3split,
         "val/loss_4split": val_loss_4split,


### PR DESCRIPTION
## Hypothesis
The baseline uses pure L1 (MAE) for the surface loss, which matches the evaluation metric. However, L1 has a constant gradient magnitude regardless of error size — a node with 10x error gets the same gradient magnitude as one with 1x error. Adding a small L2 (MSE) component creates a **quadratic penalty on large errors**, directing more gradient signal to the worst-predicted nodes (suction peaks, stagnation points, TE pressure recovery).

This is different from Huber loss (PR #2236, failed) which REPLACED L1 with L2 for large errors, weakening the penalty. Here we ADD L2 on top of L1, strengthening it.

**Expected mechanism:**
- L1 preserves metric alignment (MAE is what we optimize for)
- L2 component at alpha=0.1 adds 10% MSE penalty → nodes with 3x error get 30% more total gradient vs pure L1
- This should reduce worst-case predictions and improve MAE through variance reduction

## Instructions

### 1. Add CLI flags to `Config` dataclass (near other loss flags):
```python
l2_surface_weight: float = 0.0       # weight for auxiliary L2 (MSE) surface loss; 0=pure L1
```

### 2. Modify the surface loss computation
Find where the surface MAE loss is computed. After the existing L1 loss calculation, add the L2 component:

```python
# Existing L1 surface loss (keep as-is)
surface_l1_loss = ...  # the current MAE computation

# Add L2 component if enabled
if cfg.l2_surface_weight > 0:
    surface_l2_loss = ((pred_surface - gt_surface) ** 2 * surface_mask).sum() / surface_mask.sum().clamp(min=1)
    surface_loss = surface_l1_loss + cfg.l2_surface_weight * surface_l2_loss
else:
    surface_loss = surface_l1_loss
```

**Important details:**
- Apply L2 to the SAME surface nodes as L1 (same mask, same normalization)
- Apply to BOTH fore-foil and aft-foil surface losses
- Do NOT apply L2 to the DCT frequency loss or volume loss
- The L2 should operate on the same normalized targets as L1 (after per-sample-std normalization)
- Log `surface_l2_loss` to W&B separately so we can monitor it

### 3. Run configuration
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/blended-l1l2-alpha01" \
  --wandb_group "blended-l1l2" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --l2_surface_weight 0.1 \
  --seed 42
```
Run with seeds 42 and 73.

## Baseline (PR #2213, 2-seed avg)
| Metric | Value | Target to beat |
|--------|-------|---------------|
| p_in | 11.979 | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| p_tan | 28.341 | < 28.34 |
| p_re | 6.300 | < 6.30 |

Baseline W&B runs: hgml7i2r (s42), qic03vrg (s73)

Reproduce baseline:
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```