### PR TITLE
Augmentation Annealing: disable data aug after epoch 120 for clean fine-tuning

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1111,6 +1111,7 @@ class Config:
     aug_scale_range: float = 0.05   # half-range for scale augmentation (default ±5%)
     aug_start_epoch: int = 0        # delay augmentation onset until this epoch
     aug_stop_epoch: int = 0         # epoch after which to disable augmentation (0 = never stop)
+    aug_aoa_stop_epoch: int = 0     # epoch after which to disable AoA perturbation only (0 = never stop)
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
@@ -1647,6 +1648,8 @@ for epoch in range(MAX_EPOCHS):
 
     if cfg.aug_stop_epoch > 0 and epoch == cfg.aug_stop_epoch:
         print(f"Augmentation disabled at epoch {epoch}")
+    if cfg.aug_aoa_stop_epoch > 0 and epoch == cfg.aug_aoa_stop_epoch:
+        print(f"AoA perturbation disabled at epoch {epoch}")
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
@@ -1699,7 +1702,8 @@ for epoch in range(MAX_EPOCHS):
                 _lo = 1.0 - cfg.aug_scale_range
                 _scale = torch.rand(x.size(0), 1, 1, device=x.device) * (2 * cfg.aug_scale_range) + _lo
                 x[:, :, :2] = x[:, :, :2] * _scale
-            if cfg.aug == "aoa_perturb":
+            _aoa_active = (cfg.aug_aoa_stop_epoch == 0 or epoch < cfg.aug_aoa_stop_epoch)
+            if cfg.aug == "aoa_perturb" and _aoa_active:
                 _angle_deg = torch.rand(x.size(0), device=x.device) * 2.0 - 1.0
                 _angle_rad = _angle_deg * (torch.pi / 180.0)
                 _cos_a = torch.cos(_angle_rad).view(-1, 1, 1)

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1110,6 +1110,7 @@ class Config:
     aug: str = "none"  # none|yflip|jitter|featdrop|mixup|scale|flip_jitter|aoa_perturb|cutmix
     aug_scale_range: float = 0.05   # half-range for scale augmentation (default ±5%)
     aug_start_epoch: int = 0        # delay augmentation onset until this epoch
+    aug_stop_epoch: int = 0         # epoch after which to disable augmentation (0 = never stop)
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
@@ -1644,6 +1645,9 @@ for epoch in range(MAX_EPOCHS):
 
     t0 = time.time()
 
+    if cfg.aug_stop_epoch > 0 and epoch == cfg.aug_stop_epoch:
+        print(f"Augmentation disabled at epoch {epoch}")
+
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
 
@@ -1668,7 +1672,8 @@ for epoch in range(MAX_EPOCHS):
         mask = mask.to(device, non_blocking=True)
 
         # --- Data augmentation (training-only, applied before normalization) ---
-        if model.training and cfg.aug != "none" and epoch >= cfg.aug_start_epoch:
+        _apply_aug = (cfg.aug != "none") and (cfg.aug_stop_epoch == 0 or epoch < cfg.aug_stop_epoch)
+        if model.training and _apply_aug and epoch >= cfg.aug_start_epoch:
             if cfg.aug in ("yflip", "flip_jitter"):
                 _flip = torch.rand(x.size(0), 1, 1, device=x.device) < 0.5
                 x[:, :, 1:2] = torch.where(_flip, -x[:, :, 1:2], x[:, :, 1:2])
@@ -1744,7 +1749,7 @@ for epoch in range(MAX_EPOCHS):
         # Foil-2 DSDF magnitude augmentation (tandem samples only, training only)
         # x layout: [pos(2), saf(2), dsdf(8), ...]; foil-2 SDF = dsdf[4:8] = x[:, :, 6:10]
         # Scaling is log-normal (preserves gradient directions, adjusts magnitude only)
