### PR TITLE
AirfRANS: 4L/256d gc=1.5 + WD=1e-2 + T_max=10 — longer cycles reduce volatility

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+# airfrans-4L256d-gc15-wd1e2-tmax10


### PR DESCRIPTION
## Hypothesis

gc=1.5 + WD=1e-2 + T_max=10 at 4L/256d. Longer cosine cycles (T_max=10) reduce the clipping frequency at LR peaks compared to T_max=5, which may make gc=1.5 more stable. At 4L/256d with WD regularization, the architecture may handle gc=1.5 better than at 3L/192d. This tests whether T_max=10 unlocks gc=1.5 at the new architecture — the original gc=1.5 best (0.00935) used T_max=10, so this is a natural combination.

## Instructions

Start from the golden 4L/256d command and change grad-clip to 1.5 and T_max to 10:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 10 --grad-clip 1.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb_group airfrans-4L256d-gc
```

**Key changes:** --grad-clip 1.5 (was 1.0) + --cosine-t-max 10 (was 5)

Monitor grad norm trajectory. Report val/surface_mse and grad norm stats (mean, peak) per epoch.

## Baseline

- **Primary metric:** val_primary/surface_mse
- **Current best:** 0.007264 (val) at epoch 40
- **Best PR:** #2727 (shoya — 4L/256d + gc=1.0 + WD=1e-2 + T_max=5, 50 epochs, hit epoch cap at 61 min)
- **External target:** 0.0043 (~1.7x gap remaining)
- **W&B run:** ruurxdqs
- **Reproduce baseline:** cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999