### PR TITLE
Tandem Curriculum Ramp: smooth linear ramp instead of hard cutoff

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -2795,6 +2795,9 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+    if cfg.tandem_ramp or cfg.tandem_curriculum_ramp:
+        _ramp_len = 20.0 if cfg.tandem_curriculum_ramp else 40.0
+        metrics["train/tandem_ramp_weight"] = min(1.0, max(0.0, (epoch - 10) / _ramp_len))
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1083,6 +1083,7 @@ class Config:
     adaln_zone_temp: bool = False      # zone-aware temperature modulation
     # Phase 2 R5: tandem warm-in combinations
     tandem_ramp: bool = False          # gradual tandem surface loss warm-in (0→1 over epochs 10-50)
+    tandem_curriculum_ramp: bool = False  # shorter ramp: 0→1 over epochs 10-30 (steeper reintroduction)
     foil2_dist: bool = False           # explicit foil-2 distance feature (from secondary dsdf)
     slice_num: int = 48                # slice count (default 48, GPU6: 96)
     # Phase 3: training dynamics experiments
@@ -1981,7 +1982,7 @@ for epoch in range(MAX_EPOCHS):
 
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
-        if cfg.tandem_ramp:
+        if cfg.tandem_ramp or cfg.tandem_curriculum_ramp:
             pass  # no hard curriculum; tandem_weight applied via tandem_boost below
         elif epoch < cfg.tandem_curriculum_epochs:
             is_tandem_curr = (x[:, :, -8:].abs().sum(dim=(1, 2)) > 0.01)
@@ -2042,8 +2043,9 @@ for epoch in range(MAX_EPOCHS):
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
-        if cfg.tandem_ramp:
-            tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
+        if cfg.tandem_ramp or cfg.tandem_curriculum_ramp:
+            _ramp_len = 20.0 if cfg.tandem_curriculum_ramp else 40.0
+            tandem_weight = min(1.0, max(0.0, (epoch - 10) / _ramp_len))
             tandem_boost = torch.where(is_tandem_batch,
                                        torch.tensor(adaptive_boost * tandem_weight, device=device),
                                        torch.ones(B, device=device))
@@ -2409,13 +2411,17 @@ for epoch in range(MAX_EPOCHS):
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
     if not _do_val:
         dt = time.time() - t0
-        wandb.log({
+        _skip_log = {
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
             "epoch_time_s": dt,
             "lr": scheduler.get_last_lr()[0],
             "global_step": global_step,
-        })
+        }
+        if cfg.tandem_ramp or cfg.tandem_curriculum_ramp:
+            _ramp_len = 20.0 if cfg.tandem_curriculum_ramp else 40.0
+            _skip_log["train/tandem_ramp_weight"] = min(1.0, max(0.0, (epoch - 10) / _ramp_len))
+        wandb.log(_skip_log)
         print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
         continue
 


### PR DESCRIPTION
## Hypothesis

The current data curriculum skips tandem samples for the first 10 epochs, then reintroduces them at FULL weight. This abrupt switch creates a distribution shift shock — the gradient signal suddenly changes from single-foil-only to a mixed distribution. PR #768 student notes specifically observed instability at this transition point.

A **smooth linear ramp** from weight 0 to 1.0 over epochs 10-30 allows the model to adapt incrementally to tandem samples, maintaining stable optimization. This is well-supported by curriculum learning theory (Bengio et al., ICML 2009).

This is a pure training dynamics change — no new parameters, no architecture modification, no new features. The endpoint (full tandem weight at epoch 30) is the same as current behavior; only the path changes.

## Instructions

Add `--tandem_curriculum_ramp` flag to replace the abrupt reintroduction with a smooth ramp.

### Step 1: Add argument

```python
parser.add_argument('--tandem_curriculum_ramp', action='store_true',
                    help='Smooth linear ramp for tandem sample weights (epochs 10-30) instead of hard cutoff')
```

### Step 2: Find the tandem skip logic

Find where tandem samples are skipped during early training. Look for code like:
```python
if epoch < 10:
    # skip tandem samples or set their weight to 0
```

### Step 3: Replace with smooth ramp

```python
if args.tandem_curriculum_ramp:
    if epoch < 10:
        tandem_ramp_weight = 0.0
    elif epoch < 30:
        tandem_ramp_weight = (epoch - 10) / 20.0  # Linear: 0→1 over epochs 10-30
    else:
        tandem_ramp_weight = 1.0
else:
    # Current behavior: hard cutoff at epoch 10
    tandem_ramp_weight = 0.0 if epoch < 10 else 1.0
```

### Step 4: Apply the ramp weight

Multiply ALL tandem sample loss contributions by `tandem_ramp_weight`:

```python
# In the loss computation, where tandem samples are identified:
if is_tandem:
    loss = loss * tandem_ramp_weight
```

**Important:** The existing 1.5× tandem surface boost should still apply AFTER the ramp. So at epoch 30+, tandem samples get the full 1.5× boost. During the ramp period, they get `tandem_ramp_weight × 1.5×`.

### Step 5: Log the ramp weight

```python
if args.tandem_curriculum_ramp:
    wandb.log({"train/tandem_ramp_weight": tandem_ramp_weight})
```

### Training commands

```bash
cd cfd_tandemfoil && python train.py \
  --agent tanjiro --seed 42 \
  --wandb_name "tanjiro/tandem-ramp-s42" \
  --wandb_group "tandem-curriculum-ramp" \
  --tandem_curriculum_ramp \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same flags, --seed 73, --wandb_name "tanjiro/tandem-ramp-s73"
```

## Baseline

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |

**Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)