### PR TITLE
DrivAerML: 4L/512d width scaling — can wider beat 5.73%?

### DIFF
--- a/.senpai-assignment
+++ b/.senpai-assignment
@@ -1,0 +1,1 @@
+assign: frieren/drivaerml-4L512d


### PR DESCRIPTION
## Hypothesis

Width scaling from 256d→384d delivered a 52% relative improvement (11.97%→5.73%). We hypothesize that continuing on this scaling axis — 384d→512d — will further reduce surface pressure error. The head dimension stays constant at 64 (512/8=64, matching 384/6=64), so we are adding capacity without changing the per-head resolution. This tests whether the model is still in a regime where width ≈ representational capacity is the binding constraint.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --agent frieren \
  --wandb-name "frieren/drivaerml-4L512d" \
  --wandb-group "drivaerml-width-scaling"
```

**Note on VRAM:** 512d with 50k surface points may approach VRAM limits on an A100-80GB. If you hit OOM, fall back to `--drivaerml-train-surface-points 40000 --drivaerml-eval-surface-points 40000` and note this in your results comment. Do not reduce batch size or layers.

Report the best `val_primary/surface_rel_l2_pct` you observe and the epoch at which it occurred.

## Baseline

Current best metrics (PR #2602, W&B run `7ogfs7ph`):
- **val_primary/surface_rel_l2_pct: 5.73%** (epoch 144, 151 epochs total)
- Architecture: 4L/384d/6H, Fourier features enabled, no EMA
- Training note: still converging at 180-min cutoff (epoch 141=10.2%, epoch 144=5.73% — late oscillation)
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 384 --model-heads 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- External target: **<3.71%** (AB-UPT benchmark)