### PR TITLE
AirfRANS: Pressure-weighted loss (20x) at 4L/256d + golden config

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -109,6 +109,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
+    pressure_loss_weight: float = 1.0
 
 
 @dataclass
@@ -673,12 +674,21 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    pressure_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        preds_masked = outputs["surface_preds"][batch.surface_mask]
+        target_masked = target[batch.surface_mask]
+        if pressure_loss_weight != 1.0 and preds_masked.shape[-1] >= 3:
+            per_element_mse = (preds_masked - target_masked).pow(2)
+            weights = torch.ones(preds_masked.shape[-1], device=preds_masked.device)
+            weights[2] = pressure_loss_weight
+            surf_loss = (per_element_mse * weights).mean()
+        else:
+            surf_loss = F.mse_loss(preds_masked, target_masked)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
@@ -1051,6 +1061,7 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    pressure_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1092,7 +1103,7 @@ def train_one_epoch(
                         volume_x=batch.volume_x,
                         volume_mask=batch.volume_mask,
                     )
-                    loss, _ = loss_grouped(batch, outputs, transform)
+                    loss, _ = loss_grouped(batch, outputs, transform, pressure_loss_weight=pressure_loss_weight)
         loss.backward()
         all_params = list(model.parameters())
         if anp_head is not None:
@@ -1291,6 +1302,7 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            pressure_loss_weight=config.pressure_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis
BREAKTHROUGH FINDING: Pressure-weighted loss (20x) at 3L/192d achieved val_primary/surface_mse = **0.00435** — 40% better than the 4L/256d baseline (0.007264) and matching the external target (0.0043). The pressure channel dominates the composite MSE but gets equal gradient weight by default, causing gradient misallocation. We hypothesize that combining 20x pressure weighting with the superior 4L/256d + golden config architecture will push BELOW the external target.

## Code Change Required
You need to add `--pressure-loss-weight` support to train.py. This is a small change:

1. Add argument to the parser:
   `parser.add_argument('--pressure-loss-weight', type=float, default=1.0, help='Weight multiplier for pressure channel in loss')`

2. In the loss computation, weight the pressure channel. Find where the MSE loss is computed per-channel and multiply the pressure channel's contribution by this weight. The pressure channel is typically index 2 (after Ux, Uy) in the AirfRANS output. You can also reference nami's implementation on branch `nami/airfrans-pressure-weighted-loss` for guidance.

## Training Command
After implementing the code change:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans \
  --airfrans_task full \
  --optimizer adamw \
  --lr 7e-4 \
  --cosine-t-max 5 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --pressure-loss-weight 20.0 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --epochs 999 \
  --agent edward \
  --wandb-name "edward/airfrans-4L256d-pressure20x-golden" \
  --wandb-group "airfrans-pressure-weight"
```

Report val_primary/surface_mse, best epoch, and per-channel breakdown (especially surface_mse_p).

## Baseline
Current best: **0.007264** at epoch 40 (4L/256d, golden config, NO pressure weighting)
Pressure-weight reference: **0.00435** at epoch 241 (3L/192d, lr=3e-4, T_max=10, 20x pressure weight) — W&B run toeli7xw
External target: **0.0043**