### PR TITLE
Surface Curvature Feature: per-node discrete curvature for shape encoding

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,65 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_surface_curvature(raw_xy, is_surface, saf_norm, mask):
+    """Compute discrete Menger curvature at each surface node.
+
+    For each foil's surface, sorts nodes by angle from centroid, then computes
+    3-point curvature at each interior node. Log-scaled for stable range.
+
+    Args:
+        raw_xy:     [B, N, 2] raw x, y coordinates (before normalization)
+        is_surface: [B, N] bool surface mask
+        saf_norm:   [B, N] saf channel norm (fore: <= 0.005, aft: > 0.005)
+        mask:       [B, N] bool valid node mask
+
+    Returns: [B, N, 1] log-scaled curvature (0 for volume nodes)
+    """
+    B, N, _ = raw_xy.shape
+    curvature = torch.zeros(B, N, 1, device=raw_xy.device)
+
+    for b in range(B):
+        valid_surf = is_surface[b] & mask[b]  # [N]
+        if valid_surf.sum() < 3:
+            continue
+
+        # Separate fore and aft foil surface nodes
+        fore_mask = valid_surf & (saf_norm[b] <= 0.005)
+        aft_mask = valid_surf & (saf_norm[b] > 0.005)
+
+        for foil_mask in [fore_mask, aft_mask]:
+            idx = foil_mask.nonzero(as_tuple=True)[0]  # [K]
+            if idx.numel() < 3:
+                continue
+
+            pts = raw_xy[b, idx]  # [K, 2]
+            # Sort by angle from centroid
+            centroid = pts.mean(dim=0)  # [2]
+            angles = torch.atan2(pts[:, 1] - centroid[1], pts[:, 0] - centroid[0])
+            order = angles.argsort()
+            sorted_idx = idx[order]  # global indices in angle order
+            sorted_pts = pts[order]  # [K, 2]
+
+            K = sorted_pts.shape[0]
+            # 3-point Menger curvature with wrap-around
+            p0 = sorted_pts[torch.arange(K) - 1]         # previous neighbor (wraps)
+            p1 = sorted_pts                                # current point
+            p2 = sorted_pts[(torch.arange(K) + 1) % K]   # next neighbor (wraps)
+
+            d01 = p1 - p0  # [K, 2]
+            d02 = p2 - p0  # [K, 2]
+            d12 = p2 - p1  # [K, 2]
+            cross = d01[:, 0] * d02[:, 1] - d01[:, 1] * d02[:, 0]  # [K]
+            denom = d01.norm(dim=1) * d02.norm(dim=1) * d12.norm(dim=1) + 1e-8
+            kappa = (2.0 * cross.abs()) / denom  # [K]
+
+            # Log-scale: log(1 + kappa * 100) to compress range
+            kappa_log = torch.log1p(kappa * 100.0)
+            curvature[b, sorted_idx, 0] = kappa_log
+
+    return curvature
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1170,6 +1229,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    surface_curvature_feature: bool = False  # discrete Menger curvature at surface nodes (+1 input channel)
 
 
 cfg = sp.parse(Config)
