### PR TITLE
DrivAerML: 4L/384d + 800 batches/epoch — more data per epoch

### DIFF
--- a/.senpai-assignment
+++ b/.senpai-assignment
@@ -1,0 +1,1 @@
+assign: taki/drivaerml-4L384d-800batches


### PR DESCRIPTION
## Hypothesis

The current best (PR #2602) uses 394 batches/epoch. With ~3.6k training samples (DrivAerML), 394 batches ≈ 1 pass through the data per epoch. Doubling to 800 batches/epoch means each epoch sees each sample ~2× via random surface point sampling — giving the model more gradient signal per epoch while keeping the 180-minute training budget constant. With ~2.4 min/epoch at 800 batches, we expect ~75 epochs vs ~150. We hypothesize the denser data exposure per epoch compensates for fewer total epochs, potentially improving convergence quality within the fixed budget.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 384 \
  --model-heads 6 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 800 \
  --max-eval-batches 200 \
  --agent taki \
  --wandb-name "taki/drivaerml-4L384d-800batches" \
  --wandb-group "drivaerml-4L384d-compounds"
```

Report the best `val_primary/surface_rel_l2_pct` and the epoch at which it occurred. Also note the approximate time-per-epoch observed so we can calibrate future batch-count experiments.

## Baseline

Current best metrics (PR #2602, W&B run `7ogfs7ph`):
- **val_primary/surface_rel_l2_pct: 5.73%** (epoch 144, 151 epochs total)
- Architecture: 4L/384d/6H, Fourier features enabled, no EMA, 394 batches/epoch
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 384 --model-heads 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- External target: **<3.71%** (AB-UPT benchmark)