### PR TITLE
AirfRANS: 3L width frontier — 3L/320d, 384d, 512d

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-4L256d-gc05
+airfrans-3L-width-frontier


### PR DESCRIPTION
## Hypothesis

PR #2771 (itachi) achieved val=0.001479 with 3L/256d (46.6% improvement over baseline). This reveals that at 3 layers, 256d width already outperforms 4L/256d. The question is: what is the optimal width at 3 layers? This experiment maps the width curve: 3L/320d, 3L/384d, 3L/512d. Wider should be better up to some point where VRAM or optimization difficulty limits further gains. The 64-dim-per-head parameterization is preserved (320/5, 384/6, 512/8).

## Baseline

- **Primary metric:** val_primary/surface_mse (lower is better)
- **Current merged baseline:** 0.00277 — PR #2774 (4L/256d + gc=0.5 + WD=1e-2 + T_max=5)
- **Pending merge (PR #2771, rebasing):** 0.001479 — 3L/256d + gc=1.0, W&B run: q4hytsr6
- **External target:** 0.0043 (crushed — we are 35.6% below)
- **Width anchor:** 3L/256d got val=0.001479; does 3L/320d/384d/512d push further?

## Instructions

Run 3 experiments in parallel (1 GPU each):

**Run 1 — 3L/320d (5 heads)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 320 --model-heads 5 \
  --epochs 999 \
  --wandb-group airfrans-3L-width \
  --wandb-name airfrans-3L320d
```

**Run 2 — 3L/384d (6 heads)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 384 --model-heads 6 \
  --epochs 999 \
  --wandb-group airfrans-3L-width \
  --wandb-name airfrans-3L384d
```

**Run 3 — 3L/512d (8 heads)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --wandb-group airfrans-3L-width \
  --wandb-name airfrans-3L512d
```

Run all 3 simultaneously. Report the **best val_primary/surface_mse checkpoint** (not final epoch) for each run and the epoch at which it occurred. The key comparison is against PR #2771's 3L/256d result (val=0.001479 at ep202, W&B run q4hytsr6).