### PR TITLE
SWA: stochastic weight averaging for flatter minima

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1154,6 +1154,7 @@ class Config:
     # Phase 3: training dynamics experiments
     swa: bool = False             # GPU 0/6: uniform SWA weight averaging
     swa_start_epoch: int = 200   # epoch to start SWA (GPU 0: 200, GPU 6: 160)
+    swa_lr: float = 1e-4         # constant LR during SWA phase (default: 0.5x base lr)
     grad_accum_steps: int = 1    # GPU 2: gradient accumulation (step every N batches)
     half_target_noise: bool = False  # GPU 3: reduce target noise by 50%
     no_target_noise: bool = False    # Phase 4: completely disable target noise injection
@@ -1246,6 +1247,11 @@ class Config:
 
 
 cfg = sp.parse(Config)
+
+# SWA: compute effective swa_start_epoch as 75% of cosine_T_max when --swa is used
+# This overrides the legacy default (200) with a schedule-relative start.
+if cfg.swa:
+    cfg.swa_start_epoch = int(0.75 * cfg.cosine_T_max)
 
 if cfg.seed >= 0:
     torch.manual_seed(cfg.seed)
@@ -2440,6 +2446,13 @@ for epoch in range(MAX_EPOCHS):
                         for k in snap:
                             cs[k].mul_(swa_cyclic_n / (swa_cyclic_n + 1)).add_(snap[k].to(device) / (swa_cyclic_n + 1))
                     swa_cyclic_n += 1
+        elif cfg.swa and epoch >= cfg.swa_start_epoch:
+            # SWA phase: hold constant LR (switch once on entry, then no-op scheduler steps)
+            if swa_model is None:
+                # First SWA epoch: switch all param groups to constant swa_lr
+                for pg in base_opt.param_groups:
+                    pg['lr'] = cfg.swa_lr
+            # Don't step cosine scheduler — LR stays constant during SWA phase
         else:
             scheduler.step()
     # Two-phase LR: at switch epoch, reset optimizer LR and replace scheduler
@@ -2848,6 +2861,7 @@ for epoch in range(MAX_EPOCHS):
         if swa_model is None:
             swa_model = deepcopy(_base_model)
             swa_n = 1
+            print(f"SWA: started averaging at epoch {epoch + 1} (swa_start={cfg.swa_start_epoch}, lr={cfg.swa_lr})")
         else:
             with torch.no_grad():
                 for sp, mp in zip(swa_model.parameters(), _base_model.parameters()):
@@ -2869,12 +2883,15 @@ for epoch in range(MAX_EPOCHS):
         "val/loss": val_loss_3split,
         "val/loss_3split": val_loss_3split,
         "val/loss_4split": val_loss_4split,
-        "lr": scheduler.get_last_lr()[0],
+        "lr": cfg.swa_lr if (cfg.swa and swa_n > 0) else scheduler.get_last_lr()[0],
         "epoch_time_s": dt,
     }
     for split_metrics in val_metrics_per_split.values():
         metrics.update(split_metrics)
     metrics["global_step"] = global_step
+    if cfg.swa:
+        metrics["swa/n_checkpoints"] = swa_n
+        metrics["swa/active"] = int(epoch >= cfg.swa_start_epoch)
     learned_freqs = model.fourier_freqs_learned.abs().detach().cpu().tolist()
     for i, f in enumerate(learned_freqs):
         metrics[f"fourier_freq_{i}"] = f


### PR DESCRIPTION
## Hypothesis

**Stochastic Weight Averaging (SWA)** maintains a running average of model weights during training with a high constant learning rate, then uses the averaged weights for evaluation. SWA finds wider, flatter minima that generalize better — unlike the current cosine schedule which converges to a single sharp minimum.

This is fundamentally different from checkpoint soup (#2334 closed, which averaged checkpoints from different epochs of the same decay schedule). SWA uses a **constant high LR phase** specifically designed to explore diverse weight-space regions, and the average of these diverse points lands in a wide basin.

**Literature**: Izmailov et al. 2018, "Averaging Weights Leads to Wider Optima and Better Generalization" — SWA consistently improves generalization by 0.5-1.5% across tasks. PyTorch provides `torch.optim.swa_utils.AveragedModel` and `SWALR`.

## Instructions

### Step 1: Use PyTorch's built-in SWA utilities

```python
from torch.optim.swa_utils import AveragedModel, SWALR

# After model is defined:
if args.swa:
    swa_model = AveragedModel(model)
    swa_start = int(0.75 * args.cosine_T_max)  # Start SWA at 75% of training
    swa_scheduler = SWALR(optimizer, swa_lr=args.swa_lr)
```

### Step 2: Switch to SWA phase during training

```python
for epoch in range(max_epochs):
    # ... training step ...
    
    if args.swa and epoch >= swa_start:
        swa_scheduler.step()  # constant LR
        swa_model.update_parameters(model)
    else:
        scheduler.step()  # normal cosine schedule
```

### Step 3: Use SWA model for evaluation

```python
if args.swa:
    # Update batch norm stats for SWA model
    torch.optim.swa_utils.update_bn(train_loader, swa_model, device=device)
    # Use swa_model for evaluation
    eval_model = swa_model
else:
    eval_model = model
```

### Step 4: Add flags

- `--swa` (bool)
- `--swa_lr` (float, default=1e-4) — constant LR during SWA phase. Use 0.5× the base lr.

### Key parameters
- `swa_start` = epoch 112 (75% of 150) — this gives ~37 epochs of SWA averaging
- `swa_lr` = 1e-4 (half the base lr 2e-4 — high enough to explore, low enough for stability)
- The EMA model should still be maintained separately — compare SWA model vs EMA model at eval

### Training commands (2 seeds)

```bash
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent thorfinn --wandb_name "thorfinn/swa-s42" --wandb_group swa-weight-averaging \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 \
  --swa --swa_lr 1e-4

CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent thorfinn --wandb_name "thorfinn/swa-s73" --wandb_group swa-weight-averaging \
  --seed 73 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 \
  --swa --swa_lr 1e-4
```

### Important: SWA + EMA interaction
The current baseline uses EMA (exponential moving average). SWA is different — it's a uniform running average over the SWA phase. Both should be maintained separately. Report metrics for both the SWA model and the EMA model so we can compare which averaging strategy works better.

## Baseline

| Metric | Value | Target |
|--------|-------|--------|
| p_in | 11.709 | < 11.709 |
| p_oodc | 7.544 | < 7.544 |
| p_tan | 27.402 | < 27.402 |
| p_re | 6.481 | < 6.481 |

Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1`