@@ -1300,7 +1360,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.surface_curvature_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+surf_curv], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1761,8 +1821,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        # TE coordinate frame / wake deficit / curvature: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_curvature_feature
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1794,6 +1854,10 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        # Surface curvature feature
+        if cfg.surface_curvature_feature:
+            surf_curv = compute_surface_curvature(_raw_xy_te, is_surface, _raw_saf_norm_te, mask)
+            x = torch.cat([x, surf_curv], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2453,7 +2517,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_curvature_feature
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2484,6 +2548,10 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                # Surface curvature feature (validation path)
+                if cfg.surface_curvature_feature:
+                    surf_curv = compute_surface_curvature(_raw_xy_te, is_surface, _raw_saf_norm_te, mask)
+                    x = torch.cat([x, surf_curv], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2982,7 +3050,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.surface_curvature_feature
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3006,6 +3074,10 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    # Surface curvature feature (verification path)
+                    if cfg.surface_curvature_feature:
+                        surf_curv = compute_surface_curvature(_raw_xy_te, is_surface, _raw_saf_norm_te, mask)
+                        x = torch.cat([x, surf_curv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

Airfoil surface curvature (κ) directly correlates with pressure gradients — high curvature at the leading edge produces the suction peak, low curvature along mid-chord corresponds to gradual pressure recovery, and curvature near the TE determines the Kutta condition. The model currently has NO explicit curvature information — it must infer shape from raw coordinates and DSDF features.

Adding **discrete curvature** at each surface node provides genuinely new geometric shape information that falls in the proven input feature category (wake deficit -4.1%, TE coord frame -5.4%).

**Key distinction from prior features:** This is NEITHER positional (unlike arc-length PE, chord fraction) NOR inter-foil (unlike wake deficit, effective AoA) NOR flow-regime (unlike stagnation pressure). It's **pure local geometry shape information** — how much the surface bends at each point.

## Instructions

Compute discrete curvature at each surface node from mesh coordinates. Add as 1 new input channel.

### Implementation

1. **For each surface node**, find its 2 nearest surface neighbors (using the surface mask and KD-tree or brute-force distances within each foil):
```python
# For each foil's surface nodes:
# Sort surface nodes by angle from centroid (or by x-coordinate)
# For each surface node i, its neighbors are i-1 and i+1 in the sorted order

# 3-point curvature: given 3 consecutive points p0, p1, p2
# κ = 2 * |cross(p1-p0, p2-p0)| / (|p1-p0| * |p2-p0| * |p2-p1|)
# This is the Menger curvature — circumradius-based

def discrete_curvature(p0, p1, p2):
    # p0, p1, p2: [2] coordinate vectors
    d01 = p1 - p0
    d02 = p2 - p0
    d12 = p2 - p1
    cross = d01[0] * d02[1] - d01[1] * d02[0]  # 2D cross product
    kappa = 2 * abs(cross) / (d01.norm() * d02.norm() * d12.norm() + 1e-8)
    return kappa  # scalar curvature at p1
```

2. **For volume nodes**, set curvature = 0 (or the curvature of the nearest surface node — try both).

3. **Normalize curvature**: The raw κ values span several orders of magnitude (high at LE, near-zero at mid-chord). Apply log-scaling: `curvature_feat = log(1 + κ * chord_length)` to compress the range.

4. **For tandem configurations**: Compute curvature separately for each foil's surface nodes.

5. **Add flag**: `--surface_curvature_feature`. Update input_dim +1.

6. **Precompute at data loading time**: Curvature depends only on mesh geometry, not flow conditions. Compute once per sample at dataset init and cache it.

7. **Surface node ordering**: You'll need to establish a consistent ordering of surface nodes to identify neighbors. Options:
   - Sort by angle from foil centroid (atan2)
   - Sort by x-coordinate (simpler but ambiguous for upper/lower surface)
   - Use the DSDF gradient direction to separate upper/lower surface first, then sort by x within each

   **Warning**: The surface arc-length PE (#2278) failed partly due to angle-sort ordering issues. Curvature is more robust because small ordering errors only affect which 3 points define the curvature — the curvature VALUE is still approximately correct even with slightly wrong neighbors (curvature is a local property).

### Training command (seed 42)
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --seed 42 \
  --wandb_name "tanjiro/surface-curvature-s42" \
  --wandb_group "surface-curvature-feature" \
  --surface_curvature_feature \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and adjusted `--wandb_name`.

## Baseline (PR #2251, 2-seed avg)

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.891** | < 11.89 |
| **p_oodc** | **7.561** | < 7.56 |
| **p_tan** | **28.118** | < 28.12 |
| p_re | 6.364 | < 6.36 |

W&B baseline: 7jix2jkg (s42), epkfhxfl (s73)