### PR TITLE
TandemFoil: Surface-node cross-attention (port from PR #2372)

### DIFF
--- a/target/icml2026/core/architectures/senpai_transolver.py
+++ b/target/icml2026/core/architectures/senpai_transolver.py
@@ -10,6 +10,35 @@ import torch.nn as nn
 from .transolver_reference import ReferenceTransolver
 
 
+class SurfaceCrossAttention(nn.Module):
+    """Global all-to-all attention over surface nodes only."""
+
+    def __init__(self, embed_dim: int, num_heads: int = 4, layerscale_init: float = 1e-4):
+        super().__init__()
+        self.attn = nn.MultiheadAttention(
+            embed_dim=embed_dim, num_heads=num_heads, batch_first=True,
+        )
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 2),
+            nn.GELU(),
+            nn.Linear(embed_dim * 2, embed_dim),
+        )
+        self.norm2 = nn.LayerNorm(embed_dim)
+        self.gamma_attn = nn.Parameter(torch.full((embed_dim,), layerscale_init))
+        self.gamma_ffn = nn.Parameter(torch.full((embed_dim,), layerscale_init))
+
+    def forward(
+        self, h_surf: torch.Tensor, key_padding_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        h_attn, _ = self.attn(
+            h_surf, h_surf, h_surf, key_padding_mask=key_padding_mask,
+        )
+        h_surf = self.norm1(h_surf + self.gamma_attn * h_attn)
+        h_surf = self.norm2(h_surf + self.gamma_ffn * self.ffn(h_surf))
+        return h_surf
+
+
 class ZeroInitSurfaceRefinementHead(nn.Module):
     def __init__(
         self,
@@ -134,6 +163,8 @@ class SenpaiTransolver(ReferenceTransolver):
         surface_refine_layers: int = 2,
         surface_pressure_prior_idx: int | None = None,
         volume_pressure_prior_idx: int | None = None,
+        surface_cross_attn: bool = False,
+        surface_cross_attn_heads: int = 4,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -149,6 +180,11 @@ class SenpaiTransolver(ReferenceTransolver):
                 num_hidden_layers=surface_refine_layers,
             )
             if self.surface_refine
+            else None
+        )
+        self.sca = (
+            SurfaceCrossAttention(self.n_hidden, num_heads=surface_cross_attn_heads)
+            if surface_cross_attn
             else None
         )
 
@@ -189,6 +225,9 @@ class SenpaiTransolver(ReferenceTransolver):
             surface_x,
             self.surface_pressure_prior_idx,
         )
+        if self.sca is not None and outputs["surface_hidden"] is not None:
+            padding_mask = ~surface_mask  # True = ignore padded positions
+            outputs["surface_hidden"] = self.sca(outputs["surface_hidden"], key_padding_mask=padding_mask)
         if self.surface_head is not None and surface_preds is not None:
             surface_preds = surface_preds + self.surface_head(outputs["surface_hidden"], surface_preds)
             surface_preds = surface_preds * surface_mask.unsqueeze(-1)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -106,6 +106,8 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     save_checkpoint: bool = False
+    surface_cross_attn: bool = False
+    surface_cross_attn_heads: int = 4
 
 
 @dataclass
@@ -439,6 +441,8 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             surface_refine_layers=config.surface_refine_layers,
             surface_pressure_prior_idx=prior_idx,
             volume_pressure_prior_idx=prior_idx,
+            surface_cross_attn=config.surface_cross_attn,
+            surface_cross_attn_heads=config.surface_cross_attn_heads,
             **transolver_kwargs,
         )
     if config.model == "reference_abupt":


### PR DESCRIPTION
## Hypothesis

PR #2372 introduced cross-attention between surface nodes and the full mesh (surface-node cross-attention, SCA). This is a human-prioritized historical mechanism from issue #2545. Cross-attention allows surface nodes to gather information from the broader flow field (volume nodes), potentially improving pressure prediction accuracy at trailing edges — especially critical for TandemFoil with tandem airfoil interactions.

The standard attention in the baseline treats all nodes uniformly. Surface-node cross-attention dedicates attention heads to enable surface tokens to query volume tokens, giving the model a geometric prior that boundary conditions are tightly coupled to interior flow structure.

## Instructions

1. Look at PR #2372 in the GitHub repo for the implementation details of surface-node cross-attention.
2. Check `target/icml2026/train.py` for any `--surface-cross-attention` or `--sca` flag.
3. If the flag exists: enable it on the TandemFoil baseline config below.
4. If the flag does NOT exist: implement cross-attention between surface and volume tokens in the model's attention blocks, following the design in PR #2372.
5. Run the command below (adjusting flag name if PR #2372 uses a different name).

**Run command:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 3e-4 \
  --cosine_t_max 10 \
  --no-use-ema \
  --model_slices 64 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --surface-cross-attention \
  --wandb_group tandem-historical-mechanisms
```
(If `--surface-cross-attention` is not valid, check PR #2372 for the correct flag name.)

## Baseline

- **Primary metric:** `val_primary/surface_pressure_mae` (lower is better)
- **Current best:** 75.59 (val) / 72.12 (test)
- **Best PR:** #2490 (frieren — T_max=10, Fourier + physics + no-EMA, slices=64, Lion lr=3e-4, 14 epochs)
- **W&B run:** 77yoba65
- **Reproduce baseline:**
  ```bash
  cd target/icml2026 && python train.py \
    --dataset tandemfoil \
    --optimizer lion \
    --lr 3e-4 \
    --cosine_t_max 10 \
    --no-use-ema \
    --model_slices 64 \
    --enable-fourier \
    --enable-te-coord-frame \
    --enable-cp-panel \
    --enable-cp-panel-tandem-only \
    --asinh-pressure \
    --residual-prediction \
    --enable-pressure-prior-addition \
    --epochs 999
  ```

## Key Constraints
- `--epochs 999` is MANDATORY
- 4L/256d is too slow for TandemFoil — stick with 3L/192d (default)
- All physics features listed above are synergistic with Fourier — keep them all enabled
- Target to beat: **75.59 val_primary/surface_pressure_mae**