### PR TITLE
NeuralFoil Synthetic Data Flooding: single-foil Cp augmentation via neural surrogate

### DIFF
--- a/cfd_tandemfoil/generate_neuralfoil_data.py
+++ b/cfd_tandemfoil/generate_neuralfoil_data.py
@@ -1,0 +1,259 @@
+"""Generate synthetic single-foil surface pressure samples using NeuralFoil.
+
+Usage:
+    cd cfd_tandemfoil
+    python generate_neuralfoil_data.py --n_samples 5000 --out_dir data/neuralfoil_synthetic
+
+Generates (x, y, is_surface) tuples where:
+  x: 24-dim features (template mesh geometry, updated AoA/Re/NACA, stagger=99 as synthetic marker)
+  y: pressure targets — surface nodes get NeuralFoil Cp*q, volume nodes get freestream velocity
+  is_surface: bool mask from template
+
+Volume supervision is disabled during training (detected via stagger sentinel=99.0).
+"""
+
+import argparse
+import math
+import random
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).parent))
+from data.prepare import parse_naca
+from data.prepare_multi import load_data
+
+KINEMATIC_VISCOSITY = 1.35e-5  # m^2/s — derived from training data Re/Umag correspondence
+SYNTHETIC_MARKER = 99.0        # sentinel value for x[:, 23] (stagger) to flag synthetic samples
+
+
+def get_neuralfoil_cp(naca_str: str, aoa_deg: float, re: float, model_size: str = "large"):
+    """Return (Cp_upper, Cp_lower) at 32 x/c positions using NeuralFoil."""
+    import neuralfoil as nf
+    import aerosandbox as asb
+
+    af = asb.Airfoil(f"naca{naca_str}")
+    result = nf.get_aero_from_airfoil(af, alpha=float(aoa_deg), Re=float(re), model_size=model_size)
+
+    conf = float(result["analysis_confidence"])
+    upper_ue = np.array([result[f"upper_bl_ue/vinf_{i}"] for i in range(32)]).flatten()
+    lower_ue = np.array([result[f"lower_bl_ue/vinf_{i}"] for i in range(32)]).flatten()
+    Cp_upper = 1.0 - upper_ue ** 2
+    Cp_lower = 1.0 - lower_ue ** 2
+
+    return Cp_upper, Cp_lower, conf
+
+
+def interpolate_cp_to_nodes(pos, is_surface, Cp_upper, Cp_lower, x_nf):
+    """Interpolate NeuralFoil Cp at 32 x/c points onto mesh surface node positions.
+
+    Args:
+        pos: (N, 2) node positions
+        is_surface: (N,) bool
+        Cp_upper: (32,) Cp at x_nf positions for upper surface
+        Cp_lower: (32,) Cp at x_nf positions for lower surface
+        x_nf: (32,) x/c positions from NeuralFoil (0.015625 to 0.984375)
+
+    Returns:
+        Cp_at_nodes: (n_surf,) Cp at surface node positions
+    """
+    surf_pos = pos[is_surface]  # (n_surf, 2)
+    x_surf = surf_pos[:, 0].numpy()
+    y_surf = surf_pos[:, 1].numpy()
+
+    # Upper surface: y >= 0 (or more precisely, the top side of the airfoil)
+    # For NACA airfoils at chord-length 1, x runs from 0 to 1, y > 0 is upper surface
+    is_upper = y_surf >= 0.0
+
+    # Clamp x to NeuralFoil's valid range
+    x_clamped = np.clip(x_surf, x_nf[0], x_nf[-1])
+
+    Cp_at_nodes = np.zeros(surf_pos.shape[0], dtype=np.float32)
+    if is_upper.any():
+        Cp_at_nodes[is_upper] = np.interp(x_clamped[is_upper], x_nf, Cp_upper)
+    if (~is_upper).any():
+        Cp_at_nodes[~is_upper] = np.interp(x_clamped[~is_upper], x_nf, Cp_lower)
+
+    return Cp_at_nodes
+
+
+def create_synthetic_sample(template_x, template_y, is_surface, aoa_deg, re, naca_str, Cp_upper, Cp_lower, x_nf):
+    """Create synthetic (x, y, is_surface) from template mesh + NeuralFoil Cp.
+
+    template_x: (N, 24) — template mesh features
+    template_y: (N, 3)  — template mesh targets (not used for values, only structure)
+    is_surface: (N,)    — surface mask
+    """
+    import neuralfoil as nf
+
+    N = template_x.shape[0]
+    n_surf = is_surface.sum().item()
+
+    # Interpolate Cp to surface nodes
+    pos = template_x[:, :2]  # raw node positions
+    Cp_nodes = interpolate_cp_to_nodes(pos, is_surface, Cp_upper, Cp_lower, x_nf)
+
+    # Convert Cp → raw pressure (density-normalized: p = Cp * 0.5 * V_inf^2)
+    V_inf = re * KINEMATIC_VISCOSITY
+    q_inf = 0.5 * V_inf ** 2
+    p_surface = torch.from_numpy(Cp_nodes * q_inf)
+
+    # Build synthetic y:
+    # - surface nodes: no-slip (Ux=Uy=0), pressure from NeuralFoil
+    # - volume nodes: freestream (Ux=V_inf, Uy=0, p=0)
+    y_syn = torch.zeros(N, 3, dtype=torch.float32)
+    vol_mask = ~is_surface
+    y_syn[vol_mask, 0] = V_inf  # freestream x-velocity (needed for _umag_q)
+    y_syn[is_surface, 2] = p_surface
+
+    # Build synthetic x: copy template, update AoA/Re/NACA, set synthetic marker
+    x_syn = template_x.clone()
+    log_re = math.log(re)
+    aoa_rad = aoa_deg * math.pi / 180.0
+    naca_enc = torch.tensor(parse_naca(naca_str), dtype=torch.float32)
+
+    x_syn[:, 13] = log_re    # log_Re feature
+    x_syn[:, 14] = aoa_rad   # AoA0_rad
+    x_syn[:, 15:18] = naca_enc.expand(N, 3)  # NACA0 encoding
+    x_syn[:, 18] = 0.0       # AoA1_rad = 0 (single-foil)
+    x_syn[:, 19:22] = 0.0    # NACA1 = (0, 0, 0)
+    x_syn[:, 22] = 0.0       # gap = 0 (single-foil)
+    x_syn[:, 23] = SYNTHETIC_MARKER  # stagger = sentinel marker
+
+    return x_syn, y_syn, is_surface.clone()
+
+
+def validate_samples(templates, x_nf, n_validate=5):
+    """Compare NeuralFoil Cp against real training samples as a sanity check."""
+    import neuralfoil as nf
+    import aerosandbox as asb
+
+    print("\n--- Validation: NeuralFoil vs real data ---")
+    for i in range(min(n_validate, len(templates))):
+        x_t, y_t, is_surf = templates[i]
+        # Extract NACA and flow conditions from template
+        naca_enc = x_t[0, 15:18].tolist()
+        # Reverse parse_naca: naca_enc = (m/9, p/9, t/24)
+        # Find closest matching NACA string
+        m = round(naca_enc[0] * 9)
+        p = round(naca_enc[1] * 9)
+        t = round(naca_enc[2] * 24)
+        naca_str = f"{m}{p}{t:02d}"
+        log_re = x_t[0, 13].item()
+        re = math.exp(log_re)
+        aoa_rad = x_t[0, 14].item()
+        aoa_deg = aoa_rad * 180 / math.pi
+
+        try:
+            Cp_up, Cp_lo, conf = get_neuralfoil_cp(naca_str, aoa_deg, re)
+        except Exception as e:
+            print(f"  Sample {i}: NACA{naca_str} AoA={aoa_deg:.1f} Re={re:.0f} → NeuralFoil failed: {e}")
+            continue
+
+        # Compute real Cp from template
+        pos = x_t[:, :2]
+        surf_pos = pos[is_surf]
+        p_real = y_t[is_surf, 2].numpy()
+        V_inf = re * KINEMATIC_VISCOSITY
+        q_inf = 0.5 * V_inf ** 2
+        Cp_real = p_real / q_inf if q_inf > 0 else p_real
+
+        # NeuralFoil Cp interpolated
+        Cp_nodes = interpolate_cp_to_nodes(pos, is_surf, Cp_up, Cp_lo, x_nf)
+
+        mae = np.abs(Cp_nodes - Cp_real).mean()
+        print(f"  Sample {i}: NACA{naca_str} AoA={aoa_deg:.1f}° Re={re:.0f} | "
+              f"Cp MAE(NF vs CFD)={mae:.3f} | conf={conf:.3f}")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--n_samples", type=int, default=5000)
+    parser.add_argument("--out_dir", type=str, default="data/neuralfoil_synthetic")
+    parser.add_argument("--manifest", type=str, default="data/split_manifest.json")
+    parser.add_argument("--stats_file", type=str, default="data/split_stats.json")
+    parser.add_argument("--n_templates", type=int, default=20, help="Number of template meshes to use")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model_size", type=str, default="large")
+    parser.add_argument("--validate", action="store_true", default=True)
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+
+    import neuralfoil as nf
+    x_nf = nf.bl_x_points  # 32 x/c positions
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Loading training data for template meshes...")
+    train_ds, _, stats, _ = load_data(args.manifest, args.stats_file, debug=False)
+
+    # Sample diverse template meshes from the training set (only single-foil: gap=0)
+    template_indices = []
+    for idx in range(len(train_ds)):
+        x_t, y_t, is_surf = train_ds[idx]
+        gap = x_t[0, 22].item()
+        if abs(gap) < 0.01 and len(template_indices) < args.n_templates:
+            template_indices.append(idx)
+        if len(template_indices) >= args.n_templates:
+            break
+
+    templates = [train_ds[i] for i in template_indices]
+    print(f"Using {len(templates)} template meshes (single-foil only)")
+
+    if args.validate:
+        validate_samples(templates, x_nf, n_validate=5)
+
+    print(f"Generating {args.n_samples} synthetic samples...")
+    n_failed = 0
+    n_saved = 0
+
+    for i in range(args.n_samples):
+        # Sample random NACA geometry
+        t_pct = random.randint(8, 20)   # thickness percent
+        m_pct = random.randint(0, 6)    # max camber percent
+        p_pct = random.randint(2, 6) if m_pct > 0 else 0  # camber position (0 if symmetric)
+        naca_str = f"{m_pct}{p_pct}{t_pct:02d}"
+
+        # Sample flow conditions
+        aoa_deg = random.uniform(-15.0, 20.0)
+        re = random.uniform(5e4, 2e6)
+
+        # Run NeuralFoil
+        try:
+            Cp_up, Cp_lo, conf = get_neuralfoil_cp(naca_str, aoa_deg, re, model_size=args.model_size)
+        except Exception as e:
+            n_failed += 1
+            continue
+
+        # Skip low-confidence predictions (likely stalled/separated flow)
+        if conf < 0.3:
+            n_failed += 1
+            continue
+
+        # Pick random template mesh
+        x_t, y_t, is_surf = random.choice(templates)
+
+        # Create synthetic sample
+        x_syn, y_syn, is_surf_syn = create_synthetic_sample(
+            x_t, y_t, is_surf, aoa_deg, re, naca_str, Cp_up, Cp_lo, x_nf
+        )
+
+        # Save
+        save_path = out_dir / f"sample_{n_saved:05d}.pt"
+        torch.save({"x": x_syn, "y": y_syn, "is_surface": is_surf_syn}, save_path)
+        n_saved += 1
+
+        if (n_saved % 500) == 0:
+            print(f"  {n_saved}/{args.n_samples} saved ({n_failed} failed/skipped)")
+
+    print(f"\nDone. Saved {n_saved} samples to {out_dir} ({n_failed} failed/skipped).")
+
+
+if __name__ == "__main__":
+    main()

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -39,8 +39,28 @@ import simple_parsing as sp
 
 from data.utils import visualize
 from data.prepare_multi import X_DIM, pad_collate, load_data, VAL_SPLIT_NAMES
