### PR TITLE
MoE FFN Last Block: tandem-specialized feed-forward expert in final TransolverBlock

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -377,6 +377,7 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        moe_ffn=False,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -389,6 +390,7 @@ class TransolverBlock(nn.Module):
         self.adaln_all = adaln_all
         self.film_cond = film_cond
         self.domain_layernorm = domain_layernorm
+        self.moe_ffn = moe_ffn
         _LN = (lambda d: DomainLayerNorm(d, zeroinit=dln_zeroinit)) if domain_layernorm else nn.LayerNorm
         self.ln_1 = _LN(hidden_dim)
         self.attn = Physics_Attention_Irregular_Mesh(
@@ -422,6 +424,8 @@ class TransolverBlock(nn.Module):
             nn.init.zeros_(self.film_net[-1].bias)
         self.ln_2 = _LN(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        if moe_ffn:
+            self.mlp_tandem = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
         self.spatial_bias = nn.Sequential(
             nn.Linear(spatial_bias_input_dim, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
@@ -500,10 +504,25 @@ class TransolverBlock(nn.Module):
             fx_norm = _ln(self.ln_1, fx) * (1 + s1.unsqueeze(1)) + b1.unsqueeze(1)
             fx = _ln(self.ln_1_post, self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
             fx_norm = _ln(self.ln_2, fx) * (1 + s2.unsqueeze(1)) + b2.unsqueeze(1)
-            fx = _ln(self.ln_2_post, self.mlp(fx_norm) + fx)
+            if self.moe_ffn and tandem_mask is not None:
+                is_tan = (tandem_mask.view(-1) > 0.5)  # [B]
+                out_s = self.mlp(fx_norm)
+                out_t = self.mlp_tandem(fx_norm)
+                out = torch.where(is_tan[:, None, None].expand_as(out_s), out_t, out_s)
+                fx = _ln(self.ln_2_post, out + fx)
+            else:
+                fx = _ln(self.ln_2_post, self.mlp(fx_norm) + fx)
         else:
             fx = _ln(self.ln_1_post, self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
-            fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
+            if self.moe_ffn and tandem_mask is not None:
+                fx_ln = _ln(self.ln_2, fx)
+                is_tan = (tandem_mask.view(-1) > 0.5)  # [B]
+                out_s = self.mlp(fx_ln)
+                out_t = self.mlp_tandem(fx_ln)
+                out = torch.where(is_tan[:, None, None].expand_as(out_s), out_t, out_s)
+                fx = _ln(self.ln_2_post, out + fx)
+            else:
+                fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
@@ -794,6 +813,7 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        moe_ffn=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
@@ -866,6 +886,7 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    moe_ffn=moe_ffn if (idx == n_layers - 1) else False,
                 )
                 for idx in range(n_layers)
             ]
@@ -1170,6 +1191,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Phase 7: MoE FFN — tandem-specialized FFN expert in last TransolverBlock
+    moe_ffn: bool = False                  # enable tandem expert FFN in last block (dispatch on tandem_mask)
 
 
 cfg = sp.parse(Config)
@@ -1330,6 +1353,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    moe_ffn=cfg.moe_ffn,
 )
 
 model = Transolver(**model_config).to(device)


### PR DESCRIPTION
## Hypothesis

Round 26 confirmed that **slice routing is NOT the tandem failure driver** (attn-logit-noise σ=0.05, PR #2263, was clearly negative: p_in +3.9%). The model routes tandem samples correctly — the failure is in what the backbone **processes**, not how it routes.

Every major p_tan win has come from giving the model more explicit inter-foil signal as **input features** (gap/stagger bias, TE frame, wake deficit), not from attention routing changes. This points to a processing bottleneck: the shared FFN in the last TransolverBlock must produce a single feature manifold that generalizes across two physically distinct regimes (single-foil potential flow vs. tandem wake-affected flow).

**Hypothesis:** Giving tandem samples a **dedicated weight matrix** for the core nonlinear transformation in the last block will allow the backbone to assemble tandem-optimal representations without contaminating single-foil gradients.

**Why the last block only:** Conditioning all blocks failed (adaln_all_blocks). Earlier blocks learn shared geometry and aerodynamics primitives — only the last block needs to specialize. This is the minimal change that breaks the structural compromise at exactly the right layer.

**Why this is distinct from existing approaches:**
- `domain_velhead` / `soft_moe`: conditional OUTPUT HEADS (what is decoded), not FFN computation
- `domain_layernorm` / `adaln_output`: conditional LayerNorm affine transforms, not FFN weights
- `pressure_first` / `pressure_deep`: output channel ordering, not FFN
- This is the **first experiment** to give tandem samples a dedicated FFN weight matrix in the backbone.

## Instructions

### 1. Add config flag

In `Config` dataclass:
```python
moe_ffn: bool = False  # Tandem-specialized FFN expert in last TransolverBlock
```

Add `--moe_ffn` to argparse.

### 2. Modify TransolverBlock.__init__

Add `moe_ffn=False` parameter. When enabled, create a second FFN:
```python
if moe_ffn:
    self.mlp_tandem = MLP(hidden_dim, hidden_dim * mlp_ratio * 4, hidden_dim, n_layers=0, res=False)
self.moe_ffn = moe_ffn
```

The existing `self.mlp` becomes the single-foil expert. Use the exact same MLP constructor as the existing `self.mlp`.

### 3. Modify TransolverBlock.forward

Replace the FFN line:
```python
fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
```

With:
```python
if self.moe_ffn:
    fx_ln = _ln(self.ln_2, fx)
    is_tan = (tandem_mask.view(-1) > 0.5)  # [B] boolean
    out = self.mlp(fx_ln)                   # default: single-foil expert
    if is_tan.any():
        tan_idx = is_tan.nonzero(as_tuple=True)[0]
        out[tan_idx] = self.mlp_tandem(fx_ln[tan_idx])
    fx = _ln(self.ln_2_post, out + fx)
else:
    fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
```

**Critical:** `tandem_mask` must be available in the block's forward call. Check how `domain_velhead` or `soft_moe` accesses the tandem flag — follow the exact same pattern for passing it through.

### 4. Apply only to last block

In `Transolver.__init__`, when constructing the TransolverBlock list:
```python
TransolverBlock(..., moe_ffn=(self.moe_ffn if idx == n_layers - 1 else False))
```

Same pattern as `soft_moe`, `domain_velhead`, `pressure_first` — check how those flags are passed in the constructor loop and mirror it exactly.

### 5. Run configuration (2 seeds)

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent alphonse \
  --wandb_name "alphonse/moe-ffn-last-block-s42" \
  --wandb_group "moe-ffn-last-block" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --moe_ffn \
  --seed 42

# Seed 73: same flags with --seed 73 --wandb_name "alphonse/moe-ffn-last-block-s73"
```

Only change vs baseline: `--moe_ffn`.

### 6. What to report

Table: p_in, p_oodc, p_tan, p_re for each seed and 2-seed avg vs baseline.
W&B run IDs for both seeds.
Key signals: **p_tan is the primary target.** p_in should NOT regress (single-foil path is unchanged). If p_in regresses, the tandem_mask dispatch is incorrect — check the implementation.

If promising: suggest follow-up of applying moe_ffn to all 3 blocks (not just last) as a variation.

## Baseline (PR #2251, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in   | 11.891 | < 11.89 |
| p_oodc | 7.561  | < 7.56  |
| p_tan  | 28.118 | < 28.12 |
| p_re   | 6.364  | < 6.36  |

Baseline W&B runs: `7jix2jkg` (s42), `epkfhxfl` (s73)

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --wandb_name "alphonse/baseline-tmax150" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```