### PR TITLE
EMA Teacher Soft-Label Distillation for OOD generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1173,6 +1173,11 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # EMA teacher distillation (Mean Teacher)
+    ema_teacher_distill: bool = False       # add soft-label distillation from slow-decay EMA teacher
+    teacher_weight: float = 0.1            # weight for teacher distillation loss
+    teacher_decay: float = 0.9995          # EMA decay for teacher model (slower than eval EMA)
+    teacher_warmup: int = 20               # disable teacher loss for first N epochs
 
 
 cfg = sp.parse(Config)
@@ -1415,6 +1420,41 @@ from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
 ema_aft_srf_head = None  # EMA copy of aft-foil SRF head
+
+# EMA Teacher for distillation (Mean Teacher)
+teacher_model = None
+teacher_refine_head = None
+teacher_aft_srf_head = None
+teacher_aft_srf_ctx_head = None
+if cfg.ema_teacher_distill:
+    teacher_model = deepcopy(_base_model)
+    teacher_model.eval()
+    for p in teacher_model.parameters():
+        p.requires_grad = False
+    if refine_head is not None:
+        _refine_base_t = refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head
+        teacher_refine_head = deepcopy(_refine_base_t)
+        teacher_refine_head.eval()
+        for p in teacher_refine_head.parameters():
+            p.requires_grad = False
+    if aft_srf_head is not None:
+        _aft_base_t = aft_srf_head._orig_mod if hasattr(aft_srf_head, '_orig_mod') else aft_srf_head
+        teacher_aft_srf_head = deepcopy(_aft_base_t)
+        teacher_aft_srf_head.eval()
+        for p in teacher_aft_srf_head.parameters():
+            p.requires_grad = False
+    if aft_srf_ctx_head is not None:
+        _ctx_base_t = aft_srf_ctx_head._orig_mod if hasattr(aft_srf_ctx_head, '_orig_mod') else aft_srf_ctx_head
+        teacher_aft_srf_ctx_head = deepcopy(_ctx_base_t)
+        teacher_aft_srf_ctx_head.eval()
+        for p in teacher_aft_srf_ctx_head.parameters():
+            p.requires_grad = False
+    print(f"EMA Teacher initialized (decay={cfg.teacher_decay}, warmup={cfg.teacher_warmup} epochs, weight={cfg.teacher_weight})")
+
+    @torch.no_grad()
+    def update_teacher_ema(teacher, student, decay=0.9995):
+        for tp, sp in zip(teacher.parameters(), student.parameters()):
+            tp.data.mul_(decay).add_(sp.data, alpha=1 - decay)
 swad_initial_val = None
 swad_prev_val = float("inf")
 swad_checkpoints: list = []
@@ -2145,6 +2185,73 @@ for epoch in range(MAX_EPOCHS):
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
             loss = loss + cfg.rdrop_alpha * rdrop_loss
 