+from torch.utils.data import ConcatDataset, Dataset as TorchDataset
 
 torch.set_float32_matmul_precision('high')
+
+
+class SyntheticNeuralFoilDataset(TorchDataset):
+    """Dataset of pre-generated NeuralFoil synthetic single-foil samples.
+
+    Each sample is a .pt file with keys: x (N,24), y (N,3), is_surface (N,).
+    Stagger channel (x[:,23]=99) acts as a synthetic marker detected in the training loop.
+    """
+    def __init__(self, data_dir: str):
+        self.files = sorted(Path(data_dir).glob("sample_*.pt"))
+        if not self.files:
+            raise ValueError(f"No sample_*.pt files found in {data_dir}")
+
+    def __len__(self):
+        return len(self.files)
+
+    def __getitem__(self, idx):
+        data = torch.load(self.files[idx], map_location="cpu", weights_only=True)
+        return data["x"], data["y"], data["is_surface"]
 
 
 # ---------------------------------------------------------------------------
@@ -1170,6 +1190,9 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Phase 7: NeuralFoil synthetic data flooding
+    neuralfoil_synthetic_path: str = ""    # path to directory of synthetic sample_*.pt files
+    p_synthetic: float = 0.0              # probability of sampling a synthetic slot per epoch step
 
 
 cfg = sp.parse(Config)
