### PR TITLE
ZCA Spectral Whitening of Input Features: decorrelate the 24-dim feature covariance

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    zca_whitening: bool = False             # ZCA whitening of input features (replaces per-feature standardization)
+    zca_eps: float = 1e-5                   # regularization for near-zero singular values in ZCA
 
 
 cfg = sp.parse(Config)
@@ -1297,6 +1299,40 @@ if cfg.raw_targets or cfg.adaptive_norm:
     print(f"  {_label} stats — mean: {_raw_mean.tolist()}, std: {_raw_std.tolist()}")
 else:
     raw_stats = None
+
+# ZCA whitening: precompute decorrelation matrix from training data
+zca_mu = None
+zca_W = None
+if cfg.zca_whitening:
+    print("Computing ZCA whitening matrix from training data...")
+    _zca_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=False, **loader_kwargs)
+    _x_sum = None
+    _x_sq = None
+    _x_n = 0
+    with torch.no_grad():
+        for _x_b, _y_b, _is_surf_b, _mask_b in tqdm(_zca_loader, desc="ZCA stats", leave=False):
+            _x_b = _x_b.to(device).float()
+            _mask_b = _mask_b.to(device)
+            # Flatten valid nodes: [B, N, F] -> [M, F] where M = sum of valid nodes
+            _valid = _mask_b.bool()  # [B, N]
+            _x_flat = _x_b[_valid]  # [M, F]
+            if _x_sum is None:
+                _x_sum = _x_flat.sum(0)
+                _x_sq = (_x_flat.unsqueeze(-1) * _x_flat.unsqueeze(-2)).sum(0)  # [F, F]
+            else:
+                _x_sum += _x_flat.sum(0)
+                _x_sq += (_x_flat.unsqueeze(-1) * _x_flat.unsqueeze(-2)).sum(0)
+            _x_n += _x_flat.shape[0]
+    zca_mu = (_x_sum / _x_n).float()  # [F]
+    _cov = (_x_sq / _x_n - zca_mu.unsqueeze(-1) * zca_mu.unsqueeze(-2)).float()  # [F, F]
+    U, S, Vt = torch.linalg.svd(_cov)
+    zca_W = (U @ torch.diag(1.0 / (S + cfg.zca_eps).sqrt()) @ U.T).float()  # [F, F]
+    print(f"ZCA condition number (before)={S[0]/S[-1]:.1f}, smallest_sv={S[-1]:.2e}")
+    print(f"ZCA matrix shape: {zca_W.shape}, mu shape: {zca_mu.shape}")
+    wandb_zca_config = {"zca_condition_number": (S[0]/S[-1]).item(), "zca_smallest_sv": S[-1].item()}
+    del _zca_loader, _x_sum, _x_sq
+else:
+    wandb_zca_config = {}
 
 model_config = dict(
     space_dim=2,
@@ -1605,6 +1641,7 @@ run = wandb.init(
         "train_samples": len(train_ds),
         "val_samples": {k: len(v) for k, v in val_splits.items()},
         "split_manifest": cfg.manifest,
+        **wandb_zca_config,
     },
     mode=os.environ.get("WANDB_MODE", "online"),
 )
@@ -1774,7 +1811,10 @@ for epoch in range(MAX_EPOCHS):
             _is_tandem = (x[:, 0, 22].abs() > 0.01)  # gap feature nonzero
             _aft_foil_mask = is_surface & (_raw_saf_norm > 0.005) & _is_tandem.unsqueeze(1)
             _raw_gap_stagger = x[:, 0, 22:24]  # [B, 2] gap and stagger (raw)
-        x = (x - stats["x_mean"]) / stats["x_std"]
+        if cfg.zca_whitening:
+            x = (x - zca_mu) @ zca_W.T
+        else:
+            x = (x - stats["x_mean"]) / stats["x_std"]
         # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
         curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
         if cfg.foil2_dist:
@@ -2464,7 +2504,10 @@ for epoch in range(MAX_EPOCHS):
                     _v_is_tandem = (x[:, 0, 22].abs() > 0.01)
                     _eval_aft_mask = is_surface & (_v_saf_norm > 0.005) & _v_is_tandem.unsqueeze(1)
                     _v_gap_stagger = x[:, 0, 22:24]  # [B, 2]
-                x = (x - stats["x_mean"]) / stats["x_std"]
+                if cfg.zca_whitening:
+                    x = (x - zca_mu) @ zca_W.T
+                else:
+                    x = (x - stats["x_mean"]) / stats["x_std"]
                 # Curvature proxy: norm of first 4 dsdf channels (gradient magnitude) for surface nodes
                 curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                 if cfg.foil2_dist:
@@ -2986,7 +3029,10 @@ if cfg.surface_refine and best_metrics:
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
-                    x = (x - stats["x_mean"]) / stats["x_std"]
+                    if cfg.zca_whitening:
+                        x = (x - zca_mu) @ zca_W.T
+                    else:
+                        x = (x - stats["x_mean"]) / stats["x_std"]
                     curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                     if cfg.foil2_dist:
                         foil2_dist_feat = torch.log1p(raw_dsdf[:, :, 4:8].abs().min(dim=-1, keepdim=True).values * 10.0)


