### PR TITLE
DrivAerML: 4L/384d + eta_min=1e-5 — non-zero LR floor

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -102,6 +102,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_eta_min: float = 0.0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1227,7 +1228,7 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max, eta_min=config.cosine_eta_min)
 
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

Non-zero LR floor prevents complete learning rate collapse at cosine troughs, keeping gradients flowing during the trough phase. The 4L/384d run (PR #2602) showed late-epoch oscillation — epoch 141=10.2%, epoch 144=5.7% — suggesting the cosine troughs are hitting zero LR and allowing temporary loss of progress. Setting `eta_min=1e-5` means the LR never drops below 2% of its peak (5e-4 * 0.02 = 1e-5), which may smooth the trough behavior and produce more consistent convergence.

## Instructions

Run the following command exactly (one addition to base: `--cosine-eta-min 1e-5`):

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --cosine-eta-min 1e-5 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 384 \
  --model-heads 6 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --agent norman \
  --wandb-name "norman/drivaerml-4L384d-etamin" \
  --wandb-group "drivaerml-4L384d-compounds"
```

**Single addition from base:** `--cosine-eta-min 1e-5` (all other hyperparameters identical to PR #2602)

## Baseline

Current DrivAerML best (PR #2602):
- **val_primary/surface_rel_l2_pct:** 5.73% (epoch 144)
- **Baseline W&B run:** 7ogfs7ph (151 epochs, 180-min budget)
- **Architecture:** 4L/384d/6H + Fourier + no-EMA + AdamW lr=5e-4 + T_max=30
- **Reproduce baseline:** `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 384 --model-heads 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- **External target:** <3.71% (AB-UPT)