### PR TITLE
Biot-Savart Cross-Foil Attention Bias: physics-derived attention structure

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -493,6 +493,19 @@ def compute_vortex_panel_velocity(raw_xy, aoa_rad, is_surface, saf_norm, n_panel
     return out  # [B, N, 4]
 
 
+def compute_biot_savart_coupling(raw_xy, aoa_rad, is_surface, saf_norm, n_panels=64):
+    """Compute per-node Biot-Savart coupling magnitudes for use as spatial attention bias.
+
+    Returns: [B, N, 2] = (fore_foil_coupling_mag, aft_foil_coupling_mag)
+             fore_mag is the L2 norm of induced velocity from fore-foil panels at each node.
+             aft_mag is the L2 norm of induced velocity from aft-foil panels (0 for single-foil).
+    """
+    vp = compute_vortex_panel_velocity(raw_xy, aoa_rad, is_surface, saf_norm, n_panels=n_panels)
+    fore_mag = vp[:, :, :2].norm(dim=-1)  # [B, N]
+    aft_mag  = vp[:, :, 2:].norm(dim=-1)  # [B, N]
+    return torch.stack([fore_mag, aft_mag], dim=-1)  # [B, N, 2]
+
+
 class TransolverBlock(nn.Module):
     def __init__(
         self,
@@ -940,10 +953,12 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        biot_savart_attn_bias=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.biot_savart_attn_bias = biot_savart_attn_bias
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -1011,7 +1026,7 @@ class Transolver(nn.Module):
                     pressure_first=pressure_first if (idx == n_layers - 1) else False,
                     pressure_no_detach=pressure_no_detach,
                     pressure_deep=pressure_deep,
-                    spatial_bias_input_dim=6 if gap_stagger_spatial_bias else 4,
+                    spatial_bias_input_dim=(6 if gap_stagger_spatial_bias else 4) + (2 if biot_savart_attn_bias else 0),
                 )
                 for idx in range(n_layers)
             ]
@@ -1020,7 +1035,13 @@ class Transolver(nn.Module):
         if gap_stagger_spatial_bias:
             with torch.no_grad():
                 for block in self.blocks:
-                    block.spatial_bias[0].weight[:, 4:].zero_()
+                    block.spatial_bias[0].weight[:, 4:6].zero_()
+        # Zero-init the BS coupling columns so they start with zero influence on routing
+        if biot_savart_attn_bias:
+            base_dim = 6 if gap_stagger_spatial_bias else 4
+            with torch.no_grad():
+                for block in self.blocks:
+                    block.spatial_bias[0].weight[:, base_dim:base_dim + 2].zero_()
         # Separate pressure pathway (pressure_separate_last_block):
         # Independent MLP + pres_head that processes shared hidden features
         self._pressure_separate = False  # set from Config after construction
@@ -1088,6 +1109,7 @@ class Transolver(nn.Module):
 
     def forward(self, data, pos=None, condition=None):
         x, pos, condition = self._unpack_inputs(data, pos=pos, condition=condition)
+        bs_feat = data.get("bs_feat", None) if isinstance(data, Mapping) else None
         if x is None:
             raise ValueError("Missing required input tensor: x")
         if condition is not None:
@@ -1130,6 +1152,9 @@ class Transolver(nn.Module):
             raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26], gap_stagger], dim=-1)  # [B, N, 6]
         else:
             raw_xy = torch.cat([x[:, :, :2], x[:, :, 24:26]], dim=-1)  # x, y, curvature, dist
+        # Append Biot-Savart coupling magnitudes to raw_xy for spatial bias injection
+        if bs_feat is not None:
+            raw_xy = torch.cat([raw_xy, bs_feat], dim=-1)  # [B, N, +2]
 
         # Detect tandem samples via gap feature (index 21); shape [B,1,1,1] for broadcasting
         is_tandem = (x[:, 0, 21].abs() > 0.01).float()[:, None, None, None]
@@ -1328,6 +1353,9 @@ class Config:
     vortex_panel_velocity: bool = False    # append (u_fore, v_fore, u_aft, v_aft) induced velocity
     vortex_panel_scale: float = 0.1        # scale factor for vortex velocity channels
     vortex_panel_n: int = 64              # number of panels to subsample per foil
