### PR TITLE
Test-Time Normalization Adaptation for OOD generalization

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1173,6 +1173,9 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # Test-Time Normalization Adaptation (TTA)
+    tta_steps: int = 0                     # TTA gradient steps per val batch (0=disabled)
+    tta_lr: float = 1e-3                   # learning rate for TTA optimizer
 
 
 cfg = sp.parse(Config)
@@ -1655,6 +1658,63 @@ ema_val_loss = float("inf")
 ema_decay_val = 0.9
 best_metrics = {}
 global_step = 0
+def predict_with_tta(tta_model, x_batch, tta_steps, tta_lr):
+    """Test-time normalization adaptation: briefly fine-tune LayerNorm params, then predict.
+
+    Collects all LayerNorm/DomainLayerNorm weight/bias tensors, saves them, runs
+    tta_steps gradient steps minimizing prediction variance on the pressure channel
+    (a self-supervised signal — a well-adapted model should be confident/low-variance),
+    produces a prediction, then restores original params.
+
+    Returns: pred dict (same structure as eval_model({"x": x}))
+    """
+    # Collect LayerNorm parameters (scale and bias only, ndim <= 1)
+    # Works for both nn.LayerNorm (.weight/.bias) and DomainLayerNorm (.ln_single/.ln_tandem)
+    _tta_params = []
+    _tta_base = tta_model._orig_mod if hasattr(tta_model, '_orig_mod') else tta_model
+    for name, param in _tta_base.named_parameters():
+        lower = name.lower()
+        if any(k in lower for k in ['ln_', 'layernorm', 'layer_norm', 'norm']) and \
+                param.requires_grad and param.ndim <= 1:
+            _tta_params.append(param)
+
+    if not _tta_params or tta_steps <= 0:
+        tta_model.eval()
+        with torch.no_grad():
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                return tta_model({"x": x_batch})
+
+    # Save original values
+    _orig_vals = [p.data.clone() for p in _tta_params]
+
+    # TTA: minimize prediction variance on the pressure channel (index 2)
+    # Use enable_grad() to ensure gradients flow even if called inside torch.no_grad() context
+    tta_model.train()
+    _tta_opt = torch.optim.Adam(_tta_params, lr=tta_lr)
+    with torch.enable_grad():
+        for _ in range(tta_steps):
+            _tta_opt.zero_grad()
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                _out = tta_model({"x": x_batch})
+            _pred = _out["preds"].float()
+            # Variance across nodes for pressure channel — low variance = confident predictions
+            _tta_loss = _pred[:, :, 2].var(dim=1).mean()
+            _tta_loss.backward()
+            _tta_opt.step()
+
+    # Final prediction after adaptation
+    tta_model.eval()
+    with torch.no_grad():
+        with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+            _adapted_out = tta_model({"x": x_batch})
+
+    # Restore original params (don't contaminate across batches)
+    for param, orig in zip(_tta_params, _orig_vals):
+        param.data.copy_(orig)
+
+    return _adapted_out
+
+
 train_start = time.time()
 prev_vol_loss = 1.0
 prev_surf_loss = 0.2  # initial ratio ~5 (clamped minimum)
@@ -2582,12 +2642,13 @@ for epoch in range(MAX_EPOCHS):
                 else:
                     y_norm_scaled = y_norm / sample_stds
 
-                with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    _eval_out = eval_model({"x": x})
-                    pred = _eval_out["preds"]
-                    _eval_hidden = _eval_out["hidden"]
-                pred = pred.float()
-                _eval_hidden = _eval_hidden.float()
+                if cfg.tta_steps > 0:
+                    _eval_out = predict_with_tta(eval_model, x, cfg.tta_steps, cfg.tta_lr)
+                else:
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        _eval_out = eval_model({"x": x})
+                pred = _eval_out["preds"].float()
+                _eval_hidden = _eval_out["hidden"].float()
                 if cfg.multiply_std:
                     pred_loss = pred * sample_stds
                 else:


### PR DESCRIPTION
## Hypothesis

The model's DomainLayerNorm parameters are calibrated during training on the training distribution. At inference time, OOD samples (different Re, tandem configurations) have different activation statistics that don't match these calibrated norms. **Test-Time Adaptation (TTA)** briefly fine-tunes only the LayerNorm parameters (scale and shift — no backbone weights changed) on each test batch using a self-supervised signal before producing predictions.

