### PR TITLE
Flow-Regime Conditioned SRF via FiLM: AoA/Umag modulation on surface head

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -552,9 +552,10 @@ class SurfaceRefinementHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
-                 n_layers: int = 2, p_only: bool = False):
+                 n_layers: int = 2, p_only: bool = False, flow_film: bool = False):
         super().__init__()
         self.p_only = p_only
+        self.flow_film = flow_film
         actual_out = 1 if p_only else out_dim  # 1 for pressure-only, 3 for all fields
         layers: list[nn.Module] = []
         # Input: hidden features (n_hidden) + base predictions (out_dim)
@@ -568,17 +569,35 @@ class SurfaceRefinementHead(nn.Module):
         nn.init.zeros_(layers[-1].weight)
         nn.init.zeros_(layers[-1].bias)
         self.mlp = nn.Sequential(*layers)
+        # FiLM conditioning on (log_Re, AoA) — applied after first GELU (index 2)
+        if flow_film:
+            self.flow_film_net = nn.Sequential(
+                nn.Linear(2, 64), nn.SiLU(),
+                nn.Linear(64, hidden_dim * 2),
+            )
+            nn.init.zeros_(self.flow_film_net[-1].weight)
+            nn.init.zeros_(self.flow_film_net[-1].bias)
 
-    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor,
+                flow_cond: torch.Tensor | None = None) -> torch.Tensor:
         """
         Args:
             hidden: [M, n_hidden] — hidden features for surface nodes only
             base_pred: [M, out_dim] — base predictions for surface nodes only
+            flow_cond: [M, 2] — (log_Re, AoA) per node (only used if flow_film=True)
         Returns:
             correction: [M, out_dim] — additive correction (zero-padded for p_only)
         """
         inp = torch.cat([hidden, base_pred], dim=-1)
-        correction = self.mlp(inp)
+        x = inp
+        for i, layer in enumerate(self.mlp):
+            x = layer(x)
+            # Apply FiLM after first hidden activation (index 2 = after GELU)
+            if self.flow_film and flow_cond is not None and i == 2:
+                film_params = self.flow_film_net(flow_cond)  # [M, hidden_dim*2]
+                scale, shift = film_params.chunk(2, dim=-1)
+                x = x * (1.0 + scale) + shift
+        correction = x
         if self.p_only:
             # Pad with zeros for velocity channels: [M, 1] → [M, 3]
             zeros = torch.zeros(correction.shape[0], base_pred.shape[-1] - 1,
@@ -595,9 +614,10 @@ class AftFoilRefinementHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 192,
-                 n_layers: int = 3, film: bool = False):
+                 n_layers: int = 3, film: bool = False, flow_film: bool = False):
         super().__init__()
         self.film = film
+        self.flow_film = flow_film
         in_dim = n_hidden + out_dim
         layers: list[nn.Module] = []
         for i in range(n_layers):
@@ -615,14 +635,24 @@ class AftFoilRefinementHead(nn.Module):
             nn.init.zeros_(self.film_scale.weight)
             nn.init.zeros_(self.film_shift.weight)
             nn.init.zeros_(self.film_shift.bias)
+        # FiLM conditioning on (log_Re, AoA) — applied after first GELU (index 2)
+        if flow_film:
+            self.flow_film_net = nn.Sequential(
+                nn.Linear(2, 64), nn.SiLU(),
+                nn.Linear(64, hidden_dim * 2),
+            )
+            nn.init.zeros_(self.flow_film_net[-1].weight)
+            nn.init.zeros_(self.flow_film_net[-1].bias)
 
     def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor,
-                cond: torch.Tensor | None = None) -> torch.Tensor:
+                cond: torch.Tensor | None = None,
+                flow_cond: torch.Tensor | None = None) -> torch.Tensor:
         """
         Args:
             hidden: [A, n_hidden] — hidden features for aft-foil nodes
             base_pred: [A, out_dim] — base predictions for aft-foil nodes
             cond: [A, 2] — (gap, stagger) per node (only used if film=True)
+            flow_cond: [A, 2] — (log_Re, AoA) per node (only used if flow_film=True)
         Returns:
             correction: [A, out_dim] — additive correction
         """
