### PR TITLE
DrivAerML: 4L/384d + lr=3e-4 — lower LR for wider model

### DIFF
--- a/.senpai-assignment
+++ b/.senpai-assignment
@@ -1,0 +1,1 @@
+assign: edward/drivaerml-4L384d-lr3e4


### PR DESCRIPTION
## Hypothesis

The current best uses lr=5e-4, tuned on the original 256d model. When model capacity increases (256d→384d), the optimal learning rate often shifts lower — wider models have larger gradient norms per parameter and can benefit from more conservative updates. We also observed late-epoch oscillation in PR #2602 (epoch 141=10.2% → epoch 144=5.73%), which suggests the current LR may be too large for fine-grained convergence in the 384d regime. lr=3e-4 is the canonical Adam LR from many vision transformer papers; this tests whether a more conservative rate improves the final floor.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 3e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 384 \
  --model-heads 6 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --agent edward \
  --wandb-name "edward/drivaerml-4L384d-lr3e4" \
  --wandb-group "drivaerml-4L384d-variants"
```

Report the best `val_primary/surface_rel_l2_pct` and the epoch at which it occurred. If you observe reduced late-epoch oscillation compared to PR #2602, please note this explicitly — it will help us understand whether LR is driving the instability.

## Baseline

Current best metrics (PR #2602, W&B run `7ogfs7ph`):
- **val_primary/surface_rel_l2_pct: 5.73%** (epoch 144, 151 epochs total)
- Architecture: 4L/384d/6H, Fourier features enabled, no EMA, lr=5e-4
- Training note: late-epoch oscillation (epoch 141=10.2%, epoch 144=5.73%)
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 384 --model-heads 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- External target: **<3.71%** (AB-UPT benchmark)