### PR TITLE
Flow Matching Surface Head: generative pressure prediction (AlphaFold3-inspired)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -587,6 +587,74 @@ class SurfaceRefinementHead(nn.Module):
         return correction
 
 
+class FlowMatchingSurfaceHead(nn.Module):
+    """Conditional flow matching for surface prediction.
+    Learns a velocity field v(x_t, t, h) that maps noise -> target surface values.
+    Training: flow matching objective (no ODE simulation).
+    Inference: Euler ODE from noise to prediction.
+    """
+
+    def __init__(self, n_hidden: int = 192, out_dim: int = 3,
+                 t_embed_dim: int = 16, hidden_dim: int = 256):
+        super().__init__()
+        self.out_dim = out_dim
+        self.t_embed_dim = t_embed_dim
+        # Time embedding: sinusoidal -> MLP
+        self.t_mlp = nn.Sequential(
+            nn.Linear(t_embed_dim, 64),
+            nn.SiLU(),
+            nn.Linear(64, 64),
+        )
+        # Velocity predictor: [h + x_t + t_emb] -> v
+        self.net = nn.Sequential(
+            nn.Linear(n_hidden + out_dim + 64, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, out_dim),
+        )
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+    def time_embed(self, t: torch.Tensor) -> torch.Tensor:
+        """Sinusoidal time embedding. t: [M] in [0,1]"""
+        freqs = torch.exp(torch.linspace(0, -4, self.t_embed_dim // 2, device=t.device))
+        args = t.unsqueeze(-1) * freqs.unsqueeze(0) * 2 * 3.14159
+        return self.t_mlp(torch.cat([args.sin(), args.cos()], dim=-1))  # [M, 64]
+
+    def forward(self, h: torch.Tensor, x_t: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        """h: [M, n_hidden], x_t: [M, out_dim], t: [M] -> v: [M, out_dim]"""
+        t_emb = self.time_embed(t)
+        inp = torch.cat([h, x_t, t_emb], dim=-1)
+        return self.net(inp)
+
+    @torch.no_grad()
+    def sample(self, h: torch.Tensor, n_steps: int = 10) -> torch.Tensor:
+        """Euler ODE from noise to prediction. h: [M, n_hidden] -> x_1: [M, out_dim]"""
+        M = h.shape[0]
+        x = torch.randn(M, self.out_dim, device=h.device, dtype=h.dtype)
+        dt = 1.0 / n_steps
+        for i in range(n_steps):
+            t = torch.full((M,), i * dt, device=h.device, dtype=h.dtype)
+            v = self.forward(h, x, t)
+            x = x + v * dt
+        return x
+
+
+def flow_matching_loss(head: FlowMatchingSurfaceHead, h_surf: torch.Tensor,
+                       y_surf: torch.Tensor) -> torch.Tensor:
+    """Conditional flow matching training loss.
+    h_surf: [M, n_hidden], y_surf: [M, out_dim] -> scalar loss"""
+    M = h_surf.shape[0]
+    t = torch.rand(M, device=h_surf.device, dtype=h_surf.dtype)
+    x_0 = torch.randn_like(y_surf)
+    t_expand = t.unsqueeze(-1)
+    x_t = (1 - t_expand) * x_0 + t_expand * y_surf
+    v_target = y_surf - x_0
+    v_pred = head(h_surf, x_t, t)
+    return F.mse_loss(v_pred, v_target)
+
+
 class AftFoilRefinementHead(nn.Module):
     """Dedicated refinement head for aft-foil (boundary ID=7) surface nodes.
 
@@ -1165,6 +1233,11 @@ class Config:
     aft_foil_srf_hidden: int = 192           # hidden dim for aft-foil refinement head
     aft_foil_srf_layers: int = 3             # number of hidden layers for aft-foil refinement head
     aft_foil_srf_context: bool = False       # KNN volume context for aft-foil SRF (wake pressure recovery)
+    # Flow matching surface head
+    flow_matching_surface: bool = False      # enable flow matching for surface prediction
+    flow_matching_n_samples: int = 8         # inference samples (averaged)
+    flow_matching_weight: float = 0.5        # weight of flow matching loss vs standard loss
+    flow_matching_t_embed_dim: int = 16      # time embedding dimension
     # Phase 6: 3-way PCGrad — gradient surgery with single-foil | tandem-normal | tandem-extreme-Re
     pcgrad_3way: bool = False               # enable 3-way gradient surgery (requires --disable_pcgrad)
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
@@ -1393,6 +1466,17 @@ if cfg.aft_foil_srf:
               f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, "
               f"film={cfg.aft_foil_srf_film})")
 
+flow_surface_head = None
+if cfg.flow_matching_surface:
+    flow_surface_head = FlowMatchingSurfaceHead(
+        n_hidden=cfg.n_hidden, out_dim=3,
+        t_embed_dim=cfg.flow_matching_t_embed_dim,
+    ).to(device)
+    flow_surface_head = torch.compile(flow_surface_head, mode=cfg.compile_mode)
+    _fm_n_params = sum(p.numel() for p in flow_surface_head.parameters())
+    print(f"Flow matching surface head: {_fm_n_params:,} params "
+          f"(t_embed={cfg.flow_matching_t_embed_dim}, weight={cfg.flow_matching_weight})")
+
 from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
@@ -1418,6 +1502,8 @@ if aft_srf_head is not None:
     n_params += sum(p.numel() for p in aft_srf_head.parameters())
 if aft_srf_ctx_head is not None:
     n_params += sum(p.numel() for p in aft_srf_ctx_head.parameters())
+if flow_surface_head is not None:
+    n_params += sum(p.numel() for p in flow_surface_head.parameters())
 
 
 class SAM:
@@ -1558,6 +1644,10 @@ if aft_srf_ctx_head is not None:
     _ctx_params = list(aft_srf_ctx_head.parameters())
     base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
+if flow_surface_head is not None:
+    _fm_params = list(flow_surface_head.parameters())
+    base_opt.add_param_group({'params': _fm_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _fm_params):,} flow matching head params to optimizer")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
@@ -1655,6 +1745,8 @@ for epoch in range(MAX_EPOCHS):
         aft_srf_head.train()
     if aft_srf_ctx_head is not None:
         aft_srf_ctx_head.train()
+    if flow_surface_head is not None:
+        flow_surface_head.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
     n_batches = 0
@@ -2110,6 +2202,17 @@ for epoch in range(MAX_EPOCHS):
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
 
+        # Flow matching surface loss
+        _fm_loss = torch.tensor(0.0, device=device)
+        if flow_surface_head is not None and model.training:
+            _fm_surf_idx = surf_mask.nonzero(as_tuple=False)  # [M, 2]
+            if _fm_surf_idx.numel() > 0:
+                _fm_h = hidden[_fm_surf_idx[:, 0], _fm_surf_idx[:, 1]].detach()
+                _fm_y = y_norm[_fm_surf_idx[:, 0], _fm_surf_idx[:, 1]]
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    _fm_loss = flow_matching_loss(flow_surface_head, _fm_h, _fm_y)
+                loss = loss + cfg.flow_matching_weight * _fm_loss
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -2310,7 +2413,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _train_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if flow_surface_head is not None:
+            _train_log["train/fm_loss"] = _fm_loss.item()
+        wandb.log(_train_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -2622,6 +2728,26 @@ for epoch in range(MAX_EPOCHS):
                         pred_loss = pred_loss.clone()
                         pred_loss[aft_idx[:, 0], aft_idx[:, 1]] += _aft_corr
                         # Back-compute pred for denormalization
+                        if cfg.multiply_std:
+                            pred = pred_loss / sample_stds
+                        else:
+                            pred = pred_loss * sample_stds
+
+                # Flow matching inference: average N samples, blend with SRF prediction
+                if flow_surface_head is not None:
+                    _fm_surf_idx_v = is_surface.nonzero(as_tuple=False)
+                    if _fm_surf_idx_v.numel() > 0:
+                        _fm_h_v = _eval_hidden[_fm_surf_idx_v[:, 0], _fm_surf_idx_v[:, 1]]
+                        _fm_preds = []
+                        _fm_base = flow_surface_head._orig_mod if hasattr(flow_surface_head, '_orig_mod') else flow_surface_head
+                        for _ in range(cfg.flow_matching_n_samples):
+                            _fm_sample = _fm_base.sample(_fm_h_v.float(), n_steps=10)
+                            _fm_preds.append(_fm_sample)
+                        _fm_avg = torch.stack(_fm_preds).mean(0).float()  # [M, 3]
+                        # Blend 50/50 with existing SRF prediction
+                        pred_loss = pred_loss.clone()
+                        _existing = pred_loss[_fm_surf_idx_v[:, 0], _fm_surf_idx_v[:, 1]]
+                        pred_loss[_fm_surf_idx_v[:, 0], _fm_surf_idx_v[:, 1]] = 0.5 * _existing + 0.5 * _fm_avg
                         if cfg.multiply_std:
                             pred = pred_loss / sample_stds
                         else:


### PR DESCRIPTION
## Hypothesis

The entire research programme treats surface pressure prediction as **deterministic regression**: one input → one output. But the hardest metric — p_tan (aft-foil tandem pressure) — may fail because the conditional distribution of aft-foil pressure given (geometry, Re, gap, stagger) has high variance or multiple modes. When forced to predict a single point estimate, the model regresses to the conditional mean, which may be far from any physically realizable solution.

**Flow matching** (Lipman et al., 2022) replaces the deterministic SRF with a generative model that learns the full conditional distribution p(pressure_surface | backbone_hidden). At inference time, we sample N=8 predictions from the flow and average them, producing a statistically consistent estimate more robust to multi-modality than a point estimate.

**This is the approach used in AlphaFold3** — the structure module uses a diffusion head for per-residue coordinates instead of deterministic regression. We apply the exact same principle to surface pressure prediction.

**Critical detail:** The flow matching head operates ONLY on surface nodes (M_s << N_total), keeping computation tractable. It replaces the existing SRF head's loss, not the SRF architecture entirely.

**Target metrics:** p_tan (multi-modal tandem pressure), p_oodc (OOD samples with high prediction variance)

**References:**
- Lipman et al. "Flow Matching for Generative Modeling" (arXiv:2210.02747, 2022)
- AlphaFold3 (Abramson et al., Nature 2024) — diffusion head for structure coordinates
- Tong et al. "Improving and Generalizing Flow-Matching" (arXiv:2302.00482, 2023)

---

## Instructions

### Step 1: Add config flags

```python
flow_matching_surface: bool = False     # enable flow matching for surface prediction
flow_matching_n_samples: int = 8        # inference samples (averaged)
flow_matching_weight: float = 0.5       # weight of flow matching loss vs standard SRF loss
flow_matching_t_embed_dim: int = 16     # time embedding dimension
```

### Step 2: Implement the flow matching surface head

Add this class near the SurfaceRefinementHead:

```python
class FlowMatchingSurfaceHead(nn.Module):
    """
    Conditional flow matching for surface pressure prediction.
    Learns a velocity field v(x_t, t, h) that maps noise → target surface values.
    
    Training: flow matching objective (no ODE simulation needed).
    Inference: solve ODE from noise to prediction using Euler steps.
    """
    def __init__(self, n_hidden=192, out_dim=3, t_embed_dim=16, hidden_dim=256):
        super().__init__()
        self.out_dim = out_dim
        self.t_embed_dim = t_embed_dim
        
        # Time embedding: sinusoidal
        self.t_mlp = nn.Sequential(
            nn.Linear(t_embed_dim, 64),
            nn.SiLU(),
            nn.Linear(64, 64),
        )
        
        # Velocity predictor: [h (n_hidden) + x_t (out_dim) + t_emb (64)] → v (out_dim)
        self.net = nn.Sequential(
            nn.Linear(n_hidden + out_dim + 64, hidden_dim),
            nn.SiLU(),
            nn.Linear(hidden_dim, hidden_dim),
            nn.SiLU(),
            nn.Linear(hidden_dim, out_dim),
        )
        # Zero-init last layer for safe start
        nn.init.zeros_(self.net[-1].weight)
        nn.init.zeros_(self.net[-1].bias)
    
    def time_embed(self, t):
        """Sinusoidal time embedding. t: [M] in [0,1]"""
        freqs = torch.exp(torch.linspace(0, -4, self.t_embed_dim // 2, device=t.device))
        args = t.unsqueeze(-1) * freqs.unsqueeze(0) * 2 * 3.14159
        return self.t_mlp(torch.cat([args.sin(), args.cos()], dim=-1))  # [M, 64]
    
    def forward(self, h, x_t, t):
        """
        h: [M_s, n_hidden] — backbone hidden states at surface nodes
        x_t: [M_s, out_dim] — noisy surface values at time t
        t: [M_s] — timesteps in [0, 1]
        Returns: v: [M_s, out_dim] — predicted velocity field
        """
        t_emb = self.time_embed(t)  # [M_s, 64]
        inp = torch.cat([h, x_t, t_emb], dim=-1)  # [M_s, n_hidden + out_dim + 64]
        return self.net(inp)
    
    @torch.no_grad()
    def sample(self, h, n_steps=10):
        """
        Generate predictions via Euler ODE integration from noise.
        h: [M_s, n_hidden]
        Returns: x_1: [M_s, out_dim] — predicted surface values
        """
        M_s = h.shape[0]
        x = torch.randn(M_s, self.out_dim, device=h.device)  # start from noise
        dt = 1.0 / n_steps
        for i in range(n_steps):
            t = torch.full((M_s,), i * dt, device=h.device)
            v = self.forward(h, x, t)
            x = x + v * dt
        return x


def flow_matching_loss(head, h_surf, y_surf):
    """
    Conditional flow matching training loss.
    No ODE simulation needed — directly regress the velocity field.
    
    h_surf: [M_s, n_hidden] — backbone hidden at surface nodes
    y_surf: [M_s, out_dim] — ground truth surface (Ux, Uy, p)
    Returns: scalar loss
    """
    M_s = h_surf.shape[0]
    
    # Sample random timesteps
    t = torch.rand(M_s, device=h_surf.device)  # [M_s] in [0, 1]
    
    # Sample noise
    x_0 = torch.randn_like(y_surf)  # [M_s, out_dim]
    
    # Linear interpolation: x_t = (1-t) * x_0 + t * y
    t_expand = t.unsqueeze(-1)  # [M_s, 1]
    x_t = (1 - t_expand) * x_0 + t_expand * y_surf
    
    # Target velocity: v_target = y - x_0 (constant for linear interpolation)
    v_target = y_surf - x_0
    
    # Predicted velocity
    v_pred = head(h_surf, x_t, t)
    
    return F.mse_loss(v_pred, v_target)
```

### Step 3: Add to Transolver model

In `Transolver.__init__`:
```python
if cfg.flow_matching_surface:
    self.flow_surface = FlowMatchingSurfaceHead(
        n_hidden=cfg.n_hidden, out_dim=3,
        t_embed_dim=cfg.flow_matching_t_embed_dim
    )
```

### Step 4: Training — add flow matching loss alongside standard loss

In the training loop, after computing standard surface loss, add:

```python
if cfg.flow_matching_surface:
    # h_surf: backbone hidden states at surface nodes [M_s, n_hidden]
    # y_surf: ground truth at surface nodes [M_s, 3]
    fm_loss = flow_matching_loss(model.flow_surface, h_surf.detach(), y_surf)
    loss = loss + cfg.flow_matching_weight * fm_loss
    # Log fm_loss to W&B
```

**IMPORTANT:** Use `h_surf.detach()` — the flow matching loss should NOT backpropagate through the backbone. The backbone is trained by the standard loss. The flow matching head learns from the backbone's fixed representations. This prevents competing gradient signals.

### Step 5: Inference — use flow matching samples

In the evaluation loop, after the model's standard forward pass produces `pred`:

```python
if cfg.flow_matching_surface and hasattr(model, 'flow_surface'):
    # Get backbone hidden states at surface nodes
    h_surf = fx[:, surf_idx, :]  # [B, M_s, n_hidden]
    
    # Sample N predictions and average
    fm_preds = []
    for _ in range(cfg.flow_matching_n_samples):
        sample = model.flow_surface.sample(
            h_surf.reshape(-1, h_surf.shape[-1]),  # [B*M_s, n_hidden]
            n_steps=10
        ).reshape(h_surf.shape[0], -1, 3)  # [B, M_s, 3]
        fm_preds.append(sample)
    fm_avg = torch.stack(fm_preds).mean(0)  # [B, M_s, 3]
    
    # Blend: 50% standard SRF prediction + 50% flow matching average
    pred[:, surf_idx, :] = 0.5 * pred[:, surf_idx, :] + 0.5 * fm_avg
```

### Step 6: Add argparse flags

```python
parser.add_argument('--flow_matching_surface', action='store_true')
parser.add_argument('--flow_matching_n_samples', type=int, default=8)
parser.add_argument('--flow_matching_weight', type=float, default=0.5)
parser.add_argument('--flow_matching_t_embed_dim', type=int, default=16)
```

### Run 2 seeds

```bash
# Seed 42
cd cfd_tandemfoil && python train.py --agent nezuko \
  --wandb_name "nezuko/flow-matching-srf-s42" \
  --wandb_group "nezuko/flow-matching-surface" \
  --seed 42 \
  --flow_matching_surface --flow_matching_weight 0.5 --flow_matching_n_samples 8 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature

# Seed 73 — same with --seed 73 --wandb_name "nezuko/flow-matching-srf-s73"
```

### Report

Table: p_in, p_oodc, p_tan, p_re for both seeds and 2-seed avg vs baseline. W&B run IDs. Also report the flow matching loss value (fm_loss) at the end of training.

**Watch for:**
- If training is significantly slower (flow matching adds extra forward pass), reduce n_samples to 4 at inference
- If fm_loss doesn't decrease over training, the flow head isn't learning — try increasing flow_matching_weight to 1.0
- The key diagnostic: does the flow matching prediction VARIANCE decrease over training? If samples at inference are highly variable (std > 0.5 of prediction magnitude), the flow head hasn't converged

---

## Baseline (PR #2251, 2-seed avg)

| Metric | Value | Target to beat |
|--------|-------|----------------|
| p_in | 11.891 | < 11.89 |
| p_oodc | 7.561 | < 7.56 |
| p_tan | 28.118 | < 28.12 |
| p_re | 6.364 | < 6.36 |

Baseline W&B runs: `7jix2jkg` (s42), `epkfhxfl` (s73)