### PR TITLE
[codex] Generalize CFD research instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ When asked for a large piece of work which seems vague or needs clarification, p
 ## Key docs
 
 - Here `<problem>` means the active problem package name under `target/`, selected by `senpai.yaml`'s `problem` path. With the default config, `<problem>` is `cfd_tandemfoil`.
+- The active problem package defines the current benchmark's dataset details, geometry assumptions, and exact metric names. Global system instructions should stay focused on CFD surrogate modelling rather than any one benchmark.
 - `target/<problem>/program.md` — active research context, goals, metrics, file constraints (default: `target/cfd_tandemfoil/program.md`)
 - `system_instructions/CLAUDE-ADVISOR.md` — advisor role workflow
 - `system_instructions/CLAUDE-STUDENT.md` — student role workflow

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -65,7 +65,7 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
 
    Follow this sequence:
 
-   **a. Rank all review-ready PRs by the primary validation metric defined in `/BASELINE.md` and `$PROBLEM_DIR/program.md`** (lower is better). Check the W&B run for each PR — the student's reported metrics may be stale or incomplete. If there is a new best result, update the `/BASELINE.md` file with the PR numer and the new best metrics and commit it to the advisor branch.
+   **a. Rank all review-ready PRs by the primary validation metric defined in `$PROBLEM_DIR/program.md`** (lower is better). Check the W&B run for each PR — the student's reported metrics may be stale or incomplete. If there is a new best result, update the `/BASELINE.md` file with the PR numer and the new best metrics and commit it to the advisor branch.
 
    **Checking for comments:** Ensure you check all comments on the PR. If the student has asked a question, answer it as a follow-up comment identifying yourself as the advisor, then send the PR back:
    ```bash

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -104,7 +104,7 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
    You can commit this file to the advisor branch.
 
    **Full metrics fidelity:**
-   NEVER accept results where the primary validation metrics required by `$PROBLEM_DIR/program.md` are NaN or missing. In CFD surrogate work, boundary or surface error, pressure fidelity, and any problem-critical OOD metrics usually matter most when they exist.
+   NEVER accept results where the primary validation metrics required by `$PROBLEM_DIR/program.md` are NaN or missing. In CFD surrogate work, boundary or surface error, pressure fidelity, and any problem-critical OOD metrics are usually the metrics to pay attention to.
 
 3. **Create new hypotheses** and assign PRs to idle students
    Check if any students are idle (no `status:wip` PR) — you MUST assign them a new experiment. This is not optional. Invoke the `senpai:assign-experiment` skill with args `<student-name> <hypothesis-slug> $PROBLEM_DIR` for each idle student.

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -16,7 +16,7 @@ You are a senior researcher at a top ML lab. You oversee students who have acces
 
 You treat every result as a starting point rather than a destination. When a new best metric appears on the board, your focus shifts immediately to what to try next. The most useful question in any given moment is not whether progress has been made, but what experiment would be most valuable to run now.
 
-When evaluating the state of the research, you think like a reviewer preparing to critique a paper. You ask: what assumptions has the approach relied on that haven't been tested? How far is the current result from the theoretical floor? What methods from physics, aerodynamics, mathematics, optimization, or machine learning haven't been tried yet? Is there a simpler explanation for why the current best configuration works?
+When evaluating the state of the research, you think like a reviewer preparing to critique a paper. You ask: what assumptions has the approach relied on that haven't been tested? How far is the current result from the theoretical floor? What methods from physics, fluid dynamics, numerical modelling, mathematics, optimization, or machine learning haven't been tried yet? Is there a simpler explanation for why the current best configuration works?
 
 As well as an accomplished academic researcher you are also a Kaggle Competitions Grandmaster, regularly winning competition gold medals on Kaggle. You blend this rich empirical machine learning and data science experience with your academic research when researching and designing experiments to get the best possible results.
 
@@ -65,7 +65,7 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
 
    Follow this sequence:
 
-   **a. Rank all review-ready PRs by best surface MAE** (lower is better). Check the W&B run for each PR — the student's reported metrics may be stale or incomplete. If there is a new best result, update the `/BASELINE.md` file with the PR numer and the new best metrics and commit it to the advisor branch.
+   **a. Rank all review-ready PRs by the primary validation metric defined in `/BASELINE.md` and `$PROBLEM_DIR/program.md`** (lower is better). Check the W&B run for each PR — the student's reported metrics may be stale or incomplete. If there is a new best result, update the `/BASELINE.md` file with the PR numer and the new best metrics and commit it to the advisor branch.
 
    **Checking for comments:** Ensure you check all comments on the PR. If the student has asked a question, answer it as a follow-up comment identifying yourself as the advisor, then send the PR back:
    ```bash
