### PR TITLE
Spectral Arc-Length Loss: FFT-weighted surface pressure loss

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1118,6 +1118,9 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    spectral_arc_loss: bool = False   # Spectral FFT loss on arc-length-sorted surface pressure
+    spectral_arc_weight: float = 0.1  # weight for spectral arc-length loss
+    spectral_arc_gamma: float = 1.0   # frequency weighting exponent (0.5=mild, 1=linear, 2=aggressive)
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1786,6 +1789,10 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
+        # Spectral arc-length loss: save raw xy and saf_norm before normalization
+        _raw_xy_for_spectral = x[:, :, :2].clone() if cfg.spectral_arc_loss else None
+        _raw_saf_for_spectral = x[:, :, 2:4].norm(dim=-1) if cfg.spectral_arc_loss else None
+        _raw_tandem_for_spectral = (x[:, 0, 22].abs() > 0.01) if cfg.spectral_arc_loss else None
         # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
         _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
@@ -2135,6 +2142,46 @@ for epoch in range(MAX_EPOCHS):
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
 
+        # Spectral arc-length loss: FFT on arc-length-sorted surface pressure
+        _spectral_arc_val = torch.tensor(0.0, device=device)
+        if cfg.spectral_arc_loss and model.training:
+            _n_foils_spectral = 0
+            for b in range(B):
+                surf_idx_b = is_surface[b].nonzero(as_tuple=True)[0]
+                if surf_idx_b.numel() < 8:
+                    continue
+                _is_tan_b = _raw_tandem_for_spectral[b].item()
+                if _is_tan_b:
+                    saf_vals = _raw_saf_for_spectral[b, surf_idx_b]
+                    foil_groups = [surf_idx_b[saf_vals <= 0.005], surf_idx_b[saf_vals > 0.005]]
+                else:
+                    foil_groups = [surf_idx_b]
+                for foil_surf in foil_groups:
+                    if foil_surf.numel() < 8:
+                        continue
+                    # Sort by angle from centroid for physically meaningful arc-length ordering
+                    xy = _raw_xy_for_spectral[b, foil_surf]  # [M, 2]
+                    centroid = xy.mean(dim=0)
+                    angles = torch.atan2(xy[:, 1] - centroid[1], xy[:, 0] - centroid[0])
+                    angle_order = angles.argsort()
+                    sorted_idx = foil_surf[angle_order]
+                    # Pressure channel (channel 2 in output)
+                    p_pred = pred[b, sorted_idx, 2]
+                    p_gt = y_norm[b, sorted_idx, 2]
+                    # FFT with ortho normalization
+                    pred_fft = torch.fft.rfft(p_pred, norm='ortho')
+                    true_fft = torch.fft.rfft(p_gt, norm='ortho')
+                    freqs = torch.arange(pred_fft.shape[0], device=device, dtype=torch.float32)
+                    weights = (freqs + 1.0) ** cfg.spectral_arc_gamma
+                    weights = weights / weights.mean()
+                    _spectral_arc_val = _spectral_arc_val + ((pred_fft - true_fft).abs() * weights).mean()
+                    _n_foils_spectral += 1
+            if _n_foils_spectral > 0:
+                _spectral_arc_val = _spectral_arc_val / _n_foils_spectral
+                loss = loss + cfg.spectral_arc_weight * _spectral_arc_val
+        # Shared spectral aux term for PCGrad paths
+        _spectral_shared = cfg.spectral_arc_weight * _spectral_arc_val if cfg.spectral_arc_loss else 0.0
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -2161,8 +2208,8 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + _spectral_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + _spectral_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2207,7 +2254,7 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + _spectral_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2335,7 +2382,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.spectral_arc_loss:
+            _log_dict["train/spectral_arc_loss"] = _spectral_arc_val.item()
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Surface pressure along an airfoil is a 1D signal when parameterized by arc-length. Pointwise MAE equally weights errors at all positions. A spectral loss that upweights high-wavenumber components forces the model to reproduce sharp features — stagnation point, suction peak, pressure recovery slope — that dominate aerodynamic accuracy.

**Key distinction from the merged DCT loss (PR #2184):** That PR applied DCT on node-index order (arbitrary, physically meaningless). This PR sorts surface nodes by arc-length coordinate first, then applies torch.fft.rfft along that sorted dimension. Arc-length ordering makes the frequency spectrum physically meaningful: low frequencies = broad pressure trends, high frequencies = leading-edge singularity, stagnation point location, suction peak shape.

**Reference:** "Spectral Loss for Neural Operators" — NeurIPS ML4PS 2025 workshop. Also: Sobolev training for operator learning (arXiv:2402.09084, ICLR 2024).

## Instructions

Add a --spectral_arc_loss flag. When enabled, sort surface nodes by arc-length coordinate, then apply FFT and penalize high-frequency spectral errors.

### Step 1: Add arguments

```python
parser.add_argument('--spectral_arc_loss', action='store_true',
                    help='Spectral FFT loss on arc-length-sorted surface pressure nodes')
parser.add_argument('--spectral_arc_weight', type=float, default=0.1)
parser.add_argument('--spectral_arc_gamma', type=float, default=1.0,
                    help='Frequency weighting exponent (0.5=mild, 1=linear, 2=aggressive)')
```

### Step 2: Implement (add after surf_loss is computed)

```python
if args.spectral_arc_loss and surf_mask.any():
    B = pred.shape[0]
    spectral_losses = []
    for b in range(B):
        mask_b = surf_mask[b]
        if mask_b.sum() < 4:
            continue
        # saf_norm: arc-length normalized coord. Check which column it is in x features.
        # Try x[b, mask_b, 8] — adjust column if needed by inspecting feature names.
        arc_len = x[b, mask_b, 8]
        sort_idx = arc_len.argsort()
        pred_p = pred[b, mask_b, 2][sort_idx]  # pressure channel sorted by arc-length
        true_p = target[b, mask_b, 2][sort_idx]
        pred_fft = torch.fft.rfft(pred_p, norm='ortho')
        true_fft = torch.fft.rfft(true_p, norm='ortho')
        freqs = torch.arange(pred_fft.shape[0], device=pred.device, dtype=pred.dtype)
        weights = (freqs + 1.0) ** args.spectral_arc_gamma
        weights = weights / weights.mean()
        spectral_losses.append(((pred_fft - true_fft).abs() * weights).mean())
    if spectral_losses:
        surf_loss = surf_loss + args.spectral_arc_weight * torch.stack(spectral_losses).mean()
```

### Step 3: Run

Run 2 seeds with gamma=1.0, weight=0.1:

```bash
CUDA_VISIBLE_DEVICES=0 python train.py --agent askeladd --seed 42 \
  --wandb_name "askeladd/spectral-arc-s42" --wandb_group "spectral-arc-length-loss" \
  --spectral_arc_loss --spectral_arc_weight 0.1 --spectral_arc_gamma 1.0 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling

CUDA_VISIBLE_DEVICES=1 python train.py --agent askeladd --seed 73 \
  --wandb_name "askeladd/spectral-arc-s73" --wandb_group "spectral-arc-length-loss" \
  --spectral_arc_loss --spectral_arc_weight 0.1 --spectral_arc_gamma 1.0 \
  [same flags as above]
```

Note: First verify which column index saf_norm corresponds to in x features. Print x.shape and inspect the feature ordering from the data pipeline if unsure.

## Baseline

- **p_in:** 11.742 | **p_oodc:** 7.643 | **p_tan:** 27.874 | **p_re:** 6.419
- Baseline W&B: k5qwvce4 (seed 42), 7oa5xfhi (seed 73)