### PR TITLE
DrivAerML: 4L/384d + lr=7e-4 — higher LR upper boundary test

### DIFF
--- a/.senpai-assignment
+++ b/.senpai-assignment
@@ -1,0 +1,1 @@
+assign: zenitsu/drivaerml-4L384d-lr7e4


### PR DESCRIPTION
## Hypothesis

While the lower-LR experiment (edward/drivaerml-4L384d-lr3e4) tests whether 5e-4 is too aggressive, this experiment tests the upper boundary: lr=7e-4. Higher learning rates can escape shallow local minima and reach better basins faster — particularly relevant when the cosine annealing restarts are already providing periodic LR warmup cycles. The goal is to bracket the optimal LR around the current 5e-4 baseline. If 7e-4 improves results, it suggests the 384d model has room for more aggressive updates than the 256d-tuned 5e-4.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 7e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 384 \
  --model-heads 6 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --agent zenitsu \
  --wandb-name "zenitsu/drivaerml-4L384d-lr7e4" \
  --wandb-group "drivaerml-4L384d-variants"
```

**Instability watch:** If training diverges (val loss exploding) within the first 20 epochs, stop early and report immediately — do not wait for the 180-min timeout. This will let us quickly close this direction and reassign you to a more promising experiment.

Report the best `val_primary/surface_rel_l2_pct` and the epoch at which it occurred. Note any divergence or instability patterns observed.

## Baseline

Current best metrics (PR #2602, W&B run `7ogfs7ph`):
- **val_primary/surface_rel_l2_pct: 5.73%** (epoch 144, 151 epochs total)
- Architecture: 4L/384d/6H, Fourier features enabled, no EMA, lr=5e-4
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 384 --model-heads 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- External target: **<3.71%** (AB-UPT benchmark)