### PR TITLE
Ensemble Knowledge Distillation: soft targets from 16-seed ensemble

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,12 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Ensemble knowledge distillation
+    ensemble_distill: bool = False           # enable knowledge distillation from ensemble teacher
+    ensemble_teacher_dir: str = ""           # dir containing teacher checkpoint subdirs (model-<runid>/)
+    distill_alpha: float = 0.3               # initial distillation weight
+    distill_alpha_max: float = 0.5           # peak distillation weight (at 40% of training)
+    distill_pressure_only: bool = True       # distill only pressure channel
 
 
 cfg = sp.parse(Config)
@@ -1635,6 +1641,38 @@ prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
 running_tandem_loss = 0.05
 running_nontandem_loss = 0.05
+
+# --- Load ensemble teacher models for distillation ---
+_teacher_models = []
+_teacher_refine_heads = []
+if cfg.ensemble_distill and cfg.ensemble_teacher_dir:
+    _teacher_dir = Path(cfg.ensemble_teacher_dir)
+    _teacher_subdirs = sorted([d for d in _teacher_dir.iterdir() if d.is_dir() and (d / "checkpoint.pt").exists()])
+    print(f"Loading {len(_teacher_subdirs)} teacher models from {_teacher_dir}...")
+    for _td in _teacher_subdirs:
+        _tm = Transolver(**model_config).to(device)
+        _tm._pressure_separate = cfg.pressure_separate_last_block
+        _tm.load_state_dict(torch.load(_td / "checkpoint.pt", map_location=device, weights_only=True))
+        _tm.eval()
+        for p in _tm.parameters():
+            p.requires_grad_(False)
+        _teacher_models.append(_tm)
+        # Load teacher refinement head if it exists
+        _trh = None
+        if cfg.surface_refine and (_td / "refine_head.pt").exists():
+            _trh = SurfaceRefinementHead(
+                n_hidden=cfg.n_hidden, out_dim=3,
+                hidden_dim=cfg.surface_refine_hidden,
+                n_layers=cfg.surface_refine_layers,
+                p_only=cfg.surface_refine_p_only,
+            ).to(device)
+            _trh.load_state_dict(torch.load(_td / "refine_head.pt", map_location=device, weights_only=True))
+            _trh.eval()
+            for p in _trh.parameters():
+                p.requires_grad_(False)
+        _teacher_refine_heads.append(_trh)
+        print(f"  Loaded teacher: {_td.name}")
+    print(f"Teacher ensemble size: {len(_teacher_models)}")
 
 for epoch in range(MAX_EPOCHS):
     elapsed_min = (time.time() - train_start) / 60.0
@@ -2120,6 +2158,54 @@ for epoch in range(MAX_EPOCHS):
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
             loss = loss + cfg.rdrop_alpha * rdrop_loss
 
