### PR TITLE
AirfRANS: 4L/256d T_max=3 — ultra-short cycles for more cosine troughs

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+# airfrans-4L256d-tmax3


### PR DESCRIPTION
## Hypothesis

Even shorter cosine cycles (T_max=3) at 4L/256d. T_max=5 was optimal over T_max=10 — giving 8 full cycles in 40 epochs vs 4. The hypothesis is that T_max=3 would give ~13 cycles in the same span, providing even more frequent phase-transition opportunities and deeper basin exploration. However, T_max=3 may be too short — each cycle might not have enough epochs to settle. This tests whether the frequency gain outweighs the settling loss.

## Instructions

Start from the golden 4L/256d command and change T_max from 5 to 3:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 3 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb_group airfrans-4L256d-tmax
```

**Key change:** --cosine-t-max 3 (was 5)

Report the loss envelope behavior — does it look more or less stable than T_max=5? Note any signs of under-settling (val loss not decreasing within a cycle before the next peak).

## Baseline

- **Primary metric:** val_primary/surface_mse
- **Current best:** 0.007264 (val) at epoch 40
- **Best PR:** #2727 (shoya — 4L/256d + gc=1.0 + WD=1e-2 + T_max=5, AdamW lr=7e-4, 50 epochs, hit epoch cap at 61 min)
- **External target:** 0.0043 (~1.7x gap remaining)
- **W&B run:** ruurxdqs
- **Reproduce baseline:** cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999