### PR TITLE
AirfRANS: 3L/256d golden config — width vs depth ablation

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-4L256d-gc05
+# airfrans-3L256d-golden


### PR DESCRIPTION
## Hypothesis

3L/256d with golden config — just width scaling (256d) without depth scaling (4L). The 4L/256d breakthrough raised a key question: is the gain from depth (4L vs 3L) or width (256d vs 192d) or both together? This ablation runs the golden config (WD=1e-2 + T_max=5 + gc=1.0) with 3 layers at 256d width. If 3L/256d is competitive with 4L/256d, then width is the dominant factor. If 3L/256d is worse, then depth matters too.

## Instructions

Start from the golden 4L/256d command and reduce layers from 4 to 3 (keep 256d width and 4 heads):

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb_group airfrans-arch-scaling
```

**Key change:** --model-layers 3 (was 4, keeping --model-hidden-dim 256 --model-heads 4)

This is a controlled ablation — the only change is layers. Report val/surface_mse and compare directly to the 4L/256d baseline (0.007264). If 3L/256d scores 0.007264 or better, width was the key ingredient; if notably worse, depth also matters.

## Baseline

- **Primary metric:** val_primary/surface_mse
- **Current best:** 0.007264 (val) at epoch 40
- **Best PR:** #2727 (shoya — 4L/256d + gc=1.0 + WD=1e-2 + T_max=5, AdamW lr=7e-4, 50 epochs, hit epoch cap at 61 min)
- **External target:** 0.0043 (~1.7x gap remaining)
- **W&B run:** ruurxdqs
- **Reproduce baseline:** cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset airfrans --airfrans_task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 256 --model-heads 4 --epochs 999