### PR TITLE
AirfRANS: 3L/256d weight-decay ablation (WD=0, WD=5e-3)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+airfrans-3L256d-WD0-ablation


### PR DESCRIPTION
## Hypothesis

WD=1e-2 was inherited from 4L configs. At 3L/256d the model has fewer parameters and may not need as much regularization. This ablation tests WD=0 and WD=5e-3 against the golden WD=1e-2, with gc=1.0 and gc=0.5 to check interaction effects. Removing or reducing WD could allow the optimizer to find a better basin without being penalized for parameter magnitude.

## Baseline
val_primary/surface_mse = **0.001479** (PR #2771, 3L/256d + gc=1.0 + WD=1e-2 + T_max=5 + AdamW lr=7e-4)

## Runs

**Run 1** (CUDA 0): WD=0, gc=1.0
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 0 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-WD --wandb-name airfrans-3L256d-WD0-gc10
```

**Run 2** (CUDA 1): WD=0, gc=0.5
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 0 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-WD --wandb-name airfrans-3L256d-WD0-gc05
```

**Run 3** (CUDA 2): WD=5e-3, gc=1.0
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 5e-3 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-WD --wandb-name airfrans-3L256d-WD5e3
```

## Expected Outcome
val_primary/surface_mse < **0.001479**

At least one of WD=0 or WD=5e-3 should undercut the current best if WD=1e-2 is over-regularizing the 3L model. Report best val_primary/surface_mse per run and identify winner configuration.