This is inference-only: training is unchanged. Only 3-5 gradient steps on the test batch, updating only BatchNorm/LayerNorm parameters (gamma, beta). The self-supervised signal is minimizing prediction entropy or variance — the intuition is that a well-adapted model should make confident, low-variance predictions.

**Reference:** TENT: Fully Test-Time Adaptation by Entropy Minimization (Wang et al., ICLR 2021). This paper showed significant OOD accuracy improvements by adapting BatchNorm statistics at test time. Our DomainLayerNorm plays the same role.

**Target:** p_oodc and p_re — the ensemble-to-single-model gap is large (7.65 vs 6.6, 6.40 vs 5.8). TTA could close this gap without any training change.

## Instructions

This is an **evaluation-only** experiment. Training is identical to baseline. The modification is in the validation loop.

### Step 1: Add arguments

```python
parser.add_argument('--tta_steps', type=int, default=0,
                    help='Test-time adaptation steps (0=disabled, 3-5=typical)')
parser.add_argument('--tta_lr', type=float, default=1e-3,
                    help='Learning rate for TTA gradient steps')
```

### Step 2: Implement TTA in the validation loop

Find the validation loop (where `model.eval()` is called and val metrics are computed). Modify it to optionally perform TTA before prediction:

```python
def predict_with_tta(model, x, pos, args):
    """Run test-time normalization adaptation then predict."""
    if args.tta_steps <= 0:
        with torch.no_grad():
            return model(x, pos)
    
    # Collect only LayerNorm/DomainLayerNorm parameters (gamma, beta)
    tta_params = []
    for name, param in model.named_parameters():
        if any(ln_name in name for ln_name in ['domain_layernorm', 'norm', 'layernorm', 'layer_norm']):
            if param.requires_grad and param.ndim <= 2:  # only scale/bias tensors
                tta_params.append(param)
    
    if not tta_params:
        with torch.no_grad():
            return model(x, pos)
    
    # Save original values
    orig_params = [p.data.clone() for p in tta_params]
    
    # TTA: minimize prediction variance (entropy proxy)
    model.train()
    tta_optimizer = torch.optim.Adam(tta_params, lr=args.tta_lr)
    for step in range(args.tta_steps):
        tta_optimizer.zero_grad()
        with torch.enable_grad():
            pred = model(x, pos)
            # Minimize variance of predictions (encourages confident predictions)
            # Apply only to pressure channel (index 2)
            tta_loss = pred[:, :, 2].var(dim=1).mean()
        tta_loss.backward()
        tta_optimizer.step()
    
    # Final prediction after adaptation
    model.eval()
    with torch.no_grad():
        adapted_pred = model(x, pos)
    
    # Restore original params (don't contaminate between batches)
    for param, orig in zip(tta_params, orig_params):
        param.data = orig
    
    return adapted_pred
```

Then in the validation loop, replace `model(x, pos)` calls with `predict_with_tta(model, x, pos, args)`.

### Step 3: Run

Training is identical to baseline. Run 2 seeds:

```bash
CUDA_VISIBLE_DEVICES=0 python train.py --agent nezuko --seed 42 \
  --wandb_name "nezuko/tta-norm-s42" --wandb_group "test-time-norm-adaptation" \
  --tta_steps 3 --tta_lr 1e-3 \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling

CUDA_VISIBLE_DEVICES=1 python train.py --agent nezuko --seed 73 \
  --wandb_name "nezuko/tta-norm-s73" --wandb_group "test-time-norm-adaptation" \
  --tta_steps 3 --tta_lr 1e-3 \
  [same flags]
```

Also try `--tta_steps 5` if 3 doesn't help. The TTA adds minimal overhead (3 extra forward passes per batch during validation only).

## Baseline

- **p_in:** 11.742 | **p_oodc:** 7.643 | **p_tan:** 27.874 | **p_re:** 6.419
- Ensemble gap targets: p_oodc < 7.0 (ensemble=6.6), p_re < 6.0 (ensemble=5.8)
- Baseline W&B: k5qwvce4 (seed 42), 7oa5xfhi (seed 73)