### PR TITLE
AirfRANS: lr=7e-4 + T_max=10 + grad-clip=1.0 (spike prevention)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -105,6 +105,7 @@ class TrainConfig:
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
+    grad_clip: float = 0.0
     save_checkpoint: bool = False
 
 
@@ -1033,6 +1034,7 @@ def train_one_epoch(
     *,
     amp_mode: str = "none",
     max_batches: int = 0,
+    grad_clip: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1076,6 +1078,15 @@ def train_one_epoch(
                     )
                     loss, _ = loss_grouped(batch, outputs, transform)
         loss.backward()
+        all_params = list(model.parameters())
+        if anp_head is not None:
+            all_params += list(anp_head.parameters())
+        grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+        running.setdefault("grad_norm_mean", 0.0)
+        running["grad_norm_mean"] += float(grad_norm)
+        if grad_clip > 0 and float(grad_norm) > grad_clip:
+            running.setdefault("grad_clip_events", 0.0)
+            running["grad_clip_events"] += 1.0
         optimizer.step()
         if scheduler is not None:
             scheduler.step()
@@ -1086,6 +1097,8 @@ def train_one_epoch(
         running["loss"] += float(loss.detach().cpu().item())
         steps += 1
     running["loss"] /= max(steps, 1)
+    if "grad_norm_mean" in running:
+        running["grad_norm_mean"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
@@ -1256,6 +1269,7 @@ def main() -> None:
             model_name=config.model,
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
+            grad_clip=config.grad_clip,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The winning lr=7e-4 run (PR #2646) showed catastrophic gradient spikes at cosine LR peaks: epochs 26, 28, 38, 41 all spiked to 0.23-0.27 val_primary/surface_mse. Gradient clipping (max_norm=1.0) should prevent these spikes, allowing the model to consolidate gains after the phase transition. 

The key insight: the epoch 38 spike (0.264) likely disrupted what could have been an even better epoch 40 trough (only reached 0.031 vs 0.018 at epoch 35). Preventing that spike by clipping could allow a deeper epoch 40 basin. The phase transition mechanism appears to require a momentary drop in the loss landscape — grad-clip preserves those deep troughs by preventing destructive gradient steps from undoing progress.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 10 \
  --grad-clip 1.0 \
  --no-use-ema --enable-fourier --epochs 999 \
  --agent haku --wandb-name "haku/airfrans-lr7e4-gradclip" \
  --wandb-group "airfrans-lr7e4-compounds"
```

Key change vs baseline: added `--grad-clip 1.0` to the winning lr=7e-4+T_max=10 configuration.

Report the best `val_primary/surface_mse` and the epoch it was achieved. Specifically note:
1. Whether the spikes at cosine LR peaks (previously ~0.23-0.27) are reduced
2. The depth of the epoch 40 trough vs the baseline's epoch 40 trough (0.031)

## Baseline

Current best AirfRANS metrics (PR #2646, emma — lr=7e-4+T_max=10):
- **val_primary/surface_mse:** 0.01841 ← target to beat
- **full_val/surface_mse_p:** 0.0735
- **full_val/volume_mse:** 0.1331
- **W&B run:** 3pbxocca (41 epochs, best at epoch 35 — phase transition; epoch 38 spike to 0.264, epoch 40 trough only 0.031)
- **Reproduce baseline:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 7e-4 --cosine_t_max 10 --no-use-ema --enable-fourier --epochs 999`

External target: 0.0043 — 4.3x gap remaining.