### PR TITLE
SE(2)-Equivariant Geometry Encoding: rotation-invariant relative features

### DIFF
--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -17,6 +17,23 @@
 
 ---
 
+## 2026-04-10 18:10 — PR #2371: 1D Surface FNO Decoder: spectral pressure prediction on arc-length
+- Branch: frieren/surface-fno-decoder
+- **Hypothesis:** Replace SRF head with 1D Fourier Neural Operator on arc-length-ordered surface nodes. FNO modes=16, width=64, layers=4, grid=128. Spectral decomposition should capture smooth-but-sharp pressure distributions.
+- **Results:**
+
+| Metric | s42 | s73 | 2-seed avg | Baseline | Delta |
+|--------|-----|-----|------------|----------|-------|
+| p_in | 14.50 | 14.17 | 14.34 | 11.872 | +20.8% |
+| p_oodc | 8.85 | 8.59 | 8.72 | 7.459 | +16.9% |
+| p_tan | 34.36 | 33.49 | 33.92 | 26.319 | +28.9% |
+| p_re | 6.98 | 7.30 | 7.14 | 6.229 | +14.6% |
+
+- W&B: 40gf9jfw (s42), fdzyjdc9 (s73). Group: surface-fno
+- **Verdict: CLOSED — dead end.** All metrics 15-29% worse. Arc-length interpolation to uniform 128-point grid destroys LE/TE fine structure. Per-foil 1D processing severs tandem coupling. Only 122 epochs (hit 180-min timeout) vs 155 baseline. Spectral decomposition is wrong inductive bias for sharp surface pressure features.
+
+---
+
 ## Phase 6 Experiments (2026-04-01 onwards)
 
 ### 2026-04-10 17:15 — PR #2368: Sobolev Surface Gradient Loss — alphonse — **CLOSED** ❌


### PR DESCRIPTION
## Hypothesis

The current model's OOD generalization failure — especially on tandem cases — may partly stem from implicit coordinate-frame dependence in the input features. DSDF uses absolute (x, y) coordinates; the TE coordinate frame (`--te_coord_frame`) helps but is incomplete. Adding SE(2)-equivariant geometric features ensures that rotating the entire tandem configuration produces consistently rotated outputs — a hard physical constraint currently enforced only softly through data augmentation.

For tandem, the **relative foil orientation (stagger angle)** is critical. Equivariant encoding makes this relationship explicit rather than requiring the model to learn it from data.

**This is a pure input feature addition — no architecture change, no new modules, zero risk of breaking torch.compile.**

**Literature support:**
- arXiv:2405.20287 (2024): "Flexible SE(2) graph neural networks with applications to PDE surrogates" (Bankestad, Mogren, Pirinen) — direct application to PDE surrogates, improved OOD generalization.
- ICML 2024 AI for Science Workshop: "SE(3)-Equivariant Diffusion Graph Nets" (Lino, Pfaff, Thuerey).
- NeurIPS 2024: "Space-Time Continuous PDE Forecasting using Equivariant Neural Fields" (Knigge et al., UvA).
- NSF Public Access: "Robust Emulator for Compressible Navier-Stokes using Equivariant Geometric Convolutions" (2024).

**Target metrics:** p_tan (primary — better inter-foil relative geometry encoding), p_oodc (secondary — rotation-invariant features help OOD generalization).

## Instructions

### 1. Add flag

```python
parser.add_argument('--se2_geometry', action='store_true',
    help='Add SE(2)-invariant relative angle features from each node to foil centroids')
```

### 2. Compute SE(2)-invariant features during preprocessing

Add the following features when `--se2_geometry` is active:

```python
def compute_se2_features(coords, boundary_id):
    """
    coords: [N, 2] — (x, y) of each mesh node
    boundary_id: [N] — 0=fore foil, 1=aft foil, -1=volume/boundary
    
    Returns: [N, 8] — SE(2)-invariant features
    """
    features = torch.zeros(coords.shape[0], 8, device=coords.device)
    
    # Compute foil centroids
    fore_mask = (boundary_id == 0)
    aft_mask = (boundary_id == 1)
    
    fore_centroid = coords[fore_mask].mean(dim=0) if fore_mask.any() else coords.mean(dim=0)
    aft_centroid = coords[aft_mask].mean(dim=0) if aft_mask.any() else coords.mean(dim=0)
    
    # Relative vectors from each node to each foil centroid
    dx_fore = coords[:, 0] - fore_centroid[0]
    dy_fore = coords[:, 1] - fore_centroid[1]
    dx_aft = coords[:, 0] - aft_centroid[0]
    dy_aft = coords[:, 1] - aft_centroid[1]
    
    # Distance (SE(2)-invariant)
    r_fore = (dx_fore**2 + dy_fore**2).sqrt() + 1e-8
    r_aft = (dx_aft**2 + dy_aft**2).sqrt() + 1e-8
    
    # Angle encoding (cos θ, sin θ) — equivariant under rotation
    features[:, 0] = dx_fore / r_fore  # cos θ_fore
    features[:, 1] = dy_fore / r_fore  # sin θ_fore
    features[:, 2] = r_fore             # distance to fore centroid (invariant)
    features[:, 3] = dx_aft / r_aft     # cos θ_aft
    features[:, 4] = dy_aft / r_aft     # sin θ_aft
    features[:, 5] = r_aft              # distance to aft centroid (invariant)
    
    # Inter-foil relative geometry (critical for tandem)
    foil_vec = aft_centroid - fore_centroid
    foil_dist = foil_vec.norm() + 1e-8
    features[:, 6] = foil_vec[0] / foil_dist  # cos of stagger angle
    features[:, 7] = foil_vec[1] / foil_dist  # sin of stagger angle
    
    # For single-foil samples (no aft foil), zero out aft-related features
    if not aft_mask.any():
        features[:, 3:8] = 0.0
    
    # Scale features for stability
    features[:, 2] = features[:, 2] * 0.1  # r_fore (raw distances can be large)
    features[:, 5] = features[:, 5] * 0.1  # r_aft
    
    return features
```

### 3. Integration

Add these 8 features to the input feature tensor in the same way other features (wake_deficit, vortex_panel, etc.) are concatenated. The model's `in_dim` should increase by 8.

**Important:** These features are computed from raw (x, y) coordinates and `boundary_id`, both of which are already available in the data loader. No new data files needed.

### 4. Handle single-foil samples

For single-foil samples, zero out the aft-related features (channels 3-7). Use the same pattern as `--cp_panel_tandem_only` or `--wake_deficit_feature` for masking single-foil samples.

### Run commands

```bash
# Seed 42
CUDA_VISIBLE_DEVICES=0 python train.py \
  --agent frieren --wandb_name "frieren/se2-geometry-s42" --wandb_group se2-geometry \
  --seed 42 --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep \
  --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature \
  --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only \
  --cp_panel_scale 0.1 --wake_angle_feature --vortex_panel_velocity \
  --vortex_panel_scale 0.1 --vortex_panel_n 64 \
  --se2_geometry

# Seed 73 (same flags, --seed 73, --wandb_name "frieren/se2-geometry-s73")
```

Note: **include `--surface_refine`** — this is a pure feature addition, the SRF head is preserved.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.872** | < 11.872 |
| p_oodc | 7.459 | < 7.459 |
| **p_tan** | **26.319** | < 26.319 |
| **p_re** | **6.229** | < 6.229 |

W&B baseline: aycq1m8m (seed 42, best epoch 155), 9sk276v6 (seed 73, best epoch 156)

Reproduce:
```bash
cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output \
  --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64
```