### PR TITLE
1D Surface FNO Decoder: spectral pressure prediction on arc-length

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -689,6 +689,179 @@ class TransolverBlock(nn.Module):
         return fx
 
 
+# ─── 1D Surface FNO Decoder ───────────────────────────────────────────────────
+
+def _parameterize_surface(xy: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sort surface nodes by angle from centroid, compute cumulative arc-length.
+
+    Args:
+        xy: [N, 2] surface node coordinates (raw, not normalized)
+    Returns:
+        arc: [N] arc-length fractions in [0, 1] (at sorted node positions)
+        sort_idx: [N] indices that sort nodes by angle from centroid
+    """
+    centroid = xy.mean(dim=0)
+    angles = torch.atan2(xy[:, 1] - centroid[1], xy[:, 0] - centroid[0])
+    sort_idx = angles.argsort()
+    sorted_xy = xy[sort_idx]
+    diffs = sorted_xy[1:] - sorted_xy[:-1]
+    seg_len = diffs.norm(dim=-1)
+    arc = torch.cat([torch.zeros(1, device=xy.device, dtype=xy.dtype),
+                     seg_len.cumsum(0)])
+    arc = arc / (arc[-1] + 1e-8)
+    return arc, sort_idx
+
+
+def _interpolate_to_grid(features: torch.Tensor, arc: torch.Tensor, n_grid: int) -> torch.Tensor:
+    """Linearly interpolate node features to a uniform arc-length grid.
+
+    Args:
+        features: [N, D] features at sorted surface nodes
+        arc: [N] monotone arc-length fractions in [0, 1]
+        n_grid: number of uniform grid points
+    Returns:
+        grid_feat: [n_grid, D]
+    """
+    grid_s = torch.linspace(0, 1, n_grid, device=features.device, dtype=features.dtype)
+    idx = torch.searchsorted(arc.contiguous(), grid_s.contiguous()).clamp(1, len(arc) - 1)
+    s0, s1 = arc[idx - 1], arc[idx]
+    w = ((grid_s - s0) / (s1 - s0 + 1e-8)).clamp(0.0, 1.0).unsqueeze(1)
+    return (1.0 - w) * features[idx - 1] + w * features[idx]
+
+
+def _interpolate_from_grid(grid_out: torch.Tensor, arc: torch.Tensor,
+                            sort_idx: torch.Tensor, n_grid: int) -> torch.Tensor:
+    """Interpolate FNO output on uniform grid back to original (unsorted) node positions.
+
+    Args:
+        grid_out: [n_grid, D] FNO output on uniform grid
+        arc: [N] arc-length fractions at sorted surface nodes
+        sort_idx: [N] indices used to sort nodes (used for inverse permutation)
+        n_grid: number of uniform grid points
+    Returns:
+        node_out: [N, D] at original node ordering
+    """
+    grid_s = torch.linspace(0, 1, n_grid, device=grid_out.device, dtype=grid_out.dtype)
+    idx = torch.searchsorted(grid_s.contiguous(), arc.contiguous()).clamp(1, n_grid - 1)
+    s0, s1 = grid_s[idx - 1], grid_s[idx]
+    w = ((arc - s0) / (s1 - s0 + 1e-8)).clamp(0.0, 1.0).unsqueeze(1)
+    sorted_out = (1.0 - w) * grid_out[idx - 1] + w * grid_out[idx]
+    inv_idx = torch.argsort(sort_idx)
+    return sorted_out[inv_idx]
+
+
+class SpectralConv1d(nn.Module):
+    """1D Fourier layer: learnable spectral multiplication in frequency domain."""
+
+    def __init__(self, in_channels: int, out_channels: int, modes: int):
+        super().__init__()
+        self.modes = modes
+        self.out_channels = out_channels
+        scale = 0.02 / (in_channels * out_channels) ** 0.5
+        self.weights_re = nn.Parameter(torch.randn(in_channels, out_channels, modes) * scale)
+        self.weights_im = nn.Parameter(torch.randn(in_channels, out_channels, modes) * scale)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [B, C, N]
+        B, C, N = x.shape
+        x_ft = torch.fft.rfft(x.float(), dim=-1)          # [B, C, N//2+1]
+        n_modes = min(self.modes, x_ft.shape[-1])
+        w_c = torch.complex(self.weights_re[:, :, :n_modes], self.weights_im[:, :, :n_modes])
+        out_ft = torch.zeros(B, self.out_channels, x_ft.shape[-1],
+                             dtype=torch.cfloat, device=x.device)
+        out_ft[:, :, :n_modes] = torch.einsum('bim,iom->bom', x_ft[:, :, :n_modes], w_c)
+        return torch.fft.irfft(out_ft, n=N, dim=-1).to(x.dtype)  # [B, C_out, N]
+
+
+class FNOLayer1d(nn.Module):
+    """FNO residual block: spectral conv + pointwise conv + LayerNorm + GELU."""
+
+    def __init__(self, width: int, modes: int):
+        super().__init__()
+        self.spectral = SpectralConv1d(width, width, modes)
+        self.pointwise = nn.Conv1d(width, width, kernel_size=1)
+        self.norm = nn.LayerNorm(width)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [B, C, N]
+        h = F.gelu(self.spectral(x) + self.pointwise(x))
+        # LayerNorm over channel dim: permute to [B, N, C], norm, permute back
+        h_normed = self.norm(h.permute(0, 2, 1)).permute(0, 2, 1)
+        return x + h_normed
+
+
+class SurfaceFNO(nn.Module):
+    """1D FNO decoder for surface predictions, operating on arc-length parameterized grid.
+
+    Takes backbone hidden features at surface nodes, interpolates to a uniform
+    arc-length grid, applies spectral FNO layers, interpolates back, and returns
+    additive corrections for each surface node's (Ux, Uy, p) prediction.
+    """
+
+    def __init__(self, in_dim: int, width: int = 64, modes: int = 16,
+                 n_layers: int = 4, out_dim: int = 3):
+        super().__init__()
+        self.lift = nn.Linear(in_dim, width)
+        self.layers = nn.ModuleList([FNOLayer1d(width, modes) for _ in range(n_layers)])
+        self.proj = nn.Linear(width, out_dim)
+        # Zero-init for stable startup — starts as identity (no correction)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, h_surf_grid: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            h_surf_grid: [n_grid, in_dim] — backbone embeddings on uniform arc-length grid
+        Returns:
+            corrections: [n_grid, out_dim] — additive corrections on grid
+        """
+        x = self.lift(h_surf_grid)      # [n_grid, width]
+        x = x.unsqueeze(0).permute(0, 2, 1)   # [1, width, n_grid]
+        for layer in self.layers:
+            x = layer(x)
+        x = x.permute(0, 2, 1).squeeze(0)     # [n_grid, width]
+        return self.proj(x)             # [n_grid, out_dim]
+
+
+def _apply_surface_fno(surface_fno: nn.Module, pred: torch.Tensor,
+                       hidden: torch.Tensor, is_surface: torch.Tensor,
+                       mask: torch.Tensor, raw_xy: torch.Tensor,
+                       raw_saf_norm: torch.Tensor, n_grid: int) -> torch.Tensor:
+    """Apply SurfaceFNO to compute additive surface corrections per sample.
+
+    For each sample: splits fore/aft foils, parameterizes arc-length, runs FNO,
+    interpolates corrections back, and returns updated pred.
+    """
+    pred = pred.clone()
+    B = pred.shape[0]
+    for b in range(B):
+        surf_b = is_surface[b] & mask[b]
+        if surf_b.sum() < 3:
+            continue
+        saf_b = raw_saf_norm[b]
+        xy_b = raw_xy[b]
+        h_b = hidden[b]
+        is_tan = (saf_b[surf_b].max() > 0.005)
+        foil_masks = []
+        if is_tan:
+            fore_mask = surf_b & (saf_b <= 0.005)
+            aft_mask = surf_b & (saf_b > 0.005)
+            foil_masks = [fore_mask, aft_mask]
+        else:
+            foil_masks = [surf_b]
+        for fm in foil_masks:
+            if fm.sum() < 3:
+                continue
+            xy_f = xy_b[fm]
+            h_f = h_b[fm]
+            arc, sort_idx = _parameterize_surface(xy_f)
+            grid_feat = _interpolate_to_grid(h_f[sort_idx].float(), arc, n_grid)
+            corr_grid = surface_fno(grid_feat).to(pred.dtype)
+            node_corr = _interpolate_from_grid(corr_grid, arc, sort_idx, n_grid)
+            pred[b, fm] = pred[b, fm] + node_corr
+    return pred
+
+
 class SurfaceRefinementHead(nn.Module):
     """Lightweight MLP that predicts additive corrections for surface nodes.
 
@@ -1300,6 +1473,12 @@ class Config:
     surface_refine_layers: int = 2            # number of hidden layers in refinement MLP
     surface_refine_p_only: bool = False       # only refine pressure channel (not velocity)
     surface_refine_context: bool = False      # use surface + nearest-volume context features
+    # Phase 6: 1D Surface FNO decoder (replaces surface_refine)
+    surface_fno: bool = False              # enable 1D FNO decoder on arc-length surface grid
+    surface_fno_modes: int = 16           # number of Fourier modes to retain
+    surface_fno_width: int = 64           # FNO hidden channel width
+    surface_fno_layers: int = 4           # number of FNO layers
+    surface_fno_grid: int = 128           # uniform arc-length grid resolution
     # Phase 6: Asinh pressure transform
     asinh_pressure: bool = False             # transform pressure targets with asinh for dynamic range compression
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
@@ -1536,6 +1715,21 @@ if cfg.surface_refine:
           f"(hidden={cfg.surface_refine_hidden}, layers={cfg.surface_refine_layers}, "
           f"p_only={cfg.surface_refine_p_only}, context={cfg.surface_refine_context})")
 
+# Surface FNO decoder (replaces surface_refine when --surface_fno is active)
+surface_fno = None
+if cfg.surface_fno:
+    surface_fno = SurfaceFNO(
+        in_dim=cfg.n_hidden,
+        width=cfg.surface_fno_width,
+        modes=cfg.surface_fno_modes,
+        n_layers=cfg.surface_fno_layers,
+        out_dim=3,
+    ).to(device)
+    _fno_n_params = sum(p.numel() for p in surface_fno.parameters())
+    print(f"Surface FNO head: {_fno_n_params:,} params "
+          f"(width={cfg.surface_fno_width}, modes={cfg.surface_fno_modes}, "
+          f"layers={cfg.surface_fno_layers}, grid={cfg.surface_fno_grid})")
+
 # Aft-foil (boundary ID=7) dedicated refinement head
 aft_srf_head = None
 aft_srf_ctx_head = None
@@ -1569,6 +1763,7 @@ if cfg.aft_foil_srf:
 from copy import deepcopy
 ema_model = None
 ema_refine_head = None  # EMA copy of refinement head
+ema_surface_fno = None  # EMA copy of surface FNO head
 ema_aft_srf_head = None  # EMA copy of aft-foil SRF head
 swad_initial_val = None
 swad_prev_val = float("inf")
@@ -1587,6 +1782,8 @@ snapshot_epoch_list = [int(e) for e in cfg.snapshot_epochs_str.split(",")] if cf
 n_params = sum(p.numel() for p in model.parameters())
 if refine_head is not None:
     n_params += sum(p.numel() for p in refine_head.parameters())
+if surface_fno is not None:
+    n_params += sum(p.numel() for p in surface_fno.parameters())
 if aft_srf_head is not None:
     n_params += sum(p.numel() for p in aft_srf_head.parameters())
 if aft_srf_ctx_head is not None:
@@ -1722,6 +1919,12 @@ if refine_head is not None:
     base_opt.add_param_group({'params': _refine_params, 'lr': _base_lr})
     print(f"Added {sum(p.numel() for p in _refine_params):,} refinement head params to optimizer")
 
+# Add surface FNO head params to optimizer if enabled
+if surface_fno is not None:
+    _fno_params = list(surface_fno.parameters())
+    base_opt.add_param_group({'params': _fno_params, 'lr': _base_lr})
+    print(f"Added {sum(p.numel() for p in _fno_params):,} surface FNO params to optimizer")
+
 # Add aft-foil SRF head params to optimizer if enabled
 if aft_srf_head is not None:
     _aft_params = list(aft_srf_head.parameters())
@@ -1831,6 +2034,8 @@ for epoch in range(MAX_EPOCHS):
     model.train()
     if refine_head is not None:
         refine_head.train()
+    if surface_fno is not None:
+        surface_fno.train()
     if aft_srf_head is not None:
         aft_srf_head.train()
     if aft_srf_ctx_head is not None:
@@ -1943,7 +2148,7 @@ for epoch in range(MAX_EPOCHS):
         _raw_saf_for_dct = x[:, :, 2:4].norm(dim=-1) if cfg.dct_freq_loss else None
         _raw_tandem_for_dct = (x[:, 0, 22].abs() > 0.01) if cfg.dct_freq_loss else None
         # TE coordinate frame / wake deficit / cp_panel / vortex_panel: save raw xy and saf_norm before normalization
-        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+        _need_te_raw = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.surface_fno
         _raw_xy_te = x[:, :, :2].clone() if _need_te_raw else None
         _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw else None
         _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None  # raw gap for wake deficit
@@ -2115,6 +2320,26 @@ for epoch in range(MAX_EPOCHS):
                         correction = refine_head(surf_hidden, surf_pred).float()  # [M, 3]
                         pred = pred.clone()
                         pred[surf_idx[:, 0], surf_idx[:, 1]] = pred[surf_idx[:, 0], surf_idx[:, 1]] + correction
+
+        # Surface FNO: arc-length spectral decoder, additive correction on surface nodes
+        if surface_fno is not None and model.training and _raw_xy_te is not None:
+            with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                pred_before_fno = pred.detach()
+                pred = _apply_surface_fno(
+                    surface_fno, pred, hidden.float(), is_surface, mask,
+                    _raw_xy_te, _raw_saf_norm_te, cfg.surface_fno_grid
+                )
+            # Log FNO diagnostics every 50 gradient steps
+            if global_step % 50 == 0:
+                _fno_corr_norm = (pred.detach() - pred_before_fno)[is_surface & mask].norm().item()
+                _fno_modes_energy = sum(
+                    (layer.spectral.weights_re.detach() ** 2 + layer.spectral.weights_im.detach() ** 2).sum().item()
+                    for layer in surface_fno.layers
+                )
+                wandb.log({
+                    "train/fno_correction_norm": _fno_corr_norm,
+                    "train/fno_modes_energy": _fno_modes_energy,
+                }, step=global_step, commit=False)
 
         # Aft-foil dedicated refinement head: additive correction on boundary ID=7 nodes only
         if aft_srf_ctx_head is not None and model.training and _aft_foil_mask is not None:
@@ -2488,6 +2713,15 @@ for epoch in range(MAX_EPOCHS):
                     with torch.no_grad():
                         for ep, mp in zip(ema_refine_head.parameters(), _refine_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
+            # EMA for surface FNO head
+            if surface_fno is not None:
+                _fno_base = surface_fno
+                if ema_surface_fno is None:
+                    ema_surface_fno = deepcopy(_fno_base)
+                else:
+                    with torch.no_grad():
+                        for ep, mp in zip(ema_surface_fno.parameters(), _fno_base.parameters()):
+                            ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
             # EMA for aft-foil SRF head
             if aft_srf_head is not None:
                 _aft_base = aft_srf_head._orig_mod if hasattr(aft_srf_head, '_orig_mod') else aft_srf_head
@@ -2506,7 +2740,16 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if surface_fno is not None and ema_surface_fno is not None:
+            # Log FNO spectral weight energy (proxy for how much spectral content is learned)
+            _fno_energy = sum(
+                (p.detach() ** 2).sum().item()
+                for p in ema_surface_fno.parameters()
+                if p.requires_grad
+            )
+            _log_dict["train/fno_weight_energy"] = _fno_energy
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -2610,6 +2853,14 @@ for epoch in range(MAX_EPOCHS):
             eval_refine_head.eval()
         elif refine_head is not None:
             refine_head.eval()
+    # Select surface FNO for eval (EMA if available)
+    eval_surface_fno = surface_fno
+    if surface_fno is not None:
+        if ema_surface_fno is not None and ema_model is not None and eval_model is ema_model:
+            eval_surface_fno = ema_surface_fno
+            eval_surface_fno.eval()
+        else:
+            surface_fno.eval()
     # Select aft-foil SRF head for eval (EMA if available)
     eval_aft_srf_head = aft_srf_head
     eval_aft_srf_ctx_head = aft_srf_ctx_head
@@ -2650,7 +2901,7 @@ for epoch in range(MAX_EPOCHS):
                 dist_feat = torch.log1p(dist_surf * 10.0)  # log-scale for better gradient flow
                 _raw_aoa = x[:, 0, 14:15]  # AoA0_rad [B, 1]
                 _is_tandem_raw = (x[:, 0, 22].abs() > 0.01).float()  # [B]
-                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity
+                _need_te_raw_v = cfg.te_coord_frame or cfg.wake_deficit_feature or cfg.cp_panel or cfg.vortex_panel_velocity or cfg.surface_fno
                 _raw_xy_te = x[:, :, :2].clone() if _need_te_raw_v else None
                 _raw_saf_norm_te = x[:, :, 2:4].norm(dim=-1) if _need_te_raw_v else None
                 _raw_gap_wake = x[:, :, 22].mean(dim=1) if cfg.wake_deficit_feature else None
@@ -2797,6 +3048,19 @@ for epoch in range(MAX_EPOCHS):
                                 pred_loss = pred_loss.clone()
                                 pred_loss[surf_idx[:, 0], surf_idx[:, 1]] = pred_loss[surf_idx[:, 0], surf_idx[:, 1]] + correction
                     # Back-compute refined pred so denormalization (pred_orig) includes refinement
+                    if cfg.multiply_std:
+                        pred = pred_loss / sample_stds
+                    else:
+                        pred = pred_loss * sample_stds
+
+                # Apply surface FNO during validation
+                if eval_surface_fno is not None and _raw_xy_te is not None:
+                    with torch.amp.autocast("cuda", dtype=torch.bfloat16):
+                        pred_loss = _apply_surface_fno(
+                            eval_surface_fno, pred_loss, _eval_hidden.float(),
+                            is_surface, mask, _raw_xy_te, _raw_saf_norm_te,
+                            cfg.surface_fno_grid
+                        )
                     if cfg.multiply_std:
                         pred = pred_loss / sample_stds
                     else:
@@ -3006,6 +3270,9 @@ for epoch in range(MAX_EPOCHS):
                 refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head
             )
             torch.save(_refine_save.state_dict(), model_dir / "refine_head.pt")
+        if surface_fno is not None:
+            _fno_save = ema_surface_fno if ema_surface_fno is not None else surface_fno
+            torch.save(_fno_save.state_dict(), model_dir / "surface_fno.pt")
         if aft_srf_head is not None:
             _aft_save = ema_aft_srf_head if ema_aft_srf_head is not None else (
                 aft_srf_head._orig_mod if hasattr(aft_srf_head, '_orig_mod') else aft_srf_head


### PR DESCRIPTION
## Hypothesis

Surface pressure p(s) along an airfoil is fundamentally a **1D function of arc-length** s ∈ [0, 1]. The Transolver backbone operates on unstructured 2D mesh nodes with global slice attention — but surface pressure has strong spectral structure: low-frequency components capture the global Cp distribution (lift, drag), while high-frequency components capture the leading-edge suction peak and trailing-edge separation. A **1D Fourier Neural Operator (FNO)** decoder operating in the spectral domain on a uniform arc-length grid should capture this multi-scale structure more naturally than the current SRF (which is a pure MLP on backbone features).

**Key insight:** FNO's spectral convolution layers learn to multiply in frequency space — they can simultaneously model global pressure trends (first ~4 Fourier modes) and local sharp features (higher modes). This is the correct mathematical tool for a smooth-but-sharp 1D function like Cp(s).

**No full FNO architectures have been tried in this programme** — the failed architectures (GNOT, Galerkin, HPT, FactFormer, DeepONet, SIREN) were all different paradigms. 1D FNO as a surface decoder (not a full backbone replacement) is novel here.

**Target metrics:** p_in, p_tan (primary — better spectral decomposition of surface pressure). p_oodc, p_re (secondary — the spectral representation may generalize better across geometries/Re).

**Reference:** Li et al. (2021) "Fourier Neural Operator for Parametric PDEs" — showed FNO captures multi-scale PDE solutions efficiently via learnable spectral filters. Patel et al. (2024) "On the Fourier Neural Operator for Real-Time Surface Pressure Prediction" — directly applied FNO to surface pressure.

## Instructions

Add a `--surface_fno` flag to `cfd_tandemfoil/train.py`. When active, replace the SRF head with a 1D FNO decoder operating on surface arc-length.

### 1. Add flags
```python
parser.add_argument('--surface_fno', action='store_true',
    help='Replace SRF with 1D FNO decoder on arc-length parameterized surface')
parser.add_argument('--surface_fno_modes', type=int, default=16,
    help='Number of Fourier modes to keep (default: 16)')
parser.add_argument('--surface_fno_width', type=int, default=64,
    help='FNO hidden channel width (default: 64)')
parser.add_argument('--surface_fno_layers', type=int, default=4,
    help='Number of FNO layers (default: 4)')
parser.add_argument('--surface_fno_grid', type=int, default=128,
    help='Uniform grid resolution for surface (default: 128)')
```

### 2. Arc-length parameterization

Sort surface nodes by angle from centroid (or cumulative Euclidean distance) to get an ordered 1D curve. Then compute arc-length fraction s ∈ [0, 1]:

```python
def parameterize_surface(surface_xy, surface_mask):
    """
    surface_xy: [N_surf, 2] — coordinates of surface nodes
    Returns: arc_length [N_surf] in [0, 1], sort_indices [N_surf]
    """
    # Sort by angle from centroid
    centroid = surface_xy.mean(dim=0)
    angles = torch.atan2(surface_xy[:, 1] - centroid[1],
                         surface_xy[:, 0] - centroid[0])
    sort_idx = angles.argsort()
    sorted_xy = surface_xy[sort_idx]

    # Cumulative arc-length
    diffs = torch.diff(sorted_xy, dim=0)
    segment_lengths = diffs.norm(dim=1)
    arc = torch.cat([torch.zeros(1, device=segment_lengths.device),
                     segment_lengths.cumsum(0)])
    arc = arc / (arc[-1] + 1e-8)  # normalize to [0, 1]
    return arc, sort_idx
```

For **tandem** samples: parameterize each foil separately (fore: foil_id==1, aft: foil_id==2). Apply FNO to each independently, then concatenate results.

### 3. Interpolate to uniform grid

```python
def interpolate_to_grid(features, arc_length, n_grid=128):
    """
    features: [N_surf, D] — backbone embeddings at surface nodes
    arc_length: [N_surf] in [0, 1]
    Returns: grid_features [n_grid, D]
    """
    # Uniform grid points
    grid_s = torch.linspace(0, 1, n_grid, device=features.device)
    # Linear interpolation using torch.searchsorted
    idx = torch.searchsorted(arc_length, grid_s).clamp(1, len(arc_length) - 1)
    s0, s1 = arc_length[idx - 1], arc_length[idx]
    w = ((grid_s - s0) / (s1 - s0 + 1e-8)).unsqueeze(1)
    grid_feat = (1 - w) * features[idx - 1] + w * features[idx]
    return grid_feat
```

### 4. 1D FNO layer (pure PyTorch)

```python
class SpectralConv1d(nn.Module):
    """1D Fourier layer: multiply in frequency domain"""
    def __init__(self, in_channels, out_channels, modes):
        super().__init__()
        self.modes = modes
        # Complex weights for spectral multiplication
        self.weights = nn.Parameter(
            torch.randn(in_channels, out_channels, modes, 2) * 0.02
        )

    def forward(self, x):
        # x: [B, C, N] (batch, channels, spatial)
        B, C, N = x.shape
        x_ft = torch.fft.rfft(x, dim=-1)  # [B, C, N//2+1]
        # Multiply first 'modes' frequencies by learned weights
        weights_c = torch.view_as_complex(self.weights)  # [C_in, C_out, modes]
        out_ft = torch.zeros(B, self.weights.shape[1], N // 2 + 1,
                             dtype=torch.cfloat, device=x.device)
        out_ft[:, :, :self.modes] = torch.einsum(
            'bci,ioc->boc', x_ft[:, :, :self.modes], weights_c
        )
        return torch.fft.irfft(out_ft, n=N, dim=-1)  # [B, C_out, N]


class FNOLayer1d(nn.Module):
    def __init__(self, width, modes):
        super().__init__()
        self.spectral = SpectralConv1d(width, width, modes)
        self.linear = nn.Conv1d(width, width, 1)  # local skip
        self.norm = nn.InstanceNorm1d(width)

    def forward(self, x):
        # x: [B, C, N]
        return self.norm(x + F.gelu(self.spectral(x) + self.linear(x)))


class SurfaceFNO(nn.Module):
    def __init__(self, in_dim, width=64, modes=16, n_layers=4, out_dim=3):
        super().__init__()
        self.lift = nn.Linear(in_dim, width)
        self.layers = nn.ModuleList([FNOLayer1d(width, modes) for _ in range(n_layers)])
        self.proj = nn.Linear(width, out_dim)
        # Zero-init final projection for safe startup
        nn.init.zeros_(self.proj.weight)
        nn.init.zeros_(self.proj.bias)

    def forward(self, x):
        # x: [B, N_grid, in_dim]
        x = self.lift(x)            # [B, N_grid, width]
        x = x.permute(0, 2, 1)     # [B, width, N_grid] for Conv1d
        for layer in self.layers:
            x = layer(x)
        x = x.permute(0, 2, 1)     # [B, N_grid, width]
        return self.proj(x)         # [B, N_grid, out_dim]
```

### 5. Integration into training

When `--surface_fno` is active:
1. After backbone → extract surface node embeddings `h_surf`
2. For each foil in sample: parameterize surface → interpolate to uniform grid → run FNO
3. Interpolate FNO output back to original mesh node positions (inverse of step 2)
4. Use FNO output as the surface prediction (replace SRF head)
5. Note: **omit `--surface_refine`** since FNO replaces it

### 6. Per-foil processing for tandem

```python
if is_tandem:
    # Fore foil
    fore_arc, fore_sort = parameterize_surface(xy[fore_surf_mask])
    fore_grid = interpolate_to_grid(h[fore_surf_mask][fore_sort], fore_arc, n_grid)
    fore_out = self.surface_fno(fore_grid.unsqueeze(0))  # [1, N_grid, 3]
    # Interpolate back to original fore surface nodes
    fore_preds = interpolate_from_grid(fore_out.squeeze(0), fore_arc, fore_sort)

    # Aft foil (same process)
    aft_arc, aft_sort = parameterize_surface(xy[aft_surf_mask])
    aft_grid = interpolate_to_grid(h[aft_surf_mask][aft_sort], aft_arc, n_grid)
    aft_out = self.surface_fno(aft_grid.unsqueeze(0))
    aft_preds = interpolate_from_grid(aft_out.squeeze(0), aft_arc, aft_sort)
else:
    # Single foil
    arc, sort_idx = parameterize_surface(xy[surf_mask])
    grid = interpolate_to_grid(h[surf_mask][sort_idx], arc, n_grid)
    fno_out = self.surface_fno(grid.unsqueeze(0))
    preds = interpolate_from_grid(fno_out.squeeze(0), arc, sort_idx)
```

### Run commands

```bash
# Seed 42
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent frieren --wandb_name "frieren/surface-fno-s42" --wandb_group surface-fno \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep \
  --residual_prediction --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only \
  --cp_panel_scale 0.1 --wake_angle_feature --vortex_panel_velocity \
  --vortex_panel_scale 0.1 --vortex_panel_n 64 \
  --surface_fno --surface_fno_modes 16 --surface_fno_width 64 \
  --surface_fno_layers 4 --surface_fno_grid 128

# Seed 73 (same flags, --seed 73, --wandb_name "frieren/surface-fno-s73")
```

Note: **omit `--surface_refine`** since the FNO replaces it.

### Logging
```python
wandb.log({
    'train/fno_out_norm': fno_out.norm().item(),
    'train/fno_modes_energy': (fno_weights_complex.abs() ** 2).sum().item(),
})
```

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.872** | < 11.872 |
| p_oodc | 7.459 | < 7.459 |
| **p_tan** | **26.319** | < 26.319 |
| **p_re** | **6.229** | < 6.229 |

W&B baseline: aycq1m8m (seed 42, epoch 155), 9sk276v6 (seed 73, epoch 156)

Reproduce:
```bash
cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output \
  --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64
```