+        # EMA Teacher distillation loss
+        _teacher_loss = torch.tensor(0.0, device=device)
+        if cfg.ema_teacher_distill and model.training and epoch >= cfg.teacher_warmup:
+            with torch.no_grad():
+                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                    t_out = teacher_model({"x": x})
+                    teacher_pred = t_out["preds"].float()
+                    teacher_hidden = t_out["hidden"].float()
+                # Apply same per-sample std normalization to teacher predictions
+                if not cfg.no_perstd and not cfg.raw_targets and not cfg.adaptive_norm:
+                    if cfg.multiply_std:
+                        teacher_pred = teacher_pred * sample_stds
+                    else:
+                        teacher_pred = teacher_pred / sample_stds
+                # Surface refinement on teacher predictions
+                if teacher_refine_head is not None:
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        if cfg.surface_refine_context:
+                            t_refine_corr = teacher_refine_head(
+                                teacher_hidden, teacher_pred, is_surface, mask, x[:, :, :2]
+                            ).float()
+                            teacher_pred = teacher_pred + t_refine_corr
+                        else:
+                            t_surf_idx = is_surface.nonzero(as_tuple=False)
+                            if t_surf_idx.numel() > 0:
+                                t_surf_h = teacher_hidden[t_surf_idx[:, 0], t_surf_idx[:, 1]]
+                                t_surf_p = teacher_pred[t_surf_idx[:, 0], t_surf_idx[:, 1]]
+                                t_corr = teacher_refine_head(t_surf_h, t_surf_p).float()
+                                teacher_pred = teacher_pred.clone()
+                                teacher_pred[t_surf_idx[:, 0], t_surf_idx[:, 1]] = teacher_pred[t_surf_idx[:, 0], t_surf_idx[:, 1]] + t_corr
+                # Aft-foil refinement on teacher predictions
+                if teacher_aft_srf_ctx_head is not None and _aft_foil_mask is not None:
+                    _vol_mask_t = mask & ~is_surface
+                    _coords_t = x[:, :, :2]
+                    teacher_pred = teacher_pred.clone()
+                    for b in range(x.shape[0]):
+                        _aft_b_t = _aft_foil_mask[b].nonzero(as_tuple=True)[0]
+                        _vol_b_t = _vol_mask_t[b].nonzero(as_tuple=True)[0]
+                        if _aft_b_t.numel() == 0 or _vol_b_t.numel() == 0:
+                            continue
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            _t_corr = teacher_aft_srf_ctx_head(
+                                teacher_hidden[b, _aft_b_t], _coords_t[b, _aft_b_t],
+                                teacher_hidden[b, _vol_b_t], _coords_t[b, _vol_b_t],
+                                teacher_pred[b, _aft_b_t],
+                            ).float()
+                        teacher_pred[b, _aft_b_t] = teacher_pred[b, _aft_b_t] + _t_corr
+                elif teacher_aft_srf_head is not None and _aft_foil_mask is not None:
+                    t_aft_idx = _aft_foil_mask.nonzero(as_tuple=False)
+                    if t_aft_idx.numel() > 0:
+                        t_aft_h = teacher_hidden[t_aft_idx[:, 0], t_aft_idx[:, 1]]
+                        t_aft_p = teacher_pred[t_aft_idx[:, 0], t_aft_idx[:, 1]]
+                        _t_aft_cond = None
+                        if cfg.aft_foil_srf_film:
+                            _t_aft_cond = _raw_gap_stagger[t_aft_idx[:, 0]]
+                        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                            t_aft_corr = teacher_aft_srf_head(t_aft_h, t_aft_p, _t_aft_cond).float()
+                        teacher_pred = teacher_pred.clone()
+                        teacher_pred[t_aft_idx[:, 0], t_aft_idx[:, 1]] = teacher_pred[t_aft_idx[:, 0], t_aft_idx[:, 1]] + t_aft_corr
+            # L1 distillation loss: student should match teacher (all nodes)
+            valid_mask_t = mask.float().unsqueeze(-1)  # [B, N, 1]
+            _teacher_loss = (F.l1_loss(pred, teacher_pred.detach(), reduction='none') * valid_mask_t).sum() / valid_mask_t.sum().clamp(min=1)
+            _teacher_loss = _teacher_loss * cfg.teacher_weight
+            loss = loss + _teacher_loss
+            if global_step % 20 == 0:
+                wandb.log({"loss/teacher_distill": _teacher_loss.item(), "global_step": global_step})
+
         # PCGrad: in-dist (Group A) vs all-OOD (Group B) gradient projection
         # Group B = tandem + extreme-Re (>1σ) + extreme-AoA (>1σ), Group A = rest
         is_ood_pcgrad = is_tandem_batch | (x[:, 0, 13] > 1.0) | (x[:, 0, 14].abs() > 1.0)
@@ -2334,6 +2441,18 @@ for epoch in range(MAX_EPOCHS):
                     with torch.no_grad():
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+        # Update teacher EMA (every step, from epoch 0 — needs to accumulate before warmup ends)
+        if cfg.ema_teacher_distill:
+            update_teacher_ema(teacher_model, _base_model, decay=cfg.teacher_decay)
+            if teacher_refine_head is not None:
+                _refine_base_tu = refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head
+                update_teacher_ema(teacher_refine_head, _refine_base_tu, decay=cfg.teacher_decay)
+            if teacher_aft_srf_head is not None:
+                _aft_base_tu = aft_srf_head._orig_mod if hasattr(aft_srf_head, '_orig_mod') else aft_srf_head
+                update_teacher_ema(teacher_aft_srf_head, _aft_base_tu, decay=cfg.teacher_decay)
+            if teacher_aft_srf_ctx_head is not None:
+                _ctx_base_tu = aft_srf_ctx_head._orig_mod if hasattr(aft_srf_ctx_head, '_orig_mod') else aft_srf_ctx_head
+                update_teacher_ema(teacher_aft_srf_ctx_head, _ctx_base_tu, decay=cfg.teacher_decay)
         global_step += 1
         wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
 


