### PR TITLE
Geometry Consistency Self-Distillation: Mean Teacher on augmented mesh views

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1050,6 +1050,9 @@ class Config:
     cosine_eta_min: float = 1e-5
     ema_start_epoch: int = 140
     ema_decay: float = 0.998
+    geometry_consistency: bool = False        # Mean Teacher self-distillation on augmented mesh views
+    consistency_weight: float = 0.1           # weight for geometry consistency loss
+    consistency_jitter_sigma: float = 0.005   # jitter sigma for volume node coordinates
     temp_anneal_epoch: int = 50
     vol_ramp_epochs: int = 40
     tandem_curriculum_epochs: int = 10
@@ -1657,6 +1660,7 @@ for epoch in range(MAX_EPOCHS):
         aft_srf_ctx_head.train()
     epoch_vol = 0.0
     epoch_surf = 0.0
+    epoch_consistency = 0.0
     n_batches = 0
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch+1}/{MAX_EPOCHS} [train]", leave=False)
@@ -2242,6 +2246,23 @@ for epoch in range(MAX_EPOCHS):
                 optimizer.zero_grad()
             loss.backward()
 
+        # Geometry consistency loss: Mean Teacher self-distillation on augmented mesh views
+        if cfg.geometry_consistency and epoch > 30 and ema_model is not None:
+            vol_jitter_mask = (mask & ~is_surface).float().unsqueeze(-1)  # [B, N, 1]
+            jitter = torch.randn_like(x[:, :, :2]) * cfg.consistency_jitter_sigma
+            x_aug = x.clone()
+            x_aug[:, :, :2] = x_aug[:, :, :2] + jitter * vol_jitter_mask
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred_aug = model({"x": x_aug})["preds"].float() / sample_stds
+                with torch.no_grad():
+                    _ema_base = ema_model._orig_mod if hasattr(ema_model, '_orig_mod') else ema_model
+                    pred_ema = _ema_base({"x": x})["preds"].float() / sample_stds
+            surf_mask_3d = (mask & is_surface).float().unsqueeze(-1)  # [B, N, 1]
+            n_surf = surf_mask_3d.sum().clamp(min=1)
+            consistency_loss = ((pred_aug - pred_ema.detach()) ** 2 * surf_mask_3d).sum() / n_surf
+            (cfg.consistency_weight * consistency_loss).backward()
+            epoch_consistency += consistency_loss.item()
+
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * 0.75)
         _should_step = (cfg.grad_accum_steps <= 1 or
@@ -2384,13 +2405,16 @@ for epoch in range(MAX_EPOCHS):
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
     if not _do_val:
         dt = time.time() - t0
-        wandb.log({
+        _skip_log = {
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
             "epoch_time_s": dt,
             "lr": scheduler.get_last_lr()[0],
             "global_step": global_step,
-        })
+        }
+        if cfg.geometry_consistency and epoch_consistency > 0:
+            _skip_log["train/consistency_loss"] = epoch_consistency / max(n_batches, 1)
+        wandb.log(_skip_log)
         print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
         continue
 
@@ -2761,6 +2785,8 @@ for epoch in range(MAX_EPOCHS):
         "lr": scheduler.get_last_lr()[0],
         "epoch_time_s": dt,
     }
+    if cfg.geometry_consistency and epoch_consistency > 0:
+        metrics["train/consistency_loss"] = epoch_consistency / max(n_batches, 1)
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -2247,16 +2247,21 @@ for epoch in range(MAX_EPOCHS):
             loss.backward()
 
         # Geometry consistency loss: Mean Teacher self-distillation on augmented mesh views
+        # Use _orig_mod (uncompiled) and detach inputs to avoid "backward through graph a second time"
+        # error from torch.compile caching the first forward pass graph.
         if cfg.geometry_consistency and epoch > 30 and ema_model is not None:
+            _x_d = x.detach()
+            _ss_d = sample_stds.detach()
             vol_jitter_mask = (mask & ~is_surface).float().unsqueeze(-1)  # [B, N, 1]
-            jitter = torch.randn_like(x[:, :, :2]) * cfg.consistency_jitter_sigma
-            x_aug = x.clone()
+            jitter = torch.randn_like(_x_d[:, :, :2]) * cfg.consistency_jitter_sigma
+            x_aug = _x_d.clone()
             x_aug[:, :, :2] = x_aug[:, :, :2] + jitter * vol_jitter_mask
+            _model_raw = model._orig_mod if hasattr(model, '_orig_mod') else model
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                pred_aug = model({"x": x_aug})["preds"].float() / sample_stds
+                pred_aug = _model_raw({"x": x_aug})["preds"].float() / _ss_d
                 with torch.no_grad():
                     _ema_base = ema_model._orig_mod if hasattr(ema_model, '_orig_mod') else ema_model
-                    pred_ema = _ema_base({"x": x})["preds"].float() / sample_stds
+                    pred_ema = _ema_base({"x": _x_d})["preds"].float() / _ss_d
             surf_mask_3d = (mask & is_surface).float().unsqueeze(-1)  # [B, N, 1]
             n_surf = surf_mask_3d.sum().clamp(min=1)
             consistency_loss = ((pred_aug - pred_ema.detach()) ** 2 * surf_mask_3d).sum() / n_surf


### PR DESCRIPTION
## Hypothesis

The model overfits to specific volume mesh coordinate distributions, hurting OOD generalization (p_oodc). **Consistency training via self-distillation** on augmented geometry views forces mesh-topology-invariant representations. For each sample, create an augmented view by jittering volume (non-surface) node coordinates by sigma=0.005. The model must produce consistent surface predictions for both views. EMA model supervises the augmented-view predictions (Mean Teacher, Tarvainen & Valpola 2017).

This is a **data augmentation strategy** per human directive #1860 — novel for CFD surrogates.

**Target:** p_oodc, p_re

## Instructions

### Config flags
```python
geometry_consistency: bool = False
consistency_weight: float = 0.1
consistency_jitter_sigma: float = 0.005
```

### Implementation (in training loop, after standard loss)
```python
if cfg.geometry_consistency and epoch > 30:
    vol_mask = ~is_surface
    x_aug = x.clone()
    x_aug[:, vol_mask, :2] += torch.randn_like(x_aug[:, vol_mask, :2]) * cfg.consistency_jitter_sigma
    pred_aug = model(x_aug, ...)
    with torch.no_grad():
        pred_orig_ema = ema_model(x, ...)
    loss_consistency = F.mse_loss(pred_aug[:, surf_mask], pred_orig_ema[:, surf_mask].detach())
    loss = loss + cfg.consistency_weight * loss_consistency
```

Gate to epoch > 30 (EMA needs time to learn). Log `loss_consistency` to W&B.

### Run 2 seeds
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro \
  --wandb_name "tanjiro/geom-consistency-s42" \
  --wandb_group "tanjiro/geometry-consistency" --seed 42 \
  --geometry_consistency --consistency_weight 0.1 --consistency_jitter_sigma 0.005 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
# Seed 73 — same with --seed 73
```

### Report
Table: p_in, p_oodc, p_tan, p_re. W&B run IDs. Note VRAM impact (extra forward pass).

## Baseline (PR #2251)
| Metric | Value | Target |
|--------|-------|--------|
| p_in | 11.891 | < 11.89 |
| p_oodc | 7.561 | < 7.56 |
| p_tan | 28.118 | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B: 7jix2jkg (s42), epkfhxfl (s73)