### PR TITLE
AoA Curriculum: train easy samples first, full dist later

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1173,6 +1173,9 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # AoA curriculum learning
+    aoa_curriculum: bool = False            # curriculum: start with low-AoA (easy) samples, ramp to full
+    aoa_curriculum_warmup: int = 40         # epochs over which to ramp from easy to full distribution
 
 
 cfg = sp.parse(Config)
@@ -1247,6 +1250,16 @@ if cfg.re_stratified_sampling and not cfg.debug:
     print(f"Re-stratified sampling: {_n_extreme}/{len(train_ds)} extreme-Re samples "
           f"({_n_extreme/len(train_ds)*100:.1f}%) upweighted {cfg.re_extreme_weight}x "
           f"(log_Re thresholds: [{_re_low:.3f}, {_re_high:.3f}])")
+
+# AoA curriculum: compute difficulty rank for each training sample
+_aoa_rank = None
+_base_sample_weights = None
+if cfg.aoa_curriculum and not cfg.debug:
+    _train_aoa_abs = torch.tensor([abs(train_ds[i][0][0, 14].item()) for i in range(len(train_ds))])
+    _aoa_rank = _train_aoa_abs.argsort().argsort().float() / len(train_ds)  # 0=easiest, 1=hardest
+    _base_sample_weights = sample_weights.clone()
+    print(f"AoA curriculum: warmup={cfg.aoa_curriculum_warmup} epochs, "
+          f"|AoA| range=[{_train_aoa_abs.min():.3f}, {_train_aoa_abs.max():.3f}] rad")
 
 if cfg.debug:
     # Avoid sampler/length mismatch when train_ds is truncated
@@ -1668,6 +1681,20 @@ for epoch in range(MAX_EPOCHS):
         break
 
     t0 = time.time()
+
+    # AoA curriculum: update sampler weights based on epoch progress
+    _curriculum_progress = None
+    if _aoa_rank is not None and not cfg.debug:
+        if epoch < cfg.aoa_curriculum_warmup:
+            _curriculum_progress = epoch / cfg.aoa_curriculum_warmup
+            temperature = 0.1 + 0.9 * _curriculum_progress  # 0.1 -> 1.0
+            curriculum_weights = torch.sigmoid((temperature - _aoa_rank) / 0.1)
+            curriculum_weights = curriculum_weights / curriculum_weights.mean()  # normalize to mean=1
+            sampler.weights = _base_sample_weights * curriculum_weights.double()
+        else:
+            _curriculum_progress = 1.0
+            if epoch == cfg.aoa_curriculum_warmup:
+                sampler.weights = _base_sample_weights  # revert to base weights (uniform)
 
     # Adaptive surface weight: loss-ratio based, clamped [5, 50]
     surf_weight = max(5.0, min(50.0, prev_vol_loss / max(prev_surf_loss, 1e-8)))
@@ -2409,13 +2436,16 @@ for epoch in range(MAX_EPOCHS):
     _do_val = (epoch + 1) % cfg.val_every == 0 or epoch == 0 or epoch == MAX_EPOCHS - 1
     if not _do_val:
         dt = time.time() - t0
-        wandb.log({
+        _skip_log = {
             "train/vol_loss": epoch_vol,
             "train/surf_loss": epoch_surf,
             "epoch_time_s": dt,
             "lr": scheduler.get_last_lr()[0],
             "global_step": global_step,
-        })
+        }
+        if _curriculum_progress is not None:
+            _skip_log["curriculum/progress"] = _curriculum_progress
+        wandb.log(_skip_log)
         print(f"Epoch {epoch+1:3d} ({dt:.0f}s)  train[vol={epoch_vol:.4f} surf={epoch_surf:.4f}]  [val skipped]")
         continue
 
@@ -2789,6 +2819,8 @@ for epoch in range(MAX_EPOCHS):
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+    if _curriculum_progress is not None:
+        metrics["curriculum/progress"] = _curriculum_progress
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f


### PR DESCRIPTION
## Hypothesis

Training on all samples uniformly from epoch 0 exposes the model to high-AoA separated-flow cases early, when model capacity is not yet sufficient to handle them. These hard cases (high |AoA|, separated flow, strong pressure gradients) dominate loss variance and cause the optimizer to converge to basins that favor hard cases at the expense of overall generalization.

**Curriculum learning** (Bengio et al., 2009) trains on easy samples first, gradually introducing harder ones. For our domain: low-AoA (attached flow, smooth pressure) → high-AoA (separated flow, sharp pressure features).

