### PR TITLE
Heteroscedastic Loss: learned per-node uncertainty weighting

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -587,6 +587,36 @@ class SurfaceRefinementHead(nn.Module):
         return correction
 
 
+class VarianceHead(nn.Module):
+    """Predicts per-node log-variance for heteroscedastic loss on surface pressure.
+
+    Zero-initialized so training starts as standard MSE (log_var=0 → sigma=1).
+    """
+
+    def __init__(self, n_hidden: int, out_dim: int = 3, hidden_dim: int = 64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(n_hidden + out_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, 1),  # predicts log(sigma^2) for pressure
+        )
+        # Zero-init: log_var=0 → exp(-log_var)=1 → standard MSE at start
+        nn.init.zeros_(self.net[-1].weight)
+        nn.init.zeros_(self.net[-1].bias)
+
+    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            hidden: [M, n_hidden] — hidden features for surface nodes
+            base_pred: [M, out_dim] — base predictions for surface nodes
+        Returns:
+            log_var: [M, 1] — predicted log-variance, clamped for stability
+        """
+        inp = torch.cat([hidden, base_pred], dim=-1)
+        log_var = self.net(inp)
+        return log_var.clamp(-6, 6)  # sigma in [~0.05, ~20]
+
+
 class AftFoilRefinementHead(nn.Module):
     """Dedicated refinement head for aft-foil (boundary ID=7) surface nodes.
 
@@ -1170,6 +1200,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    heteroscedastic_loss: bool = False      # learned per-node log-variance for surface pressure (Gaussian NLL)
 
 
 cfg = sp.parse(Config)
@@ -1393,10 +1424,23 @@ if cfg.aft_foil_srf:
               f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, "
               f"film={cfg.aft_foil_srf_film})")
 
+# Variance head for heteroscedastic loss (per-node log-variance on surface pressure)
+variance_head = None
+if cfg.heteroscedastic_loss:
+    variance_head = VarianceHead(
+        n_hidden=cfg.n_hidden,
+        out_dim=3,
+        hidden_dim=64,
+    ).to(device)
+    variance_head = torch.compile(variance_head, mode=cfg.compile_mode)
+    _var_n_params = sum(p.numel() for p in variance_head.parameters())
+    print(f"Variance head (heteroscedastic): {_var_n_params:,} params")
+
 from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
 ema_aft_srf_head = None  # EMA copy of aft-foil SRF head
+ema_variance_head = None  # EMA copy of variance head
 swad_initial_val = None
 swad_prev_val = float("inf")
 swad_checkpoints: list = []
@@ -1418,6 +1462,8 @@ if aft_srf_head is not None:
     n_params += sum(p.numel() for p in aft_srf_head.parameters())
 if aft_srf_ctx_head is not None:
     n_params += sum(p.numel() for p in aft_srf_ctx_head.parameters())
+if variance_head is not None:
+    n_params += sum(p.numel() for p in variance_head.parameters())
 
 
 class SAM:
@@ -1558,6 +1604,12 @@ if aft_srf_ctx_head is not None:
     _ctx_params = list(aft_srf_ctx_head.parameters())
     base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
+
+# Add variance head params to optimizer if enabled
+if variance_head is not None:
+    _var_params = list(variance_head.parameters())
+    base_opt.add_param_group({'params': _var_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _var_params):,} variance head params to optimizer")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
@@ -1954,6 +2006,19 @@ for epoch in range(MAX_EPOCHS):
                 pred = pred.clone()
                 pred[aft_idx[:, 0], aft_idx[:, 1]] = pred[aft_idx[:, 0], aft_idx[:, 1]] + aft_correction
 
