### PR TITLE
DrivAerML: no-EMA retest of AdamW lr=5e-4 winner

### DIFF
--- a/.senpai-init-shoya-r3
+++ b/.senpai-init-shoya-r3
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Hypothesis

**No-EMA should improve DrivAerML as it did TandemFoil (-24.7%) and AirfRANS (+29% regression from EMA).** The first DrivAerML baseline (#2440) used the default EMA=True. Given that EMA is catastrophically harmful in short training regimes (2 epochs), removing it should meaningfully improve the 71.35% baseline.

## Current Baseline

| Dataset | Metric | Value | PR |
|---|---|---|---|
| DrivAerML | val_primary/surface_rel_l2_pct | **71.35%** | #2440 (AdamW lr=5e-4, EMA=True, 2 epochs) |

## Design

Two runs: direct no-EMA retest + slightly lower LR:

| Run | Config | wandb_name |
|---|---|---|
| 1 | AdamW lr=5e-4, no-EMA | shoya-noema-adamw-lr5e4 |
| 2 | AdamW lr=3e-4, no-EMA | shoya-noema-adamw-lr3e4 |

## Instructions to Student

Run these **sequentially** (one at a time):

```bash
cd target/icml2026

# Run 1: AdamW lr=5e-4, no-EMA (direct comparison to #2440 baseline)
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine_t_max 150 \
  --no-use-ema \
  --wandb_group shoya-noema-retest --wandb_name shoya-noema-adamw-lr5e4

# Run 2: AdamW lr=3e-4, no-EMA
python train.py --dataset drivaerml --optimizer adamw --lr 3e-4 --cosine_t_max 150 \
  --no-use-ema \
  --wandb_group shoya-noema-retest --wandb_name shoya-noema-adamw-lr3e4
```

**Report** `val_primary/surface_rel_l2_pct` and epochs completed. Target: beat 71.35%.