### PR TITLE
DrivAerML: 4L/256d+T_max=30 — cosine eta_min=1e-5 (non-zero floor)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -101,6 +101,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_eta_min: float = 0.0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1220,7 +1221,7 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max, eta_min=config.cosine_eta_min)
 
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

Default cosine annealing decays LR to 0 at each trough. Setting `eta_min=1e-5` prevents full LR decay, keeping some learning signal at cosine cycle valleys. This may stabilize the cosine cycle troughs and produce more consistent improvement, avoiding the "cold restart" shock where the optimizer effectively resets its momentum-state utility. This technique is used in many modern training recipes (e.g., timm, torchvision) and can prevent the model from over-fitting to a cold minima at cycle troughs.

## Instructions

Run from the repo root:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine_t_max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --cosine_eta_min 1e-5 \
  --wandb_group drivaerml-4L256d-training-tricks
```

**Note:** Check `train.py` for the eta_min flag name — may be `--eta-min`, `--cosine-eta-min`, `--cosine_eta_min`, `--lr_min`, etc.

## Baseline

- **Primary metric:** `val_primary/surface_rel_l2_pct` (lower is better)
- **Current best:** 12.70% (val) / 13.54% (test)
- **Best PR:** #2593 (shinji — Fourier+4L/256d+no-EMA+T_max=30, 45 epochs, AdamW lr=5e-4)
- **W&B run:** 3aaevlho (45 epochs, still converging at epoch cap)
- **Reproduce baseline:** `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine_t_max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

**CRITICAL OOM flags** (must include all of these):
- `--batch-size 1`
- `--drivaerml-train-surface-points 50000`
- `--drivaerml-eval-surface-points 50000`
- `--max-train-batches 394`
- `--max-eval-batches 200`
- `--model-heads 4`