### PR TITLE
Low-Rank Pressure Loss: SVD structural prior on surface predictions

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1118,6 +1118,10 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    # Phase 7: Low-rank structural prior on surface pressure error
+    lowrank_pressure_loss: bool = False  # SVD-based low-rank loss on surface pressure error
+    lowrank_lambda: float = 0.01         # weight for low-rank loss
+    lowrank_rank: int = 5                # rank cutoff (penalize singular values beyond R)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1761,6 +1765,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
+        _raw_saf_for_lowrank = (x[:, :, 2:4].norm(dim=-1) if cfg.lowrank_pressure_loss and not cfg.dct_freq_loss else _raw_saf_for_dct)
+        _raw_tandem_for_lowrank = ((x[:, 0, 22].abs() > 0.01) if cfg.lowrank_pressure_loss and not cfg.dct_freq_loss else _raw_tandem_for_dct)
         # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
         _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
@@ -2110,6 +2116,56 @@ for epoch in range(MAX_EPOCHS):
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
 
+        # Low-rank structural prior on surface pressure error
+        # Penalizes singular values beyond rank R in the per-foil surface pressure error matrix
+        # [B, M_surf]: pred error rows. Energy in high-rank components = structural noise.
+        _lowrank_loss_val = None
+        _lowrank_sv1 = None
+        _lowrank_sv5 = None
+        if cfg.lowrank_pressure_loss and model.training:
+            # Collect per-foil surface pressure error rows across batch
+            # Each row is p_pred - p_target at surface nodes for one foil.
+            # SVD of this matrix [n_rows, M_surf_max] penalizes singular values > rank R.
+            _lowrank_loss = torch.tensor(0.0, device=device)
+            _lr_rows = []
+            for b in range(B):
+                surf_idx_b = is_surface[b].nonzero(as_tuple=True)[0]
+                if surf_idx_b.numel() < cfg.lowrank_rank + 2:
+                    continue
+                _is_tan_b = _raw_tandem_for_lowrank[b].item() if _raw_tandem_for_lowrank is not None else False
+                if _is_tan_b and _raw_saf_for_lowrank is not None:
+                    saf_vals = _raw_saf_for_lowrank[b, surf_idx_b]
+                    fore_idx = surf_idx_b[saf_vals <= 0.005]
+                    aft_idx = surf_idx_b[saf_vals > 0.005]
+                    foil_groups = [fore_idx, aft_idx]
+                else:
+                    foil_groups = [surf_idx_b]
+                for foil_surf in foil_groups:
+                    if foil_surf.numel() < cfg.lowrank_rank + 2:
+                        continue
+                    p_err_row = pred[b, foil_surf, 2] - y_norm[b, foil_surf, 2]  # [M]
+                    _lr_rows.append(p_err_row)
+
+            if len(_lr_rows) >= cfg.lowrank_rank + 1:
+                # Pad rows to common length using zero-padding (preserves autograd)
+                _max_len = max(r.shape[0] for r in _lr_rows)
+                _padded = [torch.cat([r, r.new_zeros(_max_len - r.shape[0])]) for r in _lr_rows]
+                _P = torch.stack(_padded, dim=0)  # [n_rows, max_len] — gradient-tracked
+                # SVD: S [K], K = min(n_rows, max_len)
+                try:
+                    _U, _S, _Vh = torch.linalg.svd(_P, full_matrices=False)
+                    # Clamp for gradient stability near zero singular values
+                    _S = _S.clamp(min=1e-8)
+                    R = cfg.lowrank_rank
+                    if _S.shape[0] > R:
+                        _lowrank_loss = (_S[R:] ** 2).sum()
+                    loss = loss + cfg.lowrank_lambda * _lowrank_loss
+                    _lowrank_loss_val = _lowrank_loss.item()
+                    _lowrank_sv1 = _S[0].item() if _S.shape[0] > 0 else 0.0
+                    _lowrank_sv5 = _S[4].item() if _S.shape[0] > 4 else 0.0
+                except Exception:
+                    pass  # Skip if SVD fails (degenerate batch)
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -2310,7 +2366,14 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if _lowrank_loss_val is not None:
+            _step_log["train/lowrank_loss"] = _lowrank_loss_val
+            if _lowrank_sv1 is not None:
+                _step_log["train/lowrank_sv1"] = _lowrank_sv1
+            if _lowrank_sv5 is not None:
+                _step_log["train/lowrank_sv5"] = _lowrank_sv5
+        wandb.log(_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Airfoil pressure distributions are **inherently low-rank** — the Cp distribution over the chord can be well-approximated by 3-5 basis functions (POD analysis shows top-5 modes capture >95% of variance). The model's prediction errors likely have systematic structure that lives in a low-rank subspace.

Add an auxiliary loss that penalizes energy in singular values of the surface pressure error matrix beyond rank R=5:
`L_lowrank = λ * ||P_error - P_error_truncated_R||_F²`

This is **orthogonal to the DCT frequency loss** (already merged): DCT penalizes oscillatory errors at each surface position; SVD loss penalizes errors that are correlated ACROSS the chord. Together they constrain the error structure from two complementary directions.

## Instructions

After computing the standard surface pressure loss, additionally compute a low-rank structural penalty on the surface pressure predictions.

### Implementation

1. **Collect surface pressure predictions and targets** within a batch. Reshape into matrix form:
```python
# P_pred: [B, M_surf] — pressure predictions at surface nodes
# P_target: [B, M_surf] — pressure targets at surface nodes
# (M_surf = number of surface nodes per sample, typically ~200-300)

P_error = P_pred - P_target  # [B, M_surf] prediction error matrix
```

2. **Compute truncated SVD and penalty:**
```python
# Compute SVD of error matrix
U, S, Vh = torch.linalg.svd(P_error, full_matrices=False)  # S: [min(B, M_surf)]

# Energy beyond rank R
R = 5  # rank cutoff (motivated by POD analysis of airfoil Cp distributions)
if S.shape[0] > R:
    lowrank_loss = (S[R:] ** 2).sum()  # Frobenius norm of high-rank error components
else:
    lowrank_loss = torch.tensor(0.0, device=P_error.device)

# Add to total loss
total_loss = total_loss + lambda_lowrank * lowrank_loss
```

3. **Important considerations:**
   - Surface nodes must be extracted per-sample. The model uses surface masks — check how `surface_mask` is used in the loss computation.
   - For tandem configurations, apply separately to fore and aft foil surface nodes.
   - The SVD should be computed on the ERROR matrix (pred - target), not the prediction itself.
   - `torch.linalg.svd` is differentiable and works with `torch.compile`. Check that backward pass through SVD doesn't cause NaN (add `torch.clamp(S, min=1e-8)` if needed).
   - Start with λ=0.01 (weak). If promising, sweep λ={0.001, 0.01, 0.1}.

4. **Add flags:**
   - `--lowrank_pressure_loss` (bool)
   - `--lowrank_lambda 0.01` (float)
   - `--lowrank_rank 5` (int)

5. **Handling variable surface node counts:** If samples in a batch have different numbers of surface nodes, you may need to pad or compute the SVD per-sample rather than on the batch matrix. Per-sample SVD is fine — just `torch.linalg.svd(P_error_i.unsqueeze(0))` for each sample and sum the penalties.

### Training command (seed 42)
```bash
cd cfd_tandemfoil && python train.py --agent alphonse --seed 42 \
  --wandb_name "alphonse/lowrank-pressure-s42" \
  --wandb_group "lowrank-pressure-loss" \
  --lowrank_pressure_loss --lowrank_lambda 0.01 --lowrank_rank 5 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and adjusted `--wandb_name`.

### What to report
1. 2-seed average for p_in, p_oodc, p_tan, p_re
2. W&B run IDs
3. The lowrank_loss value during training (log to W&B) — is it decreasing? What fraction of total loss?
4. Any training speed impact from SVD computation

## Baseline (PR #2251, 2-seed avg)

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.891** | < 11.89 |
| **p_oodc** | **7.561** | < 7.56 |
| **p_tan** | **28.118** | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B baseline: 7jix2jkg (s42), epkfhxfl (s73)