### PR TITLE
Asymmetric surface loss: up-weight suction-side nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1118,6 +1118,7 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    suction_side_weight: float = 1.0  # weight multiplier for suction-side surface nodes (1.0 = no effect)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -2001,14 +2002,21 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Suction-side weighting: up-weight nodes where model predicts suction (p < 0)
+        _surf_pres_err = abs_err[:, :, 2:3]
+        if cfg.suction_side_weight > 1.0 and epoch >= 20:
+            with torch.no_grad():
+                is_suction = (pred[:, :, 2] < 0.0).float() * surf_mask.float()  # [B, N]
+                ss_w = 1.0 + (cfg.suction_side_weight - 1.0) * is_suction  # [B, N]
+            _surf_pres_err = _surf_pres_err * ss_w.unsqueeze(-1)
+        surf_per_sample = (_surf_pres_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
+            surf_pres = _surf_pres_err  # pressure errors (suction-weighted if enabled) [B, N, 1]
             surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
             surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
@@ -2310,7 +2318,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.suction_side_weight > 1.0 and epoch >= 20:
+            _suction_frac = is_suction.sum().item() / surf_mask.float().sum().clamp(min=1).item()
+            _log_dict["train/suction_frac"] = _suction_frac
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

For airfoils, the suction side (upper surface, negative Cp region) carries much larger pressure gradients and is the primary driver of prediction error — especially p_tan, which measures aft-foil tangential pressure. The current surface loss treats all surface nodes equally (modulo hard node mining). Explicitly up-weighting loss on suction-side nodes — identified by the sign of the model's own pressure prediction (`base_pred[:, :, 2] < 0`) — focuses gradient signal on high-pressure-gradient regions without adding any architectural complexity.

**Key insight:** The aft-foil suction peak is where wake from the fore foil impinges and modifies the suction peak location and magnitude. This is exactly what p_tan measures. Concentrating loss signal on the suction side directly targets this failure mode.

**Physics motivation:** On the suction side, dp/ds is large and the boundary layer is adverse-pressure-gradient dominated. A 1 Pa error on the suction peak matters more to integrated force prediction than 1 Pa error on the pressure side plateau. Asymmetric loss directly encodes this physical priority.

## Instructions

### Code changes in `cfd_tandemfoil/train.py`

**Step 1: Add config flag**

In the `Config` class, add:
```python
suction_side_weight: float = 1.0  # weight multiplier for suction-side surface nodes (1.0 = no effect)
```

**Step 2: Apply asymmetric weighting to surface loss**

Find the surface loss computation (where `surf_loss` is computed on surface nodes). After computing per-node surface loss, add the suction-side weighting:

```python
if cfg.suction_side_weight > 1.0 and epoch >= 20:
    # Suction side: predicted pressure < 0 (normalized Cp < 0)
    # base_pred or pred at surface nodes, pressure channel (index 2)
    is_suction = (pred[:, surf_nodes, 2] < 0.0).float()
    # Weight: suction_side_weight on suction, 1.0 on pressure side
    ss_weights = 1.0 + (cfg.suction_side_weight - 1.0) * is_suction
    # Apply multiplicatively to existing per-node weights
    surf_loss = (surf_loss_per_node * ss_weights).mean()
```

**IMPORTANT notes:**
- Gate this loss to `epoch >= 20` — early in training the model's pressure predictions are noisy, so using them to identify suction side is unreliable before that
- This should work multiplicatively with any existing hard node mining weights: a suction-side hard node gets `existing_weight × suction_side_weight`
- Use `pred` (the model's current output) not `target` to identify suction side — we want to weight where the model predicts suction, not where ground truth says suction
- Apply to BOTH foil-1 and foil-2 surface nodes
- Log the fraction of surface nodes being up-weighted periodically (sanity check: should be ~40-60% for typical airfoils)

**Step 3: Add the flag**
```
--suction_side_weight 1.5
```

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/asymmetric-surface-loss-s42" \
  --wandb_group "frieren/asymmetric-surface-loss" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --suction_side_weight 1.5

# Seed 73
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/asymmetric-surface-loss-s73" \
  --wandb_group "frieren/asymmetric-surface-loss" \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --suction_side_weight 1.5
```

### Report

Table: p_in, p_oodc, p_tan, p_re for both seeds and 2-seed avg vs baseline. W&B run IDs.

**Watch for:** p_tan should benefit most (suction peak targeting). If p_oodc regresses significantly, try reducing to `--suction_side_weight 1.2`.

**Alternative hyperparameter:** If 1.5 fails, try 2.0 in the next round.

## Baseline (PR #2213, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in | 11.979 | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| p_tan | 28.341 | < 28.34 |
| p_re | 6.300 | < 6.30 |

Baseline W&B runs: `hgml7i2r` (s42), `qic03vrg` (s73)