### PR TITLE
Foil Role Embedding: explicit fore/aft identity for tandem surface nodes

### DIFF
--- a/cfd_tandemfoil/data/prepare.py
+++ b/cfd_tandemfoil/data/prepare.py
@@ -137,25 +137,38 @@ class FullFieldDataset(Dataset):
 def pad_collate(batch):
     """Collate variable-length samples into padded batches.
 
+    Handles both 3-tuple (x, y, is_surface) and 4-tuple (x, y, is_surface, boundary) inputs.
+
     Returns:
-        x:          (B, N_max, 18) float32
+        x:          (B, N_max, C) float32
         y:          (B, N_max, 3)  float32
         is_surface: (B, N_max)     bool
         mask:       (B, N_max)     bool
+        boundary:   (B, N_max)     uint8  [optional, only if input has 4 elements]
     """
-    xs, ys, surfs = zip(*batch)
+    has_boundary = len(batch[0]) == 4
+    if has_boundary:
+        xs, ys, surfs, bids = zip(*batch)
+    else:
+        xs, ys, surfs = zip(*batch)
     max_n = max(x.shape[0] for x in xs)
     B = len(xs)
     x_pad = torch.zeros(B, max_n, xs[0].shape[1])
     y_pad = torch.zeros(B, max_n, ys[0].shape[1])
     surf_pad = torch.zeros(B, max_n, dtype=torch.bool)
     mask = torch.zeros(B, max_n, dtype=torch.bool)
-    for i, (x, y, sf) in enumerate(zip(xs, ys, surfs)):
-        n = x.shape[0]
-        x_pad[i, :n] = x
-        y_pad[i, :n] = y
-        surf_pad[i, :n] = sf
+    if has_boundary:
+        bid_pad = torch.zeros(B, max_n, dtype=torch.uint8)
+    for i in range(B):
+        n = xs[i].shape[0]
+        x_pad[i, :n] = xs[i]
+        y_pad[i, :n] = ys[i]
+        surf_pad[i, :n] = surfs[i]
         mask[i, :n] = True
+        if has_boundary:
+            bid_pad[i, :n] = bids[i]
+    if has_boundary:
+        return x_pad, y_pad, surf_pad, mask, bid_pad
     return x_pad, y_pad, surf_pad, mask
 
 

--- a/cfd_tandemfoil/data/prepare_multi.py
+++ b/cfd_tandemfoil/data/prepare_multi.py
@@ -37,12 +37,13 @@ X_DIM = 24  # total x feature dimension
 
 
 def preprocess_sample_multi(sample):
-    """Convert raw PyG sample to (x, y, is_surface) with full dual-foil features.
+    """Convert raw PyG sample to (x, y, is_surface, boundary) with full dual-foil features.
 
     Returns:
         x:          (N, 24) float32
         y:          (N, 3)  float32  — [Ux, Uy, p]
         is_surface: (N,)    bool     — True for both foil 1 and foil 2 surface nodes
