### PR TITLE
[codex] Harden senpai assignment routing

### DIFF
--- a/k8s/entrypoint-advisor.sh
+++ b/k8s/entrypoint-advisor.sh
@@ -93,6 +93,10 @@ while true; do
     SINCE=""
     [ -f "$LAST_CHECK_FILE" ] && SINCE=$(cat "$LAST_CHECK_FILE")
 
+    # --- Repair routing metadata before computing the research state ---
+    REPAIR_JSON=$(reconcile_assignment_prs "$STUDENT_NAMES" "$ADVISOR_BRANCH")
+    REPAIR_COUNT=$(printf '%s' "$REPAIR_JSON" | json_len)
+
     # --- Check research state before invoking CC ---
     REVIEW_JSON=$(list_ready_for_review_prs "$ADVISOR_BRANCH" "$SINCE")
     REVIEW_COUNT=$(printf '%s' "$REVIEW_JSON" | json_len)
@@ -109,6 +113,7 @@ while true; do
     [ "$REVIEW_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **GitHub PRs to review ($REVIEW_COUNT):** $(printf '%s' "$REVIEW_JSON" | json_numbers)"
     [ "$ISSUE_COUNT" -gt 0 ]  && TRIAGE_INFO+=$'\n'"- **GitHub issues ($ISSUE_COUNT):** $(printf '%s' "$ISSUE_JSON" | json_numbers)"
     [ "$IDLE_COUNT" -gt 0 ]   && TRIAGE_INFO+=$'\n'"- **Idle students ($IDLE_COUNT):** $(printf '%s' "$IDLE_JSON" | json_join)"
+    [ "$REPAIR_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **Routing repairs ($REPAIR_COUNT):** restored or warned on assignment metadata before triage."
     echo "$TRIAGE_INFO"
 
     # --- Log triage state and select prompt ---

--- a/k8s/entrypoint-student.sh
+++ b/k8s/entrypoint-student.sh
@@ -72,19 +72,29 @@ while true; do
     echo "=== GPU: $(nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu --format=csv,noheader 2>/dev/null) ==="
 
     # --- Check for work before invoking CC ---
-    ASSIGNED_JSON=$(student_poll_for_work "$STUDENT_NAME")
+    ASSIGNED_JSON=$(student_poll_for_work "$STUDENT_NAME" "$ADVISOR_BRANCH")
     ASSIGNED_COUNT=$(printf '%s' "$ASSIGNED_JSON" | json_len)
+    ASSIGNED_WARNING_JSON=$(student_poll_for_work_warnings "$STUDENT_NAME" "$ADVISOR_BRANCH")
+    ASSIGNED_WARNING_COUNT=$(printf '%s' "$ASSIGNED_WARNING_JSON" | json_len)
     ISSUE_JSON=$(check_gh_issues "student:$STUDENT_NAME")
     ISSUE_COUNT=$(printf '%s' "$ISSUE_JSON" | json_len)
 
     # --- Build triage info ---
     TRIAGE_INFO="## Student research state"
+    if [ "$ASSIGNED_WARNING_COUNT" -gt 0 ]; then
+        printf '%s' "$ASSIGNED_WARNING_JSON" | python3 -c '
+import json, sys
+for warning in json.load(sys.stdin):
+    print(f"WARNING: {warning}")
+'
+    fi
     if [ "$ASSIGNED_COUNT" -eq 0 ] && [ "$ISSUE_COUNT" -eq 0 ]; then
         TRIAGE_INFO+=$'\n'"- No assigned PRs or issues."
     else
         [ "$ASSIGNED_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **Assigned PRs ($ASSIGNED_COUNT):** $(printf '%s' "$ASSIGNED_JSON" | json_numbers)"
         [ "$ISSUE_COUNT" -gt 0 ]    && TRIAGE_INFO+=$'\n'"- **GitHub issues ($ISSUE_COUNT):** $(printf '%s' "$ISSUE_JSON" | json_numbers)"
     fi
+    [ "$ASSIGNED_WARNING_COUNT" -gt 0 ] && TRIAGE_INFO+=$'\n'"- **Assignment warnings ($ASSIGNED_WARNING_COUNT):** routing recovered from branch metadata; see pod log warnings above."
     echo "$TRIAGE_INFO"
 
     # --- Log triage and invoke CC ---

--- a/plugins/senpai/scripts/senpai-gh.sh
+++ b/plugins/senpai/scripts/senpai-gh.sh
@@ -73,6 +73,16 @@ swap_gh_pr_label() {
         -f "labels[]=${add}" --method POST --silent
 }
 
+# Ensure a PR/issue has a label. Safe to call even if the label already exists.
+#   ensure_gh_pr_label <number> <label>
+ensure_gh_pr_label() {
+    local num="$1" label="$2"
+    local repo
+    repo=$(print_gh_repo)
+    gh_retry gh api "repos/${repo}/issues/${num}/labels" \
+        -f "labels[]=${label}" --method POST --silent >/dev/null
+}
+
 # ---------------------------------------------------------------------------
 # Compound actions — advisor
 # ---------------------------------------------------------------------------
@@ -92,6 +102,67 @@ close_pr_with_comment() {
     local num="$1" reason="$2"
     gh_retry gh pr comment "$num" --body "ADVISOR: Closing PR #${num} because ${reason}."
     gh_retry gh pr close "$num" --delete-branch
+}
+
+# Create a draft assignment PR from a prepared body file, then verify that
+# the routing labels and base branch invariants are present.
+#   create_assignment_pr_from_file <student> <head_branch> <title> <body_file> [base_branch]
+create_assignment_pr_from_file() {
+    local student="$1" head_branch="$2" title="$3" body_file="$4" base_branch="${5:-${ADVISOR_BRANCH:-}}"
+    local pr_url num details
+
+    if [ -z "$student" ] || [ -z "$head_branch" ] || [ -z "$title" ] || [ -z "$body_file" ]; then
+        echo "create_assignment_pr_from_file: usage: <student> <head_branch> <title> <body_file> [base_branch]" >&2
+        return 2
+    fi
+    if [ ! -f "$body_file" ]; then
+        echo "create_assignment_pr_from_file: body file not found: $body_file" >&2
+        return 2
+    fi
+    if [ -z "$base_branch" ]; then
+        echo "create_assignment_pr_from_file: base branch is required" >&2
+        return 2
+    fi
+
+    pr_url=$(gh_retry gh pr create --draft \
+        --title "$title" \
+        --body-file "$body_file" \
+        --base "$base_branch" \
+        --head "$head_branch")
+
+    num=$(printf '%s' "$pr_url" | sed -n 's#.*/pull/\([0-9][0-9]*\).*#\1#p')
+    [ -n "$num" ] || num=$(gh_retry gh pr view "$head_branch" --json number --jq '.number')
+
+    ensure_gh_pr_label "$num" "$base_branch"
+    ensure_gh_pr_label "$num" "student:$student"
+    ensure_gh_pr_label "$num" "status:wip"
+
+    details=$(gh_retry gh pr view "$num" --json number,baseRefName,headRefName,labels,isDraft)
+    python3 - "$student" "$base_branch" "$head_branch" "$details" <<'PY'
+import json, sys
+
+student, base_branch, head_branch, payload = sys.argv[1:5]
+pr = json.loads(payload)
+labels = {label.get("name", "") for label in pr.get("labels", [])}
+
+errors = []
+if pr.get("baseRefName") != base_branch:
+    errors.append(f"expected base branch {base_branch}, got {pr.get('baseRefName')}")
+if pr.get("headRefName") != head_branch:
+    errors.append(f"expected head branch {head_branch}, got {pr.get('headRefName')}")
+if not pr.get("isDraft"):
+    errors.append("expected assignment PR to be draft")
+for required in (base_branch, f"student:{student}", "status:wip"):
+    if required not in labels:
+        errors.append(f"missing required label {required}")
+
+if errors:
+    for error in errors:
+        print(f"create_assignment_pr_from_file: PR #{pr.get('number')} {error}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+
+    printf '%s\n' "$pr_url"
 }
 
 # ---------------------------------------------------------------------------
@@ -130,6 +201,12 @@ print(max(ts) if ts else '')
 # Queries
 # ---------------------------------------------------------------------------
 
+_list_open_prs_for_base_branch() {
+    local branch="$1"
+    gh_retry gh pr list --base "$branch" --state open --limit 200 \
+        --json number,title,state,labels,headRefName,baseRefName,updatedAt,isDraft
+}
+
 # List human-created GitHub Issues addressed to a role (+ team issues).
 # Returns a JSON array, deduplicated by issue number.
 # Optional second arg: ISO timestamp — only return issues updated after it.
@@ -164,15 +241,25 @@ print(json.dumps(merged))
 list_ready_for_review_prs() {
     local branch="$1" since="${2:-}"
     local prs
-    prs=$(gh_retry gh pr list --label "$branch" --label "status:review" \
-        --json number,title,headRefName,labels,updatedAt)
+    prs=$(_list_open_prs_for_base_branch "$branch")
     if [ -z "$since" ]; then
-        printf '%s' "$prs"
+        printf '%s' "$prs" | python3 -c "
+import json, sys
+prs = json.loads(sys.stdin.read())
+print(json.dumps([
+    p for p in prs
+    if 'status:review' in [label.get('name', '') for label in p.get('labels', [])]
+]))
+"
     else
         printf '%s' "$prs" | python3 -c "
 import json, sys
 prs = json.loads(sys.stdin.read())
-print(json.dumps([p for p in prs if p.get('updatedAt', '') > sys.argv[1]]))
+print(json.dumps([
+    p for p in prs
+    if 'status:review' in [label.get('name', '') for label in p.get('labels', [])]
+    and p.get('updatedAt', '') > sys.argv[1]
+]))
 " "$since"
     fi
 }
@@ -182,17 +269,97 @@ print(json.dumps([p for p in prs if p.get('updatedAt', '') > sys.argv[1]]))
 #   list_all_prs <branch>
 list_all_prs() {
     local branch="$1"
-    gh_retry gh pr list --label "$branch" \
-        --json number,title,state,labels,headRefName,updatedAt,isDraft
+    _list_open_prs_for_base_branch "$branch"
 }
 
 # List WIP PRs assigned to a specific student.
 # Returns a JSON array.
 #   student_poll_for_work <student_name>
 student_poll_for_work() {
-    local name="$1"
-    gh_retry gh pr list --label "student:${name}" --label "status:wip" \
-        --json number,title,headRefName,updatedAt,body
+    local name="$1" branch="${2:-${ADVISOR_BRANCH:-}}"
+    local prs
+    prs=$(_list_open_prs_for_base_branch "$branch")
+    python3 - "$name" "$prs" <<'PY'
+import json, sys
+
+target, payload = sys.argv[1:3]
+prs = json.loads(payload)
+
+def labels(pr):
+    return [label.get("name", "") for label in pr.get("labels", [])]
+
+def owner(pr):
+    names = labels(pr)
+    student_labels = [name.split(":", 1)[1] for name in names if name.startswith("student:")]
+    head = pr.get("headRefName", "")
+    prefix = head.split("/", 1)[0] if head else ""
+    if len(student_labels) == 1:
+        return student_labels[0]
+    if len(student_labels) > 1:
+        if target in student_labels:
+            return target
+        if prefix in student_labels:
+            return prefix
+        return ""
+    return prefix
+
+out = []
+for pr in prs:
+    pr_labels = labels(pr)
+    if "status:wip" not in pr_labels:
+        continue
+    if owner(pr) == target:
+        out.append(pr)
+
+print(json.dumps(out))
+PY
+}
+
+# List routing anomalies that affect a student's work discovery.
+# Returns a JSON array of warning strings.
+#   student_poll_for_work_warnings <student_name> [advisor_branch]
+student_poll_for_work_warnings() {
+    local name="$1" branch="${2:-${ADVISOR_BRANCH:-}}"
+    local prs
+    prs=$(_list_open_prs_for_base_branch "$branch")
+    python3 - "$name" "$prs" <<'PY'
+import json, sys
+
+target, payload = sys.argv[1:3]
+prs = json.loads(payload)
+warnings = []
+
+for pr in prs:
+    labels = [label.get("name", "") for label in pr.get("labels", [])]
+    student_labels = [label for label in labels if label.startswith("student:")]
+    student_names = [label.split(":", 1)[1] for label in student_labels]
+    status_labels = [label for label in labels if label.startswith("status:")]
+    head = pr.get("headRefName", "")
+    prefix = head.split("/", 1)[0] if head else ""
+
+    relevant = prefix == target or target in student_names
+    if not relevant:
+        continue
+
+    if f"student:{target}" not in labels and prefix == target:
+        warnings.append(
+            f"PR #{pr['number']} is missing student:{target}; routing recovered from head branch {head}"
+        )
+    if len(student_labels) > 1:
+        warnings.append(
+            f"PR #{pr['number']} has multiple student labels: {', '.join(student_labels)}"
+        )
+    if len(status_labels) == 0:
+        warnings.append(
+            f"PR #{pr['number']} has no status label; student pickup may stall until advisor repair"
+        )
+    elif len(status_labels) > 1:
+        warnings.append(
+            f"PR #{pr['number']} has multiple status labels: {', '.join(status_labels)}"
+        )
+
+print(json.dumps(warnings))
+PY
 }
 
 # Compute which students are idle (have no status:wip PR).
@@ -202,18 +369,132 @@ student_poll_for_work() {
 list_idle_students() {
     local students_csv="$1" branch="$2"
     local all_prs
-    all_prs=$(gh_retry gh pr list --label "$branch" --label "status:wip" \
-        --json labels)
+    all_prs=$(_list_open_prs_for_base_branch "$branch")
     printf '%s' "$all_prs" | python3 -c "
 import json, sys
 students = [s.strip() for s in sys.argv[1].split(',') if s.strip()]
 prs = json.loads(sys.stdin.read())
 busy = set()
 for pr in prs:
-    for label in pr.get('labels', []):
-        name = label.get('name', '')
-        if name.startswith('student:'):
-            busy.add(name.split(':', 1)[1])
+    labels = [label.get('name', '') for label in pr.get('labels', [])]
+    if 'status:wip' not in labels:
+        continue
+    student_labels = [name.split(':', 1)[1] for name in labels if name.startswith('student:')]
+    head = pr.get('headRefName', '')
+    prefix = head.split('/', 1)[0] if head else ''
+    if len(student_labels) == 1:
+        busy.add(student_labels[0])
+    elif len(student_labels) > 1:
+        if prefix in students:
+            busy.add(prefix)
+        else:
+            busy.update(name for name in student_labels if name in students)
+    elif prefix in students:
+        busy.add(prefix)
 print(json.dumps([s for s in students if s not in busy]))
 " "$students_csv"
+}
+
+# Repair missing or mismatched assignment metadata for open PRs on a branch.
+# Returns a JSON array of warning strings describing the repairs or anomalies.
+#   reconcile_assignment_prs <student_names_csv> <advisor_branch>
+reconcile_assignment_prs() {
+    local students_csv="$1" branch="$2"
+    local prs actions
+    prs=$(_list_open_prs_for_base_branch "$branch")
+    actions=$(python3 - "$students_csv" "$branch" "$prs" <<'PY'
+import json, sys
+
+students = {s.strip() for s in sys.argv[1].split(",") if s.strip()}
+branch = sys.argv[2]
+prs = json.loads(sys.argv[3])
+
+def emit(kind, number, arg1="", arg2="", warning=""):
+    print("\x1f".join([kind, str(number), arg1, arg2, warning]))
+
+for pr in prs:
+    number = pr["number"]
+    labels = [label.get("name", "") for label in pr.get("labels", [])]
+    student_labels = [label for label in labels if label.startswith("student:")]
+    student_names = [label.split(":", 1)[1] for label in student_labels]
+    status_labels = [label for label in labels if label.startswith("status:")]
+    head = pr.get("headRefName", "")
+    prefix = head.split("/", 1)[0] if head else ""
+    inferred = prefix if prefix in students else ""
+
+    if len(student_labels) == 0 and inferred:
+        emit(
+            "add",
+            number,
+            f"student:{inferred}",
+            "",
+            f"PR #{number} missing student label; restored student:{inferred} from head branch {head}",
+        )
+    elif len(student_labels) == 1 and inferred and student_names[0] != inferred:
+        emit(
+            "swap",
+            number,
+            f"student:{student_names[0]}",
+            f"student:{inferred}",
+            f"PR #{number} student label mismatched head branch {head}; swapped to student:{inferred}",
+        )
+    elif len(student_labels) > 1:
+        emit(
+            "warn",
+            number,
+            "",
+            "",
+            f"PR #{number} has multiple student labels: {', '.join(student_labels)}",
+        )
+
+    if branch not in labels:
+        emit(
+            "add",
+            number,
+            branch,
+            "",
+            f"PR #{number} missing branch label {branch}; restored standard label",
+        )
+
+    if len(status_labels) == 0:
+        expected = "status:wip" if pr.get("isDraft") else "status:review"
+        emit(
+            "add",
+            number,
+            expected,
+            "",
+            f"PR #{number} missing status label; restored {expected}",
+        )
+    elif len(status_labels) > 1:
+        emit(
+            "warn",
+            number,
+            "",
+            "",
+            f"PR #{number} has multiple status labels: {', '.join(status_labels)}",
+        )
+PY
+)
+
+    local warnings=()
+    while IFS=$'\x1f' read -r action num arg1 arg2 warning; do
+        [ -z "$action" ] && continue
+        case "$action" in
+            add)
+                ensure_gh_pr_label "$num" "$arg1"
+                ;;
+            swap)
+                swap_gh_pr_label "$num" "$arg1" "$arg2"
+                ;;
+            warn)
+                ;;
+        esac
+        echo "WARNING: $warning" >&2
+        warnings+=("$warning")
+    done <<< "$actions"
+
+    python3 - <<'PY' "${warnings[@]}"
+import json, sys
+print(json.dumps(sys.argv[1:]))
+PY
 }

--- a/plugins/senpai/skills/assign-experiment/SKILL.md
+++ b/plugins/senpai/skills/assign-experiment/SKILL.md
@@ -43,12 +43,11 @@ git checkout -b "$BRANCH"
 git push -u origin "$BRANCH"
 ```
 
-3. **Create the draft PR** with the template below. Replace the placeholders with your actual hypothesis, instructions, and baseline data:
+3. **Write the PR body to a temp file**. Replace the placeholders with your actual hypothesis, instructions, and baseline data:
 
 ```bash
-gh pr create --draft \
-    --title "<Hypothesis title — clear, specific, under 70 chars>" \
-    --body "$(cat <<'PREOF'
+BODY_FILE=$(mktemp)
+cat > "$BODY_FILE" <<'PREOF'
 ## Hypothesis
 <What we think will improve metrics and why. For non-trivial changes,
 include links to papers or code that support the hypothesis.>
@@ -64,12 +63,19 @@ include links to papers or code that support the hypothesis.>
 - Baseline W&B run: <run-id> (<wandb-link>)
 - Reproduce command: `cd cfd_tandemfoil && python train.py ...`>
 PREOF
-)" \
-    --label "$ADVISOR_BRANCH" \
-    --label "student:$0" \
-    --label "status:wip" \
-    --base "$ADVISOR_BRANCH" \
-    --head "$BRANCH"
+```
+
+4. **Create the draft PR through the helper** so the assignment metadata is verified and repaired immediately if needed:
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
+create_assignment_pr_from_file \
+    "$0" \
+    "$BRANCH" \
+    "<Hypothesis title — clear, specific, under 70 chars>" \
+    "$BODY_FILE" \
+    "$ADVISOR_BRANCH"
+rm -f "$BODY_FILE"
 ```
 
 ## Important details
@@ -78,4 +84,5 @@ PREOF
 - **Be specific in instructions.** The student implements exactly what you write. Vague instructions waste GPU time.
 - **Use `--wandb_group`** in instructions when a hypothesis needs multiple iterations (e.g. "try surface weight 5, 10, 20") so related runs are grouped in W&B.
 - **One hypothesis per PR.** Bundling multiple changes makes it impossible to attribute what worked.
-- If the PR body is too long for `gh pr create`, put the core info in the body and add supplementary details as a follow-up comment.
+- **Do not call `gh pr create` directly** for assignment PRs. The helper verifies `student:<name>`, `status:wip`, and the advisor branch metadata after PR creation.
+- If the PR body is too long, keep the core instructions in the body file and add supplementary details as a follow-up comment.

--- a/plugins/senpai/skills/poll-for-work/SKILL.md
+++ b/plugins/senpai/skills/poll-for-work/SKILL.md
@@ -27,7 +27,8 @@ Check whether the advisor has assigned you an experiment PR to work on.
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
-student_poll_for_work "$0"
+student_poll_for_work "$0" "$ADVISOR_BRANCH"
+student_poll_for_work_warnings "$0" "$ADVISOR_BRANCH"
 ```
 
 2. **If PRs are returned**, for each one:
@@ -53,5 +54,7 @@ If nothing:
 ```
 NO_WORK
 ```
+
+If warnings are returned, mention them briefly. These warnings usually mean the advisor or reconciler recovered your assignment from branch metadata even though a routing label was missing.
 
 Keep the response short — the parent agent just needs to know whether to start working or keep waiting.

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -34,6 +34,7 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 | Function | What it does |
 |---|---|
 | `swap_gh_pr_label <pr#> <remove-label> <add-label>` | Atomically swap one label for another. Safe — won't error if the old label is already gone. |
+| `ensure_gh_pr_label <pr#> <label>` | Idempotently ensure a PR has a label. Safe to call even if the label is already present. |
 
 #### The `gh pr edit` footgun
 
@@ -43,6 +44,7 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 
 | Function | What it does |
 |---|---|
+| `create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]` | Create a draft assignment PR from a prepared body file, then verify that the routing labels and base branch invariants are present. |
 | `send_pr_back_to_student_with_comment <pr#> <comment>` | Send a PR back to the student with feedback. Comment on the PR, convert back to draft, swap `status:review` → `status:wip`. |
 | `close_pr_with_comment <pr#> <reason>` | Close a dead-end PR with a comment explaining why. Comment with reason, close the PR, delete the remote branch. |
 
@@ -60,8 +62,10 @@ GitHub's `gh pr edit --remove-label X --add-label Y` silently strips **all other
 | `check_gh_issues <role_label>` | List open human issues for a role label + team issues, deduplicated. Returns JSON array. |
 | `list_ready_for_review_prs <branch>` | List PRs with `status:review` on a branch. Returns JSON array. |
 | `list_all_prs <branch>` | List all open PRs on a branch (any status). Returns JSON array. |
-| `student_poll_for_work <student_name>` | List WIP PRs assigned to a student. Returns JSON array. |
+| `student_poll_for_work <student_name> [advisor_branch]` | List WIP PRs assigned to a student. Falls back to the `<student>/<slug>` head branch prefix if the `student:*` label is missing. Returns JSON array. |
+| `student_poll_for_work_warnings <student_name> [advisor_branch]` | List assignment-routing anomalies that affect a student's work discovery. Returns JSON array of warning strings. |
 | `list_idle_students <names_csv> <branch>` | Print names of students with no `status:wip` PR, one per line. |
+| `reconcile_assignment_prs <names_csv> <branch>` | Repair missing assignment metadata on open branch PRs and return a JSON array of warning strings describing the repairs or anomalies. |
 
 ## Usage examples
 

--- a/plugins/senpai/skills/survey-prs/SKILL.md
+++ b/plugins/senpai/skills/survey-prs/SKILL.md
@@ -29,6 +29,9 @@ Uses `$ADVISOR_BRANCH` and `$STUDENT_NAMES` from the environment (set by the k8s
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 
+# Repair assignment metadata first so the snapshot reflects routable PRs.
+reconcile_assignment_prs "$STUDENT_NAMES" "$ADVISOR_BRANCH"
+
 # All open PRs on the branch
 list_all_prs "$ADVISOR_BRANCH"
 
@@ -39,9 +42,10 @@ list_ready_for_review_prs "$ADVISOR_BRANCH"
 list_idle_students "$STUDENT_NAMES" "$ADVISOR_BRANCH"
 ```
 
-2. **Categorize** each PR by its status labels:
+2. **Categorize** each PR by its status labels and inferred student ownership:
    - `status:review` — ready for advisor review
-   - `status:wip` — student is working on it (note which student from the `student:*` label)
+   - `status:wip` — student is working on it
+   - infer the student from `student:*` when present, otherwise from the `<student>/<slug>` head branch prefix
    - Draft with no status — may be newly created or stalled
 
 3. **Return a structured summary** in this format:

--- a/system_instructions/CLAUDE-ADVISOR.md
+++ b/system_instructions/CLAUDE-ADVISOR.md
@@ -38,6 +38,9 @@ For lower-level GitHub operations (label swaps, sending PRs back, closing dead e
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/scripts/senpai-gh.sh"
 
+# Create an assignment PR from a prepared body file and verify routing labels
+create_assignment_pr_from_file <student> <head-branch> <title> <body-file> [base-branch]
+
 # Send a PR back to the student with feedback
 send_pr_back_to_student_with_comment <pr#> "ADVISOR: <feedback>"
 
@@ -108,6 +111,16 @@ swap_gh_pr_label <pr#> "status:review" "status:wip"
 
 3. **Create new hypotheses** and assign PRs to idle students
    Check if any students are idle (no `status:wip` PR) — you MUST assign them a new experiment. This is not optional. Invoke the `senpai:assign-experiment` skill with args `<student-name> <hypothesis-slug>` for each idle student.
+
+   Never create assignment PRs with raw `gh pr create`. Always use the assignment helper so the PR is verified with the required routing metadata:
+   - base branch = advisor branch
+   - labels include `student:<name>` and `status:wip`
+   - branch label is restored if missing
+
+   If you ever need to inspect the result manually, run:
+   ```bash
+   gh pr view <pr-number> --json number,baseRefName,headRefName,labels,isDraft
+   ```
 
    Use the @researcher-agent to review all previous experiments and research directions and generate fresh new hypotheses. Read student suggestions. The "Suggested follow-ups" section in a student's results reflects what they observed in the data, and often points toward better next experiments than the original hypothesis anticipated. Give the researcher-agent the following instructions plus any additional context you think might be relevant:
 

--- a/system_instructions/CLAUDE-STUDENT.md
+++ b/system_instructions/CLAUDE-STUDENT.md
@@ -37,6 +37,7 @@ swap_gh_pr_label <pr#> "status:wip" "status:review"
 1. **Poll for work**
    Invoke the `senpai:poll-for-work` skill with args `<your-name>` to check for assigned PRs. If nothing is assigned, wait 60 seconds and poll again.
    - Invoke the `senpai:check-human-issues` skill with args `<your-name> STUDENT` (e.g. `fern STUDENT`) to check for messages from the human research team. Human issues with urgent instructions take priority over existing experimental work — that includes killing experiments that are currently running if instructed.
+   - If the poller reports an assignment-routing warning, treat the recovered PR as real work. The system can now recover assignments from the branch name even if a routing label is missing.
 
 2. **Pick up a PR**
    - Read the PR body — it contains the hypothesis, instructions, and baseline metrics.


### PR DESCRIPTION
## What changed

This hardens the senpai assignment workflow so missing labels no longer strand student pods.

- switched PR discovery from branch labels to real GitHub base-branch queries
- made student work pickup and idle-student detection fall back to the `<student>/<slug>` head branch prefix when `student:*` labels are missing
- added advisor-side reconciliation that repairs missing assignment metadata on open PRs before each triage loop
- added a verified `create_assignment_pr_from_file` helper so assignment PR creation always restores and checks the required labels
- updated advisor and skill instructions to route assignment creation through that helper
- added student-side warning output when routing had to be recovered from branch metadata

## Why

The live `pai-2` run exposed a failure mode where follow-up PRs were opened with `status:wip` but without `student:<name>`. The student poller only looked at labels, so affected students stayed idle even though work existed.

## Impact

- missing assignment labels no longer break student pickup
- idle-student detection is more robust
- advisor loops can self-heal broken routing metadata instead of requiring manual label repair
- future assignment PRs get verified at creation time instead of relying on prompt compliance

## Validation

- `bash -n plugins/senpai/scripts/senpai-gh.sh`
- `bash -n k8s/entrypoint-student.sh`
- `bash -n k8s/entrypoint-advisor.sh`
- stubbed shell validation of `student_poll_for_work`, `student_poll_for_work_warnings`, `list_idle_students`, `reconcile_assignment_prs`, and `create_assignment_pr_from_file`
