### PR TITLE
Surface-Normal Local Frame for SRF: boundary-layer-aware input

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -422,6 +422,71 @@ def compute_cp_panel(raw_xy, aoa_rad, is_surface, saf_norm):
     return cp_panel.unsqueeze(-1)  # [B, N, 1]
 
 
+def compute_surface_normal_frame(raw_xy: torch.Tensor, is_surface: torch.Tensor,
+                                 saf_norm: torch.Tensor, saf_thresh: float = 0.005) -> torch.Tensor:
+    """Compute local tangent/normal frame features for surface nodes.
+
+    For each surface node, sorts the foil-specific contour by angle from centroid,
+    computes the surface tangent/normal from adjacent nodes (central difference),
+    and projects the node's position relative to centroid into the local frame.
+
+    Args:
+        raw_xy:     [B, N, 2]  raw (chord-normalised) (x, y) positions
+        is_surface: [B, N]     boolean mask — surface nodes only
+        saf_norm:   [B, N]     gradient-field norm to separate fore (≤thresh) / aft (>thresh)
+        saf_thresh: threshold for fore vs aft foil split
+
+    Returns:
+        frame_feats: [B, N, 2]  (pos_tangential, pos_normal) — 0 for non-surface nodes
+    """
+    B, N, _ = raw_xy.shape
+    device = raw_xy.device
+    frame_feats = torch.zeros(B, N, 2, device=device, dtype=raw_xy.dtype)
+
+    for b in range(B):
+        surf_b = is_surface[b]  # [N]
+        if surf_b.sum() == 0:
+            continue
+        fore_mask = surf_b & (saf_norm[b] <= saf_thresh)
+        aft_mask  = surf_b & (saf_norm[b] >  saf_thresh)
+
+        for group_mask in [fore_mask, aft_mask]:
+            group_idx = group_mask.nonzero(as_tuple=True)[0]  # [M]
+            M = group_idx.numel()
+            if M < 3:
+                continue
+
+            pos = raw_xy[b, group_idx]  # [M, 2]
+            cx, cy = pos[:, 0].mean(), pos[:, 1].mean()
+            centroid = torch.stack([cx, cy])  # [2]
+
+            # Sort by angle from centroid to get ordered contour
+            angles = torch.atan2(pos[:, 1] - cy, pos[:, 0] - cx)  # [M]
+            sort_order = angles.argsort()
+            sorted_pos = pos[sort_order]  # [M, 2]
+
+            # Tangent via central difference around the closed contour
+            tangent = torch.roll(sorted_pos, -1, dims=0) - torch.roll(sorted_pos, 1, dims=0)
+            tangent = tangent / tangent.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+
+            # Normal = tangent rotated 90°; ensure it points inward (toward centroid)
+            normal = torch.stack([-tangent[:, 1], tangent[:, 0]], dim=-1)
+            to_centroid = centroid.unsqueeze(0) - sorted_pos  # [M, 2]
+            if (normal * to_centroid).sum(dim=-1).mean() < 0:
+                normal = -normal
+
+            # Project position relative to centroid into local frame
+            rel_pos = sorted_pos - centroid.unsqueeze(0)  # [M, 2]
+            pos_t = (rel_pos * tangent).sum(dim=-1)   # [M] arc-length-like
+            pos_n = (rel_pos * normal).sum(dim=-1)    # [M] thickness-like
+
+            # Unsort back to original node ordering
+            unsort = sort_order.argsort()
+            frame_feats[b, group_idx] = torch.stack([pos_t[unsort], pos_n[unsort]], dim=-1)
+
+    return frame_feats  # [B, N, 2]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -627,13 +692,13 @@ class SurfaceRefinementHead(nn.Module):
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
-                 n_layers: int = 2, p_only: bool = False):
+                 n_layers: int = 2, p_only: bool = False, extra_input_dim: int = 0):
         super().__init__()
         self.p_only = p_only
         actual_out = 1 if p_only else out_dim  # 1 for pressure-only, 3 for all fields
         layers: list[nn.Module] = []
-        # Input: hidden features (n_hidden) + base predictions (out_dim)
-        in_dim = n_hidden + out_dim
+        # Input: hidden features (n_hidden) + base predictions (out_dim) + optional extra
+        in_dim = n_hidden + out_dim + extra_input_dim
         for i in range(n_layers):
             layers.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
             layers.append(nn.LayerNorm(hidden_dim))
@@ -644,15 +709,20 @@ class SurfaceRefinementHead(nn.Module):
         nn.init.zeros_(layers[-1].bias)
         self.mlp = nn.Sequential(*layers)
 
