### PR TITLE
SRF FiLM Conditioning: Re/AoA-adaptive surface decoder

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -618,9 +618,11 @@ class SurfaceRefinementHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
-                 n_layers: int = 2, p_only: bool = False):
+                 n_layers: int = 2, p_only: bool = False, film: bool = False):
         super().__init__()
         self.p_only = p_only
+        self.film = film
+        self.hidden_dim = hidden_dim
         actual_out = 1 if p_only else out_dim  # 1 for pressure-only, 3 for all fields
         layers: list[nn.Module] = []
         # Input: hidden features (n_hidden) + base predictions (out_dim)
@@ -633,18 +635,37 @@ class SurfaceRefinementHead(nn.Module):
         # Zero-init last layer so refinement starts as identity
         nn.init.zeros_(layers[-1].weight)
         nn.init.zeros_(layers[-1].bias)
-        self.mlp = nn.Sequential(*layers)
+        self.mlp = nn.ModuleList(layers)
+        # FiLM conditioning on [log(Re), AoA]: γ·h + β applied after first GELU
+        if film:
+            self.film_net = nn.Sequential(
+                nn.Linear(2, 32), nn.GELU(), nn.Linear(32, hidden_dim * 2)
+            )
+            # Zero-init output so FiLM starts as identity (γ=1, β=0)
+            nn.init.zeros_(self.film_net[-1].weight)
+            nn.init.zeros_(self.film_net[-1].bias)
+            self.film_net[-1].bias.data[:hidden_dim] = 1.0  # γ starts at 1
 
-    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor,
+                cond: torch.Tensor | None = None) -> torch.Tensor:
         """
         Args:
             hidden: [M, n_hidden] — hidden features for surface nodes only
             base_pred: [M, out_dim] — base predictions for surface nodes only
+            cond: [M, 2] — (log_Re, AoA) per surface node (only used if film=True)
         Returns:
             correction: [M, out_dim] — additive correction (zero-padded for p_only)
         """
-        inp = torch.cat([hidden, base_pred], dim=-1)
-        correction = self.mlp(inp)
+        x = torch.cat([hidden, base_pred], dim=-1)
+        for i, layer in enumerate(self.mlp):
+            x = layer(x)
+            # Apply FiLM after first GELU (index 2: Linear→LayerNorm→GELU)
+            if self.film and cond is not None and i == 2:
+                film_params = self.film_net(cond)           # [M, hidden_dim * 2]
+                gamma = film_params[:, :self.hidden_dim]    # [M, H]
+                beta = film_params[:, self.hidden_dim:]     # [M, H]
+                x = gamma * x + beta
+        correction = x
         if self.p_only:
             # Pad with zeros for velocity channels: [M, 1] → [M, 3]
             zeros = torch.zeros(correction.shape[0], base_pred.shape[-1] - 1,
@@ -1220,6 +1241,7 @@ class Config:
     surface_refine_layers: int = 2            # number of hidden layers in refinement MLP
     surface_refine_p_only: bool = False       # only refine pressure channel (not velocity)
     surface_refine_context: bool = False      # use surface + nearest-volume context features
+    srf_film: bool = False                   # FiLM conditioning on log(Re)/AoA for surface refinement head
     # Phase 6: Asinh pressure transform
     asinh_pressure: bool = False             # transform pressure targets with asinh for dynamic range compression
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
@@ -1444,6 +1466,7 @@ if cfg.surface_refine:
             hidden_dim=cfg.surface_refine_hidden,
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
+            film=cfg.srf_film,
         ).to(device)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())
@@ -2019,7 +2042,12 @@ for epoch in range(MAX_EPOCHS):
                     if surf_idx.numel() > 0:
                         surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
                         surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
-                        correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
+                        _srf_cond = None
+                        if cfg.srf_film:
+                            # [B, 2]: log(Re) and AoA per sample, expanded to per-surface-node
+                            _batch_cond = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)  # [B, 2]
+                            _srf_cond = _batch_cond[surf_idx[:, 0]]  # [M, 2]
+                        correction = refine_head(surf_hidden, surf_pred, _srf_cond).float()  # [M, 3]
                         pred = pred.clone()
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
 
@@ -2692,7 +2720,11 @@ for epoch in range(MAX_EPOCHS):
                             if surf_idx.numel() > 0:
                                 surf_hidden = _eval_hidden[surf_idx[:, 0], surf_idx[:, 1]]
                                 surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                                correction = eval_refine_head(surf_hidden, surf_pred).float()
