### PR TITLE
DrivAerML: 4L/256d lr=3e-4 with 10-epoch linear warmup

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -101,6 +101,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    warmup_epochs: int = 0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1220,7 +1221,19 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        steps_per_epoch = config.max_train_batches if config.max_train_batches > 0 else len(train_loader)
+        if config.warmup_epochs > 0:
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+                base_optimizer, start_factor=1e-5 / config.lr, end_factor=1.0, total_iters=warmup_steps,
+            )
+            cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+            scheduler = torch.optim.lr_scheduler.SequentialLR(
+                base_optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_steps],
+            )
+            print(f"[scheduler] linear warmup {config.warmup_epochs} epochs ({warmup_steps} steps) → cosine T_max={config.cosine_t_max}")
+        else:
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

The current DrivAerML best uses lr=5e-4 with cosine annealing. We know from AirfRANS experiments that lr=3e-4 often beats lr=5e-4. However, DrivAerML is a harder task with sparser data — jumping straight to lr=3e-4 from epoch 0 may underutilize early capacity. A 10-epoch linear warmup from lr=1e-5 → 3e-4 before cosine annealing kicks in (warm start → fine-tune approach) should give the model time to settle into a good basin before the aggressive cosine cycling begins, potentially beating both the current 5e-4 and a naive 3e-4 start.

## Instructions

Run with lr=3e-4 plus a 10-epoch linear warmup scheduler. If `--warmup-epochs` or `--lr-warmup` is a supported flag, use it. Otherwise implement warmup via `--warmup-steps` (10 epochs × 394 steps/epoch = 3940 steps).

**IMPORTANT OOM prevention flags — all required:**

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --layers 4 \
  --hidden-dim 256 \
  --lr 3e-4 \
  --cosine-t-max 30 \
  --warmup-epochs 10 \
  --no-use-ema \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --model-heads 4 \
  --wandb_group drivaerml-4L256d-lr3e4-warmup
```

If `--warmup-epochs` is not supported, try `--warmup-steps 3940` instead. If neither is supported, just run with `--lr 3e-4 --cosine-t-max 30` without warmup and note this in the PR.

Report: best `val_primary/surface_rel_l2_pct` achieved, at which epoch, and the W&B run ID.

## Baseline

Current best DrivAerML metrics (PR #2593, shinji):
- `val_primary/surface_rel_l2_pct`: **12.70%**
- W&B run: `3aaevlho`
- Config: 4L/256d, T_max=30, lr=5e-4, 45 epochs, `--no-use-ema`, `--enable-fourier`
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --layers 4 --hidden-dim 256 --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --model-heads 4`

External target: <3.71%