+        # Ensemble knowledge distillation
+        _distill_loss = torch.tensor(0.0, device=device)
+        if cfg.ensemble_distill and len(_teacher_models) > 0 and model.training:
+            # Alpha schedule: ramp from distill_alpha to distill_alpha_max at 40% of expected epochs,
+            # then decay to 0.1 by 80%. Use cosine_T_max as expected epoch count.
+            _expected_epochs = cfg.cosine_T_max if cfg.cosine_T_max > 0 else 150
+            _frac = epoch / max(_expected_epochs, 1)
+            if _frac < 0.4:
+                _alpha = cfg.distill_alpha + (cfg.distill_alpha_max - cfg.distill_alpha) * (_frac / 0.4)
+            elif _frac < 0.8:
+                _alpha = cfg.distill_alpha_max - (cfg.distill_alpha_max - 0.1) * ((_frac - 0.4) / 0.4)
+            else:
+                _alpha = 0.1
+            # Stochastic teacher selection: pick 1 random teacher per batch
+            # (equivalent to full ensemble mean in expectation, but 4x faster)
+            with torch.no_grad():
+                _ti = torch.randint(len(_teacher_models), (1,)).item()
+                _tm = _teacher_models[_ti]
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    _tout = _tm({"x": x})
+                _tpred = _tout["preds"].float()
+                _thidden = _tout["hidden"].float()
+                if not cfg.no_perstd and not cfg.raw_targets and not cfg.adaptive_norm:
+                    if cfg.multiply_std:
+                        _tpred = _tpred * sample_stds
+                    else:
+                        _tpred = _tpred / sample_stds
+                # Apply teacher SRF if available
+                _trh = _teacher_refine_heads[_ti] if _ti < len(_teacher_refine_heads) else None
+                if _trh is not None:
+                    _tsurf_idx = is_surface.nonzero(as_tuple=False)
+                    if _tsurf_idx.numel() > 0:
+                        _tsh = _thidden[_tsurf_idx[:, 0], _tsurf_idx[:, 1]]
+                        _tsp = _tpred[_tsurf_idx[:, 0], _tsurf_idx[:, 1]]
+                        _tcorr = _trh(_tsh, _tsp).float()
+                        _tpred = _tpred.clone()
+                        _tpred[_tsurf_idx[:, 0], _tsurf_idx[:, 1]] += _tcorr
+                _teacher_mean = _tpred  # single teacher (stochastic ensemble)
+            # Distillation loss: MSE between student and teacher on surface nodes
+            if cfg.distill_pressure_only:
+                _d_pred = pred[:, :, 2:3]
+                _d_teacher = _teacher_mean[:, :, 2:3]
+            else:
+                _d_pred = pred
+                _d_teacher = _teacher_mean
+            _distill_loss = ((_d_pred - _d_teacher).pow(2) * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
+            loss = (1.0 - _alpha) * loss + _alpha * _distill_loss
+
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
@@ -2310,7 +2396,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _train_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.ensemble_distill:
+            _train_log["train/distill_loss"] = _distill_loss.item()
+            _train_log["train/distill_alpha"] = _alpha if '_alpha' in dir() else 0.0
+        wandb.log(_train_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Our 16-seed ensemble (PR #2093) still beats the single model on two key metrics:
- **p_oodc: 6.6 vs 7.561** (ensemble -12.7% better)  
- **p_re: 5.8 vs 6.364** (ensemble -8.9% better)

Knowledge distillation (Hinton et al., 2015) transfers the ensemble's "dark knowledge" — the full output distribution across seeds, not just the mean — into a single model. The ensemble's predictions encode correlations between node pressures and subtle OOD patterns that a single model misses due to initialization-dependent local optima.

**Key bet:** By training with a mixture of ground truth labels AND ensemble soft targets, the single model can absorb the ensemble's OOD generalization (p_oodc, p_re) without needing 16x inference cost. This is fundamentally different from flow matching (which failed) — distillation uses deterministic teacher predictions, not stochastic sampling.

**Literature:**
- Hinton et al. "Distilling the Knowledge in a Neural Network" (arXiv:1503.02531, 2015)
- Allen-Zhu & Li "Towards Understanding Ensemble, Knowledge Distillation and Self-Distillation" (ICLR 2024) — shows distillation compresses multi-view information into single model
- Stanton et al. "Does Knowledge Distillation Really Work?" (NeurIPS 2021) — practical guidelines for regression distillation

## Instructions

### Phase 1: Generate Ensemble Teacher Predictions

First, generate ensemble predictions for all TRAINING samples:

1. Load the 16 seed checkpoints from the ensemble (PR #2093). These should be available in W&B or the checkpoint storage. Check `data/` or ask the advisor if checkpoint paths are unclear.
2. For each training sample, run inference through all 16 seed models and save:
   - **Mean prediction**: `y_teacher = mean(y_pred_seed_1, ..., y_pred_seed_16)` — shape [N, 3] per sample
   - **Variance** (optional, for confidence weighting): `y_var = var(y_pred_seed_1, ..., y_pred_seed_16)` 
3. Save teacher predictions to `data/ensemble_teacher_preds/` as .pt files indexed by sample ID
4. This is a one-time offline step — run before training

**If the 16 checkpoints are not accessible**, use the current baseline checkpoint with different seeds to create a smaller ensemble (e.g., 4-seed). Even a small ensemble provides useful soft targets. Alternatively, train 4 models from scratch with seeds 42, 73, 123, 456 using the baseline config — this costs 4 training runs but creates a reusable teacher.

### Phase 2: Distillation Training

Add distillation loss to the training loop:

```python
def distillation_loss(pred, teacher_pred, alpha=0.5, temperature=1.0):
    """
    Blend ground truth MSE with teacher-matching MSE.
    
    pred: [B, N, 3] model prediction (Ux, Uy, p)
    teacher_pred: [B, N, 3] ensemble teacher prediction
    alpha: weight for distillation loss (1-alpha for GT loss)
    temperature: scaling factor (1.0 for regression = identity)
    """
    distill_loss = F.mse_loss(pred, teacher_pred)
    return distill_loss

# In training loop:
# total_loss = (1 - alpha) * gt_loss + alpha * distill_loss
# where gt_loss is the existing full loss (surface MAE + DCT + PCGrad etc.)
```

### Key Implementation Details

1. **Surface-only distillation**: Apply distillation loss ONLY on surface nodes where the ensemble is strongest. Volume node predictions from the ensemble may be less reliable.
2. **Alpha schedule**: Start with alpha=0.3 (favor GT labels early), increase to alpha=0.5 by epoch 50, then decrease back to alpha=0.1 by epoch 120 (fine-tune on GT labels at the end). This "born-again" schedule lets the student first learn from the teacher, then refine on true labels.
3. **PCGrad compatibility**: The distillation loss should be added to the existing loss BEFORE PCGrad splits. It's a per-sample auxiliary signal, not a separate task.
4. **Pressure-only distillation (recommended)**: Since the ensemble leads on p_oodc and p_re (pressure metrics), distill ONLY the pressure channel (index 2) rather than all 3 channels. The velocity channels may not benefit.
5. **EMA interaction**: The EMA model is NOT the teacher — the ensemble is. EMA continues updating from the student model as usual.

### Phase 3: New Flags

- `--ensemble_distill` (bool, default False) — enable knowledge distillation
- `--ensemble_teacher_path` (str) — path to precomputed ensemble predictions directory
- `--distill_alpha 0.3` (float) — initial distillation weight
- `--distill_alpha_max 0.5` (float) — peak distillation weight
- `--distill_pressure_only` (bool, default True) — distill only pressure channel

### Phase 4: Training Runs

```
cd cfd_tandemfoil && python train.py --agent nezuko --seed 42 \
  --wandb_name "nezuko/ensemble-distill-s42" \
  --wandb_group "ensemble-distillation" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --ensemble_distill --ensemble_teacher_path data/ensemble_teacher_preds \
  --distill_alpha 0.3 --distill_alpha_max 0.5 --distill_pressure_only
```

Then seed 73 with same flags but `--seed 73`.

### Important Notes

- The teacher predictions must be in the SAME coordinate frame and normalization as the training targets (asinh-transformed pressure). If the ensemble checkpoints use different normalization, convert first.
- Teacher predictions should be generated with EMA models from each seed for maximum quality.
- If generating teacher predictions takes too long (16 forward passes per sample), subsample to the most informative samples (OOD-like training samples with extreme gap/stagger/AoA).
- The distillation loss is deterministic (no sampling, no noise) — fundamentally different from the flow matching approach that just failed.

## Baseline

Current best metrics (PR #2251, 2-seed avg):
- p_in: **11.891** (target: < 11.89)
- p_oodc: **7.561** (target: < 7.56)
- p_tan: **28.118** (target: < 28.12)
- p_re: **6.364** (target: < 6.36)
- W&B baseline runs: 7jix2jkg (s42), epkfhxfl (s73)

16-seed ensemble (PR #2093): p_in=12.1, p_oodc=6.6, p_tan=29.1, p_re=5.8