@@ -1235,12 +1258,25 @@ if cfg.debug:
     train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
                               shuffle=True, **loader_kwargs)
 else:
+    _base_ds = train_ds
+    _base_weights = sample_weights
+    if cfg.neuralfoil_synthetic_path and cfg.p_synthetic > 0:
+        _syn_ds = SyntheticNeuralFoilDataset(cfg.neuralfoil_synthetic_path)
+        _base_ds = ConcatDataset([train_ds, _syn_ds])
+        # Weight synthetic samples so P(synthetic slot) ≈ p_synthetic
+        N_real = len(train_ds)
+        N_syn = len(_syn_ds)
+        _avg_w = float(sample_weights.mean())
+        _w_syn = (cfg.p_synthetic / max(1 - cfg.p_synthetic, 1e-8)) * (N_real / max(N_syn, 1)) * _avg_w
+        _syn_weights = torch.full((N_syn,), _w_syn, dtype=sample_weights.dtype)
+        _base_weights = torch.cat([sample_weights, _syn_weights])
+        print(f"NeuralFoil synthetic: {N_syn} samples loaded, w_syn={_w_syn:.4f} (p_synthetic={cfg.p_synthetic})")
     sampler = WeightedRandomSampler(
-        weights=sample_weights,
+        weights=_base_weights,
         num_samples=len(train_ds),
         replacement=True,
     )
