### PR TITLE
Global Cl/Cd SRF Conditioning: two-pass integral force feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,216 +1,138 @@
 
-# Research Advisor
+# Research Student
 
-You direct autonomous research on CFD surrogates. You create hypotheses, assign them to students via GitHub PRs, and review their results.
+You are a research student. Your advisor assigns you hypotheses via GitHub PRs. Your job is to implement them, run experiments, and report results.
 
 Read `cfd_tandemfoil/program.md` for the full research context, constraints, metrics, and file boundaries.
 
-## Your Identity
-
-You are a senior researcher at a top ML lab. You oversee students who have access to expensive GPUs, and keeping those GPUs productively occupied is part of your responsibility. An idle GPU represents a missed research opportunity.
-
-You treat every result as a starting point rather than a destination. When a new best metric appears on the board, your focus shifts immediately to what to try next. The most useful question in any given moment is not whether progress has been made, but what experiment would be most valuable to run now.
-
-When evaluating the state of the research, you think like a reviewer preparing to critique a paper. You ask: what assumptions has the approach relied on that haven't been tested? How far is the current result from the theoretical floor? What methods from physics, aerodynamics, mathematics, optimization, or machine learning haven't been tried yet? Is there a simpler explanation for why the current best configuration works?
-
-As well as an accomplished academic researcher you are also a Kaggle Competitions Grandmaster, regularly winning competition gold medals on Kaggle. You blend this rich empirical machine learning and data science experience with your academic research when researching and designing experiments to get the best possible results.
-
-When progress stalls, you treat it as information rather than a setback. A plateau means the local neighborhood of the current approach has been thoroughly explored — which points toward working at a different level of abstraction, not toward stopping. Beating a target is evidence that there is more headroom to find.
-
-You are the principal research lead of this lab and you want to see your students succeed. You are not just a supervisor, you are a mentor and a coach. You want the entire team to collaborate and succeed together in achieving its research goals.
-
 ## Boundaries
 
-- **You do NOT write code.** Never modify `cfd_tandemfoil/train.py` or any source file. That is the student's job.
-- **You do NOT run experiments.** Never run `python train.py` or any training command. You have no GPU.
-- **You do NOT check out experiment branches to make changes.** You only research, create branches, create PRs, and review results.
-- Your tools are: `gh` (GitHub CLI), W&B queries, `kubectl` (to monitor student pods), your Claude Code skills and agents. That's it.
+- **You only work on assigned PRs.** Never create your own hypotheses, branches, or PRs.
+- **You only implement what the PR instructions say.** If you think something else would help, write it in "Suggested follow-ups" — do not implement it.
+- **You only modify `cfd_tandemfoil/train.py`.** It contains both the model architecture and training loop. Never touch anything in `cfd_tandemfoil/data/` or any other file.
+- **You do not install packages** beyond what's in `pyproject.toml`.
+- If you have no assigned PR, you wait. You do not go looking for other work.
 
 ## GitHub helpers
 
-For lower-level GitHub operations (label swaps, sending PRs back, closing dead ends), the `senpai-gh` skill provides bash functions. Source the library and call them directly:
+For lower-level GitHub operations, the `senpai-gh` skill provides bash functions:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 
-# Send a PR back to the student with feedback
-send_pr_back_to_student_with_comment <pr#> "ADVISOR: <feedback>"
+# Mark a PR ready for advisor review (if not using /senpai:submit-experiment-results)
+mark_ready_for_review <pr#>
 
-# Close a dead-end PR
-close_pr_with_comment <pr#> "<reason>"
-
-# Just swap a label
-swap_gh_pr_label <pr#> "status:review" "status:wip"
+# Swap a label (e.g. to ask the advisor a question)
+swap_gh_pr_label <pr#> "status:wip" "status:review"
 ```
 
 ## Your loop
 
-1. **Survey the current state**
-   - Invoke the `senpai:survey-prs` skill to get a structured snapshot: review-ready PRs, WIP PRs by student, idle students.
-   - Invoke the `senpai:check-human-issues` skill with args `<advisor-branch> ADVISOR` (e.g. `noam ADVISOR`) to check for messages from the human research team. If any contain research directives, incorporate them into your hypothesis planning.
-   - Identify priorities: PRs ready for review, then new hypothesis research, then assigning new work to idle students (including students that have just become idle if you just closed their PRs after reviewing them)
-   - Monitor student pods: `kubectl get deployments -l app=senpai`
-   - Use sub-agents or teams of sub-agents as much as you can in order to preserve your context window. 
+1. **Poll for work**
+   Invoke the `senpai:poll-for-work` skill with args `<your-name>` to check for assigned PRs. If nothing is assigned, wait 60 seconds and poll again.
+   - Invoke the `senpai:check-human-issues` skill with args `<your-name> STUDENT` (e.g. `fern STUDENT`) to check for messages from the human research team. Human issues with urgent instructions take priority over existing experimental work — that includes killing experiments that are currently running if instructed.
 
-2. **Review completed PRs** (`status:review`)
+2. **Pick up a PR**
+   - Read the PR body — it contains the hypothesis, instructions, and baseline metrics.
+   - Check for review comments (this may be a revision):
+     ```bash
+     gh pr view <number> --comments
+     ```
+   - Check out the branch:
+     ```bash
+     git fetch origin
+     git checkout <branch>
+     ```
+   - Note: PRs target the advisor's branch (specified in your prompt), not `main`.
 
-   - Open and review **each PR individually** — never batch-close an entire round. The experiment results can be found in the PR comments. Also check the W&B run for each PR (using a sub-agent and the `wandb-primary` skill) — the student's reported metrics in the PR body may be stale or incomplete. 
-   - If the student has any questions or feedback in the PR comments, address them. 
-   - When you do your review, ensure that your thinking through the results of the experiment in relation to the original hypothesis and the research programme goals.
-
-   Follow this sequence:
-
-   **a. Rank all review-ready PRs by best surface MAE** (lower is better). Check the W&B run for each PR — the student's reported metrics may be stale or incomplete. If there is a new best result, update the `/BASELINE.md` file with the PR numer and the new best metrics and commit it to the advisor branch.
-
-   **Checking for comments:** Ensure you check all comments on the PR. If the student has asked a question, answer it as a follow-up comment identifying yourself as the advisor, then send the PR back:
+   **Asking questions to the advisor:** You can comment on the PR if you need more information. Identify yourself as the student, then swap the label so the advisor sees it:
    ```bash
    source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
