### PR TITLE
Q-Criterion Proxy Feature: vortex zone indicator for p_tan/p_oodc

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,50 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_q_criterion_proxy(raw_x):
+    """Compute Q-criterion vortex proxy from DSDF gradient × freestream direction.
+
+    Cross-product of DSDF gradient with freestream velocity direction gives a
+    signed vorticity proxy. Weighted by surface proximity (exp decay with distance).
+
+    Args:
+        raw_x: [B, N, 24] raw input features (before normalization)
+               DSDF grad foil-1: channels 4,5 (grad_x, grad_y)
+               DSDF grad foil-2: channels 6,7 (grad_x, grad_y)
+               AoA0_rad: channel 14
+
+    Returns: [B, N, 2] — q_proxy for foil-1 and foil-2
+    """
+    # DSDF gradients (raw, unnormalized)
+    dsdf1_gx = raw_x[:, :, 4]   # [B, N] foil-1 grad x
+    dsdf1_gy = raw_x[:, :, 5]   # [B, N] foil-1 grad y
+    dsdf2_gx = raw_x[:, :, 6]   # [B, N] foil-2 grad x
+    dsdf2_gy = raw_x[:, :, 7]   # [B, N] foil-2 grad y
+
+    # Freestream direction from AoA (already in radians)
+    aoa = raw_x[:, 0, 14]  # [B]
+    u_inf_x = torch.cos(aoa).unsqueeze(1)  # [B, 1]
+    u_inf_y = torch.sin(aoa).unsqueeze(1)  # [B, 1]
+
+    # Cross product: dsdf_grad × u_inf (2D cross = gx*uy - gy*ux)
+    vort1 = dsdf1_gx * u_inf_y - dsdf1_gy * u_inf_x  # [B, N]
+    vort2 = dsdf2_gx * u_inf_y - dsdf2_gy * u_inf_x  # [B, N]
+
+    # Surface proximity decay: use DSDF gradient magnitude as distance proxy
+    dist1 = (dsdf1_gx ** 2 + dsdf1_gy ** 2).sqrt()  # [B, N]
+    dist2 = (dsdf2_gx ** 2 + dsdf2_gy ** 2).sqrt()  # [B, N]
+
+    # Exponential decay — near-surface has large gradient magnitude, far has small
+    # Actually, DSDF values themselves encode distance. Use abs min of dsdf channels.
+    dsdf_dist1 = raw_x[:, :, 4:8].abs().min(dim=-1).values  # [B, N] min dist foil-1
+    dsdf_dist2 = raw_x[:, :, 8:12].abs().min(dim=-1).values  # [B, N] min dist foil-2
+
+    q1 = vort1 * torch.exp(-dsdf_dist1 * 3.0)  # [B, N]
+    q2 = vort2 * torch.exp(-dsdf_dist2 * 3.0)  # [B, N]
+
+    return torch.stack([q1, q2], dim=-1)  # [B, N, 2]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1170,6 +1214,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    q_criterion_feature: bool = False       # Q-criterion vortex proxy from DSDF grad × freestream (+2 input channels)
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
@@ -1318,7 +1363,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (2 if cfg.q_criterion_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+q_crit], +32 fourier PE
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1791,6 +1836,7 @@ for epoch in range(MAX_EPOCHS):
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
+        _q_crit_feat = compute_q_criterion_proxy(x) if cfg.q_criterion_feature else None
         # Aft-foil mask: boundary ID=7 nodes identified by saf norm > 0.005
         # saf is at raw x[:,:,2:4]; foil-1 surface has saf≈0, foil-2 has saf>>0
         _aft_foil_mask = None
