### PR TITLE
Focal L1 Surface Loss: upweight hard surface nodes

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -1243,6 +1243,9 @@ class Config:
     cp_panel: bool = False                 # append thin-airfoil inviscid Cp to input features
     cp_panel_tandem_only: bool = False     # zero Cp feature for single-foil samples (tandem benefit only)
     cp_panel_scale: float = 1.0            # scale factor for panel Cp feature (0.1 = weak hint)
+    # Focal L1 surface loss: upweight high-error surface nodes
+    focal_l1: bool = False                 # enable focal-style L1 surface loss
+    focal_gamma: float = 1.0              # exponent for focal weighting (higher = more focus on hard nodes)
 
 
 cfg = sp.parse(Config)
@@ -2119,6 +2122,14 @@ for epoch in range(MAX_EPOCHS):
             hard_mask = (~is_tandem_batch)[:, None] & surf_mask & (surf_pres_flat >= thresh[:, None])
             hard_weights = (hard_mask.float() * 0.5 + 1.0).unsqueeze(-1)  # 1.5 hard, 1.0 else
             surf_per_sample = (surf_pres * hard_weights * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
+        # Focal L1: upweight high-error surface nodes (composes with hard-node mining)
+        if cfg.focal_l1:
+            _surf_pres = abs_err[:, :, 2:3]  # [B, N, 1]
+            _mean_err = (_surf_pres.detach() * surf_mask.unsqueeze(-1)).sum() / surf_mask.sum().clamp(min=1).float() + 1e-8
+            _focal_w = (_surf_pres.detach() / _mean_err).pow(cfg.focal_gamma).clamp(min=0.5, max=5.0)
+            if epoch >= 30:
+                _focal_w = _focal_w * hard_weights  # compose with hard-node mining
+            surf_per_sample = (_surf_pres * _focal_w * surf_mask.unsqueeze(-1)).sum(dim=(1, 2)) / surf_mask.sum(dim=1).clamp(min=1).float()
         adaptive_boost = max(1.0, min(4.0, running_tandem_loss / max(running_nontandem_loss, 1e-8)))
         if cfg.tandem_ramp:
             tandem_weight = min(1.0, max(0.0, (epoch - 10) / 40.0))
@@ -2413,7 +2424,11 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _step_metrics = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.focal_l1:
+            _step_metrics["train/focal_w_mean"] = _focal_w.mean().item()
+            _step_metrics["train/focal_w_max"] = _focal_w.max().item()
+        wandb.log(_step_metrics)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The current L1 surface loss treats all surface nodes equally. However, prediction errors concentrate at suction peaks (leading edge), separation points, and trailing edge recovery regions. A **focal-style L1 loss** that upweights high-error nodes should force the model to allocate more capacity to these critical regions, improving p_in and p_tan where suction peak accuracy dominates the error.

This is simpler and more direct than quantile regression (which catastrophically failed at +92-162% by halving gradient magnitude and diluting capacity across 3 output channels). Focal L1 keeps the same single-channel output and the same gradient direction — it only rescales gradient magnitudes.

## Instructions

### Changes to `cfd_tandemfoil/train.py`

1. **Add new flags:**
   ```python
   parser.add_argument('--focal_l1', action='store_true', help='Focal L1 surface loss')
   parser.add_argument('--focal_gamma', type=float, default=1.0, help='Focal L1 gamma exponent')
   ```

2. **Implement focal L1 weighting in the surface loss computation.** Find where the per-node surface L1 loss is computed (likely `F.l1_loss(..., reduction='none')` or similar). Replace the uniform reduction with focal weighting:

   ```python
   if args.focal_l1:
       node_errors = torch.abs(pred_surf - target_surf)
       mean_error = node_errors.detach().mean() + 1e-8
       focal_weight = (node_errors.detach() / mean_error).pow(args.focal_gamma)
       focal_weight = focal_weight.clamp(min=0.5, max=5.0)
       surf_loss = (focal_weight * node_errors).mean()
   ```

3. **Important details:**
   - Use `.detach()` on the error when computing weights — gradient should NOT flow through the weighting function
   - `clamp(min=0.5, max=5.0)` prevents degenerate outlier domination
   - Apply ONLY to the surface loss, not to volume loss or DCT loss
   - Fully compatible with existing hard-node mining

4. **Run 2 seeds:**
   ```bash
   CUDA_VISIBLE_DEVICES=0 python train.py \
     --agent tanjiro --wandb_name "tanjiro/focal-l1-g1.0-s42" --wandb_group focal-l1-surface-loss \
     --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
     --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
     --pressure_first --pressure_deep --residual_prediction --surface_refine \
     --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
     --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 \
     --focal_l1 --focal_gamma 1.0

   CUDA_VISIBLE_DEVICES=1 python train.py \
     --agent tanjiro --wandb_name "tanjiro/focal-l1-g1.0-s73" --wandb_group focal-l1-surface-loss \
     --seed 73 [same flags as above]
   ```

5. If gamma=1.0 shows promise, try gamma=0.5 in follow-up.

## Baseline
| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.709** | < 11.71 |
| **p_oodc** | **7.544** | < 7.54 |
| **p_tan** | **27.402** | < 27.40 |
| p_re | 6.481 | < 6.48 |

W&B baseline: h6fqcry4 (s42), cuhoscp9 (s73)
Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1`