### PR TITLE
Cross-benchmark: 3L architecture transfer — TandemFoil + DrivAerML

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-4L256d-gc05
+3L-architecture-transfer-tandem-driv


### PR DESCRIPTION
## Hypothesis

PR #2771 (itachi) demonstrated that on AirfRANS, reducing depth from 4L to 3L (while keeping 256d width) improved val by 46.6% (0.001479 vs 0.00277 baseline). This is a dramatic finding suggesting that for CFD surrogates, width is more important than depth at this scale. The TandemFoil baseline is already 3L/192d — does going to 3L/256d (wider at same depth) improve it? For DrivAerML, the baseline is 4L/512d — does 3L/512d (same width, fewer layers) help? This experiment tests the 3L insight across the other two benchmarks.

Note: On TandemFoil, shinji (#2789) is testing 3L/256d at lr=2e-4. This experiment uses the current best lr=1.5e-4, which is different and should give better results.

## Baseline

- **TandemFoil:** val_primary/surface_pressure_mae = 44.72 (PR #2724, 3L/192d, Lion lr=1.5e-4, T_max=10, 115 epochs)
- **DrivAerML:** val_primary/surface_rel_l2_pct = 4.619% (PR #2691, 4L/512d, AdamW lr=5e-4, T_max=30, 267 epochs)
- **AirfRANS anchor (for reference):** 3L/256d achieved 0.001479 vs 4L/256d's 0.00277 — 46.6% gain from depth reduction

## Instructions

Run 4 experiments in parallel (2 GPUs each for DrivAerML, 1 GPU each for the others):

**Run 1 — TandemFoil 3L/256d at lr=1.5e-4 (width transfer)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset tandemfoil --optimizer lion \
  --lr 1.5e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --wandb-group 3L-arch-transfer \
  --wandb-name tandem-3L256d-lr15e4
```

**Run 2 — TandemFoil 3L/256d + gc=0.5 (compound with gc insight)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset tandemfoil --optimizer lion \
  --lr 1.5e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --wandb-group 3L-arch-transfer \
  --wandb-name tandem-3L256d-gc05
```

**Run 3 — DrivAerML 3L/512d (reduce depth, keep width)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2,3 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group 3L-arch-transfer \
  --wandb-name driv-3L512d
```

**Run 4 — DrivAerML 3L/512d + gc=0.5**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4,5 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group 3L-arch-transfer \
  --wandb-name driv-3L512d-gc05
```

Report the best val checkpoint for each run. For TandemFoil, compare against val_primary/surface_pressure_mae baseline of 44.72. For DrivAerML, compare against val_primary/surface_rel_l2_pct baseline of 4.619%.