### PR TITLE
TandemFoil: 3L/256d at lr=1.25e-4 — width scaling at new best config

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+tandemfoil-3L256d-lr125e4


### PR DESCRIPTION
## Hypothesis

AirfRANS showed 3L/256d dramatically beats 3L/192d. Test whether 3L/256d also helps TandemFoil at the new best LR (lr=1.25e-4). Width scaling has not yet been tested at the new best LR/gc configs.

## Baseline

val_primary/surface_pressure_mae = **30.10** (PR #2810)

## Runs

Run all from `cd target/icml2026`.

**Run 1** (3L/256d + lr=1.25e-4 + gc=1.0, `CUDA_VISIBLE_DEVICES=0,1,2`):
```bash
SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 256 --model-heads 4 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb-group tandem-3L256d-lr125 --wandb-name tandem-3L256d-lr125e4-gc10
```

**Run 2** (3L/256d + lr=1.25e-4 + gc=0.5, `CUDA_VISIBLE_DEVICES=3,4,5`):
Same as Run 1 but `--grad-clip 0.5 --wandb-name tandem-3L256d-lr125e4-gc05`

**Run 3** (3L/256d + lr=1e-4 + gc=1.0, `CUDA_VISIBLE_DEVICES=6,7`):
Same as Run 1 but `--lr 1e-4 --wandb-name tandem-3L256d-lr1e4`

## Key Insight

3L/256d uses `--model-hidden-dim 256 --model-heads 4` (vs 192/3 for baseline). On AirfRANS this width change was the breakthrough insight (0.00277 → 0.001479). Testing at the winning TandemFoil lr=1.25e-4 to see if the same scaling law holds across datasets.

## Expected Outcome

val_primary/surface_pressure_mae < 30.10