### PR TITLE
DrivAerML: WD=1e-2 + gc=0.5 compound regularization at 4L/512d

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+drivaerml-wd1e2-gc05-compound


### PR DESCRIPTION
## Hypothesis

On AirfRANS, the winning recipe uses WD=1e-2 + gc (0.5 or 1.0) — both regularization mechanisms working together. The DrivAerML baseline uses WD=1e-4 (100x lower) and no gradient clipping. Your previous experiment (#2793) showed gc=1.5 is too loose for DrivAerML's low natural grad norms (~0.76-0.85). This experiment tests the AirfRANS-proven compound: WD=1e-2 + gc=0.5 — strong regularization + tight clipping matched to the gradient scale. We also test WD=1e-2 alone and gc=0.5 alone to measure the individual vs compound effect.

Note: taki (#2814) has WD=1e-3 + gc=0.5 (10x less WD). fern (#2794) has WD=1e-2 alone (no gc). This fills the matrix gap: WD=1e-2 + gc=0.5.

## Instructions

Run 4 experiments in parallel (2 GPUs each):

**Run 1 — WD=1e-2 + gc=0.5 (main compound)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0,1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-wd-gc \
  --wandb-name driv-wd1e2-gc05
```

**Run 2 — WD=1e-2 + gc=1.0 (looser clip)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2,3 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-wd-gc \
  --wandb-name driv-wd1e2-gc10
```

**Run 3 — WD=5e-3 + gc=0.5 (intermediate WD)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4,5 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --weight-decay 5e-3 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-wd-gc \
  --wandb-name driv-wd5e3-gc05
```

**Run 4 — WD=1e-2 + gc=0.5 + lr=7e-4 (higher LR compound)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=6,7 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 7e-4 --cosine-t-max 30 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group drivaerml-wd-gc \
  --wandb-name driv-wd1e2-gc05-lr7e4
```

Report best val_primary/surface_rel_l2_pct checkpoint for each run. Compare against baseline 4.619% and note whether the compound outperforms the individual components (fern's WD-only and ymir/kaneda's gc-only runs).

## Baseline

- **Primary metric:** val_primary/surface_rel_l2_pct (lower is better)
- **Current best:** 4.619% (PR #2691, 4L/512d, AdamW lr=5e-4, T_max=30, WD=1e-4, no gc)
- **External target:** 3.71% (1.24x gap remaining)
- **AirfRANS analogy:** WD=1e-2 + gc=1.0 at 3L/256d achieved val=0.001479 (65.6% below external target)
- **Your insight from #2793:** DrivAerML grad norms ~0.76-0.85, so gc=0.5 will clip ~every step, providing continuous regularization unlike gc=1.5