### PR TITLE
GNN Boundary Layer: local mesh message-passing for surface pressure accuracy

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -757,6 +757,77 @@ class SurfaceRefinementContextHead(nn.Module):
         return correction
 
 
+class BoundaryLayerGNN(nn.Module):
+    """GraphSAGE-style message passing on surface and near-surface nodes.
+
+    Enriches hidden representations of surface nodes by aggregating features
+    from k nearest volume neighbors, implementing local boundary layer physics.
+    Zero-inits the last layer for safe residual start.
+    """
+    def __init__(self, n_hidden: int = 192, n_layers: int = 2, k_neighbors: int = 4):
+        super().__init__()
+        self.n_layers = n_layers
+        self.k_neighbors = k_neighbors
+        self.layers = nn.ModuleList([
+            nn.Sequential(
+                nn.Linear(n_hidden * 2, n_hidden),
+                nn.SiLU(),
+                nn.Linear(n_hidden, n_hidden),
+            )
+            for _ in range(n_layers)
+        ])
+        self.layer_norms = nn.ModuleList([nn.LayerNorm(n_hidden) for _ in range(n_layers)])
+        # Zero-init output of last layer for safe residual start
+        nn.init.zeros_(self.layers[-1][-1].weight)
+        nn.init.zeros_(self.layers[-1][-1].bias)
+
+    @torch.compiler.disable
+    def forward(self, hidden, is_surface, x_coords):
+        """
+        Args:
+            hidden: [B, N, C] — hidden features from backbone
+            is_surface: [B, N] — boolean surface mask
+            x_coords: [B, N, >=2] — node coordinates (first 2 dims used)
+        Returns:
+            [B, N, C] — hidden features with enriched surface nodes
+        """
+        B, N, C = hidden.shape
+        k = self.k_neighbors
+        h = hidden.clone()
+
+        for b in range(B):
+            surf_idx = is_surface[b].nonzero(as_tuple=True)[0]  # [M_s]
+            if surf_idx.numel() == 0:
+                continue
+            vol_mask_b = ~is_surface[b]
+            vol_idx = vol_mask_b.nonzero(as_tuple=True)[0]  # [M_v]
+            if vol_idx.numel() == 0:
+                continue
+
+            # Subsample volume nodes if too many for efficiency
+            if vol_idx.shape[0] > 2000:
+                vol_idx = vol_idx[::max(1, vol_idx.shape[0] // 512)][:512]
+
+            # k-NN: find k nearest volume neighbors per surface node
+            surf_coords = x_coords[b, surf_idx, :2]  # [M_s, 2]
+            vol_coords = x_coords[b, vol_idx, :2]     # [M_v, 2]
+            dists = torch.cdist(surf_coords, vol_coords)  # [M_s, M_v]
+            k_actual = min(k, vol_idx.shape[0])
+            _, knn_local = dists.topk(k_actual, dim=-1, largest=False)  # [M_s, k]
+            neighbor_idx = vol_idx[knn_local]  # [M_s, k]
+
+            # Message passing rounds
+            for layer, ln in zip(self.layers, self.layer_norms):
+                h_surf = h[b, surf_idx]            # [M_s, C]
+                h_nbr = h[b, neighbor_idx]          # [M_s, k, C]
+                h_agg = h_nbr.mean(dim=1)           # [M_s, C]
+                h_in = torch.cat([h_surf, h_agg], dim=-1)  # [M_s, 2C]
+                delta = layer(h_in)                 # [M_s, C]
+                h[b, surf_idx] = ln(h_surf + delta)
+
+        return h
+
+
 class Transolver(nn.Module):
     def __init__(
         self,
@@ -794,9 +865,13 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        gnn_boundary_layer=False,
+        gnn_layers=2,
+        gnn_k_neighbors=4,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
+        self.gnn_boundary_layer = gnn_boundary_layer
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
         self.pressure_first = pressure_first
         self.ref = ref
@@ -896,6 +971,11 @@ class Transolver(nn.Module):
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
         self.fourier_freqs_learned = nn.Parameter(torch.tensor([1.0, 3.0, 6.0, 16.0]))
+        # GNN boundary layer: local message passing on surface/near-wall nodes
+        if gnn_boundary_layer:
+            self.gnn_bl = BoundaryLayerGNN(
+                n_hidden=n_hidden, n_layers=gnn_layers, k_neighbors=gnn_k_neighbors
+            )
 
     def initialize_weights(self):
         self.apply(self._init_weights)
@@ -994,6 +1074,11 @@ class Transolver(nn.Module):
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+
+        # GNN boundary layer: local message passing on surface/near-wall nodes
+        is_surface = data.get("is_surface") if isinstance(data, Mapping) else None
+        if self.gnn_boundary_layer and is_surface is not None:
+            fx = self.gnn_bl(fx, is_surface, x[:, :, :2])
 
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
@@ -1170,6 +1255,10 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Phase 7: GNN boundary layer — local message-passing on surface/near-wall nodes
+    gnn_boundary_layer: bool = False       # enable GNN message-passing on surface/near-wall nodes
+    gnn_layers: int = 2                    # number of GNN message-passing rounds
+    gnn_k_neighbors: int = 4              # k nearest volume neighbors per surface node
 
 
 cfg = sp.parse(Config)
@@ -1330,6 +1419,9 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    gnn_boundary_layer=cfg.gnn_boundary_layer,
+    gnn_layers=cfg.gnn_layers,
+    gnn_k_neighbors=cfg.gnn_k_neighbors,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1412,6 +1504,9 @@ snapshot_n = 0
 snapshot_epoch_list = [int(e) for e in cfg.snapshot_epochs_str.split(",")] if cfg.snapshot_ensemble else []
 
 n_params = sum(p.numel() for p in model.parameters())
+if cfg.gnn_boundary_layer:
+    _gnn_params = sum(p.numel() for p in _base_model.gnn_bl.parameters())
+    print(f"GNN boundary layer: {_gnn_params:,} params (layers={cfg.gnn_layers}, k={cfg.gnn_k_neighbors})")
 if refine_head is not None:
     n_params += sum(p.numel() for p in refine_head.parameters())
 if aft_srf_head is not None:
@@ -1886,7 +1981,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "is_surface": is_surface if cfg.gnn_boundary_layer else None})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -2114,7 +2209,7 @@ for epoch in range(MAX_EPOCHS):
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                rdrop_out = model({"x": x})
+                rdrop_out = model({"x": x, "is_surface": is_surface if cfg.gnn_boundary_layer else None})
                 rdrop_pred = rdrop_out["preds"].float() / sample_stds
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
@@ -2253,7 +2348,7 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
+                out2 = model({"x": x, "is_surface": is_surface if cfg.gnn_boundary_layer else None})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
@@ -2558,7 +2653,7 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    _eval_out = eval_model({"x": x})
+                    _eval_out = eval_model({"x": x, "is_surface": is_surface if cfg.gnn_boundary_layer else None})
                     pred = _eval_out["preds"]
                     _eval_hidden = _eval_out["hidden"]
                 pred = pred.float()
@@ -3067,7 +3162,7 @@ if cfg.surface_refine and best_metrics:
 
                     # Model forward
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        out = verify_model({"x": x})
+                        out = verify_model({"x": x, "is_surface": is_surface if cfg.gnn_boundary_layer else None})
                         pred_raw = out["preds"].float()
                         hidden = out["hidden"].float()
 


### PR DESCRIPTION
## Hypothesis

The Transolver slice attention is a **global operator** — it pools all mesh nodes into learned slices, computes slice-to-slice interactions, and broadcasts back. This is powerful for capturing global flow patterns but structurally wrong for **boundary layer physics**: near-wall pressure/velocity gradients are governed by local PDE propagation along the wall, at length scales orders of magnitude smaller than the global domain.

A small Graph Neural Network (GNN) module operating **only on surface and near-surface nodes** implements local message-passing that respects the boundary layer's inherent locality. After the Transolver backbone produces hidden states for all nodes, 2 rounds of GraphSAGE-style message passing among (a) the surface nodes and (b) their k=4 nearest volume neighbors lets near-wall information propagate locally **before** the SRF head applies its correction.

**This is fundamentally different from all previous approaches**: every prior inter-foil coupling attempt (fore-aft cross-attention, GALE, cross-DSDF) used global attention. The GNN operates locally on the wall, like a PDE solver taking small propagation steps.

**Literature support:** B-GNNs (arXiv:2503.18638, 2025) demonstrated 85% error reduction using GNN message passing with local physics-informed inputs on airfoil meshes. GraphSAGE aggregation (Hamilton et al., NeurIPS 2017) is the right choice for irregular CFD meshes.

**Target metrics:** p_tan (aft-foil tandem suction peak accuracy), p_in (leading-edge pressure)

---

## Instructions

### Step 1: Add config flags

In the `Config` class, add:
```python
gnn_boundary_layer: bool = False   # enable GNN message-passing on surface/near-wall nodes
gnn_layers: int = 2                # number of GNN message-passing rounds
gnn_k_neighbors: int = 4          # k nearest volume neighbors per surface node
```

### Step 2: Implement the BoundaryLayerGNN module

```python
class BoundaryLayerGNN(nn.Module):
    def __init__(self, n_hidden: int = 192, n_layers: int = 2):
        super().__init__()
        self.n_layers = n_layers
        self.layers = nn.ModuleList([
            nn.Sequential(
                nn.Linear(n_hidden * 2, n_hidden),
                nn.SiLU(),
                nn.Linear(n_hidden, n_hidden),
            )
            for _ in range(n_layers)
        ])
        self.layer_norms = nn.ModuleList([nn.LayerNorm(n_hidden) for _ in range(n_layers)])
        # Zero-init output of last layer for safe residual start
        nn.init.zeros_(self.layers[-1][-1].weight)
        nn.init.zeros_(self.layers[-1][-1].bias)

    def forward(self, hidden, surf_idx, neighbor_idx):
        """
        hidden: [B, N, C]
        surf_idx: [M_s] surface node indices
        neighbor_idx: [B, M_s, k] k nearest volume neighbors per surface node
        """
        h = hidden
        for layer, ln in zip(self.layers, self.layer_norms):
            h_surf = h[:, surf_idx, :]          # [B, M_s, C]
            h_nbr = h[:, neighbor_idx, :]        # [B, M_s, k, C]  (advanced indexing)
            h_agg = h_nbr.mean(dim=2)            # [B, M_s, C]
            h_in = torch.cat([h_surf, h_agg], dim=-1)  # [B, M_s, 2C]
            delta = layer(h_in)                  # [B, M_s, C]
            h_surf_new = ln(h_surf + delta)
            h = h.clone()
            h[:, surf_idx, :] = h_surf_new
        return h
```

### Step 3: Precompute neighbor indices

```python
def compute_surface_neighbors(x_coords, surf_idx, k=4):
    """
    x_coords: [B, N, 2]  node xy coordinates
    surf_idx: [M_s]
    Returns neighbor_idx: [B, M_s, k] — k nearest volume node indices per surface node
    """
    B, N, _ = x_coords.shape
    all_idx = torch.arange(N, device=x_coords.device)
    vol_mask = torch.ones(N, dtype=torch.bool, device=x_coords.device)
    vol_mask[surf_idx] = False
    vol_idx = all_idx[vol_mask]  # [M_v]

    surf_coords = x_coords[:, surf_idx, :2]   # [B, M_s, 2]
    vol_coords  = x_coords[:, vol_idx,  :2]   # [B, M_v, 2]

    # If M_v is too large (>2000), subsample 512 random volume nodes for efficiency
    if vol_idx.shape[0] > 2000:
        perm = torch.randperm(vol_idx.shape[0], device=x_coords.device)[:512]
        vol_idx = vol_idx[perm]
        vol_coords = x_coords[:, vol_idx, :2]

    diff = surf_coords.unsqueeze(2) - vol_coords.unsqueeze(1)  # [B, M_s, M_v, 2]
    dists = diff.pow(2).sum(-1)                                  # [B, M_s, M_v]
    k_actual = min(k, vol_idx.shape[0])
    _, knn_local = dists.topk(k_actual, dim=-1, largest=False)  # [B, M_s, k]
    return vol_idx[knn_local]  # [B, M_s, k]
```

**IMPORTANT efficiency note:** Call this once per batch (not per step). The mesh topology is fixed within a batch. Cache by reusing across steps if batch composition doesn't change.

### Step 4: Integrate into Transolver forward pass

In `Transolver.__init__`, add:
```python
if cfg.gnn_boundary_layer:
    self.gnn_bl = BoundaryLayerGNN(n_hidden=cfg.n_hidden, n_layers=cfg.gnn_layers)
```

In `Transolver.forward`, after the main backbone loop and **before** the SRF head:
```python
if self.cfg.gnn_boundary_layer and surf_idx is not None:
    neighbor_idx = compute_surface_neighbors(x[:, :, :2], surf_idx, k=self.cfg.gnn_k_neighbors)
    fx = self.gnn_bl(fx, surf_idx, neighbor_idx)
```

### Step 5: Add argparse flags

```python
parser.add_argument('--gnn_boundary_layer', action='store_true')
parser.add_argument('--gnn_layers', type=int, default=2)
parser.add_argument('--gnn_k_neighbors', type=int, default=4)
```

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/gnn-boundary-layer-s42" \
  --wandb_group "frieren/gnn-boundary-layer" \
  --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --gnn_boundary_layer --gnn_layers 2 --gnn_k_neighbors 4

# Seed 73
cd cfd_tandemfoil && python train.py --agent frieren \
  --wandb_name "frieren/gnn-boundary-layer-s73" \
  --wandb_group "frieren/gnn-boundary-layer" \
  --seed 73 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --gnn_boundary_layer --gnn_layers 2 --gnn_k_neighbors 4
```

### Report

Table: p_in, p_oodc, p_tan, p_re for both seeds and 2-seed avg vs baseline. W&B run IDs. Note VRAM usage.

**Watch for:** If neighbor computation is slow, cap M_v to 512 random volume nodes (already in the code above). If VRAM spikes, use surface-only message passing (k nearest surface neighbors only, simpler).

---

## Baseline (PR #2251, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in | 11.891 | < 11.89 |
| p_oodc | 7.561 | < 7.56 |
| p_tan | 28.118 | < 28.12 |
| p_re | 6.364 | < 6.36 |

Baseline W&B runs: `7jix2jkg` (s42), `epkfhxfl` (s73)