### PR TITLE
Sobolev Gradient Loss: surface pressure derivative supervision

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1118,6 +1118,8 @@ class Config:
     dct_freq_weight: float = 0.05 # weight for DCT freq loss
     dct_freq_gamma: float = 2.0   # frequency upweighting strength
     dct_freq_alpha: float = 1.5   # frequency exponent
+    sobolev_grad_loss: bool = False   # Sobolev-style arc-length gradient loss on surface pressure
+    sobolev_grad_weight: float = 0.1  # weight for Sobolev gradient loss
     # Phase 3 R10: DomainLayerNorm compounds
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
@@ -1786,6 +1788,10 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
+        _need_sob = cfg.sobolev_grad_loss
+        _raw_xy_for_sob = x[:, :, :2].clone() if _need_sob else None  # save raw x,y before normalization
+        _raw_saf_for_sob = x[:, :, 2:4].norm(dim=-1) if _need_sob else None
+        _raw_tandem_for_sob = (x[:, 0, 22].abs() > 0.01) if _need_sob else None
         # TE coordinate frame / wake deficit: save raw xy and saf_norm before normalization
         _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
@@ -2135,6 +2141,45 @@ for epoch in range(MAX_EPOCHS):
                 _dct_loss = _dct_loss / _n_foils_dct
                 loss = loss + cfg.dct_freq_weight * _dct_loss
 