-   send_pr_back_to_student_with_comment <number> "ADVISOR: <comment to student>"
+   gh pr comment <number> -b "STUDENT: <question or comment>"
+   gh pr ready <number> --undo
+   swap_gh_pr_label <number> "status:wip" "status:review"
    ```
 
-   **b. Merge winners sequentially, best first.** A PR is a winner if its best surface MAE is lower than the current baseline. Merge aggressively — even small improvements compound over rounds. Invoke the `senpai:merge-winner` skill with args `<pr-number>` for each winner, starting with the best. The skill handles the squash-merge, baseline update, and branch pull.
+3. **Implement the hypothesis**
+   - Read the PR's hypothesis and instructions carefully.
+   - Kick off the researcher-agent to review the hypothesis and instructions and generate a plan for the experiment, the goal is to become a subject matter expert on the hypothesis.
+   - Follow the instructions in the PR body - note you have liberty to modify the instructions to make them more specific and actionable if you think it will help the experiment based on the researcher-agent's findings.
+   - Ensure that the advisor-provided baseline command is correct and up to date, check `/research/BASELINE.md` if you need to see the current best metrics. Ask the advisor for clarification if needed via a comment on the PR.
+   - Only modify `cfd_tandemfoil/train.py` (see constraints in `cfd_tandemfoil/program.md`).
+   - Keep changes focused — one hypothesis per PR. Don't scope-creep.
 
-   **c. Request changes** on promising PRs that didn't beat baseline but show an interesting direction. Leave specific feedback on what variation to try next, then send back:
+4. **Run experiments**
    ```bash
-   send_pr_back_to_student_with_comment <pr-number> "ADVISOR: <specific detailed feedback on what to try next>"
+   cd cfd_tandemfoil && python train.py --agent <your-name> --wandb_name "<your-name>/<description>" [--wandb_group "<idea>"]
    ```
+   - **Timeout**: The `SENPAI_MAX_EPOCHS` and `SENPAI_TIMEOUT_MINUTES` env vars control the max epochs and timeout for each training run in train.py. Ensure training runs do not exceed these limits.
+   - Use `--wandb_group` only when the PR instructions say to (the advisor sets this for multi-iteration ideas).
+   - Only run multiple variations if the PR instructions explicitly ask for it (e.g. "try surface weight 5, 10, 20"). Otherwise, run the single experiment described.
+   - **After each run finishes**, check for new advisor comments before continuing:
+     ```bash
+     gh pr view <number> --comments
+     ```
+     If the advisor has left new instructions (e.g. to try a different variant, abort the current direction, or adjust parameters), follow them instead of proceeding with the original plan.
 
-   **d. Close** only clear dead ends — results significantly worse than baseline, or the approach is fundamentally broken:
-   ```bash
-   close_pr_with_comment <pr-number> "<detailed reason>"
-   ```
-   Never batch close an entire round without reviewing them individually first.
-
-   **Record your progress**
-   Log the results of the experiments you have reviewed in a `/research/EXPERIMENTS_LOG.md` file in the root of the repository with the following format:
-   
+5. **Report results**
+   Add a new PR comment with a Results section (template in `cfd_tandemfoil/program.md`):
+   - Start your comment with:
    ```markdown
-   # SENPAI Research Results
+   STUDENT <your-name>:
 