+        boundary:   (N,)    uint8    — raw boundary IDs (5=fore upper, 6=fore lower, 7=aft)
     """
     n = sample.pos.shape[0]
 
@@ -90,7 +91,8 @@ def preprocess_sample_multi(sample):
     assert x.shape[1] == X_DIM, f"Expected {X_DIM} features, got {x.shape[1]}"
 
     y = sample.y.float()
-    return x, y, is_surface
+    boundary = sample.boundary.clone()  # raw boundary IDs per node
+    return x, y, is_surface, boundary
 
 
 class MultiFieldDataset(Dataset):

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -794,9 +794,11 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        foil_role_embedding=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
+        self.foil_role_embedding = foil_role_embedding
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
         self.pressure_first = pressure_first
         self.ref = ref
@@ -819,6 +821,10 @@ class Transolver(nn.Module):
             self.log_sigma_surf_ux = nn.Parameter(torch.zeros(1))
             self.log_sigma_surf_uy = nn.Parameter(torch.zeros(1))
             self.log_sigma_surf_p = nn.Parameter(torch.zeros(1))
+
+        if foil_role_embedding:
+            self.fore_embed = nn.Parameter(torch.zeros(n_hidden))
+            self.aft_embed = nn.Parameter(torch.zeros(n_hidden))
 
         if self.unified_pos:
             self.preprocess = MLP(
@@ -991,6 +997,15 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+
+        # Foil role embeddings: add learned fore/aft identity to surface nodes
+        if self.foil_role_embedding:
+            _is_surf = data.get("is_surface")  # [B, N] bool, passed from training loop
+            if _is_surf is not None:
+                _saf_norm = data["x"][:, :, 2:4].norm(dim=-1)  # [B, N]
+                _is_fore = (_is_surf & (_saf_norm <= 0.005)).float().unsqueeze(-1)  # [B, N, 1]
+                _is_aft = (_is_surf & (_saf_norm > 0.005)).float().unsqueeze(-1)   # [B, N, 1]
+                fx = fx + self.fore_embed * _is_fore + self.aft_embed * _is_aft
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
@@ -1165,6 +1180,7 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    foil_role_embedding: bool = False        # learned fore/aft foil role embeddings for surface nodes
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
@@ -1330,6 +1346,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    foil_role_embedding=cfg.foil_role_embedding,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1886,7 +1903,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "is_surface": is_surface})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -2114,7 +2131,7 @@ for epoch in range(MAX_EPOCHS):
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                rdrop_out = model({"x": x})
+                rdrop_out = model({"x": x, "is_surface": is_surface})
                 rdrop_pred = rdrop_out["preds"].float() / sample_stds
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
@@ -2253,7 +2270,7 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
+                out2 = model({"x": x, "is_surface": is_surface})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
@@ -2558,7 +2575,7 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    _eval_out = eval_model({"x": x})
+                    _eval_out = eval_model({"x": x, "is_surface": is_surface})
                     pred = _eval_out["preds"]
                     _eval_hidden = _eval_out["hidden"]
                 pred = pred.float()
@@ -2898,7 +2915,7 @@ if best_metrics:
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
-                    pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
+                    pred = vis_model({"x": x_n, "mask": mask, "is_surface": is_surf_dev})["preds"].float()
                     if cfg.raw_targets:
                         y_pred = (pred * raw_stats["y_std"] + raw_stats["y_mean"]).squeeze(0).cpu()
                     elif cfg.adaptive_norm:
@@ -3067,7 +3084,7 @@ if cfg.surface_refine and best_metrics:
 
                     # Model forward
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        out = verify_model({"x": x})
+                        out = verify_model({"x": x, "is_surface": is_surface})
                         pred_raw = out["preds"].float()
                         hidden = out["hidden"].float()
 

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1000,11 +1000,10 @@ class Transolver(nn.Module):
 
         # Foil role embeddings: add learned fore/aft identity to surface nodes
         if self.foil_role_embedding:
-            _is_surf = data.get("is_surface")  # [B, N] bool, passed from training loop
-            if _is_surf is not None:
-                _saf_norm = data["x"][:, :, 2:4].norm(dim=-1)  # [B, N]
-                _is_fore = (_is_surf & (_saf_norm <= 0.005)).float().unsqueeze(-1)  # [B, N, 1]
-                _is_aft = (_is_surf & (_saf_norm > 0.005)).float().unsqueeze(-1)   # [B, N, 1]
+            _bid = data.get("boundary_id")  # [B, N] uint8
+            if _bid is not None:
+                _is_fore = ((_bid == 5) | (_bid == 6)).float().unsqueeze(-1)  # [B, N, 1]
+                _is_aft = (_bid == 7).float().unsqueeze(-1)                   # [B, N, 1]
                 fx = fx + self.fore_embed * _is_fore + self.aft_embed * _is_aft
 
         for block in self.blocks[:-1]:
@@ -1272,7 +1271,8 @@ _phys_sq_sum = torch.zeros(3, device=device)
 _phys_n = 0.0
 _stats_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
 with torch.no_grad():
-    for _x, _y, _is_surf, _mask in tqdm(_stats_loader, desc="Phys stats", leave=False):
+    for _stats_batch in tqdm(_stats_loader, desc="Phys stats", leave=False):
+        _x, _y, _is_surf, _mask = _stats_batch[:4]
         _y, _mask = _y.to(device), _mask.to(device)
         _Um, _q = _umag_q(_y, _mask)
         _yp = _phys_norm(_y, _Um, _q)
@@ -1298,7 +1298,8 @@ if cfg.raw_targets or cfg.adaptive_norm:
     _raw_sq_sum = torch.zeros(3, device=device)
     _raw_n = 0.0
     with torch.no_grad():
-        for _x, _y, _is_surf, _mask in tqdm(_stats_loader, desc=f"{_label} stats", leave=False):
+        for _stats_batch2 in tqdm(_stats_loader, desc=f"{_label} stats", leave=False):
+            _x, _y, _is_surf, _mask = _stats_batch2[:4]
             _y, _mask = _y.to(device), _mask.to(device)
             _yt = _y.clone()
             if cfg.adaptive_norm and cfg.asinh_pressure:
@@ -1679,7 +1680,13 @@ for epoch in range(MAX_EPOCHS):
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
     if cfg.grad_accum_steps > 1:
         optimizer.zero_grad()
-    for batch_idx, (x, y, is_surface, mask) in enumerate(pbar):
+    for batch_idx, batch_data in enumerate(pbar):
+        if len(batch_data) == 5:
+            x, y, is_surface, mask, boundary_id = batch_data
+            boundary_id = boundary_id.to(device, non_blocking=True)
+        else:
+            x, y, is_surface, mask = batch_data
+            boundary_id = None
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
@@ -1903,7 +1910,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x, "is_surface": is_surface})
+            out = model({"x": x, "is_surface": is_surface, "boundary_id": boundary_id})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -2131,7 +2138,7 @@ for epoch in range(MAX_EPOCHS):
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                rdrop_out = model({"x": x, "is_surface": is_surface})
+                rdrop_out = model({"x": x, "is_surface": is_surface, "boundary_id": boundary_id})
                 rdrop_pred = rdrop_out["preds"].float() / sample_stds
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
@@ -2270,7 +2277,7 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x, "is_surface": is_surface})
+                out2 = model({"x": x, "is_surface": is_surface, "boundary_id": boundary_id})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
@@ -2459,9 +2466,15 @@ for epoch in range(MAX_EPOCHS):
         n_vbatches = 0
 
         with torch.no_grad():
-            for x, y, is_surface, mask in tqdm(
+            for _vbatch in tqdm(
                 vloader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [{split_name}]", leave=False
             ):
+                if len(_vbatch) == 5:
+                    x, y, is_surface, mask, boundary_id = _vbatch
+                    boundary_id = boundary_id.to(device, non_blocking=True)
+                else:
+                    x, y, is_surface, mask = _vbatch
+                    boundary_id = None
                 x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
                 is_surface = is_surface.to(device, non_blocking=True)
                 mask = mask.to(device, non_blocking=True)
@@ -2575,7 +2588,7 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    _eval_out = eval_model({"x": x, "is_surface": is_surface})
+                    _eval_out = eval_model({"x": x, "is_surface": is_surface, "boundary_id": boundary_id})
                     pred = _eval_out["preds"]
                     _eval_hidden = _eval_out["hidden"]
                 pred = pred.float()
@@ -2875,11 +2888,17 @@ if best_metrics:
         for split_name, split_ds in val_splits.items():
             samples = []
             for i in range(min(n, len(split_ds))):
-                x, y_true, is_surface = split_ds[i]
+                _vis_item = split_ds[i]
+                if len(_vis_item) == 4:
+                    x, y_true, is_surface, _vis_bid = _vis_item
+                else:
+                    x, y_true, is_surface = _vis_item
+                    _vis_bid = None
                 with torch.no_grad():
                     x_dev = x.unsqueeze(0).to(device)
                     y_dev = y_true.unsqueeze(0).to(device)
                     is_surf_dev = is_surface.unsqueeze(0).to(device)
+                    _vis_bid_dev = _vis_bid.unsqueeze(0).to(device) if _vis_bid is not None else None
                     mask = torch.ones(1, x_dev.shape[1], dtype=torch.bool, device=device)
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
@@ -2915,7 +2934,7 @@ if best_metrics:
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
-                    pred = vis_model({"x": x_n, "mask": mask, "is_surface": is_surf_dev})["preds"].float()
+                    pred = vis_model({"x": x_n, "mask": mask, "is_surface": is_surf_dev, "boundary_id": _vis_bid_dev})["preds"].float()
                     if cfg.raw_targets:
                         y_pred = (pred * raw_stats["y_std"] + raw_stats["y_mean"]).squeeze(0).cpu()
                     elif cfg.adaptive_norm:
@@ -2984,7 +3003,13 @@ if cfg.surface_refine and best_metrics:
             all_re_values = []  # Reynolds numbers for correlation check
 
             with torch.no_grad():
-                for x, y, is_surface, mask in tqdm(_ood_re_loader, desc="Verify OOD-Re", leave=False):
+                for _vr_batch in tqdm(_ood_re_loader, desc="Verify OOD-Re", leave=False):
+                    if len(_vr_batch) == 5:
+                        x, y, is_surface, mask, boundary_id = _vr_batch
+                        boundary_id = boundary_id.to(device, non_blocking=True)
+                    else:
+                        x, y, is_surface, mask = _vr_batch
+                        boundary_id = None
                     x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
                     is_surface = is_surface.to(device, non_blocking=True)
                     mask = mask.to(device, non_blocking=True)
@@ -3084,7 +3109,7 @@ if cfg.surface_refine and best_metrics:
 
                     # Model forward
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        out = verify_model({"x": x, "is_surface": is_surface})
+                        out = verify_model({"x": x, "is_surface": is_surface, "boundary_id": boundary_id})
                         pred_raw = out["preds"].float()
                         hidden = out["hidden"].float()
 


### PR DESCRIPTION
## Hypothesis

In tandem configurations, the fore and aft foils play fundamentally different aerodynamic roles: the fore foil generates a wake that impinges on the aft foil, while the aft foil operates in a highly non-uniform inflow field. The current model has no explicit input telling it **which foil each surface node belongs to** — it must infer this from the TE coordinate frame features (dx_fore, dy_fore, r_fore, dx_aft, dy_aft, r_aft) and gap/stagger geometry.

Providing a direct, learned **foil role embedding** — a 2-dim parameter injected into the backbone hidden state for surface nodes — gives the model a first-class aerodynamic identity signal. This is directly analogous to token-type embeddings in BERT (CLS vs SEP) or position embeddings in transformers.

**Mechanism:** Two learned parameters `fore_embed` and `aft_embed` (shape `[n_hidden]`, zero-initialized) are added to the backbone hidden state `fx` for surface nodes belonging to the fore and aft foil respectively. For single-foil samples, no embedding is applied. Zero initialization ensures the model starts at the baseline solution and can only improve.

**Target metrics:** Primarily `p_tan` (tandem pressure, currently our weakest at 28.341) and `p_oodc`. The aft foil's pressure distribution under wake impingement should most benefit from explicit foil identity.

**Key distinction from in-flight experiments:**
- Frieren's decoupled tandem slice (#2258): modifies the slice routing matrix — orthogonal
- Nezuko's FiLM SRF (#2260): conditions the SRF head on flow regime — orthogonal
- Edward's per-foil whitening (#2261): normalizes prediction targets per foil — orthogonal

## Instructions

### 1. Add CLI flag

In the `Config` dataclass (near `--aft_foil_srf`):
```python
foil_role_embedding: bool = False  # learned fore/aft foil role embeddings for surface nodes
```

### 2. Add learnable parameters in Transolver.__init__

```python
if cfg.foil_role_embedding:
    self.fore_embed = nn.Parameter(torch.zeros(cfg.n_hidden))  # [192]
    self.aft_embed  = nn.Parameter(torch.zeros(cfg.n_hidden))  # [192]
```

### 3. Inject embeddings in Transolver.forward

After `fx = self.preprocess(x)` and before the TransolverBlock stack:

```python
if cfg.foil_role_embedding:
    # boundary_id is already in the data (used by aft_foil_srf):
    # Fore foil surface nodes: boundary_id in {5, 6}
    # Aft foil surface nodes: boundary_id == 7
    # Single-foil samples (gap≈0): aft mask is all False
    bid = batch.boundary_id  # [B, N] long tensor
    is_fore = ((bid == 5) | (bid == 6)).float().unsqueeze(-1)  # [B, N, 1]
    is_aft  = (bid == 7).float().unsqueeze(-1)                 # [B, N, 1]
    fx = fx + self.fore_embed * is_fore
    fx = fx + self.aft_embed  * is_aft
```

**Notes:**
- Zero init → initial behavior is identical to baseline (zero regression risk)
- Only 2×192 = 384 new parameters total
- No data pipeline changes needed

### 4. Run configuration (2 seeds)

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/foil-role-embed-s42" \
  --wandb_group "foil-role-embed" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --foil_role_embedding \
  --seed 42

# Seed 73: same flags with --seed 73 --wandb_name "tanjiro/foil-role-embed-s73"
```

### 5. What to report

Table: p_in, p_oodc, p_tan, p_re for each seed and 2-seed avg vs baseline.
W&B run IDs for both seeds. `p_tan` delta is the key signal.

## Baseline (PR #2213, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in | 11.979 | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| p_tan | 28.341 | < 28.34 |
| p_re | 6.300 | < 6.30 |

Baseline W&B runs: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --wandb_name "tanjiro/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```