### PR TITLE
Condition Token Injection: dedicated flow-condition embedding pathway

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -794,10 +794,12 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        condition_token=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.condition_token = condition_token
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -892,6 +894,16 @@ class Transolver(nn.Module):
         nn.init.constant_(self.skip_gate[0].bias, -2.0)  # starts nearly closed
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
+        if condition_token:
+            # Dedicated conditioning MLP: [log_Re, AoA0, AoA1, gap, stagger] → n_hidden
+            # Zero-init last layer so model starts as a no-op (identical to baseline)
+            self.cond_token_mlp = nn.Sequential(
+                nn.Linear(5, 64),
+                nn.SiLU(),
+                nn.Linear(64, n_hidden),
+            )
+            nn.init.zeros_(self.cond_token_mlp[-1].weight)
+            nn.init.zeros_(self.cond_token_mlp[-1].bias)
         self.re_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.aoa_head = nn.Sequential(nn.Linear(n_hidden, 32), nn.GELU(), nn.Linear(32, 1))
         self.fourier_freqs_fixed = torch.tensor([0.5, 2.0, 8.0, 32.0])  # non-learnable
@@ -991,6 +1003,19 @@ class Transolver(nn.Module):
         fx = self.preprocess(x)
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
+
+        if self.condition_token:
+            # Extract global condition scalars (stable indices in the model's input x)
+            # x[:, 0, 13]: log_Re, 14: AoA0, 18: AoA1, 22: gap, 23: stagger
+            cond_scalars = torch.stack([
+                x[:, 0, 13],  # log_Re
+                x[:, 0, 14],  # AoA_fore
+                x[:, 0, 18],  # AoA_aft (0 for single-foil)
+                x[:, 0, 22],  # gap
+                x[:, 0, 23],  # stagger
+            ], dim=-1)  # [B, 5]
+            cond_embed = self.cond_token_mlp(cond_scalars)  # [B, n_hidden]
+            fx = fx + cond_embed.unsqueeze(1)  # broadcast to all nodes
 
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
@@ -1170,6 +1195,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    condition_token: bool = False           # dedicated condition embedding (Re, AoA, gap, stagger) injected before first block
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
@@ -1348,6 +1374,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    condition_token=cfg.condition_token,
 )
 
 model = Transolver(**model_config).to(device)
@@ -2409,12 +2436,17 @@ for epoch in range(MAX_EPOCHS):
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
     if not _do_val:
         dt = time.time() - t0
+        _cond_log = {}
+        if cfg.condition_token:
+            _cond_w = _base_model.cond_token_mlp[-1].weight.data
+            _cond_log["condition_token/weight_norm"] = _cond_w.norm().item()
         wandb.log({
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
             "epoch_time_s": dt,
             "lr": scheduler.get_last_lr()[0],
             "global_step": global_step,
+            **_cond_log,
         })
         print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
         continue
@@ -2792,6 +2824,9 @@ for epoch in range(MAX_EPOCHS):
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f
+    if cfg.condition_token:
+        _cond_w = _base_model.cond_token_mlp[-1].weight.data
+        metrics["condition_token/weight_norm"] = _cond_w.norm().item()
     wandb.log(metrics)
 
     if torch.cuda.is_available():

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -895,10 +895,11 @@ class Transolver(nn.Module):
         self.placeholder_scale = nn.Parameter(torch.ones(n_hidden))
         self.placeholder_shift = nn.Parameter(torch.zeros(n_hidden))
         if condition_token:
-            # Dedicated conditioning MLP: [log_Re, AoA0, AoA1, gap, stagger] → n_hidden
+            # Dedicated conditioning MLP: [AoA0, AoA1, gap, stagger] → n_hidden
+            # Re excluded: Re conditioning comes via adaLN; including it here hurts p_re OOD
             # Zero-init last layer so model starts as a no-op (identical to baseline)
             self.cond_token_mlp = nn.Sequential(
-                nn.Linear(5, 64),
+                nn.Linear(4, 64),
                 nn.SiLU(),
                 nn.Linear(64, n_hidden),
             )
@@ -1006,14 +1007,14 @@ class Transolver(nn.Module):
 
         if self.condition_token:
             # Extract global condition scalars (stable indices in the model's input x)
-            # x[:, 0, 13]: log_Re, 14: AoA0, 18: AoA1, 22: gap, 23: stagger
+            # Re excluded — adaLN handles Re conditioning; including it here hurts p_re OOD
+            # x[:, 0, 14]: AoA0, 18: AoA1, 22: gap, 23: stagger
             cond_scalars = torch.stack([
-                x[:, 0, 13],  # log_Re
                 x[:, 0, 14],  # AoA_fore
                 x[:, 0, 18],  # AoA_aft (0 for single-foil)
                 x[:, 0, 22],  # gap
                 x[:, 0, 23],  # stagger
-            ], dim=-1)  # [B, 5]
+            ], dim=-1)  # [B, 4]
             cond_embed = self.cond_token_mlp(cond_scalars)  # [B, n_hidden]
             fx = fx + cond_embed.unsqueeze(1)  # broadcast to all nodes
 
