### PR TITLE
Mamba SSM Surface Decoder: sequential arc-length pressure prediction

### DIFF
--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,22 @@
 # SENPAI Research Results
 
+## 2026-04-10 18:00 — PR #2370: Surface-Intrinsic B-GNN: pure-PyTorch boundary GNN decoder
+- Branch: nezuko/surface-intrinsic-bgnn
+- **Hypothesis:** Replace SRF head with a surface-intrinsic boundary GNN (4 layers, k=8, hidden=192, 914K params) using arc-length k-NN connectivity. Surface-only local message passing should capture boundary layer physics better than global attention.
+- **Results:**
+
+| Metric | s42 | s73 | 2-seed avg | Baseline | Delta |
+|--------|-----|-----|------------|----------|-------|
+| p_in | 12.874 | 14.252 | 13.563 | 11.872 | +14.3% |
+| p_oodc | 7.906 | 8.110 | 8.008 | 7.459 | +7.4% |
+| p_tan | 29.023 | 30.956 | 29.990 | 26.319 | +13.9% |
+| p_re | 6.740 | 6.775 | 6.757 | 6.229 | +8.5% |
+
+- W&B: 9qchz43s (s42), rv9dd3b5 (s73). Group: surface-bgnn
+- **Verdict: CLOSED — dead end.** All metrics significantly worse. Local surface GNN cannot capture global tandem inter-foil coupling. Large correction norms (62-93) indicate B-GNN fighting backbone rather than refining. High seed variance (p_in: 12.9-14.3) shows unstable optimization from 914K params competing for gradient signal. Core learning: any decoder replacement must preserve global cross-foil context.
+
+---
+
 ## Phase 6 Experiments (2026-04-01 onwards)
 
 ### 2026-04-10 17:15 — PR #2368: Sobolev Surface Gradient Loss — alphonse — **CLOSED** ❌


### PR DESCRIPTION
## Hypothesis

Replace the Surface Refinement Head (SRF) — currently a per-node MLP — with a Mamba State Space Model operating on surface nodes ordered by arc-length. The SRF's weakness is treating surface nodes as an **unordered set**. The aft-foil boundary layer in tandem configurations has strong arc-length structure: the stagnation point shifts, the suction peak moves, and separation propagates from LE to TE. A sequential model that learns "what happened upstream on the surface" naturally captures this propagation.

**Why Mamba specifically:** Mamba processes the sequence O(n) rather than O(n²), enabling 4-6 stacked layers within the same compute budget. Its selective state space gating can learn to forget irrelevant upstream history and retain the physically-relevant wake entry state. This is a fundamentally different inductive bias from the per-node MLP in the current SRF.

**Literature support:**
- arXiv:2410.02113 (Oct 2024, revised Mar 2026): "Mamba Neural Operator: Who Wins?" — MNO outperforms FNO and comparable Transformer operators on multiple PDE benchmarks. GitHub: Math-ML-X/Mamba-Neural-Operator.
- ICML 2025 Proceedings: "Latent Mamba Operator for Partial Differential Equations" (Tiwari et al., v267) — Mamba as latent operator for PDEs.
- arXiv:2409.03231: "State-space models are accurate and efficient neural operators for dynamical systems" — SSMs match or beat attention-based operators at fraction of compute.

**Key insight from prior experiments:** PR #2370 (surface B-GNN) just failed because local surface message passing cannot capture global cross-foil coupling. This Mamba experiment addresses the same surface-level prediction problem differently: instead of local k-NN graphs, it uses sequential arc-length ordering — a 1D structure that Mamba can process very efficiently. Crucially, Mamba sees the full surface sequence (all nodes on one foil) so it has "global" surface context within each foil.

**Target metrics:** p_tan (primary — sequential structure captures aft-foil wake entry), p_in (secondary).

## Instructions

### 1. Install mamba_ssm

```bash
pip install mamba_ssm
```

If installation fails, try: `pip install mamba_ssm==2.2.2` or build from source. mamba_ssm requires CUDA and `causal-conv1d`.

### 2. Add flags

```python
parser.add_argument('--mamba_srf', action='store_true',
    help='Replace SRF head with Mamba SSM operating on arc-length-ordered surface nodes')
parser.add_argument('--mamba_srf_layers', type=int, default=4,
    help='Number of Mamba layers in MambaSRF (default: 4)')
parser.add_argument('--mamba_srf_d_state', type=int, default=16,
    help='State dimension for Mamba SSM (default: 16, try 32 if VRAM allows)')
parser.add_argument('--mamba_srf_bidirectional', action='store_true', default=True,
    help='Use bidirectional Mamba (scan both forward and reverse along arc-length)')
```

### 3. Implement MambaSRF module

