### PR TITLE
TandemFoil: lr=7.5e-5 — how low can the LR go?

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+tandemfoil-lr75e5-gc


### PR DESCRIPTION
## Hypothesis

LR trend 3e-4→1.25e-4 has consistently improved. lr=7.5e-5 tests if the trend continues below 1e-4, probing whether even lower learning rates further stabilize the Lion optimizer training dynamics on TandemFoil.

## Baseline

val_primary/surface_pressure_mae = **30.10** (PR #2810)

## Runs

Run all from `cd target/icml2026`.

**Run 1** (lr=7.5e-5 + gc=1.0, `CUDA_VISIBLE_DEVICES=0,1,2`):
```bash
SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset tandemfoil --optimizer lion --lr 7.5e-5 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb-group tandem-lowlr --wandb-name tandem-lr75e5-gc10
```

**Run 2** (lr=7.5e-5 + gc=0.5, `CUDA_VISIBLE_DEVICES=3,4,5`):
Same as Run 1 but `--grad-clip 0.5 --wandb-name tandem-lr75e5-gc05`

**Run 3** (lr=5e-5 + gc=1.0, even lower, `CUDA_VISIBLE_DEVICES=6,7`):
Same as Run 1 but `--lr 5e-5 --wandb-name tandem-lr5e5`

## Key Insight

If the LR descent trend continues, 7.5e-5 and 5e-5 could push further below 30.10. If not, this establishes the lower bound of the LR sweet spot and informs where the optimal LR lies for this problem.

## Expected Outcome

val_primary/surface_pressure_mae < 30.10