### PR TITLE
Auxiliary AoA Prediction Head: explicit flow angle decoding (like Re head)

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1173,6 +1173,9 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # Auxiliary AoA prediction head
+    aux_aoa_head: bool = False             # enable configurable AoA auxiliary head (L1 loss, analogous to Re head)
+    aoa_aux_weight: float = 0.05           # weight for auxiliary AoA loss when aux_aoa_head is enabled
 
 
 cfg = sp.parse(Config)
@@ -2095,8 +2098,12 @@ for epoch in range(MAX_EPOCHS):
         re_loss = F.mse_loss(re_pred, log_re_target)
         loss = loss + 0.01 * re_loss
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
-        aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
-        loss = loss + 0.01 * aoa_loss
+        if cfg.aux_aoa_head:
+            aoa_loss = F.l1_loss(aoa_pred.float(), aoa_target)
+            loss = loss + cfg.aoa_aux_weight * aoa_loss
+        else:
+            aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
+            loss = loss + 0.01 * aoa_loss
 
         # DCT frequency-weighted auxiliary loss on surface pressure
         if cfg.dct_freq_loss and model.training:
@@ -2161,8 +2168,9 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            _aoa_w2 = cfg.aoa_aux_weight * 0.5 if cfg.aux_aoa_head else 0.005
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + _aoa_w2 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + _aoa_w2 * aoa_loss
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2207,7 +2215,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                _aoa_w3 = cfg.aoa_aux_weight * 0.5 if cfg.aux_aoa_head else 0.005
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + _aoa_w3 * aoa_loss
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2287,8 +2296,12 @@ for epoch in range(MAX_EPOCHS):
             surf_ps2 = (abs_err2[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
             surf_loss2 = (surf_ps2 * tandem_boost).mean()
             re_loss2 = F.mse_loss(re_pred2, log_re_target)
-            aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)
-            loss2 = vol_loss2 + surf_weight * surf_loss2 + 0.01 * re_loss2 + 0.01 * aoa_loss2
+            if cfg.aux_aoa_head:
+                aoa_loss2 = F.l1_loss(aoa_pred2, aoa_target)
+                loss2 = vol_loss2 + surf_weight * surf_loss2 + 0.01 * re_loss2 + cfg.aoa_aux_weight * aoa_loss2
+            else:
+                aoa_loss2 = F.mse_loss(aoa_pred2, aoa_target)
+                loss2 = vol_loss2 + surf_weight * surf_loss2 + 0.01 * re_loss2 + 0.01 * aoa_loss2
             loss2.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
             sam_optimizer.restore()
@@ -2335,7 +2348,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.aux_aoa_head:
+            _log_dict["train/aoa_aux_loss"] = aoa_loss.item()
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

PR #780 showed that adding an auxiliary loss forcing the model to decode Reynolds number from its internal representation significantly improved val_ood_re generalization. The mechanism: the auxiliary loss aligns the latent space with the governing physics parameter, sharpening the model's internal representation of the flow condition.

**Angle of Attack (AoA) is the other primary governing parameter.** It determines:
- Stagnation point location and suction peak magnitude
- Pressure distribution asymmetry
- In tandem configs: the effective AoA of the aft foil is modified by the fore foil's downwash

AoA is already an explicit input feature, but forcing the model to *decode* it from its hidden representation should sharpen the AoA-sensitive components of the latent space — analogous to how the Re head sharpened Re-sensitive components. The expected benefit is most pronounced on val_tandem_transfer (where effective AoA varies non-trivially) and val_ood_cond (where AoA range is broader).

**Key analogy:** PR #780 (Re head) → improved val_ood_re. This PR (AoA head) → expected to improve val_tandem_transfer and val_ood_cond.

## Instructions

Add an auxiliary AoA prediction head attached at the same point as the existing Re auxiliary head (after the penultimate TransolverBlock, using the globally pooled node representation).

### Step 1: Add argument

```python
parser.add_argument('--aux_aoa_head', action='store_true',
                    help='Add auxiliary AoA prediction head (analogous to Re head from PR #780)')
parser.add_argument('--aoa_aux_weight', type=float, default=0.05,
                    help='Weight for auxiliary AoA loss (default: 0.05)')
```

### Step 2: Add head definition (alongside the Re head)

Find where the existing Re auxiliary head is defined (look for `aux_re_head` or `re_aux`). Add alongside it:

```python
if args.aux_aoa_head:
    self.aux_aoa_head = nn.Sequential(
        nn.Linear(hidden_dim, 64),
        nn.GELU(),
        nn.Linear(64, 1)
    )
```

### Step 3: Extract AoA target from the batch

AoA is already in the input features. Find where the Re target is extracted in the loss computation and add the AoA target extraction:

```python
# AoA is in the global condition vector — extract it (check which index it's at)
# Typically it's among the first global scalar features alongside Re, gap, stagger
aoa_target = ...  # [B] — the per-sample AoA in radians (or normalized)
```

**Important:** Check what normalization AoA uses in the dataset. If it's normalized, the head should predict the normalized value and compare against the normalized target. Use the same normalization convention as Re does for the Re head.

### Step 4: Compute auxiliary AoA loss

```python
if args.aux_aoa_head:
    # Pool node representation globally (same method as Re head)
    global_rep = block_outputs[-2].mean(dim=1)  # [B, hidden_dim] — penultimate block
    pred_aoa = self.aux_aoa_head(global_rep).squeeze(-1)  # [B]
    loss_aoa_aux = F.l1_loss(pred_aoa, aoa_target) * args.aoa_aux_weight
    total_loss = total_loss + loss_aoa_aux
```

### Step 5: Follow the exact same pattern as the Re head

Study how `aux_re_head` is attached, how the Re target is extracted, and how the loss is added. Mirror that pattern exactly for AoA. Do not change the Re head behavior.

### Training commands

```bash
cd cfd_tandemfoil && python train.py \
  --agent askeladd --seed 42 \
  --wandb_name "askeladd/aux-aoa-head-s42" \
  --wandb_group "aux-aoa-prediction-head" \
  --aux_aoa_head --aoa_aux_weight 0.05 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same flags, --seed 73, CUDA_VISIBLE_DEVICES=1,
#   --wandb_name "askeladd/aux-aoa-head-s73"
```

Use `--wandb_group "aux-aoa-prediction-head"` so both seeds are grouped.

### Verification

After training starts, check the W&B logs for:
- A `loss_aoa_aux` component in the training loss breakdown
- That `val_tandem_transfer mae_surf_p` improves vs baseline

## Baseline

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |

**Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)

**Reproduce command:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0
```