### PR TITLE
DrivAerML: Lion optimizer sweep (lr=1e-4/5e-5/2e-4)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+drivaerml-lion-optimizer


### PR DESCRIPTION
## Hypothesis

Lion optimizer has never been tried on DrivAerML. Lion uses gradient sign momentum which handles loss landscapes very differently from AdamW. On TandemFoil, Lion at lr=1.25e-4 was a breakthrough optimizer. For DrivAerML's 3D surfaces, Lion's clipping-like behavior might be inherently more stable than AdamW — especially relevant given that DrivAerML is highly sensitive to gradient dynamics (gc=0.5 crashed, gc=1.5 diverged).

## Baseline
val_primary/surface_rel_l2_pct = **4.619%** (PR #2691, 4L/512d/8H, T_max=30, lr=5e-4, AdamW, WD=1e-2)

## Runs

All runs keep golden config values: 4L/512d/8H, WD=1e-2, gc=1.0, T_max=30, no-use-ema, enable-fourier, 50k surface points.

**Run 1 (CUDA 0): Lion lr=1e-4**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer lion --lr 1e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-lion --wandb-name drivaerml-lion-lr1e4
```

**Run 2 (CUDA 1): Lion lr=5e-5**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer lion --lr 5e-5 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-lion --wandb-name drivaerml-lion-lr5e5
```

**Run 3 (CUDA 2): Lion lr=2e-4**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer lion --lr 2e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-lion --wandb-name drivaerml-lion-lr2e4
```

## Expected Outcome
val_primary/surface_rel_l2_pct < **4.619%**

Note: Lion typically needs ~3-10x lower LR than AdamW. Runs span 1e-4, 5e-5, and 2e-4 to cover the likely sweet spot. Report best val_primary/surface_rel_l2_pct for each run in a comment.