### PR TITLE
Focal Sample Reweighting: upweight hard-loss samples by loss^0.5

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1168,6 +1168,7 @@ class Config:
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
+    focal_sample_gamma: float = 0.0         # focal-style per-sample loss reweighting; 0=disabled
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
 
@@ -1657,6 +1658,7 @@ for epoch in range(MAX_EPOCHS):
         aft_srf_ctx_head.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
+    epoch_focal_std = 0.0
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
@@ -2016,6 +2018,13 @@ for epoch in range(MAX_EPOCHS):
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Focal sample reweighting: upweight hard samples by (loss_i / mean_loss)^gamma
+        if cfg.focal_sample_gamma > 0.0:
+            _focal_mean = surf_per_sample.detach().mean().clamp(min=1e-8)
+            focal_w = (surf_per_sample.detach() / _focal_mean).pow(cfg.focal_sample_gamma)
+            focal_w = focal_w / focal_w.mean()  # normalize to preserve gradient scale
+            surf_per_sample = surf_per_sample * focal_w
+            epoch_focal_std += focal_w.std().item()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
@@ -2260,6 +2269,10 @@ for epoch in range(MAX_EPOCHS):
             abs_err2 = (pred2 - y_norm).abs()
             vol_loss2 = (abs_err2 * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
             surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            if cfg.focal_sample_gamma > 0.0:
+                _fm2 = surf_ps2.detach().mean().clamp(min=1e-8)
+                _fw2 = (surf_ps2.detach() / _fm2).pow(cfg.focal_sample_gamma)
+                surf_ps2 = surf_ps2 * (_fw2 / _fw2.mean())
             surf_loss2 = (surf_ps2 * tandem_boost).mean()
             re_loss2 = F.mse_loss(re_pred2, log_re_target)
             aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)
@@ -2384,13 +2397,16 @@ for epoch in range(MAX_EPOCHS):
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
     if not _do_val:
         dt = time.time() - t0
-        wandb.log({
+        _log = {
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
             "epoch_time_s": dt,
             "lr": scheduler.get_last_lr()[0],
             "global_step": global_step,
-        })
+        }
+        if cfg.focal_sample_gamma > 0.0:
+            _log["train/focal_weight_std"] = epoch_focal_std / max(n_batches, 1)
+        wandb.log(_log)
         print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
         continue
 
@@ -2764,6 +2780,8 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+    if cfg.focal_sample_gamma > 0.0:
+        metrics["train/focal_weight_std"] = epoch_focal_std / max(n_batches, 1)
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f


### PR DESCRIPTION
## Hypothesis

The baseline's existing hard-sample mechanisms (PCGrad, tandem_ramp, pcgrad_extreme_pct) operate at the **gradient conflict** and **domain balance** levels — they don't dynamically prioritize samples that the model currently struggles with most. Adding focal-style per-sample reweighting at the **loss** level should direct more gradient signal to the hardest samples (extreme tandem configurations, unusual Re values) that consistently produce the highest surface error.

**Mechanism:** Compute the per-sample surface MAE, then weight each sample's contribution to the batch loss by `(loss_i / mean_loss)^gamma`. This is analogous to Focal Loss for classification (Lin et al., RetinaNet, CVPR 2017) applied to regression:
- gamma=0: standard uniform weighting (baseline)
- gamma=0.5: moderate upweighting of hard samples (2x error → 1.41x weight)
- gamma=1.0: aggressive upweighting (2x error → 2x weight)

**Key distinction from in-flight experiments:**
- **Frieren's OHNM (#2249):** reweights individual *nodes* within each sample based on per-node error. This reweights entire *samples* based on their aggregate surface MAE.
- **Nezuko's aft-foil upweight (#2253):** applies fixed 1.5x weight to aft-foil nodes. This is dynamic and sample-level.
- **PCGrad extreme pct:** only handles Re-extreme samples. This handles ANY hard sample.

Use gamma=0.5 as the first trial — moderate enough to not destabilize training but meaningful signal shift.

## Instructions

### 1. Add CLI flag to `Config` dataclass (near `pcgrad_extreme_pct`):
```python
focal_sample_gamma: float = 0.0  # focal-style per-sample loss reweighting; 0=disabled
```

### 2. Modify the per-sample loss computation

Find where the surface loss is averaged across the batch. The current structure computes surface loss per sample (or per node), then reduces with `.mean()`. You need to intercept just before the final `.mean()` reduction on surface loss.

The key change: **before the final `.mean()` call on surface_loss**, compute per-sample MAE and reweight:

```python
# After computing per-sample surface MAE (shape [B]):
if cfg.focal_sample_gamma > 0.0:
    # Compute mean loss across batch (detached to avoid second-order gradients)
    mean_loss = surface_loss_per_sample.detach().mean().clamp(min=1e-8)
    # Focal weights: samples with higher loss get more weight
    focal_weights = (surface_loss_per_sample.detach() / mean_loss).pow(cfg.focal_sample_gamma)
    # Normalize so total gradient magnitude is preserved
    focal_weights = focal_weights / focal_weights.mean()
    surface_loss = (surface_loss_per_sample * focal_weights).mean()
else:
    surface_loss = surface_loss_per_sample.mean()
```

**Implementation notes:**
- Apply focal reweighting to the SURFACE loss only, not the volume loss (we care about surface MAE)
- Use `.detach()` on the weights so no second-order gradients are computed
- Normalize weights to preserve gradient scale (prevents effective LR change)
- Apply AFTER the PCGrad split — modify each domain's surface loss separately within the PCGrad forward passes
- Log `focal_weights.std()` to W&B so we can see how much variance is in the weights

**Important:** You need to restructure the surface loss to give you per-sample values `[B]` before the `.mean()`. The current code may already compute this — look for where surface masks are applied and per-sample averaging is done.

### 3. Run configuration

```bash
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/focal-gamma05-s42" \
  --wandb_group "focal-sample-reweight" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --focal_sample_gamma 0.5 \
  --seed 42
```

Run with seeds 42 and 73. Use `--wandb_group "focal-sample-reweight"` for both runs.

### 4. Suggested follow-ups (for the comments section)
If gamma=0.5 works: try gamma=1.0 for stronger upweighting.
If gamma=0.5 hurts: the existing mechanisms already cover sample-level difficulty.

## Baseline (PR #2213, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in | 11.979 | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| p_tan | 28.341 | < 28.34 |
| p_re | 6.300 | < 6.30 |

Baseline W&B runs: hgml7i2r (s42), qic03vrg (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --wandb_name "tanjiro/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```