### PR TITLE
TandemFoil: lr=1.25e-4 + T_max=20 — longer cosine cycles for extended convergence

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+tandemfoil-lr125e4-Tmax20


### PR DESCRIPTION
## Hypothesis

Both best configs (gilbert ep157, sasuke ep161) were still descending at timeout. Longer T_max=20 cycles may allow the model to train more epochs before each LR reset, enabling deeper basin exploration within the 3-hour window.

## Baseline

val_primary/surface_pressure_mae = **30.10** (PR #2810)

## Runs

Run all from `cd target/icml2026`.

**Run 1** (lr=1.25e-4 + gc=1.0 + T_max=20, `CUDA_VISIBLE_DEVICES=0,1,2`):
```bash
SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 20 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb-group tandem-tmax-sweep --wandb-name tandem-lr125e4-gc10-Tmax20
```

**Run 2** (lr=1.25e-4 + gc=0.5 + T_max=20, `CUDA_VISIBLE_DEVICES=3,4,5`):
Same as Run 1 but `--grad-clip 0.5 --wandb-name tandem-lr125e4-gc05-Tmax20`

**Run 3** (lr=1e-4 + gc=1.0 + T_max=20, `CUDA_VISIBLE_DEVICES=6,7`):
Same as Run 1 but `--lr 1e-4 --cosine-t-max 20 --grad-clip 1.0 --wandb-name tandem-lr1e4-gc10-Tmax20`

## Key Insight

With T_max=10, both best runs were still improving at ep157-161 when the 3-hour timeout hit. T_max=20 means the model goes through fewer complete cosine cycles but each cycle is longer, potentially spending more time near the cosine minimum (near-zero LR), which may allow deeper convergence per epoch budget.

## Expected Outcome

val_primary/surface_pressure_mae < 30.10