### PR TITLE
Surface Arc-Length PE: per-foil chord-wise positional encoding for surface nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,68 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_surface_arclen_features(raw_xy, is_surface, saf_norm):
+    """Compute per-foil arc-length sin/cos features for surface nodes.
+
+    For each foil's surface nodes:
+    1. Sort by angle from centroid to get contour order
+    2. Compute cumulative arc-length fraction s in [0, 1]
+    3. Return sin(2*pi*s), cos(2*pi*s)
+
+    Volume nodes get zeros. Handles single-foil and tandem (2 foils).
+
+    Args:
+        raw_xy: [B, N, 2] raw coordinates (before normalization)
+        is_surface: [B, N] bool
+        saf_norm: [B, N] SAF channel norm — foil-1: <=0.005, foil-2: >0.005
+
+    Returns:
+        arclen_feats: [B, N, 2] sin/cos arc-length features
+    """
+    B, N, _ = raw_xy.shape
+    arclen_feats = torch.zeros(B, N, 2, device=raw_xy.device, dtype=raw_xy.dtype)
+
+    for b in range(B):
+        for foil_id in [1, 2]:
+            if foil_id == 1:
+                foil_mask = is_surface[b] & (saf_norm[b] <= 0.005)
+            else:
+                foil_mask = is_surface[b] & (saf_norm[b] > 0.005)
+
+            if foil_mask.sum() < 3:
+                continue
+
+            idx = foil_mask.nonzero(as_tuple=True)[0]  # [M_s]
+            xy = raw_xy[b, idx]  # [M_s, 2]
+
+            # Sort by angle from centroid to get contour order
+            cx, cy = xy[:, 0].mean(), xy[:, 1].mean()
+            angles = torch.atan2(xy[:, 1] - cy, xy[:, 0] - cx)
+            sort_order = angles.argsort()
+            xy_sorted = xy[sort_order]  # [M_s, 2]
+
+            # Cumulative arc-length along sorted contour
+            diffs = torch.diff(xy_sorted, dim=0)  # [M_s-1, 2]
+            seg_lens = torch.norm(diffs, dim=-1)  # [M_s-1]
+            # Add closing segment (last -> first for wraparound)
+            close_len = torch.norm(xy_sorted[-1] - xy_sorted[0]).unsqueeze(0)
+            all_lens = torch.cat([torch.zeros(1, device=raw_xy.device), seg_lens])
+            cum_len = torch.cumsum(all_lens, dim=0)  # [M_s]
+            total_len = (cum_len[-1] + close_len).clamp(min=1e-6)
+            s_frac = cum_len / total_len  # [M_s] in [0, 1)
+
+            # sin/cos embedding
+            s_sin = torch.sin(2 * torch.pi * s_frac)
+            s_cos = torch.cos(2 * torch.pi * s_frac)
+
+            # Unsort back to original node order
+            unsort_order = sort_order.argsort()
+            arclen_feats[b, idx, 0] = s_sin[unsort_order]
+            arclen_feats[b, idx, 1] = s_cos[unsort_order]
+
+    return arclen_feats
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1170,6 +1232,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    surface_arclen_pe: bool = False         # per-foil arc-length sin/cos features for surface nodes (+2 channels)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1363,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (2 if cfg.surface_arclen_pe else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+arclen], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1761,8 +1824,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        # TE coordinate frame / wake deficit / arc-length: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_arclen_pe
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1794,6 +1857,11 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        # Surface arc-length PE: sin/cos of per-foil arc-length fraction
+        if cfg.surface_arclen_pe:
+            arclen_feats = compute_surface_arclen_features(
+                _raw_xy_te, is_surface, _raw_saf_norm_te)
+            x = torch.cat([x, arclen_feats], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,7 +2521,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_arclen_pe
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2484,6 +2552,11 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                # Surface arc-length PE (validation)
+                if cfg.surface_arclen_pe:
+                    arclen_feats = compute_surface_arclen_features(
+                        _raw_xy_te, is_surface, _raw_saf_norm_te)
+                    x = torch.cat([x, arclen_feats], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2982,7 +3055,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_arclen_pe
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3006,6 +3079,11 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    # Surface arc-length PE (verify)
+                    if cfg.surface_arclen_pe:
+                        arclen_feats_vv = compute_surface_arclen_features(
+                            _raw_xy_te, is_surface, _raw_saf_norm_te)
+                        x = torch.cat([x, arclen_feats_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

On airfoil surfaces, the physically meaningful coordinate is NOT the global (x, y) position but the **arc-length fraction s in [0, 1]** from leading edge to trailing edge. Pressure distributions are smooth functions of arc-length — Cp(s) curves are the standard representation in aerodynamics. By explicitly providing arc-length fraction as a surface-node feature, the model can learn pressure as a 1D function of s, which is the natural basis.

This adds 2 new input channels (sin(2*pi*s), cos(2*pi*s)) for surface nodes only. Volume nodes get zeros. The sin/cos embedding is continuous and handles the LE-TE-LE wraparound naturally.

**This is NOT a repeat of prior arc-length PE experiments.** Prior attempts used arc-length as an additive positional encoding on ALL nodes (confusing volume nodes). This experiment:
- Restricts arc-length to **surface nodes only**
- Normalizes **per-foil** (not globally)
- Uses it as a **physics-motivated feature** (Cp(s) is smooth), not a generic PE
- The sin/cos embedding handles wraparound continuously

**Literature:**
- AeroDiT (arXiv:2412.17394, 2024) — explicit arc-length parameterization of surface pressure, ~10% improvement vs coordinate representations on OOD AoA
- NeuralFoil (arXiv:2503.16323, 2024) — arc-length fraction as primary surface coordinate

## Instructions

### Step 1: Compute Arc-Length Fraction

Add a function to compute per-foil arc-length fraction:

```python
def compute_surface_arclen_fraction(surface_xy, le_xy=None, te_xy=None):
    """
    Compute arc-length fraction for each surface node.
    
    Args:
        surface_xy: [M_s, 2] coordinates of surface nodes for one foil
    
    Returns:
        s_sin_cos: [M_s, 2] sin/cos of 2*pi*s_frac
    """
    # Compute cumulative arc length along surface node sequence
    diffs = torch.diff(surface_xy, dim=0)  # [M_s-1, 2]
    seg_lens = torch.norm(diffs, dim=-1)   # [M_s-1]
    cum_len = torch.cat([torch.zeros(1, device=surface_xy.device), 
                         torch.cumsum(seg_lens, dim=0)])  # [M_s]
    total_len = cum_len[-1].clamp(min=1e-6)
    s_frac = cum_len / total_len  # [M_s] in [0, 1]
    
    # Smooth periodic embedding
    s_sin = torch.sin(2 * math.pi * s_frac)
    s_cos = torch.cos(2 * math.pi * s_frac)
    return torch.stack([s_sin, s_cos], dim=-1)  # [M_s, 2]
```

### Step 2: Integrate into Feature Construction

In the data loading / feature construction pipeline:
1. For each sample, identify surface nodes per foil (use `boundary_id` or surface mask)
2. For each foil's surface nodes, compute arc-length sin/cos features
3. For volume nodes, set these 2 channels to 0.0
4. Append as channels 25-26 of the input feature tensor
5. Update the model's input projection: `nn.Linear(24, n_hidden)` → `nn.Linear(26, n_hidden)`

### Step 3: Handle Node Ordering

**CRITICAL:** The cumulative arc-length computation assumes surface nodes are in order along the airfoil contour. Check whether TandemFoilSet stores surface nodes in arc-length order:
- If YES: use directly
- If NO: sort surface nodes by angle from foil centroid before computing arc-length. This is O(M_s log M_s) per foil per sample — acceptable overhead.

Print the node ordering for a few samples to verify before running training.

### Step 4: New Flag

- `--surface_arclen_pe` (bool, default False) — enables arc-length features, increases input_dim to 26

### Step 5: Training Runs

Run 2 seeds:

```
cd cfd_tandemfoil && python train.py --agent fern --seed 42 \
  --wandb_name "fern/surface-arclen-pe-s42" \
  --wandb_group "surface-arclen-pe" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --surface_arclen_pe
```

Then seed 73 with same flags but `--seed 73`.

### Important Notes

- The per-feature statistics for the 2 new channels should be computed on the training set (they'll be approximately sin/cos distributions — mean near 0, std near 0.7). Include them in the standardization pipeline.
- AoA augmentation (`--aug aoa_perturb --aug_full_dsdf_rot`) rotates the surface coordinates. The arc-length fraction is invariant to rotation (it depends on inter-node distances, not absolute positions), so this is naturally compatible.
- For tandem samples with 2 foils: compute arc-length fraction independently per foil (each foil has its own s in [0,1]).
- The sin/cos embedding avoids the discontinuity at s=0/s=1 (TE) — this is important because the trailing edge is a physically meaningful location where upper/lower surfaces meet.

## Baseline

Current best metrics (PR #2251, 2-seed avg):
- p_in: **11.891** (target: < 11.89)
- p_oodc: **7.561** (target: < 7.56)
- p_tan: **28.118** (target: < 28.12)
- p_re: **6.364** (target: < 6.36)
- W&B baseline runs: 7jix2jkg (s42), epkfhxfl (s73)