@@ -631,11 +661,16 @@ class AftFoilRefinementHead(nn.Module):
         x = inp
         for i, layer in enumerate(self.mlp):
             x = layer(x)
-            # Apply FiLM after first LayerNorm+GELU (i.e., after index 2)
-            if self.film and cond is not None and i == 2:
-                gamma = self.film_scale(cond)   # [A, hidden_dim]
-                beta = self.film_shift(cond)    # [A, hidden_dim]
-                x = x * (1.0 + gamma) + beta
+            # Apply geometry FiLM then flow FiLM after first GELU (index 2)
+            if i == 2:
+                if self.film and cond is not None:
+                    gamma = self.film_scale(cond)   # [A, hidden_dim]
+                    beta = self.film_shift(cond)    # [A, hidden_dim]
+                    x = x * (1.0 + gamma) + beta
+                if self.flow_film and flow_cond is not None:
+                    film_params = self.flow_film_net(flow_cond)  # [A, hidden_dim*2]
+                    scale, shift = film_params.chunk(2, dim=-1)
+                    x = x * (1.0 + scale) + shift
         return x
 
 
@@ -1165,6 +1200,7 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    srf_flow_film: bool = False              # FiLM conditioning on (log_Re, AoA) for SRF and aft-SRF heads
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
@@ -1356,6 +1392,7 @@ if cfg.surface_refine:
             hidden_dim=cfg.surface_refine_hidden,
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
+            flow_film=cfg.srf_flow_film,
         ).to(device)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())
@@ -1386,6 +1423,7 @@ if cfg.aft_foil_srf:
             hidden_dim=cfg.aft_foil_srf_hidden,
             n_layers=cfg.aft_foil_srf_layers,
             film=cfg.aft_foil_srf_film,
+            flow_film=cfg.srf_flow_film,
         ).to(device)
         aft_srf_head = torch.compile(aft_srf_head, mode=cfg.compile_mode)
         _aft_n_params = sum(p.numel() for p in aft_srf_head.parameters())
@@ -1916,7 +1954,8 @@ for epoch in range(MAX_EPOCHS):
                     if surf_idx.numel() > 0:
                         surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
                         surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
-                        correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
+                        _srf_flow_cond = x[surf_idx[:, 0], 0, 13:15] if cfg.srf_flow_film else None
+                        correction = refine_head(surf_hidden, surf_pred, flow_cond=_srf_flow_cond).float()
                         pred = pred.clone()
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
 
@@ -1949,8 +1988,9 @@ for epoch in range(MAX_EPOCHS):
                 _aft_cond = None
                 if cfg.aft_foil_srf_film:
                     _aft_cond = _raw_gap_stagger[aft_idx[:, 0]]  # [A, 2]
+                _aft_flow_cond = x[aft_idx[:, 0], 0, 13:15] if cfg.srf_flow_film else None
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    aft_correction = aft_srf_head(aft_hidden, aft_pred, _aft_cond).float()
+                    aft_correction = aft_srf_head(aft_hidden, aft_pred, _aft_cond, _aft_flow_cond).float()
                 pred = pred.clone()
                 pred[aft_idx[:, 0], aft_idx[:, 1]] = pred[aft_idx[:, 0], aft_idx[:, 1]] + aft_correction
 
@@ -2581,7 +2621,8 @@ for epoch in range(MAX_EPOCHS):
                             if surf_idx.numel() > 0:
                                 surf_hidden = _eval_hidden[surf_idx[:, 0], surf_idx[:, 1]]
                                 surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                                correction = eval_refine_head(surf_hidden, surf_pred).float()
+                                _srf_flow_cond = x[surf_idx[:, 0], 0, 13:15] if cfg.srf_flow_film else None
+                                correction = eval_refine_head(surf_hidden, surf_pred, flow_cond=_srf_flow_cond).float()
                                 pred_loss = pred_loss.clone()
                                 pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
                     # Back-compute refined pred so denormalization (pred_orig) includes refinement
