### PR TITLE
[codex] Mention Monitor in poll-for-work skill

### DIFF
--- a/plugins/senpai/skills/poll-for-work/SKILL.md
+++ b/plugins/senpai/skills/poll-for-work/SKILL.md
@@ -15,7 +15,7 @@ effort: high
 
 # poll-for-work
 
-Check whether the advisor has assigned you an experiment PR to work on.
+Check whether the advisor has assigned you an experiment PR to work on. You can use the Claude Code `Monitor` tool here to check for assigned PRs.
 
 ## Arguments
 


### PR DESCRIPTION
## What changed
Updates the `poll-for-work` skill text to explicitly mention the Claude Code `Monitor` tool when checking for assigned PRs.

## Why
This guidance had been living on the local branch that was otherwise focused on `wandb-primary`. Splitting it out keeps the wandb diagnostics PR scoped to W&B work and gives the polling guidance its own review path.

## Impact
Students using the `poll-for-work` skill get a clearer hint about the tool they can use for assignment polling.

## Root cause
A small `poll-for-work` documentation change was committed on the same local base branch that later got reused for the wandb diagnostics work, so it leaked into an unrelated PR.

## Validation
No automated checks were run. This is a one-line skill-text change.
