### PR TITLE
DrivAerML: Conservative LR neighborhood sweep (lr=3.5e-4/4e-4/4.5e-4)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+drivaerml-conservative-lr


### PR DESCRIPTION
## Hypothesis

Every DrivAerML experiment that raised LR above 5e-4 crashed catastrophically (lr=7e-4 → 15.352%). Three independent experiments confirmed lr=3e-4 is worse. This suggests a very narrow LR optimum. We probe the neighborhood just below 5e-4 with minimal perturbations (4e-4, 4.5e-4, 3.5e-4) to determine whether the baseline can be improved with a small, careful LR reduction — or whether 5e-4 truly is the global optimum in this direction.

## Baseline
val_primary/surface_rel_l2_pct = **4.619%** (PR #2691, 4L/512d/8H, T_max=30, lr=5e-4, AdamW, WD=1e-2)

## Runs

All runs keep golden config values: 4L/512d/8H, WD=1e-2, gc=1.0, T_max=30, AdamW, no-use-ema, enable-fourier, 50k surface points.

**Run 1 (CUDA 0): lr=4e-4**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 4e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-lr-conservative --wandb-name drivaerml-lr4e4
```

**Run 2 (CUDA 1): lr=4.5e-4**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 4.5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-lr-conservative --wandb-name drivaerml-lr45e4
```

**Run 3 (CUDA 2): lr=3.5e-4**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 3.5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-lr-conservative --wandb-name drivaerml-lr35e4
```

## Expected Outcome
val_primary/surface_rel_l2_pct < **4.619%**

Report the best val_primary/surface_rel_l2_pct achieved for each run and whether training was stable throughout.