### PR TITLE
AirfRANS: 3L/256d LR sweep — find optimal lr at new architecture

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+airfrans-3L256d-lr-sweep


### PR DESCRIPTION
## Hypothesis

PR #2771 achieved val=0.001479 with 3L/256d at lr=7e-4, inheriting the LR from the 4L/256d golden config. But the optimal LR may differ at 3L — fewer transformer layers means smaller gradient magnitudes per step, potentially favoring a different LR. On TandemFoil, lower LR consistently improved results (3e-4→2e-4→1.5e-4). On the historical AirfRANS 3L/192d LR sweep (PR #2655), lr=3e-4 was MORE RELIABLE than lr=7e-4 (tighter seed variance). This experiment maps the LR landscape at 3L/256d with both gc=1.0 (baseline) and gc=0.5 (proven improvement on 4L).

## Instructions

Run 4 experiments in parallel (1 GPU each):

**Run 1 — lr=5e-4 + gc=1.0 (lower LR, baseline gc)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 5e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-3L256d-lr \
  --wandb-name airfrans-3L256d-lr5e4-gc10
```

**Run 2 — lr=3e-4 + gc=1.0 (even lower LR)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 3e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-3L256d-lr \
  --wandb-name airfrans-3L256d-lr3e4-gc10
```

**Run 3 — lr=5e-4 + gc=0.5 (lower LR + tighter gc compound)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 5e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-3L256d-lr \
  --wandb-name airfrans-3L256d-lr5e4-gc05
```

**Run 4 — lr=1e-3 + gc=0.5 (higher LR + tighter gc)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=3 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 1e-3 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-3L256d-lr \
  --wandb-name airfrans-3L256d-lr1e3-gc05
```

Report the best val_primary/surface_mse checkpoint for each run and the epoch at which it occurred. Also note any divergence epochs. The key question: does 3L/256d prefer a different LR than the inherited 7e-4?

## Baseline

- **Primary metric:** val_primary/surface_mse (lower is better)
- **Current best:** 0.001479 at epoch 202 — PR #2771 (3L/256d, gc=1.0, lr=7e-4, W&B: q4hytsr6)
- **LR anchor on old architecture:** PR #2655 at 3L/192d: lr=3e-4 range 0.0153-0.0194, lr=7e-4 range 0.0198-0.0463 (lr=3e-4 was more reliable but at 3L/192d)
- **External target:** 0.0043 (crushed — 65.6% below)