@@ -1195,7 +1196,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
-    condition_token: bool = False           # dedicated condition embedding (Re, AoA, gap, stagger) injected before first block
+    condition_token: bool = False           # dedicated condition embedding (AoA, gap, stagger) injected before first block
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)


### PR DESCRIPTION
## Hypothesis

Currently, global flow conditions (Re, AoA, gap, stagger) enter the model by concatenation to node features — they compete for representational capacity in the 24-dim+ node feature space. This is suboptimal for OOD generalization: when Re shifts by an order of magnitude, a single scalar mixed into node features may not be expressive enough to globally rescale the model's physics representation.

**Condition Token Injection** creates a dedicated conditioning pathway: an MLP maps global conditions to a full hidden_dim embedding that is ADDED to every node's representation before the first TransolverBlock. This gives the model a separate, dedicated channel for "what are the flow conditions?" that can influence all downstream computations independently of the node-level geometric features.

This is inspired by Unisolver (ICML 2025), which uses condition token injection for PDE surrogates with varying boundary conditions and shows strong OOD generalization gains. The simple additive variant (no cross-attention) is sufficient for our 4-scalar condition vector.

**Key distinction from exhausted "SRF FiLM" approach:** SRF FiLM modulated the Surface Refinement output — condition token injection operates at the backbone INPUT level, before the first TransolverBlock, providing a fundamentally different conditioning pathway from adaLN (which operates within block normalization).

**Expected gains:** p_oodc (gap/stagger conditions) and p_re (Reynolds number) — our two weakest metrics vs. ensemble.

## Instructions

Add `--condition_token` flag. Create a small MLP that maps global conditions to hidden_dim, then add the resulting embedding to every node's features before the TransolverBlocks.

### Step 1: Add argument

```python
parser.add_argument('--condition_token', action='store_true',
                    help='Add dedicated condition embedding (Re, AoA, gap, stagger) to node features')
```

### Step 2: Identify the global condition scalars

Find where the global condition features are extracted from the input. These are typically:
- `log_Re` (index 13 in node features)
- `AoA_fore` (index 14)
- `AoA_aft` (index 18, for tandem; 0 for single)
- `gap_mag` (if available as a global scalar)
- `stagger_mag` (if available as a global scalar)

Extract these per-sample scalars from the first node (they're replicated across all nodes):
```python
if args.condition_token:
    # Extract global conditions from any node (they're constant across nodes)
    cond_re = x[:, 0, 13:14]       # log_Re [B, 1]
    cond_aoa0 = x[:, 0, 14:15]     # AoA_fore [B, 1]
    cond_aoa1 = x[:, 0, 18:19]     # AoA_aft [B, 1]
    # Check if gap/stagger features exist — find their indices
    # If not directly available, set to zero
    cond_vec = torch.cat([cond_re, cond_aoa0, cond_aoa1], dim=-1)  # [B, 3+]
```

**Important:** Verify the exact feature indices by checking the input construction. Print `x[0, 0, :]` to see all features and their meanings.

### Step 3: Define the condition encoder

In the model's `__init__`:

```python
if args.condition_token:
    n_cond = 3  # Adjust based on how many condition scalars you extract
    self.condition_encoder = nn.Sequential(
        nn.Linear(n_cond, 64),
        nn.GELU(),
        nn.Linear(64, hidden_dim),  # hidden_dim = 128 typically
    )
    # Zero-init the last layer so training starts from the pretrained initialization
    nn.init.zeros_(self.condition_encoder[-1].weight)
    nn.init.zeros_(self.condition_encoder[-1].bias)
```

### Step 4: Inject the condition embedding

After the preprocessing MLP and before the first TransolverBlock:

```python
if args.condition_token:
    cond_embed = self.condition_encoder(cond_vec)  # [B, hidden_dim]
    # Add to every node's features
    x = x + cond_embed.unsqueeze(1)  # [B, N, hidden_dim] + [B, 1, hidden_dim] → broadcast
```

**Critical:** The zero-init means this starts as a no-op (adding zeros). The model gradually learns to use the condition signal. This prevents disrupting the pretrained behavior.

### Step 5: Verification

- First forward pass should show `cond_embed` is all zeros (due to zero-init)
- After a few epochs, `cond_embed` should become non-zero
- Print `cond_embed.abs().mean()` at epoch 0 and epoch 50 to confirm

### Training commands

```bash
cd cfd_tandemfoil && python train.py \
  --agent fern --seed 42 \
  --wandb_name "fern/condition-token-s42" \
  --wandb_group "condition-token-injection" \
  --condition_token \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same flags, --seed 73, CUDA_VISIBLE_DEVICES=1,
#   --wandb_name "fern/condition-token-s73"
```

## Baseline

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |

**Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)

**Reproduce command:**
```bash
cd cfd_tandemfoil && python train.py --agent <name> --wandb_name "<name>/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0
```