### PR TITLE
TandemFoil: coarse spatial-pooling auxiliary loss

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -668,8 +668,8 @@ def loss_grouped_tandem(
             outputs["surface_preds"][mask],
             prepared.surface_target[mask],
             surf_xy_norm,
-            n_bins=16,
-            weight=0.1,
+            n_bins=64,
+            weight=0.01,
         )
         total = total + aux_loss
         metrics["coarse_aux_loss"] = float(aux_loss.detach().cpu().item())

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -597,6 +597,32 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def coarse_spatial_pool_loss(
+    preds: torch.Tensor,
+    targets: torch.Tensor,
+    xy: torch.Tensor,
+    n_bins: int = 16,
+    weight: float = 0.1,
+) -> torch.Tensor:
+    x_bin = (xy[:, 0].clamp(0.0, 1.0 - 1e-6) * n_bins).long()
+    y_bin = (xy[:, 1].clamp(0.0, 1.0 - 1e-6) * n_bins).long()
+    bin_idx = x_bin * n_bins + y_bin
+    num_bins = n_bins * n_bins
+    out_preds = torch.zeros(num_bins, preds.shape[-1], device=preds.device, dtype=preds.dtype)
+    out_targets = torch.zeros(num_bins, targets.shape[-1], device=targets.device, dtype=targets.dtype)
+    out_count = torch.zeros(num_bins, device=preds.device, dtype=preds.dtype)
+    out_preds.scatter_add_(0, bin_idx.unsqueeze(1).expand_as(preds), preds)
+    out_targets.scatter_add_(0, bin_idx.unsqueeze(1).expand_as(targets), targets)
+    out_count.scatter_add_(0, bin_idx, torch.ones(len(preds), device=preds.device, dtype=preds.dtype))
+    occupied = out_count > 0
+    if not occupied.any():
+        return preds.new_tensor(0.0)
+    count_safe = out_count[occupied].unsqueeze(1)
+    pool_preds = out_preds[occupied] / count_safe
+    pool_targets = out_targets[occupied] / count_safe
+    return weight * F.mse_loss(pool_preds, pool_targets)
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
@@ -632,6 +658,21 @@ def loss_grouped_tandem(
         vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
+    if outputs["surface_preds"] is not None:
+        mask = prepared.surface_mask
+        surf_xy = prepared.surface_raw_xy[mask]
+        xy_min = surf_xy.min(dim=0).values
+        xy_max = surf_xy.max(dim=0).values
+        surf_xy_norm = (surf_xy - xy_min) / (xy_max - xy_min + 1e-8)
+        aux_loss = coarse_spatial_pool_loss(
+            outputs["surface_preds"][mask],
+            prepared.surface_target[mask],
+            surf_xy_norm,
+            n_bins=16,
+            weight=0.1,
+        )
+        total = total + aux_loss
+        metrics["coarse_aux_loss"] = float(aux_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
 
@@ -1019,7 +1060,10 @@ def train_one_epoch(
                     volume_mask=prepared.volume_mask,
                 )
                 outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                loss, _ = loss_grouped_tandem(prepared, outputs)
+                loss, train_metrics = loss_grouped_tandem(prepared, outputs)
+                if "coarse_aux_loss" in train_metrics:
+                    running.setdefault("coarse_aux_loss", 0.0)
+                    running["coarse_aux_loss"] = running["coarse_aux_loss"] + train_metrics["coarse_aux_loss"]
             else:
                 outputs = model(
                     surface_x=batch.surface_x,
@@ -1039,6 +1083,8 @@ def train_one_epoch(
         running["loss"] += float(loss.detach().cpu().item())
         steps += 1
     running["loss"] /= max(steps, 1)
+    if "coarse_aux_loss" in running:
+        running["coarse_aux_loss"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -98,6 +98,8 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    coarse_aux_bins: int = 64
+    coarse_aux_weight: float = 0.01
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -647,6 +649,8 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    coarse_aux_bins: int = 64,
+    coarse_aux_weight: float = 0.01,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
@@ -668,8 +672,8 @@ def loss_grouped_tandem(
             outputs["surface_preds"][mask],
             prepared.surface_target[mask],
             surf_xy_norm,
-            n_bins=64,
-            weight=0.01,
+            n_bins=coarse_aux_bins,
+            weight=coarse_aux_weight,
         )
         total = total + aux_loss
         metrics["coarse_aux_loss"] = float(aux_loss.detach().cpu().item())
@@ -1030,6 +1034,8 @@ def train_one_epoch(
     model_name: str,
     *,
     max_batches: int = 0,
+    coarse_aux_bins: int = 64,
+    coarse_aux_weight: float = 0.01,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1060,7 +1066,7 @@ def train_one_epoch(
                     volume_mask=prepared.volume_mask,
                 )
                 outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                loss, train_metrics = loss_grouped_tandem(prepared, outputs)
+                loss, train_metrics = loss_grouped_tandem(prepared, outputs, coarse_aux_bins=coarse_aux_bins, coarse_aux_weight=coarse_aux_weight)
                 if "coarse_aux_loss" in train_metrics:
                     running.setdefault("coarse_aux_loss", 0.0)
                     running["coarse_aux_loss"] = running["coarse_aux_loss"] + train_metrics["coarse_aux_loss"]
@@ -1252,6 +1258,8 @@ def main() -> None:
             device=device,
             model_name=config.model,
             max_batches=config.max_train_batches,
+            coarse_aux_bins=config.coarse_aux_bins,
+            coarse_aux_weight=config.coarse_aux_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The current loss functions in `train.py` — `loss_grouped_tandem()`, `loss_grouped()`, and `loss_abupt()` — only compute surface MSE plus volume MSE. They are missing a **coarse spatial-pooling auxiliary loss** term that was shown historically to be critical: in prior work (PRs #852 and #860 in the lineage), removing this auxiliary term caused a +97% regression in val_loss.

The coarse spatial-pooling auxiliary loss aggregates predictions and targets over a coarse spatial grid before computing the MSE. This acts as a low-frequency supervision signal, preventing the model from ignoring large-scale structure when it optimizes fine-grained point-level predictions. It is especially important early in training when fine-grained predictions are noisy.

Adding this term back is the highest-priority unimplemented mechanism in the current stack.

## Instructions

Focus on **TandemFoil** (`loss_grouped_tandem()` in `target/icml2026/train.py`).

### Step 1: Implement coarse spatial pooling helper

Add a helper function near the existing loss functions (around line 600):

```python
def coarse_spatial_pool_loss(
    preds: torch.Tensor,
    targets: torch.Tensor,
    xy: torch.Tensor,
    n_bins: int = 16,
    weight: float = 0.1,
) -> torch.Tensor:
    x_bin = (xy[:, 0].clamp(0.0, 1.0 - 1e-6) * n_bins).long()
    y_bin = (xy[:, 1].clamp(0.0, 1.0 - 1e-6) * n_bins).long()
    bin_idx = x_bin * n_bins + y_bin
    num_bins = n_bins * n_bins
    out_preds = torch.zeros(num_bins, preds.shape[-1], device=preds.device, dtype=preds.dtype)
    out_targets = torch.zeros(num_bins, targets.shape[-1], device=targets.device, dtype=targets.dtype)
    out_count = torch.zeros(num_bins, device=preds.device, dtype=preds.dtype)
    out_preds.scatter_add_(0, bin_idx.unsqueeze(1).expand_as(preds), preds)
    out_targets.scatter_add_(0, bin_idx.unsqueeze(1).expand_as(targets), targets)
    out_count.scatter_add_(0, bin_idx, torch.ones(len(preds), device=preds.device, dtype=preds.dtype))
    occupied = out_count > 0
    if not occupied.any():
        return preds.new_tensor(0.0)
    count_safe = out_count[occupied].unsqueeze(1)
    pool_preds = out_preds[occupied] / count_safe
    pool_targets = out_targets[occupied] / count_safe
    return weight * F.mse_loss(pool_preds, pool_targets)
```

### Step 2: Add the auxiliary loss to `loss_grouped_tandem()`

After computing `surf_loss` and `vol_loss` in `loss_grouped_tandem()`, add:

```python
# Coarse spatial-pooling auxiliary loss on surface points
surf_xy = prepared.surface_x[:, :2]
xy_min = surf_xy.min(dim=0).values
xy_max = surf_xy.max(dim=0).values
surf_xy_norm = (surf_xy - xy_min) / (xy_max - xy_min + 1e-8)
aux_loss = coarse_spatial_pool_loss(
    outputs["surface_preds"],
    prepared.surface_target,
    surf_xy_norm,
    n_bins=16,
    weight=0.1,
)
total = total + aux_loss
```

### Step 3: Run

```bash
cd target/icml2026 && python train.py \
    --dataset tandemfoil \
    --optimizer lion \
    --lr 3e-4 \
    --cosine_t_max 30 \
    --no-use-ema \
    --model_slices 64 \
    --enable-fourier \
    --enable-te-coord-frame \
    --enable-cp-panel \
    --enable-cp-panel-tandem-only \
    --asinh-pressure \
    --residual-prediction \
    --enable-pressure-prior-addition \
    --epochs 999 \
    --wandb_group tandem-coarse-aux-loss
```

### Step 4: Report

Report `val_primary/surface_pressure_mae` and the full `legacy_noam/*` metrics. Compare against baseline val 78.81.

## Baseline

- **val_primary/surface_pressure_mae:** 78.81
- **test_primary/surface_pressure_mae:** 75.13
- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 3e-4 --cosine_t_max 30 --no-use-ema --model_slices 64 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999`
- **Baseline PR:** #2495