### PR TITLE
Tandem Difficulty Curriculum: progressive exposure by gap/stagger magnitude

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,10 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Phase 7: Tandem difficulty curriculum — progressive exposure by gap/stagger magnitude
+    tandem_curriculum: bool = False        # enable curriculum scheduling for tandem samples
+    curriculum_warmup_epochs: int = 40     # epochs using only easiest 25% of tandem samples
+    curriculum_full_epochs: int = 80       # epoch at which all tandem samples become available
 
 
 cfg = sp.parse(Config)
@@ -1188,6 +1192,67 @@ train_ds, val_splits, stats, sample_weights = load_data(
     cfg.manifest, cfg.stats_file, debug=cfg.debug,
 )
 stats = {k: v.to(device) for k, v in stats.items()}
+
+
+class TandemDifficultyScheduler:
+    """Progressive tandem sample curriculum by gap+stagger magnitude."""
+    def __init__(self, tandem_local_indices, gap_values, stagger_values,
+                 warmup_epochs=40, full_epochs=80):
+        import numpy as np
+        self.warmup = warmup_epochs
+        self.full = full_epochs
+        difficulty = np.abs(gap_values) + np.abs(stagger_values)
+        difficulty = (difficulty - difficulty.min()) / (difficulty.max() - difficulty.min() + 1e-6)
+        self.sorted_indices = tandem_local_indices[np.argsort(difficulty)]
+        self.n_tandem = len(tandem_local_indices)
+        self.difficulty = difficulty
+
+    def get_available_indices(self, epoch):
+        """Return tandem indices (into train_ds) available at this epoch."""
+        if epoch < self.warmup:
+            n_avail = max(1, self.n_tandem // 4)
+        elif epoch < self.full:
+            frac = (epoch - self.warmup) / (self.full - self.warmup)
+            n_avail = int(self.n_tandem * (0.25 + 0.75 * frac))
+        else:
+            n_avail = self.n_tandem
+        return set(self.sorted_indices[:n_avail].tolist())
+
+
+# Build curriculum scheduler if enabled
+_curriculum_scheduler = None
+_base_sample_weights = None
+if cfg.tandem_curriculum:
+    import numpy as np
+    print("Scanning training set for tandem difficulty curriculum...")
+    _gap_vals = []
+    _stagger_vals = []
+    _is_tandem_arr = []
+    for i in tqdm(range(len(train_ds)), desc="Curriculum scan", leave=False):
+        _x_i = train_ds[i][0]  # x tensor only
+        _gap_i = _x_i[0, 21].item()
+        _gap_vals.append(_x_i[0, 22].item())  # gap value for difficulty
+        _stagger_vals.append(_x_i[0, 23].item())  # stagger value for difficulty
+        _is_tandem_arr.append(abs(_gap_i) > 0.01)
+    _gap_vals = np.array(_gap_vals)
+    _stagger_vals = np.array(_stagger_vals)
+    _is_tandem_arr = np.array(_is_tandem_arr)
+    _tandem_local_idx = np.where(_is_tandem_arr)[0]
+    if len(_tandem_local_idx) > 0:
+        _curriculum_scheduler = TandemDifficultyScheduler(
+            _tandem_local_idx,
+            _gap_vals[_tandem_local_idx],
+            _stagger_vals[_tandem_local_idx],
+            warmup_epochs=cfg.curriculum_warmup_epochs,
+            full_epochs=cfg.curriculum_full_epochs,
+        )
+        _base_sample_weights = sample_weights.clone()
+        print(f"  Tandem curriculum: {len(_tandem_local_idx)} tandem samples out of {len(train_ds)}")
+        print(f"  Warmup: epochs 0-{cfg.curriculum_warmup_epochs} (easiest 25%)")
+        print(f"  Ramp: epochs {cfg.curriculum_warmup_epochs}-{cfg.curriculum_full_epochs} (25%→100%)")
+    else:
+        print("  WARNING: No tandem samples found — curriculum disabled")
+        cfg.tandem_curriculum = False
 
 
 def _umag_q(y, mask):
@@ -1643,6 +1708,20 @@ for epoch in range(MAX_EPOCHS):
         break
 
     t0 = time.time()
+
+    # Tandem difficulty curriculum: update sampler weights to exclude hard tandem samples
+    if _curriculum_scheduler is not None and not cfg.debug:
+        _avail = _curriculum_scheduler.get_available_indices(epoch)
+        _new_weights = _base_sample_weights.clone()
+        _n_excluded = 0
+        for _i in range(len(_new_weights)):
+            if _is_tandem_arr[_i] and _i not in _avail:
+                _new_weights[_i] = 0.0
+                _n_excluded += 1
+        sampler.weights = _new_weights
+        _n_avail_tandem = len(_avail)
+        if epoch % 10 == 0:
+            print(f"  Curriculum: epoch {epoch}, {_n_avail_tandem}/{_curriculum_scheduler.n_tandem} tandem samples available ({_n_excluded} excluded)")
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
@@ -2767,6 +2846,10 @@ for epoch in range(MAX_EPOCHS):
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f
+    if _curriculum_scheduler is not None:
+        _avail_curr = _curriculum_scheduler.get_available_indices(epoch)
+        metrics["curriculum/n_tandem_available"] = len(_avail_curr)
+        metrics["curriculum/frac_tandem_available"] = len(_avail_curr) / max(1, _curriculum_scheduler.n_tandem)
     wandb.log(metrics)
 
     if torch.cuda.is_available():


### PR DESCRIPTION
## Hypothesis

The model sees all training samples with equal probability throughout training. But tandem configurations with extreme gap and stagger values are much harder — p_tan is 2.37x harder than p_in. A model trained on all difficulty levels simultaneously must balance competing gradient signals from easy (single-foil) and hard (extreme-gap tandem) samples, which may cause the easy samples to dominate early training and push the backbone into a basin that generalizes poorly to hard tandem cases.

Curriculum learning (Bengio et al., 2009) proposes starting with easier samples and progressively introducing harder ones. This is a DATA SCHEDULING approach — no architecture changes, pure training schedule. Orthogonal to all other modifications.

**Key bet:** Progressive tandem exposure lets the model first build a solid foundation on easy/medium tandem configs, then adapt to extreme gap/stagger cases. This directly targets p_tan by ensuring the model sees a coherent difficulty gradient rather than random difficulty at every batch.

**This is NOT a repeat of `tandem_ramp`** (already merged): tandem_ramp modulates the LOSS WEIGHT for the tandem task gradient. This experiment modulates WHICH tandem samples appear in each batch — they're complementary, non-overlapping mechanisms.

**Literature:**
- Bengio et al. "Curriculum Learning" (ICML 2009)
- Hacohen & Weinshall "On The Power of Curriculum Learning" (ICML 2019) — curriculum helps most for hard OOD test cases
- Platanios et al. "Competence-based Curriculum Learning" (NAACL 2019)

## Instructions

### Step 1: Add Curriculum Scheduler

Add a `TandemDifficultyScheduler` class in train.py:

```python
class TandemDifficultyScheduler:
    """Progressive tandem sample curriculum by gap+stagger magnitude."""
    def __init__(self, tandem_indices, gap_values, stagger_values,
                 warmup_epochs=40, full_epochs=80):
        self.warmup = warmup_epochs
        self.full = full_epochs
        # Rank tandem samples by difficulty: normalized (|gap| + |stagger|)
        difficulty = np.abs(gap_values) + np.abs(stagger_values)
        difficulty = (difficulty - difficulty.min()) / (difficulty.max() - difficulty.min() + 1e-6)
        self.sorted_indices = tandem_indices[np.argsort(difficulty)]
        self.n_tandem = len(tandem_indices)

    def get_available_indices(self, epoch):
        """Return tandem indices available at this epoch."""
        if epoch < self.warmup:
            # Easiest 25% only
            n_avail = max(1, self.n_tandem // 4)
        elif epoch < self.full:
            # Linear ramp from Q1 to all
            frac = (epoch - self.warmup) / (self.full - self.warmup)
            n_avail = int(self.n_tandem * (0.25 + 0.75 * frac))
        else:
            n_avail = self.n_tandem
        return self.sorted_indices[:n_avail]
```

### Step 2: Integrate with DataLoader

In the training loop's DataLoader/sampler:
1. At each epoch, call `scheduler.get_available_indices(current_epoch)` to get the set of tandem sample indices to include
2. Replace the uniform tandem sampling with this filtered set
3. Non-tandem samples (single-foil, extreme-Re) are ALWAYS sampled uniformly from the full set — the curriculum only applies to tandem configurations
4. The gap and stagger values for each tandem sample should be available from the dataset metadata (TandemFoilSet stores these). If not directly accessible, compute from the sample's geometry.

### Step 3: New Flags

- `--tandem_curriculum` (bool, default False) — enable curriculum scheduling
- `--curriculum_warmup_epochs 40` (int) — epochs using only easiest 25% of tandem samples
- `--curriculum_full_epochs 80` (int) — epoch at which all tandem samples become available (linear ramp from warmup to full)

### Step 4: Key Interactions with Existing Stack

- **PCGrad**: still applies — tandem task gradient remains separate from single-foil/Re tasks
- **tandem_ramp**: still applies at the sample level — the curriculum operates at batch-composition level, orthogonal
- **Augmentation**: still applies to all samples including curriculum-selected tandem samples
- **gap_stagger_spatial_bias**: still active — the spatial bias features are computed for whatever tandem samples are in the batch

### Step 5: Training Runs

Run 2 seeds:

```
cd cfd_tandemfoil && python train.py --agent frieren --seed 42 \
  --wandb_name "frieren/tandem-difficulty-curriculum-s42" \
  --wandb_group "tandem-difficulty-curriculum" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --tandem_curriculum --curriculum_warmup_epochs 40 --curriculum_full_epochs 80
```

Then seed 73 with same flags but `--seed 73`.

### Important Notes

- **Visualize first:** Before running, print the gap/stagger distribution to confirm there's a meaningful difficulty gradient. If all tandem samples cluster tightly, the curriculum has no structure to exploit.
- **Epoch budget matters:** With warmup=40 and full=80, the model sees only Q1 tandem samples for the first 40 epochs. Ensure the Q1 set has enough samples for meaningful batches — if TandemFoilSet has very few tandem samples total, reduce warmup_epochs proportionally.
- **EMA interaction:** EMA continues updating from epoch 0. In the early curriculum phase, EMA captures the "easy-tandem" model — this is fine, the EMA will update through the full curriculum.

## Baseline

Current best metrics (PR #2251, 2-seed avg):
- p_in: **11.891** (target: < 11.89)
- p_oodc: **7.561** (target: < 7.56)
- p_tan: **28.118** (target: < 28.12)
- p_re: **6.364** (target: < 6.36)
- W&B baseline runs: 7jix2jkg (s42), epkfhxfl (s73)