### PR TITLE
Panel-Method Cp Feature: inviscid Cp as physics-grounded input

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1241,6 +1241,7 @@ class Config:
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
     # Panel-method Cp feature: inviscid Cp as physics-grounded input (+1 input channel)
     cp_panel: bool = False                 # append thin-airfoil inviscid Cp to input features
+    cp_panel_tandem_only: bool = False     # zero Cp feature for single-foil samples (tandem benefit only)
 
 
 cfg = sp.parse(Config)
@@ -1851,6 +1852,7 @@ for epoch in range(MAX_EPOCHS):
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
         dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
         _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1] — save before normalization
+        _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B] tandem flag from raw gap
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
@@ -1899,6 +1901,8 @@ for epoch in range(MAX_EPOCHS):
         x = torch.cat([x, fourier_pe], dim=-1)
         if cfg.cp_panel:
             cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
+            if cfg.cp_panel_tandem_only:
+                cp_feat = cp_feat * _is_tandem_raw[:, None, None]
             x = torch.cat([x, cp_feat], dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
@@ -2549,6 +2553,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
+                _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
                 _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
@@ -2592,6 +2597,8 @@ for epoch in range(MAX_EPOCHS):
                 x = torch.cat([x, fourier_pe], dim=-1)
                 if cfg.cp_panel:
                     cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
+                    if cfg.cp_panel_tandem_only:
+                        cp_feat = cp_feat * _is_tandem_raw[:, None, None]
                     x = torch.cat([x, cp_feat], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
@@ -2970,6 +2977,7 @@ if best_metrics:
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
                     _raw_aoa_vis = x_dev[:, 0, 14:15]  # AoA0_rad [B, 1]
+                    _is_tandem_raw_vis = (x_dev[:, 0, 22].abs() > 0.01).float()  # [B]
                     _raw_gap_wake_vis = x_dev[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
                     x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                     curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
@@ -2999,6 +3007,8 @@ if best_metrics:
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
                     if cfg.cp_panel:
                         cp_feat = compute_cp_panel(_raw_xy_te_vis, _raw_aoa_vis, is_surf_dev, _raw_saf_norm_te_vis)
+                        if cfg.cp_panel_tandem_only:
+                            cp_feat = cp_feat * _is_tandem_raw_vis[:, None, None]
                         x_n = torch.cat([x_n, cp_feat], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
@@ -3085,6 +3095,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
+                    _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
                     _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
@@ -3119,6 +3130,8 @@ if cfg.surface_refine and best_metrics:
                     x = torch.cat([x, fourier_pe], dim=-1)
                     if cfg.cp_panel:
                         cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
+                        if cfg.cp_panel_tandem_only:
+                            cp_feat = cp_feat * _is_tandem_raw[:, None, None]
                         x = torch.cat([x, cp_feat], dim=-1)
 
                     # Ground truth denormalization reference

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -347,6 +347,72 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
 
 
+def compute_cp_panel(raw_xy, aoa_rad, is_surface, saf_norm):
+    """Compute inviscid flat-plate Cp per node as a physics-grounded input feature.
+
+    Uses thin-airfoil theory: Cp = ∓2·sin(α) / sqrt(t·(1-t)) where t is
+    chord-normalized position and sign depends on upper/lower surface.
+
+    Args:
+        raw_xy:     [B, N, 2] raw (pre-standardization) x, y coordinates
+        aoa_rad:    [B, 1] angle of attack in radians
+        is_surface: [B, N] bool mask for surface nodes
+        saf_norm:   [B, N] saf channel norm (fore-foil: <= 0.005)
+
+    Returns: [B, N, 1] inviscid Cp, zero for volume nodes
+    """
+    x_coords = raw_xy[:, :, 0]  # [B, N]
+    y_coords = raw_xy[:, :, 1]  # [B, N]
+
+    # Fore-foil (foil-1) surface: saf_norm <= 0.005
+    fore_surf = is_surface & (saf_norm <= 0.005)
+    # Aft-foil (foil-2) surface: saf_norm > 0.005
+    aft_surf = is_surface & (saf_norm > 0.005)
+
+    # Chord-normalize x separately for each foil
+    INF = 1e6
+    # Fore foil chord normalization
+    fore_x = x_coords.clone()
+    fore_x[~fore_surf] = INF
+    fore_x_min = fore_x.min(dim=1, keepdim=True).values.clamp(max=INF - 1)
+    fore_x[~fore_surf] = -INF
+    fore_x_max = fore_x.max(dim=1, keepdim=True).values.clamp(min=-INF + 1)
+    fore_chord = (fore_x_max - fore_x_min).clamp(min=1e-6)
+    t_fore = ((x_coords - fore_x_min) / fore_chord).clamp(0.02, 0.98)
+
+    # Aft foil chord normalization (if present)
+    aft_x = x_coords.clone()
+    aft_x[~aft_surf] = INF
+    aft_x_min = aft_x.min(dim=1, keepdim=True).values.clamp(max=INF - 1)
+    aft_x[~aft_surf] = -INF
+    aft_x_max = aft_x.max(dim=1, keepdim=True).values.clamp(min=-INF + 1)
+    aft_chord = (aft_x_max - aft_x_min).clamp(min=1e-6)
+    t_aft = ((x_coords - aft_x_min) / aft_chord).clamp(0.02, 0.98)
+
+    # Use aft-foil t for aft-foil nodes, fore-foil t for fore-foil nodes
+    t = torch.where(aft_surf, t_aft, t_fore)
+
+    # Thin-airfoil Cp denominator: sqrt(t * (1-t))
+    denom = torch.sqrt(t * (1.0 - t)).clamp(min=1e-4)
+
+    # Side sign: upper (+y relative to foil centroid) = suction, lower = pressure
+    # Compute per-foil: y relative to foil centroid
+    fore_y_mean = (y_coords * fore_surf.float()).sum(dim=1, keepdim=True) / fore_surf.float().sum(dim=1, keepdim=True).clamp(min=1)
+    aft_y_mean = (y_coords * aft_surf.float()).sum(dim=1, keepdim=True) / aft_surf.float().sum(dim=1, keepdim=True).clamp(min=1)
+    y_ref = torch.where(aft_surf, aft_y_mean, fore_y_mean)
+    side_sign = torch.sign(y_coords - y_ref)
+
+    # Cp = -side_sign * 2 * sin(|AoA|) / denom
+    aoa = aoa_rad.squeeze(-1)  # [B]
+    cp_panel = -side_sign * 2.0 * torch.sin(aoa.abs().unsqueeze(1)) / denom
+
+    # Zero for volume nodes, clamp to physical range
+    cp_panel = cp_panel * is_surface.float()
+    cp_panel = cp_panel.clamp(-4.0, 2.0)
+
+    return cp_panel.unsqueeze(-1)  # [B, N, 1]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1173,6 +1239,8 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # Panel-method Cp feature: inviscid Cp as physics-grounded input (+1 input channel)
+    cp_panel: bool = False                 # append thin-airfoil inviscid Cp to input features
 
 
 cfg = sp.parse(Config)
@@ -1318,7 +1386,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32,  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32 + (1 if cfg.cp_panel else 0),  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE, [+cp_panel]
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1786,8 +1854,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
+        # TE coordinate frame / wake deficit / cp_panel: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1829,6 +1897,9 @@ for epoch in range(MAX_EPOCHS):
         xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
         fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
         x = torch.cat([x, fourier_pe], dim=-1)
+        if cfg.cp_panel:
+            cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
+            x = torch.cat([x, cp_feat], dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -2478,7 +2549,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2519,6 +2590,9 @@ for epoch in range(MAX_EPOCHS):
                 xy_scaled = xy_norm.unsqueeze(-1) * freqs  # [B, N, 2, 4]
                 fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)  # [B, N, 16]
                 x = torch.cat([x, fourier_pe], dim=-1)
+                if cfg.cp_panel:
+                    cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
+                    x = torch.cat([x, cp_feat], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
@@ -2892,9 +2966,10 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
-                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
+                    _raw_aoa_vis = x_dev[:, 0, 14:15]  # AoA0_rad [B, 1]
                     _raw_gap_wake_vis = x_dev[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
                     x_n = (x_dev - stats["x_mean"]) / stats["x_std"]
                     curv = x_n[:, :, 2:6].norm(dim=-1, keepdim=True) * is_surf_dev.float().unsqueeze(-1)
@@ -2922,6 +2997,9 @@ if best_metrics:
                     xy_scaled = xy_norm.unsqueeze(-1) * freqs
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x_n = torch.cat([x_n, fourier_pe], dim=-1)
+                    if cfg.cp_panel:
+                        cp_feat = compute_cp_panel(_raw_xy_te_vis, _raw_aoa_vis, is_surf_dev, _raw_saf_norm_te_vis)
+                        x_n = torch.cat([x_n, cp_feat], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
                     if cfg.raw_targets:
@@ -3007,7 +3085,7 @@ if cfg.surface_refine and best_metrics:
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3039,6 +3117,9 @@ if cfg.surface_refine and best_metrics:
                     xy_scaled = xy_norm.unsqueeze(-1) * freqs
                     fourier_pe = torch.cat([xy_scaled.sin().flatten(-2), xy_scaled.cos().flatten(-2)], dim=-1)
                     x = torch.cat([x, fourier_pe], dim=-1)
+                    if cfg.cp_panel:
+                        cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
+                        x = torch.cat([x, cp_feat], dim=-1)
 
                     # Ground truth denormalization reference
                     Umag, q = _umag_q(y, mask)

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1242,6 +1242,7 @@ class Config:
     # Panel-method Cp feature: inviscid Cp as physics-grounded input (+1 input channel)
     cp_panel: bool = False                 # append thin-airfoil inviscid Cp to input features
     cp_panel_tandem_only: bool = False     # zero Cp feature for single-foil samples (tandem benefit only)
+    cp_panel_scale: float = 1.0            # scale factor for panel Cp feature (0.1 = weak hint)
 
 
 cfg = sp.parse(Config)
@@ -1903,6 +1904,8 @@ for epoch in range(MAX_EPOCHS):
             cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
             if cfg.cp_panel_tandem_only:
                 cp_feat = cp_feat * _is_tandem_raw[:, None, None]
+            if cfg.cp_panel_scale != 1.0:
+                cp_feat = cp_feat * cfg.cp_panel_scale
             x = torch.cat([x, cp_feat], dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
@@ -2599,6 +2602,8 @@ for epoch in range(MAX_EPOCHS):
                     cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
                     if cfg.cp_panel_tandem_only:
                         cp_feat = cp_feat * _is_tandem_raw[:, None, None]
+                    if cfg.cp_panel_scale != 1.0:
+                        cp_feat = cp_feat * cfg.cp_panel_scale
                     x = torch.cat([x, cp_feat], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
@@ -3009,6 +3014,8 @@ if best_metrics:
                         cp_feat = compute_cp_panel(_raw_xy_te_vis, _raw_aoa_vis, is_surf_dev, _raw_saf_norm_te_vis)
                         if cfg.cp_panel_tandem_only:
                             cp_feat = cp_feat * _is_tandem_raw_vis[:, None, None]
+                        if cfg.cp_panel_scale != 1.0:
+                            cp_feat = cp_feat * cfg.cp_panel_scale
                         x_n = torch.cat([x_n, cp_feat], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
@@ -3132,6 +3139,8 @@ if cfg.surface_refine and best_metrics:
                         cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
                         if cfg.cp_panel_tandem_only:
                             cp_feat = cp_feat * _is_tandem_raw[:, None, None]
+                        if cfg.cp_panel_scale != 1.0:
+                            cp_feat = cp_feat * cfg.cp_panel_scale
                         x = torch.cat([x, cp_feat], dim=-1)
 
                     # Ground truth denormalization reference


### PR DESCRIPTION
## Hypothesis

Add the inviscid (potential-flow) pressure coefficient Cp_panel as an additional input feature channel. The neural network then learns a viscous correction on top of a physically-grounded baseline. This mirrors Colvert et al. (Springer 2025, \"Inductive transfer-learning of high-fidelity aerodynamics from inviscid panel methods\") which showed even a cheap 2D panel solution dramatically reduces the learning burden for surface pressure prediction, with 15-30% improvement in surface pressure MAE.

**Key physics:** For incompressible flow at small-to-moderate AoA, the inviscid Cp on a thin airfoil (flat-plate approximation):
```
Cp_upper(x) = -2·sin(α) / sqrt(x·(1-x))   (suction side)  
Cp_lower(x) = +2·sin(α) / sqrt(x·(1-x))    (pressure side)
```
where x is chord-normalized position and α is AoA. This encodes FLOW PHYSICS (pressure distribution under inviscid assumptions) — qualitatively different from geometry features that fail.

## Instructions

**Step 1: Add cp_panel computation function in train.py**

```python
def compute_cp_panel(x_feat):
    """Compute inviscid flat-plate Cp per node. Returns (B, N, 1)."""
    # AoA in radians (channel 14)
    aoa = x_feat[:, :, 14:15]  # (B, N, 1) same AoA for all nodes in sample
    
    # Chord-normalized position from x-coordinate
    x_pos = x_feat[:, :, 0:1]
    x_min = x_pos.min(dim=1, keepdim=True).values
    x_max = x_pos.max(dim=1, keepdim=True).values
    t = (x_pos - x_min) / (x_max - x_min + 1e-8)
    t_safe = t.clamp(0.02, 0.98)
    denom = torch.sqrt(t_safe * (1.0 - t_safe)).clamp(min=1e-4)
    
    # Side sign: upper (+y) = suction, lower (-y) = pressure
    y_pos = x_feat[:, :, 1:2]
    side_sign = torch.sign(y_pos - y_pos.mean(dim=1, keepdim=True))
    
    cp_panel = -side_sign * 2.0 * torch.sin(aoa.abs()) / denom
    
    # Zero for volume nodes (surface nodes have near-zero DSDF)
    dsdf_min = x_feat[:, :, :8].abs().min(dim=-1, keepdim=True).values
    is_surface = (dsdf_min < 0.005).float()
    cp_panel = (cp_panel * is_surface).clamp(-4.0, 2.0)
    return cp_panel
```

**Step 2: Append to feature vector before Transolver**

In the forward pass, before the feature vector enters the model:
```python
cp_panel = compute_cp_panel(x)
x = torch.cat([x, cp_panel], dim=-1)
```

**Step 3: Update input dimension**

Find where the input channel count is set (e.g., `in_channels`, `in_dim`, or the first Linear layer's input size). It needs to be increased by 1.

**Step 4: Debug run first (5 epochs)**

```bash
cd cfd_tandemfoil && python train.py --agent thorfinn --wandb_name "thorfinn/panel-cp-debug" \
  --max_epochs 5 --seed 42 \
  --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3
```

Verify: surface nodes have non-zero cp_panel (mean ~0.2-0.5), volume nodes have ~0.

**Step 5: Full runs (2 seeds, parallel)**

```bash
# GPU 0
cd cfd_tandemfoil && python train.py \
  --agent thorfinn --wandb_name "thorfinn/panel-cp-s42" --wandb_group panel-method-cp-feature \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3

# GPU 1 (in parallel)
CUDA_VISIBLE_DEVICES=1 python train.py \
  --agent thorfinn --wandb_name "thorfinn/panel-cp-s73" --wandb_group panel-method-cp-feature \
  --seed 73 [same flags as above]
```

## Baseline

Current best single-model metrics (PR #2290, 2-seed avg):
| Metric | Value | Beat if |
|--------|-------|---------|
| p_in | 11.742 | < 11.74 |
| p_oodc | 7.643 | < 7.64 |
| p_tan | 27.874 | < 27.87 |
| p_re | 6.419 | < 6.42 |

W&B baseline runs: k5qwvce4 (seed 42), 7oa5xfhi (seed 73)