### PR TITLE
Wake Angle Feature: atan2 polar wake direction

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -303,7 +303,7 @@ def compute_te_features(raw_xy, is_surface, saf_norm):
     return torch.stack([dx_fore, dy_fore, r_fore, dx_aft, dy_aft, r_aft], dim=-1), fore_te_x, fore_te_y
 
 
-def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te_x=None, fore_te_y=None):
+def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te_x=None, fore_te_y=None, include_angle=False):
     """Compute gap-normalized fore-TE offset features for wake coupling.
 
     Encodes each node's position relative to the fore-foil trailing edge,
@@ -311,14 +311,16 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     position: (dx/gap, dy/gap) → "how deep into the fore-foil wake am I?"
 
     Args:
-        raw_xy:     [B, N, 2] raw x, y coordinates
-        is_surface: [B, N] bool
-        saf_norm:   [B, N] saf channel norm (fore-foil: <= 0.005)
-        gap_raw:    [B] raw gap values (x[:,:,22].mean(dim=1))
-        fore_te_x:  [B] pre-computed fore TE x (if None, recomputes from raw_xy)
-        fore_te_y:  [B] pre-computed fore TE y (if None, recomputes from raw_xy)
+        raw_xy:        [B, N, 2] raw x, y coordinates
+        is_surface:    [B, N] bool
+        saf_norm:      [B, N] saf channel norm (fore-foil: <= 0.005)
+        gap_raw:       [B] raw gap values (x[:,:,22].mean(dim=1))
+        fore_te_x:     [B] pre-computed fore TE x (if None, recomputes from raw_xy)
+        fore_te_y:     [B] pre-computed fore TE y (if None, recomputes from raw_xy)
+        include_angle: if True, append atan2(dy, dx)/pi as 3rd channel
 
-    Returns: [B, N, 2] = [dx/gap, dy/gap], zeroed for single-foil samples
+    Returns: [B, N, 2] = [dx/gap, dy/gap], or [B, N, 3] if include_angle=True,
+             zeroed for single-foil samples
     """
     x_coords = raw_xy[:, :, 0]  # [B, N]
     y_coords = raw_xy[:, :, 1]  # [B, N]
@@ -344,7 +346,14 @@ def compute_wake_deficit_features(raw_xy, is_surface, saf_norm, gap_raw, fore_te
     dx_norm = dx_norm * is_tandem
     dy_norm = dy_norm * is_tandem
 
-    return torch.stack([dx_norm, dy_norm], dim=-1)  # [B, N, 2]
+    channels = [dx_norm, dy_norm]
+    if include_angle:
+        # Signed polar angle of each node relative to the fore-TE, normalized to [-1, 1]
+        wake_angle = torch.atan2(dy_norm, dx_norm + 1e-8) / torch.pi  # [B, N]
+        wake_angle = wake_angle * is_tandem  # zero for single-foil
+        channels.append(wake_angle)
+
+    return torch.stack(channels, dim=-1)  # [B, N, 2] or [B, N, 3]
 
 
 def compute_cp_panel(raw_xy, aoa_rad, is_surface, saf_norm):
@@ -1236,6 +1245,7 @@ class Config:
     pcgrad_extreme_pct: float = 0.15        # top/bottom Re percentile among tandem samples to label as extreme
     te_coord_frame: bool = False            # trailing-edge-relative coordinate features (+6 input channels)
     wake_deficit_feature: bool = False      # gap-normalized fore-TE offset for wake coupling (+2 input channels)
+    wake_angle_feature: bool = False        # add atan2(dy/gap, dx/gap)/pi as 3rd wake channel (+1 input channel)
     # Re-stratified sampling
     re_stratified_sampling: bool = False    # upweight extreme-Re training samples
     re_extreme_weight: float = 2.0         # weight multiplier for extreme-Re samples (top/bottom 20th pctile)
@@ -1388,7 +1398,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + 32 + (1 if cfg.cp_panel else 0),  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], +32 fourier PE, [+cp_panel]
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.wake_angle_feature else 0) + 32 + (1 if cfg.cp_panel else 0),  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+wake_angle], +32 fourier PE, [+cp_panel]
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1882,13 +1892,15 @@ for epoch in range(MAX_EPOCHS):
             if cfg.wake_deficit_feature:
                 wake_feats = compute_wake_deficit_features(
                     _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake,
-                    fore_te_x=_fore_te_x, fore_te_y=_fore_te_y)
+                    fore_te_x=_fore_te_x, fore_te_y=_fore_te_y,
+                    include_angle=cfg.wake_angle_feature)
                 x = torch.cat([x, wake_feats], dim=-1)
         else:
             x = torch.cat([x, curv, dist_feat], dim=-1)
             if cfg.wake_deficit_feature:
                 wake_feats = compute_wake_deficit_features(
-                    _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
+                    _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake,
+                    include_angle=cfg.wake_angle_feature)
                 x = torch.cat([x, wake_feats], dim=-1)
         # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
         raw_xy = x[:, :, :2]
