### PR TITLE
Vortex-Panel Induced Velocity: per-node physics feature from inviscid theory

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -422,6 +422,77 @@ def compute_cp_panel(raw_xy, aoa_rad, is_surface, saf_norm):
     return cp_panel.unsqueeze(-1)  # [B, N, 1]
 
 
+def compute_vortex_panel_velocity(raw_xy, aoa_rad, is_surface, saf_norm, n_panels=64):
+    """Compute Biot-Savart induced velocity from flat-plate vortex panel representation.
+
+    Distributes N discrete vortex elements uniformly along each foil surface with
+    flat-plate vortex strength Γ = sin(AoA) / N_panels, then sums induced velocity
+    at every mesh node via the 2D Biot-Savart kernel:
+      u_induced = Σ Γ_i/(2π) · Δy_i/r_i²
+      v_induced = Σ -Γ_i/(2π) · Δx_i/r_i²
+
+    Args:
+        raw_xy:     [B, N, 2] raw (pre-standardization) x, y coordinates
+        aoa_rad:    [B, 1] angle of attack in radians (AoA0)
+        is_surface: [B, N] bool mask for surface nodes
+        saf_norm:   [B, N] saf channel norm (fore-foil: <= 0.005, aft-foil: > 0.005)
+        n_panels:   int, panels to subsample per foil (default 64)
+
+    Returns: [B, N, 4] = (u_fore, v_fore, u_aft, v_aft);
+             u_aft, v_aft are zero for single-foil samples
+    """
+    B, N, _ = raw_xy.shape
+    TWO_PI = 2.0 * torch.pi
+
+    fore_surf = is_surface & (saf_norm <= 0.005)  # [B, N]
+    aft_surf = is_surface & (saf_norm > 0.005)    # [B, N]
+    is_tandem = aft_surf.any(dim=1)               # [B]
+
+    # Flat-plate vortex strength: Γ = sin(AoA), divided equally among panels
+    gamma = aoa_rad.sin()  # [B, 1]
+
+    out = torch.zeros(B, N, 4, device=raw_xy.device, dtype=raw_xy.dtype)
+
+    for b in range(B):
+        # Fore foil panels
+        fore_idx = fore_surf[b].nonzero(as_tuple=False).view(-1)  # [M_fore]
+        if fore_idx.numel() > 0:
+            if fore_idx.numel() > n_panels:
+                step = fore_idx.numel() // n_panels
+                panel_idx = fore_idx[::step][:n_panels]
+            else:
+                panel_idx = fore_idx
+            n_p = panel_idx.numel()
+            p_xy = raw_xy[b, panel_idx, :]  # [n_p, 2]
+            # [N, n_p] displacement from each query node to each panel
+            dx = raw_xy[b, :, 0].unsqueeze(1) - p_xy[:, 0].unsqueeze(0)
+            dy = raw_xy[b, :, 1].unsqueeze(1) - p_xy[:, 1].unsqueeze(0)
+            r2 = dx.pow(2) + dy.pow(2) + 1e-8
+            g = gamma[b, 0].item() / n_p  # Γ per panel
+            out[b, :, 0] = (g / TWO_PI) * (dy / r2).sum(dim=1)   # u_fore
+            out[b, :, 1] = -(g / TWO_PI) * (dx / r2).sum(dim=1)  # v_fore
+
+        # Aft foil panels (tandem only)
+        if is_tandem[b]:
+            aft_idx = aft_surf[b].nonzero(as_tuple=False).view(-1)  # [M_aft]
+            if aft_idx.numel() > 0:
+                if aft_idx.numel() > n_panels:
+                    step = aft_idx.numel() // n_panels
+                    panel_idx = aft_idx[::step][:n_panels]
+                else:
+                    panel_idx = aft_idx
+                n_p = panel_idx.numel()
+                p_xy = raw_xy[b, panel_idx, :]  # [n_p, 2]
+                dx = raw_xy[b, :, 0].unsqueeze(1) - p_xy[:, 0].unsqueeze(0)
+                dy = raw_xy[b, :, 1].unsqueeze(1) - p_xy[:, 1].unsqueeze(0)
+                r2 = dx.pow(2) + dy.pow(2) + 1e-8
+                g = gamma[b, 0].item() / n_p
+                out[b, :, 2] = (g / TWO_PI) * (dy / r2).sum(dim=1)   # u_aft
+                out[b, :, 3] = -(g / TWO_PI) * (dx / r2).sum(dim=1)  # v_aft
+
+    return out  # [B, N, 4]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -1253,6 +1324,10 @@ class Config:
     cp_panel: bool = False                 # append thin-airfoil inviscid Cp to input features
     cp_panel_tandem_only: bool = False     # zero Cp feature for single-foil samples (tandem benefit only)
     cp_panel_scale: float = 1.0            # scale factor for panel Cp feature (0.1 = weak hint)
