### PR TITLE
AirfRANS: 4L/256d gc=1.5 + T_max=5 — architecture-enabled gradient clipping

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+# airfrans-4L256d-gc15-tmax5


### PR DESCRIPTION
## Hypothesis

The 4L/256d architecture's weight decay stabilization (WD=1e-2) may enable gc=1.5 where it previously caused volatility at 3L/192d. The triple compound (gc=1.5 + T_max=5 + WD=1e-2) failed at smaller architecture but at 4L/256d the richer representational capacity combined with WD regularization should absorb the larger gradient steps without divergence. gc=1.5 was the previous best on AirfRANS at 0.00935 — applying it to the 4L/256d architecture that hit 0.007264 is the highest-priority next step.

## Instructions

Start from the golden 4L/256d command and increase grad-clip from 1.0 to 1.5. Everything else stays identical:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb_group airfrans-4L256d-gc
```

**Key change:** --grad-clip 1.5 (was --grad-clip 1.0)

Monitor grad norm behavior carefully in W&B. At 3L/192d gc=1.5 caused volatility — check if 4L/256d absorbs it. Report the grad norm trajectory alongside val/surface_mse.

## Baseline

- **Primary metric:** val_primary/surface_mse
- **Current best:** 0.007264 (val) at epoch 40
- **Best PR:** #2727 (shoya — 4L/256d + gc=1.0 + WD=1e-2 + T_max=5, 50 epochs, hit epoch cap at 61 min of 180-min budget)
- **External target:** 0.0043 (~1.7x gap remaining)
- **W&B run:** ruurxdqs
- **Reproduce baseline:** cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999