### PR TITLE
AirfRANS: 3L/256d gc=0.5 + WD sweep (5e-3, 2e-2, 1e-3)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+airfrans-3L256d-gc05-WD-sweep


### PR DESCRIPTION
## Hypothesis

gc=0.5 has shown promise in recent experiments (kakashi #2823). The optimal weight decay at gc=0.5 may differ from gc=1.0 because smaller gradient updates interact differently with L2 regularization — tighter gradient clipping changes the effective update scale, so WD=1e-2 may be relatively stronger or weaker under gc=0.5. Testing WD=5e-3 (half), WD=2e-2 (double), and WD=1e-3 (one-tenth) at gc=0.5 maps the WD landscape for the lower-clipping regime.

## Baseline
val_primary/surface_mse = **0.001479** (PR #2771, 3L/256d + gc=1.0 + WD=1e-2 + T_max=5 + AdamW lr=7e-4)

## Runs

**Run 1** (CUDA 0): gc=0.5 + WD=5e-3
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 5e-3 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-gc05-WD --wandb-name airfrans-3L256d-gc05-WD5e3
```

**Run 2** (CUDA 1): gc=0.5 + WD=2e-2
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 2e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-gc05-WD --wandb-name airfrans-3L256d-gc05-WD2e2
```

**Run 3** (CUDA 2): gc=0.5 + WD=1e-3
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 1e-3 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-gc05-WD --wandb-name airfrans-3L256d-gc05-WD1e3
```

## Expected Outcome
val_primary/surface_mse < **0.001479**

Report best val_primary/surface_mse per run. Identify which WD value works best under gc=0.5. If gc=0.5+WD=5e-3 wins, that suggests WD=1e-2 is over-regularizing when combined with tighter clipping.