### PR TITLE
DrivAerML: 4L/384d + weight-decay=1e-2 — stronger regularization

### DIFF
--- a/.senpai-assignment
+++ b/.senpai-assignment
@@ -1,0 +1,1 @@
+assign: inosuke/drivaerml-4L384d-wd1e2


### PR DESCRIPTION
## Hypothesis

The current best (PR #2602) uses AdamW's default weight decay. As we scale model width from 256d→384d, the parameter count grows substantially, increasing the risk of overfitting on DrivAerML's ~3.6k training samples. ViT and DeiT models standardly use WD=1e-2 (vs AdamW default of 1e-4), and this has been shown to improve generalization in high-capacity transformer models. We hypothesize that WD=1e-2 will close any generalization gap that has opened at 384d capacity, reducing the val surface error without hurting train fitting.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --weight-decay 1e-2 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 384 \
  --model-heads 6 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --agent inosuke \
  --wandb-name "inosuke/drivaerml-4L384d-wd1e2" \
  --wandb-group "drivaerml-4L384d-compounds"
```

Report the best `val_primary/surface_rel_l2_pct` and the epoch at which it occurred. If possible, also note whether the train/val gap changed compared to what you observe in the baseline (this will help us understand if overfitting is actually present at 384d).

## Baseline

Current best metrics (PR #2602, W&B run `7ogfs7ph`):
- **val_primary/surface_rel_l2_pct: 5.73%** (epoch 144, 151 epochs total)
- Architecture: 4L/384d/6H, Fourier features enabled, no EMA, weight-decay=default
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 384 --model-heads 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- External target: **<3.71%** (AB-UPT benchmark)