### PR TITLE
[codex] add Codex support files and advisor prototypes

### DIFF
--- a/.agents/skills/alphaxiv-paper-lookup/SKILL.md
+++ b/.agents/skills/alphaxiv-paper-lookup/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: alphaxiv-paper-lookup
+description: Look up any arxiv paper on alphaxiv.org to get a structured AI-generated overview. This is faster and more reliable than trying to read a raw PDF.
+model: Codex-opus-4-6
+effort: high
+---
+
+# AlphaXiv Paper Lookup
+
+Look up any arxiv paper on alphaxiv.org to get a structured AI-generated overview. This is faster and more reliable than trying to read a raw PDF.
+
+## When to Use
+
+- User shares an arxiv URL (e.g. `arxiv.org/abs/2401.12345`)
+- User mentions a paper ID (e.g. `2401.12345`)
+- User asks you to explain, summarize, or analyze a research paper
+- User shares an alphaxiv URL (e.g. `alphaxiv.org/overview/2401.12345`)
+
+## Workflow
+
+### Step 1: Extract the paper ID
+
+Parse the paper ID from whatever the user provides:
+
+| Input                                      | Paper ID       |
+| ------------------------------------------ | -------------- |
+| `https://arxiv.org/abs/2401.12345`         | `2401.12345`   |
+| `https://arxiv.org/pdf/2401.12345`         | `2401.12345`   |
+| `https://alphaxiv.org/overview/2401.12345` | `2401.12345`   |
+| `2401.12345v2`                             | `2401.12345v2` |
+| `2401.12345`                               | `2401.12345`   |
+
+### Step 2: Fetch the machine-readable report
+
+```bash
+curl -s "https://alphaxiv.org/overview/{PAPER_ID}.md"
+```
+
+This returns the intermediate machine-readable report — a structured, detailed analysis of the paper optimized for LLM consumption. One call, plain markdown, no JSON parsing.
+
+If this returns 404, the report hasn't been generated for this paper yet.
+
+### Step 3: If you need more detail, fetch the full paper text
+
+If the report doesn't contain the specific information the user is asking about (e.g. a particular equation, table, or section), fetch the full paper text:
+
+```bash
+curl -s "https://alphaxiv.org/abs/{PAPER_ID}.md"
+```
+
+This returns the full extracted text of the paper as markdown. Only use this as a fallback — the report is usually sufficient.
+
+If this returns 404, the full text hasn't been processed yet. As a last resort, direct the user to the PDF at `https://arxiv.org/pdf/{PAPER_ID}`.
+
+## Error Handling
+
+- **404 on Step 2**: Report not generated for this paper.
+- **404 on Step 3**: Full text not yet extracted for this paper.
+
+## Notes
+
+- No authentication required — these are public endpoints.

--- a/.agents/skills/analyze-experiments/SKILL.md
+++ b/.agents/skills/analyze-experiments/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: analyze-experiments
+description: >
+  Analyzes and categorizes all ML experiment PRs in the senpai research track.
+  Use this skill whenever the user asks to: analyze experiments, categorize PRs, bucket
+  experiments, summarize what's been tried, understand experiment history, review merged
+  vs closed results, or asks "what experiments have we run / worked / failed".
+  Also triggers for: "pull the latest experiments", "what's been tried so far",
+  "category breakdown of PRs", "which experiments succeeded", "noam track analysis".
+  When a branch name is mentioned (e.g. "noam branch", "on the noam branch"), pass it
+  as the base branch to scope the fetch to just those PRs.
+---
+
+# Analyze Experiments Skill
+
+Fetches fresh experiment PR data via the list-experiments skill, categorizes each PR
+using a team of parallel readers, and produces a 5-section report: full catalogue,
+category breakdown with merge rates, merged-only wins, closed-only failures, key narratives.
+
+---
+
+## Step 1: Fetch PR data via list-experiments
+
+Read the list-experiments skill at `.agents/skills/list-experiments/SKILL.md`
+and run its Python code with the following configuration:
+
+**If a base branch was specified** (e.g. "noam", "yan", "main") — use it directly:
+```python
+BASE_BRANCH = "noam"   # replace with the branch the user mentioned
+# use the fetch command from list-experiments as-is (it uses --base BASE_BRANCH)
+```
+
+**If no branch was specified** — fetch all senpai-labelled experiments instead. Replace the `fetch()` function body with:
+```python
+cmd = ["gh", "pr", "list", "--repo", "wandb/senpai", "--json", FIELDS,
+       "--limit", "10000", "--state", "all", "--label", "senpai"]
+```
+
+Run the script and note the `experiments_summary_<ts>.md` path printed — that's your input for Steps 2–3.
+
+---
+
+## Step 2: Find split points for parallel reading
+
+The summary file can be large (thousands of lines). Divide it into 4 roughly equal chunks:
+
+```bash
+# Get total PR count and line positions for every ~25% boundary
+grep -n "^# PR" <summary_path> | awk 'BEGIN{getline l1; print l1} NR==int(total*0.25) || NR==int(total*0.5) || NR==int(total*0.75) {print} END{print}' total=$(grep -c "^# PR" <summary_path>)
+
+# Simpler: just get all PR line numbers and pick 3 evenly-spaced split points
+grep -n "^# PR" <summary_path> | awk -v n=$(grep -c "^# PR" <summary_path>) 'NR==1||NR==int(n/4)||NR==int(n/2)||NR==int(3*n/4)||NR==n{print NR, $0}'
+```
+
+Note the line numbers for the 4 batch boundaries.
+
+---
+
+## Step 3: Launch 4 parallel Explore agents
+
+Send all 4 in a single message. Each agent reads its assigned line range from the summary
+file and returns one row per PR. The agents need to read both the title AND the `## Results`
+section to assign an accurate outcome — title-based keywords set the category, the results
+section determines whether it worked.
+
+Give each agent these instructions (substituting LINE_START, LINE_END, PR range):
+
+> Read `<summary_path>` from line LINE_START to LINE_END.
+> For every PR in this range return exactly one row:
+> `PR #NNN | STATE | Category | emoji | 1-line outcome`
+>
+> **STATE**: MERGED / CLOSED / OPEN (from the `| State |` header table in each PR block)
+>
+> **Category** — pick exactly one based on the primary change being tested:
+> 1. **Loss function** — loss type (L1, MSE, Huber, cosine sim, asymmetric surf/vol split)
+> 2. **LR / optimizer** — learning rate value, warmup, scheduler, weight decay, β params, optimizer choice
+> 3. **Model architecture** — depth (n_layers), width (n_hidden), n_heads, mlp_ratio, output head design, preprocess MLP structure
+> 4. **Initialization** — weight init strategy (Xavier, Kaiming, orthogonal, learnable placeholders, init scale/gain)
+> 5. **Training efficiency** — bf16 autocast, batch size, gradient accumulation, volume node subsampling, epoch budget tricks
+> 6. **Regularization** — dropout, SWA, EMA, target noise magnitude/schedule, gradient clipping, spectral norm
+> 7. **Physics / normalization** — Cp normalization, per-sample normalization, domain-aware scaling, split surf/vol stats
+> 8. **Loss weighting** — surf_weight value or schedule, per-channel weights, domain re-weighting
+> 9. **Feature engineering** — slice count/structure, attention temperature, spatial/positional encoding (RFF, NeRF)
+> 10. **Inference fix** — fp32 for OOD splits, NaN guards, denormalization fixes, clamping
+>
+> **emoji**: ✓ improved primary metric (mae_surf_p on val_in_dist), ✗ hurt it, ~ inconclusive/noise-level, — no results yet
+>
+> **1-line outcome**: state what changed, the key metric delta (e.g. "mae_surf_p 119→103 (-14%)"), and the reason it succeeded or failed. If Results section is empty, write "No results".
+>
+> Return ONLY the data rows — no headers, no commentary.
+
+---
+
+## Step 4: Synthesize into report
+
+Combine all rows and produce a 5-section markdown report:
+
+**Section 1 — Full PR Catalogue**
+Table: `| PR | State | Category | Result | Outcome |`
+All PRs sorted by number. OPEN PRs included but marked `—`.
+
+**Section 2 — Category Breakdown (completed PRs only)**
+Table: `| Category | Total | Merged | Closed | Merge Rate | Merged PRs |`
+Compute merge rate = MERGED ÷ (MERGED + CLOSED). Sort descending by merge rate.
+OPEN PRs excluded from totals and rates.
+
+**Section 3 — Merged PRs Only**
+For each category that has merges: list the merged PRs and a sentence on what the wins had in common.
+
+**Section 4 — Closed PRs — Failure Patterns**
+Table: `| Category | Closed | Hard ✗ | Inconclusive ~ | Showed promise ✓ (not merged) |`
+Call out which categories had PRs that showed improvement but still weren't merged.
+
+**Section 5 — Key Narratives**
+3–5 bullet points on cross-cutting patterns: what reliably works, what never works,
+what the current productive frontier looks like (recent OPEN PRs).
+
+---
+
+## Notes
+
+- **OPEN PRs**: include in catalogue with `—` outcome; exclude from all merge-rate calculations.
+- **Primary metric**: `mae_surf_p` on `val_in_dist`. When that's unavailable use any reported split. Lower is better.
+- **Metric era shift**: Cp normalization (around PR #392 in the noam track) changed mae_surf_p from ~80–200 Pa to ~20–50 Pa range. Don't compare raw numbers across this boundary — only relative improvement within each era matters.
+- **Initialization vs Model architecture**: If a PR changes *only* the init strategy (Xavier, orthogonal, Kaiming, learnable init), use **Initialization**. If it changes both init and something structural, use whichever is the primary tested hypothesis.

--- a/.agents/skills/analyze-experiments/evals/evals.json
+++ b/.agents/skills/analyze-experiments/evals/evals.json
@@ -1,0 +1,104 @@
+{
+  "skill_name": "analyze-experiments",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "pull the latest noam branch experiments and give me a full category breakdown — what's been tried, what merged, what closed",
+      "expected_output": "A markdown report with: (1) full PR catalogue table, (2) category breakdown table with merge rates, (3) merged-only summary, (4) closed-only failure patterns, (5) key narrative insights. Should use parallel subagents to analyze the PRs.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "uses-9-category-taxonomy",
+          "description": "Report uses the exact 9 categories: Loss function, LR / optimizer, Model architecture, Training efficiency, Regularization, Physics / normalization, Loss weighting, Feature engineering, Inference fix — at least 7 of 9 must appear",
+          "type": "content_check"
+        },
+        {
+          "name": "has-three-views",
+          "description": "Report contains all three views: all PRs, merged-only, and closed-only sections",
+          "type": "content_check"
+        },
+        {
+          "name": "includes-merge-rates",
+          "description": "Category breakdown table includes merge rate percentages",
+          "type": "content_check"
+        },
+        {
+          "name": "includes-pr-catalogue",
+          "description": "Report includes a full PR catalogue table with individual PR rows (not just summaries)",
+          "type": "content_check"
+        },
+        {
+          "name": "identifies-cp-normalization-as-step-change",
+          "description": "Report identifies PR #392 (Cp normalization) as a major/step-change improvement",
+          "type": "content_check"
+        },
+        {
+          "name": "has-narrative-insights",
+          "description": "Report includes a narrative insights or key findings section with cross-cutting patterns",
+          "type": "content_check"
+        },
+        {
+          "name": "report-length",
+          "description": "Report is at least 1000 words (comprehensive analysis of 150 PRs)",
+          "type": "length_check"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "prompt": "i want to understand which experiment categories have had the best success rate in the senpai project. fetch the latest data and categorize all the PRs",
+      "expected_output": "A category breakdown showing merge rates per category, with the full PR catalogue and identification of which categories produced the most merged PRs.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "uses-9-category-taxonomy",
+          "description": "Report uses the exact 9 categories from the skill taxonomy — at least 7 must appear",
+          "type": "content_check"
+        },
+        {
+          "name": "has-merge-rate-comparison",
+          "description": "Report ranks or compares categories by success/merge rate",
+          "type": "content_check"
+        },
+        {
+          "name": "includes-pr-catalogue",
+          "description": "Report includes individual PR entries, not just aggregate counts",
+          "type": "content_check"
+        },
+        {
+          "name": "fetches-fresh-data",
+          "description": "Report mentions fetching data or running a script (not just working from memory)",
+          "type": "content_check"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "bucket the experiment prs — show me all, then just the merged ones, then just the failed ones",
+      "expected_output": "Three views of the experiment PRs: all PRs categorized, merged-only view, closed-only failure patterns view. Categories from the 9-category taxonomy.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "has-all-prs-section",
+          "description": "Report has a section showing all PRs (or a full catalogue)",
+          "type": "content_check"
+        },
+        {
+          "name": "has-merged-only-section",
+          "description": "Report has a distinct section for merged/successful PRs only",
+          "type": "content_check"
+        },
+        {
+          "name": "has-closed-only-section",
+          "description": "Report has a distinct section for closed/failed PRs only",
+          "type": "content_check"
+        },
+        {
+          "name": "uses-consistent-categories",
+          "description": "All three views use consistent category names from the 9-category taxonomy",
+          "type": "content_check"
+        }
+      ]
+    }
+  ]
+}

--- a/.agents/skills/git-research-log/SKILL.md
+++ b/.agents/skills/git-research-log/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: git-research-log
+description: >
+  How to document and publish ML experiment results to GitHub as a pull request.
+  Use this skill whenever a student agent has finished running experiments and
+  needs to create or update a PR — even if the instruction is just "wrap up" or
+  "log your results" or "open a PR". Also use it mid-session to update an
+  in-progress PR as trials complete.
+---
+
+# Experiment PR Skill
+
+The master agent creates an empty PR and hands it to you. Your job is to fill it out as you run trials and finalize it when you're done. The master reads these PRs to decide what to explore next — completeness and honest analysis matter more than polish.
+
+## PR Title Format
+
+```
+<experiment-name> <best-wandb-run-id-if-there-is-a-positive-result>
+```
+
+- `experiment-name`: the idea you explored (e.g. `multi-scale-attn`, `surface-loss-reweight`)
+- `best-wandb-run-id`: W&B run ID of your best result (or most recent if all crashed)
+
+## PR Description Template
+
+Fill this in as you go. Write the TL;DR last, once all trials are done.
+
+```markdown
+# <agent-name>-<experiment-name>-<best-wandb-run-id>
+
+## TL;DR - Result summary
+<2-4 sentences: what you tried, what happened overall, and the bottom line verdict>
+
+<!-- Fill in the block below only if a trial beat the baseline. Otherwise delete it. -->
+**Main Hypothesis:** <what you believed would work and why>
+**Key Result:** val_loss=X.XX | surf_Ux=X.XX | surf_p=XX.X (vs baseline: val_loss=X.XX)
+**wandb:** <url to the best run>
+
+## Trials run
+
+### <YYYY-MM-DD_HH-MM> <wandb_run_id> <trial-name>
+**Hypothesis:** <what you expected this specific run to show>
+**Background research:** <relevant context — papers, similar approaches, why you thought this might work>
+**Result:** val_loss=X.XX | surf_Ux=X.XX | surf_p=XX.X | memory=XX.XGB | status=keep/discard/crash
+**wandb:** <wandb run url>
+**Conclusion:** <what this result tells you — did the hypothesis hold? what would you try next?>
+
+### <YYYY-MM-DD_HH-MM> <wandb_run_id> <trial-name>
+...
+```
+
+Trials are ordered chronologically by start time, oldest first.
+
+## Workflow
+
+1. **Start of session**: read the PR the master created to understand your assignment
+2. **After first trial completes**: edit the PR body to add the first trial entry; set the title
+3. **As each subsequent trial finishes**: add a comment with quick metrics, then update the description to add the full trial entry
+4. **When all trials are done**: write the TL;DR, set labels, promote to ready for review
+
+Starting the PR early lets the master see in-progress results and potentially redirect you before you've finished all planned trials.

--- a/.agents/skills/git-research-log/evals/evals.json
+++ b/.agents/skills/git-research-log/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "git-research-log",
+  "evals": [
+    {
+      "id": 0,
+      "name": "fresh-assignment",
+      "prompt": "You are student-1, a student ML research agent. The master agent assigned you to explore multi-scale attention and opened PR #42 on your branch. You've now finished all 3 trials. Here are the results:\n\nTrial 1 (2026-03-13 09:15, wandb run abc123def): Basic multi-scale attention implementation. val_loss=14.2, surf_Ux=1.05, surf_p=78.3, memory=55.1GB. Tried adding a second attention scale by splitting the slice count and running two parallel attention streams at different resolutions.\n\nTrial 2 (2026-03-13 09:28, wandb run ghi456jkl): Added layer norm between scales. val_loss=13.1, surf_Ux=0.98, surf_p=72.1, memory=55.4GB.\n\nTrial 3 (2026-03-13 09:41, wandb run mno789pqr): Tuned learning rate to 3e-4 and added cosine warmup. val_loss=12.8, surf_Ux=0.91, surf_p=69.5, memory=55.4GB. This is the best result.\n\nBaseline: val_loss=15.2, surf_Ux=1.19, surf_p=83.2.\n\nFill out and finalize PR #42. Set the title, write the complete description using the correct format, add appropriate labels, and mark it ready for review. Save all the gh commands and the full PR body to a file called pr_update.md.",
+      "expected_output": "A pr_update.md file containing: correct title format, complete PR description with TL;DR and all 3 trials filled out with all required fields, gh commands to edit the PR, add labels, and mark ready for review."
+    },
+    {
+      "id": 1,
+      "name": "mid-session-update",
+      "prompt": "You are student-2, a student ML research agent. The master assigned you to explore surface loss reweighting (PR #43). Your first trial just finished and 2 more are still running.\n\nTrial 1 just done (2026-03-13 10:05, wandb run stu012vwx): Increased surf_weight from 10 to 25. val_loss=13.9, surf_Ux=1.02, surf_p=75.4, memory=54.0GB. Better than baseline (15.2) but you're not done yet.\n\nBaseline: val_loss=15.2, surf_Ux=1.19, surf_p=83.2.\n\nDo a mid-session update to PR #43: add a comment with the trial 1 results and update the description to include trial 1. Don't finalize yet — more trials are still running. Save the gh commands and PR body so far to pr_update.md.",
+      "expected_output": "A pr_update.md showing: a gh pr comment with the trial 1 metrics, and an updated PR description including trial 1 with all required fields. Should NOT mark ready for review or write a TL;DR yet."
+    },
+    {
+      "id": 2,
+      "name": "all-crashed",
+      "prompt": "You are student-3, a student ML research agent. The master assigned you to try a wider model (2x hidden dimensions). PR #44 was opened for you. All 3 trials crashed with OOM.\n\nTrial 1 (2026-03-13 11:00, wandb run yza111bcd): 2x width everywhere (dim 256→512). OOM at epoch 1.\nTrial 2 (2026-03-13 11:08, wandb run efg222hij): 1.5x width. OOM at epoch 1.\nTrial 3 (2026-03-13 11:15, wandb run klm333nop): 1.25x width. Ran 2 epochs then OOM. val_loss=16.1 at checkpoint before crash.\n\nFinalize PR #44 with an honest failure report. Save all gh commands and the full PR body to pr_update.md.",
+      "expected_output": "A pr_update.md with: TL;DR describing that the wider model approach is memory-constrained on this hardware, all 3 crash trials documented, crash label applied, no improvement label, and PR marked ready for review."
+    }
+  ]
+}