@@ -2580,13 +2592,15 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.wake_deficit_feature:
                         wake_feats = compute_wake_deficit_features(
                             _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake,
-                            fore_te_x=_fore_te_x, fore_te_y=_fore_te_y)
+                            fore_te_x=_fore_te_x, fore_te_y=_fore_te_y,
+                            include_angle=cfg.wake_angle_feature)
                         x = torch.cat([x, wake_feats], dim=-1)
                 else:
                     x = torch.cat([x, curv, dist_feat], dim=-1)
                     if cfg.wake_deficit_feature:
                         wake_feats = compute_wake_deficit_features(
-                            _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake)
+                            _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake,
+                            include_angle=cfg.wake_angle_feature)
                         x = torch.cat([x, wake_feats], dim=-1)
                 # Fourier positional encoding: append sin/cos of (x,y) at 4 learnable frequencies
                 raw_xy = x[:, :, :2]
@@ -2993,13 +3007,15 @@ if best_metrics:
                         if cfg.wake_deficit_feature:
                             wake_feats_vis = compute_wake_deficit_features(
                                 _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis,
-                                fore_te_x=_fore_te_x_vis, fore_te_y=_fore_te_y_vis)
+                                fore_te_x=_fore_te_x_vis, fore_te_y=_fore_te_y_vis,
+                                include_angle=cfg.wake_angle_feature)
                             x_n = torch.cat([x_n, wake_feats_vis], dim=-1)
                     else:
                         x_n = torch.cat([x_n, curv, dist_feat], dim=-1)
                         if cfg.wake_deficit_feature:
                             wake_feats_vis = compute_wake_deficit_features(
-                                _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis)
+                                _raw_xy_te_vis, is_surf_dev, _raw_saf_norm_te_vis, _raw_gap_wake_vis,
+                                include_angle=cfg.wake_angle_feature)
                             x_n = torch.cat([x_n, wake_feats_vis], dim=-1)
                     # Fourier PE (must match training loop)
                     raw_xy = x_n[:, :, :2]
@@ -3119,13 +3135,15 @@ if cfg.surface_refine and best_metrics:
                         if cfg.wake_deficit_feature:
                             wake_feats_vv = compute_wake_deficit_features(
                                 _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv,
-                                fore_te_x=_fore_te_x_vv, fore_te_y=_fore_te_y_vv)
+                                fore_te_x=_fore_te_x_vv, fore_te_y=_fore_te_y_vv,
+                                include_angle=cfg.wake_angle_feature)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
                     else:
                         x = torch.cat([x, curv, dist_feat], dim=-1)
                         if cfg.wake_deficit_feature:
                             wake_feats_vv = compute_wake_deficit_features(
-                                _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv)
+                                _raw_xy_te, is_surface, _raw_saf_norm_te, _raw_gap_wake_vv,
+                                include_angle=cfg.wake_angle_feature)
                             x = torch.cat([x, wake_feats_vv], dim=-1)
                     raw_xy = x[:, :, :2]
                     xy_min = raw_xy.amin(dim=1, keepdim=True)


### PR DESCRIPTION
## Hypothesis

The existing wake deficit feature (PR #2213, -4.1% p_in) encodes (dx/gap, dy/gap) — Cartesian offset from each node to the fore-foil trailing edge. Adding **atan2(dy/gap, dx/gap)** as a 3rd channel gives the signed angle of each node relative to the wake centerline. This polar representation directly encodes the "wake sector" — nodes upstream vs downstream of the wake center behave very differently (undisturbed flow vs velocity deficit + pressure recovery).

This is the natural follow-on to PR #2213 and analogous to the TE coordinate frame (PR #2207) which uses both distance and direction. Given that wake deficit gave -4.1% on p_in, this angular refinement should compound that gain.

**Reference:** Polar coordinate representations for fluid wakes are standard in experimental fluid dynamics. GeoMPNN (arXiv:2412.09399, NeurIPS 2024 ML4CFD Best Student Paper) uses directional features for geometry-aware message passing.

## Instructions

### Changes to `cfd_tandemfoil/train.py`

1. **Add flag:**
   ```python
   parser.add_argument('--wake_angle_feature', action='store_true', help='Add atan2 wake angle as 3rd wake channel')
   ```

2. **In the wake deficit feature computation**, find where `dx_gap = (x - fore_TE_x) / gap` and `dy_gap = (y - fore_TE_y) / gap` are computed. Add:
   ```python
   if args.wake_angle_feature:
       wake_angle = torch.atan2(dy_gap, dx_gap + 1e-8) / torch.pi  # normalize to [-1, 1]
       # Append as 3rd channel alongside dx_gap, dy_gap
       # wake_features now has 3 channels instead of 2
   ```

3. **Update input_dim:** The feature dimension increases by +1 (from +2 wake channels to +3). Make sure the model's input projection accounts for this.

4. **Zero for single-foil:** Like the existing wake deficit, set wake_angle=0 for single-foil samples.

5. **That's it.** This is ~15 lines of code.

6. **Run 2 seeds:**
   ```bash
   CUDA_VISIBLE_DEVICES=0 python train.py \
     --agent edward --wandb_name "edward/wake-angle-s42" --wandb_group wake-angle-feature \
     --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
     --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
     --pressure_first --pressure_deep --residual_prediction --surface_refine \
     --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
     --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 \
     --wake_angle_feature

   CUDA_VISIBLE_DEVICES=1 python train.py \
     --agent edward --wandb_name "edward/wake-angle-s73" --wandb_group wake-angle-feature \
     --seed 73 [same flags as above]
   ```

## Baseline
| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.709** | < 11.71 |
| **p_oodc** | **7.544** | < 7.54 |
| **p_tan** | **27.402** | < 27.40 |
| p_re | 6.481 | < 6.48 |

W&B baseline: h6fqcry4 (s42), cuhoscp9 (s73)
Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1`