### PR TITLE
Gradient Accumulation 2x: double effective batch size

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -2265,7 +2265,7 @@ for epoch in range(MAX_EPOCHS):
         else:
             if cfg.grad_accum_steps <= 1:
                 optimizer.zero_grad()
-            loss.backward()
+            (loss / cfg.grad_accum_steps).backward()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
         sam_active = sam_optimizer is not None and epoch >= int(MAX_EPOCHS * 0.75)
@@ -2301,7 +2301,7 @@ for epoch in range(MAX_EPOCHS):
                 scheduler.step()
             except ValueError:
                 pass
-        if epoch >= cfg.ema_start_epoch and not cfg.swad and not cfg.swa and not cfg.swa_cyclic and not cfg.snapshot_ensemble:
+        if (use_pcgrad or _should_step) and epoch >= cfg.ema_start_epoch and not cfg.swad and not cfg.swa and not cfg.swa_cyclic and not cfg.snapshot_ensemble:
             if ema_model is None:
                 ema_model = deepcopy(_base_model)
             else:


### PR DESCRIPTION
## Hypothesis

Larger effective batch sizes produce smoother gradient estimates, leading to better generalization. Our current batch size is 1 (each training step processes one sample — the meshes are large). By accumulating gradients over 2 samples before each optimizer step, we double the effective batch size to 2.

**Why this should help OOD:** Smoother gradients reduce the noise in the optimization trajectory, leading to flatter minima. Flatter minima generalize better to OOD inputs (Sharp Minima Generalization Theory — Keskar et al., 2017).

**Tradeoff:** With accumulation=2, we see half as many optimizer steps per epoch. But each step has lower gradient variance. With our 180-min timeout, the number of epochs should be nearly unchanged (the forward/backward passes dominate, not the optimizer step). We just do half as many optimizer.step() calls.

**Evidence:** Gradient accumulation is standard practice for transformers when memory limits batch size. For our case, we have memory to spare (46/96 GB used) but the mesh-per-sample is so large that batch_size=1 is natural. Accumulation=2 gives us the benefits of batch_size=2 without memory increase.

## Instructions

### Step 1: Add argument

```python
parser.add_argument('--grad_accum_steps', type=int, default=1,
                    help='Gradient accumulation steps (effective batch = batch_size * accum)')
```

### Step 2: Implement gradient accumulation

Modify the training loop:

```python
optimizer.zero_grad()
for step_i, batch in enumerate(train_loader):
    # Forward + backward
    loss = compute_loss(model, batch)
    loss = loss / args.grad_accum_steps  # Scale loss by accumulation steps
    loss.backward()
    
    # Only step optimizer every grad_accum_steps
    if (step_i + 1) % args.grad_accum_steps == 0:
        optimizer.step()
        optimizer.zero_grad()
        # Update EMA
        if ema_model is not None:
            update_ema(ema_model, model, args.ema_decay)
```

**Critical:** Scale the loss by 1/grad_accum_steps before backward(). This ensures the accumulated gradient has the correct magnitude regardless of accumulation factor.

**Critical:** EMA update should happen at the same frequency as optimizer.step() (every accum steps), not every forward pass.

### Step 3: Run 2 seeds with accum=2

```bash
cd cfd_tandemfoil && python train.py \
  --agent alphonse --wandb_name "alphonse/accum2-s42" --seed 42 \
  --wandb_group gradient-accumulation \
  --asinh_pressure --asinh_scale 0.75 --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --aug aoa_perturb --aug_full_dsdf_rot --high_p_clamp --n_layers 3 --slice_num 96 \
  --tandem_ramp --domain_layernorm --domain_velhead --ema_decay 0.999 --weight_decay 5e-5 \
  --cosine_T_max 150 --pcgrad_3way --pcgrad_extreme_pct 0.15 \
  --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --surface_refine_hidden 192 --surface_refine_layers 3 \
  --aft_foil_srf --aug_gap_stagger_sigma 0.02 --aug_dsdf2_sigma 0.05 \
  --gap_stagger_spatial_bias \
  --dct_freq_loss --dct_freq_weight 0.05 --dct_freq_gamma 2.0 --dct_freq_alpha 1.5 \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling \
  --grad_accum_steps 2

# Repeat for seed 73: --seed 73 --wandb_name "alphonse/accum2-s73"
```

## Baseline

| Metric | Baseline | Target to beat |
|--------|----------|----------------|
| p_in | 11.742 | < 11.742 |
| p_oodc | 7.643 | < 7.643 |
| p_tan | 27.874 | < 27.874 |
| p_re | 6.419 | < 6.419 |

- **Baseline W&B runs:** k5qwvce4 (seed 42), 7oa5xfhi (seed 73)
- **val/loss baseline:** ~0.37
- **Baseline effective batch size:** 1