### PR TITLE
AirfRANS: T_max=10 — weight decay=1e-2 (port TandemFoil WD finding)

### DIFF
--- a/experiments/hinata/hypothesis.txt
+++ b/experiments/hinata/hypothesis.txt
@@ -1,0 +1,1 @@
+airfrans-tmax10-wd1e2


### PR DESCRIPTION
## Hypothesis

On TandemFoil, WD=0 beat WD=1e-4 significantly. We now want to test the other direction on AirfRANS: can a higher weight decay (1e-2) provide stronger regularization that improves generalization, especially given AirfRANS's high-Reynolds-number diversity? The current best AirfRANS run uses AdamW default WD=1e-4. This experiment tests 1e-2 with the proven T_max=10 schedule that achieves the phase transition at ~epoch 40.

## Instructions

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --airfrans_task full \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine_t_max 10 \
  --no-use-ema \
  --enable-fourier \
  --weight-decay 1e-2 \
  --epochs 999 \
  --wandb_group airfrans-tmax10-wd
```

Let it run until convergence (the phase transition usually occurs around epoch 40–50 with T_max=10). Report back with best `val/surface_mse`, `val/surface_mae`, and the epoch achieved. Include the W&B run URL.

## Baseline

Current best AirfRANS metrics (PR #2556, W&B run: 7qre8z5x):
- val/surface_mse: **0.0248**
- Architecture: 3L/192d (default), AdamW lr=5e-4, T_max=10, no-EMA, Fourier
- weight-decay: 1e-4 (AdamW default)

Reproduce baseline:
```bash
cd target/icml2026 && python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 5e-4 --cosine_t_max 10 --no-use-ema --enable-fourier --epochs 999
```