### PR TITLE
Per-Foil Target Whitening: standardize pressure targets per foil

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    per_foil_pressure_norm: bool = False    # per-foil target whitening for surface pressure loss
 
 
 cfg = sp.parse(Config)
@@ -1769,10 +1770,11 @@ for epoch in range(MAX_EPOCHS):
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
-        if aft_srf_head is not None:
+        if aft_srf_head is not None or cfg.per_foil_pressure_norm:
             _raw_saf_norm = x[:, :, 2:4].norm(dim=-1)  # [B, N]
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
+        if aft_srf_head is not None:
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
         x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
@@ -1964,6 +1966,34 @@ for epoch in range(MAX_EPOCHS):
             abs_err = abs_err * sample_mask
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
+
+        # Per-foil pressure whitening: divide surface pressure error by per-foil std
+        # Equivalent to normalizing both pred and GT per foil — reweights loss so all foils
+        # contribute equally regardless of pressure magnitude.
+        if cfg.per_foil_pressure_norm and _aft_foil_mask is not None:
+            _y_pres = y_norm[:, :, 2]  # [B, N] — normalized pressure targets
+            _fore_surf = surf_mask & ~_aft_foil_mask
+            _aft_surf = _aft_foil_mask  # already includes surf_mask & tandem check
+            _fore_f = _fore_surf.float()
+            _aft_f = _aft_surf.float()
+            _fore_cnt = _fore_f.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1]
+            _aft_cnt = _aft_f.sum(dim=1, keepdim=True).clamp(min=1)    # [B, 1]
+            _fore_mean = (_y_pres * _fore_f).sum(dim=1, keepdim=True) / _fore_cnt  # [B, 1]
+            _aft_mean = (_y_pres * _aft_f).sum(dim=1, keepdim=True) / _aft_cnt     # [B, 1]
+            _fore_var = (((_y_pres - _fore_mean) ** 2) * _fore_f).sum(dim=1, keepdim=True) / _fore_cnt
+            _aft_var = (((_y_pres - _aft_mean) ** 2) * _aft_f).sum(dim=1, keepdim=True) / _aft_cnt
+            _fore_std = _fore_var.sqrt().clamp(min=0.05)  # [B, 1]
+            _aft_std = _aft_var.sqrt().clamp(min=0.05)    # [B, 1]
+            # Build per-node inverse-std weight for surface pressure channel only
+            _pfoil_w = torch.ones(B, _y_pres.shape[1], 1, device=device)
+            _pfoil_w = torch.where(_fore_surf.unsqueeze(-1), (1.0 / _fore_std).unsqueeze(-1), _pfoil_w)
+            _pfoil_w = torch.where(_aft_surf.unsqueeze(-1), (1.0 / _aft_std).unsqueeze(-1), _pfoil_w)
+            # Re-normalize weights so mean weight over surface nodes is 1.0 (preserves loss scale)
+            _surf_w_mean = (_pfoil_w.squeeze(-1) * surf_mask.float()).sum() / surf_mask.sum().clamp(min=1)
+            _pfoil_w = _pfoil_w / _surf_w_mean.clamp(min=1e-6)
+            # Apply only to pressure channel (index 2)
+            abs_err = abs_err.clone()
+            abs_err[:, :, 2:3] = abs_err[:, :, 2:3] * _pfoil_w
 
         # Progressive resolution: subsample volume nodes in loss early in training
         # Ramps from 10% → 100% of volume nodes over first 40 epochs
@@ -2310,7 +2340,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.per_foil_pressure_norm and _aft_foil_mask is not None:
+            _log_dict["train/fore_pres_std"] = _fore_std.mean().item()
+            _log_dict["train/aft_pres_std"] = _aft_std.mean().item() if _aft_surf.any() else 0.0
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1967,27 +1967,20 @@ for epoch in range(MAX_EPOCHS):
         vol_mask = mask & ~is_surface
         surf_mask = mask & is_surface
 
-        # Per-foil pressure whitening: divide surface pressure error by per-foil std
-        # Equivalent to normalizing both pred and GT per foil — reweights loss so all foils
-        # contribute equally regardless of pressure magnitude.
+        # Per-foil pressure whitening (fore-foil only): divide fore-foil surface pressure
+        # error by fore-foil std. Aft-foil nodes keep original unwhitened errors to preserve
+        # tandem transfer signal. Re-normalizes so mean weight over surface nodes is 1.0.
         if cfg.per_foil_pressure_norm and _aft_foil_mask is not None:
             _y_pres = y_norm[:, :, 2]  # [B, N] — normalized pressure targets
             _fore_surf = surf_mask & ~_aft_foil_mask
-            _aft_surf = _aft_foil_mask  # already includes surf_mask & tandem check
             _fore_f = _fore_surf.float()
-            _aft_f = _aft_surf.float()
             _fore_cnt = _fore_f.sum(dim=1, keepdim=True).clamp(min=1)  # [B, 1]
