### PR TITLE
Log1p Pressure Target: compress pressure dynamic range

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1157,6 +1157,7 @@ class Config:
     # Phase 6: Asinh pressure transform
     asinh_pressure: bool = False             # transform pressure targets with asinh for dynamic range compression
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
+    log1p_pressure: bool = False             # transform pressure targets with sign(p)*log1p(|p|) for dynamic range compression
     # Phase 6: Adaptive per-channel target normalization
     adaptive_norm: bool = False              # use per-channel running-mean/std normalization instead of physics-based
     # Phase 6: Dedicated aft-foil surface refinement head (boundary ID=7 nodes only)
@@ -1177,6 +1178,9 @@ class Config:
 
 cfg = sp.parse(Config)
 
+if cfg.log1p_pressure and cfg.asinh_pressure:
+    raise ValueError("--log1p_pressure and --asinh_pressure are mutually exclusive")
+
 if cfg.seed >= 0:
     torch.manual_seed(cfg.seed)
     torch.cuda.manual_seed_all(cfg.seed)
@@ -1191,6 +1195,16 @@ train_ds, val_splits, stats, sample_weights = load_data(
     cfg.manifest, cfg.stats_file, debug=cfg.debug,
 )
 stats = {k: v.to(device) for k, v in stats.items()}
+
+
+def _log1p_transform(p):
+    """Sign-preserving log1p: sign(p) * log1p(|p|)"""
+    return torch.sign(p) * torch.log1p(torch.abs(p))
+
+
+def _log1p_inverse(p):
+    """Inverse of sign-preserving log1p: sign(p) * (exp(|p|) - 1)"""
+    return torch.sign(p) * (torch.exp(torch.abs(p)) - 1)
 
 
 def _umag_q(y, mask):
@@ -1284,6 +1298,9 @@ with torch.no_grad():
         if cfg.asinh_pressure:
             _yp = _yp.clone()
             _yp[:, :, 2:3] = torch.asinh(_yp[:, :, 2:3] * cfg.asinh_scale)
+        if cfg.log1p_pressure:
+            _yp = _yp.clone()
+            _yp[:, :, 2:3] = _log1p_transform(_yp[:, :, 2:3])
         _m = _mask.float().unsqueeze(-1)  # [B, N, 1]
         _phys_sum += (_yp * _m).sum(dim=(0, 1))
         _phys_sq_sum += (_yp ** 2 * _m).sum(dim=(0, 1))
@@ -1305,6 +1322,8 @@ if cfg.raw_targets or cfg.adaptive_norm:
             _yt = _y.clone()
             if cfg.adaptive_norm and cfg.asinh_pressure:
                 _yt[:, :, 2:3] = torch.asinh(_yt[:, :, 2:3] * cfg.asinh_scale)
+            if cfg.adaptive_norm and cfg.log1p_pressure:
+                _yt[:, :, 2:3] = _log1p_transform(_yt[:, :, 2:3])
             _m = _mask.float().unsqueeze(-1)
             _raw_sum += (_yt * _m).sum(dim=(0, 1))
             _raw_sq_sum += (_yt ** 2 * _m).sum(dim=(0, 1))
@@ -1839,6 +1858,8 @@ for epoch in range(MAX_EPOCHS):
             y_adapt = y.clone()
             if cfg.asinh_pressure:
                 y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
+            if cfg.log1p_pressure:
+                y_adapt[:, :, 2:3] = _log1p_transform(y_adapt[:, :, 2:3])
             y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
         else:
             y_phys = _phys_norm(y, Umag, q)
@@ -1848,6 +1869,9 @@ for epoch in range(MAX_EPOCHS):
             if cfg.asinh_pressure:
                 y_phys = y_phys.clone()
                 y_phys[:, :, 2:3] = torch.asinh(y_phys[:, :, 2:3] * cfg.asinh_scale)
+            if cfg.log1p_pressure:
+                y_phys = y_phys.clone()
+                y_phys[:, :, 2:3] = _log1p_transform(y_phys[:, :, 2:3])
             y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
         # Residual prediction: subtract freestream from normalized targets
         _freestream = None
@@ -2526,6 +2550,8 @@ for epoch in range(MAX_EPOCHS):
                     y_adapt = y.clone()
                     if cfg.asinh_pressure:
                         y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
+                    if cfg.log1p_pressure:
+                        y_adapt[:, :, 2:3] = _log1p_transform(y_adapt[:, :, 2:3])
                     y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
                 else:
                     y_phys = _phys_norm(y, Umag, q)
@@ -2535,6 +2561,9 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.asinh_pressure:
                         y_phys = y_phys.clone()
                         y_phys[:, :, 2:3] = torch.asinh(y_phys[:, :, 2:3] * cfg.asinh_scale)
+                    if cfg.log1p_pressure:
+                        y_phys = y_phys.clone()
+                        y_phys[:, :, 2:3] = _log1p_transform(y_phys[:, :, 2:3])
                     y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                 # Residual prediction: subtract freestream in val loop