--- a/.agents/skills/list-experiments/SKILL.md
+++ b/.agents/skills/list-experiments/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: list-experiments
+description: Use this skill whenever you need to list all of the experiment ideas tried and in progress for this research programme. It outputs 3 files organized by usefulness — merged winners, a compact results table, and full details for deep dives. Use when generating new experimental ideas to check what has already been tried.
+---
+
+# List Experiments
+
+Run the script below to fetch all experiment PRs from the advisor branch and organize them into 3 files.
+
+The `BASE_BRANCH` should be set to the advisor branch (e.g. `noam`). Check the `$ADVISOR_BRANCH` env var or the PR base branch.
+
+## Code
+
+```python
+import subprocess, json, os, re
+from datetime import datetime
+
+BASE_BRANCH = os.environ.get("ADVISOR_BRANCH", "noam")
+
+def get_repo_info():
+    r = subprocess.run(["gh", "repo", "view", "--json", "owner,name"], capture_output=True, text=True)
+    if r.returncode:
+        raise RuntimeError(r.stderr)
+    info = json.loads(r.stdout)
+    return info["owner"]["login"], info["name"]
+
+def fetch():
+    """Fetch PRs with comments via GraphQL (single API call, paginated)."""
+    owner, name = get_repo_info()
+    prs = []
+    cursor = None
+    while True:
+        after = f', after: "{cursor}"' if cursor else ""
+        query = f'''{{
+          repository(owner: "{owner}", name: "{name}") {{
+            pullRequests(first: 100, baseRefName: "{BASE_BRANCH}", states: [OPEN, CLOSED, MERGED]{after}) {{
+              pageInfo {{ hasNextPage endCursor }}
+              nodes {{
+                number title body state mergedAt url
+                labels(first: 10) {{ nodes {{ name }} }}
+                comments(first: 100) {{ nodes {{ body }} }}
+              }}
+            }}
+          }}
+        }}'''
+        r = subprocess.run(["gh", "api", "graphql", "-f", f"query={query}"], capture_output=True, text=True)
+        if r.returncode:
+            raise RuntimeError(r.stderr)
+        data = json.loads(r.stdout)["data"]["repository"]["pullRequests"]
+        for node in data["nodes"]:
+            prs.append({
+                "number": node["number"],
+                "title": node["title"],
+                "body": node["body"] or "",
+                "state": node["state"],
+                "mergedAt": node["mergedAt"],
+                "url": node["url"],
+                "labels": [{"name": l["name"]} for l in node["labels"]["nodes"]],
+                "comments": [c["body"] for c in node["comments"]["nodes"]],
+            })
+        if not data["pageInfo"]["hasNextPage"]:
+            break
+        cursor = data["pageInfo"]["endCursor"]
+    return prs
+
+def extract_section(text, header):
+    """Extract a markdown section (# or ##) by header name."""
+    match = re.search(rf'(^#{{1,2}} {header}.*?)(?=^#{{1,2}} |\Z)', text, re.MULTILINE | re.DOTALL)
+    return match.group(1).strip() if match else None
+
+def find_results_text(pr):
+    """Search body then comments (newest first) for the Results section."""
+    body = pr.get("body", "") or ""
+    section = extract_section(body, "Results")
+    if section and "_To be filled" not in section:
+        return section
+    for comment in reversed(pr.get("comments", [])):
+        section = extract_section(comment, "Results")
+        if section and "_To be filled" not in section:
+            return section
+    return None
+
+def extract_val_loss(text):
+    if not text:
+        return None
+    patterns = [
+        r'val[/_]loss[:\s]*\*?\*?(\d+\.\d+)',
+        r'\*\*val/loss\*\*[:\s|]*\*?\*?(\d+\.\d+)',
+        r'val/loss[:\s|]+(\d+\.\d+)',
+    ]
+    for p in patterns:
+        m = re.search(p, text, re.IGNORECASE)
+        if m:
+            return float(m.group(1))
+    return None
+
+def has_results(pr):
+    return find_results_text(pr) is not None
+
+def labels_str(pr):
+    return ", ".join(l["name"] for l in pr.get("labels", []))
+
+def hypothesis_oneline(body):
+    """Extract first sentence of hypothesis."""
+    sec = extract_section(body or "", "Hypothesis")
+    if not sec:
+        return ""
+    text = re.sub(r'^#{1,2} Hypothesis\n', '', sec).strip()
+    m = re.match(r'(.+?[.!])\s', text)
+    return m.group(1) if m else text[:120]
+
+# --- Fetch ---
+prs = fetch()
+merged = sorted([p for p in prs if p.get("mergedAt")], key=lambda p: p["mergedAt"])
+with_results = [p for p in prs if has_results(p) and not p.get("mergedAt")]
+no_results = [p for p in prs if not has_results(p)]
+
+ts = datetime.now().strftime("%Y-%m-%d_%H-%M")
+outdir = "experiment_log"
+os.makedirs(outdir, exist_ok=True)
+
+# --- File 1: Merged winners (chronological) ---
+merged_path = f"{outdir}/merged_{ts}.md"
+with open(merged_path, "w") as f:
+    f.write(f"# Merged Experiments ({len(merged)} winners)\n\n")
+    f.write("These PRs beat baseline and were merged, in chronological order.\n\n")
+    for pr in merged:
+        body = pr.get("body", "") or ""
+        hyp = extract_section(body, "Hypothesis") or ""
+        results = find_results_text(pr) or ""
+        val = extract_val_loss(results)
+        val_str = f" | val_loss: {val}" if val else ""
+        f.write(f"## #{pr['number']}: {pr['title']}{val_str}\n\n")
+        if hyp:
+            f.write(f"{hyp}\n\n")
+        if results:
+            f.write(f"{results}\n\n")
+        f.write("---\n\n")
+
+# --- File 2: Compact results table ---
+table_path = f"{outdir}/results_table_{ts}.md"
+with open(table_path, "w") as f:
+    f.write(f"# Experiment Results Table\n\n")
+    f.write(f"Total: {len(prs)} PRs | Merged: {len(merged)} | ")
+    f.write(f"Ran (not merged): {len(with_results)} | Never ran: {len(no_results)}\n\n")
+
+    f.write("## Merged\n\n")
+    f.write("| PR | Title | val_loss |\n|---|---|---|\n")
+    for pr in merged:
+        results = find_results_text(pr)
+        val = extract_val_loss(results)
+        val_str = f"{val:.4f}" if val else "—"
+        f.write(f"| #{pr['number']} | {pr['title']} | {val_str} |\n")
+
+    f.write(f"\n## Ran but not merged ({len(with_results)})\n\n")
+    f.write("| PR | Title | val_loss | Hypothesis (short) |\n|---|---|---|---|\n")
+    for pr in sorted(with_results, key=lambda p: p["number"], reverse=True):
+        body = pr.get("body", "") or ""
+        results = find_results_text(pr)
+        val = extract_val_loss(results)
+        val_str = f"{val:.4f}" if val else "—"
+        hyp = hypothesis_oneline(body)
+        f.write(f"| #{pr['number']} | {pr['title']} | {val_str} | {hyp[:80]} |\n")
+
+    f.write(f"\n## Never ran ({len(no_results)})\n\n")
+    f.write("| PR | Title | Hypothesis (short) |\n|---|---|---|\n")
+    for pr in sorted(no_results, key=lambda p: p["number"], reverse=True):
+        hyp = hypothesis_oneline(pr.get("body", ""))
+        f.write(f"| #{pr['number']} | {pr['title']} | {hyp[:80]} |\n")
+
+# --- File 3: Full details (only PRs that ran) ---
+full_path = f"{outdir}/full_details_{ts}.md"
+with open(full_path, "w") as f:
+    f.write(f"# Full Experiment Details ({len(merged) + len(with_results)} experiments)\n\n")
+    for pr in merged + sorted(with_results, key=lambda p: p["number"], reverse=True):
+        body = pr.get("body", "").strip() or "_No description._"
+        state = "MERGED" if pr.get("mergedAt") else "CLOSED"
+        f.write(f"# #{pr['number']}: {pr['title']} [{state}]\n\n{body}\n\n")
+        results = find_results_text(pr)
+        if results and results not in body:
+            f.write(f"{results}\n\n")
+        f.write("---\n\n")
+
+print(f"Saved {len(prs)} PRs ({len(merged)} merged, {len(with_results)} ran, {len(no_results)} never ran):")
+print(f"  {merged_path}         — merged winners with hypothesis + results")
+print(f"  {table_path}   — compact table of all experiments")
+print(f"  {full_path}   — full PR bodies (only experiments that ran)")
+```

--- a/.agents/skills/plot-experiment-charts/SKILL.md
+++ b/.agents/skills/plot-experiment-charts/SKILL.md
@@ -1,0 +1,104 @@
+---
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+name: plot-experiment-charts
+description: >
+  Generate a training curve comparison chart and embed it in a GitHub PR description.
+  Use this skill whenever a student has finished running experiments and is preparing
+  to submit their PR for advisor review. Triggers on: "plot training curves", "add chart
+  to PR", "visualize experiment", "training curve comparison", "plot-experiment-charts",
+  "add chart", "generate comparison chart". Run this before marking the PR ready for review.
+---
+
+# Plot Experiment Charts
+
+You've just finished one or more training runs. Before submitting for review, generate a
+comparison chart so the advisor can see the training dynamics at a glance — not just the
+final numbers, but how the experiment got there. A bolded best-run line and a properly
+scaled y-axis make the story immediately readable, even if some runs diverged.
+
+This skill takes about 30 seconds. It's worth it.
+
+## What you need
+
+- **Baseline W&B run ID**: in the PR body under `## Baseline`, look for the `W&B run: \`xxxxxxxx\`` line.
+- **Your own run IDs**: the 8-character W&B IDs of the runs you just completed. Find them in the W&B run URLs or in the training output (the run ID is printed at launch).
+- **W&B credentials**: `WANDB_ENTITY` and `WANDB_PROJECT` env vars (already set in the pod environment).
+
+## Step 1 — Run the script
+
+```bash
+uv run .agents/skills/plot-experiment-charts/scripts/plot_training_curves.py \
+  --baseline <baseline-run-id> \
+  --runs <your-run-id-1>,<your-run-id-2>,...
+```
+
+The script automatically:
+- Downloads the full training history for each run using W&B's `beta_scan_history` (fast, batched)
+- Detects which of your runs achieved the lowest final `val_in_dist/mae_surf_p` and **bolds it**
+- Clamps the y-axis so the baseline curve stays readable even if some runs diverged
+- Saves `training_curves.png` in the current directory
+- Prints the GitHub raw URL to embed
+
+If you want to override which run gets bolded, pass `--bold <run-id>`.
+
+**Full flag reference:**
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--baseline` | required | 8-char W&B run ID of the current best baseline |
+| `--runs` | required | Comma-separated run IDs for your experiments (1–8) |
+| `--bold` | auto | Override which run gets the bold treatment |
+| `--output` | `training_curves.png` | Output filename |
+| `--entity` | `$WANDB_ENTITY` | W&B entity |
+| `--project` | `$WANDB_PROJECT` | W&B project |
+
+## Step 2 — Commit the chart alongside train.py
+
+```bash
+git add train.py training_curves.png
+git commit -m "<your experiment description>"
+git push origin <branch>
+```
+
+The chart lives on the experiment branch. It's visible during review — which is the only time it matters. After the PR is squash-merged and the branch deleted, the image in the archived PR body will show as broken, but by then the advisor has already reviewed it.
+
+## Step 3 — Embed in the PR body
+
+The script prints a raw GitHub URL when it finishes. Copy it and add this to the `## Results` section of the PR body:
+
+```markdown
+## Results
+
+![Training curves](https://raw.githubusercontent.com/owner/repo/branch/training_curves.png)
+
+| Metric | Baseline | This run |
+| ... |
+```
+
+Put the chart *before* the metrics table so the advisor sees the curves first, then the numbers.
+
+## Reading the chart
+
+Two panels, side by side:
+
+- **Left**: `val_in_dist/mae_surf_p` — surface pressure MAE on in-distribution data. This is the primary metric. Lower is better.
+- **Right**: `val/loss` — combined validation loss across all splits. Lower is better.
+
+The **black dashed line** is the baseline. Your runs are colored lines. The **bold colored line** is your best run — the one that would be a candidate for merging.
+
+The y-axis is clamped at 3× the baseline's best value. If a run diverges far above that, it's clipped — that's fine, the advisor just needs to see "this diverged" rather than the exact value. The important region (near the baseline) stays readable.
+
+## If a run crashed or never logged metrics
+
+The script skips runs with no history and prints a warning. Include the missing run IDs in your PR results section with a note about why they crashed — don't silently omit them.
+
+## Troubleshooting
+
+**"Run not found"** — Double-check the run ID (8 alphanumeric chars, case-sensitive). The run ID is in the W&B run URL: `wandb.ai/{entity}/{project}/runs/{run-id}`.
+
+**"No data for key val_in_dist/mae_surf_p"** — The run may have crashed before the first validation epoch. Check the run logs. Still include it in the chart call — the script handles empty runs gracefully.
+
+**Script not found** — Run from the repo root: `uv run .agents/skills/plot-experiment-charts/scripts/plot_training_curves.py ...`. If the helper script is not present in this repo checkout, generate the comparison chart manually from W&B history instead of blocking on the helper.