-    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor,
+                extra_input: torch.Tensor | None = None) -> torch.Tensor:
         """
         Args:
-            hidden: [M, n_hidden] — hidden features for surface nodes only
-            base_pred: [M, out_dim] — base predictions for surface nodes only
+            hidden:      [M, n_hidden] — hidden features for surface nodes only
+            base_pred:   [M, out_dim]  — base predictions for surface nodes only
+            extra_input: [M, extra_input_dim] — optional additional features (e.g. local frame)
         Returns:
             correction: [M, out_dim] — additive correction (zero-padded for p_only)
         """
-        inp = torch.cat([hidden, base_pred], dim=-1)
+        parts = [hidden, base_pred]
+        if extra_input is not None:
+            parts.append(extra_input)
+        inp = torch.cat(parts, dim=-1)
         correction = self.mlp(inp)
         if self.p_only:
             # Pad with zeros for velocity channels: [M, 1] → [M, 3]
@@ -1229,6 +1299,7 @@ class Config:
     surface_refine_layers: int = 2            # number of hidden layers in refinement MLP
     surface_refine_p_only: bool = False       # only refine pressure channel (not velocity)
     surface_refine_context: bool = False      # use surface + nearest-volume context features
+    srf_normal_frame: bool = False            # append local tangent/normal frame coords to SRF input (+2 channels)
     # Phase 6: Asinh pressure transform
     asinh_pressure: bool = False             # transform pressure targets with asinh for dynamic range compression
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
@@ -1454,6 +1525,7 @@ if cfg.surface_refine:
             hidden_dim=cfg.surface_refine_hidden,
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
+            extra_input_dim=2 if cfg.srf_normal_frame else 0,
         ).to(device)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())
@@ -1868,7 +1940,7 @@ for epoch in range(MAX_EPOCHS):
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
         # TE coordinate frame / wake deficit / cp_panel: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.srf_normal_frame
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -2017,6 +2089,10 @@ for epoch in range(MAX_EPOCHS):
                 pred = pred / sample_stds
 
         # Surface refinement head: additive correction on surface nodes
+        # Precompute local tangent/normal frame features if requested
+        _srf_frame_feats = None
+        if cfg.srf_normal_frame and _raw_xy_te is not None and _raw_saf_norm_te is not None:
+            _srf_frame_feats = compute_surface_normal_frame(_raw_xy_te, is_surface, _raw_saf_norm_te)
         if refine_head is not None and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                 if cfg.surface_refine_context:
@@ -2031,7 +2107,10 @@ for epoch in range(MAX_EPOCHS):
                     if surf_idx.numel() > 0:
                         surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
                         surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
-                        correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
+                        _surf_extra = None
+                        if _srf_frame_feats is not None:
+                            _surf_extra = _srf_frame_feats[surf_idx[:, 0], surf_idx[:, 1]]
+                        correction = refine_head(surf_hidden, surf_pred, _surf_extra).float()  # [M, 3]
                         pred = pred.clone()
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
 
@@ -2569,7 +2648,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
                 _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.srf_normal_frame
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2706,7 +2785,11 @@ for epoch in range(MAX_EPOCHS):
                             if surf_idx.numel() > 0:
                                 surf_hidden = _eval_hidden[surf_idx[:, 0], surf_idx[:, 1]]
                                 surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                                correction = eval_refine_head(surf_hidden, surf_pred).float()
+                                _v_surf_extra = None
+                                if cfg.srf_normal_frame and _raw_xy_te is not None and _raw_saf_norm_te is not None:
+                                    _v_frame_feats = compute_surface_normal_frame(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                                    _v_surf_extra = _v_frame_feats[surf_idx[:, 0], surf_idx[:, 1]]
+                                correction = eval_refine_head(surf_hidden, surf_pred, _v_surf_extra).float()
                                 pred_loss = pred_loss.clone()
                                 pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
                     # Back-compute refined pred so denormalization (pred_orig) includes refinement
@@ -3119,7 +3202,7 @@ if cfg.surface_refine and best_metrics:
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
                     _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.srf_normal_frame
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3223,10 +3306,14 @@ if cfg.surface_refine and best_metrics:
                     surf_idx = is_surface.nonzero(as_tuple=False)
                     correction_full = torch.zeros_like(pred_loss)
                     if surf_idx.numel() > 0:
+                        _vv_surf_extra = None
+                        if cfg.srf_normal_frame and _raw_xy_te is not None and _raw_saf_norm_te is not None:
+                            _vv_frame_feats = compute_surface_normal_frame(_raw_xy_te, is_surface, _raw_saf_norm_te)
+                            _vv_surf_extra = _vv_frame_feats[surf_idx[:, 0], surf_idx[:, 1]]
                         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                             surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]
                             surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                            correction = verify_refine(surf_hidden, surf_pred).float()
