### PR TITLE
AirfRANS: no-EMA + AdamW lr=5e-4/8e-4 clean baseline

### DIFF
--- a/.senpai-init-kohaku
+++ b/.senpai-init-kohaku
@@ -1,0 +1,1 @@
+Experiment branch for kohaku - 2026-04-20T19:58:43


### PR DESCRIPTION
## Hypothesis

**No-EMA should improve AirfRANS as it did TandemFoil.** EMA was independently confirmed harmful on AirfRANS (haku #2431: 0.3914 no-EMA vs 0.5038 with EMA, +29% regression from EMA). The current AirfRANS baseline (0.3308, #2423) uses EMA=True + AdamW lr=5e-4. Removing EMA from this winning recipe should beat it. Additionally, lr=8e-4 showed promise in kohaku #2428 (0.3278 at slices=64 with EMA) — testing both LRs without EMA.

## Current Baseline

| Dataset | Metric | Value | PR |
|---|---|---|---|
| AirfRANS | val_primary/surface_mse | **0.3308** | #2423 (AdamW lr=5e-4, EMA=True) |

## Design

Two runs testing no-EMA with the best AirfRANS optimizer/LR configurations:

| Run | LR | Config | wandb_name |
|---|---|---|---|
| 1 | 5e-4 | AdamW, no-EMA, slices=96 | kohaku-noema-adamw-lr5e4 |
| 2 | 8e-4 | AdamW, no-EMA, slices=96 | kohaku-noema-adamw-lr8e4 |

## Instructions to Student

**IMPORTANT: Run these sequentially (one at a time, max 1 job running).** Previous AirfRANS rounds showed that parallel jobs cause epoch starvation due to I/O contention.

```bash
cd target/icml2026

# Run 1: AdamW lr=5e-4, no-EMA (direct comparison to baseline #2423)
python train.py --dataset airfrans --airfrans_task full \
  --optimizer adamw --lr 5e-4 --cosine_t_max 150 \
  --no-use-ema \
  --slices 96 \
  --wandb_group kohaku-noema-baseline --wandb_name kohaku-noema-adamw-lr5e4

# Run 2: AdamW lr=8e-4, no-EMA
python train.py --dataset airfrans --airfrans_task full \
  --optimizer adamw --lr 8e-4 --cosine_t_max 150 \
  --no-use-ema \
  --slices 96 \
  --wandb_group kohaku-noema-baseline --wandb_name kohaku-noema-adamw-lr8e4
```

**Report** `val_primary/surface_mse`, `test_primary/surface_mse`, per-channel surface MSE breakdown (Ux, Uy, p, nut), and number of epochs completed. The target is to beat 0.3308 val surface MSE.