### PR TITLE
PirateNet SRF: multiplicative residual connections for physics-aware decoding

### DIFF
--- a/cfd_tandemfoil/train.py
+++ b/cfd_tandemfoil/train.py
@@ -733,6 +733,83 @@ class SurfaceRefinementHead(nn.Module):
         return correction
 
 
+class PirateNetSRF(nn.Module):
+    """Surface refinement head using PirateNet-style multiplicative residual connections.
+
+    Based on: Wang et al. "PirateNets: Physics-informed Deep Learning with
+    Residual Adaptive Networks" (ICLR 2024, https://arxiv.org/abs/2402.00326).
+
+    Each hidden layer is a PirateNet block:
+        h_new = sigmoid(gate_u(h)) * act(linear(h)) + sigmoid(gate_v(h)) * h0
+
+    where h0 is a fixed embedding of the original SRF input (backbone hidden +
+    base pred). This skip connection lets the network preserve the physics
+    representation through the decoder at every layer.
+    """
+
+    def __init__(self, n_hidden: int, out_dim: int, hidden_dim: int = 128,
+                 n_layers: int = 2, p_only: bool = False):
+        super().__init__()
+        self.p_only = p_only
+        actual_out = 1 if p_only else out_dim
+
+        # Initial projection: concat([backbone_hidden, base_pred]) → hidden_dim
+        # This projection produces h0 — the skip connection target for all layers
+        in_dim = n_hidden + out_dim
+        self.input_proj = nn.Sequential(
+            nn.Linear(in_dim, hidden_dim),
+            nn.LayerNorm(hidden_dim),
+            nn.GELU(),
+        )
+
+        # PirateNet blocks: each layer has transform + two gates
+        self.linears = nn.ModuleList([nn.Linear(hidden_dim, hidden_dim) for _ in range(n_layers)])
+        self.gate_u = nn.ModuleList([nn.Linear(hidden_dim, hidden_dim) for _ in range(n_layers)])
+        self.gate_v = nn.ModuleList([nn.Linear(hidden_dim, hidden_dim) for _ in range(n_layers)])
+        self.norms = nn.ModuleList([nn.LayerNorm(hidden_dim) for _ in range(n_layers)])
+        self.act = nn.GELU()
+
+        # Initialize gate biases to zero → sigmoid(0)=0.5 at start (balanced gating)
+        for i in range(n_layers):
+            nn.init.zeros_(self.gate_u[i].bias)
+            nn.init.zeros_(self.gate_v[i].bias)
+
+        # Output projection: zero-init so refinement starts as identity
+        self.output_proj = nn.Linear(hidden_dim, actual_out)
+        nn.init.zeros_(self.output_proj.weight)
+        nn.init.zeros_(self.output_proj.bias)
+
+    def forward(self, hidden: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            hidden: [M, n_hidden] — backbone hidden features for surface nodes
+            base_pred: [M, out_dim] — base predictions for surface nodes
+        Returns:
+            correction: [M, out_dim] — additive correction (zero-padded for p_only)
+        """
+        inp = torch.cat([hidden, base_pred], dim=-1)
+        h0 = self.input_proj(inp)  # [M, hidden_dim] — skip target for all layers
+        h = h0
+        self._last_u_mean: list[float] = []
+        self._last_v_mean: list[float] = []
+        for i in range(len(self.linears)):
+            u = torch.sigmoid(self.gate_u[i](h))
+            v = torch.sigmoid(self.gate_v[i](h))
+            if not self.training:
+                pass  # skip tracking in eval
+            else:
+                self._last_u_mean.append(u.detach().mean().item())
+                self._last_v_mean.append(v.detach().mean().item())
+            h_new = self.act(self.norms[i](self.linears[i](h)))
+            h = u * h_new + v * h0  # PirateNet multiplicative residual
+        correction = self.output_proj(h)
+        if self.p_only:
+            zeros = torch.zeros(correction.shape[0], base_pred.shape[-1] - 1,
+                                device=correction.device, dtype=correction.dtype)
+            correction = torch.cat([zeros, correction], dim=-1)
+        return correction
+
+
 class AftFoilRefinementHead(nn.Module):
     """Dedicated refinement head for aft-foil (boundary ID=7) surface nodes.
 
@@ -1300,6 +1377,7 @@ class Config:
     surface_refine_layers: int = 2            # number of hidden layers in refinement MLP
     surface_refine_p_only: bool = False       # only refine pressure channel (not velocity)
     surface_refine_context: bool = False      # use surface + nearest-volume context features
+    piratenet_srf: bool = False               # replace SRF MLP with PirateNet multiplicative residual blocks
     # Phase 6: Asinh pressure transform
     asinh_pressure: bool = False             # transform pressure targets with asinh for dynamic range compression
     asinh_scale: float = 1.0                 # scale factor before asinh: asinh(p * scale)
@@ -1514,7 +1592,19 @@ _base_model = model._orig_mod if hasattr(model, '_orig_mod') else model
 # Surface refinement head (separate module, not compiled with main model)
 refine_head = None
 if cfg.surface_refine:
-    if cfg.surface_refine_context:
+    if cfg.piratenet_srf:
+        refine_head = PirateNetSRF(
+            n_hidden=cfg.n_hidden,
+            out_dim=3,
+            hidden_dim=cfg.surface_refine_hidden,
+            n_layers=cfg.surface_refine_layers,
+            p_only=cfg.surface_refine_p_only,
+        ).to(device)
+        refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
+        _refine_n_params = sum(p.numel() for p in refine_head.parameters())
+        print(f"PirateNet SRF: {_refine_n_params:,} params "
+              f"(hidden={cfg.surface_refine_hidden}, layers={cfg.surface_refine_layers})")
+    elif cfg.surface_refine_context:
         refine_head = SurfaceRefinementContextHead(
             n_hidden=cfg.n_hidden,
             out_dim=3,
@@ -1522,6 +1612,11 @@ if cfg.surface_refine:
             n_layers=cfg.surface_refine_layers,
             k_neighbors=8,
         ).to(device)
+        refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
+        _refine_n_params = sum(p.numel() for p in refine_head.parameters())
+        print(f"Surface refinement head: {_refine_n_params:,} params "
+              f"(hidden={cfg.surface_refine_hidden}, layers={cfg.surface_refine_layers}, "
+              f"p_only={cfg.surface_refine_p_only}, context={cfg.surface_refine_context})")
     else:
         refine_head = SurfaceRefinementHead(
             n_hidden=cfg.n_hidden,
@@ -1530,11 +1625,11 @@ if cfg.surface_refine:
             n_layers=cfg.surface_refine_layers,
             p_only=cfg.surface_refine_p_only,
         ).to(device)
-    refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
-    _refine_n_params = sum(p.numel() for p in refine_head.parameters())
-    print(f"Surface refinement head: {_refine_n_params:,} params "
-          f"(hidden={cfg.surface_refine_hidden}, layers={cfg.surface_refine_layers}, "
-          f"p_only={cfg.surface_refine_p_only}, context={cfg.surface_refine_context})")
+        refine_head = torch.compile(refine_head, mode=cfg.compile_mode)
+        _refine_n_params = sum(p.numel() for p in refine_head.parameters())
+        print(f"Surface refinement head: {_refine_n_params:,} params "
+              f"(hidden={cfg.surface_refine_hidden}, layers={cfg.surface_refine_layers}, "
+              f"p_only={cfg.surface_refine_p_only}, context={cfg.surface_refine_context})")
 
 # Aft-foil (boundary ID=7) dedicated refinement head
 aft_srf_head = None
@@ -2506,7 +2601,15 @@ for epoch in range(MAX_EPOCHS):
                         for ep, mp in zip(ema_aft_srf_head.parameters(), _ctx_base.parameters()):
                             ep.data.mul_(cfg.ema_decay).add_(mp.data, alpha=1 - cfg.ema_decay)
         global_step += 1
-        wandb.log({"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step})
+        _log_dict = {"train/loss": loss.item(), "train/surf_weight": surf_weight, "global_step": global_step}
+        # Log PirateNet gate values periodically
+        if cfg.piratenet_srf and global_step % 50 == 0 and refine_head is not None:
+            _rh_base = refine_head._orig_mod if hasattr(refine_head, '_orig_mod') else refine_head
+            if hasattr(_rh_base, '_last_u_mean') and _rh_base._last_u_mean:
+                for _li, (um, vm) in enumerate(zip(_rh_base._last_u_mean, _rh_base._last_v_mean)):
+                    _log_dict[f"piratenet/gate_u_layer{_li}"] = um
+                    _log_dict[f"piratenet/gate_v_layer{_li}"] = vm
+        wandb.log(_log_dict)
 
         epoch_vol += vol_loss.item()
         epoch_surf += surf_loss.item()


### PR DESCRIPTION
## Hypothesis

Replace the standard SRF MLP with **PirateNet-style multiplicative residual connections** that preserve the backbone's physics representation through gated skip connections to the input.

**Why this should work:** Our key research insight is that physics CONSTRAINTS on the output beat conditioning/replacement approaches (Kutta TE: p_oodc -2.9%, while all decoder replacements failed). PirateNets (Wang et al., 2024, https://arxiv.org/pdf/2402.00326) are designed for exactly this: they use multiplicative gating with skip connections to the input representation, ensuring the network never loses sight of the physics input. In our SRF context, this means the surface pressure prediction always has a direct multiplicative pathway to the backbone's hidden state — the physics encoding is preserved through the decoder, not corrupted by it.

**Key architectural idea:** Standard SRF: `h -> Linear -> GELU -> Linear -> output`. PirateNet SRF: `h -> (sigma(u) * Linear(h) + sigma(v) * h0)` per layer, where h0 is the original backbone hidden state and u, v are learned gating vectors. The gating mechanism lets the network decide, per-feature, whether to use the transformed representation or the original physics encoding.

**Paper:** Wang et al. "PirateNets: Physics-informed Deep Learning with Residual Adaptive Networks" (ICLR 2024, Oral). Code: https://github.com/PredictiveIntelligenceLab/PirateNets

## Instructions

### Architecture Change

Add a new flag `--piratenet_srf` that replaces the SRF MLP layers with PirateNet-style multiplicative residual blocks.

**PirateNet SRF block:**
```python
class PirateNetBlock(nn.Module):
    def __init__(self, hidden_dim):
        super().__init__()
        self.linear = nn.Linear(hidden_dim, hidden_dim)
        self.gate_u = nn.Linear(hidden_dim, hidden_dim)
        self.gate_v = nn.Linear(hidden_dim, hidden_dim)
        self.activation = nn.GELU()
        # Initialize gate biases so sigma(u) ~ 0.5 at start (balanced)
        nn.init.zeros_(self.gate_u.bias)
        nn.init.zeros_(self.gate_v.bias)
    
    def forward(self, h, h0):
        """h: current hidden state, h0: original backbone output (skip target)"""
        u = torch.sigmoid(self.gate_u(h))  # transform gate
        v = torch.sigmoid(self.gate_v(h))  # input gate
        h_new = self.activation(self.linear(h))
        return u * h_new + v * h0  # multiplicative residual
```

Then the SRF becomes:
```python
# When --piratenet_srf is active:
h0 = backbone_output  # save for skip connections
h = h0
h = piratenet_block_1(h, h0)  # layer 1 with skip to input
h = piratenet_block_2(h, h0)  # layer 2 with skip to input
output = self.output_proj(h)   # final linear to pressure/velocity
```

### Key Implementation Details

1. **Keep the number of SRF layers the same** (2 layers). Only change the internal structure from plain MLP to PirateNet blocks.
2. **Hidden dim stays the same** as current SRF (128). The PirateNet blocks add 2 extra Linear layers per block (gate_u, gate_v) but these are small.
3. **The output projection** (final Linear to pressure/velocity channels) stays unchanged — only the intermediate SRF layers become PirateNet blocks.
4. **h0 is the backbone output** — the representation BEFORE any SRF processing. This is the key: every PirateNet block can skip back to the raw physics encoding from the backbone.
5. **Do NOT apply PirateNet to the backbone/Transolver layers** — only to the SRF decoder. The backbone is already well-tuned.

### Training Setup

Use the **exact baseline hyperparameters**. No lr changes, no schedule changes. The only difference is `--piratenet_srf`.

```bash
cd cfd_tandemfoil && python train.py \
  --agent alphonse --wandb_name "alphonse/piratenet-srf-s42" \
  --wandb_group piratenet-srf --seed 42 \
  --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 \
  --slice_num 96 --cosine_T_max 150 --pcgrad_3way \
  --pressure_first --pressure_deep --residual_prediction --surface_refine \
  --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 \
  --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature \
  --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64 \
  --piratenet_srf
```

Run both seeds (42, 73).

### What to Watch

- **p_tan** is primary — skip connections should preserve tandem-relevant physics features through the decoder
- **p_in** should NOT regress — PirateNet is strictly more expressive than plain MLP
- **Epoch time** should be nearly identical to baseline (~70s) — extra gate params are tiny
- Monitor **gate values** (sigma(u), sigma(v)). If sigma(u)->1 everywhere, skip is ignored. If sigma(v)->1, SRF is just copying backbone. Ideally, different features gate differently.

## Baseline

| Metric | 2-seed avg | Target to beat |
|--------|-----------|----------------|
| **p_in** | **11.872** | < 11.872 |
| p_oodc | 7.459 | < 7.459 |
| **p_tan** | **26.319** | < 26.319 |
| **p_re** | **6.229** | < 6.229 |

Baseline PR: #2357 (Vortex-Panel Induced Velocity)
W&B runs: aycq1m8m (seed 42), 9sk276v6 (seed 73)

Reproduce baseline:
```
cd cfd_tandemfoil && python train.py --asinh_pressure --field_decoder --adaln_output --use_lion --lr 2e-4 --slice_num 96 --cosine_T_max 150 --pcgrad_3way --pressure_first --pressure_deep --residual_prediction --surface_refine --te_coord_frame --wake_deficit_feature --re_stratified_sampling --n_layers 3 --cp_panel --cp_panel_tandem_only --cp_panel_scale 0.1 --wake_angle_feature --vortex_panel_velocity --vortex_panel_scale 0.1 --vortex_panel_n 64
```