### PR TITLE
MoE Domain-Expert FFN: deterministic tandem/single routing

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -452,6 +452,8 @@ class TransolverBlock(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         spatial_bias_input_dim=4,
+        domain_moe=False,
+        domain_moe_rank=32,
     ):
         super().__init__()
         self.last_layer = last_layer
@@ -464,6 +466,7 @@ class TransolverBlock(nn.Module):
         self.adaln_all = adaln_all
         self.film_cond = film_cond
         self.domain_layernorm = domain_layernorm
+        self.domain_moe = domain_moe
         _LN = (lambda d: DomainLayerNorm(d, zeroinit=dln_zeroinit)) if domain_layernorm else nn.LayerNorm
         self.ln_1 = _LN(hidden_dim)
         self.attn = Physics_Attention_Irregular_Mesh(
@@ -497,6 +500,17 @@ class TransolverBlock(nn.Module):
             nn.init.zeros_(self.film_net[-1].bias)
         self.ln_2 = _LN(hidden_dim)
         self.mlp = MLP(hidden_dim, hidden_dim * mlp_ratio, hidden_dim, n_layers=0, res=False, act=act)
+        if domain_moe:
+            ffn_dim = hidden_dim * mlp_ratio
+            # LoRA-style delta for fc1 (hidden_dim → ffn_dim)
+            self.tandem_lora_A1 = nn.Linear(hidden_dim, domain_moe_rank, bias=False)
+            self.tandem_lora_B1 = nn.Linear(domain_moe_rank, ffn_dim, bias=False)
+            # LoRA-style delta for fc2 (ffn_dim → hidden_dim)
+            self.tandem_lora_A2 = nn.Linear(ffn_dim, domain_moe_rank, bias=False)
+            self.tandem_lora_B2 = nn.Linear(domain_moe_rank, hidden_dim, bias=False)
+            # Zero-init B matrices so delta starts at zero (identity behavior)
+            nn.init.zeros_(self.tandem_lora_B1.weight)
+            nn.init.zeros_(self.tandem_lora_B2.weight)
         self.spatial_bias = nn.Sequential(
             nn.Linear(spatial_bias_input_dim, 64), nn.GELU(),
             nn.Linear(64, 64), nn.GELU(),
@@ -575,10 +589,24 @@ class TransolverBlock(nn.Module):
             fx_norm = _ln(self.ln_1, fx) * (1 + s1.unsqueeze(1)) + b1.unsqueeze(1)
             fx = _ln(self.ln_1_post, self.attn(fx_norm, spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
             fx_norm = _ln(self.ln_2, fx) * (1 + s2.unsqueeze(1)) + b2.unsqueeze(1)
-            fx = _ln(self.ln_2_post, self.mlp(fx_norm) + fx)
+            mlp_out = self.mlp(fx_norm)
+            if self.domain_moe and tandem_mask is not None:
+                # LoRA delta: decomposed fc1 + fc2 corrections, masked to tandem samples
+                _tm = tandem_mask.view(-1, 1, 1)  # [B, 1, 1]
+                delta1 = self.tandem_lora_B1(F.gelu(self.tandem_lora_A1(fx_norm)))
+                delta2 = self.tandem_lora_B2(F.gelu(self.tandem_lora_A2(delta1)))
+                mlp_out = mlp_out + delta2 * _tm
+            fx = _ln(self.ln_2_post, mlp_out + fx)
         else:
             fx = _ln(self.ln_1_post, self.attn(_ln(self.ln_1, fx), spatial_bias=sb, tandem_mask=tandem_mask, zone_features=zone_features) + fx)
-            fx = _ln(self.ln_2_post, self.mlp(_ln(self.ln_2, fx)) + fx)
+            fx_ln2 = _ln(self.ln_2, fx)
+            mlp_out = self.mlp(fx_ln2)
+            if self.domain_moe and tandem_mask is not None:
+                _tm = tandem_mask.view(-1, 1, 1)  # [B, 1, 1]
+                delta1 = self.tandem_lora_B1(F.gelu(self.tandem_lora_A1(fx_ln2)))
+                delta2 = self.tandem_lora_B2(F.gelu(self.tandem_lora_A2(delta1)))
+                mlp_out = mlp_out + delta2 * _tm
+            fx = _ln(self.ln_2_post, mlp_out + fx)
         se = fx.mean(dim=1, keepdim=True)
         se = F.gelu(self.se_fc1(se))
         se = torch.sigmoid(self.se_fc2(se))
@@ -864,6 +892,8 @@ class Transolver(nn.Module):
         domain_layernorm=False,
         dln_zeroinit=False,
         domain_velhead=False,
+        domain_moe=False,
+        domain_moe_rank=32,
         prog_slices=False,
         pressure_first=False,
         pressure_no_detach=False,
@@ -941,6 +971,8 @@ class Transolver(nn.Module):
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
                     spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    domain_moe=domain_moe,
+                    domain_moe_rank=domain_moe_rank,
                 )
                 for idx in range(n_layers)
             ]
@@ -1197,6 +1229,8 @@ class Config:
     domain_layernorm: bool = False     # domain-specific LayerNorm for single vs tandem
     dln_zeroinit: bool = False         # zero-init tandem LN weights (else copy from single)
     domain_velhead: bool = False       # domain-specific output heads for single vs tandem
+    domain_moe: bool = False           # domain-conditioned MoE: LoRA delta expert for tandem FFN
+    domain_moe_rank: int = 32          # rank of LoRA-style delta expert
     prog_slices: bool = False          # progressive slice warmup
     prog_slices_end: int = 128         # max slice count for prog_slices
     prog_slices_epochs: int = 100      # epochs to ramp slice_num → prog_slices_end
@@ -1423,6 +1457,8 @@ model_config = dict(
     domain_layernorm=cfg.domain_layernorm,
     dln_zeroinit=cfg.dln_zeroinit,
     domain_velhead=cfg.domain_velhead,
+    domain_moe=cfg.domain_moe,
+    domain_moe_rank=cfg.domain_moe_rank,
     prog_slices=cfg.prog_slices,
     pressure_first=cfg.pressure_first,
     pressure_no_detach=cfg.pressure_no_detach,


### PR DESCRIPTION
## Hypothesis

Replace the shared position-wise FFN in each TransolverBlock with a domain-conditioned Mixture of Experts: a shared base FFN plus a low-rank tandem-specific delta expert (LoRA-style, rank=32). Routing is **deterministic** based on the `is_tandem` flag — no learned gating, no Gumbel noise, no auxiliary balancing loss. The tandem expert specializes in wake interaction physics while the shared FFN handles common aerodynamic patterns.

**Why this should work:**
- The Gumbel MoE trial (Round 26) failed because of learned-routing instability + PCGrad incompatibility. Deterministic routing eliminates both failure modes
- Tandem and single-foil configurations have fundamentally different physics (wake coupling, circulation modification, slot acceleration). A shared FFN must compromise between both — the delta expert lets the model specialize
- LoRA-style delta experts (`W_tandem = W_shared + A @ B`) keep extra parameters under 5% of total, avoiding capacity overfitting
- This is equivalent to training two models that share attention but have separate FFNs — a form of multi-task learning with hard task boundaries

**Prior art:** Gumbel MoE (#2263) failed on PCGrad + routing collapse. This approach avoids both: routing is hardcoded, and LoRA deltas are small enough to be regularized by the shared-weight gradients.

## Instructions

### Step 1 — Add flags:
```python
domain_moe: bool = False          # enable domain-expert FFN routing
domain_moe_rank: int = 32         # rank of LoRA-style delta expert
```

### Step 2 — Modify TransolverBlock FFN:

In `TransolverBlock.__init__`, when `domain_moe=True`, add LoRA adapter layers:
```python
if domain_moe:
    # For each FFN linear layer (fc1, fc2), add LoRA-style delta
    ffn_dim = hidden_dim * mlp_ratio  # 256 * 1 = 256
    self.tandem_lora_A1 = nn.Linear(hidden_dim, domain_moe_rank, bias=False)
    self.tandem_lora_B1 = nn.Linear(domain_moe_rank, ffn_dim, bias=False)
    self.tandem_lora_A2 = nn.Linear(ffn_dim, domain_moe_rank, bias=False)
    self.tandem_lora_B2 = nn.Linear(domain_moe_rank, hidden_dim, bias=False)
    # Zero-init B matrices for safe initialization (identity at start)
    nn.init.zeros_(self.tandem_lora_B1.weight)
    nn.init.zeros_(self.tandem_lora_B2.weight)
```

### Step 3 — In TransolverBlock.forward:

The `is_tandem` flag needs to reach the TransolverBlock. Pass it through:
```python
def forward(self, x, is_tandem=None, ...):
    # Standard FFN path
    h = self.ffn(x)  # shared FFN output

    if self.domain_moe and is_tandem is not None:
        # LoRA-style delta for tandem samples only
        delta = self.tandem_lora_B1(self.tandem_lora_A1(x))  # fc1 delta
        # Apply tandem mask: [B, 1] → [B, 1, 1] broadcast
        tandem_mask = is_tandem.float().view(-1, 1, 1)  # [B, 1, 1]
        h = h + delta * tandem_mask
        # Repeat for fc2 if using 2-layer FFN
```

**Critical:** The `is_tandem` tensor must be passed through the model's forward method to reach each TransolverBlock. Check how the model forward currently works and thread `is_tandem` through.

### Step 4 — Thread `is_tandem` through the model:

In `UniPDE_3D.forward()`, accept `is_tandem` and pass to each block:
```python
def forward(self, x, fx, is_tandem=None, ...):
    ...
    for block in self.blocks:
        x = block(x, is_tandem=is_tandem, ...)
```

In the training loop, `is_tandem` is already available (used for cp_panel_tandem_only etc.). Pass it to the model call.

### Step 5 — Run experiments:
```bash
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent tanjiro --wandb_name "tanjiro/domain-moe-r32-s42" --wandb_group domain-moe-ffn \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --domain_moe --domain_moe_rank 32

CUDA_VISIBLE_DEVICES=1 python train.py [same with --seed 73]
```

**Torch.compile:** The `is_tandem` mask multiplication is a static tensor op — fully compatible. No dynamic shapes or control flow.

## Baseline (PR #2350, 2-seed avg)

| p_in | p_oodc | p_tan | p_re |
|------|--------|-------|------|
| 11.90 | 7.35 | 27.20 | 6.40 |

Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature`

## Round 40 Bold Context

This is an **architectural intervention** — the first domain-conditioned model specialization. The Gumbel MoE failure was a routing problem, not a concept problem. Deterministic routing + LoRA deltas fixes both. Expected primary gain: **p_tan** (tandem-specific wake physics learned by the delta expert).