### PR TITLE
DrivAerML: 4L/256d+T_max=30 — multi-seed replication

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -9,11 +9,13 @@ import itertools
 import json
 import math
 import os
+import random
 import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
+import numpy as np
 import torch
 import torch.nn.functional as F
 import wandb
@@ -106,6 +108,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     save_checkpoint: bool = False
+    seed: int = 42
 
 
 @dataclass
@@ -1154,6 +1157,10 @@ def compute_tandem_phys_stats(
 
 def main() -> None:
     config = parse_args()
+    random.seed(config.seed)
+    np.random.seed(config.seed)
+    torch.manual_seed(config.seed)
+    torch.cuda.manual_seed_all(config.seed)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     max_epochs_env = os.getenv("SENPAI_MAX_EPOCHS")
     timeout_env = os.getenv("SENPAI_TIMEOUT_MINUTES")


### PR DESCRIPTION
## Hypothesis

The DrivAerML 4L/256d config (PR #2593, best 12.70%) shows high run-to-run variance. Running a second seed should reveal whether 12.70% is reproducible or whether the stochastic training dynamics can land us significantly lower. If variance is high, the floor may be closer to 10–11%.

## Instructions

Run one additional seed with the exact same config as PR #2593 (the current best DrivAerML run). Use seed 1 (the original run used the default seed).

**IMPORTANT OOM prevention flags — all required:**

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --layers 4 \
  --hidden-dim 256 \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --model-heads 4 \
  --seed 1 \
  --wandb_group drivaerml-4L256d-multiseed
```

If `--seed` is not a supported flag, run with the default seed (no flag) and note the W&B run ID so we can compare variance.

Report: best `val_primary/surface_rel_l2_pct` achieved, at which epoch, and the W&B run ID.

## Baseline

Current best DrivAerML metrics (PR #2593, shinji):
- `val_primary/surface_rel_l2_pct`: **12.70%**
- W&B run: `3aaevlho`
- Config: 4L/256d, T_max=30, lr=5e-4, 45 epochs, `--no-use-ema`, `--enable-fourier`
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --layers 4 --hidden-dim 256 --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --model-heads 4`

External target: <3.71%