@@ -2680,6 +2709,9 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.asinh_pressure:
                         pred_adapt = pred_adapt.clone()
                         pred_adapt[:, :, 2:3] = torch.sinh(pred_adapt[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.log1p_pressure:
+                        pred_adapt = pred_adapt.clone()
+                        pred_adapt[:, :, 2:3] = _log1p_inverse(pred_adapt[:, :, 2:3])
                     pred_orig = pred_adapt
                 else:
                     pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
@@ -2689,6 +2721,9 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.asinh_pressure:
                         pred_phys = pred_phys.clone()
                         pred_phys[:, :, 2:3] = torch.sinh(pred_phys[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.log1p_pressure:
+                        pred_phys = pred_phys.clone()
+                        pred_phys[:, :, 2:3] = _log1p_inverse(pred_phys[:, :, 2:3])
                     if cfg.tight_denorm_clamps:
                         _pd = pred_phys.clone()
                         _pd[:, :, 0:1] = pred_phys[:, :, 0:1].clamp(-5, 5) * Umag
@@ -2931,6 +2966,9 @@ if best_metrics:
                         if cfg.asinh_pressure:
                             pred_adapt = pred_adapt.clone()
                             pred_adapt[:, :, 2:3] = torch.sinh(pred_adapt[:, :, 2:3]) / cfg.asinh_scale
+                        if cfg.log1p_pressure:
+                            pred_adapt = pred_adapt.clone()
+                            pred_adapt[:, :, 2:3] = _log1p_inverse(pred_adapt[:, :, 2:3])
                         y_pred = pred_adapt.squeeze(0).cpu()
                     else:
                         pred_phys = pred * phys_stats["y_std"] + phys_stats["y_mean"]
@@ -2940,6 +2978,9 @@ if best_metrics:
                         if cfg.asinh_pressure:
                             pred_phys = pred_phys.clone()
                             pred_phys[:, :, 2:3] = torch.sinh(pred_phys[:, :, 2:3]) / cfg.asinh_scale
+                        if cfg.log1p_pressure:
+                            pred_phys = pred_phys.clone()
+                            pred_phys[:, :, 2:3] = _log1p_inverse(pred_phys[:, :, 2:3])
                         if cfg.tight_denorm_clamps:
                             _pd = pred_phys.clone()
                             _pd[:, :, 0:1] = pred_phys[:, :, 0:1].clamp(-5, 5) * Umag
@@ -3046,12 +3087,17 @@ if cfg.surface_refine and best_metrics:
                         y_adapt = y.clone()
                         if cfg.asinh_pressure:
                             y_adapt[:, :, 2:3] = torch.asinh(y_adapt[:, :, 2:3] * cfg.asinh_scale)
+                        if cfg.log1p_pressure:
+                            y_adapt[:, :, 2:3] = _log1p_transform(y_adapt[:, :, 2:3])
                         y_norm = (y_adapt - raw_stats["y_mean"]) / raw_stats["y_std"]
                     else:
                         y_phys = _phys_norm(y, Umag, q)
                         if cfg.asinh_pressure:
                             y_phys = y_phys.clone()
                             y_phys[:, :, 2:3] = torch.asinh(y_phys[:, :, 2:3] * cfg.asinh_scale)
+                        if cfg.log1p_pressure:
+                            y_phys = y_phys.clone()
+                            y_phys[:, :, 2:3] = _log1p_transform(y_phys[:, :, 2:3])
                         y_norm = (y_phys - phys_stats["y_mean"]) / phys_stats["y_std"]
 
                     # Residual prediction
@@ -3125,6 +3171,9 @@ if cfg.surface_refine and best_metrics:
                     if cfg.asinh_pressure:
                         pred_phys_A = pred_phys_A.clone()
                         pred_phys_A[:, :, 2:3] = torch.sinh(pred_phys_A[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.log1p_pressure:
+                        pred_phys_A = pred_phys_A.clone()
+                        pred_phys_A[:, :, 2:3] = _log1p_inverse(pred_phys_A[:, :, 2:3])
                     # Physics denorm (skip for adaptive_norm — already in raw space)
                     pred_orig_A = pred_phys_A if cfg.adaptive_norm else _phys_denorm(pred_phys_A, Umag, q)
 
@@ -3146,6 +3195,9 @@ if cfg.surface_refine and best_metrics:
                     if cfg.asinh_pressure:
                         pred_manual_phys = pred_manual_phys.clone()
                         pred_manual_phys[:, :, 2:3] = torch.sinh(pred_manual_phys[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.log1p_pressure:
+                        pred_manual_phys = pred_manual_phys.clone()
+                        pred_manual_phys[:, :, 2:3] = _log1p_inverse(pred_manual_phys[:, :, 2:3])
                     # Step 6: undo physics norm: Ux*Umag, Uy*Umag, p*q
                     if cfg.adaptive_norm:
                         pred_manual_orig = pred_manual_phys
@@ -3166,6 +3218,9 @@ if cfg.surface_refine and best_metrics:
                     if cfg.asinh_pressure:
                         pred_norefine_phys = pred_norefine_phys.clone()
                         pred_norefine_phys[:, :, 2:3] = torch.sinh(pred_norefine_phys[:, :, 2:3]) / cfg.asinh_scale
+                    if cfg.log1p_pressure:
+                        pred_norefine_phys = pred_norefine_phys.clone()
+                        pred_norefine_phys[:, :, 2:3] = _log1p_inverse(pred_norefine_phys[:, :, 2:3])
                     pred_norefine_orig = pred_norefine_phys if cfg.adaptive_norm else _phys_denorm(pred_norefine_phys, Umag, q)
 
                     # Compute surface pressure MAE for all paths


### PR DESCRIPTION
## Hypothesis

The current pressure targets use an asinh transform (--asinh_pressure --asinh_scale 0.75). However, surface pressure distributions have extreme dynamic range: stagnation point pressures can be 10-100x larger than boundary layer values. MAE loss is dominated by these peak values, meaning the model optimizes stagnation/leading-edge accuracy at the expense of the rest of the surface.

**Log1p transform** — `sign(p) * log1p(|p|)` — compresses the dynamic range more aggressively than asinh for large values while preserving sign and being nearly linear for small values. This redistributes the loss contribution more evenly across the surface, which should improve mean surface MAE.

**Kaggle evidence:** Log-transforming skewed targets is one of the most reliable techniques in regression competitions. For heavy-tailed distributions, it consistently improves MAE/RMSE by 2-5% by reducing loss domination by outlier values.

**Key distinction from asinh:** asinh(x) ≈ ln(2|x|) for large x, so it already compresses. But log1p(|x|) compresses MORE aggressively: for x=100, asinh(100)≈5.3 while log1p(100)=4.6. The question is whether the additional compression helps or hurts precision on peak values.

**Important:** This changes the training target, NOT the evaluation metric. At inference, we invert the transform to get original-scale predictions. The evaluation must compute MAE on the original (untransformed) pressure values.

## Instructions

### Step 1: Add argument

```python
parser.add_argument('--log1p_pressure', action='store_true',
                    help='Apply sign(p)*log1p(|p|) transform to pressure targets')
```

### Step 2: Implement target transform

**This replaces the asinh transform for pressure, not in addition to it.**

When `--log1p_pressure` is set:
- Do NOT use `--asinh_pressure` (they are mutually exclusive)
- Apply to the pressure channel only (channel index 2 in the [Ux, Uy, p] target)

```python
def log1p_transform(p):
    """Sign-preserving log1p: sign(p) * log1p(|p|)"""
    return torch.sign(p) * torch.log1p(torch.abs(p))

def log1p_inverse(p_transformed):
    """Inverse: sign(p) * (exp(|p|) - 1)"""
    return torch.sign(p_transformed) * (torch.exp(torch.abs(p_transformed)) - 1)
```

Apply the transform to the pressure channel of targets after loading:
```python
if args.log1p_pressure:
    y[:, :, 2] = log1p_transform(y[:, :, 2])  # Transform pressure targets
```

### Step 3: Inverse transform at validation

At validation, the model predicts in log1p space. Invert before computing MAE:
```python
if args.log1p_pressure:
    pred[:, :, 2] = log1p_inverse(pred[:, :, 2])
    # Target is already in original space for MAE computation (or invert target too)
```

**Critical:** Ensure the MAE metric is computed on ORIGINAL-SCALE pressure, not transformed. The W&B logged metrics must be apples-to-apples with baseline.

### Step 4: Verify mutual exclusivity with asinh

Add a check:
```python
if args.log1p_pressure and args.asinh_pressure:
    raise ValueError("--log1p_pressure and --asinh_pressure are mutually exclusive")
```

### Step 5: Run 2 seeds (WITHOUT asinh_pressure)

```bash
cd cfd_tandemfoil && python train.py \
  --agent askeladd --wandb_name "askeladd/log1p-pressure-s42" --seed 42 \
  --wandb_group log1p-pressure-target \
  --log1p_pressure \
  --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling

# Repeat for seed 73: --seed 73 --wandb_name "askeladd/log1p-pressure-s73"
```

**Note:** `--asinh_pressure` is intentionally REMOVED. The `--asinh_scale` flag is also not needed. All other flags remain identical.

**Debug check:** After a few epochs, verify that val metrics are being computed on original-scale pressure (not transformed). Compare the scale of reported p_in/p_oodc/p_tan/p_re to baseline values — if they're in a completely different range, the inverse transform isn't being applied correctly.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 11.742 | < 11.742 |
| p_oodc | 7.643 | < 7.643 |
| p_tan | 27.874 | < 27.874 |
| p_re | 6.419 | < 6.419 |

- **Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)
- **val/loss baseline:** ~0.37 (not directly comparable since target scale changes)