### PR TITLE
Stagnation Pressure Feature: dynamic pressure q_inf as input channel

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1170,6 +1170,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    stagnation_feature: bool = False        # dynamic pressure q_inf = 0.5*Umag² as global input channel (+1)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1301,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32 + (1 if cfg.stagnation_feature else 0),  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE, [+q_inf]
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1808,6 +1809,9 @@ for epoch in range(MAX_EPOCHS):
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
         Umag, q = _umag_q(y, mask)
+        if cfg.stagnation_feature:
+            q_inf_feat = q.expand(-1, x.shape[1], -1)  # [B, 1, 1] → [B, N, 1]
+            x = torch.cat([x, q_inf_feat], dim=-1)
         if cfg.raw_targets:
             y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
         elif cfg.adaptive_norm:
@@ -2495,6 +2499,9 @@ for epoch in range(MAX_EPOCHS):
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
                 Umag, q = _umag_q(y, mask)
+                if cfg.stagnation_feature:
+                    q_inf_feat = q.expand(-1, x.shape[1], -1)
+                    x = torch.cat([x, q_inf_feat], dim=-1)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
                 elif cfg.adaptive_norm:
@@ -2898,6 +2905,9 @@ if best_metrics:
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
+                    if cfg.stagnation_feature:
+                        q_inf_feat = q.expand(-1, x_n.shape[1], -1)
+                        x_n = torch.cat([x_n, q_inf_feat], dim=-1)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
                     if cfg.raw_targets:
                         y_pred = (pred * raw_stats["y_std"] + raw_stats["y_mean"]).squeeze(0).cpu()
@@ -3017,6 +3027,9 @@ if cfg.surface_refine and best_metrics:
 
                     # Ground truth denormalization reference
                     Umag, q = _umag_q(y, mask)
+                    if cfg.stagnation_feature:
+                        q_inf_feat = q.expand(-1, x.shape[1], -1)
+                        x = torch.cat([x, q_inf_feat], dim=-1)
                     if cfg.adaptive_norm:
                         y_adapt = y.clone()
                         if cfg.asinh_pressure:


### PR DESCRIPTION
## Hypothesis

Add the freestream dynamic pressure `q_inf = 0.5 * Umag²` as a single new input channel broadcast to all nodes. This provides a **Bernoulli-derived pressure baseline** that tells the model what pressure deviation to EXPECT at each sample's velocity regime.

**Why this should work:** The model already has Umag as a global scalar, but q_inf = 0.5 * Umag² is a nonlinear derived quantity that the first linear layer must learn to compute. Providing it explicitly removes this burden. For the residual prediction framework (already merged), having a physics-informed baseline improves what the model learns to correct. This is different from the Bernoulli consistency LOSS (#2224, failed) — that imposed a hard constraint. This is just a feature, with no loss constraint.

**Category:** Input feature addition — the only category with consistent wins (wake deficit -4.1%, TE coord frame -5.4%).

## Instructions

Add 1 new input channel. Very simple implementation.

### Implementation

1. **Find where Umag is available** in the data pipeline. Read `prepare_multi.py` to locate Umag in the input tensor or global features.

2. **Compute and append q_inf:**
```python
# Umag is already a per-sample scalar in the input features
umag = x[:, :, umag_channel]  # [B, N] — broadcast Umag at all nodes
q_inf = 0.5 * umag ** 2      # [B, N] — dynamic pressure
q_inf_feat = q_inf.unsqueeze(-1)  # [B, N, 1]

x = torch.cat([x, q_inf_feat], dim=-1)  # [B, N, 25]
```

3. **Add flag** `--stagnation_feature`. Update `input_dim` to add 1 when set.

4. **Note:** Since the baseline already normalizes pressure by q_inf via `_phys_norm()` for the targets, providing q_inf as an INPUT feature gives the model explicit access to the normalization denominator. This should help especially for the residual prediction path.

### Training command (seed 42)
```bash
cd cfd_tandemfoil && python train.py --agent frieren --seed 42 \
  --wandb_name "frieren/stagnation-pressure-s42" \
  --wandb_group "stagnation-pressure-feature" \
  --stagnation_feature \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and adjusted `--wandb_name`.

## Baseline (PR #2251, 2-seed avg)

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.891** | < 11.89 |
| **p_oodc** | **7.561** | < 7.56 |
| **p_tan** | **28.118** | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B baseline: 7jix2jkg (s42), epkfhxfl (s73)