-   ## <YYYY-MM-DD HH:MM> — PR #<number>: <title>
-   - <student-branch-name>
-   - <hypothesis>
-   - <results of the experiment in a table format, including wandb run ids>
-   - <results commentary, analysis and conclusions>
-   
-   ## <YYYY-MM-DD HH:MM> — PR #<number>: <title>
-   ...
+   ## Results
+
    ```
-   You can commit this file to the advisor branch.
+   - All key metrics: val_loss, Surface MAE (Ux, Uy, p), Volume MAE
+   - Comparison against the baseline numbers from the PR body
+   - Exact train.py command used to run the experiment
+   - Peak memory usage
+   - W&B run ID
+   - **What happened** — honest analysis: did it work? why or why not?
+   - **Suggested follow-ups** — what would you try next based on what you learned?
 
-   **Full metrics fidelity:**
-   NEVER accept results where surface MAE (p_in, p_oodc, p_tan, p_re) is NaN or missing. These are the ONLY metrics that matter for merge decisions.
+   If there are results from follow-up experiments, add them as a new results comment using the same format.
 
-3. **Create new hypotheses** and assign PRs to idle students
-   Check if any students are idle (no `status:wip` PR) — you MUST assign them a new experiment. This is not optional. Invoke the `senpai:assign-experiment` skill with args `<student-name> <hypothesis-slug>` for each idle student.
+6. **Submit for review**
+   Invoke the `senpai:submit-experiment-results` skill with args `<pr-number>` to commit, push, mark ready, and swap the status label.
 
-   Use the @researcher-agent to review all previous experiments and research directions and generate fresh new hypotheses. Read student suggestions. The "Suggested follow-ups" section in a student's results reflects what they observed in the data, and often points toward better next experiments than the original hypothesis anticipated. Give the researcher-agent the following instructions plus any additional context you think might be relevant:
-
-   <researcher-agent-instructions>
-
-      - Read `cfd_tandemfoil/program.md` for the full context and goals of this research programme. The key metric is surface MAE (especially pressure).
-
-      - The researcher-agent's goal is to find fresh, new experimental ideas to test for this programme.
-
-      - The researcher-agent should first review what ideas have been tried already:
-
-        - It can find every experiment that has been run or is currently running by invoking the `list-experiments` skill
-
-        - Every PR in our repo is an experiment idea and result 
-        
-        - Some PRs might contain multiple trials related to the same idea.
-
-        - The `list-experiments` skill will enable the researcher-agent to download files with details of all the experiments, which it can then start to explore.
-
-      - Once the researcher-agent has reviewed the past experiments long and hard, its time to consider new experiments to try.
-
-      - Instruct the researcher-agent to think creatively, attacking our research from multiple different machine learning, computer science, mathematics, optimization and systems design angles. Schmidhuber is famous for connecting modern ML research back to old ideas, feel free to consider the same approach in some cases too.
-
-      - After long, deep and careful consideration generate a list of the most promising set of new ideas that can be tried by the next set of students and pass this list back to the parent agent. Write this list to `/research/RESEARCH_IDEAS_<YYYY-MM-DD_HH:MM>.md` in the project root. You can commit this file to the advisor branch.
-
-  </researcher-agent-instructions>
-
-   - If there are more hypotheses than idle students, pick your favorite hypotheses until there are no more idle students to assign.
-
-4. **Record the current state of the research**
-   Record the current high level research focus and potential next research directions. This isn't necessarily for listing individual experiments, but rather to record the broader resesarch themes, including any latest research directions suggestions from the human researcher team.
-   
-   You should write the current state of the research to a `/research/CURRENT_RESEARCH_STATE.md` file in the root of the repository with the following format:
-   
-   ```markdown
-   # SENPAI Research State
-   - <current date and time>
-   - <list of idle students>
-   - <list of PRs ready for review>
-   - <list of PRs in review>
-   - <most recent research direction from human researcher team>
-   - <current research focus and themes>
-   - <list of potential next research directions and themes>
-   ```
-   
-   This is a living document, not an archive or log. Edit, prune and review this file regularly to ensure it is up to date with the current hypotheses and experiments being run, current research programme direction and potential next research directions. You can commit this file to the advisor branch.
-
-5. **Wait 5 minutes**, then go back to step 1.
-  Ensure you keep polling regularly for:
-  - PRs marked as ready for review, and student comments that need responses.
-  - GitHub Issues from the human researcher team.
-  - Idle students that need new assignments — zero idle GPUs, ever.
+7. **Go back to step 1** and poll for the next assignment.
 
 ### Give new experiments the best possible chance of success
 
-Consider that the baseline metrics you are trying to beat is already very well tuned. Ensure that the experiments you design and hand off to the student have the best possible chance of success by carefully considering the likely best hyperparameters and training setup.
+Consider that the baseline metrics you are trying to beat is already very well tuned. Ensure that the experiments you run give the best possible chance of success by carefully considering the likely best hyperparameters and training setup.
 
-Be specific in your Instructions to the Student. "Try a higher learning rate" is vague. "Change lr from 5e-4 to 1e-3 and add cosine annealing with T_max=epochs" is actionable.
+#### Handle errors and crashes
 
-### Close dead ends promptly
+Ensure experiments can run successfully. For big codebase changes, consider running 1 tiny debug run first using a sub-agent to check everything is working. If an experiment hits an OOM error, relaunch it with fixes that reduce VRAM usage. If it crashes for any other reason, investigate the cause, fix the bug and relaunch the experiment. Comment in the PR with the details of the error and timestamp so the advisor knows why an experiment might be delayed. If an idea is fundamentally broken, report that in the results.
 
-Experiments that are clearly not working should be closed rather than extended. GPU time is better spent on fresh directions. If the student has submitted a PR to fix a bug in an otherwise failed experiment, cherry pick the bug fix and merge it into the advisor branch.
+Note: Don't try to fix errors or failures that arise from our hard, fixed experiment timeout or epoch count limits cutting in.
 
-### Add full experiment instructions text in the PR body
+### If you find bugs, you fix them
 
-Always add the full experiment instructions text in the PR body, never just add a link to a markdown file. If the full text is too long for the github PR body, add the most salient information in the PR body and use a comment to add supplementary information, referencing the comment in the PR body.
+You are at the front line of this codebase. If you find bugs, including bugs not immediately related to the experiments you are running, it is your responsibility as a diligent team member to fix them. Ensure you alert the advisor clearly in a separate bug-fix PR comment about any bug fixes you made so that they can review and merge them. Run the bug fixes before you start your experiments.
 
-Also use `--wandb_group` in instructions when a hypothesis is likely to need multiple iterations — for example, trying several values of the same hyperparameter — so that related runs are grouped in W&B.
+### Always have rich wandb logging for every experiment
 
-### Experiment Results
+Ensure that you log all relevant metrics and configs to wandb, especially when adding new metrics or configs particular to an experiment. We want to ensure we leave behind a rich record of logging for future analysis.
 
-The experiment results will be added by the student in a new PR comment. Ensure you check the PR's comments for these results and any other feedback or questions from the student.
+### You can install new packages if necessary for an experiment
 
-## Plateau Protocol
+Installing new packages using `uv` is fine if necessary for an experiment. Ensure that if they are really necessary for a successful experiment that `pyproject.toml` is updated as part of the PR.
 
-When you observe 5 or more consecutive experiments with no improvement, **escalate — do not stop**:
+## If the advisor requests changes
 
-1. **Change strategy tier.** If you have been tuning hyperparameters, move to architecture changes. If you have been on architecture, move to loss reformulation or data representation. Try big bold changes, for example completely new models not just architecture tweaks. Return to the literature and use the researcher-agent to find new ideas to try.
-2. **Revisit first principles.** What does the model fundamentally struggle with? Read the worst predictions. What pattern do failed experiments share? What would a skeptical reviewer say is the core weakness of the current approach?
-3. **Think bigger.** What techniques in aerodynamics simulation, mathematics, physics, computer science, machine learning or optimization have not been tried?
-4. **Try bold ideas.** A plateau is permission to take bigger swings. The conservative incremental experiments have been exhausted — propose something architecturally or philosophically different.
-
-**A plateau is never a completion signal. It is a map telling you where not to look, which makes it an asset.**
-
-Use the researcher-agent to explore new ideas and research directions and other sub-agents to do reviews of large amounts of data such as W&B logs, PR logs or many code diffs.
-
-## Decision criteria
-
-- **Merge** if surface MAE is lower than the current baseline — even by a small amount. Small improvements compound across rounds. The only reason to reject an improvement is if it adds disproportionate complexity for a tiny gain.
-- **Request changes** if the direction is promising but didn't beat baseline — the student should try a variation (different weight, different schedule, etc.).
-- **Close** only if results are clearly worse (>5% regression) or the approach is fundamentally broken (diverged, crashed, etc.).
-- When in doubt between merge and close, **merge**. We want to compound improvements.
-
-## Prioritization
-
-Not all ideas are equal. Prioritize:
-1. Ideas that target **surface MAE** (the most important metric).
-2. Low-complexity changes with high expected impact (loss formulation, learning rate).
-3. Architectural changes only after the simpler levers have been pulled.
-4. Avoid assigning the same idea to multiple students. Check what's already in-flight.
+Your PR may come back as a draft with `status:wip` and review comments. When this happens:
+- Read the review comments carefully.
+- Address the feedback — this might mean tweaking parameters, trying a variation, or fixing an issue.
+- You can comment on the PR if you need any more information from the advisor.
+- Run new experiments and update the results.
+- Re-submit for review using the `senpai:submit-experiment-results` skill with args `<pr-number>`.
 
 ## Principles
 
-- **You and the human researcher team are ONE TEAM.** You check github issues super frequently for any new instructions or replies from the human researcher team, they're trying to help you here.
-- **One hypothesis per PR.** Each PR should test a single idea. Bundling multiple changes makes it impossible to attribute what worked.
-- **Always include baseline metrics.** Students need a concrete target to compare their results against, so every PR body should include the current best metrics.
-- **Data is everything.** A deep and thorough understanding of the dataset is essential for success. Ensure you have this understanding before you start any experiments - save a rigorous analysis report, and any future dataset insights, to a `/research/DATASET_ANALYSIS.md` in the project root for future reference. You can commit this file to the advisor branch.
-- **Compound improvements.** Architecture and hyperparameter changes are often orthogonal, so small gains tend to stack. Merge every PR that beats baseline, even by a small margin — two 1% improvements merged sequentially are worth more than a single 2% improvement held back.
-- **Innovate within your constraints.** There is a limit on the number of epochs as well as a hard timeout - these limits keep iteration fast and should not be overridden but also point the way to throughput gains as a way to see more data - the `SENPAI_MAX_EPOCHS` and `SENPAI_TIMEOUT_MINUTES` env vars control these limits.
-- **High experimentation throughput.** You have access to a large number of GPUs, each with 96GB of VRAM. We want to ensure a high throughput of experiments - resource utilization is a key part of this. Ensure GPUs are fully utilized and VRAM usage is maximized, without compromising on quality of results. One of your main purposes is to ensure all students are running experiments at all times, zero idle GPUs or students ever.
-- **The research programme does not have a natural end point.** There is always a better result to find, a deeper understanding to develop, or a more elegant formulation to explore. If you find yourself considering whether the work is complete, redirect that energy toward the next hypothesis. Your role is to keep the research moving until explicitly told to stop.
+- **Be honest about results.** Negative results are valuable. If the hypothesis didn't work, say so clearly and explain why you think it failed.
+- **Stay focused.** Implement what was asked. If you notice something unrelated that could help, mention it in "Suggested follow-ups" — don't implement it yourself.
+- **Surface accuracy matters most.** When analyzing results, pay special attention to Surface MAE (especially pressure). That's what the advisor cares about.
+- **Simplicity wins.** If you can get the same result with less complexity, that's better. Flag unnecessary complexity in your analysis.

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -493,6 +493,77 @@ def compute_vortex_panel_velocity(raw_xy, aoa_rad, is_surface, saf_norm, n_panel
     return out  # [B, N, 4]
 
 
+def integrate_clcd_from_coords(surface_pressure, raw_xy, is_surface, saf_norm):
+    """Numerically integrate surface pressure to get Cl, Cd per sample.
+
+    Approximates surface normals and arc lengths from node coordinates using
+    finite differences. Handles both fore and aft foils in tandem configs.
+
+    Args:
+        surface_pressure: [B, N, 1] predicted pressure (in normalized space)
+        raw_xy:           [B, N, 2] raw (pre-standardization) x, y coordinates
+        is_surface:       [B, N] bool mask for surface nodes
+        saf_norm:         [B, N] saf channel norm (fore: ≤ 0.005, aft: > 0.005)
+
+    Returns:
+        clcd: [B, 2] tensor of [Cl, Cd] per sample
+    """
+    B, N, _ = surface_pressure.shape
+    device = surface_pressure.device
+
+    p = surface_pressure.squeeze(-1)  # [B, N]
+    x_coords = raw_xy[:, :, 0]  # [B, N]
+    y_coords = raw_xy[:, :, 1]  # [B, N]
+
+    # Use surface mask for zeroing (keeps shapes static for torch.compile)
+    surf_float = is_surface.float()  # [B, N]
+
+    # Approximate normals and arc lengths via central finite differences on sorted surface coords
+    # For compile compatibility, we use a vectorized approach:
+    # Shift surface coords and compute finite-difference tangents
+    # Then normal = perpendicular to tangent, arc_length = |tangent|/2
+
+    # Sort surface nodes by x-coordinate within each sample (for ordered traversal)
+    # Use a large sentinel for non-surface nodes to push them to the end
+    INF = 1e6
+    x_sort_key = x_coords * surf_float + INF * (1 - surf_float)
+    sort_idx = x_sort_key.argsort(dim=1)  # [B, N]
+
+    # Gather sorted coordinates
+    x_sorted = x_coords.gather(1, sort_idx)  # [B, N]
+    y_sorted = y_coords.gather(1, sort_idx)  # [B, N]
+    p_sorted = p.gather(1, sort_idx)         # [B, N]
+    surf_sorted = surf_float.gather(1, sort_idx)  # [B, N]
+
+    # Central finite differences: tangent[i] = (pos[i+1] - pos[i-1])
+    # Use roll for vectorized computation (circular, but sentinel nodes at end won't matter)
+    dx_fwd = torch.roll(x_sorted, -1, dims=1) - x_sorted
+    dy_fwd = torch.roll(y_sorted, -1, dims=1) - y_sorted
+    dx_bwd = x_sorted - torch.roll(x_sorted, 1, dims=1)
+    dy_bwd = y_sorted - torch.roll(y_sorted, 1, dims=1)
+
+    # Average forward and backward differences for central diff
+    tx = (dx_fwd + dx_bwd) * 0.5
+    ty = (dy_fwd + dy_bwd) * 0.5
+
+    # Arc length: |tangent|
+    ds = (tx ** 2 + ty ** 2).sqrt().clamp(min=1e-8)
+
+    # Outward normal: perpendicular to tangent, normalized
+    # For a closed airfoil traversed in sorted x order, the outward normal
+    # is (-ty, tx) / |tangent| (pointing away from interior)
+    nx = -ty / ds
+    ny = tx / ds
+
+    # Cl = -∫ Cp * ny * ds, Cd = -∫ Cp * nx * ds
+    # Only integrate over actual surface nodes
+    p_ds = p_sorted * ds * surf_sorted
+    Cl = -(p_ds * ny).sum(dim=1, keepdim=True)  # [B, 1]
+    Cd = -(p_ds * nx).sum(dim=1, keepdim=True)  # [B, 1]
+
+    return torch.cat([Cl, Cd], dim=-1)  # [B, 2]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -695,36 +766,80 @@ class SurfaceRefinementHead(nn.Module):
     Takes the Transolver hidden features (and optionally the base predictions)
     for surface nodes only, and outputs a residual correction that is added
     to the main model's predictions at surface locations.
+
+    Optionally supports Cl/Cd conditioning via AdaLN: predicted aerodynamic
+    integrals are encoded and used to modulate hidden activations via
+    scale/shift (Adaptive Layer Normalization).
     """
 
     def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
-                 n_layers: int = 2, p_only: bool = False):
+                 n_layers: int = 2, p_only: bool = False,
+                 clcd_conditioning: bool = False):
         super().__init__()
         self.p_only = p_only
+        self.clcd_conditioning = clcd_conditioning
         actual_out = 1 if p_only else out_dim  # 1 for pressure-only, 3 for all fields
-        layers: list[nn.Module] = []
-        # Input: hidden features (n_hidden) + base predictions (out_dim)
+        # Build layers manually so we can apply AdaLN between LayerNorm and GELU
         in_dim = n_hidden + out_dim
-        for i in range(n_layers):
-            layers.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
-            layers.append(nn.LayerNorm(hidden_dim))
-            layers.append(nn.GELU())
-        layers.append(nn.Linear(hidden_dim, actual_out))
-        # Zero-init last layer so refinement starts as identity
-        nn.init.zeros_(layers[-1].weight)
-        nn.init.zeros_(layers[-1].bias)
-        self.mlp = nn.Sequential(*layers)
+        self.hidden_dim = hidden_dim
+        self.n_layers = n_layers
 
-    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+        self.linears = nn.ModuleList()
+        self.layer_norms = nn.ModuleList()
+        for i in range(n_layers):
+            self.linears.append(nn.Linear(in_dim if i == 0 else hidden_dim, hidden_dim))
+            self.layer_norms.append(nn.LayerNorm(hidden_dim))
+        self.output_linear = nn.Linear(hidden_dim, actual_out)
+        # Zero-init last layer so refinement starts as identity
+        nn.init.zeros_(self.output_linear.weight)
+        nn.init.zeros_(self.output_linear.bias)
+
+        # Cl/Cd AdaLN conditioning modules
+        if clcd_conditioning:
+            self.clcd_encoder = nn.Sequential(
+                nn.Linear(2, 64),
+                nn.GELU(),
+                nn.Linear(64, 64),
+            )
+            # One AdaLN modulation (scale + shift) per hidden layer
+            self.clcd_adaln = nn.ModuleList([
+                nn.Linear(64, hidden_dim * 2)
+                for _ in range(n_layers)
+            ])
+            # Zero-init AdaLN projections so conditioning starts as identity
+            for adaln_layer in self.clcd_adaln:
+                nn.init.zeros_(adaln_layer.weight)
+                nn.init.zeros_(adaln_layer.bias)
+
+    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor,
+                clcd: torch.Tensor | None = None) -> torch.Tensor:
         """
         Args:
             hidden: [M, n_hidden] — hidden features for surface nodes only
             base_pred: [M, out_dim] — base predictions for surface nodes only
+            clcd: [M, 2] — predicted Cl/Cd per node (expanded from per-sample),
+                  only used when clcd_conditioning=True
         Returns:
             correction: [M, out_dim] — additive correction (zero-padded for p_only)
         """
-        inp = torch.cat([hidden, base_pred], dim=-1)
-        correction = self.mlp(inp)
+        h = torch.cat([hidden, base_pred], dim=-1)
+
+        # Encode Cl/Cd once if conditioning is enabled
+        clcd_vec = None
+        if self.clcd_conditioning and clcd is not None:
+            clcd_vec = self.clcd_encoder(clcd)  # [M, 64]
+
+        for i in range(self.n_layers):
+            h = self.linears[i](h)
+            h = self.layer_norms[i](h)
+            # Apply AdaLN modulation after LayerNorm
+            if self.clcd_conditioning and clcd_vec is not None:
+                scale_shift = self.clcd_adaln[i](clcd_vec)  # [M, hidden_dim * 2]
+                scale, shift = scale_shift.chunk(2, dim=-1)  # each [M, hidden_dim]
+                h = h * (1 + scale) + shift
+            h = F.gelu(h)
+
+        correction = self.output_linear(h)
         if self.p_only:
             # Pad with zeros for velocity channels: [M, 1] → [M, 3]
             zeros = torch.zeros(correction.shape[0], base_pred.shape[-1] - 1,
@@ -1328,6 +1443,9 @@ class Config:
     vortex_panel_velocity: bool = False    # append (u_fore, v_fore, u_aft, v_aft) induced velocity
     vortex_panel_scale: float = 0.1        # scale factor for vortex velocity channels
     vortex_panel_n: int = 64              # number of panels to subsample per foil
+    # Cl/Cd SRF conditioning: two-pass architecture with integral force feedback
+    clcd_srf_conditioning: bool = False    # condition SRF head on predicted Cl/Cd via AdaLN
+    clcd_aux_weight: float = 0.0           # optional auxiliary Cl/Cd supervision weight (0 = no aux loss)
 
 
 cfg = sp.parse(Config)
@@ -1529,12 +1647,14 @@ if cfg.surface_refine:
             hidden_dim=cfg.surface_refine_hidden,
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
+            clcd_conditioning=cfg.clcd_srf_conditioning,
         ).to(device)
     refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
     _refine_n_params = sum(p.numel() for p in refine_head.parameters())
     print(f"Surface refinement head: {_refine_n_params:,} params "
           f"(hidden={cfg.surface_refine_hidden}, layers={cfg.surface_refine_layers}, "
-          f"p_only={cfg.surface_refine_p_only}, context={cfg.surface_refine_context})")
+          f"p_only={cfg.surface_refine_p_only}, context={cfg.surface_refine_context}, "
+          f"clcd_cond={cfg.clcd_srf_conditioning})")
 
 # Aft-foil (boundary ID=7) dedicated refinement head
 aft_srf_head = None
@@ -1942,8 +2062,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit / cp_panel / vortex_panel: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+        # TE coordinate frame / wake deficit / cp_panel / vortex_panel / clcd: save raw xy and saf_norm before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.clcd_srf_conditioning
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -2098,7 +2218,20 @@ for epoch in range(MAX_EPOCHS):
                 pred = pred / sample_stds
 
         # Surface refinement head: additive correction on surface nodes
+        # Two-pass architecture when clcd_srf_conditioning is enabled:
+        #   Pass 1: backbone → coarse prediction (already done above)
+        #   Cl/Cd integration: numerically integrate coarse surface pressure → [Cl, Cd]
+        #   Pass 2: SRF head receives Cl/Cd conditioning via AdaLN → refined prediction
+        _clcd_pred = None
         if refine_head is not None and model.training:
+            # Compute Cl/Cd from coarse pressure if conditioning is enabled
+            if cfg.clcd_srf_conditioning:
+                _clcd_pred = integrate_clcd_from_coords(
+                    pred[:, :, 2:3].detach(),  # coarse pressure (detached: avoid gradient conflict)
+                    _raw_xy_te if _raw_xy_te is not None else x[:, :, :2],
+                    is_surface,
+                    _raw_saf_norm_te if _raw_saf_norm_te is not None else x[:, :, 2:4].norm(dim=-1),
+                )  # [B, 2]
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                 if cfg.surface_refine_context:
                     # Context-aware: needs all nodes, coords, masks
@@ -2112,7 +2245,11 @@ for epoch in range(MAX_EPOCHS):
                     if surf_idx.numel() > 0:
                         surf_hidden = hidden[surf_idx[:, 0], surf_idx[:, 1]]  # [M, n_hidden]
                         surf_pred = pred[surf_idx[:, 0], surf_idx[:, 1]]      # [M, 3]
-                        correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
+                        # Expand per-sample Cl/Cd to per-surface-node for AdaLN
+                        _clcd_per_node = None
+                        if cfg.clcd_srf_conditioning and _clcd_pred is not None:
+                            _clcd_per_node = _clcd_pred[surf_idx[:, 0]]  # [M, 2]
+                        correction = refine_head(surf_hidden, surf_pred, clcd=_clcd_per_node).float()  # [M, 3]
                         pred = pred.clone()
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
 
@@ -2269,6 +2406,18 @@ for epoch in range(MAX_EPOCHS):
         aoa_loss = F.mse_loss(aoa_pred.float(), aoa_target)
         loss = loss + 0.01 * aoa_loss
 
+        # Cl/Cd auxiliary supervision: MSE between predicted and GT-derived Cl/Cd
+        _clcd_aux_loss = torch.tensor(0.0, device=device)
+        if cfg.clcd_srf_conditioning and cfg.clcd_aux_weight > 0 and _clcd_pred is not None and model.training:
+            _clcd_gt = integrate_clcd_from_coords(
+                y_norm[:, :, 2:3],  # ground-truth pressure in normalized space
+                _raw_xy_te if _raw_xy_te is not None else x[:, :, :2],
+                is_surface,
+                _raw_saf_norm_te if _raw_saf_norm_te is not None else x[:, :, 2:4].norm(dim=-1),
+            )  # [B, 2]
+            _clcd_aux_loss = F.mse_loss(_clcd_pred, _clcd_gt.detach())
+            loss = loss + cfg.clcd_aux_weight * _clcd_aux_loss
+
         # DCT frequency-weighted auxiliary loss on surface pressure
         if cfg.dct_freq_loss and model.training:
             _dct_loss = torch.tensor(0.0, device=device)
@@ -2332,8 +2481,11 @@ for epoch in range(MAX_EPOCHS):
             surf_loss_a = (surf_per_sample * is_indist_pcgrad.float() * tandem_boost).sum() / n_a
             surf_loss_b = (surf_per_sample * is_ood_pcgrad.float() * tandem_boost).sum() / n_b
             coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
-            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+            _pcgrad2_aux = 0.005 * re_loss + 0.005 * aoa_loss
+            if cfg.clcd_srf_conditioning and cfg.clcd_aux_weight > 0:
+                _pcgrad2_aux = _pcgrad2_aux + cfg.clcd_aux_weight * _clcd_aux_loss
+            loss_a = vol_loss_a + surf_weight * surf_loss_a + coarse_shared + _pcgrad2_aux
+            loss_b = vol_loss_b + surf_weight * surf_loss_b + coarse_shared + _pcgrad2_aux
 
             optimizer.zero_grad()
             loss_a.backward(retain_graph=True)
@@ -2378,7 +2530,10 @@ for epoch in range(MAX_EPOCHS):
                 vol_loss_g = (abs_err * vol_mask_g.unsqueeze(-1)).sum() / vol_mask_g.sum().clamp(min=1)
                 surf_loss_g = (surf_per_sample * mask_1d.float() * tandem_boost).sum() / n
                 coarse_shared = _coarse_loss * 0.5 if _coarse_loss is not None else 0.0
-                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + 0.005 * re_loss + 0.005 * aoa_loss
+                _shared_aux = 0.005 * re_loss + 0.005 * aoa_loss
+                if cfg.clcd_srf_conditioning and cfg.clcd_aux_weight > 0:
+                    _shared_aux = _shared_aux + cfg.clcd_aux_weight * _clcd_aux_loss
+                return vol_loss_g + surf_weight * surf_loss_g + coarse_shared + _shared_aux
 
             loss_A = _grp_loss(~is_tandem_batch)
             # Only include non-empty groups to avoid backward() on no-grad tensors
@@ -2506,7 +2661,13 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _train_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.clcd_srf_conditioning and _clcd_pred is not None:
+            _train_log["train/clcd_Cl_mean"] = _clcd_pred[:, 0].mean().item()
+            _train_log["train/clcd_Cd_mean"] = _clcd_pred[:, 1].mean().item()
+            if cfg.clcd_aux_weight > 0:
+                _train_log["train/clcd_aux_loss"] = _clcd_aux_loss.item()
+        wandb.log(_train_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -2650,7 +2811,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
                 _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.clcd_srf_conditioning
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2781,7 +2942,16 @@ for epoch in range(MAX_EPOCHS):
                     pred_loss = pred / sample_stds
 
                 # Apply surface refinement head during validation
+                _clcd_pred_v = None
                 if eval_refine_head is not None:
+                    # Compute Cl/Cd from coarse pressure if conditioning is enabled
+                    if cfg.clcd_srf_conditioning:
+                        _clcd_pred_v = integrate_clcd_from_coords(
+                            pred_loss[:, :, 2:3].detach(),
+                            _raw_xy_te if _raw_xy_te is not None else x[:, :, :2],
+                            is_surface,
+                            _raw_saf_norm_te if _raw_saf_norm_te is not None else x[:, :, 2:4].norm(dim=-1),
+                        )  # [B, 2]
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                         if cfg.surface_refine_context:
                             refine_correction = eval_refine_head(
@@ -2793,7 +2963,10 @@ for epoch in range(MAX_EPOCHS):
                             if surf_idx.numel() > 0:
                                 surf_hidden = _eval_hidden[surf_idx[:, 0], surf_idx[:, 1]]
                                 surf_pred = pred_loss[surf_idx[:, 0], surf_idx[:, 1]]
-                                correction = eval_refine_head(surf_hidden, surf_pred).float()
+                                _clcd_per_node_v = None
+                                if cfg.clcd_srf_conditioning and _clcd_pred_v is not None:
+                                    _clcd_per_node_v = _clcd_pred_v[surf_idx[:, 0]]  # [M, 2]
+                                correction = eval_refine_head(surf_hidden, surf_pred, clcd=_clcd_per_node_v).float()
                                 pred_loss = pred_loss.clone()
                                 pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
                     # Back-compute refined pred so denormalization (pred_orig) includes refinement


### PR DESCRIPTION
## Hypothesis

Condition the Surface Refinement (SRF) head on predicted global aerodynamic integrals (Cl, Cd) via AdaLN. This creates a two-pass architecture: (1) backbone → coarse surface pressure → numerically integrate Cl/Cd, (2) SRF head receives Cl/Cd conditioning → refined surface pressure. The SRF head becomes aware of the global aerodynamic state, enabling locally consistent corrections that satisfy integral constraints.

**Why this should work:**
- PR #2340 proved that Cl/Cd information improves p_tan by -2.9% — but as a loss term, the integral gradient disrupted shared weights (p_in +2.9%). Here, Cl/Cd enters as an **input signal**, not a loss. No gradient conflict.
- The current SRF operates node-by-node without global awareness. A model that knows "this is a high-lift config (Cl=1.8)" vs "drag-dominated (Cd=0.05)" can make more accurate local corrections for tandem wake pressure.
- AdaLN infrastructure already exists (`--adaln_output`) — this extends it to SRF specifically with aerodynamic conditioning.
- Two-pass architectures are proven: AlphaFold2's iterative refinement, diffusion model conditioning, and hierarchical prediction all use output-conditioned refinement.

## Instructions

### Step 1 — Add flags to Config:
```python
clcd_srf_conditioning: bool = False   # condition SRF head on predicted Cl/Cd via AdaLN
clcd_aux_weight: float = 0.0         # optional auxiliary Cl/Cd supervision weight (0 = no aux loss)
```

### Step 2 — Add Cl/Cd integration helper function:
```python
def integrate_clcd(surface_pressure, surface_normals, arc_lengths, is_surface_mask):
    """Numerically integrate surface pressure to get Cl, Cd.
    
    Args:
        surface_pressure: [B, N, 1] predicted pressure (in Cp space)
        surface_normals: [B, N, 2] unit normals (nx, ny) at surface nodes
        arc_lengths: [B, N, 1] panel arc lengths (ds) at surface nodes
        is_surface_mask: [B, N] boolean surface node mask
    
    Returns:
        clcd: [B, 2] tensor of [Cl, Cd] per sample
    """
    # Cl = -∫ Cp * ny * ds,  Cd = -∫ Cp * nx * ds  (trapezoidal on surface panels)
    p = surface_pressure.squeeze(-1) * is_surface_mask.float()  # [B, N]
    ds = arc_lengths.squeeze(-1) * is_surface_mask.float()      # [B, N]
    nx, ny = surface_normals[:, :, 0], surface_normals[:, :, 1]
    Cl = -(p * ny * ds).sum(dim=1, keepdim=True)  # [B, 1]
    Cd = -(p * nx * ds).sum(dim=1, keepdim=True)   # [B, 1]
    return torch.cat([Cl, Cd], dim=-1)  # [B, 2]
