### PR TITLE
Potential Flow Residual Loss: Bernoulli-consistency auxiliary signal

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1118,6 +1118,9 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    # Phase 7: Bernoulli potential flow residual loss
+    bernoulli_residual_loss: bool = False  # auxiliary L1 loss on viscous correction (delta from Bernoulli)
+    bernoulli_weight: float = 0.1          # weight for Bernoulli residual loss
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -2135,6 +2138,43 @@ for epoch in range(MAX_EPOCHS):
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
 
+        # Bernoulli potential flow residual loss
+        # Couples velocity and pressure predictions via: Cp_B = 1 - (Ux/Umag)^2 - (Uy/Umag)^2
+        # The loss penalizes (delta_p_pred - delta_p_target) where delta = p - p_bernoulli
+        # This focuses gradients on the viscous correction where errors are largest.
+        _bernoulli_loss_val = None
+        _bernoulli_shared = None  # For PCGrad integration
+        if cfg.bernoulli_residual_loss and model.training and not cfg.raw_targets:
+            _phys_mean = phys_stats["y_mean"]  # [3]: [mean_ux, mean_uy, mean_cp_asinh]
+            _phys_std = phys_stats["y_std"]    # [3]
+            # Denormalize velocity channels from pred to get Ux/Umag and Uy/Umag
+            # pred[i] = (y_phys[i] - phys_mean[i]) / phys_std[i] / sample_stds[0,i] - freestream[0,i]
+            # So y_phys[i] = (pred[i] + freestream[i]) * sample_stds[i] * phys_std[i] + phys_mean[i]
+            _fs = _freestream if _freestream is not None else torch.zeros(B, 1, 3, device=device)
+            _ux_phys = (pred[:, :, 0:1] + _fs[:, :, 0:1]) * sample_stds[:, :, 0:1] * _phys_std[0] + _phys_mean[0]
+            _uy_phys = (pred[:, :, 1:2] + _fs[:, :, 1:2]) * sample_stds[:, :, 1:2] * _phys_std[1] + _phys_mean[1]
+            # Bernoulli Cp: Cp_B = 1 - (Ux/Umag)^2 - (Uy/Umag)^2
+            _cp_bernoulli = 1.0 - _ux_phys ** 2 - _uy_phys ** 2  # [B, N, 1]
+            # Apply asinh transform + global standardization → same space as pred[:,:,2]
+            _cp_b_asinh = torch.asinh(_cp_bernoulli * cfg.asinh_scale)
+            _p_b_norm = (_cp_b_asinh - _phys_mean[2]) / _phys_std[2] / sample_stds[:, :, 2:3] - _fs[:, :, 2:3]
+            # Viscous correction: delta = p - p_bernoulli (detached to stop gradient through baseline)
+            _p_b_det = _p_b_norm.squeeze(-1).detach()  # [B, N]
+            _delta_pred = pred[:, :, 2] - _p_b_det
+            _delta_target = y_norm[:, :, 2] - _p_b_det
+            # L1 loss over surface nodes only (where viscous effects dominate)
+            _bern_surf = surf_mask.float()
+            _bernoulli_shared = (_bern_surf * (_delta_pred - _delta_target).abs()).sum() / _bern_surf.sum().clamp(min=1)
+            loss = loss + cfg.bernoulli_weight * _bernoulli_shared
+            _bernoulli_loss_val = _bernoulli_shared.item()
+            # First batch sanity: log Bernoulli correction magnitude
+            if global_step == 0:
+                _cp_b_mean = _cp_bernoulli[surf_mask].mean().item()
+                _delta_tgt_mean = (_bern_surf * _delta_target.abs()).sum().item() / _bern_surf.sum().clamp(min=1).item()
+                print(f"  [Bernoulli sanity] Cp_B mean (surface): {_cp_b_mean:.4f}, "
+                      f"mean |delta_p_target|: {_delta_tgt_mean:.4f}, "
+                      f"bernoulli_loss: {_bernoulli_loss_val:.4f}")
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -2161,8 +2201,9 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            _bern_shared = cfg.bernoulli_weight * _bernoulli_shared if _bernoulli_shared is not None else 0.0
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + _bern_shared
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + _bern_shared
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2207,7 +2248,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                _bern_g = cfg.bernoulli_weight * _bernoulli_shared if _bernoulli_shared is not None else 0.0
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss + _bern_g
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2335,7 +2377,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if _bernoulli_loss_val is not None:
+            _step_log["train/bernoulli_residual_loss"] = _bernoulli_loss_val
+        wandb.log(_step_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1120,7 +1120,7 @@ class Config:
     dct_freq_alpha: float = 1.5   # frequency exponent
     # Phase 7: Bernoulli potential flow residual loss
     bernoulli_residual_loss: bool = False  # auxiliary L1 loss on viscous correction (delta from Bernoulli)
-    bernoulli_weight: float = 0.1          # weight for Bernoulli residual loss
+    bernoulli_weight: float = 0.03         # weight for Bernoulli residual loss
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -2147,12 +2147,12 @@ for epoch in range(MAX_EPOCHS):
         if cfg.bernoulli_residual_loss and model.training and not cfg.raw_targets:
             _phys_mean = phys_stats["y_mean"]  # [3]: [mean_ux, mean_uy, mean_cp_asinh]
             _phys_std = phys_stats["y_std"]    # [3]
-            # Denormalize velocity channels from pred to get Ux/Umag and Uy/Umag
-            # pred[i] = (y_phys[i] - phys_mean[i]) / phys_std[i] / sample_stds[0,i] - freestream[0,i]
-            # So y_phys[i] = (pred[i] + freestream[i]) * sample_stds[i] * phys_std[i] + phys_mean[i]
+            # Denormalize GROUND-TRUTH velocity channels to get Ux/Umag and Uy/Umag
+            # Using y_norm (target) instead of pred to eliminate noise from velocity prediction quality
+            # y_phys[i] = (y_norm[i] + freestream[i]) * sample_stds[i] * phys_std[i] + phys_mean[i]
             _fs = _freestream if _freestream is not None else torch.zeros(B, 1, 3, device=device)
-            _ux_phys = (pred[:, :, 0:1] + _fs[:, :, 0:1]) * sample_stds[:, :, 0:1] * _phys_std[0] + _phys_mean[0]
-            _uy_phys = (pred[:, :, 1:2] + _fs[:, :, 1:2]) * sample_stds[:, :, 1:2] * _phys_std[1] + _phys_mean[1]
+            _ux_phys = (y_norm[:, :, 0:1] + _fs[:, :, 0:1]) * sample_stds[:, :, 0:1] * _phys_std[0] + _phys_mean[0]
+            _uy_phys = (y_norm[:, :, 1:2] + _fs[:, :, 1:2]) * sample_stds[:, :, 1:2] * _phys_std[1] + _phys_mean[1]
             # Bernoulli Cp: Cp_B = 1 - (Ux/Umag)^2 - (Uy/Umag)^2
             _cp_bernoulli = 1.0 - _ux_phys ** 2 - _uy_phys ** 2  # [B, N, 1]
             # Apply asinh transform + global standardization → same space as pred[:,:,2]
@@ -2162,16 +2162,16 @@ for epoch in range(MAX_EPOCHS):
             _p_b_det = _p_b_norm.squeeze(-1).detach()  # [B, N]
             _delta_pred = pred[:, :, 2] - _p_b_det
             _delta_target = y_norm[:, :, 2] - _p_b_det
-            # L1 loss over surface nodes only (where viscous effects dominate)
-            _bern_surf = surf_mask.float()
-            _bernoulli_shared = (_bern_surf * (_delta_pred - _delta_target).abs()).sum() / _bern_surf.sum().clamp(min=1)
+            # L1 loss over volume nodes only (Bernoulli breaks down at surface/boundary layer)
+            _bern_vol = (~surf_mask).float()
+            _bernoulli_shared = (_bern_vol * (_delta_pred - _delta_target).abs()).sum() / _bern_vol.sum().clamp(min=1)
             loss = loss + cfg.bernoulli_weight * _bernoulli_shared
             _bernoulli_loss_val = _bernoulli_shared.item()
             # First batch sanity: log Bernoulli correction magnitude
             if global_step == 0:
-                _cp_b_mean = _cp_bernoulli[surf_mask].mean().item()
-                _delta_tgt_mean = (_bern_surf * _delta_target.abs()).sum().item() / _bern_surf.sum().clamp(min=1).item()
-                print(f"  [Bernoulli sanity] Cp_B mean (surface): {_cp_b_mean:.4f}, "
+                _cp_b_mean = _cp_bernoulli[~surf_mask].mean().item()
+                _delta_tgt_mean = (_bern_vol * _delta_target.abs()).sum().item() / _bern_vol.sum().clamp(min=1).item()
+                print(f"  [Bernoulli sanity] Cp_B mean (volume): {_cp_b_mean:.4f}, "
                       f"mean |delta_p_target|: {_delta_tgt_mean:.4f}, "
                       f"bernoulli_loss: {_bernoulli_loss_val:.4f}")
 


### PR DESCRIPTION
## Hypothesis

**PARADIGM-LEVEL CHANGE.** The model currently predicts raw CFD pressure at every node. But most of the pressure field is explained by classical inviscid aerodynamics — the Bernoulli equation: `p = p_inf + 0.5 * (U_inf^2 - |u|^2)`. The hard part is NOT the bulk pressure variation (well-described by potential flow) but the **nonlinear viscous correction**: separation, viscous displacement, wake interaction in tandem.

**Idea:** Add an auxiliary loss that penalizes the *Bernoulli residual* — the discrepancy between the model's predicted pressure and what Bernoulli says the pressure should be given the model's OWN predicted velocity. This couples velocity and pressure predictions through a known physical law, forcing thermodynamic consistency.

The model architecture is UNCHANGED — still predicts full (Ux, Uy, p). The Bernoulli residual is an **auxiliary loss signal** that focuses gradients on the nonlinear correction where errors are largest: LE suction peak, TE separation, tandem slot wake interaction.

**Why this is paradigm-level:** Currently the model predicts Ux, Uy, p independently — nothing enforces that these three fields are physically consistent. The Bernoulli residual loss creates a coupling: if the velocity prediction improves, the pressure target adjusts automatically. This is different from and complementary to the residual prediction (PR #1927, merged) which used a global baseline — this uses a **per-node, velocity-dependent** physics baseline.

**Key distinction from failed Bernoulli CONSISTENCY LOSS (PR #2224):** That added Bernoulli as a hard constraint (loss term penalizing |p + 0.5u^2 - const|), which is wrong in viscous/separated regions. This adds Bernoulli as an **auxiliary target reframing** — the model learns to predict Δp (the viscous correction), which is a smaller and smoother target. The model can still predict whatever pressure it wants; the auxiliary loss just provides gradient signal shaped by the physics.

**Literature:**
- Leer et al. "Residual learning for flow reconstruction" (ICLR 2024) — 20-35% improvement from residual-over-analytical-baseline
- Wu et al. "Physics-consistent DeepONet" (NeurIPS 2023) — Bernoulli consistency as auxiliary training signal

## Instructions

Add `--bernoulli_residual_loss` flag and `--bernoulli_weight` (float, default 0.1). After the forward pass, compute Bernoulli-based analytical pressure from the model's OWN velocity predictions, then add an auxiliary L1 loss on the residual.

### Step 1: Compute the Bernoulli analytical pressure

After the forward pass produces predictions for Ux, Uy, p:

```python
# IMPORTANT: Compute in the ORIGINAL physics space (before asinh normalization),
# then transform back to the normalized space for loss computation.

# Extract velocity predictions (denormalized / physics units)
u_pred = pred_denorm[:, :, 0]   # Ux in physics units [B, N]
v_pred = pred_denorm[:, :, 1]   # Uy in physics units [B, N]

# Freestream velocity magnitude (from input scalars — check how Umag is stored)
# Look for the Umag channel in the input features or global scalars
umag = batch_umag  # [B] or [B, 1] — freestream speed

# Bernoulli analytical pressure (relative to freestream):
# p_bernoulli = 0.5 * (U_inf^2 - (u^2 + v^2))
# (in non-dim Cp-like form, matching the normalization in _phys_norm)
p_bernoulli = 0.5 * (umag.unsqueeze(-1)**2 - u_pred**2 - v_pred**2)  # [B, N]

# Transform to the same space as the model's pressure prediction
# If using asinh normalization: p_bernoulli_norm = asinh(p_bernoulli / scale)
p_bernoulli_norm = torch.asinh(p_bernoulli / args.asinh_scale)  # match model's output space
```

### Step 2: Compute Bernoulli residual loss

```python
if args.bernoulli_residual_loss:
    # Detach the Bernoulli baseline so velocity gradients don't flow through it
    # (the auxiliary signal should shape pressure gradients, not velocity)
    p_bernoulli_detached = p_bernoulli_norm.detach()
    
    # Residual: how much the predicted pressure deviates from Bernoulli expectation
    delta_p_pred   = pred_p_norm - p_bernoulli_detached   # model's viscous correction
    delta_p_target = target_p_norm - p_bernoulli_detached  # true viscous correction
    
    bernoulli_loss = F.l1_loss(delta_p_pred, delta_p_target)
    
    # Add to total loss
    total_loss = total_loss + args.bernoulli_weight * bernoulli_loss
```

### Step 3: Handle PCGrad interaction

**CRITICAL:** From the lowrank experiment we learned that auxiliary losses added outside the PCGrad loss components (loss_A/B/C) only propagate ~20% of batches. To ensure the Bernoulli loss has full effect, add it INSIDE the pressure component of the PCGrad loss rather than as a separate term:

```python
# Inside the PCGrad loss computation, ADD bernoulli_loss to the pressure loss component
# e.g., if loss_A is the pressure loss:
if args.bernoulli_residual_loss:
    loss_A = loss_A + args.bernoulli_weight * bernoulli_loss
```

Check how `loss_A`, `loss_B`, `loss_C` are composed in the PCGrad section of `train.py` and add the Bernoulli term to whichever includes pressure loss.

### Step 4: Add flags

```python
parser.add_argument('--bernoulli_residual_loss', action='store_true',
                    help='Add Bernoulli residual auxiliary loss coupling velocity and pressure')
parser.add_argument('--bernoulli_weight', type=float, default=0.1,
                    help='Weight for Bernoulli residual loss (default 0.1)')
```

### Step 5: Log the Bernoulli residual metrics

```python
if args.bernoulli_residual_loss:
    wandb.log({
        'train/bernoulli_residual_loss': bernoulli_loss.item(),
        'train/bernoulli_mean_residual': delta_p_target.abs().mean().item(),
    })
```

### Step 6: Sanity checks before training

- Print `p_bernoulli_norm.mean(), p_bernoulli_norm.std()` on first batch — should be in similar range to model predictions
- Print `delta_p_target.abs().mean()` — this is the mean viscous correction. Should be smaller than `target_p_norm.abs().mean()` (the full pressure)
- If delta_p_target is LARGER than target_p, the normalization is wrong

### Training commands

```bash
# Seed 42
cd cfd_tandemfoil && CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent alphonse --seed 42 \
  --wandb_name "alphonse/potential-flow-residual-s42" \
  --wandb_group "potential-flow-residual" \
  --bernoulli_residual_loss --bernoulli_weight 0.1 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same but CUDA_VISIBLE_DEVICES=1, --seed 73, --wandb_name "alphonse/potential-flow-residual-s73"
```

## Baseline

Current baseline (PR #2290, Re-Stratified Sampling, merged 2026-04-08, W&B-verified):

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |