### PR TITLE
Effective AoA Aft Feature: thin-airfoil downwash correction for tandem

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,8 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    effective_aoa_feature: bool = False     # thin-airfoil downwash correction for aft foil (+1 input channel)
+    effective_aoa_k: float = 0.10           # coupling coefficient for downwash AoA correction
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1302,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.effective_aoa_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+eff_aoa], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1758,6 +1760,7 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        _raw_gap = x[:, 0, 22] if cfg.effective_aoa_feature else None  # raw gap for effective AoA
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
@@ -1794,6 +1797,17 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        # Effective AoA feature: thin-airfoil downwash correction for aft foil
+        if cfg.effective_aoa_feature:
+            _aoa_val = _raw_aoa.squeeze(-1)  # [B]
+            _is_tandem_eff = (_raw_gap.abs() > 1e-4)  # [B]
+            _eff_aoa = torch.where(
+                _is_tandem_eff,
+                _aoa_val + cfg.effective_aoa_k * _aoa_val / (_raw_gap.abs() + 0.1),
+                _aoa_val,
+            )  # [B]
+            _eff_aoa_feat = _eff_aoa.unsqueeze(-1).unsqueeze(-1).expand(-1, x.shape[1], 1)  # [B, N, 1]
+            x = torch.cat([x, _eff_aoa_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,6 +2467,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
+                _raw_gap_eff = x[:, 0, 22] if cfg.effective_aoa_feature else None
                 _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
@@ -2484,6 +2499,17 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                # Effective AoA feature (validation path)
+                if cfg.effective_aoa_feature:
+                    _aoa_val_v = _raw_aoa.squeeze(-1)  # [B]
+                    _is_tandem_eff_v = (_raw_gap_eff.abs() > 1e-4)  # [B]
+                    _eff_aoa_v = torch.where(
+                        _is_tandem_eff_v,
+                        _aoa_val_v + cfg.effective_aoa_k * _aoa_val_v / (_raw_gap_eff.abs() + 0.1),
+                        _aoa_val_v,
+                    )  # [B]
+                    _eff_aoa_feat_v = _eff_aoa_v.unsqueeze(-1).unsqueeze(-1).expand(-1, x.shape[1], 1)
+                    x = torch.cat([x, _eff_aoa_feat_v], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2986,6 +3012,7 @@ if cfg.surface_refine and best_metrics:
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
+                    _raw_gap_eff_vv = x[:, 0, 22] if cfg.effective_aoa_feature else None
                     x = (x - stats["x_mean"]) / stats["x_std"]
                     curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                     if cfg.foil2_dist:
@@ -3006,6 +3033,17 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    # Effective AoA feature (verification path)
+                    if cfg.effective_aoa_feature:
+                        _aoa_val_vv = _raw_aoa.squeeze(-1)  # [B]
+                        _is_tandem_eff_vv = (_raw_gap_eff_vv.abs() > 1e-4)  # [B]
+                        _eff_aoa_vv = torch.where(
+                            _is_tandem_eff_vv,
+                            _aoa_val_vv + cfg.effective_aoa_k * _aoa_val_vv / (_raw_gap_eff_vv.abs() + 0.1),
+                            _aoa_val_vv,
+                        )  # [B]
+                        _eff_aoa_feat_vv = _eff_aoa_vv.unsqueeze(-1).unsqueeze(-1).expand(-1, x.shape[1], 1)
+                        x = torch.cat([x, _eff_aoa_feat_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

The aft foil in a tandem configuration operates in the wake of the fore foil. The fore foil's circulation creates a **downwash** that shifts the effective angle-of-attack seen by the aft foil. Classical thin-airfoil theory gives: `AoA_effective ≈ AoA_global + k * AoA_global / gap_normalized`, where k is a coupling coefficient.

This aerodynamic interference effect is **entirely absent from the current input space** — the model only sees global AoA, not the modified effective AoA at the aft foil. For single-foil samples, effective AoA = global AoA (no correction). For tandem, the correction is significant, especially at large AoA / small gap.

**Why this should work:** Every p_tan win has come from explicit inter-foil geometry/physics features. The wake deficit feature (PR #2213, -4.1% p_in) encoded geometric displacement. This encodes **aerodynamic interference** (AoA perturbation). They target different aspects of fore→aft coupling and are complementary.

## Instructions

Add 1 new input channel: effective AoA for the aft foil, computed from thin-airfoil downwash theory. Sweep over coupling coefficient k={0.05, 0.10, 0.20}.

### Implementation

1. **Identify tandem vs single-foil samples** in the batch. The data pipeline should have a flag or you can infer from gap/stagger being nonzero.

2. **Compute effective AoA:**
```python
# Global scalars already in input features:
aoa_val = x[:, 0, aoa_channel]   # [B] — global AoA in radians
gap_norm = x[:, 0, gap_channel]  # [B] — normalized gap (already in features)

k = 0.10  # coupling coefficient (hyperparameter)

# For tandem: effective AoA = AoA + k * AoA / (|gap| + epsilon)
# For single-foil: effective AoA = AoA (no correction)
is_tandem = (gap_norm.abs() > 1e-4)  # [B] bool

eff_aoa = torch.where(
    is_tandem,
    aoa_val + k * aoa_val / (gap_norm.abs() + 0.1),  # downwash correction
    aoa_val  # single-foil: unchanged
)

# Broadcast to all nodes as new input channel
eff_aoa_feature = eff_aoa.unsqueeze(-1).unsqueeze(-1).expand(-1, N, -1)  # [B, N, 1]
x = torch.cat([x, eff_aoa_feature], dim=-1)  # [B, N, 25]
```

3. **Add flag** `--effective_aoa_feature` and `--effective_aoa_k 0.10` (float). Update `input_dim` calculation to add 1 when this flag is set.

4. **Run 3 values of k** using `--wandb_group "effective-aoa-aft"`:
   - k=0.05 (weak coupling)
   - k=0.10 (moderate coupling) — **start here**
   - k=0.20 (strong coupling)

5. **Important:** Read `prepare_multi.py` to find the correct channel indices for AoA and gap. The gap might be encoded as normalized gap-stagger features.

### Training command (seed 42, k=0.10)
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --seed 42 \
  --wandb_name "tanjiro/effective-aoa-k0.10-s42" \
  --wandb_group "effective-aoa-aft" \
  --effective_aoa_feature --effective_aoa_k 0.10 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and adjusted `--wandb_name`.

**If k=0.10 looks promising, run k=0.05 and k=0.20 as follow-ups.** If k=0.10 clearly fails, report and close — no need for the sweep.

### What to report
1. 2-seed average for p_in, p_oodc, p_tan, p_re (for each k value tested)
2. W&B run IDs
3. Whether the feature has different effects on tandem vs single-foil validation splits

## Baseline (PR #2251, 2-seed avg)

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.891** | < 11.89 |
| **p_oodc** | **7.561** | < 7.56 |
| **p_tan** | **28.118** | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B baseline: 7jix2jkg (s42), epkfhxfl (s73)