### PR DESCRIPTION
## Hypothesis

Use the existing EMA model as a "teacher" and add a soft-label distillation loss during training. The EMA model accumulates a temporally smoothed version of the student's learned behavior — its predictions are typically more stable, better calibrated, and more generalizable. By distilling the teacher's predictions as soft targets, the student receives a consistency regularization signal that reduces overfitting to noisy training samples.

This is **Mean Teacher** (Tarvainen & Valpola, NeurIPS 2017) — a well-established technique for semi-supervised learning. The key insight: OOD test conditions are analogous to unlabeled samples in semi-supervised learning — the teacher's temporal ensemble provides a more stable representation that generalizes better.

**Key distinction from failed approaches:** This is NOT multi-seed ensemble distillation (which failed because seeds don't provide enough diversity). This is within-run temporal self-distillation using the existing EMA mechanism.

## Instructions

Add `--ema_teacher_distill` flag. Use a SEPARATE slow-decay EMA as the teacher (not the existing evaluation EMA).

### Step 1: Add arguments

```python
parser.add_argument('--ema_teacher_distill', action='store_true',
                    help='Add soft-label distillation from slow-decay EMA teacher model')
parser.add_argument('--teacher_weight', type=float, default=0.1,
                    help='Weight for teacher distillation loss (default: 0.1)')
parser.add_argument('--teacher_decay', type=float, default=0.9995,
                    help='EMA decay for teacher model (slower than eval EMA)')
parser.add_argument('--teacher_warmup', type=int, default=20,
                    help='Disable teacher loss for first N epochs (teacher needs to accumulate)')
```

### Step 2: Create the teacher EMA model

The codebase already has an EMA mechanism. Create a SEPARATE teacher EMA with slower decay:

```python
if args.ema_teacher_distill:
    import copy
    teacher_model = copy.deepcopy(model)
    teacher_model.eval()
    for p in teacher_model.parameters():
        p.requires_grad = False
    
    @torch.no_grad()
    def update_teacher_ema(teacher, student, decay=0.9995):
        for tp, sp in zip(teacher.parameters(), student.parameters()):
            tp.data.mul_(decay).add_(sp.data, alpha=1 - decay)
```

### Step 3: Compute teacher predictions (detached)

In the training loop, after the student forward pass:

```python
if args.ema_teacher_distill and epoch >= args.teacher_warmup:
    with torch.no_grad():
        teacher_pred = teacher_model(x_input)  # Same input as student
    
    # Soft-label distillation loss: student should match teacher
    teacher_loss = F.l1_loss(pred, teacher_pred.detach()) * args.teacher_weight
    total_loss = total_loss + teacher_loss
    
    wandb.log({"loss/teacher_distill": teacher_loss.item()})
```

### Step 4: Update teacher EMA after each step

```python
if args.ema_teacher_distill:
    update_teacher_ema(teacher_model, model, decay=args.teacher_decay)
```

### Important details

- The teacher forward pass adds ~50% compute overhead (one extra forward pass, no backward). This should still allow ~100+ epochs in 180 min (vs 148 baseline). If it's too slow, reduce teacher forward frequency to every 2nd step.
- Teacher predictions must be DETACHED — no gradients flow through the teacher.
- The teacher_warmup=20 ensures the teacher has accumulated meaningful weights before being used as a target.
- Apply teacher loss to ALL nodes (surface + volume), not just surface — the consistency regularization benefits from full-field supervision.

### Training commands

```bash
cd cfd_tandemfoil && python train.py \
  --agent alphonse --seed 42 \
  --wandb_name "alphonse/ema-teacher-s42" \
  --wandb_group "ema-teacher-distillation" \
  --ema_teacher_distill --teacher_weight 0.1 --teacher_decay 0.9995 --teacher_warmup 20 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --re_extreme_weight 2.0

# Seed 73: same flags, --seed 73, --wandb_name "alphonse/ema-teacher-s73"
```

## Baseline

| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.742** | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| **p_tan** | **27.874** | < 27.87 |
| p_re | 6.419 | < 6.42 |

**Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)