### PR TITLE
Cross-benchmark: dropout=0.1 regularization — first dropout test

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-4L256d-gc05
+cross-benchmark-dropout


### PR DESCRIPTION
### Hypothesis
Dropout (--model-dropout, default 0.0) has never been tested in this research programme. The recurring divergence patterns across all three datasets — AirfRANS T_max=5 spike at ep205, TandemFoil gradient explosions, DrivAerML late overfitting — suggest the model may be overparameterized relative to the data distribution. Moderate dropout (0.1) could act as an implicit regularizer: reducing the sharpest divergence events, smoothing the loss landscape, and potentially enabling the model to hold deep trough states rather than immediately rebounding. The test is whether the regularization benefit outweighs the reduced per-step capacity.

### Instructions
Run 4 experiments in parallel (1 GPU each for AirfRANS/TandemFoil, 2 GPUs for DrivAerML):

**Run 1 — AirfRANS 3L/256d + dropout=0.1 (best architecture)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --model-dropout 0.1 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group cross-dropout \
  --wandb-name airfrans-3L256d-dropout01
\`\`\`

**Run 2 — TandemFoil 3L/192d + dropout=0.1 (current best config)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset tandemfoil --optimizer lion \
  --lr 1.5e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --model-dropout 0.1 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --wandb-group cross-dropout \
  --wandb-name tandem-3L192d-dropout01
\`\`\`

**Run 3 — DrivAerML 4L/512d + dropout=0.1 (current best architecture)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2,3 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 \
  --model-dropout 0.1 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group cross-dropout \
  --wandb-name driv-4L512d-dropout01
\`\`\`

**Run 4 — AirfRANS 3L/256d + dropout=0.05 (lighter dose)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --model-dropout 0.05 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group cross-dropout \
  --wandb-name airfrans-3L256d-dropout005
\`\`\`

Report best val checkpoints for each run. Key question: does dropout prevent the ~ep202-205 divergence on AirfRANS? Does it improve TandemFoil stability at cosine peaks?

### Baseline
- **AirfRANS:** val_primary/surface_mse = 0.00277 (PR #2774, 4L/256d + gc=0.5); pending best: 0.001479 (PR #2771, 3L/256d + gc=1.0)
- **TandemFoil:** val_primary/surface_pressure_mae = 44.72 (PR #2724, 3L/192d, Lion lr=1.5e-4)
- **DrivAerML:** val_primary/surface_rel_l2_pct = 4.619% (PR #2691, 4L/512d)
- **Dropout default:** 0.0 (never tested with non-zero value)