### PR TITLE
Surface-Node Cross-Attention: global surface-only attention post-backbone

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -981,10 +981,12 @@ class Transolver(nn.Module):
         gap_stagger_spatial_bias=False,
         surface_cross_attn=False,
         surface_cross_attn_heads=4,
+        surface_cross_attn_tandem_only=False,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.surface_cross_attn_tandem_only = surface_cross_attn_tandem_only
         self.surface_cross_attn = (
             SurfaceCrossAttention(n_hidden, num_heads=surface_cross_attn_heads)
             if surface_cross_attn else None
@@ -1210,10 +1212,13 @@ class Transolver(nn.Module):
                 h_surf = torch.stack(h_surf_list, dim=0)      # [B, max_surf, D]
                 key_padding_mask = torch.stack(pad_masks, dim=0)  # [B, max_surf]
                 h_surf_updated = self.surface_cross_attn(h_surf, key_padding_mask=key_padding_mask)
+                # Tandem-conditional: only scatter back for tandem samples when tandem_only=True
+                is_tandem_bool = (x[:, 0, 21].abs() > 0.01)  # [B]
                 fx = fx.clone()
                 for b in range(B):
                     n_s = n_surf[b].item()
-                    fx[b, is_surf_mask[b]] = h_surf_updated[b, :n_s]
+                    if not self.surface_cross_attn_tandem_only or is_tandem_bool[b]:
+                        fx[b, is_surf_mask[b]] = h_surf_updated[b, :n_s]
                 fx_deep = fx  # update deep repr with enriched surface states
 
         # Auxiliary Re prediction from pre-output-head hidden representation
@@ -1403,6 +1408,8 @@ class Config:
     # Phase 7: Surface cross-attention — global all-to-all attention on surface nodes
     surface_cross_attn: bool = False           # enable global surface-only cross-attention post-backbone
     surface_cross_attn_heads: int = 4          # number of attention heads for surface cross-attention
+    surface_cross_attn_tandem_only: bool = False  # apply SCA only to tandem samples; skip single-foil
+    surface_cross_attn_lr_scale: float = 1.0   # LR multiplier for SCA params (1.0 = same as base lr)
 
 
 cfg = sp.parse(Config)
@@ -1580,6 +1587,7 @@ model_config = dict(
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
     surface_cross_attn=cfg.surface_cross_attn,
     surface_cross_attn_heads=cfg.surface_cross_attn_heads,
+    surface_cross_attn_tandem_only=cfg.surface_cross_attn_tandem_only,
 )
 
 model = Transolver(**model_config).to(device)
@@ -1774,20 +1782,27 @@ class Lookahead:
         return self.base_optimizer.param_groups
 
 
-attn_params = [p for n, p in model.named_parameters() if any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
-other_params = [p for n, p in model.named_parameters() if not any(k in n for k in ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias'])]
+_attn_keys = ['Wqkv', 'temperature', 'slice_weight', 'attn_scale', 'spatial_bias']
+# Separate SCA params into their own group when lr_scale != 1.0
+_use_sca_lr = cfg.surface_cross_attn and cfg.surface_cross_attn_lr_scale != 1.0
+sca_params = [p for n, p in model.named_parameters() if 'surface_cross_attn' in n] if _use_sca_lr else []
+_sca_ids = {id(p) for p in sca_params}
+attn_params = [p for n, p in model.named_parameters() if any(k in n for k in _attn_keys) and id(p) not in _sca_ids]
+other_params = [p for n, p in model.named_parameters() if not any(k in n for k in _attn_keys) and id(p) not in _sca_ids]
 _base_lr = cfg.two_phase_lr_1 if cfg.two_phase_lr else cfg.lr
+_param_groups = [
+    {'params': attn_params, 'lr': _base_lr * 0.5},
+    {'params': other_params, 'lr': _base_lr},
+]
+if sca_params:
+    _sca_lr = _base_lr * cfg.surface_cross_attn_lr_scale
+    _param_groups.append({'params': sca_params, 'lr': _sca_lr})
+    print(f"SCA params: {sum(p.numel() for p in sca_params):,} params at lr={_sca_lr:.2e} ({cfg.surface_cross_attn_lr_scale}x)")
 if cfg.use_lion:
-    base_opt = Lion([
-        {'params': attn_params, 'lr': _base_lr * 0.5},
-        {'params': other_params, 'lr': _base_lr}
-    ], weight_decay=cfg.weight_decay)
+    base_opt = Lion(_param_groups, weight_decay=cfg.weight_decay)
     optimizer = base_opt  # Lion has its own momentum; skip Lookahead
 else:
-    base_opt = torch.optim.AdamW([
-        {'params': attn_params, 'lr': _base_lr * 0.5},
-        {'params': other_params, 'lr': _base_lr}
-    ], weight_decay=cfg.weight_decay)
+    base_opt = torch.optim.AdamW(_param_groups, weight_decay=cfg.weight_decay)
     if cfg.use_lookahead:
         optimizer = Lookahead(base_opt, k=10, alpha=0.8)
     else:

--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -903,6 +903,45 @@ class SurfaceRefinementContextHead(nn.Module):
         return correction
 
 
+class SurfaceCrossAttention(nn.Module):
+    """Global all-to-all attention over surface nodes only.
+
+    Applied to the hidden representation before the final output head.
+    Enables direct surface-to-surface communication, including fore-TE to aft-LE
+    wake coupling in tandem configurations.
+    Zero-init on output projections ensures safe startup (identity-like behaviour).
+    """
+
+    def __init__(self, embed_dim, num_heads=4):
+        super().__init__()
+        self.attn = nn.MultiheadAttention(
+            embed_dim=embed_dim, num_heads=num_heads, batch_first=True
+        )
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 2),
+            nn.GELU(),
+            nn.Linear(embed_dim * 2, embed_dim),
+        )
+        self.norm2 = nn.LayerNorm(embed_dim)
+        # Zero-init output projections so initial routing is unchanged
+        nn.init.zeros_(self.ffn[-1].weight)
+        nn.init.zeros_(self.ffn[-1].bias)
+        nn.init.zeros_(self.attn.out_proj.weight)
+        nn.init.zeros_(self.attn.out_proj.bias)
+
+    def forward(self, h_surf, key_padding_mask=None):
+        """
+        h_surf:           [B, S, D] — surface node embeddings, padded to max S
+        key_padding_mask: [B, S] bool — True for padded (non-surface) positions
+        Returns:          [B, S, D] — updated surface embeddings
+        """
+        h_attn, _ = self.attn(h_surf, h_surf, h_surf, key_padding_mask=key_padding_mask)
+        h_surf = self.norm1(h_surf + h_attn)
+        h_surf = self.norm2(h_surf + self.ffn(h_surf))
+        return h_surf
+
+
 class Transolver(nn.Module):
     def __init__(
         self,
@@ -940,10 +979,16 @@ class Transolver(nn.Module):
         pressure_no_detach=False,
         pressure_deep=False,
         gap_stagger_spatial_bias=False,
+        surface_cross_attn=False,
+        surface_cross_attn_heads=4,
     ):
         super().__init__()
         self.__name__ = "UniPDE_3D"
         self.gap_stagger_spatial_bias = gap_stagger_spatial_bias
+        self.surface_cross_attn = (
+            SurfaceCrossAttention(n_hidden, num_heads=surface_cross_attn_heads)
+            if surface_cross_attn else None
+        )
         self.pressure_first = pressure_first
         self.ref = ref
         self.unified_pos = unified_pos
@@ -1144,6 +1189,33 @@ class Transolver(nn.Module):
         # Deep hidden representation (post all non-last blocks, pre output head)
         fx_deep = fx  # [B, N, n_hidden]
 
+        # Surface cross-attention: enrich hidden states at surface nodes before last block
+        is_surf_mask = data.get("is_surface", None) if isinstance(data, Mapping) else None
+        if self.surface_cross_attn is not None and is_surf_mask is not None:
+            B, N, D = fx.shape
+            n_surf = is_surf_mask.sum(dim=1)  # [B]
+            max_surf = n_surf.max().item()
+            if max_surf > 0:
+                h_surf_list = []
+                pad_masks = []
+                for b in range(B):
+                    h_s = fx[b, is_surf_mask[b]]  # [S_b, D]
+                    pad_len = max_surf - h_s.shape[0]
+                    if pad_len > 0:
+                        h_s = F.pad(h_s, (0, 0, 0, pad_len))
+                    h_surf_list.append(h_s)
+                    key_pad = torch.zeros(max_surf, dtype=torch.bool, device=fx.device)
+                    key_pad[n_surf[b]:] = True
+                    pad_masks.append(key_pad)
+                h_surf = torch.stack(h_surf_list, dim=0)      # [B, max_surf, D]
+                key_padding_mask = torch.stack(pad_masks, dim=0)  # [B, max_surf]
+                h_surf_updated = self.surface_cross_attn(h_surf, key_padding_mask=key_padding_mask)
+                fx = fx.clone()
+                for b in range(B):
+                    n_s = n_surf[b].item()
+                    fx[b, is_surf_mask[b]] = h_surf_updated[b, :n_s]
+                fx_deep = fx  # update deep repr with enriched surface states
+
         # Auxiliary Re prediction from pre-output-head hidden representation
         re_pred = self.re_head(fx.mean(dim=1))  # [B, 1]
         aoa_pred = self.aoa_head(fx.mean(dim=1))
@@ -1328,6 +1400,9 @@ class Config:
     vortex_panel_velocity: bool = False    # append (u_fore, v_fore, u_aft, v_aft) induced velocity
     vortex_panel_scale: float = 0.1        # scale factor for vortex velocity channels
     vortex_panel_n: int = 64              # number of panels to subsample per foil
+    # Phase 7: Surface cross-attention — global all-to-all attention on surface nodes
+    surface_cross_attn: bool = False           # enable global surface-only cross-attention post-backbone
+    surface_cross_attn_heads: int = 4          # number of attention heads for surface cross-attention
 
 
 cfg = sp.parse(Config)
@@ -1503,6 +1578,8 @@ model_config = dict(
     pressure_no_detach=cfg.pressure_no_detach,
     pressure_deep=cfg.pressure_deep,
     gap_stagger_spatial_bias=cfg.gap_stagger_spatial_bias,
+    surface_cross_attn=cfg.surface_cross_attn,
+    surface_cross_attn_heads=cfg.surface_cross_attn_heads,
 )
 
 model = Transolver(**model_config).to(device)
@@ -2082,7 +2159,7 @@ for epoch in range(MAX_EPOCHS):
                 y_norm = y_norm / sample_stds
 
         with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-            out = model({"x": x})
+            out = model({"x": x, "is_surface": is_surface})
             pred = out["preds"]
             re_pred = out["re_pred"]
             aoa_pred = out["aoa_pred"]
@@ -2310,7 +2387,7 @@ for epoch in range(MAX_EPOCHS):
         rdrop_loss = torch.tensor(0.0, device=device)
         if cfg.rdrop and model.training:
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                rdrop_out = model({"x": x})
+                rdrop_out = model({"x": x, "is_surface": is_surface})
                 rdrop_pred = rdrop_out["preds"].float() / sample_stds
             valid_mask = mask.float().unsqueeze(-1)
             rdrop_loss = ((pred - rdrop_pred) ** 2 * valid_mask).sum() / valid_mask.sum().clamp(min=1)
@@ -2449,7 +2526,7 @@ for epoch in range(MAX_EPOCHS):
             sam_optimizer.zero_grad()
             # Recompute forward at perturbed parameters (simplified loss, no coarse/pcgrad)
             with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                out2 = model({"x": x})
+                out2 = model({"x": x, "is_surface": is_surface})
                 pred2 = out2["preds"].float() / sample_stds
                 re_pred2 = out2["re_pred"].float()
                 aoa_pred2 = out2["aoa_pred"].float()
@@ -2506,7 +2583,13 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _wandb_log = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        if cfg.surface_cross_attn:
+            _sca = _base_model.surface_cross_attn
+            if _sca is not None:
+                _wandb_log["train/surf_xattn_ffn_out_norm"] = _sca.ffn[-1].weight.norm().item()
+                _wandb_log["train/surf_xattn_attn_out_norm"] = _sca.attn.out_proj.weight.norm().item()
+        wandb.log(_wandb_log)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()
@@ -2770,7 +2853,7 @@ for epoch in range(MAX_EPOCHS):
                     y_norm_scaled = y_norm / sample_stds
 
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                    _eval_out = eval_model({"x": x})
+                    _eval_out = eval_model({"x": x, "is_surface": is_surface})
                     pred = _eval_out["preds"]
                     _eval_hidden = _eval_out["hidden"]
                 pred = pred.float()
@@ -3127,7 +3210,7 @@ if best_metrics:
                             vp_feat = vp_feat * cfg.vortex_panel_scale
                         x_n = torch.cat([x_n, vp_feat], dim=-1)
                     Umag, q = _umag_q(y_dev, mask)
-                    pred = vis_model({"x": x_n, "mask": mask})["preds"].float()
+                    pred = vis_model({"x": x_n, "mask": mask, "is_surface": is_surf_dev})["preds"].float()
                     if cfg.raw_targets:
                         y_pred = (pred * raw_stats["y_std"] + raw_stats["y_mean"]).squeeze(0).cpu()
                     elif cfg.adaptive_norm:
@@ -3312,7 +3395,7 @@ if cfg.surface_refine and best_metrics:
 
                     # Model forward
                     with torch.amp.autocast("cuda", dtype=torch.bfloat16):
-                        out = verify_model({"x": x})
+                        out = verify_model({"x": x, "is_surface": is_surface})
                         pred_raw = out["preds"].float()
                         hidden = out["hidden"].float()
 


### PR DESCRIPTION
## Hypothesis

After the Transolver backbone's slice attention (which operates on ALL mesh nodes including far-field volume), **surface nodes lack a direct communication pathway to each other**. Specifically, for tandem configurations, the fore-foil trailing edge surface nodes and aft-foil leading edge surface nodes — the most aerodynamically coupled pair in the entire mesh — communicate only indirectly through slice assignments that may route them through different slices.

A dedicated **surface-only cross-attention layer** after the backbone enables:
1. Direct surface-to-surface information transfer with O(S²) cost (S ≈ 400-800 surface nodes, negligible vs backbone O(N×96))
2. For tandem: fore TE → aft LE attention flow models the physical wake coupling directly
3. Global pressure equilibrium: all surface nodes "see" each other in a single layer, enforcing integral consistency (Kutta condition, pressure recovery)

**This is architecturally different from all prior attention modifications:**
- Biot-Savart attention bias (#2367): tried to modify existing slice routing — failed because slice attention has no pairwise injection point
- Cross-foil AR decoding (#2369, thorfinn): conditions aft on fore predictions sequentially — different mechanism
- Surface B-GNN (#2370, nezuko): local k-NN message passing — this is global all-to-all

**Backed by:** Jena et al. (arXiv:2503.18638, 2025) B-GNN paper shows surface-only global communication is the key architectural insight for 88% OOD error reduction on airFRANS. Our approach keeps the Transolver backbone (which works well for volume) and adds surface-only attention as a post-processing decoder.

**Target:** p_tan (primary — direct cross-foil surface communication), p_in (global pressure consistency).

## Instructions

### 1. Add flag
```python
parser.add_argument('--surface_cross_attn', action='store_true',
    help='Add global surface-only cross-attention layer after backbone')
parser.add_argument('--surface_cross_attn_heads', type=int, default=4,
    help='Number of attention heads for surface cross-attention (default: 4)')
```

### 2. Surface cross-attention module
```python
class SurfaceCrossAttention(nn.Module):
    """Global all-to-all attention over surface nodes only."""
    def __init__(self, embed_dim, num_heads=4):
        super().__init__()
        self.attn = nn.MultiheadAttention(
            embed_dim=embed_dim, num_heads=num_heads, batch_first=True
        )
        self.norm1 = nn.LayerNorm(embed_dim)
        self.ffn = nn.Sequential(
            nn.Linear(embed_dim, embed_dim * 2),
            nn.GELU(),
            nn.Linear(embed_dim * 2, embed_dim),
        )
        self.norm2 = nn.LayerNorm(embed_dim)
        # Zero-init the FFN output and attention output proj for safe startup
        nn.init.zeros_(self.ffn[-1].weight)
        nn.init.zeros_(self.ffn[-1].bias)
        nn.init.zeros_(self.attn.out_proj.weight)
        nn.init.zeros_(self.attn.out_proj.bias)

    def forward(self, h_surf):
        """
        h_surf: [B, S, D] — surface node embeddings (padded to max S per batch)
        Returns: [B, S, D] — updated surface embeddings
        """
        # Self-attention: every surface node attends to all surface nodes
        h_attn, _ = self.attn(h_surf, h_surf, h_surf)
        h_surf = self.norm1(h_surf + h_attn)
        h_surf = self.norm2(h_surf + self.ffn(h_surf))
        return h_surf
```

### 3. Integrate into forward pass

After the last TransolverBlock produces hidden embeddings `h` (shape `[B, N, D]`):

```python
if self.args.surface_cross_attn:
    # Extract surface node embeddings
    # surface_mask: [B, N] bool identifying surface nodes
    B, N, D = h.shape
    
    # Gather surface nodes per sample
    # Approach: for each sample in batch, gather surface embeddings
    # Pad to max surface count
    max_surf = surface_mask.sum(dim=1).max().item()  # max surface nodes in batch
    
    h_surf_list = []
    surf_masks = []
    for b in range(B):
        s_mask = surface_mask[b]  # [N]
        h_s = h[b, s_mask]  # [S_b, D]
        pad_len = max_surf - h_s.shape[0]
        if pad_len > 0:
            h_s = F.pad(h_s, (0, 0, 0, pad_len))  # [max_surf, D]
        h_surf_list.append(h_s)
        # Build attention mask for padding
        key_padding = torch.zeros(max_surf, dtype=torch.bool, device=h.device)
        key_padding[s_mask.sum():] = True
        surf_masks.append(key_padding)
    
    h_surf = torch.stack(h_surf_list, dim=0)  # [B, max_surf, D]
    key_padding_mask = torch.stack(surf_masks, dim=0)  # [B, max_surf]
    
    # Run surface cross-attention
    h_surf_updated = self.surface_cross_attn(h_surf)
    
    # Scatter back: update only surface node positions in full h
    for b in range(B):
        s_mask = surface_mask[b]
        n_surf = s_mask.sum().item()
        h[b, s_mask] = h_surf_updated[b, :n_surf]
```

**Note:** For the MultiheadAttention, pass `key_padding_mask` to mask padded positions:
```python
h_attn, _ = self.attn(h_surf, h_surf, h_surf, key_padding_mask=key_padding_mask)
```

### 4. Keep SRF head
The surface cross-attention operates between the backbone and the SRF head — it enriches surface embeddings before SRF refinement. **Keep `--surface_refine` active.**

### 5. Efficient implementation note
Surface nodes are ~400-800 per foil (both foils included for tandem). The self-attention is O(S²) ≈ O(640K) — negligible vs backbone. The padding/gather/scatter is the main overhead; keep it clean.

### Run commands

```bash
# Seed 42
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent askeladd --wandb_name "askeladd/surf-xattn-s42" --wandb_group surface-cross-attention \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only \
  --cp_panel_scale 0.1 --wake_angle_feature --vortex_panel_velocity \
  --vortex_panel_scale 0.1 --vortex_panel_n 64 \
  --surface_cross_attn --surface_cross_attn_heads 4

# Seed 73 (same flags, --seed 73, --wandb_name "askeladd/surf-xattn-s73")
```

### Logging
```python
if self.args.surface_cross_attn:
    wandb.log({
        'train/surf_xattn_out_norm': h_attn.norm().item(),
        'train/surf_xattn_ffn_norm': self.surface_cross_attn.ffn[-1].weight.norm().item(),
    })
```

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.872** | < 11.872 |
| p_oodc | 7.459 | < 7.459 |
| **p_tan** | **26.319** | < 26.319 |
| **p_re** | **6.229** | < 6.229 |

W&B baseline: aycq1m8m (seed 42, epoch 155), 9sk276v6 (seed 73, epoch 156)

Reproduce:
```bash
cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output \
  --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64
```