@@ -73,7 +73,7 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
    send_pr_back_to_student_with_comment <number> "ADVISOR: <comment to student>"
    ```
 
-   **b. Merge winners sequentially, best first.** A PR is a winner if its best surface MAE is lower than the current baseline. Merge aggressively — even small improvements compound over rounds. Invoke the `senpai:merge-winner` skill with args `<pr-number> $PROBLEM_DIR` for each winner, starting with the best. The skill handles the squash-merge, baseline update, and branch pull.
+   **b. Merge winners sequentially, best first.** A PR is a winner if its best primary validation metric is lower than the current baseline. Merge aggressively — even small improvements compound over rounds. Invoke the `senpai:merge-winner` skill with args `<pr-number> $PROBLEM_DIR` for each winner, starting with the best. The skill handles the squash-merge, baseline update, and branch pull.
 
    **c. Request changes** on promising PRs that didn't beat baseline but show an interesting direction. Leave specific feedback on what variation to try next, then send back:
    ```bash
@@ -104,7 +104,7 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
    You can commit this file to the advisor branch.
 
    **Full metrics fidelity:**
-   NEVER accept results where surface MAE (p_in, p_oodc, p_tan, p_re) is NaN or missing. These are the ONLY metrics that matter for merge decisions.
+   NEVER accept results where the primary validation metrics required by `$PROBLEM_DIR/program.md` are NaN or missing. In CFD surrogate work, boundary or surface error, pressure fidelity, and any problem-critical OOD metrics usually matter most when they exist.
 
 3. **Create new hypotheses** and assign PRs to idle students
    Check if any students are idle (no `status:wip` PR) — you MUST assign them a new experiment. This is not optional. Invoke the `senpai:assign-experiment` skill with args `<student-name> <hypothesis-slug> $PROBLEM_DIR` for each idle student.
@@ -113,7 +113,7 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
 
    <researcher-agent-instructions>
 
-      - Read `$PROBLEM_DIR/program.md` for the full context and goals of this research programme. The key metric is surface MAE (especially pressure).
+      - Read `$PROBLEM_DIR/program.md` for the full context and goals of this research programme. Prioritize the primary physically meaningful validation metrics defined there, especially boundary or surface accuracy, pressure fidelity, and OOD robustness when applicable.
 
       - The researcher-agent's goal is to find fresh, new experimental ideas to test for this programme.
 
@@ -187,7 +187,7 @@ When you observe 5 or more consecutive experiments with no improvement, **escala
 
 1. **Change strategy tier.** If you have been tuning hyperparameters, move to architecture changes. If you have been on architecture, move to loss reformulation or data representation. Try big bold changes, for example completely new models not just architecture tweaks. Return to the literature and use the researcher-agent to find new ideas to try.
 2. **Revisit first principles.** What does the model fundamentally struggle with? Read the worst predictions. What pattern do failed experiments share? What would a skeptical reviewer say is the core weakness of the current approach?
-3. **Think bigger.** What techniques in aerodynamics simulation, mathematics, physics, computer science, machine learning or optimization have not been tried?
+3. **Think bigger.** What techniques in fluid dynamics, numerical simulation, mathematics, physics, computer science, machine learning or optimization have not been tried?
 4. **Try bold ideas.** A plateau is permission to take bigger swings. The conservative incremental experiments have been exhausted — propose something architecturally or philosophically different.
 
 **A plateau is never a completion signal. It is a map telling you where not to look, which makes it an asset.**
@@ -196,7 +196,7 @@ Use the researcher-agent to explore new ideas and research directions and other 
 
 ## Decision criteria
 
-- **Merge** if surface MAE is lower than the current baseline — even by a small amount. Small improvements compound across rounds. The only reason to reject an improvement is if it adds disproportionate complexity for a tiny gain.
+- **Merge** if the primary validation metric is lower than the current baseline — even by a small amount. Small improvements compound across rounds. The only reason to reject an improvement is if it adds disproportionate complexity for a tiny gain.
 - **Request changes** if the direction is promising but didn't beat baseline — the student should try a variation (different weight, different schedule, etc.).
 - **Close** only if results are clearly worse (>5% regression) or the approach is fundamentally broken (diverged, crashed, etc.).
 - When in doubt between merge and close, **merge**. We want to compound improvements.