```python
from mamba_ssm import Mamba

class MambaSRF(nn.Module):
    """Mamba State Space Model operating on arc-length-ordered surface nodes."""
    
    def __init__(self, d_model=192, d_state=16, d_conv=4, expand=2, 
                 n_layers=4, bidirectional=True, out_dim=3):
        super().__init__()
        self.bidirectional = bidirectional
        self.n_layers = n_layers
        
        # Forward Mamba layers
        self.fwd_layers = nn.ModuleList([
            Mamba(d_model=d_model, d_state=d_state, d_conv=d_conv, expand=expand)
            for _ in range(n_layers)
        ])
        self.fwd_norms = nn.ModuleList([nn.LayerNorm(d_model) for _ in range(n_layers)])
        
        if bidirectional:
            # Reverse Mamba layers (separate parameters)
            self.rev_layers = nn.ModuleList([
                Mamba(d_model=d_model, d_state=d_state, d_conv=d_conv, expand=expand)
                for _ in range(n_layers)
            ])
            self.rev_norms = nn.ModuleList([nn.LayerNorm(d_model) for _ in range(n_layers)])
            # Combine forward + reverse
            self.combine = nn.Linear(d_model * 2, d_model)
        
        # Output projection (zero-init for safe startup)
        self.out_proj = nn.Linear(d_model, out_dim)
        nn.init.zeros_(self.out_proj.weight)
        nn.init.zeros_(self.out_proj.bias)
    
    def forward(self, h_surf, arc_lengths, foil_ids=None):
        """
        h_surf: [B, N_surf, d_model] — backbone embeddings at surface nodes
        arc_lengths: [B, N_surf] — arc-length position along surface
        foil_ids: [B, N_surf] — 0=fore, 1=aft (for tandem: process each foil separately)
        
        Returns: [B, N_surf, out_dim] — surface predictions (p, Ux, Uy)
        """
        B, N, D = h_surf.shape
        
        # Sort nodes by arc-length within each foil
        # For tandem: process fore and aft foils as separate sequences
        if foil_ids is not None:
            # Process each foil independently, concatenate results
            output = torch.zeros(B, N, self.out_proj.out_features, device=h_surf.device)
            for fid in [0, 1]:
                mask = (foil_ids == fid)  # [B, N]
                if not mask.any():
                    continue
                # This is tricky with variable-length sequences per batch
                # Simpler approach: process ALL surface nodes together, sorted by (foil_id, arc_length)
                # The Mamba will naturally reset state between foils via the sort gap
                pass
            # FALLBACK: just sort all surface nodes by arc_length (simpler, let Mamba figure out foil boundaries)
        
        # Sort by arc-length
        sort_idx = arc_lengths.argsort(dim=1)  # [B, N]
        h_sorted = torch.gather(h_surf, 1, sort_idx.unsqueeze(-1).expand(-1, -1, D))  # [B, N, D]
        
        # Forward pass through Mamba layers
        h_fwd = h_sorted
        for i in range(self.n_layers):
            h_fwd = h_fwd + self.fwd_layers[i](self.fwd_norms[i](h_fwd))
        
        if self.bidirectional:
            # Reverse pass (flip sequence, run Mamba, flip back)
            h_rev = h_sorted.flip(dims=[1])
            for i in range(self.n_layers):
                h_rev = h_rev + self.rev_layers[i](self.rev_norms[i](h_rev))
            h_rev = h_rev.flip(dims=[1])
            
            # Combine forward and reverse
            h_combined = self.combine(torch.cat([h_fwd, h_rev], dim=-1))
        else:
            h_combined = h_fwd
        
        # Output projection
        out_sorted = self.out_proj(h_combined)  # [B, N, out_dim]
        
        # Unsort back to original node ordering
        unsort_idx = sort_idx.argsort(dim=1)
        output = torch.gather(out_sorted, 1, unsort_idx.unsqueeze(-1).expand(-1, -1, out_sorted.size(-1)))
        
        return output
```

### 4. Integration with the model

When `--mamba_srf` is active:
- **Keep `--surface_refine` OFF** — the MambaSRF replaces SRF entirely.
- After the Transolver backbone produces node embeddings `h` (shape [B, N_total, d_model]):
  - Extract surface node embeddings: `h_surf = h[:, surface_mask, :]`
  - Compute arc-lengths from surface coordinates (Euclidean cumulative distance along the ordered boundary)
  - Run: `surf_preds = self.mamba_srf(h_surf, arc_lengths)`
  - These become the final surface pressure/velocity predictions

**Arc-length computation:** If `arc_length` is not already available in the data, compute it:
```python
def compute_arc_lengths(coords):
    """coords: [B, N_surf, 2] sorted along boundary"""
    diffs = coords[:, 1:] - coords[:, :-1]  # [B, N-1, 2]
    segment_lengths = diffs.norm(dim=-1)      # [B, N-1]
    arc = torch.zeros(coords.shape[0], coords.shape[1], device=coords.device)
    arc[:, 1:] = segment_lengths.cumsum(dim=1)
    # Normalize to [0, 1]
    arc = arc / (arc[:, -1:] + 1e-8)
    return arc
```

### 5. CRITICAL: torch.compile compatibility

**Mamba broke torch.compile in Phase 5.** You MUST handle this:
- Option A (preferred): Wrap only the backbone with `torch.compile`, leave MambaSRF in eager mode.
- Option B: If the training script uses a global `torch.compile(model)`, add a `--no_compile` flag and use it.
- Test that training starts without compile errors before launching the full run.

### 6. Logging

```python
wandb.log({
    'train/mamba_out_norm': surf_preds.norm().item(),
    'train/mamba_h_norm': h_surf.norm().item(),
})
```

### Run commands

```bash
# Seed 42
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent nezuko --wandb_name "nezuko/mamba-srf-s42" --wandb_group mamba-srf \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep \
  --residual_prediction --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only \
  --cp_panel_scale 0.1 --wake_angle_feature --vortex_panel_velocity \
  --vortex_panel_scale 0.1 --vortex_panel_n 64 \
  --mamba_srf --mamba_srf_layers 4 --mamba_srf_d_state 16 --mamba_srf_bidirectional

# Seed 73 (same flags, --seed 73, --wandb_name "nezuko/mamba-srf-s73")
```

Note: **omit `--surface_refine`** — MambaSRF replaces it.

If torch.compile fails, add `--no_compile` (or equivalent flag to disable compile).

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.872** | < 11.872 |
| p_oodc | 7.459 | < 7.459 |
| **p_tan** | **26.319** | < 26.319 |
| **p_re** | **6.229** | < 6.229 |

W&B baseline: aycq1m8m (seed 42, best epoch 155), 9sk276v6 (seed 73, best epoch 156)

Reproduce:
```bash
cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output \
  --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64
```