+                            correction = verify_refine(surf_hidden, surf_pred, _vv_surf_extra).float()
                         pred_loss_refined = pred_loss.clone()
                         pred_loss_refined[surf_idx[:, 0], surf_idx[:, 1]] += correction
                         correction_full[surf_idx[:, 0], surf_idx[:, 1]] = correction


### PR DESCRIPTION
## Hypothesis

The Surface Refinement Head (SRF) corrects backbone predictions using surface node features, but it operates in global Cartesian coordinates. Boundary layer physics are fundamentally aligned with the **surface-normal direction**: pressure gradient ∂p/∂n ≈ 0 at the wall (thin BL assumption), suction peak intensity scales with normal curvature, and separation occurs along the tangential direction. 

This experiment adds a surface-normal local coordinate frame to the SRF input: for each surface node, we compute the inward normal direction from adjacent node positions, build a 2×2 rotation matrix R = [tangent | normal], and append the node's position reprojected into this frame as 2 extra input channels. The SRF MLP then sees both global features AND locally-aligned coordinates, making wall-normal corrections geometrically transparent.

**Why it's different from TE frame (already in baseline):** The trailing-edge coordinate frame (`--te_coord_frame`) is TE-relative — it aligns coordinates with the trailing edge direction. The surface-normal frame is *wall-normal at each node* — it varies continuously along the airfoil contour, aligning with the surface tangent/normal at each point. These are orthogonal sources of geometric information.

**Why it helps:** Pressure distribution has a characteristic pattern as a function of surface arc-length: suction peak near LE, favorable gradient on upper surface, adverse gradient toward TE. The SRF currently must infer this pattern from global (x, y) coordinates. Adding tangential/normal projections makes the surface geometry explicit at each node, allowing the SRF to learn "near-LE suction correction" vs "TE recovery correction" more directly.

**Literature:**
- "Neural fields for rapid aircraft aerodynamics simulations" (Nature Scientific Reports, Oct 2024): surface-normal projection for BL enforcement
- GeoMPNN (arXiv:2412.09399, NeurIPS 2024 ML4CFD Best Student Paper): geometric coordinate frames for physics-aware mesh learning

## Instructions

Add a `--srf_normal_frame` flag. When enabled, compute per-surface-node normal directions and append tangential/normal projections to the SRF input.

**Implementation:**

1. For each sample, identify surface nodes (boundary_id ∈ {6, 7}).

2. For each surface node i, compute the surface tangent direction from adjacent nodes:
   ```python
   # Sort surface nodes by angle from centroid to get ordered contour
   # For node i, tangent = normalize(pos[i+1] - pos[i-1])  (central difference)
   # Normal = perpendicular to tangent (rotated 90° inward toward centroid)
   tangent_x, tangent_y = ...  # [N_surface]
   normal_x = -tangent_y       # inward normal
   normal_y = tangent_x
   ```

3. For each surface node, compute the rotation into the local frame:
   ```python
   # Local coordinates of node position (relative to centroid or chord midpoint)
   pos_local_t = pos_x * tangent_x + pos_y * tangent_y  # tangential component
   pos_local_n = pos_x * normal_x + pos_y * normal_y    # normal component
   ```

4. Append (pos_local_t, pos_local_n) as 2 additional channels to surface node features. For volume nodes, set these to zero (they are not surface-aligned).

5. The SRF head already operates only on surface nodes — pass the augmented features in. Adjust SRF input_dim += 2 accordingly.

6. Add flag: `--srf_normal_frame` (bool)

**Note on ordering:** The surface nodes in the dataset may not be ordered along the contour. Sort them by angle from the foil centroid (atan2(y - cy, x - cx)) to get a consistent ordering before computing tangents.

Run:
```
python train.py [full baseline flags] --srf_normal_frame --wandb_group round38/srf-normal-frame --seed 42
python train.py [full baseline flags] --srf_normal_frame --wandb_group round38/srf-normal-frame --seed 73
```

## Baseline

Current best metrics (PR #2350 — Wake Angle Feature, 2-seed avg):

| Metric | Target to beat |
|--------|---------------|
| p_in   | < 11.90       |
| p_oodc | < 7.35        |
| p_tan  | < 27.20       |
| p_re   | < 6.40        |

Reproduce baseline:
```
cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature
```

W&B runs: 0gkeylyz (seed 42), sksq5fp5 (seed 73) — entity=wandb-applied-ai-team, project=senpai-v1