### PR TITLE
Flow-Regime MoE Output Routing: expert specialization by config

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -757,6 +757,52 @@ class SurfaceRefinementContextHead(nn.Module):
         return correction
 
 
+class RegimeMoE(nn.Module):
+    """Flow-regime Mixture-of-Experts output head.
+
+    Soft-gates n_experts output MLPs using 4 global flow regime features
+    [re_norm, aoa_norm, is_tandem, gap_norm]. Each expert maps hidden → out_dim.
+    Output is zero-initialized (additive correction behavior at init).
+
+    The gate is conditioned on global flow conditions, not per-node features,
+    so routing is consistent across all nodes in a sample.
+    """
+
+    def __init__(self, hidden_dim: int, n_experts: int = 3, out_dim: int = 3, regime_dim: int = 4):
+        super().__init__()
+        self.n_experts = n_experts
+        # Gate: global regime features → expert weights
+        self.gate = nn.Linear(regime_dim, n_experts)
+        nn.init.zeros_(self.gate.weight)
+        nn.init.zeros_(self.gate.bias)
+        # Experts: each is a 2-layer MLP hidden → hidden → out_dim
+        self.experts = nn.ModuleList([
+            nn.Sequential(
+                nn.Linear(hidden_dim, hidden_dim), nn.GELU(),
+                nn.Linear(hidden_dim, out_dim)
+            )
+            for _ in range(n_experts)
+        ])
+        # Zero-init last linear of each expert (additive correction starts at 0)
+        for expert in self.experts:
+            nn.init.zeros_(expert[-1].weight)
+            nn.init.zeros_(expert[-1].bias)
+
+    def forward(self, h: torch.Tensor, regime_feats: torch.Tensor):
+        """
+        Args:
+            h: [B, N, hidden_dim] — node hidden representations (pre-output-head)
+            regime_feats: [B, 4] — global regime features per sample
+        Returns:
+            blended: [B, N, out_dim] — soft-blended expert outputs
+            weights: [B, n_experts] — gate weights (for load-balance logging)
+        """
+        weights = F.softmax(self.gate(regime_feats), dim=-1)  # [B, n_experts]
+        expert_outs = torch.stack([e(h) for e in self.experts], dim=-1)  # [B, N, out_dim, n_experts]
+        blended = (expert_outs * weights[:, None, None, :]).sum(-1)  # [B, N, out_dim]
+        return blended, weights
+
+
 class Transolver(nn.Module):
     def __init__(
         self,
@@ -1173,6 +1219,10 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # Flow-regime MoE output head
+    moe_output: bool = False               # replace output head with regime-conditioned MoE
+    moe_n_experts: int = 3                 # number of MoE experts (default 3: single, tandem-normal, tandem-extreme)
+    moe_balance_weight: float = 0.01       # load-balancing auxiliary loss weight (entropy maximization)
 
 
 cfg = sp.parse(Config)
@@ -1411,6 +1461,18 @@ if cfg.aft_foil_srf:
               f"(hidden={cfg.aft_foil_srf_hidden}, layers={cfg.aft_foil_srf_layers}, "
               f"film={cfg.aft_foil_srf_film})")
 
+# Flow-regime MoE output head
+moe_head = None
+if cfg.moe_output:
+    moe_head = RegimeMoE(
+        hidden_dim=model_config["n_hidden"],
+        n_experts=cfg.moe_n_experts,
+        out_dim=3,
+        regime_dim=4,
+    ).to(device)
+    _moe_n_params = sum(p.numel() for p in moe_head.parameters())
+    print(f"RegimeMoE head: {_moe_n_params:,} params (n_experts={cfg.moe_n_experts})")
+
 from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
@@ -1576,6 +1638,12 @@ if aft_srf_ctx_head is not None:
     _ctx_params = list(aft_srf_ctx_head.parameters())
     base_opt.add_param_group({'params': _ctx_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _ctx_params):,} aft-foil SRF context head params to optimizer")
+
+# Add MoE head params to optimizer if enabled
+if moe_head is not None:
+    _moe_params = list(moe_head.parameters())
+    base_opt.add_param_group({'params': _moe_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _moe_params):,} RegimeMoE head params to optimizer")
 
 sam_optimizer = SAM(base_opt, rho=0.05) if cfg.adaln_sam else None
 if cfg.scheduler_type == "warm_restarts":
@@ -1979,6 +2047,23 @@ for epoch in range(MAX_EPOCHS):
                 pred = pred.clone()
                 pred[aft_idx[:, 0], aft_idx[:, 1]] = pred[aft_idx[:, 0], aft_idx[:, 1]] + aft_correction
 
+        # Flow-regime MoE output head: additive correction on top of base predictions
+        _moe_weights = None
+        if moe_head is not None and model.training:
+            # Extract regime features (after normalization)
+            _is_tandem_moe = (x[:, 0, 21].abs() > 0.01).float()  # [B] — matches existing tandem detection
+            _gap_moe = x[:, 0, 22] * _is_tandem_moe  # gap (zeroed for single-foil)
+            _regime_feats = torch.stack([
+                x[:, 0, 13],      # log(Re) normalized
+                x[:, 0, 14],      # AoA0 normalized
+                _is_tandem_moe,   # is_tandem
+                _gap_moe,         # gap magnitude (0 for single-foil)
+            ], dim=-1)  # [B, 4]
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                _moe_correction, _moe_weights = moe_head(hidden.half(), _regime_feats)
+            _moe_correction = _moe_correction.float()
+            pred = pred + _moe_correction
+
         sq_err = (pred - y_norm) ** 2
         abs_err = (pred - y_norm).abs()
         if cfg.tandem_ramp:
@@ -2097,6 +2182,20 @@ for epoch in range(MAX_EPOCHS):
         aoa_target = x[:, 0, 14:15]  # AoA0_rad from normalized input
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
+
+        # MoE load-balancing: maximize gate entropy to prevent expert collapse
+        if _moe_weights is not None and model.training:
+            # Entropy of gate distribution: higher = more balanced routing
+            _gate_entropy = -(_moe_weights * _moe_weights.log().clamp(min=-10)).sum(-1).mean()
+            _balance_loss = -cfg.moe_balance_weight * _gate_entropy  # negative = maximize
+            loss = loss + _balance_loss
+            if global_step % 20 == 0:
+                wandb.log({
+                    "moe/gate_entropy": _gate_entropy.item(),
+                    "moe/balance_loss": _balance_loss.item(),
+                    "moe/weights_mean": _moe_weights.mean(0).detach().cpu().tolist(),
+                    "global_step": global_step,
+                })
 
         # DCT frequency-weighted auxiliary loss on surface pressure
         if cfg.dct_freq_loss and model.training:
@@ -2651,6 +2750,22 @@ for epoch in range(MAX_EPOCHS):
                             pred = pred_loss / sample_stds
                         else:
                             pred = pred_loss * sample_stds
+
+                # Apply MoE output head during validation
+                if moe_head is not None:
+                    _is_tandem_moe_v = (x[:, 0, 21].abs() > 0.01).float()
+                    _gap_moe_v = x[:, 0, 22] * _is_tandem_moe_v
+                    _regime_feats_v = torch.stack([
+                        x[:, 0, 13], x[:, 0, 14], _is_tandem_moe_v, _gap_moe_v
+                    ], dim=-1)
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        _moe_corr_v, _ = moe_head(_eval_hidden.half(), _regime_feats_v)
+                    _moe_corr_v = _moe_corr_v.float()
+                    pred_loss = pred_loss + _moe_corr_v
+                    if cfg.multiply_std:
+                        pred = pred_loss / sample_stds
+                    else:
+                        pred = pred_loss * sample_stds
 
                 sq_err = (pred_loss - y_norm_scaled) ** 2
                 abs_err = (pred_loss - y_norm_scaled).abs()


### PR DESCRIPTION
## Hypothesis

The current model uses a single output projection for all flow regimes (single-foil, tandem, high-Re). Different regimes have qualitatively different pressure distributions — tandem interference creates wakes and downwash absent in single-foil, while high-Re adds turbulent boundary layer effects. A lightweight Mixture-of-Experts at the output stage lets the model specialize.

**Key distinction from failed MoE FFN routing:** That approach used hard dispatch of tokens to FFN experts (starved experts in small-dataset regime). This approach uses SOFT blending of output-stage expert heads, conditioned on global flow regime features. The full Transolver backbone is shared — only the final output projection is split.

**Reference:** "Mixture of Experts for External Aerodynamics" (arXiv:2508.21249, 2025). Reports 8-15% improvement on regime boundaries.

## Instructions

Replace the final output linear layer with a 3-expert soft-routed MoE head.

### Step 1: Add arguments

```python
parser.add_argument('--moe_output', action='store_true')
parser.add_argument('--moe_n_experts', type=int, default=3)
parser.add_argument('--moe_balance_weight', type=float, default=0.01,
                    help='Load-balancing aux loss weight')
```

### Step 2: Implement RegimeMoE module

```python
class RegimeMoE(nn.Module):
    def __init__(self, hidden_dim, n_experts=3, out_dim=3):
        super().__init__()
        self.gate = nn.Linear(4, n_experts)  # input: [re_norm, aoa_norm, is_tandem, gap_norm]
        nn.init.zeros_(self.gate.weight)  # uniform initial routing
        nn.init.zeros_(self.gate.bias)
        self.experts = nn.ModuleList([
            nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.GELU(),
                          nn.Linear(hidden_dim, out_dim))
            for _ in range(n_experts)
        ])
    
    def forward(self, h, regime_feats):
        # h: [B, N, hidden_dim], regime_feats: [B, 4]
        weights = F.softmax(self.gate(regime_feats), dim=-1)  # [B, n_experts]
        expert_outs = torch.stack([e(h) for e in self.experts], dim=-1)  # [B, N, 3, n_experts]
        blended = (expert_outs * weights[:, None, None, :]).sum(-1)  # [B, N, 3]
        return blended, weights
```

### Step 3: Extract regime features from input

In the forward pass, extract global flow condition features:

```python
# re_norm = x[:, 0, 14] (normalized Re — check column index)
# aoa_norm = x[:, 0, 15] (or wherever AoA is stored)
# is_tandem = (x[:, :, 7].abs().max(dim=1).values > 0.01).float()  # nonzero dsdf2 = tandem
# gap_norm = x[:, :, 16].abs().max(dim=1).values  # gap magnitude proxy
# regime_feats = torch.stack([re_norm, aoa_norm, is_tandem, gap_norm], dim=-1)  # [B, 4]
```

Verify the actual column indices by inspecting x features in a debug run.

### Step 4: Add load-balancing loss

```python
if args.moe_output:
    # Maximize entropy of gate distribution to prevent collapse
    gate_entropy = -(weights * weights.log().clamp(min=-10)).sum(-1).mean()
    balance_loss = -args.moe_balance_weight * gate_entropy  # negative because we maximize entropy
    total_loss = total_loss + balance_loss
```

### Step 5: Run

```bash
CUDA_VISIBLE_DEVICES=0 python train.py --agent alphonse --seed 42 \
  --wandb_name "alphonse/moe-output-s42" --wandb_group "moe-output-routing" \
  --moe_output --moe_n_experts 3 --moe_balance_weight 0.01 \
  [+ all baseline flags from reproduce command]

CUDA_VISIBLE_DEVICES=1 python train.py --agent alphonse --seed 73 \
  --wandb_name "alphonse/moe-output-s73" --wandb_group "moe-output-routing" \
  --moe_output --moe_n_experts 3 --moe_balance_weight 0.01 \
  [+ all baseline flags]
```

## Baseline

- **p_in:** 11.742 | **p_oodc:** 7.643 | **p_tan:** 27.874 | **p_re:** 6.419
- Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 --pressure_first --pressure_deep --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 --gap_stagger_spatial_bias --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 --te_coord_frame --wake_deficit_feature --re_stratified_sampling`