### PR TITLE
Asymmetric Quantile (Pinball) Loss on Pressure Channel

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1118,6 +1118,9 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    # Asymmetric quantile (pinball) loss on surface pressure
+    pinball_pressure: bool = False  # use asymmetric pinball loss for pressure on surface nodes
+    pinball_tau: float = 0.65      # quantile parameter (>0.5 penalizes underprediction more)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1981,6 +1984,12 @@ for epoch in range(MAX_EPOCHS):
 
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
+        # Pinball loss for surface pressure: asymmetric quantile loss
+        if cfg.pinball_pressure:
+            _residual_p = y_norm[:, :, 2:3] - pred[:, :, 2:3]  # target - pred
+            _pinball_p = torch.where(_residual_p > 0,
+                                     cfg.pinball_tau * _residual_p,
+                                     (cfg.pinball_tau - 1) * _residual_p)  # [B, N, 1], non-negative
         if cfg.tandem_ramp:
             pass  # no hard curriculum; tandem_weight applied via tandem_boost below
         elif epoch < cfg.tandem_curriculum_epochs:
@@ -2026,19 +2035,21 @@ for epoch in range(MAX_EPOCHS):
         else:
             vol_loss = (abs_err * vol_mask_train.unsqueeze(-1)).sum() / vol_mask_train.sum().clamp(min=1)
         is_tandem_batch = (x[:, 0, 21].abs() > 0.01)
-        surf_per_sample = (abs_err[:, :, 2:3] * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        _surf_p_err = _pinball_p if cfg.pinball_pressure else abs_err[:, :, 2:3]
+        surf_per_sample = (_surf_p_err * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         tandem_err = surf_per_sample[is_tandem_batch].mean().item() if is_tandem_batch.any() else running_tandem_loss
         nontandem_err = surf_per_sample[~is_tandem_batch].mean().item() if (~is_tandem_batch).any() else running_nontandem_loss
         running_tandem_loss = 0.9 * running_tandem_loss + 0.1 * tandem_err
         running_nontandem_loss = 0.9 * running_nontandem_loss + 0.1 * nontandem_err
         # Asymmetric hard-node mining for non-tandem samples after epoch 30 (vectorized)
         if epoch >= 30:
-            surf_pres = abs_err[:, :, 2:3]  # pressure errors [B, N, 1]
-            surf_pres_flat = surf_pres[:, :, 0]  # [B, N]
-            surf_pres_masked = surf_pres_flat.masked_fill(~surf_mask, float('nan'))
+            surf_pres = _surf_p_err  # pressure errors [B, N, 1] (pinball or L1)
+            # Use L1 for threshold selection (hard-node identification), loss uses _surf_p_err
+            surf_pres_l1 = abs_err[:, :, 2:3][:, :, 0]  # [B, N] always L1 for thresholding
+            surf_pres_masked = surf_pres_l1.masked_fill(~surf_mask, float('nan'))
             thresh = torch.nanmedian(surf_pres_masked, dim=1).values  # [B]
             thresh = thresh.nan_to_num(float('inf'))  # safe: inf → no hard nodes
-            hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
+            hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_l1 >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
@@ -2335,7 +2346,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.pinball_pressure:
+            _log_dict["train/pinball_p_surf"] = (_surf_p_err * surf_mask.unsqueeze(-1)).sum().item() / surf_mask.sum().clamp(min=1).item()
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The current L1 loss treats overprediction and underprediction of pressure equally. In aerodynamics, the suction peak on the upper surface (Cp << 0) is the primary driver of lift and the most error-sensitive region. A symmetric loss allows the model to "hedge" toward the mean, smoothing the suction peak.

The **pinball (quantile) loss** with tau > 0.5 penalizes underprediction more than overprediction:

```
L(y, yhat, tau) = tau * max(y - yhat, 0) + (1-tau) * max(yhat - y, 0)
```

With tau=0.65, underpredictions are penalized ~1.86× more than overpredictions. This asymmetry pushes the model toward accurately capturing the suction peak rather than smoothing it.

**This is orthogonal to the existing 2× p-channel surface weight** — it changes the *shape* of the loss, not just the *scale*. Quantile regression is a standard Kaggle technique for skewed-error targets (Koenker & Bassett, 1978).

## Instructions

Add `--pinball_pressure` flag and `--pinball_tau` hyperparameter. Apply the asymmetric loss ONLY to the pressure channel on SURFACE nodes.

### Step 1: Add arguments

```python
parser.add_argument('--pinball_pressure', action='store_true',
                    help='Use asymmetric pinball loss for pressure channel on surface nodes')
parser.add_argument('--pinball_tau', type=float, default=0.65,
                    help='Quantile parameter for pinball loss (>0.5 penalizes underprediction more)')
```

### Step 2: Implement pinball loss function

```python
def pinball_loss(pred, target, tau=0.65):
    """Asymmetric quantile (pinball) loss.
    tau > 0.5: penalize underprediction (pred < target) more.
    """
    residual = target - pred
    return torch.where(residual > 0, tau * residual, (tau - 1) * residual).mean()
```

### Step 3: Apply to pressure channel in surface loss computation

Find where the surface pressure loss is computed (look for the L1 loss computation on the pressure channel for surface nodes). Replace only the **pressure channel** component of the **surface** loss:

```python
if args.pinball_pressure:
    # For surface nodes, use pinball loss on pressure channel only
    # Keep L1 for Ux, Uy channels; keep L1 for volume nodes
    loss_p_surface = pinball_loss(pred_p_surface, target_p_surface, tau=args.pinball_tau)
else:
    loss_p_surface = F.l1_loss(pred_p_surface, target_p_surface)
```

**Critical details:**
- Apply ONLY to the pressure channel (not Ux, Uy)
- Apply ONLY to surface nodes (keep symmetric L1 for volume nodes)
- The existing 2× p-channel surface weight and pinball loss are orthogonal — both should be active simultaneously
- Do NOT change the PCGrad loss computation or any other loss component

### Step 4: Log the effective loss components

Add a W&B log for the pinball pressure loss so we can verify it's active:
```python
wandb.log({"loss_pinball_p": loss_p_surface.item()})
```

### Training commands

```bash
cd cfd_tandemfoil && python train.py \
  --agent nezuko --seed 42 \
  --wandb_name "nezuko/pinball-pressure-s42" \
  --wandb_group "asymmetric-quantile-cp-loss" \
  --pinball_pressure --pinball_tau 0.65 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same flags, --seed 73, CUDA_VISIBLE_DEVICES=1,
#   --wandb_name "nezuko/pinball-pressure-s73"
```

### Monitoring

Watch for:
- If p_in and p_tan improve but Ux/Uy MAE degrades: tau is correct, pressure improvement is real
- If all metrics degrade: tau may be too aggressive; would try tau=0.55 next
- If metrics are flat: the model may already be well-calibrated on pressure asymmetry

## Baseline

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |

**Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)

**Reproduce command:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0
```