+        # Heteroscedastic loss: predict per-node log-variance for surface pressure
+        _surf_log_var = None
+        if variance_head is not None and model.training:
+            surf_idx_var = is_surface.nonzero(as_tuple=False)  # [M, 2]
+            if surf_idx_var.numel() > 0:
+                surf_hidden_var = hidden[surf_idx_var[:, 0], surf_idx_var[:, 1]]
+                surf_pred_var = pred[surf_idx_var[:, 0], surf_idx_var[:, 1]]
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    log_var_surf = variance_head(surf_hidden_var, surf_pred_var).float()  # [M, 1]
+                # Scatter into full [B, N, 1] tensor for loss computation
+                _surf_log_var = torch.zeros(pred.shape[0], pred.shape[1], 1, device=device)
+                _surf_log_var[surf_idx_var[:, 0], surf_idx_var[:, 1]] = log_var_surf
+
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if cfg.tandem_ramp:
@@ -2015,7 +2080,16 @@ for epoch in range(MAX_EPOCHS):
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
-            surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            if _surf_log_var is not None:
+                # Heteroscedastic NLL: 0.5 * (exp(-log_var) * sq_err + log_var) per surface node
+                _hetero_per_node = 0.5 * (torch.exp(-_surf_log_var) * sq_err[:, :, 2:3] + _surf_log_var)
+                surf_per_sample = (_hetero_per_node * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+            else:
+                surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        elif _surf_log_var is not None:
+            # Heteroscedastic NLL without hard-node mining (before epoch 30)
+            _hetero_per_node = 0.5 * (torch.exp(-_surf_log_var) * sq_err[:, :, 2:3] + _surf_log_var)
+            surf_per_sample = (_hetero_per_node * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
@@ -2309,8 +2383,25 @@ for epoch in range(MAX_EPOCHS):
                     with torch.no_grad():
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+            # EMA for variance head (heteroscedastic loss)
+            if variance_head is not None:
+                _var_base = variance_head._orig_mod if hasattr(variance_head, '_orig_mod') else variance_head
+                if ema_variance_head is None:
+                    ema_variance_head = deepcopy(_var_base)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_variance_head.parameters(), _var_base.parameters()):
+                            ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        # Log heteroscedastic variance stats
+        _hetero_log = {}
+        if _surf_log_var is not None:
+            _sv = _surf_log_var[surf_mask.unsqueeze(-1).expand_as(_surf_log_var)]
+            _hetero_log = {
+                "train/hetero_log_var_mean": _sv.mean().item(),
+                "train/hetero_log_var_std": _sv.std().item(),
+            }
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step, **_hetero_log})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The model predicts (Ux, Uy, p) with MSE loss, treating all nodes equally. But some surface nodes are inherently harder than others — LE suction peaks, TE separation points, and wake-impingement regions have larger pressure gradients and more complex physics. Currently, the model allocates capacity equally across easy and hard nodes.

Heteroscedastic loss (Kendall & Gal, NeurIPS 2017) lets the model learn WHERE it's uncertain by predicting an additional log-variance channel. The loss becomes a Gaussian negative log-likelihood that automatically down-weights noisy/hard nodes and focuses capacity on predictable patterns:

```
loss = (pred - target)^2 / (2 * exp(log_var)) + 0.5 * log_var
```

The first term reduces loss for high-variance (hard) nodes; the second term prevents the model from "cheating" by predicting infinite variance everywhere. The balance is learned end-to-end.

**Key bet:** The model currently wastes capacity trying to perfectly predict intrinsically hard nodes (TE separation, wake impingement). Heteroscedastic loss redistributes effort toward nodes where accuracy is achievable, improving OVERALL surface MAE even if some individual nodes get worse.

**This is fundamentally different from hard-node mining** (which UP-weights hard nodes). Heteroscedastic loss lets the MODEL decide which nodes are hard vs noisy — and reduces effort on truly noisy nodes while maintaining effort on learnable hard nodes.

**Literature:**
- Kendall & Gal "What Uncertainties Do We Need in Bayesian Deep Learning for Computer Vision" (NeurIPS 2017)
- Seitzer et al. "On the Pitfalls of Heteroscedastic Uncertainty Estimation with Probabilistic Neural Networks" (ICLR 2022) — practical guidance