+                                _srf_cond_val = None
+                                if cfg.srf_film:
+                                    _batch_cond_val = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)
+                                    _srf_cond_val = _batch_cond_val[surf_idx[:, 0]]
+                                correction = eval_refine_head(surf_hidden, surf_pred, _srf_cond_val).float()
                                 pred_loss = pred_loss.clone()
                                 pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
                     # Back-compute refined pred so denormalization (pred_orig) includes refinement
@@ -3208,7 +3240,11 @@ if cfg.surface_refine and best_metrics:
                         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                             surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]
                             surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                            correction = verify_refine(surf_hidden, surf_pred).float()
+                            _srf_cond_vv = None
+                            if cfg.srf_film:
+                                _batch_cond_vv = torch.stack([x[:, 0, 13], x[:, 0, 14]], dim=-1)
+                                _srf_cond_vv = _batch_cond_vv[surf_idx[:, 0]]
+                            correction = verify_refine(surf_hidden, surf_pred, _srf_cond_vv).float()
                         pred_loss_refined = pred_loss.clone()
                         pred_loss_refined[surf_idx[:, 0], surf_idx[:, 1]] += correction
                         correction_full[surf_idx[:, 0], surf_idx[:, 1]] = correction


### PR DESCRIPTION
## Hypothesis

The SRF head receives backbone hidden states but has no explicit conditioning on flow conditions (Re, AoA). At extreme Re, the boundary layer physics change qualitatively (laminar vs turbulent separation). **FiLM conditioning** injects log(Re) and AoA as learned scale+shift on SRF hidden activations: h = γ(conditions) · h + β(conditions). This lets the SRF apply different correction strategies at different flow regimes without a separate head.

Directly targets p_re (our weakest vs the ensemble) and p_oodc. Reference: FiLM (Perez et al. 2018), meta-learning neural operators (ICLR 2025).

## Instructions

### Changes to `cfd_tandemfoil/train.py`

1. **Add flag:**
   ```python
   parser.add_argument('--srf_film', action='store_true', help='FiLM conditioning on SRF')
   ```

2. **In SurfaceRefinementHead.__init__, add FiLM layers:**
   ```python
   if args.srf_film:
       # Conditioning: [log(Re), AoA] → γ, β for each hidden layer
       self.film_net = nn.Sequential(
           nn.Linear(2, 32), nn.GELU(), nn.Linear(32, hidden_dim * 2)
       )
       # Zero-init output so FiLM starts as identity (γ=1, β=0)
       nn.init.zeros_(self.film_net[-1].weight)
       nn.init.zeros_(self.film_net[-1].bias)
       # Set bias for γ part to 1.0 (identity scale)
       self.film_net[-1].bias.data[:hidden_dim] = 1.0
   ```

3. **In SurfaceRefinementHead.forward, apply FiLM after each GELU:**
   ```python
   if hasattr(self, 'film_net'):
       # cond: [B, 2] = [log(Re)/log(1e6), AoA/0.3]  (normalized)
       film_params = self.film_net(cond)  # [B, hidden*2]
       gamma = film_params[:, :hidden_dim].unsqueeze(1)  # [B, 1, H]
       beta = film_params[:, hidden_dim:].unsqueeze(1)   # [B, 1, H]
       h = gamma * h + beta  # Apply after first GELU
   ```

4. **Apply to BOTH fore-foil SRF and aft-foil SRF.** Extract (log_Re, AoA) from the batch condition features.

5. **Run 2 seeds:**
   ```bash
   CUDA_VISIBLE_DEVICES=0 python train.py \
     --agent tanjiro --wandb_name "tanjiro/srf-film-s42" --wandb_group srf-film-conditioning \
     --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
     --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
     --pressure_first --pressure_deep --residual_prediction --surface_refine \
     --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
     --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 \
     --srf_film

   CUDA_VISIBLE_DEVICES=1 python train.py \
     --agent tanjiro --wandb_name "tanjiro/srf-film-s73" --wandb_group srf-film-conditioning \
     --seed 73 [same flags]
   ```

## Baseline
| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.709** | < 11.71 |
| **p_oodc** | **7.544** | < 7.54 |
| **p_tan** | **27.402** | < 27.40 |
| p_re | 6.481 | < 6.48 |

W&B baseline: h6fqcry4 (s42), cuhoscp9 (s73)
Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1`