-            _aft_cnt = _aft_f.sum(dim=1, keepdim=True).clamp(min=1)    # [B, 1]
             _fore_mean = (_y_pres * _fore_f).sum(dim=1, keepdim=True) / _fore_cnt  # [B, 1]
-            _aft_mean = (_y_pres * _aft_f).sum(dim=1, keepdim=True) / _aft_cnt     # [B, 1]
             _fore_var = (((_y_pres - _fore_mean) ** 2) * _fore_f).sum(dim=1, keepdim=True) / _fore_cnt
-            _aft_var = (((_y_pres - _aft_mean) ** 2) * _aft_f).sum(dim=1, keepdim=True) / _aft_cnt
             _fore_std = _fore_var.sqrt().clamp(min=0.05)  # [B, 1]
-            _aft_std = _aft_var.sqrt().clamp(min=0.05)    # [B, 1]
-            # Build per-node inverse-std weight for surface pressure channel only
+            # Build per-node inverse-std weight: fore-foil gets 1/std, everything else stays 1.0
             _pfoil_w = torch.ones(B, _y_pres.shape[1], 1, device=device)
             _pfoil_w = torch.where(_fore_surf.unsqueeze(-1), (1.0 / _fore_std).unsqueeze(-1), _pfoil_w)
-            _pfoil_w = torch.where(_aft_surf.unsqueeze(-1), (1.0 / _aft_std).unsqueeze(-1), _pfoil_w)
             # Re-normalize weights so mean weight over surface nodes is 1.0 (preserves loss scale)
             _surf_w_mean = (_pfoil_w.squeeze(-1) * surf_mask.float()).sum() / surf_mask.sum().clamp(min=1)
             _pfoil_w = _pfoil_w / _surf_w_mean.clamp(min=1e-6)
@@ -2343,7 +2336,6 @@ for epoch in range(MAX_EPOCHS):
         _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
         if cfg.per_foil_pressure_norm and _aft_foil_mask is not None:
             _log_dict["train/fore_pres_std"] = _fore_std.mean().item()
-            _log_dict["train/aft_pres_std"] = _aft_std.mean().item() if _aft_surf.any() else 0.0
         wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()


### PR DESCRIPTION
## Hypothesis

The current baseline uses global `--asinh_pressure --asinh_scale 0.75` to compress the pressure distribution before prediction. But each foil has its own pressure regime — the aft-foil in tandem operates in a lower-pressure recovery region with fundamentally different dynamic range from the fore-foil. The model must simultaneously handle both distributions with a single global transform.

**Idea:** Normalize the surface pressure prediction target **per-sample, per-foil** to zero mean / unit variance before computing the loss, then de-normalize at inference. This forces the model to predict the **SHAPE** of each foil's pressure distribution relative to its own mean — a much more transferable representation than predicting absolute pressure levels.

**Why this should help p_tan specifically:** The tandem transfer failure mode is that the aft-foil pressure distribution is OOD (NACA6416 creates a different wake). Per-foil normalization removes the absolute pressure level from the prediction task. The model no longer needs to get the absolute pressure right for an OOD aft-foil — it only needs to get the distribution shape right. This is analogous to instance normalization making CNNs style-invariant.

**Why this is distinct from prior work:**
- PR #597 (per-sample std normalization): merged early but skipped tandem to preserve dual-foil learning. This does per-FOIL normalization including tandem.
- PR #2068 (asymmetric surface loss) and #2108 (asymmetric asinh scales): output-space modifications, not target normalization.
- PR #2136 (per-foil physics normalization, failed): tried to fix the Umag denominator (input normalization). This normalizes the TARGET distribution per foil — fundamentally different.
- `--asinh_pressure`: compresses the GLOBAL distribution. Per-foil whitening operates BEFORE asinh, making the two transforms composable.

**Expected impact:** -3 to -8% p_tan (OOD foil shape transfer gap). Modest p_oodc improvement possible.

**Confidence:** MEDIUM. Per-foil normalization is aerodynamically natural (engineers always non-dimensionalize per body). Changes to the prediction target have been the most impactful category historically (pressure-first: -4.8% p_in, residual prediction: meaningful gains across board).

## Instructions

### 1. Add config flag

In the config dataclass section, add:

```python
per_foil_pressure_norm: bool = False    # Per-foil target whitening for surface pressure
```

### 2. Implement per-foil normalization utility

Add a helper function near the surface loss computation:

```python
def per_foil_whitening(pressure_values, boundary_ids, eps=0.05):
    """
    Normalize pressure per-foil (per boundary ID group) within each sample.
    
    Args:
        pressure_values: [B, N_surface, 1] or [B, N_surface] — surface pressure
        boundary_ids: [B, N_surface] — integer boundary IDs (5,6 = fore-foil, 7 = aft-foil)
        eps: minimum std to avoid division by zero
    
    Returns:
        normalized_pressure: same shape as input, per-foil zero-mean unit-variance
        foil_means: [B, N_surface, 1] — per-node mean (for de-normalization)
        foil_stds: [B, N_surface, 1] — per-node std (for de-normalization)
    """
    squeeze = False
    if pressure_values.dim() == 2:
        pressure_values = pressure_values.unsqueeze(-1)
        squeeze = True
    
    B, N, C = pressure_values.shape
    foil_means = torch.zeros_like(pressure_values)
    foil_stds = torch.ones_like(pressure_values)
    
    # Fore-foil: boundary IDs 5, 6
    fore_mask = (boundary_ids == 5) | (boundary_ids == 6)  # [B, N]
    # Aft-foil: boundary ID 7
    aft_mask = (boundary_ids == 7)  # [B, N]
    
    for mask in [fore_mask, aft_mask]:
        if mask.any():
            mask_expanded = mask.unsqueeze(-1).expand_as(pressure_values)  # [B, N, C]
            # Per-sample, per-foil mean and std
            for b in range(B):
                if mask[b].any():
                    vals = pressure_values[b][mask[b]]  # [n_foil_nodes, C]
                    m = vals.mean(dim=0, keepdim=True)  # [1, C]
                    s = vals.std(dim=0, keepdim=True).clamp(min=eps)  # [1, C]
                    foil_means[b][mask[b]] = m.expand(mask[b].sum(), C)
                    foil_stds[b][mask[b]] = s.expand(mask[b].sum(), C)
    
    normalized = (pressure_values - foil_means) / foil_stds
    
    if squeeze:
        normalized = normalized.squeeze(-1)
        foil_means = foil_means.squeeze(-1)
        foil_stds = foil_stds.squeeze(-1)
    
    return normalized, foil_means, foil_stds
```

**IMPORTANT performance note:** The per-sample loop is a concern for torch.compile. If you encounter compilation issues, vectorize using `scatter_mean` and `scatter_std` operations, or use masked operations with `torch.where`. An alternative vectorized approach:

```python
# Vectorized: assign foil_id per node (0=fore, 1=aft), then use scatter
foil_id = torch.where(aft_mask, 1, 0)  # [B, N]
# Use torch_scatter or manual gather/scatter for per-group stats
```

### 3. Apply in the surface loss computation

Find where the surface pressure loss is computed (look for `mae_surf_p` or surface loss calculation). Apply whitening to both the **prediction** and the **ground truth** before computing loss:

```python
if cfg.per_foil_pressure_norm:
    # Get boundary IDs for surface nodes
    # boundary_ids should be available from the data (look for boundary_id in the dataset)
    gt_pressure_norm, foil_means, foil_stds = per_foil_whitening(gt_pressure, boundary_ids)
    pred_pressure_norm = (pred_pressure - foil_means) / foil_stds
    surface_loss = F.l1_loss(pred_pressure_norm, gt_pressure_norm)
else:
    surface_loss = F.l1_loss(pred_pressure, gt_pressure)
```

**For evaluation metrics:** De-normalize predictions before computing MAE:
```python
if cfg.per_foil_pressure_norm:
    pred_pressure_denorm = pred_pressure_norm * foil_stds + foil_means
    # Use pred_pressure_denorm for metric computation
```

### 4. Find the boundary_ids tensor

The boundary IDs should be available in the dataset. Look for `boundary_id` or similar fields in the data loading code (`data/prepare_multi.py` or the Dataset class). The surface node boundary IDs identify which foil each node belongs to:
- IDs 5, 6: fore-foil surface nodes
- ID 7: aft-foil surface nodes (only present in tandem samples)

If boundary IDs are not directly available at the loss computation site, you may need to thread them through from the dataloader. Check how `--aft_foil_srf` accesses the aft-foil mask — it uses a similar mechanism.

### 5. Run commands

```bash
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/per-foil-whiten-s42" --wandb_group "round22/per-foil-whiten" \
  --per_foil_pressure_norm \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Then seed 73:
```bash
cd cfd_tandemfoil && python train.py --agent edward \
  --wandb_name "edward/per-foil-whiten-s73" --wandb_group "round22/per-foil-whiten" \
  --per_foil_pressure_norm \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

### Debugging tips
- **torch.compile:** The per-sample loop in `per_foil_whitening` may break compilation. If so, vectorize with masked scatter operations.
- **Single-foil samples:** For single-foil samples, there is no aft-foil (no boundary ID 7 nodes). The normalization should only apply to fore-foil nodes. Ensure the aft_mask is empty for these samples.
- **Interaction with asinh:** Per-foil whitening should be applied BEFORE asinh compression in the target pipeline: raw pressure → per-foil whitening → asinh → model prediction. At inference: model output → un-asinh → de-whiten.

## Baseline

**Current baseline (PR #2213, 2-seed avg):**

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.979** | < 11.98 |
| **p_oodc** | **7.643** | < 7.65 |
| **p_tan** | **28.341** | < 28.34 |
| **p_re** | **6.300** | < 6.30 |

Baseline W&B runs: hgml7i2r (seed 42), qic03vrg (seed 73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```