### PR TITLE
Re-Stratified Sampling: upweight extreme Reynolds number training samples

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,9 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Re-stratified sampling
+    re_stratified_sampling: bool = False    # upweight extreme-Re training samples
+    re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
 
 
 cfg = sp.parse(Config)
@@ -1229,6 +1232,21 @@ def _phys_denorm(y_p, Umag, q):
 
 loader_kwargs = dict(collate_fn=pad_collate, num_workers=cfg.num_workers, pin_memory=True,
                      persistent_workers=True, prefetch_factor=2)
+
+if cfg.re_stratified_sampling and not cfg.debug:
+    # Re-stratified sampling: upweight extreme-Re samples in the training set
+    # Extract log_Re from each training sample (x feature index 13)
+    _train_log_re = torch.tensor([train_ds[i][0][0, 13].item() for i in range(len(train_ds))])
+    _re_low = torch.quantile(_train_log_re.float(), 0.2).item()
+    _re_high = torch.quantile(_train_log_re.float(), 0.8).item()
+    _re_extreme = (_train_log_re < _re_low) | (_train_log_re > _re_high)
+    _re_weights = torch.where(_re_extreme, cfg.re_extreme_weight, 1.0).double()
+    # Multiply with existing domain weights (don't replace)
+    sample_weights = sample_weights * _re_weights
+    _n_extreme = _re_extreme.sum().item()
+    print(f"Re-stratified sampling: {_n_extreme}/{len(train_ds)} extreme-Re samples "
+          f"({_n_extreme/len(train_ds)*100:.1f}%) upweighted {cfg.re_extreme_weight}x "
+          f"(log_Re thresholds: [{_re_low:.3f}, {_re_high:.3f}])")
 
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
@@ -1618,6 +1636,13 @@ for _sname in VAL_SPLIT_NAMES:
 wandb.define_metric("lr", step_metric="global_step")
 wandb.define_metric("epoch_time_s", step_metric="global_step")
 wandb.define_metric("val_predictions", step_metric="global_step")
+
+if cfg.re_stratified_sampling and '_train_log_re' in dir():
+    wandb.log({"re_stratification/log_re_histogram": wandb.Histogram(_train_log_re.numpy()),
+               "re_stratification/n_extreme": _n_extreme,
+               "re_stratification/pct_extreme": _n_extreme / len(train_ds) * 100,
+               "re_stratification/re_low_thresh": _re_low,
+               "re_stratification/re_high_thresh": _re_high})
 
 model_dir = Path(f"models/model-{run.id}")
 model_dir.mkdir(parents=True)


### PR DESCRIPTION
## Hypothesis

The p_re test split uses OOD Reynolds numbers. The current training samples are drawn uniformly over the Re range, meaning extreme-Re samples (near the edges of the training distribution) are underrepresented in gradient updates. By giving 2× weight to the top and bottom 20th percentile of training Re values via a static WeightedRandomSampler, we double the effective coverage of Re extremes without dynamic reweighting (which failed in hard mining #2000).

**Why this should work:** The p_re regression (6.300 → 6.364) and the gap between single model (6.364) and 16-seed ensemble (5.8) suggest the model doesn't see enough Re diversity during training. Static Re-stratification is simpler and more stable than focal/OHNM reweighting (both in the exhausted list) — it changes only the sampling distribution, not the loss function.

**Note:** The baseline already applies Cp normalization (via `_phys_norm()`), so the Re² pressure scaling is already handled. This experiment targets the data distribution directly.

## Instructions

Modify the DataLoader's sampling strategy to upweight samples with extreme Reynolds numbers. This is a pure sampling change — no architecture or loss modification.

### Implementation

1. **At dataset initialization**, compute Re percentile bands:
```python
# Get Re values for all training samples
# Re may be stored in the dataset as a per-sample scalar
# Check prepare_multi.py or the dataset __getitem__ to find how Re is accessed

import numpy as np
from torch.utils.data import WeightedRandomSampler

# Collect Re values across training set
train_re_values = []
for i in range(len(train_dataset)):
    sample = train_dataset[i]
    re_val = sample['re']  # or however Re is stored
    train_re_values.append(re_val)
train_re_values = np.array(train_re_values)

log_re = np.log(train_re_values + 1)
re_low_thresh = np.percentile(log_re, 20)
re_high_thresh = np.percentile(log_re, 80)
re_extreme_mask = (log_re < re_low_thresh) | (log_re > re_high_thresh)

# Sampling weights: 2x for extreme-Re, 1x for others
weights = np.where(re_extreme_mask, 2.0, 1.0)

# If existing domain weighting exists, MULTIPLY (don't replace):
# weights = weights * existing_domain_weights

sampler = WeightedRandomSampler(
    weights=weights.tolist(),
    num_samples=len(weights),
    replacement=True
)
```

2. **Replace the DataLoader's sampler** with the Re-stratified sampler. Check how the current DataLoader is configured — it may already use a custom sampler for domain balancing. If so, multiply the Re weights with existing weights.

3. **Add flags:**
   - `--re_stratified_sampling` (bool) — enable Re-stratified sampling
   - `--re_extreme_weight 2.0` (float) — weight multiplier for extreme-Re samples (default 2.0)

4. **Important considerations:**
   - Read how Re is stored in the dataset. It might be in `flowState`, global metadata, or derived from Umag.
   - If the dataset already uses domain-based sampling (tandem vs single-foil weighting), the Re weights should MULTIPLY existing weights, not replace them.
   - With replacement=True and 2× weight, extreme-Re samples appear ~2× as often per epoch. Total epoch size stays the same.
   - Log the actual Re distribution of sampled batches to W&B to verify the stratification works.

### Training command (seed 42)
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --seed 42 \
  --wandb_name "nezuko/re-stratified-s42" \
  --wandb_group "re-stratified-sampling" \
  --re_stratified_sampling --re_extreme_weight 2.0 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and adjusted `--wandb_name`.

### What to report
1. 2-seed average for p_in, p_oodc, p_tan, p_re
2. W&B run IDs
3. Whether p_re specifically improved (primary target)
4. The Re distribution of sampled batches (log a histogram to verify stratification)

## Baseline (PR #2251, 2-seed avg)

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.891** | < 11.89 |
| **p_oodc** | **7.561** | < 7.56 |
| **p_tan** | **28.118** | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B baseline: 7jix2jkg (s42), epkfhxfl (s73)