### PR TITLE
DrivAerML: no-EMA + lr=8e-4 + slices reduction for more epochs

### DIFF
--- a/.senpai-init-norman-r6
+++ b/.senpai-init-norman-r6
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Hypothesis

**Reducing slices may give more DrivAerML epochs, like the TandemFoil breakthrough.** On TandemFoil, slices=64 (vs 96) gave 11 epochs instead of 2 — a 42% improvement. DrivAerML currently gets only 2 epochs at default settings. Reducing slices to 64 or 48 may enable 3-4 epochs, which could compound with the no-EMA + lr=8e-4 winning recipe.

## Current Baseline

| Dataset | Metric | Value | PR |
|---|---|---|---|
| DrivAerML | val_primary/surface_rel_l2_pct | **56.91%** | #2467 (no-EMA + AdamW lr=8e-4, 2 epochs) |

## Instructions to Student

**Run sequentially.**

```bash
cd target/icml2026

# Run 1: slices=64 + no-EMA + lr=8e-4
python train.py --dataset drivaerml --optimizer adamw --lr 8e-4 --cosine_t_max 150 \
  --no-use-ema --model_slices 64 \
  --wandb_group norman-drivaerml-slices --wandb_name norman-slices64-noema-lr8e4

# Run 2: slices=48 + no-EMA + lr=8e-4
python train.py --dataset drivaerml --optimizer adamw --lr 8e-4 --cosine_t_max 150 \
  --no-use-ema --model_slices 48 \
  --wandb_group norman-drivaerml-slices --wandb_name norman-slices48-noema-lr8e4
```

**Report** `val_primary/surface_rel_l2_pct`, epochs (hoping for 3+), and compare to 56.91% baseline. The key question: does more epochs at lower slices compensate for reduced resolution?