+    # Biot-Savart attention bias: per-node coupling magnitudes injected as spatial slice-assignment bias
+    biot_savart_attn_bias: bool = False    # inject Biot-Savart (fore,aft) coupling mags as spatial bias
+    biot_savart_bias_scale: float = 1.0    # scale for BS spatial bias channels
 
 
 cfg = sp.parse(Config)
@@ -1503,6 +1531,7 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    biot_savart_attn_bias=cfg.biot_savart_attn_bias,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1942,8 +1971,8 @@ for epoch in range(MAX_EPOCHS):
         _raw_x_for_dct = x[:, :, 0].clone() if cfg.dct_freq_loss else None  # save raw x before normalization
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
-        # TE coordinate frame / wake deficit / cp_panel / vortex_panel: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+        # TE coordinate frame / wake deficit / cp_panel / vortex_panel / biot_savart_attn_bias: save raw xy before normalization
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.biot_savart_attn_bias
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -2000,6 +2029,13 @@ for epoch in range(MAX_EPOCHS):
             if cfg.vortex_panel_scale != 1.0:
                 vp_feat = vp_feat * cfg.vortex_panel_scale
             x = torch.cat([x, vp_feat], dim=-1)
+        # Biot-Savart spatial attention bias: compute coupling magnitudes [B, N, 2]
+        _bs_coup = None
+        if cfg.biot_savart_attn_bias:
+            _bs_coup = compute_biot_savart_coupling(
+                _raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te, n_panels=cfg.vortex_panel_n)
+            if cfg.biot_savart_bias_scale != 1.0:
+                _bs_coup = _bs_coup * cfg.biot_savart_bias_scale
         if model.training and epoch < cfg.noise_anneal_epochs:
             noise_scale = 0.05 * (1 - epoch / cfg.noise_anneal_epochs)
             x[:, :, 2:25] = x[:, :, 2:25] + noise_scale * torch.randn_like(x[:, :, 2:25])
@@ -2082,7 +2118,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "bs_feat": _bs_coup})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -2310,7 +2346,7 @@ for epoch in range(MAX_EPOCHS):
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                rdrop_out = model({"x": x})
+                rdrop_out = model({"x": x, "bs_feat": _bs_coup})
                 rdrop_pred = rdrop_out["preds"].float() / sample_stds
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
@@ -2449,7 +2485,7 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
+                out2 = model({"x": x, "bs_feat": _bs_coup})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
@@ -2650,7 +2686,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
                 _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.biot_savart_attn_bias
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2706,6 +2742,12 @@ for epoch in range(MAX_EPOCHS):
                     if cfg.vortex_panel_scale != 1.0:
                         vp_feat = vp_feat * cfg.vortex_panel_scale
                     x = torch.cat([x, vp_feat], dim=-1)
+                _bs_coup_v = None
+                if cfg.biot_savart_attn_bias:
+                    _bs_coup_v = compute_biot_savart_coupling(
+                        _raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te, n_panels=cfg.vortex_panel_n)
+                    if cfg.biot_savart_bias_scale != 1.0:
+                        _bs_coup_v = _bs_coup_v * cfg.biot_savart_bias_scale
                 Umag, q = _umag_q(y, mask)
                 if cfg.raw_targets:
                     y_norm = (y - raw_stats["y_mean"]) / raw_stats["y_std"]
@@ -2770,7 +2812,7 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    _eval_out = eval_model({"x": x})
+                    _eval_out = eval_model({"x": x, "bs_feat": _bs_coup_v})
                     pred = _eval_out["preds"]
                     _eval_hidden = _eval_out["hidden"]
                 pred = pred.float()
@@ -3079,7 +3121,7 @@ if best_metrics:
                     raw_dsdf = x_dev[:, :, 2:10]
                     dist_surf = raw_dsdf.abs().min(dim=-1, keepdim=True).values
                     dist_feat = torch.log1p(dist_surf * 10.0)
-                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+                    _need_te_raw_vis = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.biot_savart_attn_bias
                     _raw_xy_te_vis = x_dev[:, :, :2].clone() if _need_te_raw_vis else None
                     _raw_saf_norm_te_vis = x_dev[:, :, 2:4].norm(dim=-1) if _need_te_raw_vis else None
                     _raw_aoa_vis = x_dev[:, 0, 14:15]  # AoA0_rad [B, 1]
