### PR TITLE
Chord Fraction Feature: per-node chord-wise position for SRF

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -303,6 +303,86 @@ def compute_te_features(raw_xy, is_surface, saf_norm):
     return torch.stack([dx_fore, dy_fore, r_fore, dx_aft, dy_aft, r_aft], dim=-1), fore_te_x, fore_te_y
 
 
+def compute_chord_fraction_feature(raw_xy, is_surface, saf_norm):
+    """Compute chord-fraction feature: projection of (node - LE) onto chord direction, / chord_len.
+
+    For each node, finds the nearest foil's LE and TE (by saf_norm threshold) and computes
+    the dimensionless chord-wise position. Surface nodes have values in [0, 1]; volume nodes
+    may exceed this range and are clamped to [-0.5, 1.5].
+
+    For tandem configurations, aft-foil nodes (saf_norm > 0.005) use the aft foil's chord frame.
+
+    Args:
+        raw_xy:     [B, N, 2] pre-standardization (x, y) coordinates
+        is_surface: [B, N] bool
+        saf_norm:   [B, N] norm of raw saf channels (x[:,:,2:4] pre-standardization)
+
+    Returns: [B, N, 1] chord fraction, clamped to [-0.5, 1.5]
+    """
+    x_coords = raw_xy[:, :, 0]  # [B, N]
+    y_coords = raw_xy[:, :, 1]  # [B, N]
+    INF = 1e6
+
+    # --- Fore foil LE and TE ---
+    fore_surf = is_surface & (saf_norm <= 0.005)
+    fore_surf_safe = fore_surf | (~fore_surf.any(dim=1, keepdim=True))  # fallback for all-False
+    # TE = max x
+    fore_te_masked = x_coords * fore_surf.float() - INF * (~fore_surf_safe).float()
+    fore_te_idx = fore_te_masked.topk(1, dim=1)[1].squeeze(1)
+    fore_te_x = x_coords.gather(1, fore_te_idx.unsqueeze(1)).squeeze(1)  # [B]
+    fore_te_y = y_coords.gather(1, fore_te_idx.unsqueeze(1)).squeeze(1)  # [B]
+    # LE = min x (negate to find argmin via topk)
+    fore_le_masked = -(x_coords * fore_surf.float() - INF * (~fore_surf_safe).float())
+    fore_le_idx = fore_le_masked.topk(1, dim=1)[1].squeeze(1)
+    fore_le_x = x_coords.gather(1, fore_le_idx.unsqueeze(1)).squeeze(1)  # [B]
+    fore_le_y = y_coords.gather(1, fore_le_idx.unsqueeze(1)).squeeze(1)  # [B]
+
+    # Fore chord unit vector and length
+    fore_cv_x = fore_te_x - fore_le_x  # [B]
+    fore_cv_y = fore_te_y - fore_le_y  # [B]
+    fore_chord_len = (fore_cv_x ** 2 + fore_cv_y ** 2).sqrt().clamp(min=1e-6)  # [B]
+    fore_cu_x = fore_cv_x / fore_chord_len  # unit vector
+    fore_cu_y = fore_cv_y / fore_chord_len
+
+    # Fore chord fraction for all nodes
+    dx = x_coords - fore_le_x.unsqueeze(1)  # [B, N]
+    dy = y_coords - fore_le_y.unsqueeze(1)
+    fore_cf = (dx * fore_cu_x.unsqueeze(1) + dy * fore_cu_y.unsqueeze(1)) / fore_chord_len.unsqueeze(1)
+
+    # --- Aft foil LE and TE (tandem only) ---
+    aft_surf = is_surface & (saf_norm > 0.005)
+    is_tandem = aft_surf.any(dim=1)  # [B]
+
+    chord_frac = fore_cf
+    if is_tandem.any():
+        aft_surf_safe = aft_surf | (~aft_surf.any(dim=1, keepdim=True))
+        aft_te_masked = x_coords * aft_surf.float() - INF * (~aft_surf_safe).float()
+        aft_te_idx = aft_te_masked.topk(1, dim=1)[1].squeeze(1)
+        aft_te_x = x_coords.gather(1, aft_te_idx.unsqueeze(1)).squeeze(1)
+        aft_te_y = y_coords.gather(1, aft_te_idx.unsqueeze(1)).squeeze(1)
+
+        aft_le_masked = -(x_coords * aft_surf.float() - INF * (~aft_surf_safe).float())
+        aft_le_idx = aft_le_masked.topk(1, dim=1)[1].squeeze(1)
+        aft_le_x = x_coords.gather(1, aft_le_idx.unsqueeze(1)).squeeze(1)
+        aft_le_y = y_coords.gather(1, aft_le_idx.unsqueeze(1)).squeeze(1)
+
+        aft_cv_x = aft_te_x - aft_le_x
+        aft_cv_y = aft_te_y - aft_le_y
+        aft_chord_len = (aft_cv_x ** 2 + aft_cv_y ** 2).sqrt().clamp(min=1e-6)
+        aft_cu_x = aft_cv_x / aft_chord_len
+        aft_cu_y = aft_cv_y / aft_chord_len
+
+        dx_aft = x_coords - aft_le_x.unsqueeze(1)
+        dy_aft = y_coords - aft_le_y.unsqueeze(1)
+        aft_cf = (dx_aft * aft_cu_x.unsqueeze(1) + dy_aft * aft_cu_y.unsqueeze(1)) / aft_chord_len.unsqueeze(1)
+
+        # Assign aft chord fraction for nodes near aft foil; fore chord fraction elsewhere
+        use_aft = (saf_norm > 0.005) & is_tandem.unsqueeze(1)  # [B, N]
+        chord_frac = torch.where(use_aft, aft_cf, fore_cf)
+
+    return chord_frac.clamp(-0.5, 1.5).unsqueeze(-1)  # [B, N, 1]
+
+
 def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te_x=None, fore_te_y=None):
     """Compute gap-normalized fore-TE offset features for wake coupling.
 
@@ -1170,6 +1250,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    chord_fraction_feature: bool = False   # chord-wise position (LE→TE fraction) per node (+1 input channel)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1381,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.chord_fraction_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+chord_frac], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1761,8 +1842,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        # TE coordinate frame / wake deficit / chord fraction: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.chord_fraction_feature
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1794,6 +1875,9 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        if cfg.chord_fraction_feature:
+            chord_frac_feat = compute_chord_fraction_feature(_raw_xy_te, is_surface, _raw_saf_norm_te)
+            x = torch.cat([x, chord_frac_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,7 +2537,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.chord_fraction_feature
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2484,6 +2568,9 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                if cfg.chord_fraction_feature:
+                    chord_frac_feat = compute_chord_fraction_feature(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                    x = torch.cat([x, chord_frac_feat], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2982,7 +3069,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.chord_fraction_feature
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3006,6 +3093,9 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    if cfg.chord_fraction_feature:
+                        chord_frac_vv = compute_chord_fraction_feature(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                        x = torch.cat([x, chord_frac_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

The SRF head currently has no notion of WHERE on the chord it is making surface corrections. The suction peak at ~15% chord needs a very different correction than the trailing edge at 100% chord. Adding a **chord-fraction feature** ∈ [0, 1] (0=LE, 1=TE) gives the SRF head an explicit 1D coordinate for chord-wise position.

**Why this should work:** Every durable improvement in this programme has come from per-node physics features (wake deficit -4.1% p_in, TE coord frame -5.4% p_in, gap-stagger spatial bias -3.0% p_tan). Chord fraction provides genuinely new positional information that the model currently infers indirectly from DSDF features.

**Key difference from Surface Arc-Length PE (#2278, CLOSED):** That approach used sin/cos encoding of arc-length fraction from angle-sorted node ordering — it failed because (1) angle-sort ordering was unreliable near TE for cambered airfoils, (2) zero features for volume nodes confused attention. This approach is strictly simpler: just the dot product of (node position - LE) onto the chord unit vector, normalized by chord length. **No node ordering required.** Volume nodes get their projected chord fraction (geometrically valid for most interior nodes).

## Instructions

Add 1 new input channel: chord fraction for each node. No new architecture needed — just increase input_dim by 1.

### Implementation

1. **Compute chord fraction** from node (x, y) and foil LE/TE coordinates:
```python
# LE and TE coordinates are already available from the TE coordinate frame feature
# (merged in PR #2207). Reuse the same LE/TE detection logic.
chord_vec = te_xy - le_xy           # [B, 2] — per-sample chord vector
chord_len = chord_vec.norm(dim=-1, keepdim=True).clamp(min=1e-6)  # [B, 1]
chord_unit = chord_vec / chord_len  # [B, 2]

node_xy = x[:, :, 0:2]             # [B, N, 2]
offset = node_xy - le_xy.unsqueeze(1)  # [B, N, 2] — relative to LE
chord_frac = (offset * chord_unit.unsqueeze(1)).sum(dim=-1, keepdim=True) / chord_len.unsqueeze(1)
# chord_frac: [B, N, 1] — 0 at LE, 1 at TE for surface nodes

# Clamp to reasonable range (surface nodes ∈ [0,1], volume nodes may exceed)
chord_frac = chord_frac.clamp(-0.5, 1.5)

x = torch.cat([x, chord_frac], dim=-1)  # [B, N, 25]
```

2. **For tandem configurations:** Compute chord fraction separately for each foil using respective LE/TE coords. The fore foil and aft foil each get their own chord fraction. For volume nodes between foils, use the nearest foil's LE/TE.

3. **Add flag** `--chord_fraction_feature`. Update `input_dim` calculation to add 1 when set.

4. **Read `prepare_multi.py`** to understand how TE coordinate frame computes LE/TE positions — reuse that logic. The LE is typically the node with minimum x-coordinate on each foil surface; TE is maximum x.

### Training command (seed 42)
```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --seed 42 \
  --wandb_name "thorfinn/chord-fraction-s42" \
  --wandb_group "chord-fraction-feature" \
  --chord_fraction_feature \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and `--wandb_name "thorfinn/chord-fraction-s73"`.

### What to report
1. 2-seed average for p_in, p_oodc, p_tan, p_re
2. W&B run IDs
3. Whether the chord fraction feature has different effects on fore vs aft foil pressure accuracy

## Baseline (PR #2251, 2-seed avg)

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.891** | < 11.89 |
| **p_oodc** | **7.561** | < 7.56 |
| **p_tan** | **28.118** | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B baseline: 7jix2jkg (s42), epkfhxfl (s73)