### PR TITLE
Velocity Angle Feature: per-node local incidence angle from DSDF gradient

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    vel_angle_feature: bool = False         # per-node local incidence angle from DSDF gradient and AoA (+2 input channels)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1301,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (2 if cfg.vel_angle_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+vel_angle], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1758,6 +1759,7 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        _va_dsdf_raw = x[:, :, 4:6].clone() if cfg.vel_angle_feature else None  # DSDF gradient pair for foil-1 surface normal
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
@@ -1794,6 +1796,16 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        # Velocity angle feature: per-node local incidence angle from DSDF gradient and AoA
+        if cfg.vel_angle_feature and _va_dsdf_raw is not None:
+            _va_grad_norm = _va_dsdf_raw / _va_dsdf_raw.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+            _va_cos_aoa = torch.cos(_raw_aoa).unsqueeze(1).expand(-1, x.shape[1], -1)
+            _va_sin_aoa = torch.sin(_raw_aoa).unsqueeze(1).expand(-1, x.shape[1], -1)
+            _va_freestream = torch.cat([_va_cos_aoa, _va_sin_aoa], dim=-1)
+            _va_cos_inc = (_va_freestream * _va_grad_norm).sum(dim=-1, keepdim=True)
+            _va_sin_inc = (_va_freestream[:, :, 0:1] * _va_grad_norm[:, :, 1:2]
+                           - _va_freestream[:, :, 1:2] * _va_grad_norm[:, :, 0:1])
+            x = torch.cat([x, _va_cos_inc, _va_sin_inc], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,6 +2465,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
+                _va_dsdf_raw = x[:, :, 4:6].clone() if cfg.vel_angle_feature else None
                 _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
@@ -2484,6 +2497,15 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                if cfg.vel_angle_feature and _va_dsdf_raw is not None:
+                    _va_grad_norm = _va_dsdf_raw / _va_dsdf_raw.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+                    _va_cos_aoa = torch.cos(_raw_aoa).unsqueeze(1).expand(-1, x.shape[1], -1)
+                    _va_sin_aoa = torch.sin(_raw_aoa).unsqueeze(1).expand(-1, x.shape[1], -1)
+                    _va_freestream = torch.cat([_va_cos_aoa, _va_sin_aoa], dim=-1)
+                    _va_cos_inc = (_va_freestream * _va_grad_norm).sum(dim=-1, keepdim=True)
+                    _va_sin_inc = (_va_freestream[:, :, 0:1] * _va_grad_norm[:, :, 1:2]
+                                   - _va_freestream[:, :, 1:2] * _va_grad_norm[:, :, 0:1])
+                    x = torch.cat([x, _va_cos_inc, _va_sin_inc], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2871,6 +2893,8 @@ if best_metrics:
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
                     _raw_gap_wake_vis = x_dev[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
+                    _va_dsdf_raw_vis = x_dev[:, :, 4:6].clone() if cfg.vel_angle_feature else None
+                    _raw_aoa_vis = x_dev[:, 0, 14:15]
                     x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                     curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
                     if cfg.te_coord_frame:
@@ -2888,6 +2912,15 @@ if best_metrics:
                             wake_feats_vis = compute_wake_deficit_features(
                                 _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis)
                             x_n = torch.cat([x_n, wake_feats_vis], dim=-1)
+                    if cfg.vel_angle_feature and _va_dsdf_raw_vis is not None:
+                        _va_grad_norm = _va_dsdf_raw_vis / _va_dsdf_raw_vis.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+                        _va_cos_aoa = torch.cos(_raw_aoa_vis).unsqueeze(1).expand(-1, x_n.shape[1], -1)
+                        _va_sin_aoa = torch.sin(_raw_aoa_vis).unsqueeze(1).expand(-1, x_n.shape[1], -1)
+                        _va_freestream = torch.cat([_va_cos_aoa, _va_sin_aoa], dim=-1)
+                        _va_cos_inc = (_va_freestream * _va_grad_norm).sum(dim=-1, keepdim=True)
+                        _va_sin_inc = (_va_freestream[:, :, 0:1] * _va_grad_norm[:, :, 1:2]
+                                       - _va_freestream[:, :, 1:2] * _va_grad_norm[:, :, 0:1])
+                        x_n = torch.cat([x_n, _va_cos_inc, _va_sin_inc], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
@@ -2982,6 +3015,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
+                    _va_dsdf_raw = x[:, :, 4:6].clone() if cfg.vel_angle_feature else None
                     _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
@@ -3006,6 +3040,15 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    if cfg.vel_angle_feature and _va_dsdf_raw is not None:
+                        _va_grad_norm = _va_dsdf_raw / _va_dsdf_raw.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+                        _va_cos_aoa = torch.cos(_raw_aoa).unsqueeze(1).expand(-1, x.shape[1], -1)
+                        _va_sin_aoa = torch.sin(_raw_aoa).unsqueeze(1).expand(-1, x.shape[1], -1)
+                        _va_freestream = torch.cat([_va_cos_aoa, _va_sin_aoa], dim=-1)
+                        _va_cos_inc = (_va_freestream * _va_grad_norm).sum(dim=-1, keepdim=True)
+                        _va_sin_inc = (_va_freestream[:, :, 0:1] * _va_grad_norm[:, :, 1:2]
+                                       - _va_freestream[:, :, 1:2] * _va_grad_norm[:, :, 0:1])
+                        x = torch.cat([x, _va_cos_inc, _va_sin_inc], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

For each mesh node, compute the angle between the global freestream direction and the local surface-normal direction (derived from DSDF gradient channels already in the input). This gives a per-node **local incidence angle** — a physically meaningful quantity that changes node-by-node and is especially perturbed at aft-foil nodes by the fore-foil wake.

**Why this should work:** Every durable improvement in this programme has come from per-node physics features as input additions (wake deficit -4.1% p_in, TE coordinate frame -5.4% p_in, gap-stagger spatial bias -3.0% p_tan). This follows the exact same pattern: derive a new physical quantity from existing data that the model cannot easily compute on its own.

**Key mechanism:** The DSDF features (channels representing distance-gradient direction at each node) encode local surface geometry. The freestream direction is a global scalar (AoA). The cross-product of these two produces a per-node scalar angle that encodes how directly the flow hits each part of the airfoil. For tandem aft-foil nodes, this local incidence is highly perturbed by the fore-foil wake — which is NOT captured by global AoA alone.

## Instructions

Add 2 new input channels (sin, cos of local incidence angle) computed from existing DSDF gradient channels and the AoA scalar. No new architecture needed — just increase input_dim from 24 to 26.

### Implementation

1. **Identify the DSDF gradient channels** in the input tensor. Read `cfd_tandemfoil/prepare_multi.py` to find which channels contain the DSDF gradient direction (normalized gradient in x, y for foil 1). These are the channels that encode the surface normal direction.

2. **Compute local incidence angle** for each node:
```python
# In feature construction (before model forward):
# DSDF gradient direction for foil1: find the correct channel indices
dsdf1_grad = x[:, :, dsdf1_gx_idx:dsdf1_gy_idx+1]  # [B, N, 2] — DSDF gradient direction
dsdf1_norm = dsdf1_grad / (dsdf1_grad.norm(dim=-1, keepdim=True).clamp(min=1e-6))

# Freestream direction from AoA (find correct channel index for AoA):
aoa_rad = x[:, :, aoa_channel]  # broadcast from global scalar
freestream_dir = torch.stack([torch.cos(aoa_rad), torch.sin(aoa_rad)], dim=-1)  # [B, N, 2]

# Local incidence angle: angle between freestream and DSDF-normal
cos_incidence = (freestream_dir * dsdf1_norm).sum(dim=-1, keepdim=True)  # [B, N, 1]
sin_incidence = (freestream_dir[:, :, 0:1] * dsdf1_norm[:, :, 1:2] 
                - freestream_dir[:, :, 1:2] * dsdf1_norm[:, :, 0:1])  # [B, N, 1]

# Append to input: 2 new channels
x = torch.cat([x, cos_incidence, sin_incidence], dim=-1)  # [B, N, 26]
```

3. **Add flag** `--vel_angle_feature` to control this. Update `input_dim` calculation to add 2 when this flag is set.

4. **Important:** Read `prepare_multi.py` carefully to identify the exact channel indices for DSDF gradient (x, y components) and AoA. The channel layout matters. For volume nodes far from any surface, the DSDF gradient may be noisy — the feature should still be well-defined (cos/sin of angle between noisy gradient and freestream is bounded [-1, 1]).

### Training command (seed 42)
```bash
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/vel-angle-mag-feature-s42" \
  --wandb_group "vel-angle-mag-feature" \
  --vel_angle_feature \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and `--wandb_name "edward/vel-angle-mag-feature-s73"`.

### What to report
1. 2-seed average for p_in, p_oodc, p_tan, p_re
2. W&B run IDs
3. Peak VRAM and epoch count

## Baseline (PR #2251, 2-seed avg)

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.891** | < 11.89 |
| **p_oodc** | **7.561** | < 7.56 |
| **p_tan** | **28.118** | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B baseline: 7jix2jkg (s42), epkfhxfl (s73)