+    # Vortex-panel induced velocity: per-node Biot-Savart feature from flat-plate theory (+4 input channels)
+    vortex_panel_velocity: bool = False    # append (u_fore, v_fore, u_aft, v_aft) induced velocity
+    vortex_panel_scale: float = 0.1        # scale factor for vortex velocity channels
+    vortex_panel_n: int = 64              # number of panels to subsample per foil
 
 
 cfg = sp.parse(Config)
@@ -1398,7 +1473,7 @@ else:
 
 model_config = dict(
     space_dim=2,
-    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.wake_angle_feature else 0) + 32 + (1 if cfg.cp_panel else 0),  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+wake_angle], +32 fourier PE, [+cp_panel]
+    fun_dim=X_DIM - 2 + 2 + (1 if cfg.foil2_dist else 0) + (6 if cfg.te_coord_frame else 0) + (2 if cfg.wake_deficit_feature else 0) + (1 if cfg.wake_angle_feature else 0) + 32 + (1 if cfg.cp_panel else 0) + (4 if cfg.vortex_panel_velocity else 0),  # +curv, +dist, [+foil2dist], [+te_feats], [+wake_deficit], [+wake_angle], +32 fourier PE, [+cp_panel], [+vortex_panel]
     out_dim=3,
     n_hidden=cfg.n_hidden,
     n_layers=cfg.n_layers,
@@ -1867,8 +1942,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit / cp_panel: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
+        # TE coordinate frame / wake deficit / cp_panel / vortex_panel: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -1919,6 +1994,12 @@ for epoch in range(MAX_EPOCHS):
             if cfg.cp_panel_scale != 1.0:
                 cp_feat = cp_feat * cfg.cp_panel_scale
             x = torch.cat([x, cp_feat], dim=-1)
+        if cfg.vortex_panel_velocity:
+            vp_feat = compute_vortex_panel_velocity(
+                _raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te, n_panels=cfg.vortex_panel_n)
+            if cfg.vortex_panel_scale != 1.0:
+                vp_feat = vp_feat * cfg.vortex_panel_scale
+            x = torch.cat([x, vp_feat], dim=-1)
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -2569,7 +2650,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
                 _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2619,6 +2700,12 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.cp_panel_scale != 1.0:
                         cp_feat = cp_feat * cfg.cp_panel_scale
                     x = torch.cat([x, cp_feat], dim=-1)
+                if cfg.vortex_panel_velocity:
+                    vp_feat = compute_vortex_panel_velocity(
+                        _raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te, n_panels=cfg.vortex_panel_n)
+                    if cfg.vortex_panel_scale != 1.0:
+                        vp_feat = vp_feat * cfg.vortex_panel_scale
+                    x = torch.cat([x, vp_feat], dim=-1)
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
@@ -2992,7 +3079,7 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
-                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
+                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
                     _raw_aoa_vis = x_dev[:, 0, 14:15]  # AoA0_rad [B, 1]
@@ -3033,6 +3120,12 @@ if best_metrics:
                         if cfg.cp_panel_scale != 1.0:
                             cp_feat = cp_feat * cfg.cp_panel_scale
                         x_n = torch.cat([x_n, cp_feat], dim=-1)