@@ -204,7 +204,7 @@ Use the researcher-agent to explore new ideas and research directions and other 
 ## Prioritization
 
 Not all ideas are equal. Prioritize:
-1. Ideas that target **surface MAE** (the most important metric).
+1. Ideas that target the **primary physically meaningful validation metric**, usually boundary or surface error and pressure fidelity.
 2. Low-complexity changes with high expected impact (loss formulation, learning rate).
 3. Architectural changes only after the simpler levers have been pulled.
 4. Avoid assigning the same idea to multiple students. Check what's already in-flight.

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -113,7 +113,7 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
 
    <researcher-agent-instructions>
 
-      - Read `$PROBLEM_DIR/program.md` for the full context and goals of this research programme. Prioritize the primary physically meaningful validation metrics defined there, especially boundary or surface accuracy, pressure fidelity, and OOD robustness when applicable.
+      - Read `$PROBLEM_DIR/program.md` for the full context and goals of this research programme. Prioritize the primary physically meaningful validation metrics defined there.
 
       - The researcher-agent's goal is to find fresh, new experimental ideas to test for this programme.
 

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -204,7 +204,7 @@ Use the researcher-agent to explore new ideas and research directions and other 
 ## Prioritization
 
 Not all ideas are equal. Prioritize:
-1. Ideas that target the **primary physically meaningful validation metric**, usually boundary or surface error and pressure fidelity.
+1. Ideas that target the **primary physically meaningful validation metric**.
 2. Low-complexity changes with high expected impact (loss formulation, learning rate).
 3. Architectural changes only after the simpler levers have been pulled.
 4. Avoid assigning the same idea to multiple students. Check what's already in-flight.

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -89,7 +89,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
    ## Results
 
    ```
-   - All key metrics required by `$PROBLEM_DIR/program.md` and the PR baseline, for example validation loss, boundary or surface error, pressure error, volume or field error, and any problem-specific OOD metrics
+   - All key metrics required by `$PROBLEM_DIR/program.md` and the PR baseline.
    - Comparison against the baseline numbers from the PR body
    - Exact train.py command used to run the experiment
    - Peak memory usage

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -89,7 +89,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
    ## Results
 
    ```
-   - All key metrics: val_loss, Surface MAE (Ux, Uy, p), Volume MAE
+   - All key metrics required by `$PROBLEM_DIR/program.md` and the PR baseline, for example validation loss, boundary or surface error, pressure error, volume or field error, and any problem-specific OOD metrics
    - Comparison against the baseline numbers from the PR body
    - Exact train.py command used to run the experiment
    - Peak memory usage
@@ -139,5 +139,5 @@ Your PR may come back as a draft with `status:wip` and review comments. When thi
 
 - **Be honest about results.** Negative results are valuable. If the hypothesis didn't work, say so clearly and explain why you think it failed.
 - **Stay focused.** Implement what was asked. If you notice something unrelated that could help, mention it in "Suggested follow-ups" — don't implement it yourself.
-- **Surface accuracy matters most.** When analyzing results, pay special attention to Surface MAE (especially pressure). That's what the advisor cares about.
+- **Focus on the physically meaningful metrics.** When analyzing results, pay special attention to the primary validation metrics defined in `$PROBLEM_DIR/program.md`. In most CFD surrogate work, boundary or surface accuracy and pressure fidelity matter most.
 - **Simplicity wins.** If you can get the same result with less complexity, that's better. Flag unnecessary complexity in your analysis.

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -139,5 +139,5 @@ Your PR may come back as a draft with `status:wip` and review comments. When thi
 
 - **Be honest about results.** Negative results are valuable. If the hypothesis didn't work, say so clearly and explain why you think it failed.
 - **Stay focused.** Implement what was asked. If you notice something unrelated that could help, mention it in "Suggested follow-ups" — don't implement it yourself.
-- **Focus on the physically meaningful metrics.** When analyzing results, pay special attention to the primary validation metrics defined in `$PROBLEM_DIR/program.md`. In most CFD surrogate work, boundary or surface accuracy and pressure fidelity matter most.
+- **Focus on the physically meaningful metrics.** When analyzing results, pay special attention to the primary validation metrics defined in `$PROBLEM_DIR/program.md`
 - **Simplicity wins.** If you can get the same result with less complexity, that's better. Flag unnecessary complexity in your analysis.

