### PR TITLE
Learnable Per-Domain Cp Scale: self-calibrating physics hint

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -885,6 +885,8 @@ class Transolver(nn.Module):
             self.log_sigma_surf_ux = nn.Parameter(torch.zeros(1))
             self.log_sigma_surf_uy = nn.Parameter(torch.zeros(1))
             self.log_sigma_surf_p = nn.Parameter(torch.zeros(1))
+        # Learnable Cp scale: sigmoid(param) * 0.2, init sigmoid(0)*0.2 = 0.1
+        self.cp_learnable_scale_param = nn.Parameter(torch.tensor(0.0))
 
         if self.unified_pos:
             self.preprocess = MLP(
@@ -1243,6 +1245,7 @@ class Config:
     cp_panel: bool = False                 # append thin-airfoil inviscid Cp to input features
     cp_panel_tandem_only: bool = False     # zero Cp feature for single-foil samples (tandem benefit only)
     cp_panel_scale: float = 1.0            # scale factor for panel Cp feature (0.1 = weak hint)
+    cp_panel_learnable_scale: bool = False  # learnable Cp scale replacing fixed cp_panel_scale
 
 
 cfg = sp.parse(Config)
@@ -1904,7 +1907,9 @@ for epoch in range(MAX_EPOCHS):
             cp_feat = compute_cp_panel(_raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te)
             if cfg.cp_panel_tandem_only:
                 cp_feat = cp_feat * _is_tandem_raw[:, None, None]
-            if cfg.cp_panel_scale != 1.0:
+            if cfg.cp_panel_learnable_scale:
+                cp_feat = cp_feat * (torch.sigmoid(_base_model.cp_learnable_scale_param) * 0.2)
+            elif cfg.cp_panel_scale != 1.0:
                 cp_feat = cp_feat * cfg.cp_panel_scale
             x = torch.cat([x, cp_feat], dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
@@ -2413,7 +2418,10 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _wlog = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.cp_panel_learnable_scale:
+            _wlog["train/cp_learned_scale"] = (torch.sigmoid(_base_model.cp_learnable_scale_param) * 0.2).item()
+        wandb.log(_wlog)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

The Panel Cp feature uses a fixed scale=0.1 found empirically by PR #2319 (after trying 1.0 and 0.0). A **learnable scale parameter per domain** (tandem vs single-foil), initialized to 0.1, lets the model self-calibrate the Cp signal strength during training. The tandem domain may benefit from a different effective scale than single-foil.

This removes a hand-tuned hyperparameter and may find a better operating point. Low risk, low complexity (~20 LoC).

## Instructions

### Changes to `cfd_tandemfoil/train.py`

1. **Add flag:**
   ```python
   parser.add_argument('--cp_panel_learnable_scale', action='store_true')
   ```

2. **Replace fixed cp_panel_scale with learnable parameter:**
   ```python
   if args.cp_panel_learnable_scale:
       # Learnable log-scale, initialized so sigmoid(x)*0.2 ≈ 0.1
       # sigmoid(-0.41) ≈ 0.4, 0.4 * 0.2 = 0.08 ≈ 0.1
       self.cp_log_scale_tandem = nn.Parameter(torch.tensor(0.0))  
       # Effective scale = sigmoid(param) * 0.2, range (0, 0.2)
       # At init: sigmoid(0) * 0.2 = 0.1 (matches current baseline)
   ```

3. **In feature construction:**
   ```python
   if args.cp_panel_learnable_scale:
       eff_scale = torch.sigmoid(self.cp_log_scale_tandem) * 0.2
       cp_features = cp_features * eff_scale
   else:
       cp_features = cp_features * args.cp_panel_scale
   ```

4. **Log learned scale to W&B:**
   ```python
   wandb.log({'train/cp_learned_scale': (torch.sigmoid(self.cp_log_scale_tandem) * 0.2).item()})
   ```

5. **Run 2 seeds:**
   ```bash
   CUDA_VISIBLE_DEVICES=0 python train.py \
     --agent nezuko --wandb_name "nezuko/learnable-cp-s42" --wandb_group learnable-cp-scale \
     --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
     --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
     --pressure_first --pressure_deep --residual_prediction --surface_refine \
     --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
     --cp_panel --cp_panel_tandem_only --cp_panel_learnable_scale

   CUDA_VISIBLE_DEVICES=1 python train.py \
     --agent nezuko --wandb_name "nezuko/learnable-cp-s73" --wandb_group learnable-cp-scale \
     --seed 73 [same flags]
   ```

   Note: do NOT pass --cp_panel_scale when using --cp_panel_learnable_scale (the learned param replaces it).

## Baseline
| Metric | 2-seed avg | Target |
|--------|-----------|--------|
| **p_in** | **11.709** | < 11.71 |
| **p_oodc** | **7.544** | < 7.54 |
| **p_tan** | **27.402** | < 27.40 |
| p_re | 6.481 | < 6.48 |

W&B baseline: h6fqcry4 (s42), cuhoscp9 (s73)
Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1`