### PR TITLE
AirfRANS: Pressure-weight sweep — 30x at 3L/192d

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -109,6 +109,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
+    pressure_loss_weight: float = 1.0
 
 
 @dataclass
@@ -673,12 +674,21 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    pressure_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        preds_masked = outputs["surface_preds"][batch.surface_mask]
+        target_masked = target[batch.surface_mask]
+        if pressure_loss_weight != 1.0 and preds_masked.shape[-1] >= 3:
+            per_element_mse = (preds_masked - target_masked).pow(2)
+            weights = torch.ones(preds_masked.shape[-1], device=preds_masked.device)
+            weights[2] = pressure_loss_weight
+            surf_loss = (per_element_mse * weights).mean()
+        else:
+            surf_loss = F.mse_loss(preds_masked, target_masked)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
@@ -1051,6 +1061,7 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    pressure_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1092,7 +1103,7 @@ def train_one_epoch(
                         volume_x=batch.volume_x,
                         volume_mask=batch.volume_mask,
                     )
-                    loss, _ = loss_grouped(batch, outputs, transform)
+                    loss, _ = loss_grouped(batch, outputs, transform, pressure_loss_weight=pressure_loss_weight)
         loss.backward()
         all_params = list(model.parameters())
         if anp_head is not None:
@@ -1291,6 +1302,7 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            pressure_loss_weight=config.pressure_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis
BREAKTHROUGH: Pressure-weighted loss (20x) at 3L/192d achieved val_primary/surface_mse = **0.00435** (W&B run toeli7xw, nami PR #2703). This is a 40% improvement over the 4L/256d baseline (0.007264) and matches the external target (0.0043).

We need to find the optimal pressure weight. This experiment tests 30x (higher than nami's 20x) to determine if more aggressive pressure upweighting pushes convergence even deeper, or if 20x is already near optimal. If 30x > 20x, we'll test 50x next. If 30x < 20x, the optimum is at or below 20x.

## Instructions

You need to add `--pressure-loss-weight` support to train.py. This is a small, targeted change:

1. Add argument to the parser:
   `parser.add_argument('--pressure-loss-weight', type=float, default=1.0, help='Weight multiplier for pressure channel in loss')`

2. In the loss computation, weight the pressure channel. The pressure channel is typically index 2 (Ux=0, Uy=1, p=2, nut=3) in the AirfRANS output. Multiply the pressure channel's MSE contribution by the weight factor. You can reference nami's implementation on branch `nami/airfrans-pressure-weighted-loss` for guidance.

After implementing the code change, run:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans \
  --airfrans_task full \
  --optimizer adamw \
  --lr 3e-4 \
  --cosine-t-max 10 \
  --no-use-ema \
  --enable-fourier \
  --pressure-loss-weight 30.0 \
  --epochs 999 \
  --seed 789 \
  --agent tetsuo \
  --wandb-name "tetsuo/airfrans-pressure30x-3L192d" \
  --wandb-group "airfrans-pressure-weight-sweep"
```

Note: Using nami's exact config (3L/192d default arch, lr=3e-4, T_max=10, seed=789) but with 30x instead of 20x. This isolates the weight effect.

Report val_primary/surface_mse, best epoch, per-channel breakdown (especially surface_mse_p), and total epochs.

## Baseline
- **Current merged best:** 0.007264 (4L/256d golden config, NO pressure weight) — PR #2727
- **Pressure-weight reference:** 0.00435 at epoch 241 (3L/192d, lr=3e-4, T_max=10, **20x** pressure weight) — W&B toeli7xw, nami PR #2703
- **External target:** 0.0043