### PR TITLE
AirfRANS: 4L/256d WD=5e-3 — lighter weight decay for deeper basins

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+# airfrans-4L256d-wd5e3


### PR DESCRIPTION
## Hypothesis

Lighter weight decay (5e-3 vs 1e-2) at 4L/256d. WD=1e-2 is in the winning config and clearly helps. But is 1e-2 optimal or is it slightly over-regularizing? At 4L/256d the model has more capacity and may not need as strong regularization to generalize. Lighter WD=5e-3 allows the optimizer to explore parameter space more freely, which might find deeper basins at the cost of slightly higher variance. The question is whether WD=1e-2 is preventing the model from reaching lower loss valleys.

## Instructions

Start from the golden 4L/256d command and change weight decay from 1e-2 to 5e-3:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 5e-3 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb_group airfrans-4L256d-wd
```

**Key change:** --weight-decay 5e-3 (was 1e-2)

Report val/surface_mse trajectory and note if training is more or less stable than the WD=1e-2 baseline.

## Baseline

- **Primary metric:** val_primary/surface_mse
- **Current best:** 0.007264 (val) at epoch 40
- **Best PR:** #2727 (shoya — 4L/256d + gc=1.0 + WD=1e-2 + T_max=5, AdamW lr=7e-4, 50 epochs, hit epoch cap at 61 min)
- **External target:** 0.0043 (~1.7x gap remaining)
- **W&B run:** ruurxdqs
- **Reproduce baseline:** cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999