### PR TITLE
Point Cloud MixUp: linear interpolation data augmentation for OOD robustness

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,10 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Point Cloud MixUp data augmentation
+    mixup: bool = False                     # enable MixUp augmentation (stacks on top of other augs)
+    mixup_alpha: float = 0.2               # Beta distribution parameter (smaller = weaker mixing)
+    mixup_prob: float = 0.5                # probability of applying MixUp per batch
 
 
 cfg = sp.parse(Config)
@@ -1754,6 +1758,20 @@ for epoch in range(MAX_EPOCHS):
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
 
+        # Point Cloud MixUp stage 1: mix raw inputs after augmentations, before preprocessing
+        _mixup_active = False
+        _mixup_lam = None
+        _mixup_idx = None
+        if model.training and cfg.mixup and torch.rand(1).item() < cfg.mixup_prob:
+            _mixup_active = True
+            _B_mix = x.size(0)
+            _beta = torch.distributions.Beta(torch.tensor(cfg.mixup_alpha), torch.tensor(cfg.mixup_alpha))
+            _mixup_lam = _beta.sample((_B_mix,)).to(x.device).view(_B_mix, 1, 1)
+            _mixup_idx = torch.randperm(_B_mix, device=x.device)
+            x = _mixup_lam * x + (1 - _mixup_lam) * x[_mixup_idx]
+            is_surface = is_surface | is_surface[_mixup_idx]  # union of surface nodes
+            mask = mask & mask[_mixup_idx]  # intersection of valid masks
+
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
@@ -1843,6 +1861,9 @@ for epoch in range(MAX_EPOCHS):
                 _fs_phys[:, 0, 2] = 0.0  # p/q
                 _freestream = (_fs_phys - phys_stats["y_mean"]) / phys_stats["y_std"]  # [B, 1, 3]
             y_norm = y_norm - _freestream  # subtract freestream (broadcasts over N)
+        # Point Cloud MixUp stage 2: mix normalized targets in transformed space
+        if _mixup_active:
+            y_norm = _mixup_lam * y_norm + (1 - _mixup_lam) * y_norm[_mixup_idx]
         if model.training and not cfg.no_target_noise:
             noise_progress = min(1.0, epoch / max(cfg.noise_anneal_epochs, 1))
             if cfg.half_target_noise:


### PR DESCRIPTION
## Hypothesis

MixUp (Zhang et al., ICLR 2018) creates virtual training samples by linearly interpolating pairs of existing samples: x_mix = λ*x_1 + (1-λ)*x_2, y_mix = λ*y_1 + (1-λ)*y_2, where λ ~ Beta(α, α). This simple data augmentation technique has been shown to:
- Improve OOD generalization by 2-5% in classification and regression tasks
- Act as a vicinal risk minimizer — training on the manifold between data points
- Reduce overconfidence on out-of-distribution inputs

For CFD: interpolating between two airfoil configurations creates "virtual" intermediate geometries with plausible intermediate pressure fields. This directly expands the effective training distribution — a data augmentation approach per human directive #1860.

**Key constraint:** MixUp requires matching tensor shapes between paired samples. For TandemFoilSet, this means pairing samples with the SAME number of nodes (same mesh). If all samples share a common mesh topology, standard MixUp applies directly. If not, restrict to same-type pairs (tandem-tandem, single-single).

**Literature:**
- Zhang et al. "MixUp: Beyond Empirical Risk Minimization" (ICLR 2018)
- Verma et al. "Manifold Mixup: Better Representations by Interpolating Hidden States" (ICML 2019) — for intermediate layers
- Chen et al. "PointMixup: Augmentation for Point Clouds" (ECCV 2020) — MixUp for 3D point clouds

## Instructions

### Step 1: Implement MixUp in Training Loop

```python
def mixup_batch(x1, y1, x2, y2, alpha=0.2):
    """
    MixUp two samples with random interpolation factor.
    
    x1, x2: [N, D] input features (same shape required)
    y1, y2: [N, C] targets
    alpha: Beta distribution parameter (smaller = weaker mixing)
    
    Returns mixed inputs, targets, and lambda value.
    """
    lam = np.random.beta(alpha, alpha) if alpha > 0 else 1.0
    x_mix = lam * x1 + (1 - lam) * x2
    y_mix = lam * y1 + (1 - lam) * y2
    return x_mix, y_mix, lam
```

### Step 2: Integration with DataLoader

At each training step:
1. Draw a batch of samples normally
2. Create a shuffled copy of the batch (random permutation within the batch)
3. Apply MixUp between original and shuffled: `x_mix, y_mix, lam = mixup_batch(x_orig, y_orig, x_shuffled, y_shuffled, alpha=0.2)`
4. Train on the mixed batch

**Important:** MixUp should apply to:
- Input features (all 24 channels): x_mix = λ*x_1 + (1-λ)*x_2
- Targets (Ux, Uy, p): y_mix = λ*y_1 + (1-λ)*y_2
- Domain masks: mix by taking the union (if either sample has a surface node at position i, treat it as surface)
- PCGrad task assignment: assign mixed sample to the majority task of the two parents (e.g., if both are tandem → tandem; if mixed → single_foil)

**CRITICAL constraint:** Only mix samples with the same number of nodes. In the DataLoader, check that both samples in a pair have matching shapes. If they don't (e.g., single-foil vs tandem with different meshes), skip MixUp for that pair and use the original sample.

### Step 3: New Flags

- `--mixup` (bool, default False) — enable MixUp augmentation
- `--mixup_alpha 0.2` (float) — Beta distribution parameter. Smaller values = weaker mixing (closer to original samples). 0.2 is standard.
- `--mixup_prob 0.5` (float) — probability of applying MixUp to each batch. Not every batch needs mixing.

### Step 4: Training Runs

```
cd cfd_tandemfoil && python train.py --agent askeladd --seed 42 \
  --wandb_name "askeladd/pointcloud-mixup-s42" \
  --wandb_group "pointcloud-mixup" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --mixup --mixup_alpha 0.2 --mixup_prob 0.5
```

Then seed 73 with same flags but `--seed 73`.

### Important Notes

- **asinh transform:** MixUp should apply AFTER the asinh pressure transform to targets (mix in transformed space). Mixing raw pressures then transforming is not equivalent to mixing transformed pressures.
- **Augmentation stacking:** MixUp applies ON TOP of existing augmentations (aoa_perturb, gap_stagger_sigma). The order is: (1) load sample, (2) apply standard augmentations, (3) apply MixUp to the augmented batch.
- **Validation:** Do NOT apply MixUp during validation — only training.
- **EMA:** EMA continues normally — it just sees the model trained on mixed samples.
- **Hard-node mining:** If using error-based hard-node mining, compute errors on the MIXED targets, not original targets. The mixed sample is the "ground truth" for that training step.
- **DSDF features:** When mixing input features, the DSDF gradient channels get interpolated between two geometries. This creates "virtual" geometries that don't correspond to physical meshes — but MixUp's power comes precisely from training on these impossible intermediate points.

## Baseline

Current best metrics (PR #2251, 2-seed avg):
- p_in: **11.891** (target: < 11.89)
- p_oodc: **7.561** (target: < 7.56)
- p_tan: **28.118** (target: < 28.12)
- p_re: **6.364** (target: < 6.36)
- W&B baseline runs: 7jix2jkg (s42), epkfhxfl (s73)