### PR TITLE
Backbone Hidden Noise: Gaussian noise injection for OOD robustness

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -512,6 +512,8 @@ class TransolverBlock(nn.Module):
             film_out = self.film_net(condition)  # [B, H*2]
             gamma, beta = film_out.chunk(2, dim=-1)  # each [B, H]
             fx = gamma.unsqueeze(1) * fx + beta.unsqueeze(1)
+        if self.training and cfg.backbone_noise > 0:
+            fx = fx + torch.randn_like(fx) * cfg.backbone_noise
         if self.last_layer:
             fx_ln = self.ln_3(fx)
             if self.soft_moe:
@@ -1170,6 +1172,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    backbone_noise: float = 0.0             # std of Gaussian noise added to backbone hidden states during training (0=disabled)
 
 
 cfg = sp.parse(Config)


### PR DESCRIPTION
## Hypothesis

Round 19's spectral norm experiment (#2243) revealed a key insight: **OOD failure is in the backbone representation, not the output heads.** Spectral norm on SRF heads improved p_in (-2.5%) but worsened OOD metrics — because the backbone features themselves are erratic on OOD inputs.

**Adding small Gaussian noise to backbone hidden states during training** directly addresses this. By perturbing the learned features at each TransolverBlock, we force the downstream layers (and SRF heads) to be robust to small representation perturbations — which is exactly what OOD inputs cause.

This is fundamentally different from:
- **Input noise** (#2235, failed): corrupts geometric features before encoding
- **Dropout** (#2245, failed): removes entire neurons, too aggressive for SRF
- **Weight noise / SAM**: perturbs parameters, not features

**Backbone hidden noise** adds noise at the RIGHT level of abstraction — after encoding but before output — forcing the model to learn smooth, robust mappings from features to predictions.

**Analogies:**
- Denoising autoencoders (Vincent et al., 2008): inject noise in latent space, force reconstruction robustness
- Noise injection in RNNs (Gal & Ghahramani, 2016): improves sequence model robustness
- Gaussian noise regularization (Bishop, 1995): equivalent to Tikhonov regularization on the learned representation

**σ = 0.01**: Very small relative to hidden state magnitudes (which are O(1) after LayerNorm). Enough to regularize without destroying signal.

**Confidence:** Medium. The theoretical motivation is strong (directly targets the identified failure mode). The uncertainty is in calibrating σ — too large destroys convergence, too small has no effect.

## Instructions

### Code changes in `cfd_tandemfoil/train.py`

**Step 1: Add config flag**

In the `Config` class, add:
```python
backbone_noise: float = 0.0   # std of Gaussian noise added to backbone hidden states during training (0=disabled)
```

**Step 2: Add noise in TransolverBlock.forward()**

In the `TransolverBlock.forward()` method, add noise to the output hidden state AFTER the residual connection and LayerNorm but BEFORE returning. This way, each block's output is perturbed:

```python
def forward(self, fx, ...):
    # ... existing forward pass ...
    # At the very end, after all computations:
    if self.training and cfg.backbone_noise > 0:
        fx = fx + torch.randn_like(fx) * cfg.backbone_noise
    return fx
```

**IMPORTANT:** 
- Only during training (`self.training`), never at inference.
- Apply AFTER the residual connection — we want to perturb the COMBINED representation, not just the attention output.
- Apply to ALL TransolverBlocks (the noise compounds slightly across layers, which is fine at σ=0.01).

**Step 3: Verify torch.compile compatibility**

`torch.randn_like` should be compatible with torch.compile. If not, use a pre-allocated noise buffer.

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent edward --wandb_name "edward/backbone-noise-s42" \
  --wandb_group "round20/backbone-hidden-noise" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --backbone_noise 0.01

# Seed 73
cd cfd_tandemfoil && python train.py \
  --agent edward --wandb_name "edward/backbone-noise-s73" \
  --wandb_group "round20/backbone-hidden-noise" \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --backbone_noise 0.01
```

New flag: `--backbone_noise 0.01`

### Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

**Focus on p_oodc and p_re** — these are the OOD metrics that should benefit most from backbone robustness. If p_in degrades, the noise may be too large. If nothing changes, the noise may be too small.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| p_tan  | **28.341** | < 28.34 |
| p_re   | **6.300**  | < 6.30  |

W&B: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```