### PR TITLE
Multi-Scale Intermediate Skips: FPN-style output aggregation

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -794,10 +794,12 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        multi_scale_skip=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.multi_scale_skip = multi_scale_skip
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -885,6 +887,17 @@ class Transolver(nn.Module):
             nn.Linear(n_hidden, 1),
         )
         self.initialize_weights()
+        # Multi-scale skip connections: FPN-style projections from intermediate blocks to output
+        if multi_scale_skip:
+            n_intermediate = max(n_layers - 1, 1)  # blocks[:-1]
+            self.skip_heads = nn.ModuleList([
+                nn.Linear(n_hidden, out_dim, bias=False) for _ in range(n_intermediate)
+            ])
+            self.skip_scales = nn.ParameterList([
+                nn.Parameter(torch.zeros(1)) for _ in range(n_intermediate)
+            ])
+            for head in self.skip_heads:
+                nn.init.zeros_(head.weight)
         self.out_skip = nn.Linear(n_hidden, out_dim)
         nn.init.zeros_(self.out_skip.weight)
         nn.init.zeros_(self.out_skip.bias)
@@ -992,8 +1005,11 @@ class Transolver(nn.Module):
         fx_pre = fx  # save for skip
         fx = fx * self.placeholder_scale[None, None, :] + self.placeholder_shift[None, None, :]
 
+        _block_outputs = [] if self.multi_scale_skip else None
         for block in self.blocks[:-1]:
             fx = block(fx, raw_xy=raw_xy, tandem_mask=is_tandem, condition=block_condition, zone_features=zone_features)
+            if _block_outputs is not None:
+                _block_outputs.append(fx)
 
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
@@ -1018,6 +1034,12 @@ class Transolver(nn.Module):
 
         gate = self.skip_gate(fx_pre)
         fx = fx + gate * self.out_skip(fx_pre)
+        # Multi-scale skip: add zero-init projections from intermediate block outputs
+        if self.multi_scale_skip and _block_outputs is not None:
+            for i, (block_out, head, scale) in enumerate(
+                zip(_block_outputs, self.skip_heads, self.skip_scales)
+            ):
+                fx = fx + head(block_out) * scale  # scale starts at 0.0
         self._validate_output_dims(fx)
         return {"preds": fx, "re_pred": re_pred, "aoa_pred": aoa_pred, "hidden": fx_deep}
 
@@ -1170,6 +1192,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    multi_scale_skip: bool = False         # FPN-style skip connections from intermediate blocks to output
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
@@ -1348,6 +1371,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    multi_scale_skip=cfg.multi_scale_skip,
 )
 
 model = Transolver(**model_config).to(device)
@@ -2335,7 +2359,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _skip_log = {}
+        if cfg.multi_scale_skip:
+            for i, s in enumerate(_base_model.skip_scales):
+                _skip_log[f"skip_scale_{i}"] = s.item()
+        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step, **_skip_log})
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The current architecture is sequential: node features pass through N TransolverBlocks and only the FINAL block's output feeds the prediction head. Earlier blocks capture local/low-frequency features (geometry, wall proximity) while later blocks capture global/high-frequency features (pressure gradients, wake effects).

For pressure prediction, BOTH scales matter: the suction peak is a sharp, local feature (high frequency) while the overall pressure distribution is a global feature (low frequency). A learnable weighted mixture across all blocks allows the model to select the appropriate scale for each output channel.

This is the FPN (Feature Pyramid Network) / U-Net principle — one of the most reliable improvements in image segmentation for tasks requiring multi-scale accuracy. The existing preprocess skip connection (PR #774) demonstrates this architecture is receptive to skip connections.

**Safety:** All skip heads are zero-initialized, so worst case = current baseline (adding zeros).

## Instructions

Add `--multi_scale_skip` flag. Add learnable weighted skip connections from each TransolverBlock to the prediction head.

### Step 1: Add argument

```python
parser.add_argument('--multi_scale_skip', action='store_true',
                    help='FPN-style skip connections from all intermediate TransolverBlocks to output')
```

### Step 2: Define skip projection heads

In the model's `__init__`, after the TransolverBlocks are defined:

```python
if args.multi_scale_skip:
    n_blocks = args.n_layers  # typically 3
    out_dim = 3  # Ux, Uy, p
    self.skip_heads = nn.ModuleList([
        nn.Linear(hidden_dim, out_dim, bias=False) for _ in range(n_blocks)
    ])
    self.skip_scales = nn.ParameterList([
        nn.Parameter(torch.zeros(1)) for _ in range(n_blocks)
    ])
    # Zero-init all skip head weights — starts as identity (adding zeros)
    for head in self.skip_heads:
        nn.init.zeros_(head.weight)
```

### Step 3: Collect intermediate outputs

In the forward pass, collect each TransolverBlock's output:

```python
block_outputs = []
for i, block in enumerate(self.blocks):
    x = block(x, ...)  # existing forward pass
    if args.multi_scale_skip:
        block_outputs.append(x)
```

### Step 4: Add skip predictions to final output

After the final prediction head computes `pred`:

```python
if args.multi_scale_skip:
    for i, (block_out, head, scale) in enumerate(
        zip(block_outputs, self.skip_heads, self.skip_scales)
    ):
        # scale starts at 0.0, gradually learns to contribute
        pred = pred + head(block_out) * torch.sigmoid(scale)
```

Using `sigmoid(scale)` with scale initialized at 0 gives an initial contribution of 0.5 * 0 = 0 (since head weights are zero). As training progresses, both the head weights and scale can grow.

**Alternative (simpler):** Just use the scale directly:
```python
pred = pred + head(block_out) * scale  # scale starts at 0.0
```

Use the simpler version first.

### Step 5: Verification

- At epoch 0: all skip_scales should be ~0, skip contribution should be ~0
- At epoch 50: check if any skip_scales have grown significantly (indicates the model finds intermediate features useful)
- Log `skip_scale_0`, `skip_scale_1`, `skip_scale_2` to W&B

### Training commands

```bash
cd cfd_tandemfoil && python train.py \
  --agent edward --seed 42 \
  --wandb_name "edward/multi-scale-skip-s42" \
  --wandb_group "multi-scale-intermediate-skips" \
  --multi_scale_skip \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same flags, --seed 73, --wandb_name "edward/multi-scale-skip-s73"
```

## Baseline

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |

**Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)