@@ -3126,8 +3168,14 @@ if best_metrics:
                         if cfg.vortex_panel_scale != 1.0:
                             vp_feat = vp_feat * cfg.vortex_panel_scale
                         x_n = torch.cat([x_n, vp_feat], dim=-1)
+                    _bs_coup_vis = None
+                    if cfg.biot_savart_attn_bias:
+                        _bs_coup_vis = compute_biot_savart_coupling(
+                            _raw_xy_te_vis, _raw_aoa_vis, is_surf_dev, _raw_saf_norm_te_vis, n_panels=cfg.vortex_panel_n)
+                        if cfg.biot_savart_bias_scale != 1.0:
+                            _bs_coup_vis = _bs_coup_vis * cfg.biot_savart_bias_scale
                     Umag, q = _umag_q(y_dev, mask)
-                    pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
+                    pred = vis_model({"x": x_n, "mask": mask, "bs_feat": _bs_coup_vis})["preds"].float()
                     if cfg.raw_targets:
                         y_pred = (pred * raw_stats["y_std"] + raw_stats["y_mean"]).squeeze(0).cpu()
                     elif cfg.adaptive_norm:
@@ -3212,7 +3260,7 @@ if cfg.surface_refine and best_metrics:
                     dist_feat = torch.log1p(dist_surf * 10.0)
                     _raw_aoa = x[:, 0, 14:15]
                     _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+                    _need_te_raw_vv = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.biot_savart_attn_bias
                     _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_vv else None
                     _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_vv else None
                     _raw_gap_wake_vv = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -3259,6 +3307,12 @@ if cfg.surface_refine and best_metrics:
                         if cfg.vortex_panel_scale != 1.0:
                             vp_feat = vp_feat * cfg.vortex_panel_scale
                         x = torch.cat([x, vp_feat], dim=-1)
+                    _bs_coup_vv = None
+                    if cfg.biot_savart_attn_bias:
+                        _bs_coup_vv = compute_biot_savart_coupling(
+                            _raw_xy_te, _raw_aoa, is_surface, _raw_saf_norm_te, n_panels=cfg.vortex_panel_n)
+                        if cfg.biot_savart_bias_scale != 1.0:
+                            _bs_coup_vv = _bs_coup_vv * cfg.biot_savart_bias_scale
 
                     # Ground truth denormalization reference
                     Umag, q = _umag_q(y, mask)
@@ -3312,7 +3366,7 @@ if cfg.surface_refine and best_metrics:
 
                     # Model forward
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        out = verify_model({"x": x})
+                        out = verify_model({"x": x, "bs_feat": _bs_coup_vv})
                         pred_raw = out["preds"].float()
                         hidden = out["hidden"].float()
 


### PR DESCRIPTION
## Hypothesis