--- a/.agents/skills/rlm/SKILL.md
+++ b/.agents/skills/rlm/SKILL.md
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+---
+name: rlm
+description: >
+  Recursive Language Model (RLM) helper for writing parallel async LLM pipelines.
+  Use this skill whenever the task involves processing many items with an LLM in
+  parallel: fan-out extraction, batch classification, bulk annotation, parallel
+  summarisation, or any "map each item → LLM call → aggregate results" workflow.
+  Triggers for: "process all X in parallel", "use RLM", "fan out LLM calls",
+  "batch LLM", "parallel Codex calls", "process hundreds of PRs / files / rows
+  with Codex", "RLM pattern", "recursive language model", "async LLM", "sub-LLM".
+  Also use proactively whenever a script needs to call the Anthropic API in a loop
+  over a list of items — replace the loop with this pattern instead.
+---
+
+# RLM (Recursive Language Model) Skill
+
+**Based on:** [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) — Zhang, Kraska & Khattab (MIT, 2025)
+**Reference implementation:** `tools/update_wandb_run_metadata.py` — extracts W&B run IDs from 1,678 PR bodies using 30 parallel sub-LLM calls.
+
+---
+
+## Core concept
+
+Instead of one LLM call over a huge context, the **root** (this script/agent) splits
+the input into atomic items and fans out to parallel **sub-LLMs** — one call per item.
+Each sub-LLM operates on a small, focused context and returns structured JSON.
+The root aggregates the results.
+
+```
+Root orchestrator (this script)
+├── item_0  →  sub-LLM call  →  result_0
+├── item_1  →  sub-LLM call  →  result_1   (all fired concurrently,
+├── item_2  →  sub-LLM call  →  result_2    capped by semaphore)
+│   ...
+└── item_N  →  sub-LLM call  →  result_N
+```
+
+The four strategies from the paper — use the one that fits:
+
+| Strategy | When to use | Sub-LLM prompt shape |
+|---|---|---|
+| **Peek** | Inspect a sample before committing to a strategy | "Here are 3 rows — what fields exist?" |
+| **Grep** | Narrow a large corpus to relevant items first | "Does this chunk contain X? Answer yes/no" |
+| **Partition + Map** | Process every item independently | "Extract Y from this item. Return JSON." |
+| **Summarise** | Compress each chunk before a second aggregation pass | "Summarise the key facts in 3 sentences." |
+
+For most senpai tasks (PR analysis, run tagging, metric extraction) **Partition + Map** is the right choice.
+
+---
+
+## Boilerplate template
+
+Copy this and fill in the three marked sections.
+
+```python
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""<One-line description of what this script does.>
+
+RLM pattern: root fans out to up to LLM_CONCURRENCY parallel sub-LLM calls,
+one per item. Each sub-LLM returns structured JSON.
+
+Usage: uv run tools/<script_name>.py
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from anthropic import AsyncAnthropic
+from dotenv import load_dotenv
+from tqdm.asyncio import tqdm as atqdm
+
+# ---------------------------------------------------------------------------
+# Config — adjust as needed
+# ---------------------------------------------------------------------------
+
+MODEL = "Codex-sonnet-4-6"       # sub-LLM model
+LLM_CONCURRENCY = 30              # max parallel API calls (safe limit for Sonnet)
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+# ---------------------------------------------------------------------------
+# ① SUB-LLM PROMPT — fill this in
+# ---------------------------------------------------------------------------
+
+PROMPT_TEMPLATE = """\
+<Task description for the sub-LLM. Be explicit about the output format.>
+
+Item:
+{item_text}
+
+Respond ONLY with valid JSON, no other text:
+{{"field1": "...", "field2": [...]}}
+If nothing found: {{"field1": null, "field2": []}}"""
+
+
+# ---------------------------------------------------------------------------
+# ② SUB-LLM CALL — one per item
+# ---------------------------------------------------------------------------
+
+async def process_item(
+    item: dict,                        # dict with at minimum an "id" key
+    client: AsyncAnthropic,
+    sem: asyncio.Semaphore,
+) -> dict:
+    """Call the sub-LLM for a single item. Returns item dict merged with result."""
+    # ③ EXTRACT the text to pass to the LLM from your item dict
+    item_text = item.get("body") or item.get("text") or str(item)
+
+    if not item_text.strip():
+        return {**item, "llm_result": None}
+
+    async with sem:
+        response = await client.messages.create(
+            model=MODEL,
+            max_tokens=512,                    # increase for longer responses
+            messages=[{
+                "role": "user",
+                "content": PROMPT_TEMPLATE.format(item_text=item_text[:12_000]),
+            }],
+        )
+
+    parsed = json.loads(response.content[0].text.strip())
+    return {**item, "llm_result": parsed}
+
+
+# ---------------------------------------------------------------------------
+# ROOT ORCHESTRATOR — fan-out + aggregate
+# ---------------------------------------------------------------------------
+
+async def run_rlm(items: list[dict]) -> list[dict]:
+    """Fan out sub-LLM calls over all items, return results in completion order."""
+    client = AsyncAnthropic()
+    sem = asyncio.Semaphore(LLM_CONCURRENCY)
+    tasks = [process_item(item, client, sem) for item in items]
+    return await atqdm.gather(*tasks, desc=f"RLM ({MODEL})", total=len(tasks))
+
+
+# ---------------------------------------------------------------------------
+# MAIN
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    # ③ LOAD YOUR ITEMS — replace with your actual data source
+    items = [
+        {"id": 1, "body": "first item text ..."},
+        {"id": 2, "body": "second item text ..."},
+    ]
+    print(f"Processing {len(items)} items with RLM...")
+    results = asyncio.run(run_rlm(items))
+
+    # ③ AGGREGATE — replace with your actual post-processing
+    for r in results:
+        if r.get("llm_result"):
+            print(r["id"], r["llm_result"])
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Rate limits and concurrency
+
+| Model | Safe `LLM_CONCURRENCY` | Notes |
+|---|---|---|
+| `Codex-sonnet-4-6` | 30 | Default — good balance of speed and cost |
+| `Codex-haiku-4-5` | 50 | Use for cheap, high-volume sub-calls |
+| `Codex-opus-4-6` | 5 | Heavy model; use only for root-level synthesis |
+
+Use a **second semaphore** for downstream rate-limited APIs (e.g. W&B, GitHub):
+
+```python
+WANDB_CONCURRENCY = 10   # W&B API is stricter than Anthropic
+
+async def update_downstream(item: dict, api, sem: asyncio.Semaphore) -> bool:
+    async with sem:
+        try:
+            return await asyncio.to_thread(_sync_api_call, item)
+        except Exception as e:
+            print(f"\n  [skip] {item['id']}: {e}", file=sys.stderr)
+            return False
+
+async def run_updates(items: list[dict], api) -> int:
+    sem = asyncio.Semaphore(WANDB_CONCURRENCY)
+    tasks = [update_downstream(item, api, sem) for item in items]
+    results = await atqdm.gather(*tasks, desc="Updating downstream", total=len(tasks))
+    return sum(results)
+```
+
+---
+
+## Prompt engineering for sub-LLMs
+
+Sub-LLM prompts should be:
+
+1. **Extractive, not generative** — "extract X" not "describe X". Constrain the search space.
+2. **JSON-only output** — always end with `Respond ONLY with valid JSON`. Avoids markdown fences.
+3. **Schema explicit in the prompt** — show the exact keys and types expected.
+4. **Null/empty case handled** — always include the empty-result example so the model doesn't hallucinate.
+5. **Item context in the prompt header** — include `PR #NNN: title` or similar so the model can orient itself.
+
+**Validation pattern** — always validate LLM output before use:
+
+```python
+def validate_run_ids(raw: list) -> list[str]:
+    """Example: validate 8-char W&B run IDs."""
+    return [
+        r for r in raw
+        if isinstance(r, str)
+        and len(r) == 8
+        and r.isalnum()
+        and any(c.isdigit() for c in r)
+    ]
+```
+
+---
+
+## Two-pass pattern: regex first, LLM second
+
+For extraction tasks where a regex can find most cases, use it as a cheap first pass and
+only invoke LLM where needed. This cuts cost by ~80% on typical PR corpora:
+
+```python
+def regex_pass(items: list[dict]) -> dict[int, list[str]]:
+    return {item["id"]: RUN_ID_RE.findall(item.get("body", "")) for item in items}
+
+async def llm_pass(items: list[dict]) -> dict[int, list[str]]:
+    results = await run_rlm(items)
+    return {r["id"]: r["llm_result"].get("run_ids", []) for r in results}
+
+def merge(regex: dict, llm: dict, ids: list[int]) -> dict[int, list[str]]:
+    """Prefer LLM result; fall back to regex."""
+    return {i: (llm.get(i) or regex.get(i, [])) for i in ids}
+```
+
+---
+
+## Multi-role classification
+
+When a single item has multiple extracted entities that need different labels (e.g. one PR
+has a "final" run and several "pre-merge" runs), ask the sub-LLM to classify each entity:
+
+```python
+PROMPT_TEMPLATE = """\
+Extract all W&B run IDs from this PR body and classify each one.
+
+Roles:
+- "final": the best/featured run reported in the Results section (at most one)
+- "pre-merge": earlier or preliminary runs mentioned in the body
+
+PR #{pr_number}: {pr_title}
+
+{pr_body}
+
+Respond ONLY with valid JSON:
+{{"runs": [{{"run_id": "abc12345", "role": "final"}}, {{"run_id": "xyz98765", "role": "pre-merge"}}]}}
+If no run IDs: {{"runs": []}}"""
+```
+
+---
+
+## Error handling philosophy
+
+- **Don't wrap sub-LLM calls in try/except** — let `asyncio.gather` propagate LLM errors.
+  A malformed JSON response from one call failing the whole batch surfaces the bug immediately.
+- **Do wrap downstream side-effects** (W&B updates, DB writes, file writes) in a narrow
+  try/except — these fail for external reasons (404, rate limit) unrelated to the logic.
+- **json.loads will raise on bad JSON** — this is intentional. If you need resilience,
+  add a Peek pass first to validate the model reliably returns JSON before the main run.
+
+---
+
+## Worked example in this repo
+
+**`tools/update_wandb_run_metadata.py`** — full production example:
+- **Input**: 1,678 GitHub PRs (closed + merged)
+- **Partition + Map**: 30 parallel `Codex-sonnet-4-6` calls extract W&B run IDs + classify role
+- **Downstream action**: 10-concurrent W&B config updates via `asyncio.to_thread`
+- **Result**: 1,255 W&B runs tagged with `gh_pr_branch`, `gh_pr_status`, `gh_pr_url`, `gh_pr_run_stage`
+- **Wall time**: ~4 min LLM pass + ~2 min W&B pass for 1,678 items
+
+Key excerpt:
+
+```python
+async def run_llm_pass(prs: list[dict], client: AsyncAnthropic) -> dict[int, list[dict]]:
+    sem = asyncio.Semaphore(LLM_CONCURRENCY)   # 30
+    tasks = [extract_runs_llm(pr, client, sem) for pr in prs]
+    results = await atqdm.gather(*tasks, desc="RLM: extracting run IDs", total=len(tasks))
+    return {pr["number"]: runs for pr, runs in zip(prs, results)}
+```
+
+---
+
+## When NOT to use RLM
+
+| Situation | Better approach |
+|---|---|
+| Single item or < 5 items | Direct LLM call, no async needed |
+| Items have dependencies (B needs A's output) | Sequential chain, not fan-out |
+| Need the LLM to reason across all items together | Single call with all items in context |
+| Pure regex/heuristic suffices | Skip LLM entirely |
+| Reading a codebase for patterns | Use Codex's built-in Grep/Read tools |

--- a/.agents/skills/slidev/SKILL.md
+++ b/.agents/skills/slidev/SKILL.md
@@ -1,0 +1,970 @@
+---
+name: slidev
+description: Comprehensive guide for Slidev - a web-based presentation framework for developers. Covers Markdown syntax, layouts, components, animations, theming, and exporting. Use this skill when creating or working with developer presentations using Slidev.
+---
+
+# Slidev
+
+## Overview
+
+Slidev is a presentation platform for developers that enables creating slides using Markdown while leveraging Vue and web technologies for interactive, pixel-perfect designs. This skill provides complete guidance for creating, customizing, and exporting Slidev presentations.
+
+Use this skill when:
+
+- Creating new developer presentations
+- Working with Markdown-based slides
+- Adding interactive components and animations
+- Customizing slide layouts and themes
+- Integrating code blocks with syntax highlighting
+- Exporting presentations to PDF, PPTX, or PNG
+- Setting up Slidev projects
+
+## Quick Start
+
+### Installation and Setup
+
+Create a new Slidev presentation:
+
+```bash
+# Using pnpm (recommended)
+pnpm create slidev
+
+# Using npm
+npm init slidev
+
+# Using yarn
+yarn create slidev
+
+# Using bun
+bun create slidev
+```
+
+Or try online at https://sli.dev/new (StackBlitz)
+
+### Essential Commands
+
+Start development server:
+
+```bash
+slidev
+# or specify entry file
+slidev slides.md
+```
+
+Build for production:
+
+```bash
+slidev build
+```
+
+Export to PDF:
+
+```bash
+slidev export
+```
+
+Export to other formats:
+
+```bash
+slidev export --format pptx
+slidev export --format png
+slidev export --format md
+```
+
+Format slides:
+
+```bash
+slidev format
+```
+
+---
+
+## Markdown Syntax
+
+### Slide Separators
+
+Separate slides with `---` padded by blank lines:
+
+```md
+# Slide 1
+
+Content here
+
+---
+
+# Slide 2
+
+More content
+```
+
+### Frontmatter and Headmatter
+
+Configure entire deck with headmatter (first YAML block):
+
+```md
+---
+theme: default
+background: https://cover.sli.dev
+title: My Presentation
+info: |
+  ## Slidev Starter
+  Presentation slides for developers
+class: text-center
+highlighter: shiki
+---
+```
+
+Configure individual slides with frontmatter:
+
+```md
+---
+layout: center
+background: ./images/bg.jpg
+class: text-white
+---
+
+# Centered Slide
+
+Content here
+```
+
+### Code Blocks
+
+Code with syntax highlighting:
+
+````md
+```ts
+console.log('Hello, World!')
+```
+````
+
+With line numbers:
+
+````md
+```ts {lines:true}
+function greet(name: string) {
+  console.log(`Hello, ${name}!`)
+}
+```
+````
+
+With line highlighting:
+
+````md
+```ts {2,4-6}
+function calculate() {
+  const x = 10  // highlighted
+  const y = 20
+  const sum = x + y  // highlighted
+  const product = x * y  // highlighted
+  const difference = x - y  // highlighted
+  return sum
+}
+```
+````
+
+### Presenter Notes
+
+Add notes at the end of slides using comment blocks:
+
+```md
+# Slide Title
+
+Content visible to audience
+
+<!--
+Notes for presenter only
+Can include **markdown** and HTML
+-->
+```
+
+---
+
+## Layouts
+
+### Using Layouts
+
+Specify layout in frontmatter:
+
+```md
+---
+layout: cover
+---
+
+# Presentation Title
+```
+
+### Built-in Layouts
+
+**Basic Layouts:**
+- `default` - Standard layout for any content
+- `center` - Centers content on screen
+- `cover` - Opening slide for presentations
+- `end` - Closing slide
+- `none` - Unstyled layout
+
+**Content Layouts:**
+- `intro` - Introduction with title and author details
+- `section` - Marks new presentation sections
+- `quote` - Displays quotations with emphasis
+- `fact` - Highlights data or facts prominently
+- `statement` - Features affirmations as main content
+- `full` - Utilizes entire screen space
+
+**Image Layouts:**
+- `image` - Full-screen image display
+- `image-left` - Image on left, content on right
+- `image-right` - Image on right, content on left
+
+**Iframe Layouts:**
+- `iframe` - Full-screen web page embedding
+- `iframe-left` - Web page on left side
+- `iframe-right` - Web page on right side
+
+**Multi-Column Layouts:**
+- `two-cols` - Two-column content separation
+- `two-cols-header` - Header spanning both columns with left/right split
+
+### Two-Column Layout Example
+
+```md
+---
+layout: two-cols
+---
+
+# Left Column
+
+Content for left side
+
+::right::
+
+# Right Column
+
+Content for right side
+```
+
+### Two-Column with Header
+
+```md
+---
+layout: two-cols-header
+---
+
+# Header Across Both Columns
+
+::left::
+
+Left column content
+
+::right::
+
+Right column content
+```
+
+---
+
+## Components
+
+### Built-in Components
+
+**Navigation:**
+- `<Link>` - Navigate between slides
+- `<Arrow>` - Directional lines with customization
+- `<VDragArrow>` - Draggable arrows
+
+**Text:**
+- `<AutoFitText>` - Auto-sizing text to fit container
+- `<TitleRenderer>` - Display parsed slide titles
+- `<Toc>` - Table of contents generation
+
+**Media:**
+- `<Youtube>` - Embed YouTube videos
+- `<Tweet>` - Embed Twitter posts
+- `<SlidevVideo>` - HTML5 video with autoplay
+
+**Utilities:**
+- `<SlideCurrentNo>` - Current slide number
+- `<SlidesTotal>` - Total slide count
+- `<Transform>` - Scaling and transformation
+- `<LightOrDark>` - Theme-based content rendering
+- `<RenderWhen>` - Conditional rendering by context
+- `<VSwitch>` - Cycle between content on click
+- `<VDrag>` - Draggable functionality
+
+### Component Usage Examples
+
+```md
+<Youtube id="dQw4w9WgXcQ" />
+
+<Tweet id="1234567890" />
+
+<Arrow x1="100" y1="100" x2="200" y2="200" />
+
+<AutoFitText :max="300" :min="20">
+  This text will auto-size
+</AutoFitText>
+
+<Toc minDepth="1" maxDepth="2" />
+```
+
+### Custom Components
+
+Create custom Vue components in `./components/` directory. They are auto-imported without manual registration.
+
+Example structure:
+
+```
+./components/
+  MyComponent.vue
+  Counter.vue
+slides.md
+```
+
+Use in slides:
+
+```md
+<MyComponent />
+
+<Counter :initial="10" />
+```
+
+---
+
+## Animations
+
+### Click Animations
+
+**v-click Directive:**
+
+```md
+<div v-click>Appears on click</div>
+<div v-click>Appears on next click</div>
+```
+
+**v-after Directive:**
+
+```md
+<div v-click>First</div>
+<div v-after>Appears with previous</div>
+```
+
+**v-clicks for Lists:**
+
+```md
+<v-clicks>
+
+- First item
+- Second item
+- Third item
+
+</v-clicks>
+```
+
+### Animation Positioning
+
+**Absolute positioning:**
+
+```md
+<div v-click="1">Shows at step 1</div>
+<div v-click="2">Shows at step 2</div>
+<div v-click="3">Shows at step 3</div>
+```
+
+**Relative positioning:**
+
+```md
+<div v-click>First</div>
+<div v-click="+2">Skip one step</div>
+<div v-click="-1">Same time as previous</div>
+```
+
+### Motion Animations
+
+Use `@vueuse/motion` for directional animations:
+
+```md
+<div
+  v-motion
+  :initial="{ x: -80 }"
+  :enter="{ x: 0 }">
+  Slides in from left
+</div>
+```
+
+### Slide Transitions
+
+Configure in frontmatter:
+
+```md
+---
+transition: slide-left
+---
+```
+
+Available transitions:
+- `fade`
+- `slide-left`
+- `slide-right`
+- `slide-up`
+- `slide-down`
+- `view-transition`
+
+---
+
+## Styling
+
+### UnoCSS Integration
+
+Slidev uses UnoCSS with Tailwind-compatible utilities:
+
+```md
+<div class="grid grid-cols-2 gap-4">
+  <div class="bg-blue-500 p-4">Column 1</div>
+  <div class="bg-red-500 p-4">Column 2</div>
+</div>
+```
+
+### Custom Styles
+
+Create `./styles/index.css`:
+
+```css
+.my-custom-class {
+  @apply text-2xl font-bold text-blue-500;
+}
+```
+
+### Slide-Scoped Styles
+
+Add styles to specific slides:
+
+```md
+# Slide Title
+
+Content here
+
+<style>
+h1 {
+  color: #3b82f6;
+}
+</style>
+```
+
+### Dark Mode Support
+
+UnoCSS dark mode utilities:
+
+```md
+<div class="bg-white dark:bg-black text-black dark:text-white">
+  Adapts to theme
+</div>
+```
+
+---
+
+## Exporting
+
+### Browser Export (Recommended)
+
+1. Start dev server: `slidev`
+2. Click "Export" button in navigation bar
+3. Or visit `http://localhost:3030/export`
+4. Choose format and download
+
+### CLI Export
+
+Install Playwright first:
+
+```bash
+pnpm add -D playwright-chromium
+```
+
+Export to PDF:
+
+```bash
+slidev export
+# or specify output
+slidev export --output my-presentation.pdf
+```
+
+Export to PPTX:
+
+```bash
+slidev export --format pptx
+```
+
+Export to PNG:
+
+```bash
+slidev export --format png
+```
+
+Export with animations:
+
+```bash
+slidev export --with-clicks
+```
+
+Export specific slides:
+
+```bash
+slidev export --range 1,6-8,10
+```
+
+Export in dark mode:
+
+```bash
+slidev export --dark
+```
+
+### Export Options
+
+- `--output` - Custom filename
+- `--format` - Export format (pdf, pptx, png, md)
+- `--with-clicks` - Include animation steps
+- `--range` - Specific slides (e.g., 1,6-8,10)
+- `--dark` - Use dark theme
+- `--timeout` - Increase timeout for large presentations
+- `--wait` - Add delay before export
+- `--with-toc` - Generate PDF outline
+
+---
+
+## Configuration
+
+### Directory Structure
+
+```
+./
+├─ components/       # Custom Vue components
+├─ layouts/          # Custom layouts
+├─ public/           # Static assets
+├─ setup/            # Custom setup code
+├─ snippets/         # Code snippets
+├─ styles/           # Custom styles
+├─ slides.md         # Main presentation file
+├─ vite.config.ts    # Vite configuration
+└─ uno.config.ts     # UnoCSS configuration
+```
+
+### UnoCSS Configuration
+
+Create `uno.config.ts`:
+
+```ts
+import { defineConfig } from 'unocss'
+
+export default defineConfig({
+  shortcuts: {
+    'bg-main': 'bg-white text-[#181818] dark:(bg-[#121212] text-[#ddd])'
+  }
+})
+```
+
+### Vite Configuration
+
+Extend Vite config in `vite.config.ts`:
+
+```ts
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  // Your custom Vite config
+})
+```
+
+---
+
+## Features
+
+### Code Features
+
+**Line Numbers:**
+
+````md
+```ts {lines:true}
+function example() {
+  return true
+}
+```
+````
+
+**Line Highlighting:**
+
+````md
+```ts {2-4}
+function calculate() {
+  const x = 10  // highlighted
+  const y = 20  // highlighted
+  const sum = x + y  // highlighted
+  return sum
+}
+```
+````
+
+**Monaco Editor:**
+
+````md
+```ts {monaco}
+// Editable code block
+console.log('Edit me!')
+```
+````
+
+**Monaco with Auto-Run:**
+
+````md
+```ts {monaco-run}
+console.log('Runs automatically')
+```
+````
+
+### Diagrams
+
+**Mermaid:**
+
+````md
+```mermaid
+graph TD
+  A[Start] --> B[Process]
+  B --> C[End]
+```
+````
+
+**PlantUML:**
+
+````md
+```plantuml
+@startuml
+Alice -> Bob: Hello
+Bob -> Alice: Hi
+@enduml
+```
+````
+
+### LaTeX
+
+Inline math:
+
+```md
+Pythagorean theorem: $a^2 + b^2 = c^2$
+```
+
+Block math:
+
+```md
+$$
+\int_0^\infty e^{-x^2} dx = \frac{\sqrt{\pi}}{2}
+$$
+```
+
+### Icons
+
+Use Iconify icons directly:
+
+```md
+<carbon-logo-github /> GitHub
+<mdi-heart class="text-red-500" /> Love
+```
+
+### Drawing
+
+Enable drawing on slides with presenter mode. Drawings are synchronized across devices.
+
+### Recording
+
+Record presentations with audio using the built-in recording feature.
+
+---
+
+## Advanced Features
+
+### Importing Slides
+
+Import slides from other files:
+
+```md
+---
+src: ./slides/intro.md
+---
+
+---
+src: ./slides/content.md
+---
+```
+
+### Global Layers
+
+Create `global-top.vue` or `global-bottom.vue` for persistent UI elements:
+
+```vue
+<!-- global-top.vue -->
+<template>
+  <div class="fixed top-0 left-0 right-0 p-4">
+    Header content on all slides
+  </div>
+</template>
+```
+
+### Custom Shortcuts
+
+Configure in frontmatter:
+
+```md
+---
+shortcuts:
+  next: space
+  prev: shift+space
+  toggleOverview: o
+---
+```
+
+### Remote Access
+
+Enable remote control for presentations:
+
+```bash
+slidev --remote
+```
+
+Access from another device using the displayed URL.
+
+---
+
+## Theming
+
+### Using Themes
+
+Install theme package:
+
+```bash
+pnpm add slidev-theme-seriph
+```
+
+Configure in headmatter:
+
+```md
+---
+theme: seriph
+---
+```
+
+### Available Official Themes
+
+- `default` - Built-in default theme
+- `seriph` - Elegant serif theme
+- `apple-basic` - Apple-style theme
+- `bricks` - Brick-pattern theme
+- `shibainu` - Cute Shiba Inu theme
+
+Browse more at https://sli.dev/themes/gallery
+
+### Creating Custom Themes
+
+Generate theme package:
+
+```bash
+pnpm create slidev-theme
+```
+
+For detailed theme development, see `references/theming.md`.
+
+---
+
+## Best Practices
+
+### Organization
+
+- Use one slide per concept
+- Keep slides focused and minimal
+- Use layouts consistently
+- Group related slides in sections
+
+### Performance
+
+- Optimize images before importing
+- Lazy load heavy components
+- Use built-in components when possible
+- Test export early for large presentations
+
+### Collaboration
+
+- Version control `slides.md` and assets
+- Document custom components
+- Share themes via npm packages
+- Use consistent formatting
+
+### Presenting
+
+- Test presenter mode before presenting
+- Prepare speaker notes
+- Test all interactive features
+- Have PDF backup ready
+
+---
+
+## Troubleshooting
+
+### Build Issues
+
+If build fails, try:
+
+```bash
+# Clear cache
+rm -rf node_modules/.vite
+
+# Rebuild
+slidev build
+```
+
+### Export Issues
+
+**Missing content:** Add wait time
+
+```bash
+slidev export --wait 2000
+```
+
+**Broken emojis:** Install system fonts or use icon libraries
+
+**Large file size:** Export specific slides or reduce image quality
+
+### Port Conflicts
+
+Specify custom port:
+
+```bash
+slidev --port 3333
+```
+
+### Theme Not Loading
+
+Ensure theme is installed:
+
+```bash
+pnpm add slidev-theme-NAME
+```
+
+And configured correctly in headmatter:
+
+```md
+---
+theme: NAME
+---
+```
+
+---
+
+## Resources
+
+For comprehensive documentation on specific topics, see:
+
+- `references/syntax-guide.md` - Complete Markdown syntax reference
+- `references/components-api.md` - Detailed component API documentation
+- `references/theming.md` - Theme creation and customization
+- `references/features.md` - Advanced features and integrations
+
+### Official Links
+
+- Website: https://sli.dev
+- Documentation: https://sli.dev/guide
+- GitHub: https://github.com/slidevjs/slidev
+- Themes Gallery: https://sli.dev/themes/gallery
+- Discord Community: https://chat.sli.dev
+
+---
+
+## Common Workflows
+
+### Creating Basic Presentation
+
+```bash
+# Initialize
+pnpm create slidev
+
+# Edit slides.md
+# Add content with Markdown
+
+# Start dev server
+slidev
+
+# Export when done
+slidev export
+```
+
+### Using Custom Components
+
+```bash
+# Create component
+mkdir components
+cat > components/Counter.vue << 'EOF'
+<script setup lang="ts">
+import { ref } from 'vue'
+const count = ref(0)
+</script>
+
+<template>
+  <button @click="count++">
+    Count: {{ count }}
+  </button>
+</template>
+EOF
+
+# Use in slides.md
+# <Counter />
+```
+
+### Theming Workflow
+
+```bash
+# Install theme
+pnpm add slidev-theme-seriph
+
+# Configure in slides.md headmatter
+# ---
+# theme: seriph
+# ---
+
+# Preview
+slidev
+```
+
+### Multi-File Presentation
+
+Create slide files:
+
+```bash
+mkdir slides
+echo "# Introduction" > slides/intro.md
+echo "# Content" > slides/content.md
+```
+
+Import in `slides.md`:
+
+```md
+---
+src: ./slides/intro.md
+---
+
+---
+src: ./slides/content.md
+---
+```
+
+---
+
+## Technology Stack
+
+Slidev is built on:
+
+- **Vite** - Fast build tool
+- **Vue 3** - Component framework
+- **UnoCSS** - Atomic CSS engine
+- **Shiki** - Syntax highlighter
+- **Monaco Editor** - Code editor
+- **Mermaid** - Diagram generation
+- **KaTeX** - Math rendering
+- **VueUse** - Vue composition utilities
+- **Iconify** - Icon library
+
+This enables fast development, rich interactivity, and extensive customization options.

--- a/.agents/skills/wandb-primary/SKILL.md
+++ b/.agents/skills/wandb-primary/SKILL.md
@@ -1,0 +1,450 @@
+---
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+name: wandb-primary
+description: Comprehensive primary skill for agents working with Weights & Biases. Covers both the W&B SDK (training runs, metrics, artifacts, sweeps) and the Weave SDK (GenAI traces, evaluations, scorers). Includes helper libraries, gotcha tables, and data analysis patterns. Use this skill whenever the user asks about W&B runs, Weave traces, evaluations, training metrics, loss curves, model comparisons, or any Weights & Biases data — even if they don't say "W&B" explicitly.
+---
+
+# W&B Primary Skill
+
+## Python environment detection (DO THIS FIRST)
+
+Before running any Python code, you MUST determine how the user runs Python in this project. Check for clues in this order:
+
+1. Look for `pyproject.toml`, `uv.lock`, `poetry.lock`, `Pipfile`, `requirements.txt`, `setup.py`, `setup.cfg`, `Makefile`, or `docker-compose.yml` in the project root
+2. Check if there is an activated virtual environment (`$VIRTUAL_ENV`, `.venv/`, `venv/`)
+3. Check for a `Dockerfile` or CI config that reveals the runtime
+4. If the user has explicitly told you how they run Python, use that
+
+Once you know the environment, **write your finding into this skill** by replacing the placeholder below so that all subsequent code blocks use the correct commands. If you cannot determine the environment from any of the above, default to `uv`.
+
+<!-- AGENT: Replace the content between the ENVIRONMENT markers with the detected environment -->
+<!-- ENVIRONMENT_START -->
+**Detected Python environment:** _not yet detected_
+
+```
+# Run command: <not yet detected>
+# Install command: <not yet detected>
+```
+<!-- ENVIRONMENT_END -->
+
+**Examples of what to write here:**
+
+| Environment | Run command | Install command |
+|---|---|---|
+| uv | `uv run script.py` | `uv pip install pandas` |
+| poetry | `poetry run python script.py` | `poetry add pandas` |
+| conda | `conda run python script.py` | `conda install pandas` |
+| bare venv | `python script.py` (with venv activated) | `pip install pandas` |
+| docker | `docker exec <ctr> python script.py` | `docker exec <ctr> pip install pandas` |
+
+**If you cannot determine the environment, write this:**
+
+```
+# Run command: uv run script.py        # always use uv run, never bare python
+# Install command: uv pip install <pkg>
+```
+
+---
+
+This skill covers everything an agent needs to work with Weights & Biases:
+
+- **W&B SDK** (`wandb`) — training runs, metrics, artifacts, sweeps, system metrics
+- **Weave SDK** (`weave`) — GenAI traces, evaluations, scorers, token usage
+- **Helper libraries** — `wandb_helpers.py` and `weave_helpers.py` for common operations
+
+## When to use what
+
+| I need to... | Use |
+|---|---|
+| Query training runs, loss curves, hyperparameters | **W&B SDK** (`wandb.Api()`) — see `references/WANDB_SDK.md` |
+| Query GenAI traces, calls, evaluations | **Weave SDK** (`weave.init()`, `client.get_calls()`) — see `references/WEAVE_SDK.md` |
+| Convert Weave wrapper types to plain Python | **`weave_helpers.unwrap()`** |
+| Build a DataFrame from training runs | **`wandb_helpers.runs_to_dataframe()`** |
+| Extract eval results for analysis | **`weave_helpers.eval_results_to_dicts()`** |
+| Need low-level Weave filtering (CallsFilter, Query) | **Raw Weave SDK** (`weave.init()`, `client.get_calls()`) — see `references/WEAVE_SDK.md` |
+| Judge curve shape (spikes, smoothness, slope, overfit) | **`training_diagnostics` + `curve_plots`** — use the workflow below, then load `references/TRAINING_DIAGNOSTICS.md` for the heuristics |
+
+---
+
+## Bundled files
+
+### Helper libraries
+
+```python
+import sys
+sys.path.insert(0, ".agents/skills/wandb-primary/scripts")
+
+# Weave helpers (traces, evals, GenAI)
+from weave_helpers import (
+    unwrap,                  # Recursively convert Weave types -> plain Python
+    get_token_usage,         # Extract token counts from a call's summary
+    eval_results_to_dicts,   # predict_and_score calls -> list of result dicts
+    pivot_solve_rate,        # Build task-level pivot table across agents
+    results_summary,         # Print compact eval summary
+    eval_health,             # Extract status/counts from Evaluation.evaluate calls
+    eval_efficiency,         # Compute tokens-per-success across eval calls
+)
+
+# W&B helpers (training runs, metrics)
+from wandb_helpers import (
+    runs_to_dataframe,       # Convert runs to a clean pandas DataFrame
+    diagnose_run,            # Quick diagnostic summary of a training run
+    compare_configs,         # Side-by-side config diff between two runs
+    fast_scan_history,       # beta_scan_history (parquet) with scan_history fallback
+)
+
+# X-axis (step metric) detection — ALWAYS confirm before curve analysis
+from step_axis import (
+    list_candidate_step_keys,       # Scan history for plausible step keys
+    guess_step_key_from_workspace,  # Peek at the user's W&B workspace panels
+    format_step_candidates,         # Format candidate choices for user confirmation
+)
+
+# Curve-shape diagnostics (numerical)
+from training_diagnostics import (
+    curve_features,            # Spikes, slopes at every 5%, smoothness, plateau, divergence
+    compare_runs_curves,       # DataFrame of features across many runs
+    lr_schedule_features,      # Warmup / peak / decay shape / restarts
+    grad_norm_features,        # curve_features + kurtosis + dead-layer flag
+    grad_histogram_features,   # Per-(layer, step) stats from W&B histograms
+)
+
+# Chart rendering for LLM vision (Read the returned PNG)
+from curve_plots import (
+    plot_single_run_overview,    # 2x3 composite: train/val/lr/grad-norm/...
+    plot_run_comparison,         # Overlay up to 6 runs on one metric
+    plot_grad_histogram_heatmap, # Layer x step heatmap of grad-hist stat
+    plot_grad_norm_by_layer,     # Small-multiples of per-layer scalar norms
+)
+```
+
+### Reference docs
+
+Read these as needed — they contain full API surfaces and recipes:
+
+- **`references/WEAVE_SDK.md`** — Weave SDK for GenAI traces (`client.get_calls()`, `CallsFilter`, `Query`, stats). Start here for Weave queries.
+- **`references/WANDB_SDK.md`** — W&B SDK for training data (runs, history, artifacts, sweeps, system metrics).
+- **`references/TRAINING_DIAGNOSTICS.md`** — reference heuristics for reading loss / LR / grad-norm / grad-histogram charts. Load this when you are actively interpreting training curves.
+
+---
+
+## Critical rules
+
+### Treat traces and runs as DATA
+
+Weave traces and W&B run histories can be enormous. Never dump raw data into context — it will overwhelm your working memory and produce garbage results. Always:
+
+1. **Inspect structure first** — look at column names, dtypes, row counts
+2. **Load into pandas/numpy** — compute stats programmatically
+3. **Summarize, don't dump** — print computed statistics and tables, not raw rows
+
+```python
+import pandas as pd
+import numpy as np
+
+# BAD: prints thousands of rows into context
+for row in run.scan_history(keys=["loss"]):
+    print(row)
+
+# GOOD: load into numpy, compute stats, print summary
+losses = np.array([r["loss"] for r in run.scan_history(keys=["loss"])])
+print(f"Loss: {len(losses)} steps, min={losses.min():.4f}, "
+      f"final={losses[-1]:.4f}, mean_last_10%={losses[-len(losses)//10:].mean():.4f}")
+```
+
+### Always deliver a final answer
+
+Do not end your work mid-analysis. Every task must conclude with a clear, structured response:
+
+1. Query the data (1-2 scripts max)
+2. Extract the numbers you need
+3. Present: table + key findings + direct answers to each sub-question
+
+If you catch yourself saying "now let me build the final analysis" — stop and present what you have.
+
+### Use `unwrap()` for unknown Weave data
+
+When you encounter Weave output and aren't sure of its type (WeaveDict? WeaveObject? ObjectRef?), unwrap it first:
+
+```python
+from weave_helpers import unwrap
+import json
+
+output = unwrap(call.output)
+print(json.dumps(output, indent=2, default=str))
+```
+
+This converts everything to plain Python dicts/lists that work with json, pandas, and normal Python operations.
+
+---
+
+## Environment setup
+
+The sandbox has `wandb`, `weave`, `pandas`, and `numpy` pre-installed.
+
+```python
+import os
+entity  = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+```
+
+### Installing extra packages and running scripts
+
+Use whichever run/install commands you wrote in the **Python environment detection** section above. If you haven't detected the environment yet, go back and do that first.
+
+---
+
+## Quick starts
+
+### W&B SDK — training runs
+
+```python
+import wandb
+import pandas as pd
+api = wandb.Api()
+
+path = f"{entity}/{project}"
+runs = api.runs(path, filters={"state": "finished"}, order="-created_at")
+
+# Convert to DataFrame (always slice — never list() all runs)
+from wandb_helpers import runs_to_dataframe
+rows = runs_to_dataframe(runs, limit=100, metric_keys=["loss", "val_loss", "accuracy"])
+df = pd.DataFrame(rows)
+print(df.describe())
+```
+
+For full W&B SDK reference (filters, history, artifacts, sweeps), read `references/WANDB_SDK.md`.
+
+### Weave — SDK
+
+```python
+import weave
+client = weave.init(f"{entity}/{project}")  # positional string, NOT keyword arg
+calls = client.get_calls(limit=10)
+```
+
+For raw SDK patterns (CallsFilter, Query, advanced filtering), read `references/WEAVE_SDK.md`.
+
+---
+
+## Key patterns
+
+### Weave eval inspection
+
+Evaluation calls follow this hierarchy:
+
+```
+Evaluation.evaluate (root)
+  ├── Evaluation.predict_and_score (one per dataset row x trials)
+  │     ├── model.predict (the actual model call)
+  │     ├── scorer_1.score
+  │     └── scorer_2.score
+  └── Evaluation.summarize
+```
+
+Extract per-task results into a DataFrame:
+
+```python
+from weave_helpers import eval_results_to_dicts, results_summary
+
+# pas_calls = list of predict_and_score call objects
+results = eval_results_to_dicts(pas_calls, agent_name="my-agent")
+print(results_summary(results))
+
+df = pd.DataFrame(results)
+print(df.groupby("passed")["score"].mean())
+```
+
+### Eval health and efficiency
+
+```python
+from weave_helpers import eval_health, eval_efficiency
+
+health = eval_health(eval_calls)
+df = pd.DataFrame(health)
+print(df.to_string(index=False))
+
+efficiency = eval_efficiency(eval_calls)
+print(pd.DataFrame(efficiency).to_string(index=False))
+```
+
+### Token usage
+
+```python
+from weave_helpers import get_token_usage
+
+usage = get_token_usage(call)
+print(f"Tokens: {usage['total_tokens']} (in={usage['input_tokens']}, out={usage['output_tokens']})")
+```
+
+### Cost estimation
+
+```python
+call_with_costs = client.get_call("id", include_costs=True)
+costs = call_with_costs.summary.get("weave", {}).get("costs", {})
+```
+
+### Run diagnostics
+
+```python
+from wandb_helpers import diagnose_run
+
+run = api.run(f"{path}/run-id")
+diag = diagnose_run(run)
+for k, v in diag.items():
+    print(f"  {k}: {v}")
+```
+
+### Error analysis — open coding to axial coding
+
+For structured failure analysis on eval results:
+
+1. **Understand data shape** — use `project.summary()`, `calls.input_shape()`, `calls.output_shape()`
+2. **Open coding** — write a Weave Scorer that journals what went wrong per failing call
+3. **Axial coding** — write a second Scorer that classifies notes into a taxonomy
+4. **Summarize** — count primary labels with `collections.Counter`
+
+See `references/WEAVE_SDK.md` for the full SDK reference.
+
+### W&B Reports
+
+Install `wandb[workspaces]` using the install command from the **Python environment detection** section.
+
+```python
+from wandb.apis import reports as wr
+import wandb_workspaces.expr as expr
+
+report = wr.Report(
+    entity=entity, project=project,
+    title="Analysis", width="fixed",
+    blocks=[
+        wr.H1(text="Results"),
+        wr.PanelGrid(
+            runsets=[wr.Runset(entity=entity, project=project)],
+            panels=[wr.LinePlot(title="Loss", x="_step", y=["loss"])],
+        ),
+    ],
+)
+# report.save(draft=True)  # only when asked to publish
+```
+
+Use `expr.Config("lr")`, `expr.Summary("loss")`, `expr.Tags().isin([...])` for runset filters — not dot-path strings.
+
+---
+
+## Training curve analysis workflow
+
+Use this when the user asks whether a run is healthy, why training diverged, whether a run overfit, or which run has the best training dynamics.
+
+Keep the inline workflow short and load detail on demand:
+
+1. Confirm `step_key` before doing any curve work. Never assume `_step`.
+2. Compute features with the bundled helpers instead of hand-rolling spike or slope logic.
+3. Render PNGs and inspect them visually.
+4. Load `references/TRAINING_DIAGNOSTICS.md` while you interpret the results.
+5. End with a verdict, evidence tied to step ranges, and concrete next actions.
+
+### Required sequence
+
+Use `list_candidate_step_keys()`, `guess_step_key_from_workspace()`, and `format_step_candidates()` to confirm the x-axis. If there is one obvious candidate and it matches the workspace guess, say which `step_key` you picked. Otherwise, ask the user to choose before plotting or comparing runs.
+
+For a single run, compute a compact feature table from the metrics that actually exist, then render `plot_single_run_overview(run, step_key=step_key)`. If gradient histograms or per-layer scalar norms are logged, add `plot_grad_histogram_heatmap()` or `plot_grad_norm_by_layer()`.
+
+For multi-run comparisons, use `compare_runs_curves()` for the ranking table and `plot_run_comparison()` for the overlay. Keep overlays to at most 6 runs; if there are more, rank first and then plot the shortlist.
+
+### Output shape
+
+Do not dump raw history rows or the full spike/slope payloads unless you are drilling into a specific anomaly. Summaries should stay compact.
+
+Use this response shape:
+
+```text
+Verdict: <healthy | unstable | overfit | plateaued | diverged | converged>
+Evidence:
+- <specific step range> — <what the metrics and plot show>
+- <specific step range> — <what changed and why it matters>
+Next actions:
+- <concrete hyperparameter, logging, or code change>
+```
+
+Load `references/TRAINING_DIAGNOSTICS.md` for the interpretation heuristics, especially when the numbers and the image disagree.
+
+---
+
+## Gotchas
+
+### Weave API
+
+| Gotcha | Wrong | Right |
+|--------|-------|-------|
+| weave.init args | `weave.init(project="x")` | `weave.init("x")` (positional) |
+| Parent filter | `filter={'parent_id': 'x'}` | `filter={'parent_ids': ['x']}` (plural, list) |
+| WeaveObject access | `rubric.get('passed')` | `getattr(rubric, 'passed', None)` |
+| Nested output | `out.get('succeeded')` | `out.get('output').get('succeeded')` (output.output) |
+| ObjectRef comparison | `name_ref == "foo"` | `str(name_ref) == "foo"` |
+| CallsFilter import | `from weave import CallsFilter` | `from weave.trace.weave_client import CallsFilter` |
+| Query import | `from weave import Query` | `from weave.trace_server.interface.query import Query` |
+| Eval status path | `summary["status"]` | `summary["weave"]["status"]` |
+| Eval success count | `summary["success_count"]` | `summary["weave"]["status_counts"]["success"]` |
+| When in doubt | Guess the type | `unwrap()` first, then inspect |
+
+### WeaveDict vs WeaveObject
+
+- **WeaveDict**: dict-like, supports `.get()`, `.keys()`, `[]`. Used for: `call.inputs`, `call.output`, `scores` dict
+- **WeaveObject**: attribute-based, use `getattr()`. Used for: scorer results (rubric), dataset rows
+- **When in doubt**: use `unwrap()` to convert everything to plain Python
+
+### W&B API
+
+| Gotcha | Wrong | Right |
+|--------|-------|-------|
+| Summary access | `run.summary["loss"]` | `run.summary_metrics.get("loss")` |
+| Loading all runs | `list(api.runs(...))` | `runs[:200]` (always slice) |
+| History — all fields | `run.history()` | `run.history(samples=500, keys=["loss"])` |
+| scan_history — no keys | `scan_history()` | `scan_history(keys=["loss"])` (explicit) |
+| Raw data in context | `print(run.history())` | Load into DataFrame, compute stats |
+| Metric at step N | iterate entire history | `scan_history(keys=["loss"], min_step=N, max_step=N+1)` |
+| Cache staleness | reading live run | `api.flush()` first |
+
+### Package management
+
+| Gotcha | Details |
+|--------|---------|
+| Using the wrong runner | Always use the run/install commands from the **Python environment detection** section — never guess |
+| Bare `python` when env unknown | If you haven't detected the environment yet, default to `uv run script.py` (never bare `python`) |
+
+### Weave logging noise
+
+Weave prints version warnings to stderr. Suppress with:
+
+```python
+import logging
+logging.getLogger("weave").setLevel(logging.ERROR)
+```
+
+---
+
+## Quick reference
+
+```python
+# --- Weave: Init and get calls ---
+import weave
+client = weave.init(f"{entity}/{project}")
+calls = client.get_calls(limit=10)
+
+# --- W&B: Best run by loss ---
+best = api.runs(path, filters={"state": "finished"}, order="+summary_metrics.loss")[:1]
+print(f"Best: {best[0].name}, loss={best[0].summary_metrics.get('loss')}")
+
+# --- W&B: Loss curve to numpy ---
+losses = np.array([r["loss"] for r in run.scan_history(keys=["loss"])])
+print(f"min={losses.min():.6f}, final={losses[-1]:.6f}, steps={len(losses)}")
+
+# --- W&B: Compare two runs ---
+from wandb_helpers import compare_configs
+diffs = compare_configs(run_a, run_b)
+print(pd.DataFrame(diffs).to_string(index=False))
+```

--- a/.agents/skills/wandb-primary/references/TRAINING_DIAGNOSTICS.md
+++ b/.agents/skills/wandb-primary/references/TRAINING_DIAGNOSTICS.md
@@ -1,0 +1,95 @@
+<!--
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: skills
+-->
+
+# Training Curve Intuition — A Researcher's Reading Guide
+
+Use this as reference material while interpreting training curves. It captures the gut judgments experienced ML researchers apply when they look at loss curves, LR schedules, grad norms, and gradient histograms.
+
+Recommended order: confirm the real `step_key`, compute features with `training_diagnostics.py`, open the PNGs from `curve_plots.py`, then use the heuristics below to write a verdict with step-indexed evidence.
+
+---
+
+## 1. What a healthy loss curve looks like
+
+- **Monotone-ish decrease**: small fluctuations around a falling trend.
+- **Diminishing returns**: fast early drop, slow tail — the curve "bends" on log-y.
+- **Smooth tail**: rolling std small relative to the run's range (`smoothness < ~0.02`).
+- **Grad-norm slowly decays** alongside the loss; no late spikes.
+- **Monotonicity_pct** ≥ 55–60% for loss-type metrics (consecutive decreases dominate).
+
+**Red flag signals to look for even when the final number looks good:**
+- Fat noise band across the whole run = LR too high or batch-size too small.
+- Smooth but flat = already converged OR plateau; check slope at the last 20%.
+
+## 2. Instability patterns
+
+- **Co-occurring spikes**: a loss spike at step S that aligns with a grad-norm spike at the same step is a near-certain sign the optimizer took a bad step (too-high LR, bad batch, fp16 overflow). One or two can be harmless if recovered; more than a handful means instability.
+- **Divergence after LR peak**: loss spikes right after warmup ends → warmup too short or peak LR too high.
+- **NaN mid-run**: hard instability. Check `nan_inf_count` and the first step; the fix is almost never in the loss — it's in the optimizer, precision, or data pipeline.
+- **Escalating spike frequency**: if the spike rate rises in the last 30% of training, the optimizer is losing stability — usually needs gradient clipping or a lower LR floor.
+
+## 3. Overfitting signatures
+
+- Train loss keeps decreasing; val loss **turns upward** in the final 20–30%.
+- Train/val gap **widens** in the tail (`val_tail - train_tail` grows).
+- A shape with val loss forming a shallow U — the bottom of the U is the right stopping point.
+- If a run ends at "lowest final val loss" but earlier val loss was lower, the run **overshot** and should be stopped earlier in subsequent runs.
+
+## 4. Plateau vs convergence
+
+Both look like a flat tail. To distinguish:
+
+- **Convergence**: tail slope ≈ 0, tail std small, loss near its run-wide min. Verdict: done.
+- **Plateau**: tail slope ≈ 0, tail std small, but loss is still far from reasonable targets. Verdict: stuck — try LR bump, data quality, curriculum.
+
+Look at `checkpoint_slopes`. If the last 3 segments all sit near zero and the value is below a known "good" threshold, call it **converged**. If it's flat but far from target, call it **plateaued**.
+
+## 5. LR schedule reading
+
+- **Warmup**: roughly 1–10% of training steps for most setups; very long warmup (>20%) only if training is very unstable.
+- **Cosine decay**: smooth sinusoidal fall from peak to near-zero. Verify `decay_shape == "cosine"`.
+- **Linear decay**: straight line from peak to final. Verify `decay_shape == "linear"`.
+- **Flat tail** (LR pinned at a small value for the final segment): often good; lets the model settle.
+- **Restarts**: `restart_steps` non-empty means LR went back up after its global peak. Intentional (SGDR) or a bug — ask before assuming.
+- **Mismatch with loss**: if loss starts diverging right at the LR peak step, the peak is too high. If loss flatlines as soon as LR enters the decay segment, decay may be too aggressive.
+
+## 6. Grad-norm intuition
+
+- Early grad-norm **high and dropping** is normal — the model is adjusting large weights.
+- Stable mid-run grad-norm is good.
+- **Late-training grad-norm spikes** indicate instability. A single spike that recovers is fine; repeated spikes in the last 30% → lower LR or clip more aggressively.
+- **Sudden drop to ~zero** (`dead_flag` in `grad_norm_features`) often means a layer died (ReLU collapse) or the schedule drove LR to zero prematurely.
+- **Kurtosis** > ~3 indicates heavy-tailed update distribution — often a sign of rare catastrophic updates that gradient clipping would catch.
+
+## 7. Reading gradient histogram heatmaps
+
+The heatmap is (layer × step) → a summary stat (default `mean_abs`). A few patterns:
+
+- **Horizontal bands** (one row much brighter/darker than its neighbors) are usually a **layer-type artefact**, not a pathology — embedding layers, LayerNorms, and biases naturally sit at different magnitudes than the dense weights around them. Don't raise an alarm just from banding.
+- **Row collapsing to near-zero mid-training** while neighbors stay bright = **dead layer**. A big deal; usually a bad init or a ReLU saturation problem.
+- **Late-training widening** (kurtosis rising, `max_abs` blowing out) in several rows = **optimizer instability**.
+- **Entire column dark** = grads were ~0 that step — check if the run logged during a no-op step (warmup? eval? clipped grads?).
+- **Rows near the output darker than input rows** across all steps = **vanishing gradient** signature (deep models, poor init). Rows near the input dark means exploding gradients elsewhere.
+
+When viewing the heatmap PNG, first pick out structural patterns (bands, dark corridors, columns), then zoom to step ranges of interest using the numeric `grad_histogram_features` DataFrame to drill in.
+
+## 8. Comparing runs
+
+When overlaying runs, weight the verdict by **all four** of:
+
+1. **Final metric** (final_10pct_mean): the obvious ranking dimension.
+2. **Smoothness**: a noisy winner is often a worse run — variance in eval samples masks what's happening.
+3. **Slope at 80–100%**: if one run is still falling while another flattens, the still-falling run would probably win with more steps.
+4. **Spike count**: a clean run generalizes better than a noisy one at the same final metric.
+
+Rules of thumb when ranking:
+
+- Prefer **smoother + slightly higher final** over **noisier + slightly lower final** when the gap is within 2× the final-10%-std.
+- A run that is still descending at 100% is evidence to **train longer**, not evidence that the hyperparameters are bad.
+- If two runs tie on final metric but one has 10× more spikes, the stable one is the better policy for future work.
+- A run with lower peak-grad-norm at the same final metric is generally more robust.
+
+Present the verdict as: **winner → why**, **runner-up → why**, **losers → how they failed** (divergence / overfit / plateau / noise), and a concrete **next action** (train longer, drop LR, add clipping, etc.).

--- a/.agents/skills/wandb-primary/references/WANDB_SDK.md
+++ b/.agents/skills/wandb-primary/references/WANDB_SDK.md
@@ -1,0 +1,451 @@
+<!--
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: skills
+-->
+
+# W&B SDK Reference — Runs, Metrics, Artifacts
+
+Reference for querying Weights & Biases training data using the `wandb` Python SDK. Covers runs, metrics history, artifacts, sweeps, and system metrics.
+
+**Key principle**: Always load data into pandas/numpy for analysis. Never dump raw history or run lists into context — it will overwhelm your working memory. Look at structure first, then query specific fields.
+
+## Quick Start
+
+```python
+import wandb
+import pandas as pd
+import numpy as np
+
+api = wandb.Api()
+
+# Entity and project from environment
+import os
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+path = f"{entity}/{project}"
+
+# List runs
+runs = api.runs(path, filters={"state": "finished"}, order="-created_at")
+print(f"Found {len(runs)} finished runs")
+```
+
+---
+
+## Runs
+
+### Listing and filtering
+
+```python
+# All runs (lazy iterator)
+runs = api.runs(path)
+
+# By state
+runs = api.runs(path, filters={"state": "finished"})
+
+# By config value
+runs = api.runs(path, filters={"config.model": "gpt-4"})
+runs = api.runs(path, filters={"config.learning_rate": {"$lt": 0.01}})
+
+# By summary metric
+runs = api.runs(path, filters={"summary_metrics.accuracy": {"$gt": 0.9}})
+runs = api.runs(path, filters={"summary_metrics.loss": {"$lt": 0.5}})
+
+# By display name (regex)
+runs = api.runs(path, filters={"display_name": {"$regex": ".*v2.*"}})
+
+# By tags
+runs = api.runs(path, filters={"tags": {"$in": ["production"]}})
+runs = api.runs(path, filters={"tags": {"$nin": ["deprecated"]}})
+
+# Date range
+runs = api.runs(path, filters={
+    "$and": [
+        {"created_at": {"$gt": "2025-01-01T00:00:00"}},
+        {"created_at": {"$lt": "2025-06-01T00:00:00"}},
+    ]
+})
+
+# Config key exists
+runs = api.runs(path, filters={"config.special_param": {"$exists": True}})
+
+# Compound filters
+runs = api.runs(path, filters={
+    "$and": [
+        {"config.model": "transformer"},
+        {"summary_metrics.loss": {"$lt": 0.5}},
+        {"state": "finished"},
+    ]
+})
+```
+
+### Filter operators
+
+`$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$exists`, `$regex`, `$and`, `$or`, `$nor`
+
+### Filterable fields
+
+`state`, `display_name`, `config.KEY`, `summary_metrics.KEY`, `tags`, `created_at`, `group`, `job_type`
+
+### Sorting
+
+```python
+runs = api.runs(path, order="-created_at")              # newest first
+runs = api.runs(path, order="+summary_metrics.loss")     # lowest loss first
+runs = api.runs(path, order="-summary_metrics.val_acc")  # highest accuracy first
+```
+
+### Pagination
+
+```python
+runs = api.runs(path, per_page=100)
+first_50 = runs[:50]    # slice to limit (lazy)
+total = len(runs)        # triggers count query
+```
+
+**IMPORTANT**: Always slice runs — never `list()` all runs on large projects.
+
+### Run properties
+
+```python
+run = api.run(f"{path}/run-id")
+
+# Identity
+run.id           # str: 8-char hash
+run.name         # str: display name
+run.entity       # str
+run.project      # str
+run.url          # str: full URL
+run.path         # list: [entity, project, run_id]
+
+# State & metadata
+run.state        # "finished", "failed", "crashed", "running"
+run.created_at   # str: ISO timestamp
+run.tags         # list[str]
+
+# Config (hyperparameters)
+run.config       # dict — logged at wandb.init()
+lr = run.config.get("learning_rate")
+clean_config = {k: v for k, v in run.config.items() if not k.startswith("_")}
+
+# Summary (final metric values)
+run.summary_metrics  # dict (read-only snapshot — prefer for reads)
+final_loss = run.summary_metrics.get("loss")
+```
+
+### Runs to DataFrame
+
+```python
+runs = api.runs(path, filters={"state": "finished"}, order="-created_at")
+rows = []
+for run in runs[:200]:  # ALWAYS slice
+    rows.append({
+        "id": run.id,
+        "name": run.name,
+        "state": run.state,
+        "created_at": run.created_at,
+        **{f"config.{k}": v for k, v in run.config.items() if not k.startswith("_")},
+        "loss": run.summary_metrics.get("loss"),
+        "accuracy": run.summary_metrics.get("accuracy"),
+    })
+df = pd.DataFrame(rows)
+print(df.describe())
+```
+
+---
+
+## Metrics History
+
+Two methods with very different behavior:
+
+### `run.history()` — sampled, fast, DataFrame
+
+```python
+# Quick 500-point overview (default)
+df = run.history()
+
+# Specific metrics with more samples
+df = run.history(samples=2000, keys=["loss", "val_loss", "learning_rate"])
+```
+
+**Behavior**: Server-side downsamples to `samples` points using min/max bucketing. Fast, but misses data points. Good for overviews and plotting.
+
+### `run.scan_history()` — full, unsampled, iterator
+
+```python
+# ALL loss values (no sampling)
+losses = [row["loss"] for row in run.scan_history(keys=["loss"])]
+
+# Step range
+for row in run.scan_history(keys=["loss"], min_step=1000, max_step=2000):
+    print(row["_step"], row.get("loss"))
+
+# To DataFrame
+rows = list(run.scan_history(keys=["loss", "val_loss"], page_size=2000))
+df = pd.DataFrame(rows)
+```
+
+**Behavior**: Returns ALL logged rows, unsampled. Use when you need precision.
+
+### `run.beta_scan_history()` — faster, parquet-backed (beta)
+
+```python
+# Same shape as scan_history, reads local parquet when available
+for row in run.beta_scan_history(keys=["loss"], page_size=1000):
+    ...
+```
+
+**Behavior**: Reads the run's exported parquet via wandb-core instead of paginating the API. Significantly faster on repeat queries. W&B flags this as "still in development." Our helper `wandb_helpers.fast_scan_history(run, ...)` prefers it and falls back to `scan_history` on any error — use that rather than calling beta directly.
+
+### When to use which
+
+| Use case | Method |
+|----------|--------|
+| Quick plot / overview | `history(samples=500)` |
+| Dashboard summary | `history(samples=1000, keys=[...])` |
+| Anomaly detection | `scan_history(keys=[...])` |
+| Exact loss values | `scan_history(keys=["loss"])` |
+| System metrics (GPU/CPU) | `history(stream="system")` |
+| Very long runs | `scan_history()` (iterator) |
+
+### Bulk history — multiple runs
+
+```python
+runs = api.runs(path, filters={"state": "finished"})
+df = runs.histories(samples=200, keys=["loss", "val_loss"], format="pandas")
+# df has columns: run_id, _step, loss, val_loss
+```
+
+---
+
+## Data Analysis Patterns
+
+**Rule**: Always use pandas and numpy. Never print raw data into context.
+
+### Finding the minimum loss
+
+```python
+df = pd.DataFrame(list(run.scan_history(keys=["loss", "_step"])))
+min_idx = df["loss"].idxmin()
+print(f"Min loss: {df.loc[min_idx, 'loss']:.6f} at step {df.loc[min_idx, '_step']}")
+```
+
+### Rolling statistics for smoothed analysis
+
+```python
+df = pd.DataFrame(list(run.scan_history(keys=["loss"])))
+loss = df["loss"].dropna()
+
+window = 50
+df["rolling_mean"] = loss.rolling(window, center=True).mean()
+df["rolling_std"] = loss.rolling(window, center=True).std()
+
+final_window = loss.tail(len(loss) // 10)
+print(f"Final 10% — mean: {final_window.mean():.6f}, std: {final_window.std():.6f}")
+```
+
+### Spike and anomaly detection
+
+```python
+loss = df["loss"].dropna()
+window = 50
+rolling_mean = loss.rolling(window, center=True).mean()
+rolling_std = loss.rolling(window, center=True).std()
+
+# Spikes: points > 3 sigma from rolling mean
+threshold = 3.0
+spikes = loss[(loss - rolling_mean).abs() > threshold * rolling_std]
+print(f"Spikes (>{threshold} sigma): {len(spikes)}")
+
+# Divergence: sustained increase
+diff = loss.diff().rolling(window).mean()
+diverging = diff[diff > 0]
+if len(diverging) > window:
+    print(f"Possible divergence starting at step {diverging.index[0]}")
+
+# Plateau: loss barely changing
+change_rate = loss.diff().abs().rolling(window).mean()
+plateaus = change_rate[change_rate < 1e-5]
+if len(plateaus) > window:
+    print(f"Plateau at step {plateaus.index[0]}, value ~{loss.iloc[plateaus.index[0]]:.6f}")
+
+# NaN/Inf
+nan_steps = df[df["loss"].isna()]["_step"].tolist() if "_step" in df else []
+if nan_steps:
+    print(f"NaN loss at {len(nan_steps)} steps")
+```
+
+### Overfitting detection
+
+```python
+df = pd.DataFrame(list(run.scan_history(keys=["loss", "val_loss"])))
+train = df["loss"].dropna()
+val = df["val_loss"].dropna()
+
+if len(val) > 10:
+    tail_pct = len(val) // 5
+    train_tail = train.tail(tail_pct).mean()
+    val_tail = val.tail(tail_pct).mean()
+    gap = val_tail - train_tail
+    overfit = val_tail > train_tail * 1.2
+    print(f"Train/val gap: {gap:.4f}, overfit: {overfit}")
+```
+
+### Sweep analysis — finding best hyperparameters
+
+```python
+runs = api.runs(path, filters={"state": "finished"}, order="+summary_metrics.loss")
+rows = []
+for run in runs[:100]:
+    config = {k: v for k, v in run.config.items() if not k.startswith("_")}
+    rows.append({
+        "name": run.name,
+        **config,
+        "loss": run.summary_metrics.get("loss"),
+        "val_loss": run.summary_metrics.get("val_loss"),
+    })
+
+sweep_df = pd.DataFrame(rows)
+print("Best 5 by loss:")
+print(sweep_df.nsmallest(5, "loss").to_string(index=False))
+
+# Hyperparameter importance (simple correlation with loss)
+numeric = sweep_df.select_dtypes(include=[np.number])
+if "loss" in numeric.columns:
+    corr = numeric.corr()["loss"].drop("loss", errors="ignore").sort_values()
+    print("\nCorrelation with loss:")
+    print(corr.to_string())
+```
+
+### Side-by-side run comparison
+
+```python
+run_a = api.run(f"{path}/run-a")
+run_b = api.run(f"{path}/run-b")
+
+# Config diff
+config_df = pd.DataFrame([run_a.config, run_b.config]).T
+config_df.columns = [run_a.name, run_b.name]
+diff = config_df[config_df.iloc[:, 0] != config_df.iloc[:, 1]]
+print("Config differences:")
+print(diff.to_string())
+
+# Metric comparison
+for key in ["loss", "accuracy", "val_loss"]:
+    a = run_a.summary_metrics.get(key, "N/A")
+    b = run_b.summary_metrics.get(key, "N/A")
+    print(f"  {key}: {a} vs {b}")
+```
+
+---
+
+## Artifacts
+
+```python
+# Fetch by name + version/alias
+artifact = api.artifact(f"{path}/model-weights:latest")
+artifact = api.artifact(f"{path}/model-weights:v3")
+
+# Properties
+artifact.name         # str
+artifact.type         # str: "model", "dataset"
+artifact.version      # str: "v0", "v1"
+artifact.aliases      # list[str]: ["latest", "best"]
+artifact.metadata     # dict
+artifact.size         # int: bytes
+artifact.created_at   # str
+
+# Download
+local_path = artifact.download()
+artifact.download(root="/tmp/data")
+artifact.download(path_prefix="train/")
+
+# Lineage
+producer = artifact.logged_by()
+consumers = artifact.used_by()
+
+# From a run
+for art in run.logged_artifacts():
+    print(art.name, art.type, art.aliases)
+
+# Check existence
+exists = api.artifact_exists(f"{path}/my-model:v0")
+```
+
+---
+
+## System Metrics
+
+```python
+# GPU, CPU, memory, disk
+sys_df = run.history(stream="system")
+# Columns: system.cpu, system.memory, system.disk,
+#           system.gpu.0.gpu, system.gpu.0.memory, system.gpu.0.temp
+
+# GPU utilization analysis
+if "system.gpu.0.gpu" in sys_df.columns:
+    gpu = sys_df["system.gpu.0.gpu"].dropna()
+    print(f"GPU util: mean={gpu.mean():.1f}%, min={gpu.min():.1f}%, max={gpu.max():.1f}%")
+    low = gpu[gpu < 50]
+    print(f"Low utilization (<50%): {len(low)}/{len(gpu)} samples")
+
+# Memory
+if "system.gpu.0.memory" in sys_df.columns:
+    mem = sys_df["system.gpu.0.memory"].dropna()
+    print(f"GPU memory: mean={mem.mean():.1f}%, max={mem.max():.1f}%")
+
+# Latest snapshot
+latest = run.system_metrics  # dict
+```
+
+---
+
+## Projects
+
+```python
+projects = list(api.projects(entity, per_page=200))
+for p in projects[:20]:
+    print(p.name, getattr(p, "created_at", None))
+```
+
+---
+
+## Common Gotchas
+
+| Gotcha | Wrong | Right |
+|--------|-------|-------|
+| Summary access | `run.summary["loss"]` | `run.summary_metrics.get("loss")` |
+| Loading all runs | `list(api.runs(...))` | `runs[:200]` (always slice) |
+| History — all fields | `run.history()` | `run.history(samples=500, keys=["loss"])` |
+| History — no keys | `scan_history()` | `scan_history(keys=["loss"])` (explicit) |
+| Raw data in context | `print(run.history())` | Load into DataFrame, compute stats, print summary |
+| Comparing configs | manual key-by-key | `pd.DataFrame([a.config, b.config]).T` |
+| Metric at step N | iterate history | `scan_history(keys=["loss"], min_step=N, max_step=N+1)` |
+| Cache staleness | reading live run | `api.flush()` first |
+
+---
+
+## Quick Reference
+
+```python
+# Find best run by loss
+best = api.runs(path, filters={"state": "finished"}, order="+summary_metrics.loss")[:1]
+print(f"Best: {best[0].name}, loss={best[0].summary_metrics['loss']}")
+
+# Get a run's full loss curve into numpy
+losses = np.array([r["loss"] for r in run.scan_history(keys=["loss"])])
+print(f"Loss: min={losses.min():.6f}, final={losses[-1]:.6f}, steps={len(losses)}")
+
+# Compare N runs on one metric
+runs = api.runs(path, filters={"state": "finished"})[:20]
+data = [(r.name, r.summary_metrics.get("loss", float("inf"))) for r in runs]
+df = pd.DataFrame(data, columns=["run", "loss"]).sort_values("loss")
+print(df.to_string(index=False))
+
+# Download best model artifact
+best_run = api.runs(path, order="+summary_metrics.loss")[:1][0]
+for art in best_run.logged_artifacts():
+    if art.type == "model":
+        art.download(root="/tmp/best_model")
+        print(f"Downloaded {art.name}:{art.version}")
+```

--- a/.agents/skills/wandb-primary/references/WEAVE_SDK.md
+++ b/.agents/skills/wandb-primary/references/WEAVE_SDK.md
@@ -1,0 +1,224 @@
+<!--
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: skills
+-->
+
+# Weave SDK Reference — Traces, Calls, Evaluations
+
+Reference for querying Weave GenAI trace data using the `weave` Python SDK. Covers initialization, querying calls, filtering, MongoDB-style queries, server-side stats, and reading call data.
+
+**Key principle**: Weave traces can be large. Always use `unwrap()` to convert Weave wrapper types to plain Python, then load into pandas for analysis. Never dump raw call data into context.
+
+Use the bundled `weave_helpers.py` for common operations (unwrap, token extraction, eval results). This reference covers the full SDK for when you need more control.
+
+## Initialization
+
+```python
+import weave
+
+# IMPORTANT: positional string, NOT keyword args
+client = weave.init("entity/project")    # CORRECT
+# weave.init(project="entity/project")   # WRONG — TypeError
+
+import os
+entity = os.environ["WANDB_ENTITY"]
+project = os.environ["WANDB_PROJECT"]
+client = weave.init(f"{entity}/{project}")
+
+# The client object is your entry point
+# client.entity, client.project, client.get_calls(), client.get_call()
+```
+
+## Querying calls
+
+```python
+from weave.trace.weave_client import CallsFilter
+
+# Basic queries
+calls = client.get_calls(limit=100)
+calls = client.get_calls(filter=CallsFilter(trace_roots_only=True), limit=50)
+
+# Filter by op name (use wildcard * for version hash)
+op_ref = f"weave:///{client.entity}/{client.project}/op/Evaluation.evaluate:*"
+calls = client.get_calls(filter=CallsFilter(op_names=[op_ref]))
+
+# Filter by parent (get children of an eval call)
+# IMPORTANT: it's parent_ids (PLURAL) and takes a LIST
+children = list(client.get_calls(
+    filter=CallsFilter(parent_ids=["019ca0aa-745b-73f9-be4c-05e1759d3ca7"])
+))
+
+# Sort by most recent
+calls = client.get_calls(
+    sort_by=[{"field": "started_at", "direction": "desc"}],
+    limit=10,
+)
+
+# Count without fetching all data (cheap)
+count = len(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
+
+# Restrict columns for performance
+calls = client.get_calls(columns=["op_name", "started_at"], limit=1000)
+
+# Convert to pandas
+df = client.get_calls(limit=500).to_pandas()
+```
+
+## Efficient counting (calls_query_stats)
+
+For projects with 100k+ traces, use server-side stats instead of fetching all calls:
+
+```python
+from weave.trace_server.trace_server_interface import CallsQueryStatsReq
+
+stats = client.server.calls_query_stats(CallsQueryStatsReq(
+    project_id=f"{client.entity}/{client.project}",
+    filter={"op_names": [f"weave:///{client.entity}/{client.project}/op/rollout:*"]},
+))
+print(f"rollout call count: {stats.count}")
+
+# Count by different op names
+for op_name in ["rollout", "ruler_score_group", "openai.chat.completions.create"]:
+    stats = client.server.calls_query_stats(CallsQueryStatsReq(
+        project_id=f"{client.entity}/{client.project}",
+        filter={"op_names": [f"weave:///{client.entity}/{client.project}/op/{op_name}:*"]},
+    ))
+    print(f"  {op_name}: {stats.count}")
+
+# Count root-only traces
+stats = client.server.calls_query_stats(CallsQueryStatsReq(
+    project_id=f"{client.entity}/{client.project}",
+    filter={"trace_roots_only": True},
+))
+print(f"Root traces: {stats.count}")
+```
+
+## CallsFilter fields
+
+```python
+CallsFilter(
+    op_names=["weave:///entity/project/op/MyOp:*"],
+    parent_ids=["call-id-123"],       # children of specific call(s)
+    trace_ids=["trace-id-abc"],       # all calls in a trace
+    call_ids=["id1", "id2"],          # specific calls by ID
+    trace_roots_only=True,            # only root-level calls (no parent)
+    wb_run_ids=["run-id"],            # calls from a W&B run
+)
+```
+
+## Advanced queries (MongoDB-style)
+
+```python
+from weave.trace_server.interface.query import Query
+
+# Find error calls
+error_calls = client.get_calls(
+    query=Query(**{
+        "$expr": {
+            "$not": [{"$eq": [{"$getField": "exception"}, {"$literal": None}]}]
+        }
+    })
+)
+
+# Op name contains substring
+calls = client.get_calls(
+    query=Query(**{
+        "$expr": {
+            "$contains": {
+                "input": {"$getField": "op_name"},
+                "substr": {"$literal": ".score"},
+                "case_insensitive": True,
+            }
+        }
+    })
+)
+```
+
+**Operators:** `$eq`, `$gt`, `$lt`, `$gte`, `$lte`, `$and`, `$or`, `$not`, `$in`, `$contains`
+**Operands:** `{"$getField": "field.path"}`, `{"$literal": value}`
+
+## Reading call data
+
+```python
+call = client.get_call("call-id-here")
+
+# Identity
+call.id              # str: call UUID
+call.op_name         # str: full ref URI
+call.func_name       # str: just "Evaluation.evaluate"
+call.display_name    # str | None
+call.trace_id        # str
+call.parent_id       # str | None (None = root)
+
+# Timing
+call.started_at      # datetime
+call.ended_at        # datetime | None
+duration = (call.ended_at - call.started_at).total_seconds()
+
+# I/O — these are WeaveDict/WeaveObject, use unwrap() if needed
+call.inputs          # WeaveDict (dict-like)
+call.output          # WeaveDict or WeaveObject or None
+call.exception       # str | None
+
+# Status
+status = call.summary.get("weave", {}).get("status")
+# "success", "error", "running", "descendant_error"
+
+# Token usage (keyed by model name)
+usage = call.summary.get("usage", {})
+for model_name, u in usage.items():
+    input_tokens = u.get("input_tokens") or u.get("prompt_tokens") or 0
+    output_tokens = u.get("output_tokens") or u.get("completion_tokens") or 0
+    total = u.get("total_tokens", 0)
+
+# Children
+children = list(client.get_calls(filter=CallsFilter(parent_ids=[call.id])))
+```
+
+## Evaluation call hierarchy
+
+```
+Evaluation.evaluate (root)
+  +-- Evaluation.predict_and_score (one per dataset row x trials)
+  |     +-- model.predict (the actual model call)
+  |     +-- scorer_1.score
+  |     +-- scorer_2.score
+  +-- Evaluation.summarize
+```
+
+## Eval status and health data locations
+
+```python
+summary = eval_call.summary
+
+# Status
+summary["weave"]["status"]                    # "success" | "error" | "descendant_error" | "running"
+
+# Descendant call counts
+summary["weave"]["status_counts"]["success"]  # int
+summary["weave"]["status_counts"]["error"]    # int
+
+# Token usage (keyed by model name)
+summary["usage"]["gpt-4o"]["total_tokens"]    # int
+summary["usage"]["gpt-4o"]["input_tokens"]    # int
+summary["usage"]["gpt-4o"]["output_tokens"]   # int
+
+# Cost (if include_costs=True was used)
+summary["weave"]["costs"]                     # dict
+```
+
+## Import paths
+
+These are easy to get wrong:
+
+```python
+# CallsFilter
+from weave.trace.weave_client import CallsFilter
+
+# Query (MongoDB-style)
+from weave.trace_server.interface.query import Query
+
+# Stats endpoint
+from weave.trace_server.trace_server_interface import CallsQueryStatsReq
+```

--- a/.agents/skills/wandb-primary/scripts/curve_plots.py
+++ b/.agents/skills/wandb-primary/scripts/curve_plots.py
@@ -1,0 +1,442 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+"""Chart rendering for LLM vision consumption.
+
+These functions produce PNGs that Claude reads back with the Read tool to
+form gestalt impressions of training runs — the visual complement to the
+numeric features in `training_diagnostics.py`.
+
+Default output directory: `/tmp/wandb_plots/<run_id>/`. Ephemeral per
+design — repo should not fill up with run artefacts.
+
+All public functions return the path to the written PNG.
+
+Usage:
+    from curve_plots import (
+        plot_single_run_overview,
+        plot_run_comparison,
+        plot_grad_histogram_heatmap,
+        plot_grad_norm_by_layer,
+    )
+
+    png = plot_single_run_overview(run, step_key="_step")
+    # Then Read the png path with the Read tool so Claude sees the image.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+matplotlib.use("Agg")  # safe for headless pods
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from training_diagnostics import (  # noqa: E402
+    curve_features,
+    grad_histogram_features,
+)
+from wandb_helpers import discover_history_keys, fast_scan_history  # noqa: E402
+
+
+DEFAULT_ROOT = Path("/tmp/wandb_plots")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _ensure_out_dir(run_id: str, out_dir: str | os.PathLike | None) -> Path:
+    root = Path(out_dir) if out_dir else DEFAULT_ROOT / run_id
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _load_history(
+    run: Any,
+    keys: list[str],
+    step_key: str,
+    samples: int = 2000,
+) -> pd.DataFrame:
+    """Fast downsampled history for plotting. Uses server-side bucketing."""
+    df = None
+    try:
+        df = run.history(samples=samples, keys=keys, x_axis=step_key, pandas=True)
+    except Exception:
+        df = None
+    if df is None or len(df) == 0 or step_key not in df.columns:
+        # Fall back to full scan (prefers beta_scan_history parquet).
+        df = pd.DataFrame(list(fast_scan_history(run, keys=keys)))
+    return df
+
+
+def _mark_spikes(ax: plt.Axes, values: np.ndarray, steps: np.ndarray, features: dict) -> None:
+    spikes = features.get("spikes", [])
+    if not spikes:
+        return
+    spike_steps = [s["step"] for s in spikes]
+    spike_vals = [s["value"] for s in spikes]
+    ax.scatter(spike_steps, spike_vals, c="red", s=16, zorder=5, label=f"{len(spikes)} spike(s)")
+
+
+def _panel(ax: plt.Axes, steps: np.ndarray, values: np.ndarray, title: str,
+           direction: str = "decreasing", log_y: bool = False) -> None:
+    ax.plot(steps, values, linewidth=1.2, color="#1f77b4")
+    feats = curve_features(values, steps, direction=direction)
+    _mark_spikes(ax, values, steps, feats)
+    ax.set_title(title, fontsize=10)
+    ax.grid(True, alpha=0.3)
+    if log_y and np.nanmin(values) > 0:
+        ax.set_yscale("log")
+    # Annotate: final, min, smoothness.
+    txt = (f"final={feats.get('last', float('nan')):.3g}  "
+           f"min={feats.get('min', float('nan')):.3g}  "
+           f"smooth={feats.get('smoothness', float('nan')):.2g}  "
+           f"spikes={feats.get('spike_count', 0)}")
+    ax.text(0.02, 0.98, txt, transform=ax.transAxes, fontsize=7,
+            verticalalignment="top", family="monospace",
+            bbox={"boxstyle": "round,pad=0.2", "facecolor": "white", "alpha": 0.7})
+
+
+# ---------------------------------------------------------------------------
+# Single-run overview
+# ---------------------------------------------------------------------------
+
+DEFAULT_OVERVIEW_METRICS: dict[str, dict[str, Any]] = {
+    "train_loss": {"keys": ["loss", "train/loss", "train_loss"], "direction": "decreasing", "log_y": True},
+    "val_loss": {"keys": ["val_loss", "val/loss", "validation/loss"], "direction": "decreasing", "log_y": True},
+    "lr": {"keys": ["lr", "learning_rate", "train/lr"], "direction": "auto", "log_y": False},
+    "grad_norm": {"keys": ["grad_norm", "train/grad_norm", "gradients/global_norm"], "direction": "decreasing", "log_y": True},
+    "accuracy": {"keys": ["accuracy", "val/accuracy", "val_acc"], "direction": "increasing", "log_y": False},
+    "throughput": {"keys": ["throughput", "samples_per_sec", "train/throughput"], "direction": "auto", "log_y": False},
+}
+
+
+def _resolve_metric(df_columns: set[str], candidates: list[str]) -> str | None:
+    for c in candidates:
+        if c in df_columns:
+            return c
+    return None
+
+
+def plot_single_run_overview(
+    run: Any,
+    step_key: str,
+    metrics: list[tuple[str, list[str], str, bool]] | None = None,
+    out_dir: str | os.PathLike | None = None,
+    samples: int = 2000,
+) -> Path:
+    """Render a 2x3 small-multiples composite PNG for one run.
+
+    Args:
+        run: A W&B Run object.
+        step_key: Confirmed x-axis step key.
+        metrics: Optional override list of `(title, candidate_keys, direction,
+            log_y)` tuples. If omitted, uses the default 6-panel layout
+            (train loss, val loss, lr, grad norm, accuracy, throughput),
+            auto-resolving each candidate against the run's logged keys.
+        out_dir: Override output directory. Default
+            `/tmp/wandb_plots/<run_id>/`.
+        samples: Server-side sample count passed to `run.history`.
+
+    Returns:
+        Path to the written PNG.
+    """
+    out = _ensure_out_dir(run.id, out_dir)
+
+    # Decide the 6 panels.
+    if metrics is None:
+        panels: list[tuple[str, list[str], str, bool]] = [
+            (title, cfg["keys"], cfg["direction"], cfg["log_y"])
+            for title, cfg in DEFAULT_OVERVIEW_METRICS.items()
+        ]
+    else:
+        panels = metrics
+
+    # Pull all needed keys in one history call.
+    all_keys: list[str] = [step_key]
+    for _, candidates, _, _ in panels:
+        all_keys.extend(candidates)
+    df = _load_history(
+        run,
+        keys=list(dict.fromkeys(all_keys)),
+        step_key=step_key,
+        samples=samples,
+    )
+    cols = set(df.columns)
+
+    fig, axes = plt.subplots(2, 3, figsize=(15, 8), sharex=True)
+    steps = df[step_key].to_numpy() if step_key in df.columns else np.arange(len(df))
+
+    for ax, (title, candidates, direction, log_y) in zip(axes.flat, panels):
+        resolved = _resolve_metric(cols, candidates)
+        if resolved is None:
+            ax.set_title(f"{title} — not logged", fontsize=10, color="gray")
+            ax.text(0.5, 0.5, "metric not found", transform=ax.transAxes,
+                    ha="center", va="center", color="gray", fontsize=9)
+            ax.grid(True, alpha=0.3)
+            continue
+        series = df[[step_key, resolved]].dropna()
+        if len(series) == 0:
+            ax.set_title(f"{title} ({resolved}) — empty", fontsize=10, color="gray")
+            continue
+        s = series[step_key].to_numpy()
+        v = series[resolved].to_numpy()
+        _panel(ax, s, v, f"{title} ({resolved})", direction=direction, log_y=log_y)
+
+    for ax in axes[-1]:
+        ax.set_xlabel(step_key)
+    fig.suptitle(f"{run.name} [{run.id}]   x-axis: {step_key}", fontsize=12)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+
+    path = out / "overview.png"
+    fig.savefig(path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Multi-run comparison
+# ---------------------------------------------------------------------------
+
+def plot_run_comparison(
+    runs: list[Any],
+    metric: str,
+    step_key: str,
+    out_dir: str | os.PathLike | None = None,
+    max_runs: int = 6,
+    highlight: str | None = None,
+    samples: int = 2000,
+    log_y: bool = True,
+) -> Path:
+    """Overlay a single metric across multiple runs.
+
+    Args:
+        runs: List of W&B Run objects. Must be <= `max_runs` unless caller
+            explicitly raises the cap.
+        metric: Metric to compare.
+        step_key: Confirmed x-axis.
+        out_dir: Override output directory. Default
+            `/tmp/wandb_plots/compare_<N>runs_<metric>/`.
+        max_runs: Hard cap on overlay density. Default 6.
+        highlight: Optional run id or name to render bold.
+        samples: history() sample count.
+        log_y: Log-scale the y-axis (sensible for losses).
+
+    Returns:
+        Path to the written PNG.
+    """
+    if len(runs) > max_runs:
+        raise ValueError(
+            f"plot_run_comparison got {len(runs)} runs but max_runs={max_runs}. "
+            "Pass a smaller list (e.g. top-k by final metric) or explicitly "
+            "raise max_runs if you know the chart will still be readable."
+        )
+    if not runs:
+        raise ValueError("plot_run_comparison got an empty run list.")
+
+    slug = metric.replace("/", "_")
+    root = Path(out_dir) if out_dir else DEFAULT_ROOT / f"compare_{len(runs)}runs_{slug}"
+    root.mkdir(parents=True, exist_ok=True)
+
+    fig, ax = plt.subplots(figsize=(11, 6))
+    colors = plt.cm.tab10.colors  # up to 10 distinct colors
+    aligned: list[pd.Series] = []
+
+    for i, run in enumerate(runs):
+        df = _load_history(run, keys=[metric, step_key], step_key=step_key, samples=samples)
+        if metric not in df.columns or step_key not in df.columns:
+            continue
+        df = df[[step_key, metric]].dropna()
+        if len(df) == 0:
+            continue
+        is_hl = highlight is not None and (highlight == run.id or highlight == run.name)
+        lw = 2.4 if is_hl else 1.2
+        alpha = 1.0 if is_hl else 0.85
+        ax.plot(df[step_key].to_numpy(), df[metric].to_numpy(),
+                label=run.name, linewidth=lw, alpha=alpha,
+                color=colors[i % len(colors)])
+        aligned.append(df.set_index(step_key)[metric])
+
+    # Faint min-max band across runs.
+    if len(aligned) >= 2:
+        concat = pd.concat(aligned, axis=1).sort_index()
+        lo = concat.min(axis=1)
+        hi = concat.max(axis=1)
+        ax.fill_between(concat.index, lo, hi, alpha=0.08, color="gray",
+                        label="min-max band")
+
+    if log_y and all((s.dropna() > 0).all() for s in aligned if len(s)):
+        ax.set_yscale("log")
+
+    ax.set_title(f"{metric}  —  {len(runs)} runs  (x: {step_key})", fontsize=12)
+    ax.set_xlabel(step_key)
+    ax.set_ylabel(metric)
+    ax.grid(True, alpha=0.3)
+    ax.legend(fontsize=8, loc="best")
+    fig.tight_layout()
+
+    path = root / f"comparison_{slug}.png"
+    fig.savefig(path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Gradient histogram heatmap
+# ---------------------------------------------------------------------------
+
+def plot_grad_histogram_heatmap(
+    run: Any,
+    layer_prefix: str = "gradients/",
+    metric: str = "mean_abs",
+    step_key: str = "_step",
+    out_dir: str | os.PathLike | None = None,
+    n_step_buckets: int = 60,
+) -> Path:
+    """Per-layer gradient-histogram stat as a heatmap (layer x step).
+
+    Reads histogram-logged gradients (typically from `wandb.watch`),
+    computes per-bin summary stats, and renders a heatmap where:
+      - rows = layers (ordered by name)
+      - columns = step buckets (binned for readability)
+      - color = chosen stat (`mean_abs`, `kurtosis`, `variance`, `max_abs`)
+
+    Args:
+        run: A W&B Run object.
+        layer_prefix: Prefix for histogram keys.
+        metric: Which per-histogram stat to visualize.
+        step_key: Confirmed step key.
+        out_dir: Override output directory.
+        n_step_buckets: Column count in the heatmap.
+
+    Returns:
+        Path to the written PNG.
+    """
+    df = grad_histogram_features(run, layer_prefix=layer_prefix, step_key=step_key)
+    if len(df) == 0:
+        raise ValueError(f"No gradient histogram data for run {run.id}.")
+    if metric not in df.columns:
+        raise ValueError(f"Unknown histogram metric `{metric}`. "
+                         f"Available: {list(df.columns)}")
+
+    # Bucket steps into N evenly-spaced bins.
+    step_min, step_max = df["step"].min(), df["step"].max()
+    edges = np.linspace(step_min, step_max, n_step_buckets + 1)
+    df["step_bucket"] = np.clip(
+        np.searchsorted(edges, df["step"], side="right") - 1,
+        0, n_step_buckets - 1,
+    )
+
+    pivot = df.pivot_table(
+        index="layer", columns="step_bucket", values=metric, aggfunc="mean",
+    )
+    pivot = pivot.sort_index()
+    bucket_centers = 0.5 * (edges[:-1] + edges[1:])
+
+    out = _ensure_out_dir(run.id, out_dir)
+    fig, ax = plt.subplots(figsize=(max(10, n_step_buckets * 0.15),
+                                    max(4, len(pivot) * 0.25)))
+
+    data = pivot.to_numpy()
+    norm = matplotlib.colors.LogNorm(vmin=max(np.nanmin(data[data > 0]), 1e-12),
+                                     vmax=np.nanmax(data)) if (data > 0).any() else None
+    im = ax.imshow(data, aspect="auto", cmap="viridis", norm=norm,
+                   interpolation="nearest")
+    ax.set_yticks(range(len(pivot.index)))
+    ax.set_yticklabels(pivot.index, fontsize=7)
+    step_tick_idx = np.linspace(0, n_step_buckets - 1, min(10, n_step_buckets)).astype(int)
+    ax.set_xticks(step_tick_idx)
+    ax.set_xticklabels([f"{bucket_centers[i]:.0f}" for i in step_tick_idx], fontsize=8)
+    ax.set_xlabel(step_key)
+    ax.set_ylabel("layer")
+    ax.set_title(f"{run.name} — grad histograms, {metric} (log color)")
+    fig.colorbar(im, ax=ax, label=metric)
+    fig.tight_layout()
+
+    path = out / f"grad_histograms_{metric}.png"
+    fig.savefig(path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Per-layer grad norm small-multiples
+# ---------------------------------------------------------------------------
+
+def plot_grad_norm_by_layer(
+    run: Any,
+    step_key: str,
+    layer_prefix: str = "parameters/",
+    max_layers: int = 16,
+    out_dir: str | os.PathLike | None = None,
+    samples: int = 2000,
+    probe_rows: int = 500,
+) -> Path:
+    """Small-multiples of per-layer scalar grad norms.
+
+    Looks for scalar (non-histogram) keys matching `layer_prefix*` — e.g.
+    `parameters/layer1.weight_grad_norm`. Renders up to `max_layers`
+    subplots on a shared x-axis.
+    """
+    layer_keys = discover_history_keys(
+        run,
+        lambda key, value: (
+            key.startswith(layer_prefix)
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        ),
+        max_rows=probe_rows,
+    )
+    if not layer_keys:
+        raise ValueError(
+            f"No scalar per-layer keys found with prefix `{layer_prefix}`. "
+            "If you want per-layer grad norms, log them as scalars "
+            f"(e.g. `wandb.log({{'{layer_prefix}layer1_grad_norm': ...}})`)."
+        )
+    overflow = max(0, len(layer_keys) - max_layers)
+    layer_keys = layer_keys[:max_layers]
+
+    df = _load_history(run, keys=[step_key, *layer_keys], step_key=step_key, samples=samples)
+    out = _ensure_out_dir(run.id, out_dir)
+
+    n = len(layer_keys)
+    cols = min(4, n)
+    rows = (n + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(4 * cols, 2.4 * rows),
+                             sharex=True, squeeze=False)
+
+    for ax, key in zip(axes.flat, layer_keys):
+        series = df[[step_key, key]].dropna()
+        if len(series) == 0:
+            ax.set_title(key, fontsize=8, color="gray")
+            ax.text(0.5, 0.5, "no data", transform=ax.transAxes,
+                    ha="center", va="center", color="gray", fontsize=8)
+            continue
+        ax.plot(series[step_key].to_numpy(), series[key].to_numpy(),
+                linewidth=1.0, color="#2ca02c")
+        ax.set_title(key[len(layer_prefix):], fontsize=8)
+        ax.grid(True, alpha=0.3)
+        if (series[key] > 0).all():
+            ax.set_yscale("log")
+
+    for ax in axes.flat[n:]:
+        ax.set_visible(False)
+
+    for ax in axes[-1]:
+        ax.set_xlabel(step_key)
+    title = f"{run.name} — per-layer grad norm"
+    if overflow:
+        title += f"   (showing {n}/{n + overflow} layers)"
+    fig.suptitle(title, fontsize=11)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+
+    path = out / "grad_norm_by_layer.png"
+    fig.savefig(path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    return path

--- a/.agents/skills/wandb-primary/scripts/step_axis.py
+++ b/.agents/skills/wandb-primary/scripts/step_axis.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+"""X-axis step-metric detection for W&B runs.
+
+Training curves are meaningless without knowing which column is the x-axis.
+Different training stacks log different step keys — `_step` (wandb default),
+`global_step` (HF Trainer), `trainer/global_step`, `epoch`, or custom names
+like `train/step`. The skill MUST confirm this with the user before any
+curve-shape or plotting work. These helpers feed that confirmation step.
+
+Usage:
+    from step_axis import (
+        list_candidate_step_keys,
+        guess_step_key_from_workspace,
+        format_step_candidates,
+    )
+
+    candidates = list_candidate_step_keys(run)
+    guess = guess_step_key_from_workspace(entity, project)
+    # Then show `format_step_candidates(candidates, guess)` to the user via
+    # AskUserQuestion and wait for confirmation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from wandb_helpers import fast_scan_history
+
+# Common step-key names in order of likelihood.
+KNOWN_STEP_KEYS: tuple[str, ...] = (
+    "_step",
+    "global_step",
+    "trainer/global_step",
+    "train/step",
+    "step",
+    "epoch",
+    "train/epoch",
+    "iteration",
+    "iter",
+)
+
+
+def list_candidate_step_keys(run: Any, sample_rows: int = 50) -> list[str]:
+    """Return plausible step-axis keys logged in this run's history.
+
+    Scans the first `sample_rows` rows of history (no keys filter) to learn
+    which columns the run actually logs, then keeps only those that match a
+    known step-key name OR appear numeric and monotonically non-decreasing
+    across the sample.
+
+    Ordering: known-name matches first (in `KNOWN_STEP_KEYS` order), then
+    any other monotonic-numeric candidates, sorted alphabetically.
+
+    Args:
+        run: A W&B Run object from api.run().
+        sample_rows: How many rows to inspect (default 50).
+
+    Returns:
+        List of candidate column names. Never raises; returns [] if the
+        history is empty or unreadable.
+    """
+    try:
+        rows = []
+        for i, row in enumerate(fast_scan_history(run)):
+            rows.append(row)
+            if i + 1 >= sample_rows:
+                break
+    except Exception:
+        return []
+    if not rows:
+        return []
+
+    all_keys: set[str] = set()
+    for r in rows:
+        all_keys.update(r.keys())
+
+    # Known keys that actually appear.
+    known_hits = [k for k in KNOWN_STEP_KEYS if k in all_keys]
+
+    # Monotonic-numeric columns not already matched.
+    monotonic_extras: list[str] = []
+    for key in sorted(all_keys):
+        if key in known_hits:
+            continue
+        if key.startswith("_") and key != "_step":
+            continue
+        values = [r.get(key) for r in rows if r.get(key) is not None]
+        if len(values) < 5:
+            continue
+        if not all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in values):
+            continue
+        if all(values[i + 1] >= values[i] for i in range(len(values) - 1)):
+            monotonic_extras.append(key)
+
+    return known_hits + monotonic_extras
+
+
+def guess_step_key_from_workspace(entity: str, project: str) -> str | None:
+    """Peek at the project's most recent workspace and return the x-axis
+    its first line-plot uses. This reflects what the human actually looks
+    at in the W&B UI.
+
+    Degrades silently: returns None if `wandb_workspaces` isn't installed,
+    if no workspace or line plot exists, or if anything else goes wrong.
+    Never raises.
+
+    Args:
+        entity: W&B entity name.
+        project: W&B project name.
+
+    Returns:
+        The x-axis metric name, or None.
+    """
+    try:
+        import wandb_workspaces.workspaces as ws  # type: ignore
+    except Exception:
+        return None
+
+    try:
+        workspaces = ws.Workspace.list(entity=entity, project=project)
+    except Exception:
+        return None
+    if not workspaces:
+        return None
+
+    # Most recent first; the list's order depends on the SDK version, so try
+    # all of them until one yields a usable line plot.
+    for wsp_ref in workspaces:
+        try:
+            wsp = wsp_ref.load() if hasattr(wsp_ref, "load") else wsp_ref
+        except Exception:
+            continue
+        sections = getattr(wsp, "sections", None) or []
+        for section in sections:
+            panels = getattr(section, "panels", None) or []
+            for panel in panels:
+                x = getattr(panel, "x", None)
+                if isinstance(x, str) and x:
+                    return x
+    return None
+
+
+def format_step_candidates(
+    candidates: list[str],
+    workspace_guess: str | None,
+) -> list[tuple[str, str]]:
+    """Format candidates as (label, description) pairs ready to hand to
+    AskUserQuestion.
+
+    The workspace guess (if any) is placed first and labeled "(Recommended)".
+    Duplicate entries are dropped.
+
+    Args:
+        candidates: Output of `list_candidate_step_keys`.
+        workspace_guess: Output of `guess_step_key_from_workspace`.
+
+    Returns:
+        List of (label, description) tuples. Empty if no candidates at all.
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    if workspace_guess:
+        ordered.append(workspace_guess)
+        seen.add(workspace_guess)
+    for c in candidates:
+        if c not in seen:
+            ordered.append(c)
+            seen.add(c)
+
+    pairs: list[tuple[str, str]] = []
+    for i, key in enumerate(ordered):
+        is_ws_guess = key == workspace_guess
+        if is_ws_guess:
+            label = f"{key} (Recommended)"
+            desc = "Matches the x-axis used by this project's W&B workspace panels."
+        elif key in KNOWN_STEP_KEYS:
+            desc = f"Standard step-key `{key}` logged in this run's history."
+            label = key
+        else:
+            desc = f"Custom monotonic column `{key}` found in this run's history."
+            label = key
+        pairs.append((label, desc))
+    return pairs

--- a/.agents/skills/wandb-primary/scripts/training_diagnostics.py
+++ b/.agents/skills/wandb-primary/scripts/training_diagnostics.py
@@ -1,0 +1,518 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+"""Curve-shape diagnostics for W&B training runs.
+
+This is the numerical counterpart to `curve_plots.py`. It turns a noisy loss
+curve into a compact dict of features that mirror how an experienced ML
+researcher eyeballs a chart: spikes, smoothness, checkpoint slopes,
+plateaus, divergence. Pair these features with a PNG that Claude reads via
+vision — the two cross-check each other.
+
+No plotting, no filesystem side-effects. Only wandb scan_history access;
+caller is expected to pass a confirmed step key.
+
+Usage:
+    from training_diagnostics import (
+        curve_features,
+        compare_runs_curves,
+        lr_schedule_features,
+        grad_norm_features,
+        grad_histogram_features,
+    )
+
+    feats = curve_features(loss_series, step_series, direction="decreasing")
+    df = compare_runs_curves([run_a, run_b], metric="loss", step_key="_step")
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Literal
+
+import numpy as np
+import pandas as pd
+
+from wandb_helpers import discover_history_keys, fast_scan_history
+
+
+Direction = Literal["decreasing", "increasing", "auto"]
+
+
+# ---------------------------------------------------------------------------
+# Core single-curve features
+# ---------------------------------------------------------------------------
+
+def curve_features(
+    values: Iterable[float] | pd.Series | np.ndarray,
+    steps: Iterable[float] | pd.Series | np.ndarray | None = None,
+    n_checkpoints: int = 20,
+    direction: Direction = "auto",
+    spike_z: float = 3.0,
+) -> dict[str, Any]:
+    """Extract researcher-intuition features from a single metric curve.
+
+    Args:
+        values: Metric values, one per step.
+        steps: Step values matching `values`. If None, uses positional index.
+        n_checkpoints: Number of evenly-spaced segments to compute a slope
+                       over (default 20, i.e. every 5% of the run).
+        direction: "decreasing" (loss-like), "increasing" (accuracy-like),
+                   or "auto" — pick based on whether first half mean > second
+                   half mean.
+        spike_z: Z-score threshold for spike detection.
+
+    Returns:
+        Dict with numeric features. NaN/Inf values are dropped before stats
+        but counted separately.
+    """
+    v = np.asarray(list(values), dtype=float)
+    s = np.arange(len(v), dtype=float) if steps is None else np.asarray(list(steps), dtype=float)
+
+    if len(v) == 0:
+        return {"n_points": 0}
+
+    nan_mask = ~np.isfinite(v)
+    nan_count = int(nan_mask.sum())
+    first_nan_step = float(s[nan_mask][0]) if nan_count else None
+
+    # Drop NaN/Inf for all subsequent stats.
+    good = np.isfinite(v)
+    v_clean = v[good]
+    s_clean = s[good]
+    n = len(v_clean)
+    if n == 0:
+        return {
+            "n_points": 0,
+            "nan_inf_count": nan_count,
+            "first_nan_step": first_nan_step,
+        }
+
+    # Direction.
+    if direction == "auto":
+        half = n // 2 or 1
+        direction = "decreasing" if v_clean[:half].mean() > v_clean[-half:].mean() else "increasing"
+
+    # Basic stats.
+    argmin_i = int(np.argmin(v_clean))
+    argmax_i = int(np.argmax(v_clean))
+    final_tail = max(1, n // 10)
+    final_slice = v_clean[-final_tail:]
+
+    # Smoothness: rolling std / rolling mean, averaged over the curve.
+    window = max(5, n // 50)  # ~2% of steps
+    series = pd.Series(v_clean)
+    rolling_mean = series.rolling(window, center=True, min_periods=1).mean()
+    rolling_std = series.rolling(window, center=True, min_periods=1).std()
+    # Scale rolling std by the curve's range so smoothness is comparable
+    # across metrics of different magnitudes.
+    curve_range = float(v_clean.max() - v_clean.min()) or 1.0
+    smoothness = float((rolling_std / curve_range).dropna().mean())
+
+    # Spikes: points > spike_z std above local mean (for loss-like) or below
+    # (for accuracy-like). We flag in whichever direction is "bad".
+    residual = series - rolling_mean
+    if direction == "decreasing":
+        spike_mask = residual > spike_z * rolling_std
+    else:
+        spike_mask = residual < -spike_z * rolling_std
+    spike_idx = np.where(spike_mask.fillna(False))[0]
+    spikes = [
+        {
+            "step": float(s_clean[i]),
+            "value": float(v_clean[i]),
+            "z_score": float(residual.iloc[i] / rolling_std.iloc[i])
+            if rolling_std.iloc[i] and np.isfinite(rolling_std.iloc[i])
+            else float("inf"),
+            "magnitude": float(abs(residual.iloc[i])),
+        }
+        for i in spike_idx
+    ]
+
+    # Monotonicity: % of consecutive deltas in the expected direction.
+    deltas = np.diff(v_clean)
+    if direction == "decreasing":
+        mono_pct = float((deltas <= 0).mean() * 100)
+    else:
+        mono_pct = float((deltas >= 0).mean() * 100)
+
+    # Checkpoint slopes: linear fit over n_checkpoints segments.
+    checkpoint_slopes: list[dict[str, float]] = []
+    if n >= n_checkpoints * 2:
+        edges = np.linspace(0, n, n_checkpoints + 1, dtype=int)
+        for i in range(n_checkpoints):
+            a, b = edges[i], edges[i + 1]
+            if b - a < 2:
+                continue
+            xs = s_clean[a:b]
+            ys = v_clean[a:b]
+            # Guard: if steps are constant, skip slope.
+            if xs[-1] == xs[0]:
+                continue
+            slope = float(np.polyfit(xs, ys, 1)[0])
+            checkpoint_slopes.append({
+                "pct_start": round(100 * a / n, 1),
+                "pct_end": round(100 * b / n, 1),
+                "step_start": float(xs[0]),
+                "step_end": float(xs[-1]),
+                "slope": slope,
+            })
+
+    # Plateau regions: stretches where rolling |change| is tiny relative
+    # to the curve range.
+    change = series.diff().abs().rolling(window, min_periods=1).mean()
+    plateau_tol = curve_range * 1e-4
+    plateau_mask = (change < plateau_tol).fillna(False).to_numpy()
+    plateau_regions: list[dict[str, float]] = []
+    if plateau_mask.any():
+        # Find contiguous runs of True longer than `window`.
+        idx = 0
+        while idx < len(plateau_mask):
+            if plateau_mask[idx]:
+                start = idx
+                while idx < len(plateau_mask) and plateau_mask[idx]:
+                    idx += 1
+                end = idx
+                if end - start >= window:
+                    plateau_regions.append({
+                        "start_step": float(s_clean[start]),
+                        "end_step": float(s_clean[end - 1]),
+                        "value": float(v_clean[start:end].mean()),
+                    })
+            else:
+                idx += 1
+
+    # Divergence: in the last 20%, is the rolling mean of deltas
+    # consistently in the wrong direction?
+    tail_start = max(0, n - max(window, n // 5))
+    tail_delta = deltas[max(0, tail_start - 1):]
+    if direction == "decreasing":
+        divergent = bool(len(tail_delta) > window and tail_delta.mean() > 0)
+    else:
+        divergent = bool(len(tail_delta) > window and tail_delta.mean() < 0)
+    divergence_start = None
+    if divergent:
+        # Earliest step in the tail where the running mean crossed zero in
+        # the wrong direction.
+        rolling_delta = pd.Series(deltas).rolling(window, min_periods=1).mean()
+        if direction == "decreasing":
+            bad = rolling_delta > 0
+        else:
+            bad = rolling_delta < 0
+        bad_idx = np.where(bad.fillna(False))[0]
+        if len(bad_idx):
+            divergence_start = float(s_clean[bad_idx[0]])
+
+    return {
+        "n_points": n,
+        "direction": direction,
+        "first": float(v_clean[0]),
+        "last": float(v_clean[-1]),
+        "min": float(v_clean.min()),
+        "max": float(v_clean.max()),
+        "argmin_step": float(s_clean[argmin_i]),
+        "argmax_step": float(s_clean[argmax_i]),
+        "final_10pct_mean": float(final_slice.mean()),
+        "final_10pct_std": float(final_slice.std()),
+        "smoothness": smoothness,
+        "monotonicity_pct": mono_pct,
+        "spike_count": len(spikes),
+        "spikes": spikes,
+        "checkpoint_slopes": checkpoint_slopes,
+        "plateau_regions": plateau_regions,
+        "divergence": {"detected": divergent, "start_step": divergence_start},
+        "nan_inf_count": nan_count,
+        "first_nan_step": first_nan_step,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cross-run comparison
+# ---------------------------------------------------------------------------
+
+SCALAR_FEATURE_KEYS: tuple[str, ...] = (
+    "n_points",
+    "first",
+    "last",
+    "min",
+    "max",
+    "argmin_step",
+    "argmax_step",
+    "final_10pct_mean",
+    "final_10pct_std",
+    "smoothness",
+    "monotonicity_pct",
+    "spike_count",
+    "nan_inf_count",
+)
+
+
+def compare_runs_curves(
+    runs: list[Any],
+    metric: str,
+    step_key: str,
+    names: list[str] | None = None,
+    direction: Direction = "auto",
+) -> pd.DataFrame:
+    """Build a DataFrame of curve features across multiple runs.
+
+    One row per run, columns are the scalar features from `curve_features`.
+    Non-scalar fields (spike list, slopes, plateaus) are omitted to keep
+    the frame compact; grab them per-run via `curve_features` if needed.
+
+    Args:
+        runs: List of W&B Run objects.
+        metric: Metric name to pull from each run's history.
+        step_key: Confirmed x-axis step key. MUST be known — never guessed.
+        names: Optional display names; defaults to run.name.
+        direction: Passed through to `curve_features`.
+
+    Returns:
+        DataFrame indexed by run name. If `len(runs) > 6`, attaches a
+        warning in `df.attrs["warning"]`; caller decides whether to proceed.
+    """
+    rows: list[dict[str, Any]] = []
+    warning = None
+    if len(runs) > 6:
+        warning = (
+            f"compare_runs_curves got {len(runs)} runs. Overlay plots become "
+            "unreadable past 6; consider selecting top-k or grouping before "
+            "plotting. Feature table is still computed."
+        )
+    for i, run in enumerate(runs):
+        display = names[i] if names else run.name
+        history = list(fast_scan_history(run, keys=[metric, step_key]))
+        values = [r.get(metric) for r in history if r.get(metric) is not None]
+        steps = [r.get(step_key) for r in history if r.get(metric) is not None]
+        feats = curve_features(values, steps, direction=direction)
+        row: dict[str, Any] = {"run": display, "run_id": run.id}
+        for k in SCALAR_FEATURE_KEYS:
+            row[k] = feats.get(k)
+        row["divergence_detected"] = feats.get("divergence", {}).get("detected")
+        rows.append(row)
+
+    df = pd.DataFrame(rows).set_index("run")
+    if warning:
+        df.attrs["warning"] = warning
+    return df
+
+
+# ---------------------------------------------------------------------------
+# LR schedule
+# ---------------------------------------------------------------------------
+
+def lr_schedule_features(
+    values: Iterable[float] | pd.Series | np.ndarray,
+    steps: Iterable[float] | pd.Series | np.ndarray | None = None,
+) -> dict[str, Any]:
+    """Summarize a learning rate schedule.
+
+    Detects warmup length, peak LR + step, and the shape of the decay
+    segment (linear / cosine / exponential / constant / unknown). Flags
+    any unexpected restarts (LR increases after peak).
+    """
+    v = np.asarray(list(values), dtype=float)
+    s = np.arange(len(v), dtype=float) if steps is None else np.asarray(list(steps), dtype=float)
+    good = np.isfinite(v)
+    v = v[good]
+    s = s[good]
+    n = len(v)
+    if n == 0:
+        return {"n_points": 0}
+
+    peak_i = int(np.argmax(v))
+    peak_lr = float(v[peak_i])
+    peak_step = float(s[peak_i])
+
+    # Warmup: from start up to peak (if peak isn't right at step 0).
+    warmup_len = int(peak_i)
+    warmup_slope = None
+    if warmup_len >= 3:
+        warmup_slope = float(np.polyfit(s[:peak_i + 1], v[:peak_i + 1], 1)[0])
+
+    # Decay segment.
+    decay_v = v[peak_i:]
+    decay_s = s[peak_i:]
+    decay_shape = "unknown"
+    if len(decay_v) >= 5:
+        # Constant?
+        if float(decay_v.std()) / (abs(peak_lr) or 1.0) < 1e-3:
+            decay_shape = "constant"
+        else:
+            # Fit linear vs exponential (log-linear) and compare residuals.
+            xs = decay_s - decay_s[0]
+            lin_coef = np.polyfit(xs, decay_v, 1)
+            lin_resid = float(np.mean((decay_v - np.polyval(lin_coef, xs)) ** 2))
+            positive = decay_v[decay_v > 0]
+            positive_xs = xs[: len(positive)]
+            exp_resid = float("inf")
+            if len(positive) >= 5 and len(positive) == len(positive_xs):
+                exp_coef = np.polyfit(positive_xs, np.log(positive), 1)
+                exp_pred = np.exp(np.polyval(exp_coef, positive_xs))
+                exp_resid = float(np.mean((positive - exp_pred) ** 2))
+            # Cosine: 0.5 * (peak) * (1 + cos(pi * t / T)).
+            t_norm = xs / (xs[-1] or 1.0)
+            cosine_pred = 0.5 * peak_lr * (1.0 + np.cos(np.pi * t_norm))
+            cos_resid = float(np.mean((decay_v - cosine_pred) ** 2))
+            scores = {"linear": lin_resid, "exponential": exp_resid, "cosine": cos_resid}
+            decay_shape = min(scores, key=scores.get)
+
+    # Restarts: after a real decay segment, LR rises meaningfully from a local
+    # trough. This catches cosine restarts that stay below the initial peak.
+    restart_steps: list[float] = []
+    local_trough = peak_lr
+    i = peak_i + 1
+    while i < n:
+        local_trough = min(local_trough, float(v[i - 1]))
+        if v[i] <= v[i - 1]:
+            local_trough = min(local_trough, float(v[i]))
+            i += 1
+            continue
+        if local_trough < peak_lr * 0.99 and v[i] > local_trough * 1.01:
+            restart_steps.append(float(s[i]))
+            while i + 1 < n and v[i + 1] >= v[i]:
+                i += 1
+            local_trough = float(v[i])
+        i += 1
+
+    return {
+        "n_points": n,
+        "peak_lr": peak_lr,
+        "peak_step": peak_step,
+        "warmup_steps": warmup_len,
+        "warmup_slope": warmup_slope,
+        "final_lr": float(v[-1]),
+        "decay_shape": decay_shape,
+        "restart_steps": restart_steps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Grad norm
+# ---------------------------------------------------------------------------
+
+def grad_norm_features(
+    values: Iterable[float] | pd.Series | np.ndarray,
+    steps: Iterable[float] | pd.Series | np.ndarray | None = None,
+) -> dict[str, Any]:
+    """Grad-norm specific features on top of generic curve_features.
+
+    Adds tail heaviness (kurtosis — excess kurtosis; heavy-tailed updates
+    are concerning) and a `dead_flag` when grad-norm collapses near zero
+    and stays there, which usually means a layer has stopped learning.
+    """
+    feats = curve_features(values, steps, direction="decreasing")
+    v = np.asarray(list(values), dtype=float)
+    v = v[np.isfinite(v)]
+    if len(v) < 10:
+        feats["kurtosis"] = None
+        feats["dead_flag"] = False
+        return feats
+
+    mean = v.mean()
+    std = v.std() or 1.0
+    kurt = float(((v - mean) ** 4).mean() / (std ** 4) - 3.0)
+    feats["kurtosis"] = kurt
+
+    # Dead flag: final 10% mean is <1% of the run-wide median and doesn't
+    # move.
+    tail = v[-max(1, len(v) // 10):]
+    median = float(np.median(v)) or 1.0
+    feats["dead_flag"] = bool(tail.mean() < median * 0.01 and tail.std() < median * 0.001)
+    return feats
+
+
+# ---------------------------------------------------------------------------
+# Grad histograms (per-layer over time)
+# ---------------------------------------------------------------------------
+
+def _histogram_stats(hist: Any) -> dict[str, float] | None:
+    """Compute summary stats from a W&B-logged histogram payload.
+
+    W&B stores histograms as a dict-like: `{"bins": [...], "values": [...]}`
+    or as a wandb.Histogram repr. `values` are counts per bin (len = len(bins) - 1).
+    """
+    if hist is None:
+        return None
+    if isinstance(hist, dict):
+        bins = hist.get("bins")
+        counts = hist.get("values")
+    else:
+        bins = getattr(hist, "bins", None)
+        counts = getattr(hist, "histogram", None) or getattr(hist, "values", None)
+    if bins is None or counts is None:
+        return None
+    bins = np.asarray(bins, dtype=float)
+    counts = np.asarray(counts, dtype=float)
+    if len(bins) < 2 or len(counts) < 1:
+        return None
+
+    centers = 0.5 * (bins[:-1] + bins[1:])
+    total = counts.sum()
+    if total <= 0:
+        return None
+    probs = counts / total
+
+    mean = float((probs * centers).sum())
+    variance = float((probs * (centers - mean) ** 2).sum())
+    std = variance ** 0.5 or 1e-12
+    kurtosis = float((probs * ((centers - mean) / std) ** 4).sum() - 3.0)
+    mean_abs = float((probs * np.abs(centers)).sum())
+    max_abs = float(np.abs(centers[counts > 0]).max()) if (counts > 0).any() else 0.0
+    max_bin_idx = int(np.argmax(counts))
+    pct_at_max_bin = float(counts[max_bin_idx] / total * 100)
+
+    return {
+        "mean": mean,
+        "mean_abs": mean_abs,
+        "variance": variance,
+        "kurtosis": kurtosis,
+        "max_abs": max_abs,
+        "pct_at_max_bin": pct_at_max_bin,
+    }
+
+
+def grad_histogram_features(
+    run: Any,
+    layer_prefix: str = "gradients/",
+    step_key: str = "_step",
+    probe_rows: int = 500,
+) -> pd.DataFrame:
+    """Parse W&B-logged gradient histograms into a (layer, step) frame.
+
+    Args:
+        run: A W&B Run object.
+        layer_prefix: Prefix for gradient histogram keys. Default
+            `gradients/` matches wandb.watch's default layout.
+        step_key: Confirmed step-axis key.
+        probe_rows: Max history rows to scan while discovering histogram keys.
+
+    Returns:
+        DataFrame with one row per (layer, step), columns:
+        mean, mean_abs, variance, kurtosis, max_abs, pct_at_max_bin.
+        Raises ValueError with a helpful message if no histogram keys found.
+    """
+    hist_keys = discover_history_keys(
+        run,
+        lambda key, _value: key.startswith(layer_prefix),
+        max_rows=probe_rows,
+    )
+    if not hist_keys:
+        raise ValueError(
+            f"No histogram keys found with prefix `{layer_prefix}` in run "
+            f"{run.id}. If you want per-layer grad histograms, call "
+            "`wandb.watch(model, log='gradients', log_freq=N)` during training."
+        )
+
+    rows: list[dict[str, Any]] = []
+    for row in fast_scan_history(run, keys=[*hist_keys, step_key]):
+        step = row.get(step_key)
+        if step is None:
+            continue
+        for key in hist_keys:
+            stats = _histogram_stats(row.get(key))
+            if stats is None:
+                continue
+            layer = key[len(layer_prefix):]
+            rows.append({"layer": layer, "step": step, **stats})
+    return pd.DataFrame(rows)

--- a/.agents/skills/wandb-primary/scripts/wandb_helpers.py
+++ b/.agents/skills/wandb-primary/scripts/wandb_helpers.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+"""Helpers for working with W&B (Weights & Biases) training data.
+
+The wandb SDK is for the W&B Models product — training runs, metrics history,
+hyperparameter sweeps, artifacts, and system metrics. These helpers convert
+run data into pandas-friendly structures for analysis.
+
+Usage (in sandbox):
+    import sys
+    sys.path.insert(0, ".agents/skills/wandb-primary/scripts")
+    from wandb_helpers import (
+        runs_to_dataframe,   # Convert runs to a clean pandas DataFrame
+        diagnose_run,        # Quick diagnostic summary of a training run
+        compare_configs,     # Side-by-side config diff between two runs
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterator
+
+
+# ---------------------------------------------------------------------------
+# Fast history scan (beta_scan_history with fallback)
+# ---------------------------------------------------------------------------
+
+def _scan_history_kwargs(
+    keys: list[str] | None,
+    min_step: int,
+    max_step: int | None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if keys is not None:
+        kwargs["keys"] = keys
+    if min_step:
+        kwargs["min_step"] = min_step
+    if max_step is not None:
+        kwargs["max_step"] = max_step
+    return kwargs
+
+def fast_scan_history(
+    run: Any,
+    keys: list[str] | None = None,
+    page_size: int = 1000,
+    min_step: int = 0,
+    max_step: int | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Iterate a run's full history using the fastest available method.
+
+    Prefers `run.beta_scan_history` (reads locally-cached parquet, no API
+    round-trips) and falls back to `run.scan_history` if the beta API isn't
+    present or raises. Signature matches the common subset of both.
+
+    W&B marks `beta_scan_history` as "still in development" — the fallback
+    exists so callers don't have to branch.
+
+    Args:
+        run: A W&B Run object.
+        keys: Metrics to fetch; None returns all.
+        page_size: Rows per batch (beta only).
+        min_step: Inclusive lower bound.
+        max_step: Exclusive upper bound.
+
+    Yields:
+        dict rows, same shape as `scan_history`.
+    """
+    fallback_kwargs = _scan_history_kwargs(keys, min_step, max_step)
+    beta = getattr(run, "beta_scan_history", None)
+    if beta is not None:
+        yielded = 0
+        try:
+            for row in beta(
+                keys=keys,
+                page_size=page_size,
+                min_step=min_step,
+                max_step=max_step,
+            ):
+                yielded += 1
+                yield row
+            return
+        except Exception:
+            if yielded:
+                skipped = 0
+                for row in run.scan_history(**fallback_kwargs):
+                    if skipped < yielded:
+                        skipped += 1
+                        continue
+                    yield row
+                return
+    yield from run.scan_history(**fallback_kwargs)
+
+
+def discover_history_keys(
+    run: Any,
+    predicate: Callable[[str, Any], bool],
+    max_rows: int = 500,
+) -> list[str]:
+    """Find history keys that may appear only after sparse logging intervals."""
+    found: set[str] = set()
+    for i, row in enumerate(fast_scan_history(run)):
+        for key, value in row.items():
+            if predicate(key, value):
+                found.add(key)
+        if found or i + 1 >= max_rows:
+            break
+    return sorted(found)
+
+
+# ---------------------------------------------------------------------------
+# Runs -> DataFrame
+# ---------------------------------------------------------------------------
+
+def runs_to_dataframe(
+    runs: Any,
+    limit: int = 200,
+    metric_keys: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert W&B runs to a list of flat dicts (ready for pd.DataFrame).
+
+    Always slices runs to avoid loading entire projects into memory.
+
+    Args:
+        runs: W&B Runs object from api.runs().
+        limit: Max runs to process (default 200).
+        metric_keys: Summary metric keys to include. If None, includes
+                     "loss", "val_loss", "accuracy".
+
+    Returns:
+        List of dicts with run metadata + config + selected metrics.
+    """
+    if metric_keys is None:
+        metric_keys = ["loss", "val_loss", "accuracy"]
+
+    rows = []
+    for run in runs[:limit]:
+        row = {
+            "id": run.id,
+            "name": run.name,
+            "state": run.state,
+            "created_at": run.created_at,
+        }
+        # Config (skip internal keys)
+        for k, v in run.config.items():
+            if not k.startswith("_"):
+                row[f"config.{k}"] = v
+        # Summary metrics
+        for key in metric_keys:
+            row[key] = run.summary_metrics.get(key)
+        rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Run diagnostics
+# ---------------------------------------------------------------------------
+
+def diagnose_run(run: Any) -> dict[str, Any]:
+    """Quick diagnostic summary of a training run.
+
+    Loads the full loss history and checks for convergence, overfitting,
+    NaN values, and other common training issues.
+
+    Args:
+        run: A W&B Run object from api.run().
+
+    Returns:
+        Dict with diagnostic keys: total_steps, final_loss, min_loss,
+        min_loss_step, has_nan, final_10pct_mean, train_val_gap,
+        likely_overfit, converged.
+    """
+    import pandas as pd
+
+    df = pd.DataFrame(list(run.scan_history(keys=["loss", "val_loss"])))
+    loss = df["loss"].dropna()
+
+    diagnostics: dict[str, Any] = {
+        "total_steps": len(loss),
+        "final_loss": loss.iloc[-1] if len(loss) else None,
+        "min_loss": loss.min() if len(loss) else None,
+        "min_loss_step": int(loss.idxmin()) if len(loss) else None,
+        "has_nan": bool(loss.isna().any()),
+        "final_10pct_mean": float(loss.tail(max(1, len(loss) // 10)).mean())
+        if len(loss)
+        else None,
+    }
+
+    # Overfitting check (val_loss diverging from train loss)
+    if "val_loss" in df.columns:
+        val = df["val_loss"].dropna()
+        if len(val) > 10:
+            tail_size = max(1, len(val) // 5)
+            train_tail = float(loss.tail(tail_size).mean())
+            val_tail = float(val.tail(tail_size).mean())
+            diagnostics["train_val_gap"] = round(val_tail - train_tail, 6)
+            diagnostics["likely_overfit"] = val_tail > train_tail * 1.2
+
+    # Convergence check
+    if len(loss) > 100:
+        last_pct = loss.tail(max(1, len(loss) // 10))
+        diagnostics["converged"] = bool(last_pct.std() < last_pct.mean() * 0.01)
+
+    return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Config comparison
+# ---------------------------------------------------------------------------
+
+def compare_configs(run_a: Any, run_b: Any) -> list[dict[str, Any]]:
+    """Side-by-side config comparison between two W&B runs.
+
+    Returns only the keys that differ between the two runs.
+
+    Args:
+        run_a: First W&B Run object.
+        run_b: Second W&B Run object.
+
+    Returns:
+        List of dicts with: key, run_a_name, run_a_value, run_b_name, run_b_value
+    """
+    config_a = {k: v for k, v in run_a.config.items() if not k.startswith("_")}
+    config_b = {k: v for k, v in run_b.config.items() if not k.startswith("_")}
+
+    all_keys = sorted(set(config_a) | set(config_b))
+    diffs = []
+    for k in all_keys:
+        val_a = config_a.get(k)
+        val_b = config_b.get(k)
+        if val_a != val_b:
+            diffs.append({
+                "key": k,
+                run_a.name: val_a,
+                run_b.name: val_b,
+            })
+    return diffs

--- a/.agents/skills/wandb-primary/scripts/weave_helpers.py
+++ b/.agents/skills/wandb-primary/scripts/weave_helpers.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: skills
+
+"""Helpers for working with Weave trace data.
+
+Weave is the W&B product for GenAI/LLM application development — tracing,
+evaluations, and scorers. These helpers convert Weave's wrapper types to plain
+Python and extract structured data from calls and evals for pandas analysis.
+
+Usage (in sandbox):
+    import sys
+    sys.path.insert(0, ".agents/skills/wandb-primary/scripts")
+    from weave_helpers import (
+        unwrap,                  # Recursively convert Weave types -> plain Python
+        get_token_usage,         # Extract token counts from a call's summary
+        eval_results_to_dicts,   # predict_and_score calls -> list of result dicts
+        pivot_solve_rate,        # Build task-level pivot table across agents
+        results_summary,         # Print compact eval summary
+        eval_health,             # Extract status/counts from Evaluation.evaluate calls
+        eval_efficiency,         # Compute tokens-per-success across eval calls
+    )
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Recursive unwrap — convert Weave types to plain Python
+# ---------------------------------------------------------------------------
+
+def unwrap(obj: Any) -> Any:
+    """Recursively convert Weave wrapper types to plain Python dicts/lists.
+
+    Weave returns WeaveDict, WeaveObject, ObjectRecord, ObjectRef, and other
+    wrapper types that look like Python builtins but aren't. This function
+    converts everything to plain dicts/lists so you can:
+    - json.dumps() the result
+    - Pass it to pandas
+    - Inspect unknown structures without guessing the type
+
+    Safe to call on already-plain objects (returns them unchanged).
+
+    Usage:
+        call = client.get_call("some-id")
+        output = unwrap(call.output)
+        print(json.dumps(output, indent=2, default=str))
+    """
+    # WeaveDict -> dict (has .keys() and .get() but isn't a plain dict)
+    if hasattr(obj, "keys") and hasattr(obj, "get") and not isinstance(obj, dict):
+        return {k: unwrap(obj[k]) for k in obj.keys()}
+
+    # WeaveObject / ObjectRecord -> dict via internal _val
+    if hasattr(obj, "__dict__") and hasattr(obj, "_val"):
+        try:
+            record = object.__getattribute__(obj, "_val")
+            if hasattr(record, "__dict__"):
+                return {
+                    k: unwrap(v)
+                    for k, v in vars(record).items()
+                    if not k.startswith("_")
+                }
+        except Exception:
+            pass
+
+    # ObjectRef -> string representation
+    if hasattr(obj, "entity") and hasattr(obj, "_digest"):
+        return str(obj)
+
+    # Iterable (list, tuple, WeaveList) -> list
+    if hasattr(obj, "__iter__") and not isinstance(obj, (str, bytes, dict)):
+        try:
+            return [unwrap(item) for item in obj]
+        except TypeError:
+            pass
+
+    # Plain scalar — return as-is
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Token usage extraction
+# ---------------------------------------------------------------------------
+
+def get_token_usage(call: Any) -> dict[str, int]:
+    """Extract total token usage from a Weave call's summary.
+
+    Works with both OpenAI-style (prompt_tokens/completion_tokens)
+    and Anthropic-style (input_tokens/output_tokens) field names.
+
+    Returns:
+        {"input_tokens": int, "output_tokens": int, "total_tokens": int}
+    """
+    usage = {}
+    try:
+        usage = call.summary.get("usage", {})
+    except Exception:
+        return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+    total_input = 0
+    total_output = 0
+    for _model, u in (usage.items() if hasattr(usage, "items") else []):
+        total_input += u.get("input_tokens") or u.get("prompt_tokens") or 0
+        total_output += u.get("output_tokens") or u.get("completion_tokens") or 0
+    return {
+        "input_tokens": total_input,
+        "output_tokens": total_output,
+        "total_tokens": total_input + total_output,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Eval result extraction
+# ---------------------------------------------------------------------------
+
+def eval_results_to_dicts(
+    pas_calls: list[Any],
+    agent_name: str = "unknown",
+) -> list[dict[str, Any]]:
+    """Extract per-task results from predict_and_score calls.
+
+    Converts Weave's nested WeaveDict/WeaveObject output into flat dicts
+    suitable for pandas DataFrames.
+
+    Args:
+        pas_calls: List of Weave predict_and_score call objects.
+        agent_name: Name of the agent for labeling.
+
+    Returns:
+        List of dicts with keys: task, agent, score, passed, succeeded,
+        error, tool_calls, traj_len, duration_s
+    """
+    results = []
+    for c in pas_calls:
+        try:
+            example = c.inputs.get("example")
+            task_name = str(example.get("name")) if example else "unknown"
+        except Exception:
+            task_name = "unknown"
+
+        out = c.output
+        rubric_score = None
+        rubric_passed = None
+        succeeded = None
+        error = None
+        tool_calls_count = 0
+        traj_len = 0
+
+        if out:
+            # Scorer results
+            scores = out.get("scores") if hasattr(out, "get") else None
+            if scores:
+                rubric = scores.get("rubric") if hasattr(scores, "get") else None
+                if rubric:
+                    rubric_passed = getattr(rubric, "passed", None)
+                    meta = getattr(rubric, "metadata", None)
+                    if meta:
+                        rubric_score = (
+                            meta.get("score")
+                            if hasattr(meta, "get")
+                            else getattr(meta, "score", None)
+                        )
+
+            # Model output (nested: output.output)
+            model_out = out.get("output") if hasattr(out, "get") else None
+            if model_out and hasattr(model_out, "get"):
+                succeeded = model_out.get("succeeded")
+                error = model_out.get("error")
+                tc = model_out.get("tool_calls")
+                tool_calls_count = len(tc) if tc else 0
+                traj = model_out.get("trajectory")
+                traj_len = len(traj) if traj else 0
+
+        # Duration
+        duration = None
+        if c.started_at and c.ended_at:
+            duration = (c.ended_at - c.started_at).total_seconds()
+
+        results.append({
+            "task": task_name,
+            "agent": agent_name,
+            "score": rubric_score,
+            "passed": rubric_passed,
+            "succeeded": succeeded,
+            "error": str(error)[:100] if error else None,
+            "tool_calls": tool_calls_count,
+            "traj_len": traj_len,
+            "duration_s": round(duration, 1) if duration else None,
+        })
+
+    results.sort(key=lambda r: r.get("task", ""))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Pivot table — solve rate per task across agents
+# ---------------------------------------------------------------------------
+
+def pivot_solve_rate(all_results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build a pivot table: one row per task, aggregated across all agents.
+
+    Args:
+        all_results: Combined results from multiple eval runs
+                     (each dict must have: task, agent, score, passed).
+
+    Returns:
+        List of dicts with: task, agents_passed, agents_attempted,
+        pass_rate, mean_score, best_agent, worst_agent
+    """
+    by_task: dict[str, list[dict]] = defaultdict(list)
+    for r in all_results:
+        by_task[r["task"]].append(r)
+
+    pivot = []
+    for task in sorted(by_task):
+        entries = by_task[task]
+        n = len(entries)
+        passed = sum(1 for e in entries if e.get("passed"))
+        scores = [e["score"] for e in entries if e.get("score") is not None]
+        mean_score = sum(scores) / len(scores) if scores else 0.0
+
+        best = max(entries, key=lambda e: e.get("score") or 0)
+        worst = min(entries, key=lambda e: e.get("score") or 0)
+
+        pivot.append({
+            "task": task,
+            "agents_passed": passed,
+            "agents_attempted": n,
+            "pass_rate": f"{passed / n:.0%}" if n > 0 else "0%",
+            "mean_score": round(mean_score, 3),
+            "best_agent": (
+                f"{best['agent']} ({best.get('score', 0):.2f})"
+                if best.get("score", 0) != worst.get("score", 0)
+                else "—"
+            ),
+            "worst_agent": (
+                f"{worst['agent']} ({worst.get('score', 0):.2f})"
+                if best.get("score", 0) != worst.get("score", 0)
+                else "—"
+            ),
+        })
+    return pivot
+
+
+# ---------------------------------------------------------------------------
+# Pretty-print helpers
+# ---------------------------------------------------------------------------
+
+def results_summary(results: list[dict[str, Any]]) -> str:
+    """Print a compact summary of eval results."""
+    if not results:
+        return "No results."
+
+    n = len(results)
+    scores = [r["score"] for r in results if r.get("score") is not None]
+    mean_score = sum(scores) / len(scores) if scores else 0.0
+    passed = sum(1 for r in results if r.get("passed"))
+    succeeded = sum(1 for r in results if r.get("succeeded"))
+    timed_out = sum(
+        1 for r in results
+        if r.get("error") and "timeout" in str(r["error"]).lower()
+    )
+
+    lines = [
+        f"Tasks: {n}",
+        f"Mean rubric score: {mean_score:.3f}",
+        f"Rubric passed: {passed}/{n} ({passed / n:.1%})",
+        f"Succeeded: {succeeded}/{n} ({succeeded / n:.1%})",
+    ]
+    if timed_out:
+        lines.append(f"Timed out: {timed_out}/{n}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Eval health analysis
+# ---------------------------------------------------------------------------
+
+def eval_health(eval_calls: list[Any]) -> list[dict[str, Any]]:
+    """Extract health metrics from a list of Evaluation.evaluate calls.
+
+    Args:
+        eval_calls: List of Weave call objects for Evaluation.evaluate.
+
+    Returns:
+        List of dicts with: display_name, started_at, status, success_count,
+        error_count, total_tokens, call_id
+    """
+    rows = []
+    for ec in eval_calls:
+        summary = {}
+        try:
+            summary = ec.summary or {}
+        except Exception:
+            pass
+
+        weave_meta = summary.get("weave", {}) if hasattr(summary, "get") else {}
+        status = weave_meta.get("status", "unknown")
+        status_counts = weave_meta.get("status_counts", {})
+        success_count = status_counts.get("success", 0)
+        error_count = status_counts.get("error", 0)
+
+        usage = summary.get("usage", {}) if hasattr(summary, "get") else {}
+        total_tokens = 0
+        for _model, u in (usage.items() if hasattr(usage, "items") else []):
+            total_tokens += u.get("total_tokens", 0)
+
+        display = getattr(ec, "display_name", None) or "unnamed"
+        started = ec.started_at.strftime("%Y-%m-%d %H:%M") if ec.started_at else ""
+
+        rows.append({
+            "display_name": display,
+            "started_at": started,
+            "status": status,
+            "success_count": success_count,
+            "error_count": error_count,
+            "total_tokens": total_tokens,
+            "call_id": ec.id,
+        })
+    return rows
+
+
+def eval_efficiency(eval_calls: list[Any]) -> list[dict[str, Any]]:
+    """Compute cost efficiency (tokens per success) for eval calls.
+
+    Args:
+        eval_calls: List of Weave call objects for Evaluation.evaluate.
+
+    Returns:
+        List of dicts sorted by tokens_per_success (ascending = most efficient).
+    """
+    health = eval_health(eval_calls)
+    rows = []
+    for h in health:
+        if h["status"] in ("running", "unknown"):
+            continue
+        sc = h["success_count"]
+        tps = h["total_tokens"] / sc if sc > 0 else float("inf")
+        rows.append({
+            "display_name": h["display_name"],
+            "total_tokens": h["total_tokens"],
+            "success_count": sc,
+            "error_count": h["error_count"],
+            "tokens_per_success": round(tps),
+        })
+    rows.sort(key=lambda r: r["tokens_per_success"])
+    return rows

--- a/.agents/skills/web-search-advanced-research-paper/SKILL.md
+++ b/.agents/skills/web-search-advanced-research-paper/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: web-search-advanced-research-paper
+description: Search for research papers and academic content using Exa advanced search. Full filter support including date ranges and text filtering. Use when searching for academic papers, arXiv preprints, or scientific research.
+context: fork
+model: Codex-opus-4-6
+effort: high
+---
+
+# Web Search Advanced - Research Paper Category
+
+Use the `exa` MCP server to search for research papers and academic content.
+
+## Tool Restriction (Critical)
+
+ONLY use `web_search_advanced_exa` with `category: "research paper"`. Do NOT use other categories or tools.
+
+## Full Filter Support
+
+The `research paper` category supports ALL available parameters:
+
+### Core
+- `query` (required)
+- `numResults`
+- `type` ("auto", "fast", "deep", "neural")
+
+### Domain filtering
+- `includeDomains` (e.g., ["arxiv.org", "openreview.net"])
+- `excludeDomains`
+
+### Date filtering (ISO 8601)
+- `startPublishedDate` / `endPublishedDate`
+- `startCrawlDate` / `endCrawlDate`
+
+### Text filtering
+- `includeText` (must contain ALL)
+- `excludeText` (exclude if ANY match)
+
+**Array size restriction:** `includeText` and `excludeText` only support **single-item arrays**. Multi-item arrays (2+ items) cause 400 errors. To match multiple terms, put them in the `query` string or run separate searches.
+
+### Content extraction
+- `textMaxCharacters` / `contextMaxCharacters`
+- `enableSummary` / `summaryQuery`
+- `enableHighlights` / `highlightsNumSentences` / `highlightsPerUrl` / `highlightsQuery`
+
+### Additional
+- `userLocation`
+- `moderation`
+- `additionalQueries`
+- `maxAgeHours` / `livecrawlTimeout`
+- `subpages` / `subpageTarget`
+
+## Token Isolation (Critical)
+
+Never run Exa searches in main context. Always spawn Task agents:
+- Agent calls `web_search_advanced_exa` with `category: "research paper"`
+- Agent merges + deduplicates results before presenting
+- Agent returns distilled output (brief markdown or compact JSON)
+- Main context stays clean regardless of search volume
+
+## When to Use
+
+Use this category when you need:
+- Academic papers from arXiv, OpenReview, PubMed, etc.
+- Scientific research on specific topics
+- Literature reviews with date filtering
+- Papers containing specific methodologies or terms
+
+## Examples
+
+Recent papers on a topic:
+```
+web_search_advanced_exa {
+  "query": "transformer attention mechanisms efficiency",
+  "category": "research paper",
+  "startPublishedDate": "2024-01-01",
+  "numResults": 15,
+  "type": "auto"
+}
+```
+
+Papers from specific venues:
+```
+web_search_advanced_exa {
+  "query": "large language model agents",
+  "category": "research paper",
+  "includeDomains": ["arxiv.org", "openreview.net"],
+  "includeText": ["LLM"],
+  "numResults": 20,
+  "type": "deep"
+}
+```
+
+## Output Format
+
+Return:
+1) Results (structured list with title, authors, date, abstract summary)
+2) Sources (URLs with publication venue)
+3) Notes (methodology differences, conflicting findings)
+
+## Follow-up
+
+You can use the initial summary findings from this skill to identify full papers to download and read using other skills or web search.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,7 @@
+[shell_environment_policy]
+inherit = "core"
+
+[shell_environment_policy.set]
+CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "20"
+CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"
+CLAUDE_CODE_SUBAGENT_MODEL = "claude-sonnet-4-6"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+<!--
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: senpai
+-->
+
+# senpai — Development Context
+
+Development of an Autonomous ML research loop on CFD surrogates
+
+## User Clarifications
+
+### Interviewing the developer about how to do a task:
+When asked for a large piece of work which seems vague or needs clarification, please interview me in detail using the AskUserQuestionTool about literally anything: technical implementation, UI & UX, concerns, tradeoffs, etc. but make sure the questions are not obvious. Be very in-depth and continue interviewing me continually until it's complete, then write the learnings to README.md
+
+
+## Coding guidelines and philosophy
+
+- You should generate code that is simple and redable, avoid unnecesary abstractions and complexity. This is a research codebase so we want to be mantainable and readable.
+- Avoid overly defensive coding, no need for a lot of `try, except` patterns, no need for fallbacks or backups - I want the code to fail if something is wrong so that i can fix it.
+- Do not add demo-only flags or placeholder CLI options that gate real functionality (e.g., `--run` just to toggle execution); scripts should run their main logic directly.
+- Adhere to python 3.12+ conventions
+
+## Key docs
+
+- `cfd_tandemfoil/program.md` — research context, goals, metrics, file constraints
+- `system_instructions/Codex-ADVISOR.md` — advisor role workflow
+- `system_instructions/Codex-STUDENT.md` — student role workflow
+
+## Architecture
+
+- **Advisor pod** — no GPU, runs Codex in a loop. Queries W&B, reviews student PRs, generates new hypotheses, and creates draft PRs to assign work.
+- **Student pods** — GPU workers, each running Codex. Poll for assigned PRs, implement the hypothesis, run training, report results.
+- **GitHub Issues** — human-to-agent communication channel. Agents poll for and respond to these alongside their normal PR workflow.
+
+## k8s layout
+
+- `k8s/advisor-deployment.yaml` / `k8s/student-deployment.yaml` — pod specs
+- `k8s/entrypoint-advisor.sh` / `k8s/entrypoint-student.sh` — startup scripts
+- `k8s/launch.py` — helper to template and apply deployments
+
+## system_instructions/
+
+Role-specific AGENTS.md files. The Student and Advisor both use Codex. At pod launch, the appropriate role-specific file is copied over this AGENTS.md:
+- `system_instructions/Codex-ADVISOR.md` → advisor pods
+- `system_instructions/Codex-STUDENT.md` → student pods

--- a/k8s/senpai-scout-workflow.yaml
+++ b/k8s/senpai-scout-workflow.yaml
@@ -1,0 +1,37 @@
+apiVersion: agentic.coreweave.com/v1alpha1
+kind: Workflow
+metadata:
+  name: senpai-scout-daily
+spec:
+  agent:
+    agentDefinitionName: senpai-scout
+    agentDefinitionVersion: main
+  environment:
+    template: workspaces-agentic
+    timeout: 45m
+    env:
+      SEMANTIC_SCHOLAR_ENDPOINT: "https://api.semanticscholar.org"
+    secrets:
+      GITHUB_TOKEN: "REPLACE_ME_ghp_xxx"
+      SLACK_WEBHOOK_URL: "REPLACE_ME_https://hooks.slack.com/services/..."
+      WANDB_API_KEY: "REPLACE_ME_wandb_xxx"
+      KUBECONFIG_B64: "REPLACE_ME_base64_of_pai2_kubeconfig"
+      SEMANTIC_SCHOLAR_API_KEY: ""
+  parameters:
+    - name: research_tag
+      type: string
+      required: true
+    - name: max_launches
+      type: string
+      required: false
+      default: "1"
+    - name: focus
+      type: string
+      required: false
+      default: ""
+  schedule:
+    cron: "0 14 * * *"
+    timezone: "UTC"
+  steps:
+    - name: run
+      action: agent.execute

--- a/plugins/senpai/scripts/check-notifications.sh
+++ b/plugins/senpai/scripts/check-notifications.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+#
+# PreToolUse hook: check for new PRs, issues, or idle students and inject
+# them as additionalContext into the running CC session.
+#
+# Throttled by NOTIFY_INTERVAL_S (default 120s) — exits silently when the
+# cache is fresh, so the hook adds near-zero overhead on most tool calls.
+# Only runs inside pods (IS_SANDBOX=1).
+
+# --- Guard: only run in pods ---
+[ "${IS_SANDBOX:-}" = "1" ] || exit 0
+
+WORKDIR="${WORKDIR:-/workspace/senpai}"
+CACHE_DIR="${WORKDIR}/advisor_logs"
+[ -n "${STUDENT_NAME:-}" ] && CACHE_DIR="${WORKDIR}/student_logs"
+CACHE_FILE="${CACHE_DIR}/.notify_cache_ts"
+INTERVAL="${NOTIFY_INTERVAL_S:-120}"
+
+# --- Throttle: skip if checked recently ---
+if [ -f "$CACHE_FILE" ]; then
+    last=$(cat "$CACHE_FILE")
+    now=$(date +%s)
+    elapsed=$(( now - last ))
+    [ "$elapsed" -lt "$INTERVAL" ] && exit 0
+fi
+
+# --- Source helpers ---
+source "${WORKDIR}/plugins/senpai/scripts/senpai-gh.sh" 2>/dev/null || exit 0
+
+# --- Run role-appropriate checks ---
+lines=()
+
+if [ -n "${STUDENT_NAME:-}" ]; then
+    # Student: check for assigned PRs and issues
+    assigned=$(student_poll_for_work "$STUDENT_NAME" 2>/dev/null)
+    assigned_n=$(printf '%s' "$assigned" | json_len 2>/dev/null || echo 0)
+    issues=$(check_gh_issues "student:$STUDENT_NAME" 2>/dev/null)
+    issues_n=$(printf '%s' "$issues" | json_len 2>/dev/null || echo 0)
+
+    [ "$assigned_n" -gt 0 ] && lines+=("Assigned PRs ($assigned_n): $(printf '%s' "$assigned" | json_numbers)")
+    [ "$issues_n" -gt 0 ]   && lines+=("GitHub issues ($issues_n): $(printf '%s' "$issues" | json_numbers)")
+else
+    # Advisor: check for review PRs, issues, and idle students
+    since=""
+    last_check="${WORKDIR}/advisor_logs/.last_check_ts"
+    [ -f "$last_check" ] && since=$(cat "$last_check")
+
+    reviews=$(list_ready_for_review_prs "${ADVISOR_BRANCH:-}" "$since" 2>/dev/null)
+    reviews_n=$(printf '%s' "$reviews" | json_len 2>/dev/null || echo 0)
+    issues=$(check_gh_issues "${ADVISOR_BRANCH:-}" "$since" 2>/dev/null)
+    issues_n=$(printf '%s' "$issues" | json_len 2>/dev/null || echo 0)
+    idle=$(list_idle_students "${STUDENT_NAMES:-}" "${ADVISOR_BRANCH:-}" 2>/dev/null)
+    idle_n=$(printf '%s' "$idle" | json_len 2>/dev/null || echo 0)
+
+    [ "$reviews_n" -gt 0 ] && lines+=("PRs ready for review ($reviews_n): $(printf '%s' "$reviews" | json_numbers)")
+    [ "$issues_n" -gt 0 ]  && lines+=("GitHub issues ($issues_n): $(printf '%s' "$issues" | json_numbers)")
+    [ "$idle_n" -gt 0 ]    && lines+=("Idle students ($idle_n): $(printf '%s' "$idle" | json_join)")
+fi
+
+# --- Update throttle timestamp ---
+date +%s > "$CACHE_FILE"
+
+# --- Exit silently if nothing actionable ---
+[ ${#lines[@]} -eq 0 ] && exit 0
+
+# --- Build additionalContext ---
+msg="[NOTIFICATION] New items detected since last check:"
+for line in "${lines[@]}"; do
+    msg+=$'\n'"- ${line}"
+done
+msg+=$'\n'"Act on these when you reach a natural stopping point."
+
+# --- Output hook JSON ---
+python3 -c "
+import json, sys
+print(json.dumps({'hookSpecificOutput': {'additionalContext': sys.argv[1]}}))
+" "$msg"


### PR DESCRIPTION
## What changed

This PR adds the repo-local Codex support files and advisor-side prototype assets that were only living in a local worktree:

- `.codex/config.toml`
- `.agents/skills/...`
- `AGENTS.md`
- `k8s/senpai-scout-workflow.yaml`
- `plugins/senpai/scripts/check-notifications.sh`

It also fixes a few stale repo-local references inside the imported skill docs so they point at `.agents/...` instead of older absolute or `.Codex/...` paths.

## Why

These files are useful when working with Codex in this repo and should live in `main` rather than only in one local worktree.

The prototype files are not wired into production by default, but they are useful to preserve in-repo for future advisor workflow work.

## Validation

- `bash -n plugins/senpai/scripts/check-notifications.sh`
- spot-checked the imported skill paths after rewriting stale references