-    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size,
+    train_loader = DataLoader(_base_ds, batch_size=cfg.batch_size,
                               sampler=sampler, **loader_kwargs)
 
 val_loaders = {
@@ -1667,6 +1703,14 @@ for epoch in range(MAX_EPOCHS):
         is_surface = is_surface.to(device, non_blocking=True)
         mask = mask.to(device, non_blocking=True)
 
+        # --- Detect and clear synthetic marker (NeuralFoil samples: stagger sentinel = 99.0) ---
+        if cfg.p_synthetic > 0:
+            _is_synthetic = (x[:, 0, 23] > 50.0)  # [B] bool, raw x before normalization
+            if _is_synthetic.any():
+                x[:, :, 23] = x[:, :, 23].masked_fill(_is_synthetic.unsqueeze(1), 0.0)
+        else:
+            _is_synthetic = None
+
         # --- Data augmentation (training-only, applied before normalization) ---
         if model.training and cfg.aug != "none" and epoch >= cfg.aug_start_epoch:
             if cfg.aug in ("yflip", "flip_jitter"):
@@ -1986,6 +2030,10 @@ for epoch in range(MAX_EPOCHS):
                 vol_mask_train[vol_indices[perm, 0], vol_indices[perm, 1]] = True
         else:
             vol_mask_train = vol_mask
+
+        # Mask all volume nodes for synthetic samples (surface-only supervision)
+        if _is_synthetic is not None and _is_synthetic.any():
+            vol_mask_train = vol_mask_train & ~_is_synthetic.unsqueeze(1)
 
         if cfg.boundary_aware:
             vol_dist = dist_feat[:, :, 0]  # [B, N], log1p-scaled dist-to-surface
@@ -2310,7 +2358,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if _is_synthetic is not None and _is_synthetic.any():
+            _log_dict["train/n_synthetic_in_batch"] = _is_synthetic.float().sum().item()
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "weave",
     "tqdm",
     "matplotlib",
+    "neuralfoil",
+    "aerosandbox",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Hypothesis

The training set has limited coverage of the (AoA, Re) parameter space for single-foil configurations. By using NeuralFoil (Sharpe, 2024, arXiv:2503.16323) — a neural surrogate trained on 1M+ XFoil runs that predicts full Cp distributions in <1ms — we can generate thousands of additional synthetic single-foil surface pressure samples spanning a dense grid of AoA, Re, thickness, and camber values.

This directly expands the training distribution rather than adding input features (which failed in prior panel-method experiments). The synthetic samples provide surface-only supervision — volume nodes are masked during training for these samples.

**Key bet:** Broader single-foil coverage improves in-distribution precision (p_in) and OOD generalization (p_oodc, p_re) by giving the model more diverse surface pressure patterns to learn from. This is a DATA GENERATION approach per human directive #1860.

**Literature:**
- Sharpe "NeuralFoil" (arXiv:2503.16323, 2024) — <1ms per query, competitive with XFoil
- Vinuesa & Brunton (Nature Comp Sci, 2022) — synthetic data flooding for CFD surrogates

## Instructions

### Phase 1: Offline Data Generation (run once before training)

Create a script `cfd_tandemfoil/generate_neuralfoil_data.py`:

1. Install NeuralFoil: `pip install neuralfoil`
2. Generate 5000 synthetic single-foil samples:
   - AoA: uniform(-15, 20) degrees
   - Re: uniform(5e4, 2e6)
   - NACA thickness: uniform(0.08, 0.20)
   - NACA camber: uniform(0.0, 0.06)
3. For each sample, call `neuralfoil.get_aero_from_airfoil_name()` with `model_size="large"` to get surface Cp distributions (Cp_upper, Cp_lower at chord-wise positions)
4. Convert Cp to pressure: `p = p_inf + 0.5 * rho * V_inf^2 * Cp` (use Re to derive V_inf with assumed chord=1, kinematic viscosity=1.5e-5)
5. Save to a directory `data/neuralfoil_synthetic/` as individual .pt files with fields: `aoa`, `re`, `surface_xy`, `surface_p`, `surface_upper_mask`
6. Interpolate NeuralFoil's chord-wise Cp points onto the TandemFoilSet single-foil surface node x-positions via linear interpolation

### Phase 2: Training Integration in train.py

1. Add flag `--neuralfoil_synthetic_path` (str, default None) pointing to the generated data directory
2. Add flag `--p_synthetic 0.3` (float) — probability of sampling a synthetic sample in each batch position
3. When loading a synthetic sample:
   - Surface nodes: use the NeuralFoil-derived pressure as target
   - Volume nodes: set domain_mask=0 (no volume supervision for synthetic samples)
   - Input features: construct the standard 24-dim features from the synthetic geometry (DSDF from surface coords, domain flags, Re, AoA)
   - PCGrad: assign synthetic samples to the `single_foil` gradient task group
4. The synthetic DataLoader should be separate from the main TandemFoilSet DataLoader, with random mixing at the batch level

### Phase 3: Training

Run 2 seeds with the full baseline config plus synthetic data:

```
cd cfd_tandemfoil && python train.py --agent alphonse --seed 42 \
  --wandb_name "alphonse/neuralfoil-synthetic-flood-s42" \
  --wandb_group "neuralfoil-synthetic-flood" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --neuralfoil_synthetic_path data/neuralfoil_synthetic --p_synthetic 0.3
```

Then seed 73 with same flags but `--seed 73`.

### Important Implementation Notes

- NeuralFoil outputs Cp (pressure coefficient), NOT raw pressure. You MUST convert to raw pressure using the dynamic pressure formula.
- The asinh transform applies to targets — apply it to synthetic targets too.
- Validate by comparing NeuralFoil Cp at a few AoA/Re values against actual TandemFoilSet single-foil samples before running full training.
- If TandemFoilSet uses non-NACA geometries, check `data/README.md` — NeuralFoil is trained on NACA-family airfoils.
- Run the data generation script first, verify it produces valid samples, then proceed to training.

## Baseline

Current best metrics (PR #2251, 2-seed avg):
- p_in: **11.891** (target: < 11.89)
- p_oodc: **7.561** (target: < 7.56)
- p_tan: **28.118** (target: < 28.12)
- p_re: **6.364** (target: < 6.36)
- W&B baseline runs: 7jix2jkg (s42), epkfhxfl (s73)