### PR TITLE
TandemFoil: lr=1.25e-4 — WD ablation at new best config

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+tandemfoil-lr125e4-WDsweep


### PR DESCRIPTION
## Hypothesis

WD=1e-2 is the current default at the winning lr=1.25e-4 config. Test whether lighter WD (5e-3, 1e-3) or no WD (0) helps at this LR. Lower weight decay may allow the model to reach sharper minima that generalize better on this dataset.

## Baseline

val_primary/surface_pressure_mae = **30.10** (PR #2810)

## Runs

Run all from `cd target/icml2026`.

**Run 1** (WD=5e-3 + gc=1.0, `CUDA_VISIBLE_DEVICES=0,1,2`):
```bash
SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 5e-3 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb-group tandem-wd-sweep --wandb-name tandem-lr125e4-wd5e3
```

**Run 2** (WD=1e-3 + gc=1.0, `CUDA_VISIBLE_DEVICES=3,4,5`):
Same as Run 1 but `--weight-decay 1e-3 --wandb-name tandem-lr125e4-wd1e3`

**Run 3** (WD=0 + gc=1.0, `CUDA_VISIBLE_DEVICES=6,7`):
Same as Run 1 but `--weight-decay 0 --wandb-name tandem-lr125e4-wd0`

## Key Insight

At lower LRs, the effect of weight decay changes — Lion with lower LR may already be implicitly regularizing more. Testing the WD range 0→1e-2 at the winning lr=1.25e-4 establishes whether WD=1e-2 is optimal or whether relaxing it unlocks additional performance.

## Expected Outcome

val_primary/surface_pressure_mae < 30.10