### PR TITLE
Target Noise Regularization: Gaussian noise on training targets

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1173,6 +1173,8 @@ class Config:
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
+    # Target noise regularization: relative Gaussian noise on raw targets
+    target_noise: float = 0.0              # std of relative Gaussian noise added to raw targets (0=disabled)
 
 
 cfg = sp.parse(Config)
@@ -1832,6 +1834,10 @@ for epoch in range(MAX_EPOCHS):
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
+        # Relative target noise regularization (applied to raw targets before normalization)
+        if cfg.target_noise > 0 and model.training:
+            noise_std = cfg.target_noise * y.abs().clamp(min=0.01)
+            y = y + torch.randn_like(y) * noise_std
         Umag, q = _umag_q(y, mask)
         if cfg.raw_targets:
             y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]


### PR DESCRIPTION
## Hypothesis

Adding small Gaussian noise to training targets prevents the model from memorizing exact training values, forcing it to learn smoother, more generalizable representations. This is a classic regularization technique (label smoothing for regression) that is especially effective when the model is close to overfitting the training distribution.

**Why now:** Our baseline has been heavily tuned over 136 merged PRs. The model likely fits the training data very well — but our OOD metrics (p_oodc 7.64 vs ensemble 6.6, p_re 6.42 vs ensemble 5.8) suggest overfitting to the training distribution. Adding target noise acts as implicit Bayesian regularization — it's equivalent to training with a data augmentation that smears the target distribution, encouraging the model to predict the conditional mean rather than memorizing individual samples.

**Evidence:** Label smoothing / target noise is one of the most reliable regularization techniques in Kaggle competitions for structured regression. Szegedy et al. (CVPR 2016) showed label smoothing improved ImageNet accuracy; the regression analog (Gaussian target noise) has similar benefits for OOD robustness.

**Key insight:** The noise should be proportional to local target variance — high-pressure regions can tolerate more noise than low-pressure regions. We'll use relative noise: noise_std = sigma * |target_value|.

## Instructions

### Step 1: Add arguments

```python
parser.add_argument('--target_noise', type=float, default=0.0,
                    help='Std of Gaussian noise added to targets during training (relative to |target|)')
```

### Step 2: Apply noise during training only

After loading targets but before loss computation:

```python
if args.target_noise > 0 and model.training:
    # Relative Gaussian noise: proportional to |target|
    noise_std = args.target_noise * y.abs().clamp(min=0.01)  # Floor to prevent zero noise
    noise = torch.randn_like(y) * noise_std
    y_noisy = y + noise
    # Use y_noisy for loss computation
    y = y_noisy
```

**Important:** Do NOT apply noise during validation — metrics must be computed on clean targets.

### Step 3: Run 2 seeds with sigma=0.01

Start with small noise (1% relative):

```bash
cd cfd_tandemfoil && python train.py \
  --agent tanjiro --wandb_name "tanjiro/target-noise-0.01-s42" --seed 42 \
  --wandb_group target-noise-regularization \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling \
  --target_noise 0.01

# Repeat for seed 73: --seed 73 --wandb_name "tanjiro/target-noise-0.01-s73"
```

**Compute overhead:** Near zero — one randn_like per batch.

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 11.742 | < 11.742 |
| p_oodc | 7.643 | < 7.643 |
| p_tan | 27.874 | < 27.874 |
| p_re | 6.419 | < 6.419 |

- **Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)
- **val/loss baseline:** ~0.37