### PR TITLE
Aft-Foil Surface Loss Upweighting: 1.5x weight on aft-foil nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1165,6 +1165,7 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    aft_foil_loss_weight: float = 1.0        # multiplier for aft-foil surface loss (1.0 = no change)
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
@@ -1774,6 +1775,12 @@ for epoch in range(MAX_EPOCHS):
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
+        # Aft-foil loss upweighting mask (independent of aft_srf_head)
+        _aft_loss_mask = None
+        if cfg.aft_foil_loss_weight != 1.0:
+            _afw_saf_norm = x[:, :, 2:4].norm(dim=-1) if _aft_foil_mask is None else _raw_saf_norm
+            _afw_is_tandem = (x[:, 0, 22].abs() > 0.01) if _aft_foil_mask is None else _is_tandem
+            _aft_loss_mask = is_surface & (_afw_saf_norm > 0.005) & _afw_is_tandem.unsqueeze(1)
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
@@ -2001,7 +2008,16 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Aft-foil loss upweighting: apply per-node weights before reduction
+        _aft_w = None
+        if _aft_loss_mask is not None:
+            _aft_w = torch.ones_like(abs_err[:, :, :1])  # [B, N, 1]
+            _aft_w[_aft_loss_mask] = cfg.aft_foil_loss_weight
+            if batch_idx == 0 and epoch == 0:
+                n_aft = _aft_loss_mask.sum().item()
+                n_surf = surf_mask.sum().item()
+                print(f"Aft-foil loss upweight: {n_aft}/{n_surf} surface nodes at {cfg.aft_foil_loss_weight}x")
+        surf_per_sample = (abs_err[:, :, 2:3] * (_aft_w if _aft_w is not None else 1.0) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
@@ -2015,7 +2031,7 @@ for epoch in range(MAX_EPOCHS):
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            surf_per_sample = (surf_pres * hard_weights * (_aft_w if _aft_w is not None else 1.0) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
@@ -2259,7 +2275,7 @@ for epoch in range(MAX_EPOCHS):
                 aoa_pred2 = out2["aoa_pred"].float()
             abs_err2 = (pred2 - y_norm).abs()
             vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
-            surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            surf_ps2 = (abs_err2[:, :, 2:3] * (_aft_w if _aft_w is not None else 1.0) * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
             surf_loss2 = (surf_ps2 * tandem_boost).mean()
             re_loss2 = F.mse_loss(re_pred2, log_re_target)
             aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)


### PR DESCRIPTION
## Hypothesis

p_tan (28.341) is the hardest metric and the primary bottleneck. It measures surface pressure accuracy on the aft foil in tandem configurations, which is dominated by complex wake interactions from the fore foil.

Currently, the surface loss treats all surface nodes equally — fore-foil and aft-foil nodes contribute the same loss weight. But aft-foil predictions are systematically harder and more important for p_tan.

**Upweighting aft-foil surface loss by 1.5x** directs more optimization pressure toward the harder aft-foil predictions. This is analogous to class imbalance weighting in classification — the "harder class" (aft-foil) gets more attention.

**Why this should help:**
1. **Gradient allocation:** With equal weights, the optimizer spends equal effort on fore-foil (easier, already accurate) and aft-foil (harder, main source of p_tan error). 1.5x shifts gradient budget toward the bottleneck.
2. **Different from OHNM:** Online Hard Node Mining (#2249, in flight) upweights hard NODES within each foil. This upweights the entire AFT FOIL — they're orthogonal and complementary.
3. **Backed by data:** The higher weight decay experiment (#2246) showed p_tan improved with stronger regularization. Aft-foil upweighting is a more targeted way to improve p_tan without the p_in regression from global regularization.

**Risk:** If 1.5x is too aggressive, fore-foil accuracy (p_in) could degrade as the optimizer underweights it. The 1.5x factor is conservative — enough to shift gradient allocation meaningfully without starving fore-foil training.

**Confidence:** Medium. Loss weighting is a direct, well-understood lever. The uncertainty is in the exact multiplier.

## Instructions

### Code changes in `cfd_tandemfoil/train.py`

**Step 1: Add config flag**

In the `Config` class, add:
```python
aft_foil_loss_weight: float = 1.0   # multiplier for aft-foil (boundary_id=7) surface loss (1.0 = no change)
```

**Step 2: Apply the weight in the surface loss computation**

Find where the surface loss is computed. There should be a section that computes per-node losses on surface nodes. The aft-foil surface nodes are identified by `boundary_id == 7` (or a similar mask like `saf_norm` or the foil-2 mask).

Apply the weight BEFORE reduction:
```python
# After computing per-node surface loss but BEFORE mean/sum reduction:
if cfg.aft_foil_loss_weight != 1.0:
    # boundary_id 7 = aft-foil surface nodes
    aft_mask = (boundary_id == 7)  # adjust variable name as needed
    node_weights = torch.ones_like(surface_loss_per_node)
    node_weights[aft_mask] = cfg.aft_foil_loss_weight
    surface_loss_per_node = surface_loss_per_node * node_weights
```

**IMPORTANT:** Only modify the surface loss term, not the volume loss. The weight should apply equally to all channels (Ux, Uy, p) on aft-foil nodes. Look at the existing code to understand how boundary IDs are stored — likely in `data['boundary_id']` or similar.

**Step 3: Verify the mask is correct**

Print the number of aft-foil nodes being upweighted in the first batch to confirm the mask works:
```python
if step == 0 and cfg.aft_foil_loss_weight != 1.0:
    n_aft = aft_mask.sum().item()
    n_surf = surface_mask.sum().item()
    print(f"Aft-foil loss upweight: {n_aft}/{n_surf} surface nodes at {cfg.aft_foil_loss_weight}x")
```

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent nezuko --wandb_name "nezuko/aft-upweight-1.5-s42" \
  --wandb_group "round20/aft-foil-loss-upweight" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --aft_foil_loss_weight 1.5

# Seed 73
cd cfd_tandemfoil && python train.py \
  --agent nezuko --wandb_name "nezuko/aft-upweight-1.5-s73" \
  --wandb_group "round20/aft-foil-loss-upweight" \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --aft_foil_loss_weight 1.5
```

New flag: `--aft_foil_loss_weight 1.5`

### Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

**Focus on p_tan** — this is the target metric. Also watch p_in closely — if it degrades, the upweighting may be stealing gradient budget from fore-foil.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| p_tan  | **28.341** | < 28.34 |
| p_re   | **6.300**  | < 6.30  |

W&B: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```