### PR TITLE
AirfRANS: 4L/256d lr=5e-4 — lower LR for deeper basin exploration

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+# airfrans-4L256d-lr5e4


### PR DESCRIPTION
## Hypothesis

Lower LR (5e-4 vs 7e-4) at 4L/256d. The winning TandemFoil insight was that lower LR + more epochs beats higher LR — lr=2e-4 at 3L/192d beat lr=3e-4 at 5L/256d by 14.7% on TandemFoil. The same principle may apply to AirfRANS: at 4L/256d a lower LR could allow more stable descent into deeper loss basins with the cosine schedule providing periodic escape opportunities. The golden config hit epoch cap at 61 min, suggesting the model was still improving — slower LR + more epochs may find a deeper trough.

## Instructions

Start from the golden 4L/256d command and decrease lr from 7e-4 to 5e-4:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 5e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb_group airfrans-4L256d-lr
```

**Key change:** --lr 5e-4 (was 7e-4)

Let the run go for the full epoch budget. The lower LR may need more epochs to converge — report the full trajectory and note the epoch at which the best val metric was achieved.

## Baseline

- **Primary metric:** val_primary/surface_mse
- **Current best:** 0.007264 (val) at epoch 40
- **Best PR:** #2727 (shoya — 4L/256d + gc=1.0 + WD=1e-2 + T_max=5, AdamW lr=7e-4, 50 epochs, hit epoch cap at 61 min of 180-min budget)
- **External target:** 0.0043 (~1.7x gap remaining)
- **W&B run:** ruurxdqs
- **Reproduce baseline:** cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999