### PR TITLE
DrivAerML: 4L/256d+T_max=30 — 25k surface points (2x more epochs)

### DIFF
--- a/experiments/giyu/hypothesis.txt
+++ b/experiments/giyu/hypothesis.txt
@@ -1,0 +1,1 @@
+drivaerml-4L256d-25kpts


### PR DESCRIPTION
## Hypothesis
Reducing surface points from 50k to 25k halves memory pressure per sample. With the same batch budget, this may allow the model to see more geometry variation within training time, potentially improving generalization — or reveal that 50k points are necessary to capture fine-grained pressure gradients. This also tests whether fewer surface points allow more effective training within the epoch constraint.

Note: baseline uses `--max-train-batches 394` to cap GPU time. With 25k points, the per-batch memory is lower, but we keep the same step cap to maintain fair wall-clock comparison.

## Instructions

Run the following command (copy-paste exactly):

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine_t_max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 25000 \
  --drivaerml-eval-surface-points 25000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group drivaerml-4L256d-surface-pts
```

Report back with the best `val/surface_rel_l2_pct` and epoch at which it was achieved, plus the W&B run URL.

## Baseline

Current best DrivAerML metrics (PR #2593, W&B run: 3aaevlho):
- val/surface_rel_l2_pct: **12.70%**
- Architecture: 4L/256d, AdamW lr=5e-4, T_max=30, no-EMA, Fourier
- Surface points: 50k train + 50k eval

Reproduce baseline:
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine_t_max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```