### PR TITLE
Continuity PDE Loss: mass-conservation penalty for OOD generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -20,6 +20,7 @@ KNOWN LIMITATIONS (inherited from read-only prepare.py):
     Tandem surface loss is therefore underweighted.
 """
 
+import math
 import os
 import time
 from collections.abc import Mapping
@@ -345,6 +346,51 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     dy_norm = dy_norm * is_tandem
 
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
+
+
+def compute_continuity_residual(u_pred, pos_raw, vol_mask, n_sample=512, k=6):
+    """SPH-style meshfree div(u)=0 residual on subsampled interior nodes.
+
+    Approximates ∇·u at each sampled interior node via:
+        div_i ≈ (1/k) * Σ_j [(r_ij · Δu_ij) / |r_ij|²]
+    where j are k nearest interior neighbors.
+
+    Args:
+        u_pred:   [B, N, 3] predicted fields (channels 0:2 = Ux, Uy)
+        pos_raw:  [B, N, 2] raw (unnormalized) x,y positions
+        vol_mask: [B, N] bool — True for interior (volume) nodes
+        n_sample: max interior nodes to subsample per batch element
+        k:        number of nearest neighbors for divergence estimate
+
+    Returns:
+        scalar mean-squared divergence residual
+    """
+    losses = []
+    for b in range(u_pred.shape[0]):
+        int_idx = vol_mask[b].nonzero(as_tuple=True)[0]
+        n_int = int_idx.shape[0]
+        if n_int < k + 1:
+            continue
+        n_s = min(n_sample, n_int)
+        perm = torch.randperm(n_int, device=u_pred.device)[:n_s]
+        s_idx = int_idx[perm]
+        pos_s = pos_raw[b, s_idx]      # [n_s, 2]
+        u_s = u_pred[b, s_idx, :2]     # [n_s, 2]
+        with torch.no_grad():
+            dists = torch.cdist(pos_s, pos_s)  # [n_s, n_s]
+            _, nb_idx = dists.topk(k + 1, largest=False, dim=1)
+            nb_idx = nb_idx[:, 1:]             # [n_s, k] — exclude self
+        pos_nb = pos_s[nb_idx]         # [n_s, k, 2]
+        u_nb = u_s[nb_idx]             # [n_s, k, 2]
+        dr = pos_nb - pos_s.unsqueeze(1)       # [n_s, k, 2]
+        du = u_nb - u_s.unsqueeze(1)           # [n_s, k, 2]
+        dr_sq = (dr ** 2).sum(-1, keepdim=True).clamp(min=1e-8)  # [n_s, k, 1]
+        flux = (dr * du).sum(-1, keepdim=True) / dr_sq           # [n_s, k, 1]
+        div = flux.sum(1).squeeze(-1) / k                         # [n_s]
+        losses.append(div.pow(2).mean())
+    if not losses:
+        return u_pred.new_tensor(0.0)
+    return torch.stack(losses).mean()
 
 
 class TransolverBlock(nn.Module):
@@ -1170,6 +1216,9 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    # Continuity PDE loss: meshfree div(u)=0 penalty on interior nodes
+    continuity_loss: bool = False           # enable SPH-style continuity residual penalty
+    continuity_weight: float = 1e-3        # weight for continuity residual term
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
@@ -1791,6 +1840,7 @@ for epoch in range(MAX_EPOCHS):
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
+        _raw_xy_for_cont = x[:, :, 0:2].clone() if cfg.continuity_loss else None  # raw positions for continuity loss
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
@@ -2050,6 +2100,13 @@ for epoch in range(MAX_EPOCHS):
         else:
             tandem_boost = torch.where(is_tandem_batch, adaptive_boost, 1.0).to(device)
         surf_loss = (surf_per_sample * tandem_boost).mean()
+
+        # Continuity PDE loss: meshfree div(u)=0 penalty on interior nodes
+        _cont_loss = None
+        if cfg.continuity_loss and _raw_xy_for_cont is not None and model.training:
+            _cont_loss = compute_continuity_residual(
+                pred, _raw_xy_for_cont, vol_mask, n_sample=512, k=6)
+
         if cfg.uncertainty_loss:
             bm = _base_model
             surf_ux_loss = (abs_err[:, :, 0:1] * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1)
@@ -2061,6 +2118,8 @@ for epoch in range(MAX_EPOCHS):
                     surf_p_loss  * torch.exp(-2 * bm.log_sigma_surf_p)  / 2 + bm.log_sigma_surf_p)
         else:
             loss = vol_loss + surf_weight * surf_loss
+            if _cont_loss is not None:
+                loss = loss + cfg.continuity_weight * _cont_loss
 
         # Multi-scale loss: coarse spatial pooling
         _coarse_loss = None
@@ -2207,7 +2266,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                cont_shared = cfg.continuity_weight * _cont_loss * 0.5 if _cont_loss is not None else 0.0
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + cont_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2335,7 +2395,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _cont_log = {}
+        if cfg.continuity_loss and _cont_loss is not None:
+            _cont_log["train/continuity_loss"] = _cont_loss.item()
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step, **_cont_log})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

**PARADIGM-LEVEL PHYSICS-INFORMED LOSS.** The model predicts (Ux, Uy, p) with NO constraint that the velocity field satisfies ∇·u = 0 (incompressible continuity equation). For in-distribution samples, the training data implicitly teaches mass conservation. But for OOD configs (extreme Re, unusual geometry), the model may predict velocity fields that violate ∇·u = 0 — which correlates with poor pressure prediction, since in incompressible flow **pressure IS the Lagrange multiplier enforcing ∇·u = 0**.

Add a PINN-style continuity residual penalty: `L_cont = ||∂Ux/∂x + ∂Uy/∂y||²` computed on the predicted velocity field using finite differences on mesh edges. This forces physical consistency of the velocity field, which should improve OOD pressure generalization (p_oodc, p_re).

**Key difference from past PINN attempts:** Previous PINN experiments tried to enforce the FULL Navier-Stokes system (expensive, architecture-incompatible). The continuity equation is much simpler — only first derivatives, clean discrete approximation via the divergence theorem on mesh dual cells. ~5 lines in the loss computation.

**Why it targets p_oodc and p_re:** Single-model p_oodc=7.643 vs ensemble 6.6 (-13.7%), p_re=6.419 vs ensemble 5.8 (-9.6%). The ensemble achieves better OOD by implicitly averaging out mass-conservation violations across 16 seeds. The continuity loss enforces this directly.

## Instructions

Add `--continuity_loss` flag and `--continuity_weight` (float, default 1e-3). Compute divergence residual from predicted velocity on mesh edges, penalize violations.

### Step 1: Compute discrete divergence

```python
from torch_scatter import scatter_add  # or use torch.scatter_reduce_

def continuity_residual(u_pred, edge_index, pos):
    """Approximate div(u) at each node via 1-ring Gauss divergence.
    
    u_pred:     [B*N, 2] predicted velocity in PHYSICAL units (Ux, Uy)
    edge_index: [2, E] mesh edge connectivity  
    pos:        [B*N, 2] node positions
    Returns:    [B*N] divergence residual at each node
    """
    src, dst = edge_index
    edge_vec = pos[dst] - pos[src]                     # [E, 2]
    edge_len = edge_vec.norm(dim=-1).clamp(min=1e-8)   # [E]
    edge_normal = torch.stack([-edge_vec[:, 1], edge_vec[:, 0]], dim=-1)  # [E, 2] perpendicular
    edge_normal = edge_normal / edge_len.unsqueeze(-1)  # unit normal
    
    u_avg = 0.5 * (u_pred[src] + u_pred[dst])          # [E, 2] edge-averaged velocity
    flux = (u_avg * edge_normal).sum(dim=-1) * edge_len  # [E] outward flux per edge
    
    # Sum flux contributions at each node
    div = torch.zeros(u_pred.shape[0], device=u_pred.device)
    div.scatter_add_(0, dst, flux)
    
    return div  # ≈ ∂Ux/∂x + ∂Uy/∂y at each node
```

### Step 2: Apply loss on interior nodes only

```python
if args.continuity_loss:
    # IMPORTANT: Compute in PHYSICAL units (after denormalization)
    u_pred_phys = denormalize_velocity(pred[:, :, 0:2])  # [B, N, 2] or [B*N, 2]
    
    with torch.no_grad():
        # Identify interior nodes (exclude surface + domain boundary)
        # Surface nodes: already have a mask in the training code
        # Domain boundary: nodes with DSDF > some threshold (far field)
        interior_mask = ~surface_mask & (dsdf < boundary_threshold)
    
    div_residual = continuity_residual(
        u_pred_phys.reshape(-1, 2),
        batch.edge_index,
        batch.pos
    )  # [B*N]
    
    # Mask to interior nodes only
    div_residual_interior = div_residual[interior_mask.reshape(-1)]
    
    # L2 penalty
    continuity_loss = (div_residual_interior ** 2).mean()
    
    # Log for monitoring
    wandb.log({'train/continuity_loss': continuity_loss.item()})
```

### Step 3: Add to PCGrad loss components

**CRITICAL LESSON from lowrank experiment:** Auxiliary losses outside PCGrad loss_A/B/C only propagate ~20% of batches. Add continuity loss to the VELOCITY component of the PCGrad loss:

```python
# Inside PCGrad loss computation, add to the velocity loss component
if args.continuity_loss:
    loss_B = loss_B + args.continuity_weight * continuity_loss  # or whichever is the velocity loss
```

Check how loss_A, loss_B, loss_C are defined and add to the velocity component.

### Step 4: Flags

```python
parser.add_argument('--continuity_loss', action='store_true',
                    help='Add mass-conservation (div(u)=0) penalty on predicted velocity')
parser.add_argument('--continuity_weight', type=float, default=1e-3,
                    help='Weight for continuity loss (start small, default 1e-3)')
```

### Step 5: Sanity checks

Before full training, verify:
1. Print `div_residual.abs().mean()` on first batch — should be non-zero (model starts with imperfect predictions)
2. Print `interior_mask.sum()` — should be majority of nodes (surface nodes are ~5-10% of total)
3. Verify the divergence residual magnitude is in a reasonable range relative to the main loss

### Training commands

```bash
# Seed 42
cd cfd_tandemfoil && CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent edward --seed 42 \
  --wandb_name "edward/continuity-pde-s42" \
  --wandb_group "continuity-pde-loss" \
  --continuity_loss --continuity_weight 1e-3 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same but CUDA_VISIBLE_DEVICES=1, --seed 73, --wandb_name "edward/continuity-pde-s73"
```

## Baseline

Current baseline (PR #2290, W&B-verified):

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |