### PR TITLE
Linear Warmup + Cosine Decay: stabilize early training

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1048,6 +1048,7 @@ class Config:
     warmup_start_factor: float = 0.2
     cosine_T_max: int = 230
     cosine_eta_min: float = 1e-5
+    warmup_epochs: int = 0  # linear warmup epochs with near-zero start (0=use default warmup)
     ema_start_epoch: int = 140
     ema_decay: float = 0.998
     temp_anneal_epoch: int = 50
@@ -1597,15 +1598,26 @@ elif cfg.scheduler_type == "onecycle":
         final_div_factor=cfg.onecycle_final_div_factor,
     )
 else:  # sequential (default)
+    if cfg.warmup_epochs > 0:
+        # Near-zero start warmup (PR #2326): start at lr*1e-3, ramp to full lr
+        _wu_iters = cfg.warmup_epochs
+        _wu_start = 1e-3
+        _cos_T = cfg.cosine_T_max - cfg.warmup_epochs  # budget-adjusted
+        print(f"[warmup_epochs={cfg.warmup_epochs}] LinearLR(start_factor={_wu_start}) "
+              f"-> CosineAnnealingLR(T_max={_cos_T})")
+    else:
+        _wu_iters = cfg.warmup_total_iters
+        _wu_start = cfg.warmup_start_factor
+        _cos_T = cfg.cosine_T_max
     warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
-        base_opt, start_factor=cfg.warmup_start_factor, total_iters=cfg.warmup_total_iters
+        base_opt, start_factor=_wu_start, total_iters=_wu_iters
     )
     cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-        base_opt, T_max=cfg.cosine_T_max, eta_min=cfg.cosine_eta_min
+        base_opt, T_max=_cos_T, eta_min=cfg.cosine_eta_min
     )
     scheduler = torch.optim.lr_scheduler.SequentialLR(
         base_opt, schedulers=[warmup_scheduler, cosine_scheduler],
-        milestones=[cfg.warmup_total_iters]
+        milestones=[_wu_iters]
     )
 step_scheduler_per_batch = (cfg.scheduler_type == "onecycle")
 


### PR DESCRIPTION
## Hypothesis

The current training uses Lion optimizer with a fixed cosine schedule (T_max=150, no warmup). Lion is a sign-based optimizer that is more sensitive to learning rate than Adam — the paper (Chen et al., 2024) specifically recommends using a warmup period to stabilize early training dynamics.

**Key observation:** Our baseline trains ~147 epochs in 180 minutes. With cosine T_max=150, the LR starts at its maximum (2e-4) from epoch 0 and decays to ~0 by epoch 150. The first few epochs — when the model parameters are randomly initialized — use the full learning rate on a loss landscape that is highly non-convex. This can cause the optimizer to overshoot into poor basins early, requiring many subsequent epochs to recover.

**Literature support:**
- Chen et al., "Symbolic Discovery of Optimization Algorithms" (NeurIPS 2024): Lion benefits from warmup due to sign-based updates.
- Gotmare et al., "A Closer Look at Deep Learning Heuristics: LR Warmup" (ICLR 2019): Warmup reduces variance of gradient estimates in early training, leading to better final solutions.
- Loshchilov & Hutter (2017): CosineAnnealing with warmup is standard for transformer training.

**Hypothesis:** Adding 5-10 epochs of linear warmup (0 → lr) before cosine decay will:
1. Prevent early overshooting and help the model find better initial loss basins
2. Improve OOD metrics (p_oodc, p_re) since OOD generalization is most sensitive to early training dynamics
3. Not hurt convergence since the warmup period is short (3-7% of total training)

## Instructions

Add a `--warmup_epochs` argument and implement linear warmup before cosine annealing.

### Step 1: Add argument

```python
parser.add_argument('--warmup_epochs', type=int, default=0,
                    help='Linear warmup epochs before cosine decay (0=disabled)')
```

### Step 2: Replace the LR scheduler

Currently the code uses `CosineAnnealingLR(optimizer, T_max=args.cosine_T_max)`.

Replace with a `SequentialLR` that chains warmup + cosine:

```python
if args.warmup_epochs > 0:
    warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
        optimizer,
        start_factor=1e-3,    # Start at lr * 1e-3 = 2e-7
        end_factor=1.0,       # Ramp to full lr = 2e-4
        total_iters=args.warmup_epochs
    )
    cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
        optimizer,
        T_max=args.cosine_T_max - args.warmup_epochs  # Remaining epochs for cosine
    )
    scheduler = torch.optim.lr_scheduler.SequentialLR(
        optimizer,
        schedulers=[warmup_scheduler, cosine_scheduler],
        milestones=[args.warmup_epochs]
    )
else:
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
        optimizer, T_max=args.cosine_T_max
    )
```

**Important:** Adjust cosine T_max so that warmup + cosine together fill the full 150-epoch budget: `T_max = 150 - warmup_epochs`. This ensures the schedule still completes at the training cutoff.

### Step 3: Run 3 experiments (2 seeds each)

Try warmup_epochs=5, 10, 15 to find the optimal warmup length:

```bash
# Warmup 5 epochs (seed 42)
cd cfd_tandemfoil && python train.py \
  --agent edward --wandb_name "edward/warmup5-s42" --seed 42 \
  --wandb_group warmup-cosine-schedule \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling \
  --warmup_epochs 5

# Repeat for seed 73: --seed 73 --wandb_name "edward/warmup5-s73"
```

**Run warmup_epochs=5 first** (2 seeds). Only if promising, try warmup=10. Use 2 GPUs to run both seeds in parallel:

```bash
CUDA_VISIBLE_DEVICES=0 python train.py ... --warmup_epochs 5 --seed 42 &
CUDA_VISIBLE_DEVICES=1 python train.py ... --warmup_epochs 5 --seed 73 &
wait
```

If warmup=5 is promising, run warmup=10 on the remaining GPUs. Do NOT run all 3 values simultaneously — sequential is fine here since we want to see the 5-epoch result first.

## Baseline

Current best metrics (PR #2290, 2-seed avg):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 11.742 | < 11.742 |
| p_oodc | 7.643 | < 7.643 |
| p_tan | 27.874 | < 27.874 |
| p_re | 6.419 | < 6.419 |

- **Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)
- **val/loss baseline:** ~0.37

**Reproduce baseline (no warmup):**
```bash
cd cfd_tandemfoil && python train.py --agent edward --wandb_name "edward/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling
```