@@ -2617,8 +2658,9 @@ for epoch in range(MAX_EPOCHS):
                         _ah = _eval_hidden[aft_idx[:, 0], aft_idx[:, 1]]
                         _ap = pred_loss[aft_idx[:, 0], aft_idx[:, 1]]
                         _ac = _v_gap_stagger[aft_idx[:, 0]] if cfg.aft_foil_srf_film else None
+                        _afc = x[aft_idx[:, 0], 0, 13:15] if cfg.srf_flow_film else None
                         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                            _aft_corr = eval_aft_srf_head(_ah, _ap, _ac).float()
+                            _aft_corr = eval_aft_srf_head(_ah, _ap, _ac, _afc).float()
                         pred_loss = pred_loss.clone()
                         pred_loss[aft_idx[:, 0], aft_idx[:, 1]] += _aft_corr
                         # Back-compute pred for denormalization
@@ -3080,7 +3122,8 @@ if cfg.surface_refine and best_metrics:
                         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                             surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]
                             surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                            correction = verify_refine(surf_hidden, surf_pred).float()
+                            _vrf_flow_cond = x[surf_idx[:, 0], 0, 13:15] if cfg.srf_flow_film else None
+                            correction = verify_refine(surf_hidden, surf_pred, flow_cond=_vrf_flow_cond).float()
                         pred_loss_refined = pred_loss.clone()
                         pred_loss_refined[surf_idx[:, 0], surf_idx[:, 1]] += correction
                         correction_full[surf_idx[:, 0], surf_idx[:, 1]] = correction


### PR DESCRIPTION
## Hypothesis

The SurfaceRefinementHead currently corrects surface predictions using only local hidden features and base predictions — it has **no knowledge of what flow regime it is operating in**. The correction needed at extreme AoA (separated flow, different pressure gradients) is fundamentally different from the correction at cruise AoA. Similarly, corrections at high Umag differ from low Umag in the p_oodc split.

**Idea:** Add FiLM (Feature-wise Linear Modulation) conditioning on global flow regime (AoA, Umag) to the main `SurfaceRefinementHead`. A small 2-layer MLP takes (normalized_AoA, normalized_Umag) as input and outputs (scale, shift) vectors applied after the first hidden layer of the SRF MLP. This gives the SRF explicit flow-regime signal so it can learn different corrections for different operating points.

