### PR TITLE
Cross-benchmark: no-Lookahead ablation — first test of default-on wrapper

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+cross-benchmark-no-lookahead


### PR DESCRIPTION
## Hypothesis

The Lookahead optimizer wrapper (`--use-lookahead`, default True) has been active in EVERY experiment in this programme but has NEVER been ablated. When we removed EMA (also default True), it was a breakthrough — training improved dramatically across all datasets. Lookahead maintains a "slow weights" copy and interpolates periodically, which could either: (a) smooth the optimization trajectory and find better basins (positive), or (b) dampen the sharp gradient steps that gc=0.5 proved are beneficial, pulling the model away from deep troughs (negative). Given that the programme has since moved toward aggressive optimization (gc=0.5, rapid cosine cycling, high LR), Lookahead's conservative interpolation may now be counterproductive. This is a clean ablation: one variable, three datasets, current best configs.

## Instructions

Run 4 experiments in parallel (1 GPU each for AirfRANS/TandemFoil, 2 for DrivAerML):

**Run 1 — AirfRANS 3L/256d no-Lookahead**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --no-use-lookahead --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group no-lookahead-ablation \
  --wandb-name airfrans-3L256d-nolook
```

**Run 2 — TandemFoil 3L/192d no-Lookahead**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset tandemfoil --optimizer lion \
  --lr 1.5e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --no-use-lookahead --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --wandb-group no-lookahead-ablation \
  --wandb-name tandem-3L192d-nolook
```

**Run 3 — DrivAerML 4L/512d no-Lookahead**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2,3 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --no-use-lookahead --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group no-lookahead-ablation \
  --wandb-name driv-4L512d-nolook
```

**Run 4 — AirfRANS 3L/256d no-Lookahead + gc=0.5 (compound)**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 1e-2 \
  --no-use-ema --no-use-lookahead --enable-fourier \
  --model-layers 3 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group no-lookahead-ablation \
  --wandb-name airfrans-3L256d-nolook-gc05
```

Report best val checkpoints for each. The key comparison is with-Lookahead (current baselines) vs without. If removing Lookahead improves any dataset, it's an EMA-like finding that changes the default recipe.

## Baseline

- **AirfRANS:** val_primary/surface_mse = 0.001479 (PR #2771, 3L/256d + gc=1.0 + Lookahead ON)
- **TandemFoil:** val_primary/surface_pressure_mae = 44.72 (PR #2724, 3L/192d + Lookahead ON)
- **DrivAerML:** val_primary/surface_rel_l2_pct = 4.619% (PR #2691, 4L/512d + Lookahead ON)
- **Precedent:** Removing EMA (also default True) was a major breakthrough. Lookahead is the last untested default-on wrapper.