### PR TITLE
Log-Re Pressure Scaling: Re-normalize pressure loss for OOD-Re generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -1170,6 +1171,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    logre_pressure_scale: bool = False      # normalize surface pressure loss by log(Re) to improve OOD-Re generalization
 
 
 cfg = sp.parse(Config)
@@ -1758,6 +1760,7 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        _raw_log_re = x[:, 0, 13:14] if cfg.logre_pressure_scale else None  # log(Re) [B, 1] — save before normalization for logre scaling
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
@@ -2016,6 +2019,11 @@ for epoch in range(MAX_EPOCHS):
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Log-Re pressure scaling: de-emphasize high-Re samples whose absolute pressure deviations are naturally larger
+        if cfg.logre_pressure_scale and _raw_log_re is not None:
+            _re_actual = torch.exp(_raw_log_re.squeeze(-1))  # [B], actual Reynolds number
+            _logre_scale = torch.log(_re_actual + 1.0) / math.log(1e5 + 1.0)  # [B], ~1.0 at Re=1e5
+            surf_per_sample = surf_per_sample / _logre_scale.clamp(min=0.1)
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
@@ -2310,7 +2318,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _logre_log = {}
+        if cfg.logre_pressure_scale and _raw_log_re is not None:
+            _logre_log["train/logre_scale_mean"] = _logre_scale.mean().item()
+            _logre_log["train/logre_scale_std"] = _logre_scale.std().item()
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step, **_logre_log})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The Reynolds number in our dataset spans ~2 orders of magnitude. Pressure scales with dynamic pressure q = 0.5 * rho * V^2 ∝ Re^2 at fixed geometry (incompressible flow, unit chord). The current asinh pressure transform (merged, PR #2054) compresses extreme values but does **not** account for Re-dependent pressure scaling.

**The bet:** Our residual prediction head predicts p_node - p_freestream. At high Re, these deviations are LARGER in absolute terms, creating an implicit train-test distribution shift that specifically hurts p_re (OOD Reynolds number). If we normalize pressure loss contributions by log(Re), the target distribution becomes more Re-invariant and p_re generalization should improve.

This is a **loss normalization change only** — no architecture changes, no new input features. Concretely: the loss for each sample in the batch is divided by a mild log-Re scale factor, so high-Re samples don't dominate gradients over low-Re samples in a Re-unfair way. At inference, the model still outputs physical pressure units (inverse transform applied).

**Why log(Re) not Re or Re^2:** log(Re) is mild — it only adjusts by a factor of ~2.3× across the full Re range (10^3 to 10^5), whereas Re^2 would create a 10,000× range that destabilizes training. Log-scaling mirrors the fact that turbulence intensity scales with log(Re) in the boundary layer.

**Why this wasn't tried before:** The asinh transform already handles absolute magnitude compression. This is a complementary Re-dependent normalization addressing a different issue: not "large pressures are hard" (asinh fixes that) but "high-Re pressure fields have systematically larger magnitudes" (logRe fixes that).

**Literature:**
- Schlichting "Boundary Layer Theory" — Cp = 2(p - p_inf)/(rho U^2), all dimensionless pressure scalings
- Kashefi & Mukerji "Point-cloud deep learning of porous media for permeability prediction" (arXiv:2104.11029) — target normalization by physical scale significantly improves Re-range generalization

## Instructions

### Step 1: Read how Re enters the current loss

Read `cfd_tandemfoil/train.py` and find:
1. Where `re` (Reynolds number) is stored in the batch — likely in `batch.cond` or similar
2. Where the pressure MAE loss is computed for surface nodes
3. Where `asinh_pressure` transformation is applied to targets

### Step 2: Implement `--logre_pressure_scale` flag

Add a new flag `--logre_pressure_scale` (store_true). When enabled:

```python
import math

# In the loss computation, after computing pressure MAE on surface nodes:
# re is the per-sample Reynolds number, shape [B] or scalar per sample

# Compute per-sample log-Re scale factor:
# Normalize so that the scale factor is 1.0 at Re=1e5 (typical mid-range value)
log_re_scale = torch.log(re + 1.0) / math.log(1e5 + 1.0)  # shape [B], ~1.0 at Re=1e5

# Apply as per-sample weight to pressure loss (surface nodes only, pressure channel only):
# pressure_loss_per_sample has shape [B] (mean over nodes for each sample)
pressure_loss_scaled = pressure_loss_per_sample / log_re_scale  # divide by scale

# Then take mean over batch:
pressure_loss = pressure_loss_scaled.mean()
```

**Key details:**
- Apply scaling ONLY to the pressure channel in the surface node loss
- Do NOT apply to velocity field losses — pressure-only Re normalization
- Division by `log_re_scale` de-emphasizes high-Re samples (which have naturally larger pressure deviations) relative to low-Re samples
- At inference/validation: the model outputs physical pressure units directly — this is a **loss-side normalization only**, NOT a target transformation. No inverse scaling needed at eval time.
- If Re is not directly available in per-sample form, extract from `batch.cond` (the conditioning vector that also carries AoA, Umag, gap, stagger)

### Step 3: Run training

```bash
cd cfd_tandemfoil && python train.py --agent edward --seed 42 \
  --wandb_name "edward/logre-pressure-scaling-s42" \
  --wandb_group "logre-pressure-scaling" \
  --logre_pressure_scale \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```

Seed 73: same with `--seed 73` and `--wandb_name "edward/logre-pressure-scaling-s73"`.

### Step 4: If logre_pressure_scale helps p_re

If p_re improves by ≥1%, add a note in your results and I'll decide whether to sweep the normalization reference (try Re=1e4 vs Re=1e5 as the unit-scale anchor).

## Baseline

Current best metrics (PR #2251, cosine T_max=150, 2-seed avg):

| Metric | Baseline | Target |
|--------|---------|--------|
| p_in   | 11.891  | < 11.89 |
| p_oodc | 7.561   | < 7.56 |
| p_tan  | 28.118  | < 28.12 |
| p_re   | 6.364   | < 6.36 (**primary target**) |

⚠️ p_re = 6.364 is a regression vs PR #2213's 6.300. Primary goal of this experiment is to recover that regression and improve further.

Baseline W&B runs: 7jix2jkg (seed 42), epkfhxfl (seed 73).

Reproduce baseline:
```bash
cd cfd_tandemfoil && python train.py --agent <name> --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature
```