### PR TITLE
AirfRANS: pressure-upweighted MSE loss (20x) — plateau-breaking

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -109,6 +109,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
+    pressure_loss_weight: float = 1.0
 
 
 @dataclass
@@ -673,12 +674,21 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    pressure_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        preds_masked = outputs["surface_preds"][batch.surface_mask]
+        target_masked = target[batch.surface_mask]
+        if pressure_loss_weight != 1.0 and preds_masked.shape[-1] >= 3:
+            per_element_mse = (preds_masked - target_masked).pow(2)
+            weights = torch.ones(preds_masked.shape[-1], device=preds_masked.device)
+            weights[2] = pressure_loss_weight
+            surf_loss = (per_element_mse * weights).mean()
+        else:
+            surf_loss = F.mse_loss(preds_masked, target_masked)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
@@ -1051,6 +1061,7 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    pressure_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1092,7 +1103,7 @@ def train_one_epoch(
                         volume_x=batch.volume_x,
                         volume_mask=batch.volume_mask,
                     )
-                    loss, _ = loss_grouped(batch, outputs, transform)
+                    loss, _ = loss_grouped(batch, outputs, transform, pressure_loss_weight=pressure_loss_weight)
         loss.backward()
         all_params = list(model.parameters())
         if anp_head is not None:
@@ -1291,6 +1302,7 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            pressure_loss_weight=config.pressure_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

PLATEAU-BREAKING IDEA. The pressure channel (p) dominates surface_mse, contributing ~99% of the composite loss (p≈1.15 vs Ux≈0.001, Uy≈0.00007, nut≈0.0001). Yet all 4 channels get equal gradient signal (25% each) in the unweighted MSE. This is a gradient misallocation problem: we spend 75% of our optimization budget on channels that barely matter for the primary metric.

Upweighting the pressure channel loss by 20x means 95% of gradient signal targets the bottleneck. This is zero compute overhead and directly addresses the root cause of our distance from the 0.0043 target.

## Instructions

Add a `--pressure-loss-weight` flag to train.py (default 1.0). When set to 20.0, multiply the MSE loss for the pressure channel (index 2, the `p` channel in [Ux, Uy, p, nut]) by this factor before averaging across channels.

Concretely, change the per-channel loss from:
```python
loss = mse(pred, target).mean()
```
to something like:
```python
weights = torch.ones(4, device=pred.device)
weights[2] = args.pressure_loss_weight  # pressure channel
loss = (mse(pred, target) * weights).mean()
```

Then run with the winning AirfRANS config + seed=789:

```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 3e-4 --cosine-t-max 10 \
  --no-use-ema --enable-fourier --epochs 999 --seed 789 \
  --pressure-loss-weight 20.0 \
  --agent nami --wandb-name "nami/airfrans-pressure-weighted-20x" \
  --wandb-group "airfrans-plateau-breaking"
```

Report the best `val_primary/surface_mse` and the per-channel breakdown (surface_mse_Ux, surface_mse_Uy, surface_mse_p, surface_mse_nut).

## Baseline

- **AirfRANS best:** 0.0153 (val) at epoch 41 — PR #2655 (3L/192d, Fourier, lr=3e-4, T_max=10, seed=789)
- **Per-channel breakdown (test):** Ux≈0.001, Uy≈0.00007, p≈1.15, nut≈0.0001
- **External target:** 0.0043 (3.6x gap remaining)
- **W&B run:** srd0fcew
- **Reproduce (baseline):**
  ```bash
  cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 3e-4 --cosine-t-max 10 --no-use-ema --enable-fourier --epochs 999 --seed 789
  ```