### PR TITLE
AirfRANS: 3L/256d cosine T_max sweep (T_max=3, 7 with gc variants)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+airfrans-3L256d-Tmax3-short-cycles


### PR DESCRIPTION
## Hypothesis

T_max=5 is the current best (PR #2771), but there may be evidence of divergence around ep200 in cosine cycles. T_max=3 gives faster cosine resets, which could prevent the LR from staying elevated too long during the danger window — shorter cycles mean the model returns to low LR more frequently, acting as a built-in annealing safeguard. T_max=7 is tested as a longer cycle comparison. Both are paired with gc variants to map the interaction between cycle length and gradient stability.

## Baseline
val_primary/surface_mse = **0.001479** (PR #2771, 3L/256d + gc=1.0 + WD=1e-2 + T_max=5 + AdamW lr=7e-4)

## Runs

**Run 1** (CUDA 0): T_max=3 + gc=1.0
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 3 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-Tmax --wandb-name airfrans-3L256d-Tmax3-gc10
```

**Run 2** (CUDA 1): T_max=3 + gc=0.5
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 3 --grad-clip 0.5 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-Tmax --wandb-name airfrans-3L256d-Tmax3-gc05
```

**Run 3** (CUDA 2): T_max=7 + gc=0.5
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 7 --grad-clip 0.5 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-Tmax --wandb-name airfrans-3L256d-Tmax7-gc05
```

## Expected Outcome
val_primary/surface_mse < **0.001479**

Report best val_primary/surface_mse per run. If T_max=3 outperforms T_max=5, that confirms shorter cycles prevent divergence. If T_max=7 is competitive, it suggests longer warm cycles are beneficial — useful signal for further T_max search.