### PR TITLE
Per-head K/V projection in Physics_Attention_Irregular_Mesh

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -139,7 +139,8 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
 
     def __init__(self, dim, heads=8, dim_head=64, dropout=0.0, slice_num=64,
                  linear_no_attention=False, learned_kernel=False,
-                 decouple_slice=False, zone_temp=False, prog_slices=False):
+                 decouple_slice=False, zone_temp=False, prog_slices=False,
+                 per_head_kv=False):
         super().__init__()
         inner_dim = dim_head * heads
         self.dim_head = dim_head
@@ -154,6 +155,7 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
         self.decouple_slice = decouple_slice
         self.zone_temp = zone_temp
         self.prog_slices = prog_slices
+        self.per_head_kv = per_head_kv
         if prog_slices:
             # Buffer for masking inactive slices; updated per-epoch by training loop
             self.register_buffer('slice_mask', torch.zeros(slice_num))
@@ -230,9 +232,13 @@ class Physics_Attention_Irregular_Mesh(nn.Module):
             out_slice_token = slice_token
         else:
             q_slice_token = self.to_q(slice_token)
-            slice_token_kv = slice_token.mean(dim=1, keepdim=True)
-            k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
-            v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
+            if self.per_head_kv:
+                k_slice_token = self.to_k(slice_token)
+                v_slice_token = self.to_v(slice_token)
+            else:
+                slice_token_kv = slice_token.mean(dim=1, keepdim=True)
+                k_slice_token = self.to_k(slice_token_kv).expand(-1, self.heads, -1, -1)
+                v_slice_token = self.to_v(slice_token_kv).expand(-1, self.heads, -1, -1)
             if self.learned_kernel:
                 B, H, S, D = q_slice_token.shape
                 q_exp = q_slice_token.unsqueeze(-2).expand(B, H, S, S, D)
@@ -377,6 +383,7 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        per_head_kv=False,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -402,6 +409,7 @@ class TransolverBlock(nn.Module):
             decouple_slice=decouple_slice,
             zone_temp=zone_temp,
             prog_slices=prog_slices,
+            per_head_kv=per_head_kv,
         )
         if adaln_all:
             # AdaLN-Zero: cond → (scale1, bias1, scale2, bias2) for ln_1 and ln_2
@@ -794,6 +802,7 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        per_head_kv=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -866,6 +875,7 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    per_head_kv=per_head_kv,
                 )
                 for idx in range(n_layers)
             ]
@@ -1170,6 +1180,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    per_head_kv: bool = False               # per-head K/V projection in attention (no mean collapse)
 
 
 cfg = sp.parse(Config)
@@ -1330,6 +1341,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    per_head_kv=cfg.per_head_kv,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

In `Physics_Attention_Irregular_Mesh`, the K/V projection collapses all heads' slice tokens to a shared mean before computing keys and values:

```python
slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # [B, 1, slice_num, d]
K = self.to_k(slice_token_kv)
V = self.to_v(slice_token_kv)
```

This means every attention head queries the **same global mean** key-value pool — there is no head specialization in what is stored in K/V. Head 0 might specialize in pressure gradients, head 1 in wake patterns, head 2 in surface boundary layer — but they all write to the same K/V bank, which the mean actively homogenizes.

**Fix:** Remove the `.mean(dim=1, keepdim=True)` collapse. Each head uses its own slice tokens directly for K/V projection. Q already comes from per-head slice tokens, so this makes Q, K, V all per-head — a symmetric and more natural attention formulation.

**Why it might help p_tan:** The tandem interaction involves long-range wake effects from the fore foil reaching the aft. A head that specializes in inter-foil communication needs its own K/V, not one contaminated by the mean of a boundary-layer-focused head. Removing the shared mean bottleneck allows genuine head specialization.

**Parameter count:** Unchanged — `to_k` and `to_v` are `nn.Linear(d, d_head)` applied per-head. The same number of parameters, just applied to per-head inputs instead of the head-mean. The einsum `'bhnd,bhsd->bhns'` already handles the per-head case.

## Instructions

### Code change in `cfd_tandemfoil/train.py`

In `Physics_Attention_Irregular_Mesh.forward`, find:
```python
slice_token_kv = slice_token.mean(dim=1, keepdim=True)  # collapse to shared mean
K = self.to_k(slice_token_kv)
V = self.to_v(slice_token_kv)
```

Replace with (gated by the new flag):
```python
if self.per_head_kv:
    # Each head uses its own slice tokens for K/V — no mean collapse
    K = self.to_k(slice_token)   # [B, H, slice_num, d_head]
    V = self.to_v(slice_token)   # [B, H, slice_num, d_head]
else:
    slice_token_kv = slice_token.mean(dim=1, keepdim=True)
    K = self.to_k(slice_token_kv)
    V = self.to_v(slice_token_kv)
```

In `Physics_Attention_Irregular_Mesh.__init__`, add:
```python
self.per_head_kv = per_head_kv  # bool, passed from config
```

In `Config`, add:
```python
per_head_kv: bool = False
```

Wire `cfg.per_head_kv` through to the attention module construction.

**IMPORTANT:** Check the einsum shapes. If `to_k` expects `[B, 1, slice_num, d]` and you're now passing `[B, H, slice_num, d]`, it should broadcast correctly since it's an `nn.Linear` applied to the last dim. Verify the attention computation `attn = einsum('bhnd,bhsd->bhns', Q, K)` still works — it should, since both Q and K are now `[B, H, slice_num, d_head]`. The softmax and V aggregation should also be unchanged.

**Training stability:** The shared-mean K/V was implicitly regularizing (all heads see the same keys). Removing it may increase training variance. If loss spikes in the first 20 epochs, add a small initialization delta: zero-initialize `to_k` and `to_v` and add a residual `K = self.to_k(slice_token) + slice_token` for the first run to preserve the effective baseline behavior at init.

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent askeladd \
  --wandb_name "askeladd/per-head-kv-s42" \
  --wandb_group "askeladd/per-head-kv-slice" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --per_head_kv

# Seed 73
cd cfd_tandemfoil && python train.py --agent askeladd \
  --wandb_name "askeladd/per-head-kv-s73" \
  --wandb_group "askeladd/per-head-kv-slice" \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --per_head_kv
```

### Report

Table: p_in, p_oodc, p_tan, p_re for both seeds and 2-seed avg vs baseline. W&B run IDs.

**Watch for:** If training loss is unstable in first 30 epochs (spikes), try zero-initializing `to_k`/`to_v` with residual. Report VRAM usage — should be slightly higher since we're no longer collapsing to 1 head before K/V projection.

**Early abort:** If after epoch 50, all four metrics are >5% worse than a naive mid-training baseline, abort and report.

## Baseline (PR #2213, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in | 11.979 | < 11.98 |
| p_oodc | 7.643 | < 7.65 |
| p_tan | 28.341 | < 28.34 |
| p_re | 6.300 | < 6.30 |

Baseline W&B runs: `hgml7i2r` (s42), `qic03vrg` (s73)