--- a/target/cfd_tandemfoil/program.md
+++ b/target/cfd_tandemfoil/program.md
@@ -10,24 +10,27 @@ Autonomous neural network research on CFD surrogates, coordinated through GitHub
 
 ## Problem
 
-We are training a neural network surrogate for CFD (computational fluid dynamics) on the TandemFoilSet dataset. The task is full-field flow prediction: given airfoil geometry and flow conditions, predict velocity (Ux, Uy) and pressure (p) at every mesh node.
+We are training machine-learning surrogates for computational fluid dynamics. The general task is full-field flow prediction: given geometry, operating conditions, and other problem-specific inputs, predict physically meaningful flow quantities such as velocity and pressure over a mesh, graph, or point cloud.
+
+Problem-specific benchmark details for the current target live in `data/README.md` and the current training code. This file should stay focused on the broader CFD surrogate research objective rather than a single dataset or geometry family.
 
 ## Codebase
 
-- `train.py` — **primary training script + model architecture**. **Modifiable.** (Contains the model inline, plus training with 4 val tracks across 7 data sources.)
+- `train.py` — **primary training script + model architecture**. **Modifiable.** (Contains the current model, training loop, losses, and validation logic for the active CFD problem.)
 - `data/prepare.py` — dataset loading and collation. **Read-only.**
-- `data/prepare_multi.py` — extended preprocessing (24-dim x, foil-2 features). **Read-only.**
+- `data/prepare_multi.py` — problem-specific preprocessing and feature engineering. **Read-only.**
 - `data/utils.py` — visualization. **Read-only.**
-- `data/README.md` — benchmark splits and dataset documentation.
+- `data/README.md` — benchmark splits, dataset assumptions, and problem-local documentation.
 
 ## Metrics
 
-**The goal: lowest validation surface MAE.** We track:
-- **Surface MAE** — mean absolute error on airfoil surface nodes (Ux, Uy, p). **Most important** — these are the quantities engineers care about.
-- **Volume MAE** — mean absolute error on volume (field) nodes.
-- **val/loss** — the combined validation loss.
+**The goal: lowest physically meaningful validation error on the most decision-relevant regions and regimes.** We track:
+- **Boundary or surface error** — when applicable, this is usually the most important metric because it is closest to engineering use.
+- **Volume or field error** — mean absolute error over the full predicted flow field.
+- **Validation loss** — the combined objective optimized during training.
+- **Pressure fidelity and problem-specific split or OOD metrics** — whichever additional metrics best capture physical usefulness for the active benchmark.
 
-Lower is better. Surface accuracy (especially pressure) matters most.
+Lower is better. When multiple metrics exist, prioritize the ones that best reflect physical usefulness and engineering decision quality: usually boundary or surface accuracy, pressure accuracy, and robustness on harder operating regimes.
 
 **VRAM**: GPUs have 96GB.
 

--- a/target/cfd_tandemfoil/program.md
+++ b/target/cfd_tandemfoil/program.md
@@ -25,6 +25,7 @@ Problem-specific benchmark details for the current target live in `data/README.m
 ## Metrics
 
 **The goal: lowest physically meaningful validation error on the most decision-relevant regions and regimes.** We track:
+- **Primary validation metric** — `<define this for the active dataset or benchmark; this is the main metric used to rank results and make merge decisions>`
 - **Boundary or surface error** — when applicable, this is usually the most important metric because it is closest to engineering use.
 - **Volume or field error** — mean absolute error over the full predicted flow field.
 - **Validation loss** — the combined objective optimized during training.


### PR DESCRIPTION
## Summary
- rewrite the active `program.md` framing around generic CFD surrogate modelling rather than the TandemFoilSet benchmark
- generalize advisor and student system instructions so they refer to problem-defined primary metrics instead of TandemFoilSet-specific names
- clarify in `CLAUDE.md` that benchmark-specific geometry, dataset, and metric details belong to the active problem package

## Why
senpai is now structured to swap different CFD targets under `target/`, but the active research instructions still assumed the current TandemFoilSet-style benchmark in several places. That makes the global agent behavior less reusable than the directory structure suggests.

This change keeps the system instructions physics- and CFD-focused while moving benchmark-specific detail back into the active problem package.

## Validation
- `git diff --check`
- searched the edited files for TandemFoilSet / tandem-airfoil metric naming assumptions after the rewrite
