### PR TITLE
DrivAerML: no-EMA + lr=8e-4 + 4L/256d model capacity

### DIFF
--- a/.senpai-init-alphonse-r6
+++ b/.senpai-init-alphonse-r6
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Hypothesis

**Bigger model may help DrivAerML at the winning LR.** DrivAerML baseline (#2467) uses 3L/192d. 4L/256d has 2.7x more parameters and may better represent the complex 3D car geometry. Unlike AirfRANS where 4L/256d was slower but not better, DrivAerML's larger geometry may benefit from increased capacity.

## Current Baseline

| Dataset | Metric | Value | PR |
|---|---|---|---|
| DrivAerML | val_primary/surface_rel_l2_pct | **56.91%** | #2467 (no-EMA + AdamW lr=8e-4, 3L/192d) |

## Instructions to Student

**Run sequentially.**

```bash
cd target/icml2026

# Run 1: 4L/256d + no-EMA + lr=8e-4
python train.py --dataset drivaerml --optimizer adamw --lr 8e-4 --cosine_t_max 150 \
  --no-use-ema \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --wandb_group alphonse-drivaerml-capacity --wandb_name alphonse-4L256d-noema-lr8e4

# Run 2: 4L/256d + no-EMA + lr=5e-4 (lower LR for bigger model)
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine_t_max 150 \
  --no-use-ema \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --wandb_group alphonse-drivaerml-capacity --wandb_name alphonse-4L256d-noema-lr5e4
```

**Report** `val_primary/surface_rel_l2_pct` and epochs. Target: beat 56.91%.