### PR TITLE
TandemFoil: cosine schedule T_max sweep (10, 20, 30, 50) at slices=64

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1075,6 +1075,24 @@ def main() -> None:
     if max_epochs_env:
         config.epochs = min(config.epochs, int(max_epochs_env))
 
+    import core.datasets as _ds
+    _ds.RUNTIME_CACHE_CASES = 3000
+
+    if config.dataset in ("tandemfoil", "tandemfoilset"):
+        from tandemfoil.data import prepare_multi
+        _orig_init = _ds.TandemFoilCaseDataset.__init__
+        _shared_base = [None]
+
+        def _patched_init(self, split_indices, manifest_path=_ds.DEFAULT_TANDEM_MANIFEST, *, debug=False):
+            if _shared_base[0] is None:
+                _orig_init(self, split_indices, manifest_path, debug=debug)
+                _shared_base[0] = self.base
+            else:
+                self.base = _shared_base[0]
+                self.indices = list(split_indices)
+
+        _ds.TandemFoilCaseDataset.__init__ = _patched_init
+
     bundle = build_bundle(config)
     if bundle.spec.name == "tandemfoilset":
         phys_stats = compute_tandem_phys_stats(
@@ -1204,7 +1222,7 @@ def main() -> None:
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
-        print(json.dumps(epoch_metrics, sort_keys=True))
+        print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     final_test_metrics: dict[str, float] = {}
     if test_loaders:
@@ -1253,7 +1271,7 @@ def main() -> None:
         if run is not None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
-        print(json.dumps({"final_test_metrics": final_test_metrics}, sort_keys=True))
+        print(json.dumps({"final_test_metrics": final_test_metrics}, sort_keys=True), flush=True)
 
     output_dir = Path(config.output_dir)
     write_run_summary(


### PR DESCRIPTION
## Hypothesis

TandemFoil training completes only 2–5 epochs within the 30-min timeout. With cosine_t_max=150 (default), the LR remains near its initial value throughout — the cosine annealing phase never activates. Reducing T_max to 10, 20, 30, or 50 forces the full LR decay cycle within the actual epoch budget, potentially unlocking significantly better convergence in the available compute time.

## Instructions

Run 4 parallel trials on 4 GPUs. All use Lion lr=3e-4, model_slices=64 (for faster epochs vs default slices=96). Only cosine_t_max varies.

```bash
cd target/icml2026

# v0: T_max=10
CUDA_VISIBLE_DEVICES=0 python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 3e-4 --model_slices 64 --cosine_t_max 10 \
  --wandb_group tandem-cosine-schedule \
  --wandb_run_name v0-tmax10 &

# v1: T_max=20
CUDA_VISIBLE_DEVICES=1 python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 3e-4 --model_slices 64 --cosine_t_max 20 \
  --wandb_group tandem-cosine-schedule \
  --wandb_run_name v1-tmax20 &

# v2: T_max=30
CUDA_VISIBLE_DEVICES=2 python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 3e-4 --model_slices 64 --cosine_t_max 30 \
  --wandb_group tandem-cosine-schedule \
  --wandb_run_name v2-tmax30 &

# v3: T_max=50
CUDA_VISIBLE_DEVICES=3 python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 3e-4 --model_slices 64 --cosine_t_max 50 \
  --wandb_group tandem-cosine-schedule \
  --wandb_run_name v3-tmax50 &

wait
```

Report: epochs completed, `val_primary/surface_pressure_mae` at each epoch (also report per-split: `val_re_rand`, `val_geom_camber_rc`, `val_geom_camber_cruise`, `val_single_in_dist`). Look at the W&B lr curve — report approximate LR at final epoch for each variant.

## Baseline

- **val_primary/surface_pressure_mae:** 269.32 (val) / 262.56 (test)
- **Config:** AdamW lr=5e-4, cosine_t_max=150, slices=96, 2 epochs
- **PR:** #2416 (alphonse, W&B run: r5t674uy)

## Results

_To be filled in by student_