**Why this is distinct from prior FiLM/conditioning work:**
- Phase 2/3 FiLM (PRs #1103, #1461): conditioned the BACKBONE on Re+AoA. The backbone already receives global flow information. This targets the **SRF HEAD** specifically.
- `--adaln_output` (merged): conditions the last TransolverBlock's output on (Umag, AoA). This is backbone conditioning. The SRF head post-processes backbone output with no flow conditioning.
- AftFoilRefinementHead with `--film`: conditions on tandem GEOMETRY (gap/stagger). This conditions on FLOW REGIME (AoA, Umag). Orthogonal axes.

**Physical motivation:** Surface pressure coefficient Cp = (p - p_inf) / q scales with flow conditions. SRF correction for attached flow (cruise AoA) is a small residual; for separated flow (extreme AoA), it's a large correction for suction peak collapse. FiLM conditioning lets the SRF modulate correction magnitude/direction based on regime without inferring this from local features alone.

**Zero-init safety:** FiLM outputs initialized to identity (scale=1, shift=0) — at epoch 0, model is identical to baseline. No regression risk.

**Expected impact:** -3 to -6% p_oodc (extreme AoA/Umag is the primary p_oodc driver), -2 to -4% p_re. p_tan likely flat.

**References:**
- Perez et al. "FiLM: Visual Reasoning with a General Conditioning Layer" (AAAI 2018)
- The `condition` tensor in the training loop already carries normalized (Umag, AoA) — used by `--adaln_output`

## Instructions

### 1. Add config flag

In the config dataclass section (~line 1050-1200 area), add:

```python
srf_flow_film: bool = False    # FiLM conditioning on (AoA, Umag) for SRF head
```

### 2. Modify SurfaceRefinementHead

In `SurfaceRefinementHead.__init__` (find the class definition), add a `flow_film` parameter:

```python
def __init__(self, n_hidden, out_dim, hidden_dim=192, n_layers=3, flow_film=False):
    super().__init__()
    self.flow_film = flow_film
    # ... existing layers ...
    
    if flow_film:
        # 2-input (AoA, Umag) → (scale, shift) for hidden_dim
        self.flow_film_net = nn.Sequential(
            nn.Linear(2, 128), nn.SiLU(),
            nn.Linear(128, hidden_dim * 2)  # first half = scale, second half = shift
        )
        # Zero-init: identity modulation at start (scale=0 → 1+0=1, shift=0)
        nn.init.zeros_(self.flow_film_net[-1].weight)
        nn.init.zeros_(self.flow_film_net[-1].bias)
```

### 3. Modify SurfaceRefinementHead.forward

Accept optional `flow_cond` tensor and apply FiLM after the first hidden activation:

```python
def forward(self, hidden, base_pred, flow_cond=None):
    # ... existing: concatenate hidden + base_pred, pass through first layer + activation ...
    x = self.layers[0](torch.cat([hidden, base_pred], dim=-1))
    x = F.silu(x)
    
    # FiLM modulation after first hidden activation
    if self.flow_film and flow_cond is not None:
        # flow_cond: [B, 2] → expand to [B, N_surface, 2] if needed
        if flow_cond.dim() == 2:
            flow_cond = flow_cond.unsqueeze(1).expand(-1, x.shape[1], -1)
        film_params = self.flow_film_net(flow_cond)  # [B, N, hidden_dim*2]
        scale, shift = film_params.chunk(2, dim=-1)
        x = x * (1 + scale) + shift  # FiLM: identity when scale=0, shift=0
    
    # ... remaining layers ...
    for layer in self.layers[1:]:
        x = F.silu(layer(x))  # or however remaining layers are structured
    return x
```

### 4. Pass flow_cond at call sites

The `condition` tensor is already available in the training loop — used by `--adaln_output`. It contains (Umag, AoA) per sample. Find where condition is constructed and pass it to the SRF head:

```python
# At SRF head instantiation:
refine_head = SurfaceRefinementHead(n_hidden, 3, hidden_dim=192, n_layers=3, flow_film=cfg.srf_flow_film)

# At call site in forward pass:
flow_cond = condition[:, :2] if cfg.srf_flow_film else None  # (Umag, AoA)
correction = refine_head(hidden_surf, base_pred_surf, flow_cond=flow_cond)
```

**Apply to both the main SRF head AND the aft-foil SRF head** (if `--aft_foil_srf` is enabled).

### 5. Run commands

```bash
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/srf-flow-film-s42" --wandb_group "round22/srf-flow-film" \
  --srf_flow_film \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Then seed 73:
```bash
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/srf-flow-film-s73" --wandb_group "round22/srf-flow-film" \
  --srf_flow_film \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

### Debugging tips
- **torch.compile compatibility:** FiLM uses standard tensor ops (Linear, SiLU, chunk, multiply, add). No dynamic control flow — fully compile-safe.
- **Memory:** FiLM net adds ~33K parameters (negligible). VRAM unchanged.
- **If crash:** Check `flow_cond` shape. The condition tensor is [B, cond_dim] — slice to first 2 channels with `condition[:, :2]`.

## Baseline

**Current baseline (PR #2213, 2-seed avg):**

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.979** | < 11.98 |
| **p_oodc** | **7.643** | < 7.65 |
| **p_tan** | **28.341** | < 28.34 |
| **p_re** | **6.300** | < 6.30 |

Baseline W&B runs: hgml7i2r (seed 42), qic03vrg (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```