Use the Biot-Savart vortex-panel induced velocities (already computed in `--vortex_panel_velocity`, PR #2357) as **additive attention biases** in the Transolver's cross-node attention. Instead of treating the induced velocity as just another input feature, inject it as a structural prior in the attention mechanism itself — nodes from fore foil and aft foil that are aerodynamically coupled get explicit attention bias toward each other.

**Why this should work:**
- PR #2357 proved that Biot-Savart information improves p_tan -3.2% and p_re -2.7% as an input feature. As an attention bias, the same physics delivers a *structural prior* on which node pairs should interact, not just additional input channels
- The attention bias approach (like ALiBi in language models) directly shapes which nodes attend to which — a Biot-Savart-derived bias tells the model "this volume node is strongly influenced by the fore foil vortex sheet" without requiring the model to infer this from features
- This is analogous to physics-informed attention in recent work (e.g., "Relative Positional Encoding via Kernel Regression", arXiv:2212.10271)
- The feature version (PR #2357) and attention bias version are **orthogonal** — they can both be active simultaneously. The feature gives local context per node; the bias shapes global attention structure.

## Instructions

You have already implemented `compute_vortex_panel_velocity()` in train.py (from PR #2357). This experiment extends it to use the inter-foil Biot-Savart magnitudes as attention biases.

### Step 1 — Add flag:
```python
biot_savart_attn_bias: bool = False   # inject Biot-Savart inter-foil coupling as attention bias
```

### Step 2 — Compute the attention bias tensor

For each batch, compute a per-pair aerodynamic coupling magnitude:
```python
def compute_biot_savart_bias(xy, is_surface, is_tandem, aoa_rad, n_panels=64):
    """Compute inter-foil attention bias from Biot-Savart kernel.
    
    Returns: [B, N, N] bias where bias[b, i, j] = induced velocity magnitude
    that foil-1 nodes contribute to foil-2 nodes and vice versa.
    For single-foil samples: all zeros.
    """
    B, N, _ = xy.shape
    bias = torch.zeros(B, N, N, device=xy.device)
    
    for b in range(B):
        if not is_tandem[b]:
            continue
        # Get surface nodes for fore foil (boundary_id == 6) and aft foil (boundary_id == 7)
        # Use is_surface mask to identify surface nodes
        # Compute vortex panels from surface nodes
        # Evaluate Biot-Savart at ALL nodes (not just surface)
        # bias[b, i, j] = |induced_velocity(from_foil_containing_j, at_node_i)|
        # For same-foil pairs: 0 (no cross-foil coupling)
        # For cross-foil pairs: Biot-Savart magnitude
        ...
    return bias  # [B, N, N]
```

The key difference from PR #2357: there, you computed the induced velocity as a node feature. Here, you compute a pairwise attention bias — the magnitude of coupling between node i (influenced) and node j (source).

**Simplified implementation:** Use the existing `compute_vortex_panel_velocity()` function as a helper. The bias for node i from foil f is the L2 norm of the induced velocity at node i from foil f's panels:
```python
# u_fore_at_all_nodes: [B, N] — induced velocity magnitude from fore foil
# For node pairs: bias[b, i, j] = u_fore[b, i] if node j is on fore foil else 0
fore_foil_nodes = (boundary_id == 6)  # [B, N]
aft_foil_nodes  = (boundary_id == 7)  # [B, N]
# Cross-foil bias: [B, N_aft, N_fore] attention bias
bias[b][aft_foil_nodes[b]][:, fore_foil_nodes[b]] = u_fore[b][aft_foil_nodes[b]].unsqueeze(-1)
```

### Step 3 — Inject into Transolver attention

In `TransolverBlock` (or `Physics_Attention_Irregular_Mesh`), accept an optional `attn_bias` argument:
```python
def forward(self, x, attn_bias=None, ...):
    # Standard attention computation
    attn_logits = Q @ K.T / sqrt(d_k)  # [B, H, N, N]
    if attn_bias is not None:
        # Add bias (broadcast across heads)
        attn_logits = attn_logits + attn_bias.unsqueeze(1)  # [B, 1, N, N]
    attn_weights = softmax(attn_logits)
    ...
```

Thread `attn_bias` from the training loop through `model.forward()` to each block.

### Step 4 — Scale the bias

The attention logits are O(1/sqrt(d_k)) scale. The Biot-Savart magnitudes (with scale=0.1 from PR #2357) may need scaling:
```python
attn_bias = biot_savart_bias * cfg.biot_savart_bias_scale  # new flag, try 1.0, 0.1, 10.0
```

Start with `--biot_savart_bias_scale 1.0`. If the model ignores the bias (attention entropy unchanged), try 10.0. If it overwhelms attention, try 0.1.

### Step 5 — Run experiments:
```bash
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent askeladd --wandb_name "askeladd/bsattn-s42" --wandb_group biot-savart-attention-bias \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64 \
  --biot_savart_attn_bias --biot_savart_bias_scale 1.0

CUDA_VISIBLE_DEVICES=1 python train.py [same with --seed 73]
```

**Torch.compile note:** The `attn_bias` tensor addition is static-shape — fully compatible. The pairwise computation loop has fixed sizes.

## Baseline (PR #2357, 2-seed avg — newly merged)

| p_in | p_oodc | p_tan | p_re |
|------|--------|-------|------|
| 11.872 | 7.459 | 26.319 | 6.229 |

Reproduce: `cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64`

## Round 40 Bold Context

This is the **#4 bold experiment** and builds directly on your PR #2357 win. You proved Biot-Savart physics information helps (+3.2% p_tan). Now we test whether using it as an *attention structural bias* — shaping which nodes attend to which — provides additional gains on top of the input feature approach. The feature + attention bias together may compound.