### PR TITLE
Enable compiled ICML trainer by default

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -74,7 +74,7 @@ class TrainConfig:
     persistent_workers: bool = True
     prefetch_factor: int = 4
     amp_mode: str = "bf16"
-    compile_model: bool = False
+    compile_model: bool = True
     debug: bool = False
     max_train_batches: int = 0
     max_eval_batches: int = 0


### PR DESCRIPTION
## Summary
- enable `compile_model` by default in the shared ICML trainer
- keep `--no-compile-model` as the explicit escape hatch
- preserve the existing bf16 + worker auto-tuning path already in `radford`

## Why
The throughput work is already in `radford`, but the trainer still required an explicit `--compile-model` to hit the fastest DrivAerML path. Making compile default-on moves the branch onto the best measured configuration while keeping a one-flag opt-out.

## Validation
- `python -m py_compile target/icml2026/train.py`
- verified `TrainConfig().compile_model == True`
- cluster smoke on shared `train.py` without `--compile-model`:
  - dataset `drivaerml`
  - `5` train batches, `5` eval batches
  - completed cleanly with final val/test metrics