## Instructions

### Step 1: Add Variance Prediction Head

Add a small MLP that predicts per-node log-variance from the SRF hidden state:

```python
class VarianceHead(nn.Module):
    def __init__(self, n_hidden=192):
        super().__init__()
        self.net = nn.Sequential(
            nn.Linear(n_hidden, 64),
            nn.SiLU(),
            nn.Linear(64, 1),  # predicts log(sigma^2) for pressure
        )
        # Initialize to predict log_var=0 (sigma=1) → standard MSE at start
        nn.init.zeros_(self.net[-1].weight)
        nn.init.zeros_(self.net[-1].bias)
    
    def forward(self, hidden):
        log_var = self.net(hidden)
        # Clamp for numerical stability
        return log_var.clamp(-6, 6)  # sigma in [~0.05, ~20]
```

### Step 2: Replace Surface Pressure MSE with Heteroscedastic Loss

```python
def heteroscedastic_loss(pred_p, target_p, log_var):
    """
    Gaussian NLL for surface pressure prediction.
    
    pred_p: [B, M_s, 1] predicted pressure
    target_p: [B, M_s, 1] target pressure
    log_var: [B, M_s, 1] predicted log-variance
    """
    precision = torch.exp(-log_var)  # 1/sigma^2
    mse = (pred_p - target_p) ** 2
    loss = 0.5 * (precision * mse + log_var)
    return loss.mean()
```

**Apply heteroscedastic loss ONLY to the pressure channel (p).** Velocity channels (Ux, Uy) keep standard MSE — pressure is where the model struggles most and where learned weighting helps.

### Step 3: Integration

- The VarianceHead takes the same hidden state as the SRF head (backbone output at surface nodes)
- At training time: compute heteroscedastic_loss instead of MSE for the pressure component of the surface loss
- At validation/test time: ignore the variance prediction — just use the mean prediction for metrics (the variance head doesn't affect predictions, only the loss landscape)
- Log `mean(log_var)` and `std(log_var)` to W&B for debugging — this shows whether the model is learning meaningful variance estimates

### Step 4: New Flags

- `--heteroscedastic_loss` (bool, default False) — enable learned variance for surface pressure
- The VarianceHead adds ~12K params (trivial)

### Step 5: Training Runs

```
cd cfd_tandemfoil && python train.py --agent fern --seed 42 \
  --wandb_name "fern/heteroscedastic-loss-s42" \
  --wandb_group "heteroscedastic-loss" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --heteroscedastic_loss
```

Then seed 73 with same flags but `--seed 73`.

### Important Notes

- **Zero-init is critical.** With zeros init, log_var=0 → exp(-log_var)=1 → loss = 0.5*(mse + 0) = standard MSE. The model starts identical to baseline and gradually learns where to allocate uncertainty.
- **Clamp log_var to [-6, 6]** for stability. This allows sigma in range [~0.05, ~20].
- **PCGrad:** The heteroscedastic loss feeds into the same pressure task gradient as before. PCGrad sees the re-weighted gradients.
- **Hard-node mining interaction:** If hard-node mining selects the top-K error nodes, the heteroscedastic loss changes which nodes have large gradient signal. They may be complementary or conflicting — report both metrics and W&B variance maps.
- **DCT freq loss:** Keep DCT loss unchanged (applied to the mean prediction, not variance-weighted). The heteroscedastic loss only applies to the per-node surface pressure MSE term.
- **asinh transform:** The variance is in asinh-transformed pressure space, which is appropriate since that's the space where the model operates.

## Baseline

Current best metrics (PR #2251, 2-seed avg):
- p_in: **11.891** (target: < 11.89)
- p_oodc: **7.561** (target: < 7.56)
- p_tan: **28.118** (target: < 28.12)
- p_re: **6.364** (target: < 6.36)
- W&B baseline runs: 7jix2jkg (s42), epkfhxfl (s73)