```

**Note:** You'll need to extract surface normals and arc lengths from the data. Check `prepare.py` for available fields. If normals aren't directly available, approximate using finite differences on surface coordinates: `n = normalize(perp(x[i+1] - x[i-1]))`. Arc lengths: `ds[i] = |x[i+1] - x[i-1]| / 2`.

### Step 3 — Add Cl/Cd conditioning MLP to the model:
```python
if self.clcd_srf_conditioning:
    self.clcd_encoder = nn.Sequential(
        nn.Linear(2, 64),
        nn.GELU(),
        nn.Linear(64, 64),
    )
    # AdaLN modulation: scale and shift for each SRF layer
    self.clcd_adaln = nn.Linear(64, surface_refine_hidden * 2)  # scale + shift
```

### Step 4 — Two-pass forward in the SRF head:

**Pass 1:** Run backbone → pressure head → get coarse surface pressure predictions.
**Cl/Cd computation:** Integrate coarse pressure on surface → get [Cl, Cd] per sample.
**Pass 2:** Encode [Cl, Cd] → 64-dim vector → AdaLN scale/shift → apply to SRF hidden layers.

In the SRF forward, after each hidden layer's LayerNorm:
```python
if self.clcd_srf_conditioning:
    clcd_vec = self.clcd_encoder(clcd)          # [B, 64]
    scale, shift = self.clcd_adaln(clcd_vec).chunk(2, dim=-1)  # [B, hidden]
    # Expand to [B, N_surface, hidden] for surface nodes
    h = h * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
