### PR TITLE
AirfRANS 4L/256d: zero weight decay (WD ablation)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,0 +1,1 @@
+# airfrans-4L256d-nowd


### PR DESCRIPTION
## Hypothesis
WD=1e-2 is part of the golden config, but there is evidence that weight decay fights grad-clip at higher clipping values. At 4L/256d, the architecture may provide sufficient implicit regularization through depth and width that explicit L2 penalty is unnecessary or even harmful. Removing WD entirely isolates its contribution and may allow the optimizer to exploit curvature more aggressively.

## Instructions
Run the following command exactly:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 0 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb_group airfrans-4L256d-wd
```

Key change from golden config: `--weight-decay 0` (was 1e-2). All other settings match the proven 4L/256d golden config.

## Baseline
Current best metrics from BASELINE.md (PR #2727, W&B run: ruurxdqs):
- val_primary/surface_mse: **0.007264** (primary metric, lower is better)
- External target: 0.0043 (~1.7x gap remaining)
- Architecture: 4L/256d, 4 heads, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5, no-EMA, enable-fourier

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans --airfrans_task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999
```