### PR TITLE
AirfRANS: 2L depth frontier — test ultra-shallow network

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+airfrans-2L-depth-frontier


### PR DESCRIPTION
## Hypothesis

AirfRANS val history: 4L/256d achieved 0.00277, then 3L/256d achieved 0.001479 (46.6% improvement from simply REMOVING a layer). This is a striking depth-vs-width result. The inductive bias towards shallower networks on this 2D CFD dataset may be a fundamental property — fewer layers means less over-transformation of the local pressure features, allowing the model to preserve physically meaningful gradients. If the trend continues, 2L/256d or 2L/384d could push further below 0.001479. We also test 2L with wider dimensions to compensate for the lost capacity.

## Instructions

Run 4 experiments in parallel (1 GPU each):

**Run 1 — 2L/256d (direct depth reduction)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-2L-depth \
  --wandb-name airfrans-2L256d
\`\`\`

**Run 2 — 2L/384d (wider to compensate for fewer layers)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 384 --model-heads 6 \
  --epochs 999 \
  --wandb-group airfrans-2L-depth \
  --wandb-name airfrans-2L384d
\`\`\`

**Run 3 — 2L/512d (widest shallow variant)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --wandb-group airfrans-2L-depth \
  --wandb-name airfrans-2L512d
\`\`\`

**Run 4 — 2L/256d + gc=0.5 (combine with gc insight)**
\`\`\`bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=3 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-2L-depth \
  --wandb-name airfrans-2L256d-gc05
\`\`\`

Run all 4 simultaneously. Report the **best val_primary/surface_mse checkpoint** (not final epoch). If any run diverges, note the epoch. The key question: does going from 3L to 2L continue the trend, or is 3L the sweet spot?

## Baseline

- **Primary metric:** val_primary/surface_mse (lower is better)
- **Current merged baseline:** 0.00277 (PR #2774, 4L/256d + gc=0.5)
- **Pending best (PR #2771, awaiting rebase):** 0.001479 at ep202 (3L/256d + gc=1.0, W&B: q4hytsr6)
- **Depth trend:** 4L→3L gave 46.6% improvement. Does 3L→2L continue?
- **External target:** 0.0043 (we are 35.6% below with the merged baseline)