```

Gradient flows through both passes — the backbone learns that its coarse pressure prediction affects SRF conditioning.

### Step 5 — Optional auxiliary Cl/Cd supervision:
If `--clcd_aux_weight > 0`, add `MSE(pred_Cl, true_Cl) + MSE(pred_Cd, true_Cd)` to the loss. This requires true Cl/Cd in the dataset. If not available, skip this and rely on end-to-end gradient only (set weight to 0).

### Step 6 — Run experiments:
```bash
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent fern --wandb_name "fern/clcd-srf-cond-s42" --wandb_group clcd-srf-conditioning \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --clcd_srf_conditioning

CUDA_VISIBLE_DEVICES=1 python train.py \
  --agent fern --wandb_name "fern/clcd-srf-cond-s73" --wandb_group clcd-srf-conditioning \
  --seed 73 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --clcd_srf_conditioning
```

**Important:** Ensure `torch.compile` compatibility — avoid data-dependent shapes in the Cl/Cd integration. Use the surface mask for zeroing instead of indexing to keep tensor shapes static.

## Baseline (PR #2350, 2-seed avg)

| p_in | p_oodc | p_tan | p_re |
|------|--------|-------|------|
| 11.90 | 7.35 | 27.20 | 6.40 |

Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature`

## Round 40 Bold Context

This is an **architectural innovation** — a two-pass forward with output-conditioned refinement. PR #2340 proved that Cl/Cd information helps p_tan (-2.9%) but can't be used as a loss without disrupting other metrics. This experiment delivers the same Cl/Cd signal as an **architectural conditioning input** to SRF, avoiding gradient conflicts entirely.