### PR TITLE
Mirror Symmetry Augmentation: exact y-reflection to double training data

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1113,6 +1113,7 @@ class Config:
     aug_full_dsdf_rot: bool = False  # also rotate DSDF gradient pairs in aoa_perturb
     aug_gap_stagger_sigma: float = 0.0  # std of Gaussian noise added to gap/stagger features (0=disabled)
     aug_dsdf2_sigma: float = 0.0        # log-normal scale for foil-2 DSDF magnitude aug (0=disabled, tandem only)
+    mirror_augmentation: bool = False   # exact y-reflection symmetry augmentation (p=0.5 per sample)
     gap_stagger_spatial_bias: bool = False  # condition spatial bias MLP on gap/stagger (tandem geometry-aware routing)
     dct_freq_loss: bool = False   # DCT frequency-weighted auxiliary loss on surface pressure
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
@@ -1778,6 +1779,15 @@ for epoch in range(MAX_EPOCHS):
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
+
+        # Exact y-reflection symmetry augmentation (applied after all other augs)
+        if model.training and cfg.mirror_augmentation:
+            _mirror = (torch.rand(x.size(0), device=x.device) < 0.5).view(-1, 1, 1)  # [B, 1, 1]
+            # Negate y-signed input channels: pos_y(1), saf_y(3), dsdf_y(5,7,9,11), AoA0(14), AoA1(18), stagger(23)
+            for _ch in [1, 3, 5, 7, 9, 11, 14, 18, 23]:
+                x[:, :, _ch:_ch+1] = torch.where(_mirror, -x[:, :, _ch:_ch+1], x[:, :, _ch:_ch+1])
+            # Negate Uy target
+            y[:, :, 1:2] = torch.where(_mirror, -y[:, :, 1:2], y[:, :, 1:2])
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

**BOLD DATA AUGMENTATION.** Incompressible flow over an airfoil at angle α has an exact physical symmetry: reflecting the geometry vertically (y → -y) and negating AoA (α → -α) gives an exact mirror-image CFD solution with Ux → Ux, Uy → -Uy, p → p. This is NOT approximate — it is exact for incompressible Navier-Stokes with no-slip walls.

This DOUBLES the effective training set at zero computational cost and zero approximation error. Every training sample generates an equally valid second sample via exact reflection.

**Why this is different from existing augmentation:** The current augmentation suite uses approximate perturbations (AoA jitter, DSDF noise, Re scaling, full DSDF rotation). Mirror symmetry is EXACT — the reflected sample is as valid as the original CFD solution. This has never been tried in 1903 experiments despite being a first-principles technique.

**Why it targets p_oodc and p_re:** The ensemble gap on p_oodc (7.643 single vs 6.6 ensemble, -13.7%) suggests the model has high variance on OOD conditions. Doubling the effective dataset via exact symmetry reduces variance — the model sees both α and -α configurations, making it more robust to unseen AoA/condition combinations.

## Instructions

Add `--mirror_augmentation` flag. With probability 0.5 per sample, apply exact y-reflection augmentation in the training loop.

### Step 1: Understand which features need flipping

Read `prepare_multi.py` and `train.py` to identify ALL input channels (`x`) and target channels (`y`) that are y-signed:

**Must negate under y-reflection:**
- y-coordinates in node positions (pos[:, 1])
- Uy velocity (target y-component)
- AoA input feature (α → -α)
- DSDF gradient y-components (dsdf1_grad_y, dsdf2_grad_y)
- Any other y-signed feature: TE coord dy channels, wake deficit dy channel, gap-stagger spatial bias y-component

**Unchanged (symmetric in y):**
- x-coordinates
- Ux velocity
- Pressure (p)
- DSDF scalar distance (unsigned)
- DSDF gradient x-components
- Re, Umag (scalars)

### Step 2: Implement the mirror transform

```python
def apply_mirror_augmentation(x, y, pos, p_mirror=0.5):
    """Apply exact y-reflection symmetry with probability p_mirror per sample.
    
    x:   [B, N, C_in]  input features
    y:   [B, N, C_out] targets (Ux, Uy, p)
    pos: [B, N, 2]     node positions
    """
    if not self.training:
        return x, y, pos
    
    B = x.shape[0]
    mirror_mask = torch.rand(B, device=x.device) < p_mirror  # [B] bool
    
    if not mirror_mask.any():
        return x, y, pos
    
    # Clone to avoid in-place modification of original data
    x = x.clone()
    y = y.clone()
    pos = pos.clone()
    
    # Apply to selected samples
    m = mirror_mask.unsqueeze(-1).unsqueeze(-1)  # [B, 1, 1] for broadcasting
    
    # Flip y-coordinates
    pos[:, :, 1] = torch.where(mirror_mask.unsqueeze(-1), -pos[:, :, 1], pos[:, :, 1])
    
    # Flip y-velocity target
    y[:, :, 1] = torch.where(mirror_mask.unsqueeze(-1), -y[:, :, 1], y[:, :, 1])
    
    # Flip signed y-features in input x
    # YOU MUST IDENTIFY THE CORRECT CHANNEL INDICES by reading prepare_multi.py
    # Example channel mapping (VERIFY THESE):
    y_signed_channels = [
        aoa_channel,           # AoA
        dsdf1_grad_y_channel,  # DSDF1 gradient y
        dsdf2_grad_y_channel,  # DSDF2 gradient y  
        te_dy_fore_channel,    # TE coord dy (fore)
        te_dy_aft_channel,     # TE coord dy (aft)
        wake_dy_channel,       # Wake deficit dy
        gsb_y_channel,         # Gap-stagger spatial bias y
    ]
    for ch in y_signed_channels:
        x[:, :, ch] = torch.where(mirror_mask.unsqueeze(-1), -x[:, :, ch], x[:, :, ch])
    
    return x, y, pos
```

### Step 3: Apply in the training loop

Apply mirror augmentation AFTER data loading, BEFORE the forward pass. Apply it AFTER the existing augmentations (AoA perturb, DSDF rotation) so it also reflects those augmented samples.

```python
if args.mirror_augmentation:
    x, y, pos = apply_mirror_augmentation(x, y, pos, p_mirror=0.5)
```

### Step 4: CRITICAL — verify feature channels

**Before running full training**, verify on a single sample:
1. Pick a sample, apply mirror augmentation
2. Print the original and mirrored AoA, Uy, and y-coordinate values
3. Verify: mirrored AoA = -original AoA, mirrored Uy = -original Uy, mirrored y = -original y
4. Verify: Ux and p are UNCHANGED
5. Check DSDF gradient y-components flip sign

If ANY feature is missed, the model sees physically inconsistent data — which would be worse than no augmentation.

### Step 5: Check AoA distribution in training set

Before training, print the distribution of AoA values in the training set. If the training set already contains both positive and negative AoA samples symmetrically, the mirror augmentation adds less new information. If the AoA distribution is skewed or limited to one sign, the augmentation is more valuable.

### Training commands

```bash
# Seed 42
cd cfd_tandemfoil && CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent tanjiro --seed 42 \
  --wandb_name "tanjiro/mirror-symmetry-s42" \
  --wandb_group "mirror-symmetry-augmentation" \
  --mirror_augmentation \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same but CUDA_VISIBLE_DEVICES=1, --seed 73, --wandb_name "tanjiro/mirror-symmetry-s73"
```

## Baseline

Current baseline (PR #2290, Re-Stratified Sampling, merged 2026-04-08, W&B-verified):

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |