### PR TITLE
DrivAerML: Weight decay ablation (WD=0/5e-3/2e-2)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+drivaerml-WD0-ablation


### PR DESCRIPTION
## Hypothesis

WD=1e-2 was set in the golden config but has never been ablated on DrivAerML. With only 394 training batches per epoch on 3D surface data, strong weight decay (1e-2) may be reducing the model's effective capacity — acting like implicit capacity reduction on top of the already-limited data regime. WD=0 removes this constraint entirely; WD=5e-3 (half baseline) gives lighter regularization; WD=2e-2 (double baseline) tests whether more regularization helps with the small dataset. The interaction with the cosine LR schedule also makes WD worth probing — at T_max=30, the LR drops low enough that WD could dominate.

## Baseline
val_primary/surface_rel_l2_pct = **4.619%** (PR #2691, 4L/512d/8H, T_max=30, lr=5e-4, AdamW, WD=1e-2)

## Runs

All runs keep golden config values: 4L/512d/8H, lr=5e-4, gc=1.0, T_max=30, AdamW, no-use-ema, enable-fourier, 50k surface points.

**Run 1 (CUDA 0): WD=0**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 0 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-WD --wandb-name drivaerml-WD0
```

**Run 2 (CUDA 1): WD=5e-3**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 5e-3 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-WD --wandb-name drivaerml-WD5e3
```

**Run 3 (CUDA 2): WD=2e-2**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 2e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-WD --wandb-name drivaerml-WD2e2
```

## Expected Outcome
val_primary/surface_rel_l2_pct < **4.619%**

Report val_primary/surface_rel_l2_pct for each run. Note whether training was stable and whether any run showed signs of underfitting (WD=0) or overfitting (WD=2e-2).