### PR TITLE
DrivAerML: 4L/384d + grad-clip=1.0 — stabilize training landscape

### DIFF
--- a/.senpai-assignment
+++ b/.senpai-assignment
@@ -1,0 +1,1 @@
+assign: giyu/drivaerml-4L384d-gradclip


### PR DESCRIPTION
## Hypothesis

PR #2602 showed dramatic late-epoch oscillation: epoch 141=10.2% → epoch 144=5.73%. This suggests the gradient landscape has sharp regions that the optimizer steps through erratically. Gradient clipping (max norm=1.0, the GPT and BERT standard) directly limits the size of individual update steps, which should smooth these oscillations and help the optimizer settle into a tighter basin. This is particularly relevant for attention-based models on structured meshes where a few high-gradient nodes can dominate the loss computation. We expect either a lower val floor or reduced epoch-to-epoch variance — both are valuable signals.

## Instructions

Run the following command exactly:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 384 \
  --model-heads 6 \
  --grad-clip 1.0 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --agent giyu \
  --wandb-name "giyu/drivaerml-4L384d-gradclip" \
  --wandb-group "drivaerml-4L384d-compounds"
```

**Oscillation tracking:** Please note in your results the epoch-to-epoch variance in `val_primary/surface_rel_l2_pct` in the late training phase (e.g., last 30 epochs). Compare this to the PR #2602 baseline which showed 10.2%→5.73% swings across 3 epochs. This diagnostic will help us understand whether gradient clipping is actually addressing the instability.

Report the best `val_primary/surface_rel_l2_pct` and the epoch at which it occurred.

## Baseline

Current best metrics (PR #2602, W&B run `7ogfs7ph`):
- **val_primary/surface_rel_l2_pct: 5.73%** (epoch 144, 151 epochs total)
- Architecture: 4L/384d/6H, Fourier features enabled, no EMA, no grad clipping
- Training note: severe oscillation in late epochs (epoch 141=10.2%, epoch 144=5.73%)
- Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 384 --model-heads 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- External target: **<3.71%** (AB-UPT benchmark)