### PR DESCRIPTION
## Hypothesis

The current input preprocessing applies per-feature standardization: `x = (x - x_mean) / x_std`. This normalizes each of the 24 features independently but leaves **between-feature correlations intact**. The 24 input dimensions (xy coords, DSDF channels, TE frame distances, wake deficit, Re, gap, stagger, etc.) are highly correlated — all derived from a small number of underlying physical parameters (chord, AoA, Re, gap, stagger). This redundancy creates a poorly-conditioned optimization landscape.

**ZCA (Zero-phase Component Analysis) whitening** replaces per-feature standardization with a full covariance decorrelation: `x_whitened = (x - mu) @ W_zca.T`. The ZCA matrix `W_zca = U @ diag(1/sqrt(S+ε)) @ U.T` is precomputed once from training data and decorrelates ALL 24 feature dimensions simultaneously, producing an isotropic feature space where all directions are equally informative. This is the provably optimal preprocessing for gradient-based optimization (LeCun 1998, "Efficient BackProp").

**Why this fits our success lineage:** Our most consistent improvements come from data-representation changes: asinh pressure transform, TE coordinate frame, wake deficit feature. ZCA operates at the same level — transforming the input representation without any architectural change. It is **free at inference time** (a fixed linear transform).

**Why p_oodc:** ZCA ensures that OOD feature combinations (extreme Re, unseen gap values) are treated with equal importance in gradient space, rather than dominated by the largest-variance training-set directions.

**Key difference from per-foil whitening (PR #2261, in-flight):** That approach normalizes *output targets* per foil. This decorrelates *input features* globally. Complementary, not redundant.

**ZCA safety guarantee:** ZCA is an orthogonal rotation in feature space. The model can learn to invert it if ZCA is suboptimal — there is no regression floor.

## Instructions

Add ZCA whitening as an optional replacement for per-feature standardization. ~50 lines in `train.py`.

### Step 1: Add config flag

Near the other preprocessing flags, add:
```python
zca_whitening: bool = False
zca_eps: float = 1e-5  # regularization for near-zero singular values
```

### Step 2: Precompute ZCA matrix at training start

Find where `stats` is loaded (search for `x_mean` near dataset/stats setup). Add after stats loading, when `cfg.zca_whitening` is True:

```python
if cfg.zca_whitening:
    print("Computing ZCA whitening matrix from training data...")
    x_all = []
    for batch in train_loader:
        x_b = batch.x.float()
        x_all.append(x_b.reshape(-1, x_b.shape[-1]))
    X = torch.cat(x_all, dim=0)  # [N_total_nodes, 24]

    mu_zca = X.mean(0)  # [24]
    X_c = X - mu_zca
    C = (X_c.T @ X_c) / len(X_c)  # [24, 24]
    U, S, Vt = torch.linalg.svd(C)
    W_zca = U @ torch.diag(1.0 / (S + cfg.zca_eps).sqrt()) @ U.T  # [24, 24]
    zca_mu = mu_zca.to(device)
    zca_W = W_zca.to(device)
    print(f"ZCA condition number (before)={S[0]/S[-1]:.1f}, smallest_sv={S[-1]:.2e}")
```

**The ZCA pass over training data takes ~1-2 minutes (once). Budget this within the 180-min timeout.**

### Step 3: Apply ZCA in all forward passes

There are 4 occurrences of `x = (x - stats["x_mean"]) / stats["x_std"]` in train.py (training, validation, visualization variants). Replace each with:

```python
if cfg.zca_whitening:
    x = (x - zca_mu) @ zca_W.T
else:
    x = (x - stats["x_mean"]) / stats["x_std"]
```

**Note:** `zca_mu` replaces `stats["x_mean"]` as the centering term. Both are per-feature means — use `zca_mu` in the ZCA path for consistency.

### Step 4: Checkpoint

Save `zca_mu` and `zca_W` in the checkpoint:
```python
if cfg.zca_whitening:
    checkpoint['zca_mu'] = zca_mu.cpu()
    checkpoint['zca_W'] = zca_W.cpu()
```

### Step 5: Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py \
  --agent fern --wandb_name "fern/zca-whitening-s42" \
  --wandb_group "round25/spectral-feature-whitening" \
  --seed 42 \
  --zca_whitening \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aft_foil_srf_hidden 192 --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature

# Seed 73: identical with --seed 73 --wandb_name "fern/zca-whitening-s73"
```

New flag vs baseline: `--zca_whitening` only.

### Step 6: If training is unstable (loss spikes in first 10 epochs)

Try `--lr 1.5e-4` — ZCA whitening changes the effective scale of the input, which can shift the optimal LR slightly. Report if you try this variant.

### Step 7: Report results

Table: p_in, p_oodc, p_tan, p_re for both seeds + 2-seed average vs baseline. Include W&B run IDs. Also report the ZCA condition number diagnostics from Step 2 output.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in   | **11.979** | < 11.98 |
| p_oodc | **7.643**  | < 7.65  |
| p_tan  | **28.341** | < 28.34 |
| p_re   | **6.300**  | < 6.30  |

Baseline W&B: `hgml7i2r` (seed 42), `qic03vrg` (seed 73) — PR #2213.

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent fern --wandb_name "fern/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 160 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```