### PR TITLE
Attention Logit Noise: targeted slice routing regularization (σ=0.05)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 attn_logit_noise_std=0.0):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -154,6 +155,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.decouple_slice = decouple_slice
         self.zone_temp = zone_temp
         self.prog_slices = prog_slices
+        self.attn_logit_noise_std = attn_logit_noise_std
         if prog_slices:
             # Buffer for masking inactive slices; updated per-epoch by training loop
             self.register_buffer('slice_mask', torch.zeros(slice_num))
@@ -239,11 +241,15 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
                 k_exp = k_slice_token.unsqueeze(-3).expand(B, H, S, S, D)
                 qk_cat = torch.cat([q_exp, k_exp], dim=-1)
                 attn_logits = self.kernel_mlp(qk_cat).squeeze(-1)
+                if self.training and self.attn_logit_noise_std > 0:
+                    attn_logits = attn_logits + torch.randn_like(attn_logits) * self.attn_logit_noise_std
                 attn_weights = F.softmax(attn_logits, dim=-1)
             else:
                 q_norm = F.normalize(q_slice_token, dim=-1)
                 k_norm = F.normalize(k_slice_token, dim=-1)
                 attn_logits = torch.matmul(q_norm, k_norm.transpose(-2, -1)) * self.attn_scale
+                if self.training and self.attn_logit_noise_std > 0:
+                    attn_logits = attn_logits + torch.randn_like(attn_logits) * self.attn_logit_noise_std
                 attn_weights = F.softmax(attn_logits, dim=-1)
             out_slice_token = torch.matmul(attn_weights, v_slice_token)
             out_slice_token = out_slice_token + self.slice_residual_scale * slice_token
@@ -377,6 +383,7 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        attn_logit_noise_std=0.0,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -402,6 +409,7 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            attn_logit_noise_std=attn_logit_noise_std,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -794,6 +802,7 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        attn_logit_noise_std=0.0,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -866,6 +875,7 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    attn_logit_noise_std=attn_logit_noise_std,
                 )
                 for idx in range(n_layers)
             ]
@@ -1170,6 +1180,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    attn_logit_noise_std: float = 0.0       # std dev of Gaussian noise added to cross-slice attn logits during training
 
 
 cfg = sp.parse(Config)
@@ -1330,6 +1341,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    attn_logit_noise_std=cfg.attn_logit_noise_std,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

PR #2254 (backbone hidden noise, σ=0.01) failed because additive noise on hidden states compounds through residual connections — too blunt, destabilizes training across all blocks simultaneously. The autopsy identified **attention logit noise** as the mechanistically correct target.

The slice attention logits — the `attn_logits` tensor computed just before the slice-token softmax in `Physics_Attention_Irregular_Mesh` — are the ideal injection point:
- Perturbation affects **slice routing stochasticity** without propagating through residual connections
- This is directly analogous to DropAttention (Zehui Lin et al., 2019), shown to be a strong OOD regularizer by preventing over-reliance on specific attention patterns
- For our CFD model, tandem OOD failures stem from the model routing aft-foil wake nodes to "wrong" slices — logit noise forces robust attention patterns

**Mechanism:** During training only (not eval/EMA), add Gaussian noise N(0, σ²) to the pre-softmax attention logit matrix (`attn_logits`) in all 3 TransolverBlocks. The noise is applied to the cross-slice cosine similarity product, NOT to the per-node slice assignment weights (`slice_weights`). The slice assignment routing remains deterministic.

**Key distinction from PR #2254 (failed):**
- #2254 added noise to `hidden_states` after residual connection → propagates, compounds, destabilizes
- This adds noise to `attn_logits` (pre-softmax, no residual) → contained, targeted, stochastic routing only
- σ=0.05 on logits that are O(1) scale → ~5% routing perturbation, much lower effective noise

## Instructions

### 1. Add CLI flag

In `Config` dataclass:
```python
attn_logit_noise_std: float = 0.0  # std dev of Gaussian noise added to slice attn logits during training
```

### 2. Locate the attention logit computation

In `Physics_Attention_Irregular_Mesh.forward`, find where `attn_logits` (or equivalent: the output of `q @ k.transpose()` scaled by 1/sqrt(d)) is computed, just before the softmax/temperature scaling in the cross-slice attention. This is the tensor of shape `[B, n_head, slice_num, slice_num]` (or `[B, slice_num, slice_num]`).

### 3. Add noise injection

Immediately after computing `attn_logits` and **before** the softmax:
```python
# Attention logit noise — applied during training only, not eval/EMA
if self.training and attn_logit_noise_std > 0:
    attn_logits = attn_logits + torch.randn_like(attn_logits) * attn_logit_noise_std
```

Where `attn_logit_noise_std` is passed in from the config or stored as a module attribute during `__init__`.

**Critical:** Apply ONLY to the **cross-slice attention logits** (the `[B, slice_num, slice_num]` computation), NOT to the per-node-to-slice assignment logits (`slice_weights`). The slice assignment should remain deterministic.

Apply to all 3 TransolverBlocks (pass the noise std when constructing each block).

### 4. Run configuration (2 seeds)

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/attn-logit-noise-s42" \
  --wandb_group "attn-logit-noise" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --attn_logit_noise_std 0.05 \
  --seed 42

# Seed 73: same flags with --seed 73 --wandb_name "alphonse/attn-logit-noise-s73"
```

Only change vs baseline: `--attn_logit_noise_std 0.05`.

### 5. What to report

Table: p_in, p_oodc, p_tan, p_re for each seed and 2-seed avg vs baseline. W&B run IDs for both seeds.
Key signals: p_oodc and p_tan (OOD generalization metrics).

If results are promising: suggest trying σ=0.1 (stronger routing stochasticity) as a follow-up.

## Baseline (PR #2213, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in | 11.979 | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| p_tan | 28.341 | < 28.34 |
| p_re | 6.300 | < 6.30 |

Baseline W&B runs: `hgml7i2r` (s42), `qic03vrg` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/baseline-wake-deficit" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```