-        if model.training and cfg.aug_dsdf2_sigma > 0.0:
+        if model.training and cfg.aug_dsdf2_sigma > 0.0 and _apply_aug:
             _is_tandem_aug2 = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero → tandem
             if _is_tandem_aug2.any():
                 _dsdf2_scale = torch.exp(


### PR DESCRIPTION
## Hypothesis

The baseline applies data augmentation (AoA perturbation, gap/stagger noise, DSDF rotation) for ALL ~149 epochs of training. In the last ~30 epochs, the cosine LR is very low (approaching 1e-5), meaning the model is making tiny fine-tuning updates. But the augmentation continues adding noise to every training batch, perturbing the optimization landscape at a time when the model should be converging to a precise minimum.

**Disabling augmentation after epoch 120** creates a two-phase training strategy:
- **Phase 1 (epochs 0-120):** Full augmentation — learn robust, generalized features from diverse augmented samples
- **Phase 2 (epochs 120-149):** Clean data only — fine-tune on the real data distribution for maximum precision

**Why this should help:**
1. **Augmentation noise vs convergence precision:** Augmentation is beneficial during the exploratory phase of training (high LR, early epochs) but counterproductive during fine-tuning (low LR, late epochs). The model's gradients in late training are dominated by augmentation noise rather than signal about the true optimum.
2. **Established technique:** Augmentation annealing is standard in vision (e.g., AugMax, DeiT-III). The principle: start with strong aug to learn robust features, then remove it to fit the true distribution precisely.
3. **EMA benefits:** The EMA model averages the last ~4-5 epochs of updates. If those updates are on clean data (not augmented), the EMA captures a more precise center of the converged region.

**Epoch 120 rationale:** At epoch 120/160 of the cosine schedule, LR ≈ 2.5e-5 (1/8th of peak). This is the natural transition point where exploration gives way to exploitation. 29 clean epochs at low LR is enough for fine-tuning.

**Confidence:** Medium-high. The technique is well-established in vision and the logic applies directly. The risk is that augmentation in late training is actually still beneficial for OOD robustness — but the low LR means the model barely moves regardless.

## Instructions

### Code changes in `cfd_tandemfoil/train.py`

**Step 1: Add config flag**

In the `Config` class, add:
```python
aug_stop_epoch: int = 0   # epoch after which to disable augmentation (0 = never stop, keep aug for all epochs)
```

**Step 2: Conditionally skip augmentation**

Find where data augmentation is applied during training. There should be a section in the training loop (likely after loading a batch, before the forward pass) with augmentation code gated by `cfg.aug != "none"` or similar.

Wrap the augmentation block with an epoch check:
```python
# Before existing augmentation code:
apply_aug = (cfg.aug != "none") and (cfg.aug_stop_epoch == 0 or epoch < cfg.aug_stop_epoch)

if apply_aug:
    # ... existing augmentation code (AoA perturbation, gap/stagger, DSDF rotation, etc.) ...
```

**IMPORTANT:**
- This should disable ALL augmentation types: AoA perturbation, gap/stagger noise, DSDF rotation, dsdf2_sigma — everything in the augmentation block.
- Do NOT disable the `tandem_ramp` or other curriculum schedules — those are loss weighting, not data augmentation.
- Log when augmentation stops: `if epoch == cfg.aug_stop_epoch: print(f"Augmentation disabled at epoch {epoch}")`

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/aug-anneal-120-s42" \
  --wandb_group "round20/aug-annealing" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --aug_stop_epoch 120

# Seed 73
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/aug-anneal-120-s73" \
  --wandb_group "round20/aug-annealing" \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --aug_stop_epoch 120
```

New flag: `--aug_stop_epoch 120`

### Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds, 2-seed avg, baseline comparison, W&B run IDs.

**Watch for:** p_in should benefit most (clean fine-tuning on in-distribution). p_oodc and p_re might degrade if late-training augmentation was helping OOD — this is the key trade-off to measure.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| p_tan  | **28.341** | < 28.34 |
| p_re   | **6.300**  | < 6.30  |

W&B: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent askeladd --wandb_name "askeladd/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```