### PR TITLE
DrivAerML: no-EMA + higher LR bracket (8e-4, 1e-3)

### DIFF
--- a/.senpai-init-violet-r3
+++ b/.senpai-init-violet-r3
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Hypothesis

**Higher learning rates may help DrivAerML with no-EMA.** In #2440, all AdamW LRs (3e-4, 5e-4, 8e-4) converged to nearly identical values (~71.4-71.8%) with EMA=True. Without EMA suppression, the optimizer trajectory is more sensitive to LR, and higher LRs may converge faster in the 2-epoch budget. On TandemFoil, no-EMA + higher LR had mixed results; on AirfRANS, lr=8e-4 showed slight promise.

## Current Baseline

| Dataset | Metric | Value | PR |
|---|---|---|---|
| DrivAerML | val_primary/surface_rel_l2_pct | **71.35%** | #2440 (AdamW lr=5e-4, EMA=True) |

## Design

Two runs testing higher LRs with no-EMA:

| Run | LR | wandb_name |
|---|---|---|
| 1 | 8e-4 | violet-noema-lr8e4 |
| 2 | 1e-3 | violet-noema-lr1e3 |

## Instructions to Student

Run these **sequentially** (one at a time):

```bash
cd target/icml2026

# Run 1: AdamW lr=8e-4, no-EMA
python train.py --dataset drivaerml --optimizer adamw --lr 8e-4 --cosine_t_max 150 \
  --no-use-ema \
  --wandb_group violet-drivaerml-lr --wandb_name violet-noema-lr8e4

# Run 2: AdamW lr=1e-3, no-EMA
python train.py --dataset drivaerml --optimizer adamw --lr 1e-3 --cosine_t_max 150 \
  --no-use-ema \
  --wandb_group violet-drivaerml-lr --wandb_name violet-noema-lr1e3
```

**Report** `val_primary/surface_rel_l2_pct` and epochs completed for each run. Compare against shoya's no-EMA results at lr=5e-4.