@@ -1819,6 +1865,9 @@ for epoch in range(MAX_EPOCHS):
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                 x = torch.cat([x, wake_feats], dim=-1)
+        # Q-criterion proxy feature
+        if cfg.q_criterion_feature:
+            x = torch.cat([x, _q_crit_feat], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
         # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -2482,6 +2531,7 @@ for epoch in range(MAX_EPOCHS):
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
+                _q_crit_feat_v = compute_q_criterion_proxy(x) if cfg.q_criterion_feature else None
                 # Aft-foil mask for eval (same logic as training)
                 _eval_aft_mask = None
                 if eval_aft_srf_head is not None:
@@ -2509,6 +2559,9 @@ for epoch in range(MAX_EPOCHS):
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
                         x = torch.cat([x, wake_feats], dim=-1)
+                # Q-criterion proxy feature (validation path)
+                if cfg.q_criterion_feature:
+                    x = torch.cat([x, _q_crit_feat_v], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
                 # Normalize xy to [0,1] per-sample for consistent Fourier encoding
@@ -3011,6 +3064,7 @@ if cfg.surface_refine and best_metrics:
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
+                    _q_crit_feat_vv = compute_q_criterion_proxy(x) if cfg.q_criterion_feature else None
                     x = (x - stats["x_mean"]) / stats["x_std"]
                     curv = x[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surface.float().unsqueeze(-1)
                     if cfg.foil2_dist:
@@ -3031,6 +3085,9 @@ if cfg.surface_refine and best_metrics:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
+                    # Q-criterion proxy feature (verification path)
+                    if cfg.q_criterion_feature:
+                        x = torch.cat([x, _q_crit_feat_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)
                     xy_max = raw_xy.amax(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

**Physics-motivated input feature targeting p_tan and p_oodc.** The Q-criterion in fluid mechanics (Q = 0.5*(||Ω||² - ||S||²)) distinguishes vortex-dominated regions (Q > 0: wake vortices, tandem slot, separation) from strain-dominated regions (Q < 0: freestream, attached BL). The model currently has no way to identify which nodes are in vortex-dominated wake zones — it must infer this from DSDF distance alone.

We compute a **Q-criterion proxy** from existing input features at inference time (no CFD data required):
- The cross-product of the DSDF gradient direction with the freestream velocity direction approximates the local signed vorticity near the airfoil surface
- Weighted by `exp(-dsdf * 3.0)` to decay away from the surface (where boundary-layer vorticity is physically dominant)
- This gives a per-node scalar that is positive in upper-surface wake zones, negative below the foil, and near-zero in the freestream

For tandem configs: the slot between fore and aft foils is a strong vortex zone (fore-TE trailing vortex impinging on aft-foil suction surface). This is exactly where p_tan errors are concentrated. An explicit vortex-zone indicator should help the model partition its capacity between attached-flow and wake-interaction regimes.

**Why it follows the winning pattern:** Every durable gain has come from physics-motivated input features. This is purely feature engineering (no architecture change, no loss change). Never tried in any of 1903 experiments.

**Target metrics:** p_tan (biggest gap: 27.87 vs ensemble 29.1), p_oodc (7.64 vs ensemble 6.6)

**Literature support:** RITA paper (arXiv:2504.06758) shows local flow invariants (Q, R, velocity gradient tensor) classify flow regime from geometry features alone with high accuracy.

## Instructions

### Step 1: Understand the input feature structure

Read `prepare_multi.py` and `train.py` to identify:
- The channel index of DSDF for foil 1 (scalar distance, channel ~0 in DSDF group)
- The channel indices of DSDF gradient x,y for foil 1 (channels ~1,2 in DSDF group)
- The channel indices of DSDF scalar and gradient for foil 2
- The AoA channel index

### Step 2: Implement the Q-criterion proxy feature

Add `--q_criterion_feature` flag. When enabled, compute the proxy from existing input channels and append to `x`:

```python
def compute_q_criterion_proxy(x, pos, args):
    """Compute vorticity proxy from DSDF gradient x freestream direction.
    
    Returns: [B, N, 2] — q_proxy for foil1 and foil2 (tandem) or [foil1, 0] for single.
    """
    # VERIFY THESE CHANNEL INDICES by reading prepare_multi.py output feature order
    # Typical layout: dsdf1 (dist), dsdf1_grad_x, dsdf1_grad_y, dsdf2 (dist), dsdf2_grad_x, dsdf2_grad_y
    dsdf1_dist    = x[:, :, DSDF1_DIST_CH]      # [B, N] distance to foil 1
    dsdf1_grad_x  = x[:, :, DSDF1_GRADX_CH]     # [B, N] DSDF grad x, foil 1
    dsdf1_grad_y  = x[:, :, DSDF1_GRADY_CH]     # [B, N] DSDF grad y, foil 1
    dsdf2_dist    = x[:, :, DSDF2_DIST_CH]      # [B, N] distance to foil 2
    dsdf2_grad_x  = x[:, :, DSDF2_GRADX_CH]     # [B, N] DSDF grad x, foil 2
    dsdf2_grad_y  = x[:, :, DSDF2_GRADY_CH]     # [B, N] DSDF grad y, foil 2
    aoa_val       = x[:, 0, AOA_CH]             # [B] AoA in whatever units stored
    
    # Convert AoA to radians if stored in degrees (check units in prepare_multi.py)
    aoa_rad = aoa_val * (np.pi / 180.0) if aoa_in_degrees else aoa_val
    
    # Freestream direction vector [cos(AoA), sin(AoA)]
    u_inf_x = torch.cos(aoa_rad).unsqueeze(1)   # [B, 1]
    u_inf_y = torch.sin(aoa_rad).unsqueeze(1)   # [B, 1]
    
    # Cross product: dsdf_grad × u_inf = dsdf_grad_x * u_inf_y - dsdf_grad_y * u_inf_x
    # Positive = upper-surface/wake zone, Negative = lower-surface zone
    vort_proxy_foil1 = dsdf1_grad_x * u_inf_y - dsdf1_grad_y * u_inf_x  # [B, N]
    vort_proxy_foil2 = dsdf2_grad_x * u_inf_y - dsdf2_grad_y * u_inf_x  # [B, N]
    
    # Weight by surface proximity: decays exponentially away from surface
    # Use dsdf distance (normalized) — smaller dsdf = closer to surface = stronger BL vorticity
    q_proxy_foil1 = vort_proxy_foil1 * torch.exp(-dsdf1_dist.abs() * 3.0)  # [B, N]
    q_proxy_foil2 = vort_proxy_foil2 * torch.exp(-dsdf2_dist.abs() * 3.0)  # [B, N]
    
    # For single-foil samples, foil2 DSDF is typically zero — q_proxy_foil2 ≈ 0 naturally
    # Stack as 2 new channels
    q_features = torch.stack([q_proxy_foil1, q_proxy_foil2], dim=-1)  # [B, N, 2]
    
    return q_features
```

Then append to `x` before the forward pass:
```python
if args.q_criterion_feature:
    q_feat = compute_q_criterion_proxy(x, pos, args)
    x = torch.cat([x, q_feat], dim=-1)  # [B, N, C+2]
```

**CRITICAL CHECK before training:** On a single batch, verify:
1. Print q_proxy values for surface nodes — should show positive values on upper surface, negative on lower surface for a positive AoA sample
2. Print q_proxy for wake nodes (far downstream) — should decay toward zero
3. For a tandem sample: check that foil2 q_proxy also has non-zero values in the slot region

If the signs look wrong (all positive or all negative everywhere), check the AoA sign convention in your data.

### Step 3: Model input dimension

Since we add 2 new input channels, the model's input dimension changes. Ensure the embedding layer handles the larger input:
- If using `--n_layers 3 --slice_num 96` with default input dim, the model auto-detects input size from data
- Verify the model initializes correctly with the new feature by checking the first forward pass doesn't error

### Step 4: Training commands

```bash
# Seed 42
cd cfd_tandemfoil && CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent tanjiro --seed 42 \
  --wandb_name "tanjiro/q-criterion-proxy-s42" \
  --wandb_group "q-criterion-proxy-feature" \
  --q_criterion_feature \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same but CUDA_VISIBLE_DEVICES=1, --seed 73, --wandb_name "tanjiro/q-criterion-proxy-s73"
```

## Baseline

Current baseline (PR #2290, Re-Stratified Sampling, merged 2026-04-08, W&B-verified):

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| p_in   | 11.742 | < 11.74 |
| p_oodc | 7.643  | < 7.64 |
| **p_tan** | **27.874** | < 27.87 (PRIMARY TARGET) |
| p_re   | 6.419  | < 6.42 |

W&B baseline runs: k5qwvce4 (seed 42), 7oa5xfhi (seed 73). Group: `re-stratified-sampling`.

Reproduce baseline:
```bash
cd cfd_tandemfoil && python train.py --agent tanjiro --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0
```