### PR TITLE
DrivAerML: 600 batches/epoch + gradient clipping (max_norm=1.0)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -106,6 +106,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     save_checkpoint: bool = False
+    grad_clip: float = 0.0
 
 
 @dataclass
@@ -1033,6 +1034,7 @@ def train_one_epoch(
     *,
     amp_mode: str = "none",
     max_batches: int = 0,
+    grad_clip: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1076,6 +1078,16 @@ def train_one_epoch(
                     )
                     loss, _ = loss_grouped(batch, outputs, transform)
         loss.backward()
+        if grad_clip > 0:
+            params = list(model.parameters())
+            if anp_head is not None:
+                params += list(anp_head.parameters())
+            grad_norm = torch.nn.utils.clip_grad_norm_(params, grad_clip).item()
+            if "grad_norm" not in running:
+                running["grad_norm"] = 0.0
+                running["grad_norm_count"] = 0.0
+            running["grad_norm"] += grad_norm
+            running["grad_norm_count"] += 1.0
         optimizer.step()
         if scheduler is not None:
             scheduler.step()
@@ -1086,6 +1098,9 @@ def train_one_epoch(
         running["loss"] += float(loss.detach().cpu().item())
         steps += 1
     running["loss"] /= max(steps, 1)
+    if "grad_norm" in running and running["grad_norm_count"] > 0:
+        running["grad_norm"] /= running["grad_norm_count"]
+        del running["grad_norm_count"]
     running["train_steps"] = float(steps)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
@@ -1256,6 +1271,7 @@ def main() -> None:
             model_name=config.model,
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
+            grad_clip=config.grad_clip,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Compound the 600-batch improvement (11.97% val) with gradient clipping (max_norm=1.0) to stabilize DrivAerML training. Askeladd's multi-seed experiment revealed extreme training instability on DrivAerML (seed=1 → 43.93% vs default → 12.70%). Gradient clipping should stabilize training and reduce variance, potentially pushing below 11.97%. Gradient clipping is a proven technique for taming rugged optimization landscapes — it prevents large gradient steps from destabilizing well-found minima.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --grad-clip 1.0 \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 600 --max-eval-batches 200 \
  --agent shoya --wandb-name "shoya/drivaerml-600batch-gradclip" \
  --wandb-group "drivaerml-600batch-compounds"
```

Key change vs baseline: added `--grad-clip 1.0` to the 600-batches/epoch configuration.

Report the best `val_primary/surface_rel_l2_pct` and the epoch it was achieved. Also report total epochs completed within the timeout.

## Baseline

Current best DrivAerML metrics (PR #2645, taki — 600 batches/epoch):
- **val_primary/surface_rel_l2_pct:** 11.97% ← target to beat
- **test_primary/surface_rel_l2_pct:** 13.03%
- **W&B run:** dar47nwl (34 epochs, 30-min timeout)
- **Reproduce baseline:** `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine_t_max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 600 --max-eval-batches 200`

**CRITICAL flags (required to avoid OOM):**
- `--batch-size 1`
- `--drivaerml-train-surface-points 50000`
- `--drivaerml-eval-surface-points 50000`
- `--max-train-batches 600`
- `--max-eval-batches 200`
- `--model-heads 4` (required for 4L/256d)

External target: <3.71% (AB-UPT) — 3.2x gap remaining.