### PR TITLE
TandemFoil: wake-angle + core physics + no-EMA

### DIFF
--- a/.senpai-init-fern-r3
+++ b/.senpai-init-fern-r3
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Hypothesis

**Wake-angle is the single most impactful physics feature.** In PR #2413 (full physics stack), removing wake-angle caused the largest quality drop: +22.7 val MAE (270.74→293.44). The core physics subset (#2414: TE+Cp+asinh+residual) does NOT include wake-angle or wake-deficit. Adding just the wake features (wake-deficit + wake-angle) to the core physics subset with no-EMA may improve the TandemFoil baseline without the computational overhead of the full vortex-panel features.

## Current Baseline

| Dataset | Metric | Value | PR |
|---|---|---|---|
| TandemFoil | val_primary/surface_pressure_mae | **197.87** | #2412 (no-EMA, Lion lr=3e-4, no physics) |

## Design

Two runs: core physics + wake features vs core physics alone, both with no-EMA:

| Run | Physics Features | wandb_name |
|---|---|---|
| 1 | Core + wake-deficit + wake-angle | fern-core-plus-wake-noema |
| 2 | Core only (control, same as tanjiro's recipe) | fern-core-only-noema |

## Instructions to Student

Run these **sequentially** (one at a time):

```bash
cd target/icml2026

# Run 1: Core physics + wake features + no-EMA
python train.py --dataset tandemfoil --optimizer lion --lr 3e-4 --cosine_t_max 50 \
  --no-use-ema \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --enable-wake-deficit --enable-wake-angle \
  --wandb_group fern-wake-angle --wandb_name fern-core-plus-wake-noema

# Run 2: Core physics only + no-EMA (control)
python train.py --dataset tandemfoil --optimizer lion --lr 3e-4 --cosine_t_max 50 \
  --no-use-ema \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --wandb_group fern-wake-angle --wandb_name fern-core-only-noema
```

**Report** `val_primary/surface_pressure_mae` and epochs completed for each run. The key question: does adding wake-angle/wake-deficit to the core physics + no-EMA recipe improve over the 197.87 baseline?