**Why this targets OOD:** The p_oodc and p_re validation splits contain AoA/Re combinations not seen in training. A model trained with curriculum develops more robust feature representations — it learns the basic pressure physics first (attached flow is well-described by thin-airfoil theory), then learns the corrections for separation. This structured learning improves generalization to unseen conditions.

**Evidence:** Curriculum learning consistently improves OOD regression generalization in structured prediction tasks (Kaggle competition evidence; also Hacohen & Weinshall, "On The Power of Curriculum Learning in Training DNNs", ICML 2019).

## Instructions

### Step 1: Add arguments

```python
parser.add_argument('--aoa_curriculum', action='store_true',
                    help='Curriculum training: start with low-AoA samples, ramp to full')
parser.add_argument('--aoa_curriculum_warmup', type=int, default=40,
                    help='Epochs over which to ramp from easy to full distribution (default 40)')
```

### Step 2: Implement curriculum sampler

After the dataset is loaded, sort training samples by |AoA| (absolute angle of attack). During training, use a probability-weighted sampler that starts by overweighting low-AoA samples and smoothly transitions to uniform:

```python
if args.aoa_curriculum:
    # Get AoA for each training sample
    # AoA is typically in the input features or metadata
    # Check data structure: aoa might be in x[:, 0, aoa_feature_idx] or in sample metadata
    aoa_abs = []
    for i in range(len(train_dataset)):
        sample = train_dataset[i]
        # Extract AoA — check which feature index contains AoA
        # It's likely a global feature (same for all nodes in a sample)
        aoa_val = sample['x'][0, AOA_FEATURE_IDX].abs().item()
        aoa_abs.append(aoa_val)
    aoa_abs = torch.tensor(aoa_abs)
    
    # Rank samples by difficulty (|AoA|)
    aoa_rank = aoa_abs.argsort().argsort().float() / len(aoa_abs)  # 0 = easiest, 1 = hardest
    
    # During training, epoch-dependent sampling weights:
    def get_curriculum_weights(epoch, warmup_epochs, difficulty_rank):
        """Returns per-sample weights. Early: favor easy. Late: uniform."""
        if epoch >= warmup_epochs:
            return torch.ones_like(difficulty_rank)
        progress = epoch / warmup_epochs  # 0 -> 1
        # Sigmoid ramp: hard samples gradually included
        # At progress=0: weight for hardest ~0.05, easiest ~1.0
        # At progress=1: all weights ~1.0
        temperature = 0.1 + 0.9 * progress  # 0.1 -> 1.0
        weights = torch.sigmoid((temperature - difficulty_rank) / 0.1)
        weights = weights / weights.mean()  # Normalize to mean=1
        return weights
```

### Step 3: Use WeightedRandomSampler with epoch-dependent weights

At the start of each epoch, recompute the curriculum weights and create a new sampler:

```python
if args.aoa_curriculum:
    curriculum_weights = get_curriculum_weights(epoch, args.aoa_curriculum_warmup, aoa_rank)
    # Combine with existing re_stratified weights if both are active
    if args.re_stratified_sampling:
        final_weights = curriculum_weights * re_weights  # Element-wise multiply
    else:
        final_weights = curriculum_weights
    train_sampler = WeightedRandomSampler(final_weights, len(train_dataset), replacement=True)
    train_loader = DataLoader(train_dataset, batch_size=..., sampler=train_sampler, ...)
```

**Important:** Rebuild the DataLoader each epoch (or at least update the sampler weights). This is cheap — the overhead is just recomputing weights and creating a new sampler.

### Step 4: Run 2 seeds

```bash
cd cfd_tandemfoil && python train.py \
  --agent fern --wandb_name "fern/aoa-curriculum-s42" --seed 42 \
  --wandb_group aoa-curriculum-training \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling \
  --aoa_curriculum --aoa_curriculum_warmup 40

# Repeat for seed 73: --seed 73 --wandb_name "fern/aoa-curriculum-s73"
```

**Note:** The AoA feature index in the input tensor needs to be identified from the data pipeline. Check the feature ordering in prepare_multi.py or the dataset class. If AoA is not directly in the node features, it may be in a separate metadata field.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 11.742 | < 11.742 |
| p_oodc | 7.643 | < 7.643 |
| p_tan | 27.874 | < 27.874 |
| p_re | 6.419 | < 6.419 |

- **Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)
- **val/loss baseline:** ~0.37