### PR TITLE
DrivAerML: higher LR (7e-4, 8e-4, 1e-3) + gc=0.5 compound

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-4L256d-gc05
+drivaerml-higher-lr-gc05


### PR DESCRIPTION
## Hypothesis

Three experiments (PRs #2797 ray, #2779 levi, #2781 chrome-previous) confirmed lower LR (3e-4) hurts DrivAerML — the model needs at least lr=5e-4 to converge within the 180-min budget. The question is whether HIGHER LR helps. On AirfRANS, gc=0.5 allowed more aggressive optimization steps, yielding 28.9% improvement. DrivAerML may have a similar dynamic: higher LR + gc=0.5 stability could reach deeper minima faster. This tests lr=7e-4, 8e-4, and 1e-3, all combined with gc=0.5 to prevent the gradient spikes that would destabilize higher LRs. Note: shinobu (#2806) has lr=7e-4 WITHOUT gc — this provides the gc comparison.

## Instructions

Run 4 experiments in parallel (2 GPUs each):

**Run 1 — lr=7e-4 + gc=0.5**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0,1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 7e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-lr-gc \
  --wandb-name driv-lr7e4-gc05
```

**Run 2 — lr=8e-4 + gc=0.5**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2,3 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 8e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-lr-gc \
  --wandb-name driv-lr8e4-gc05
```

**Run 3 — lr=1e-3 + gc=0.5**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4,5 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 1e-3 --cosine-t-max 30 --grad-clip 0.5 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-lr-gc \
  --wandb-name driv-lr1e3-gc05
```

**Run 4 — lr=5e-4 + gc=0.5 + WD=1e-2 (compound regularization)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=6,7 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-lr-gc \
  --wandb-name driv-lr5e4-gc05-wd1e2
```

Report best val_primary/surface_rel_l2_pct checkpoint for each run. Compare all against baseline 4.619% and note whether gc=0.5 + higher LR outperforms shinobu's lr=7e-4 baseline (no gc).

## Baseline

- **Primary metric:** val_primary/surface_rel_l2_pct (lower is better)
- **Current best:** 4.619% (PR #2691, 4L/512d, AdamW lr=5e-4, T_max=30, no gc)
- **External target:** 3.71% (1.24x gap remaining)
- **Key context:** Lower LR (3e-4) failed on 3 independent experiments. Higher LR direction is the motivated next step.
- **Reproduce baseline:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```