### PR TITLE
AirfRANS: no-EMA + T_max=50 + lr=8e-4 variants (optimize golden config)

### DIFF
--- a/.senpai-init-emma-r6
+++ b/.senpai-init-emma-r6
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Hypothesis

**T_max=150 is poorly matched for 6-epoch AirfRANS training.** Your winning recipe (#2455) used T_max=150, but at 6 epochs the LR barely decays. Shorter T_max (50) would complete ~3 full cosine cycles, potentially finding better minima. Also test lr=8e-4 which was the DrivAerML breakthrough.

## Current Baseline (YOUR recipe!)

| Dataset | Metric | Value | PR |
|---|---|---|---|
| AirfRANS | val_primary/surface_mse | **0.2597** | #2455 (3L/192d, no-EMA, no-Fourier, AdamW lr=5e-4, T_max=150, 6 epochs) |

## Instructions to Student

**Run ONE AT A TIME.**

```bash
cd target/icml2026

# Run 1: T_max=50 (complete cosine cycles at 6 epochs)
python train.py --dataset airfrans --airfrans_task full \
  --optimizer adamw --lr 5e-4 --cosine_t_max 50 \
  --no-use-ema \
  --slices 96 \
  --wandb_group emma-noema-variants --wandb_name emma-noema-tmax50

# Run 2: lr=8e-4 + T_max=150 (higher LR, DrivAerML winning recipe)
python train.py --dataset airfrans --airfrans_task full \
  --optimizer adamw --lr 8e-4 --cosine_t_max 150 \
  --no-use-ema \
  --slices 96 \
  --wandb_group emma-noema-variants --wandb_name emma-noema-lr8e4
```

**Report** val/test surface_mse, per-channel breakdown, epochs (expect 6+). Target: beat 0.2597.