### PR TITLE
TandemFoil: Multi-query attention audit — more epochs via K/V reduction

### DIFF
--- a/target/icml2026/core/architectures/transolver_reference.py
+++ b/target/icml2026/core/architectures/transolver_reference.py
@@ -85,7 +85,7 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0, multi_query: bool = False):
+    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0, multi_query: bool = False, kv_heads: int = 0):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -94,13 +94,23 @@ class TransolverAttention(nn.Module):
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
-        self.multi_query = multi_query
+
+        if multi_query:
+            self._kv_heads = 1
+        elif 0 < kv_heads < num_heads:
+            self._kv_heads = kv_heads
+        else:
+            self._kv_heads = num_heads
+
+        if self._kv_heads < num_heads:
+            if num_heads % self._kv_heads != 0:
+                raise ValueError("num_heads must be divisible by kv_heads")
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_slice = LinearProjection(self.dim_head, num_slices)
-        if multi_query:
+        if self._kv_heads < num_heads:
             self.to_q = LinearProjection(self.dim_head, self.dim_head, bias=False)
             self.to_k = LinearProjection(self.dim_head, self.dim_head, bias=False)
             self.to_v = LinearProjection(self.dim_head, self.dim_head, bias=False)
@@ -124,11 +134,14 @@ class TransolverAttention(nn.Module):
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
-        if self.multi_query:
+        if self._kv_heads < self.num_heads:
             q = self.to_q(slice_tokens)
-            shared_kv = slice_tokens.mean(dim=1, keepdim=True)
-            k = self.to_k(shared_kv).expand(-1, self.num_heads, -1, -1)
-            v = self.to_v(shared_kv).expand(-1, self.num_heads, -1, -1)
+            B, H, S, D = slice_tokens.shape
+            heads_per_group = H // self._kv_heads
+            grouped = slice_tokens.view(B, self._kv_heads, heads_per_group, S, D)
+            grouped_kv = grouped.mean(dim=2)
+            k = self.to_k(grouped_kv).unsqueeze(2).expand(-1, -1, heads_per_group, -1, -1).contiguous().view(B, H, S, D)
+            v = self.to_v(grouped_kv).unsqueeze(2).expand(-1, -1, heads_per_group, -1, -1).contiguous().view(B, H, S, D)
         else:
             q, k, v = self.qkv(slice_tokens).chunk(3, dim=-1)
         out_slice = F.scaled_dot_product_attention(
@@ -151,6 +164,7 @@ class TransformerBlock(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         multi_query: bool = False,
+        kv_heads: int = 0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -161,6 +175,7 @@ class TransformerBlock(nn.Module):
             num_slices=num_slices,
             dropout=dropout,
             multi_query=multi_query,
+            kv_heads=kv_heads,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -181,6 +196,7 @@ class Transformer(nn.Module):
         num_slices: int,
         dropout: float = 0.0,
         multi_query: bool = False,
+        kv_heads: int = 0,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -192,6 +208,7 @@ class Transformer(nn.Module):
                     num_slices=num_slices,
                     dropout=dropout,
                     multi_query=multi_query,
+                    kv_heads=kv_heads,
                 )
                 for _ in range(depth)
             ]
@@ -221,6 +238,7 @@ class ReferenceTransolver(nn.Module):
         mlp_ratio: int = 4,
         slice_num: int = 96,
         multi_query: bool = False,
+        kv_heads: int = 0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -250,6 +268,7 @@ class ReferenceTransolver(nn.Module):
             num_slices=slice_num,
             dropout=dropout,
             multi_query=multi_query,
+            kv_heads=kv_heads,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.out = LinearProjection(n_hidden, surface_output_dim + volume_output_dim)

--- a/target/icml2026/core/architectures/transolver_reference.py
+++ b/target/icml2026/core/architectures/transolver_reference.py
@@ -85,7 +85,7 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0, multi_query: bool = False):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -94,12 +94,18 @@ class TransolverAttention(nn.Module):
         self.dim_head = hidden_dim // num_heads
         self.num_slices = num_slices
         self.dropout = dropout