+        # Sobolev gradient loss: arc-length derivative supervision on surface pressure
+        _sobolev_loss_val = None
+        if cfg.sobolev_grad_loss and model.training:
+            _sobolev_loss = torch.tensor(0.0, device=device)
+            _n_foils_sob = 0
+            for b in range(B):
+                surf_idx_b = is_surface[b].nonzero(as_tuple=True)[0]
+                if surf_idx_b.numel() < 4:
+                    continue
+                _is_tan_b = _raw_tandem_for_sob[b].item()
+                if _is_tan_b:
+                    saf_vals = _raw_saf_for_sob[b, surf_idx_b]
+                    foil_groups = [surf_idx_b[saf_vals <= 0.005], surf_idx_b[saf_vals > 0.005]]
+                else:
+                    foil_groups = [surf_idx_b]
+                for foil_surf in foil_groups:
+                    if foil_surf.numel() < 4:
+                        continue
+                    # Sort by angle from centroid for proper closed-contour ordering
+                    xy = _raw_xy_for_sob[b, foil_surf]  # [M, 2]
+                    cx, cy = xy[:, 0].mean(), xy[:, 1].mean()
+                    angles = torch.atan2(xy[:, 1] - cy, xy[:, 0] - cx)
+                    sort_order = angles.argsort()
+                    sorted_idx = foil_surf[sort_order]
+                    xy_sorted = xy[sort_order]  # [M, 2]
+                    # Arc-length spacing between consecutive nodes
+                    ds = (xy_sorted[1:] - xy_sorted[:-1]).norm(dim=-1).clamp(min=1e-6)  # [M-1]
+                    # Pressure channel (channel 2) finite differences
+                    p_pred = pred[b, sorted_idx, 2]  # [M]
+                    p_gt = y_norm[b, sorted_idx, 2]  # [M]
+                    pred_grad = (p_pred[1:] - p_pred[:-1]) / ds
+                    true_grad = (p_gt[1:] - p_gt[:-1]) / ds
+                    _sobolev_loss = _sobolev_loss + (pred_grad - true_grad).abs().mean()
+                    _n_foils_sob += 1
+            if _n_foils_sob > 0:
+                _sobolev_loss = _sobolev_loss / _n_foils_sob
+                _sobolev_loss_val = _sobolev_loss
+                loss = loss + cfg.sobolev_grad_weight * _sobolev_loss
+
         # R-drop: second forward pass with different dropout mask for consistency
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
@@ -2161,8 +2206,9 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            _sob_shared = cfg.sobolev_grad_weight * _sobolev_loss_val if _sobolev_loss_val is not None else 0.0
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + _sob_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + _sob_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2207,7 +2253,8 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                _sob_shared = cfg.sobolev_grad_weight * _sobolev_loss_val if _sobolev_loss_val is not None else 0.0
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + _sob_shared + 0.005 * re_loss + 0.005 * aoa_loss
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2335,7 +2382,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _train_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if _sobolev_loss_val is not None:
+            _train_log["train/sobolev_grad_loss"] = _sobolev_loss_val.item()
+        wandb.log(_train_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Surface pressure MAE is low on average but the model may be systematically wrong about stagnation point location and suction peak position — errors that are aerodynamically critical but have low MAE (e.g., a shifted stagnation point). These errors are captured by dCp/ds (first derivative along arc-length), not by pointwise MAE.

Adding a Sobolev-style gradient loss term forces the model to reproduce pressure gradient features, not just pointwise values. This is motivated by the success of derivative-weighted losses in PDE operator learning.

**Reference:** "Sobolev Training for Operator Learning" (arXiv:2402.09084, ICLR 2024). Adding derivative-weighted loss improves PDE solution sharpness and accuracy simultaneously.

## Instructions

Add a `--sobolev_grad_loss` flag. When enabled, compute finite differences of pressure along arc-length-sorted surface nodes and add a gradient MAE term to the surface loss.

### Step 1: Add arguments

```python
parser.add_argument('--sobolev_grad_loss', action='store_true',
                    help='Add arc-length gradient supervision to surface pressure loss')
parser.add_argument('--sobolev_grad_weight', type=float, default=0.1,
                    help='Weight for Sobolev gradient loss (start with 0.1)')
```

### Step 2: Implement (add after surf_loss is computed)

```python
if args.sobolev_grad_loss and surf_mask.any():
    B = pred.shape[0]
    grad_losses = []
    for b in range(B):
        mask_b = surf_mask[b]
        if mask_b.sum() < 3:
            continue
        # Sort surface nodes by arc-length (saf_norm column — check feature index)
        arc_len = x[b, mask_b, 8]  # adjust column index if needed
        sort_idx = arc_len.argsort()
        arc_sorted = arc_len[sort_idx]
        
        pred_p = pred[b, mask_b, 2][sort_idx]  # pressure, arc-length sorted
        true_p = target[b, mask_b, 2][sort_idx]
        
        # Arc-length spacing for normalization
        ds = (arc_sorted[1:] - arc_sorted[:-1]).clamp(min=1e-6)
        
        # Finite-difference gradients normalized by spacing
        pred_grad = (pred_p[1:] - pred_p[:-1]) / ds
        true_grad = (true_p[1:] - true_p[:-1]) / ds
        
        grad_losses.append((pred_grad - true_grad).abs().mean())
    
    if grad_losses:
        sobolev_loss = torch.stack(grad_losses).mean()
        surf_loss = surf_loss + args.sobolev_grad_weight * sobolev_loss
```

### Step 3: Run

Run 2 seeds with weight=0.1:

```bash
CUDA_VISIBLE_DEVICES=0 python train.py --agent fern --seed 42 \
  --wandb_name "fern/sobolev-grad-s42" --wandb_group "sobolev-gradient-loss" \
  --sobolev_grad_loss --sobolev_grad_weight 0.1 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling

CUDA_VISIBLE_DEVICES=1 python train.py --agent fern --seed 73 \
  --wandb_name "fern/sobolev-grad-s73" --wandb_group "sobolev-gradient-loss" \
  --sobolev_grad_loss --sobolev_grad_weight 0.1 \
  [same flags]
```

If weight=0.1 doesn't beat baseline, also try 0.05. If there is high arc-length spacing variance (non-uniform mesh), normalize by ds (arc-length spacing) as shown above.

## Baseline

- **p_in:** 11.742 | **p_oodc:** 7.643 | **p_tan:** 27.874 | **p_re:** 6.419
- Baseline W&B: k5qwvce4 (seed 42), 7oa5xfhi (seed 73)
- Reproduce command:
```bash
cd cfd_tandemfoil && python train.py --agent fern --seed 42 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling
```