### PR TITLE
Sample Mixup: interpolate training samples for OOD robustness

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1173,6 +1173,9 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # Sample-level mixup augmentation
+    mixup: bool = False                    # enable sample-level mixup (interpolate batch pairs)
+    mixup_alpha: float = 0.2              # Beta distribution parameter for mixup lambda
 
 
 cfg = sp.parse(Config)
@@ -1778,6 +1781,19 @@ for epoch in range(MAX_EPOCHS):
                 # Identity for non-tandem samples
                 _dsdf2_scale = _dsdf2_scale * _is_tandem_aug2.float() + (~_is_tandem_aug2).float()
                 x[:, :, 6:10] = x[:, :, 6:10] * _dsdf2_scale.view(-1, 1, 1)
+
+        # Sample-level mixup augmentation (applied after other aug, before normalization)
+        if cfg.mixup and model.training:
+            _alpha = torch.tensor(cfg.mixup_alpha)
+            _lam = float(torch.distributions.Beta(_alpha, _alpha).sample())
+            _lam = max(_lam, 1 - _lam)  # ensure lambda >= 0.5 (closer to original sample)
+            _B_mx = x.size(0)
+            _mix_idx = torch.randperm(_B_mx, device=x.device)
+            x = _lam * x + (1 - _lam) * x[_mix_idx]
+            y = _lam * y + (1 - _lam) * y[_mix_idx]
+            # Use intersection of masks so padded regions remain masked
+            mask = mask & mask[_mix_idx]
+            is_surface = is_surface & is_surface[_mix_idx]
 
         raw_dsdf = x[:, :, 2:10]  # original dsdf before standardization
         dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values


### PR DESCRIPTION
## Hypothesis

Mixup (Zhang et al., ICLR 2018) interpolates between pairs of training samples: `x_mix = λ*x_i + (1-λ)*x_j`, `y_mix = λ*y_i + (1-λ)*y_j` where λ ~ Beta(α, α). This creates virtual training samples that lie between existing data points, forcing the model to learn smooth interpolations across the input space.

**Why this should help OOD metrics:** Our biggest gaps to the 16-seed ensemble are on p_oodc (-14%) and p_re (-9%). These OOD splits test the model on conditions (AoA, Re) not seen in training. Mixup generates virtual samples at interpolated conditions, effectively expanding the training distribution. The model learns that predictions should vary smoothly with AoA and Re — exactly the inductive bias needed for OOD generalization.

**Key constraint:** Standard image-space mixup doesn't directly apply because our samples have different mesh topologies (different number of nodes, different connectivity). However, our data loader already pads samples to a common size. We can do **sample-level mixup** — interpolating the padded feature tensors and target tensors of two samples in the same batch.

**Literature support:**
- Zhang et al., "mixup: Beyond Empirical Risk Minimization" (ICLR 2018): 1-3% improvement on supervised tasks via linear interpolation.
- Yao et al., "Improving Out-of-Distribution Robustness via Selective Augmentation" (ICML 2022): Mixup specifically improves OOD robustness when mixing across domain boundaries.
- For PDE surrogates: "Augmentation Strategies for Operator Learning" (NeurIPS ML4PS 2024 workshop) — mixup on coefficient-space shows 5-12% OOD improvement.

**Hypothesis:** Mixing pairs of training samples with different (AoA, Re, geometry) creates virtual samples the model has never seen, acting as a free data augmentation that specifically targets the interpolation gaps where OOD errors arise. The model learns smoother functions of the conditioning variables.

## Instructions

Implement sample-level mixup in the training loop. This operates on the already-padded batch tensors.

### Step 1: Add arguments

```python
parser.add_argument('--mixup', action='store_true',
                    help='Enable sample-level mixup augmentation')
parser.add_argument('--mixup_alpha', type=float, default=0.2,
                    help='Beta distribution parameter for mixup (default 0.2)')
```

### Step 2: Implement mixup in the training loop

After loading a batch but **before** the forward pass, randomly mix pairs of samples:

```python
if args.mixup and model.training:
    # Sample mixup coefficient from Beta(alpha, alpha)
    lam = np.random.beta(args.mixup_alpha, args.mixup_alpha)
    lam = max(lam, 1 - lam)  # Ensure lam >= 0.5 (closer to original sample)
    
    # Random permutation for pairing
    batch_size = x.size(0)
    index = torch.randperm(batch_size, device=x.device)
    
    # Mix inputs and targets
    x_mixed = lam * x + (1 - lam) * x[index]
    y_mixed = lam * y + (1 - lam) * y[index]
    
    # Also mix the mask (use the intersection — only nodes valid in BOTH samples)
    # This is critical: padded regions must stay masked
    mask_mixed = mask & mask[index]  # Both samples must have a real node here
    
    # Use mixed data for this training step
    x = x_mixed
    y = y_mixed
    mask = mask_mixed
```

**Critical implementation detail — mask handling:** When mixing two samples with different mesh sizes, some nodes will be padding in one sample but real in the other. Use the intersection of masks (`mask & mask[index]`) so only positions where BOTH samples have real nodes contribute to the mixed loss. This avoids mixing real values with padding zeros.

**Critical implementation detail — domain features:** Some features (like `is_tandem`, `re`, `aoa`) are sample-level constants that get broadcast to all nodes. After mixing, these become interpolated values (e.g., `is_tandem = 0.7`), which is fine — the model should learn smooth responses to these conditions.

### Step 3: Handle surface mask and domain features

The `surf_mask` (which nodes are on the foil surface) also needs intersection:

```python
if args.mixup and model.training:
    surf_mask_mixed = surf_mask & surf_mask[index]
    surf_mask = surf_mask_mixed
```

### Step 4: Run 2 seeds with alpha=0.2

```bash
cd cfd_tandemfoil && python train.py \
  --agent nezuko --wandb_name "nezuko/mixup-a0.2-s42" --seed 42 \
  --wandb_group node-mixup-augmentation \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling \
  --mixup --mixup_alpha 0.2

# Repeat for seed 73: --seed 73 --wandb_name "nezuko/mixup-a0.2-s73"
```

Run both seeds in parallel on 2 GPUs:
```bash
CUDA_VISIBLE_DEVICES=0 python train.py ... --seed 42 &
CUDA_VISIBLE_DEVICES=1 python train.py ... --seed 73 &
wait
```

**Do NOT use mixup during validation** — validation must use clean (unmixed) samples for comparable metrics.

**Compute overhead:** Near zero — one random permutation and one linear interpolation per batch. No extra forward/backward passes.

## Baseline

Current best metrics (PR #2290, 2-seed avg):

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 11.742 | < 11.742 |
| p_oodc | 7.643 | < 7.643 |
| p_tan | 27.874 | < 27.874 |
| p_re | 6.419 | < 6.419 |

- **Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)
- **val/loss baseline:** ~0.37

**Reproduce baseline:**
```bash
cd cfd_tandemfoil && python train.py --agent nezuko --wandb_name "nezuko/baseline" \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling
```