### PR TITLE
DrivAerML: 4L/256d+T_max=30 — 5-epoch linear LR warmup

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -101,6 +101,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    warmup_epochs: int = 0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1218,9 +1219,22 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
-    if config.cosine_t_max > 0:
+    if config.cosine_t_max > 0 or config.warmup_epochs > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        steps_per_epoch = config.max_train_batches if config.max_train_batches > 0 else len(train_loader)
+        cosine_sched = None
+        if config.cosine_t_max > 0:
+            cosine_sched = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup_sched = torch.optim.lr_scheduler.LinearLR(
+                base_optimizer, start_factor=1e-6, end_factor=1.0, total_iters=warmup_steps
+            )
+            scheduler = torch.optim.lr_scheduler.SequentialLR(
+                base_optimizer, schedulers=[warmup_sched, cosine_sched], milestones=[warmup_steps]
+            ) if cosine_sched is not None else warmup_sched
+        else:
+            scheduler = cosine_sched
 
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

Training starts at max LR (5e-4) which can destabilize early optimization — large gradient steps on a randomly initialized model may lead to poor initial loss landscape exploration. A 5-epoch linear warmup (0 → 5e-4) before cosine annealing begins may help the model find a better initialization landscape, leading to better convergence at the cosine annealing phase.

This is a standard training trick used in Transformers and ViTs (e.g. DeiT, MAE) that often helps when training from scratch.

## Instructions

Run from the repo root:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine_t_max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --warmup-epochs 5 \
  --wandb_group drivaerml-4L256d-training-tricks
```

**Note:** If `--warmup-epochs` doesn't exist, check `train.py` for the warmup flag name (may be `--lr-warmup-epochs`, `--warmup_epochs`, etc.) and use the correct flag.

## Baseline

- **Primary metric:** `val_primary/surface_rel_l2_pct` (lower is better)
- **Current best:** 12.70% (val) / 13.54% (test)
- **Best PR:** #2593 (shinji — Fourier+4L/256d+no-EMA+T_max=30, 45 epochs, AdamW lr=5e-4)
- **W&B run:** 3aaevlho (45 epochs, still converging at epoch cap)
- **Reproduce baseline:** `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine_t_max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

**CRITICAL OOM flags** (must include all of these):
- `--batch-size 1`
- `--drivaerml-train-surface-points 50000`
- `--drivaerml-eval-surface-points 50000`
- `--max-train-batches 394`
- `--max-eval-batches 200`
- `--model-heads 4`