+        self.multi_query = multi_query
 
         self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
         self.in_project_x = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_fx = LinearProjection(hidden_dim, hidden_dim)
         self.in_project_slice = LinearProjection(self.dim_head, num_slices)
-        self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
+        if multi_query:
+            self.to_q = LinearProjection(self.dim_head, self.dim_head, bias=False)
+            self.to_k = LinearProjection(self.dim_head, self.dim_head, bias=False)
+            self.to_v = LinearProjection(self.dim_head, self.dim_head, bias=False)
+        else:
+            self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
 
@@ -118,8 +124,13 @@ class TransolverAttention(nn.Module):
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
         slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
-        qkv = self.qkv(slice_tokens)
-        q, k, v = qkv.chunk(3, dim=-1)
+        if self.multi_query:
+            q = self.to_q(slice_tokens)
+            shared_kv = slice_tokens.mean(dim=1, keepdim=True)
+            k = self.to_k(shared_kv).expand(-1, self.num_heads, -1, -1)
+            v = self.to_v(shared_kv).expand(-1, self.num_heads, -1, -1)
+        else:
+            q, k, v = self.qkv(slice_tokens).chunk(3, dim=-1)
         out_slice = F.scaled_dot_product_attention(
             q,
             k,
@@ -139,6 +150,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        multi_query: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -148,6 +160,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            multi_query=multi_query,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -167,6 +180,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        multi_query: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -177,6 +191,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    multi_query=multi_query,
                 )
                 for _ in range(depth)
             ]
@@ -205,6 +220,7 @@ class ReferenceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        multi_query: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,6 +249,7 @@ class ReferenceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            multi_query=multi_query,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.out = LinearProjection(n_hidden, surface_output_dim + volume_output_dim)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -106,6 +106,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     save_checkpoint: bool = False
+    multi_query: bool = False
 
 
 @dataclass
@@ -415,6 +416,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
+        "multi_query": config.multi_query,
     }
     if config.model == "reference_transolver":
         return ReferenceTransolver(

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -107,6 +107,7 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     save_checkpoint: bool = False
     multi_query: bool = False
+    kv_heads: int = 0
 
 
 @dataclass
@@ -417,6 +418,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
         "multi_query": config.multi_query,
+        "kv_heads": config.kv_heads,
     }
     if config.model == "reference_transolver":
         return ReferenceTransolver(


### PR DESCRIPTION
## Hypothesis

Multi-Query Attention (MQA) from PR #513 reduces the number of key/value heads while keeping all query heads, significantly reducing attention computation. On TandemFoil we get exactly 14 epochs in 30 minutes — MQA's reduced K/V overhead could unlock 1-2 more epochs, compounding with our T_max=10 rapid-cycling discovery.

If MQA gives even 10% throughput improvement, we go from 14 → 15+ epochs, which at current convergence rate could push well below the 75.59 baseline.

Historical reference: PR #513 introduced MQA to the transolver attention blocks.

## Instructions

1. **Audit the code**: Check `target/icml2026/train.py` and related model files for any `--multi-query`, `--mqa`, or `--num-kv-heads` flags. Check if MQA is already implemented but disabled.

2. **If a flag exists**: Run with MQA enabled on TandemFoil baseline config:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil --optimizer lion --lr 3e-4 --cosine_t_max 10 \
  --no-use-ema --model_slices 64 --enable-fourier \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --multi-query --wandb_group mqa-attention-audit
```

3. **If no MQA flag**: Check PR #513 for the implementation. Modify the attention block to share K/V across heads (1 K/V head, all Q heads). Then run the baseline config with MQA active.

4. **Always run a control** (identical config WITHOUT MQA) to measure throughput delta.

5. **Report**: epochs achieved in budget, time/epoch, best val_primary/surface_pressure_mae, throughput change %.

## Baseline

- **Dataset:** TandemFoil
- **val_primary/surface_pressure_mae:** 75.59 (target to beat)
- **Epochs at 30-min budget:** 14
- **W&B run:** 77yoba65
- **Reproduce:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil --optimizer lion --lr 3e-4 --cosine_t_max 10 \
  --no-use-ema --model_slices 64 --enable-fourier \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999
```