### PR TITLE
AirfRANS: Pressure-weight sweep — 10x at 3L/192d

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -109,6 +109,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
+    pressure_loss_weight: float = 1.0
 
 
 @dataclass
@@ -673,12 +674,21 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    pressure_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        preds_masked = outputs["surface_preds"][batch.surface_mask]
+        target_masked = target[batch.surface_mask]
+        if pressure_loss_weight != 1.0 and preds_masked.shape[-1] >= 3:
+            per_element_mse = (preds_masked - target_masked).pow(2)
+            weights = torch.ones(preds_masked.shape[-1], device=preds_masked.device)
+            weights[2] = pressure_loss_weight
+            surf_loss = (per_element_mse * weights).mean()
+        else:
+            surf_loss = F.mse_loss(preds_masked, target_masked)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
@@ -1051,6 +1061,7 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    pressure_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1092,7 +1103,7 @@ def train_one_epoch(
                         volume_x=batch.volume_x,
                         volume_mask=batch.volume_mask,
                     )
-                    loss, _ = loss_grouped(batch, outputs, transform)
+                    loss, _ = loss_grouped(batch, outputs, transform, pressure_loss_weight=pressure_loss_weight)
         loss.backward()
         all_params = list(model.parameters())
         if anp_head is not None:
@@ -1291,6 +1302,7 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            pressure_loss_weight=config.pressure_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis
BREAKTHROUGH: Pressure-weighted loss (20x) at 3L/192d achieved val_primary/surface_mse = **0.00435** (W&B toeli7xw, nami PR #2703). We need to find the optimal weight. This experiment tests 10x (below nami's 20x) to determine if the optimal is at or below 20x. If 10x >= 20x performance, the optimum is at a moderate value; if 10x < 20x, then more aggressive weighting helps. Together with tetsuo (30x), this brackets the optimum around nami's 20x.

## Code Change Required
Add `--pressure-loss-weight` support to train.py (small change, +14/-2 lines):

1. Add to arg parser: `parser.add_argument('--pressure-loss-weight', type=float, default=1.0)`
2. Weight the pressure channel MSE in the loss. The pressure channel is index 2 (Ux=0, Uy=1, p=2, nut=3). Multiply its contribution by this factor.
Reference implementation: branch `nami/airfrans-pressure-weighted-loss`

## Training Command
\`\`\`bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans \
  --airfrans_task full \
  --optimizer adamw \
  --lr 3e-4 \
  --cosine-t-max 10 \
  --no-use-ema \
  --enable-fourier \
  --pressure-loss-weight 10.0 \
  --epochs 999 \
  --seed 789 \
  --agent chihiro \
  --wandb-name "chihiro/airfrans-pressure10x-3L192d" \
  --wandb-group "airfrans-pressure-weight-sweep"
\`\`\`

Note: Using nami's exact config but with 10x instead of 20x. Isolates the weight factor.

Report val_primary/surface_mse, best epoch, per-channel breakdown.

## Baseline
Current best (merged): **0.007264** (4L/256d, gc=1.0, WD=1e-2, T_max=5)
Pressure-weight reference: **0.00435** at epoch 241 (3L/192d, lr=3e-4, T_max=10, **20x**) — W&B toeli7xw
External target: 0.0043
Weight sweep: **10x (this)**, 20x (nami), 30x (tetsuo)