+                    if cfg.vortex_panel_velocity:
+                        vp_feat = compute_vortex_panel_velocity(
+                            _raw_xy_te_vis, _raw_aoa_vis, is_surf_dev, _raw_saf_norm_te_vis, n_panels=cfg.vortex_panel_n)
+                        if cfg.vortex_panel_scale != 1.0:
+                            vp_feat = vp_feat * cfg.vortex_panel_scale
+                        x_n = torch.cat([x_n, vp_feat], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
                     pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
                     if cfg.raw_targets:
@@ -3119,7 +3212,7 @@ if cfg.surface_refine and best_metrics:
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
                     _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3160,6 +3253,12 @@ if cfg.surface_refine and best_metrics:
                         if cfg.cp_panel_scale != 1.0:
                             cp_feat = cp_feat * cfg.cp_panel_scale
                         x = torch.cat([x, cp_feat], dim=-1)
+                    if cfg.vortex_panel_velocity:
+                        vp_feat = compute_vortex_panel_velocity(
+                            _raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te, n_panels=cfg.vortex_panel_n)
+                        if cfg.vortex_panel_scale != 1.0:
+                            vp_feat = vp_feat * cfg.vortex_panel_scale
+                        x = torch.cat([x, vp_feat], dim=-1)
 
                     # Ground truth denormalization reference
                     Umag, q = _umag_q(y, mask)


### PR DESCRIPTION
## Hypothesis

Panel Cp (PR #2319) and wake angle (PR #2350) proved that inviscid physics features improve surface pressure prediction. Both encode *surface-only* quantities. This experiment extends the physics oracle to **every mesh node** by computing the 2D velocity field induced by a discrete vortex-panel representation of both foils via the Biot-Savart kernel.

For each mesh node, we sum the induced velocity contributions from all vortex panels:
- u_ind = Σ Γ_i/(2π) · Δy_i/r_i²
- v_ind = Σ -Γ_i/(2π) · Δx_i/r_i²

where Γ_i are vortex strengths from flat-plate theory (Γ ∝ sin(α)), (Δx_i, Δy_i) is the vector from panel i to the query node, and r_i is their distance.

For tandem configurations, both foils contribute separate induced velocity channels: (u_fore, v_fore, u_aft, v_aft). For single-foil, only (u_fore, v_fore) are nonzero (u_aft, v_aft = 0). This gives 4 additional input channels per node.

**Why it helps for tandem:** The aft foil sees a downwash induced by the fore foil's vortex sheet that modifies the effective angle of attack. Panel Cp encodes this only at the surface; induced velocity encodes it at *every* node in the volume, giving the backbone a richer physics context for tandem wake physics. This is the main driver of p_tan error that panel Cp couldn't fully resolve.

**Literature:**
- Hess & Smith (1966) panel method: classical 2D vortex-panel theory
- NeuralFoil (arXiv:2503.16323, Mar 2025): uses panel method as physics oracle
- GeoMPNN (arXiv:2412.09399, NeurIPS 2024): geometry-aware per-node features for mesh learning

## Instructions

Add a `--vortex_panel_velocity` flag to `train.py`. When enabled (along with the existing `--wake_deficit_feature` or independently), compute 4 additional input channels per node.

**Implementation outline:**

1. In the collation / feature-building section, for each sample:
   - Extract surface node positions for fore foil (boundary_id=6) and aft foil (boundary_id=7, tandem-only)
   - Compute N_panels (e.g. 64) control points along each foil surface by subsampling the ordered boundary nodes
   - Compute flat-plate vortex strengths: Γ = (U∞ · sin(AoA)) / N_panels for each panel (uniform distribution)
   - For each mesh node (x_q, y_q), compute induced velocity from each panel (x_p, y_p):
     ```python
     dx = x_q - x_p  # [N_nodes, N_panels]
     dy = y_q - y_p
     r2 = dx**2 + dy**2 + 1e-8
     u_induced = (Gamma / (2 * pi)) * dy / r2  # sum over panels
     v_induced = -(Gamma / (2 * pi)) * dx / r2
     ```
   - Sum over panels: u_fore = u_induced.sum(dim=-1), v_fore = v_induced.sum(dim=-1)
   - For tandem: repeat for aft foil panels → (u_aft, v_aft); zero for single-foil
   - Scale all 4 channels by `--vortex_panel_scale` (default 0.1, same as cp_panel_scale)

2. Concatenate (u_fore, v_fore, u_aft, v_aft) to the per-node input features (adjust input_dim += 4)

3. Add flags:
   - `--vortex_panel_velocity` (bool, enables the feature)
   - `--vortex_panel_scale` (float, default=0.1)
   - `--vortex_panel_n` (int, default=64, number of panels per foil)

4. Run with `--wandb_group round38/vortex-panel` using the full baseline command + `--vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64`

**Two seeds:** s42 and s73, same as all recent baselines.

**Important:** If the O(N_nodes × N_panels) computation is slow (85K × 64 = 5.4M per foil), use torch broadcasting and ensure it runs in the collation step (not in the training loop). Consider caching the induced velocities in the dataloader if memory allows.

## Baseline

Current best metrics (PR #2350 — Wake Angle Feature, 2-seed avg):

| Metric | Target to beat |
|--------|---------------|
| p_in   | < 11.90       |
| p_oodc | < 7.35        |
| p_tan  | < 27.20       |
| p_re   | < 6.40        |

Reproduce baseline:
```
cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature
```

W&B runs: 0gkeylyz (seed 42), sksq5fp5 (seed 73) — entity=wandb-applied-ai-team, project=senpai-v1