### PR TITLE
AirfRANS: 3L/256d aggressive LR regime (lr=1.2e-3, 8e-4 + gc=0.5 + WD variants)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+airfrans-3L256d-lr1e3-gc05


### PR DESCRIPTION
## Hypothesis

Push an aggressive training regime at 3L/256d: higher LR combined with tighter gradient clipping (gc=0.5) and reduced weight decay (WD=5e-3). The 3L architecture may be under-optimized at lr=7e-4 — it is shallower and has less parameter coupling, which could allow it to safely traverse a larger step size. lr=1.2e-3 + gc=0.5 + WD=5e-3 represents a regime change. lr=8e-4 tests a more moderate step above baseline, also with gc=0.5, to isolate the gc effect from the LR effect.

## Baseline
val_primary/surface_mse = **0.001479** (PR #2771, 3L/256d + gc=1.0 + WD=1e-2 + T_max=5 + AdamW lr=7e-4)

## Runs

**Run 1** (CUDA 0): lr=1.2e-3 + gc=0.5 + WD=5e-3
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 1.2e-3 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 5e-3 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-aggressive --wandb-name airfrans-3L256d-lr12e3-gc05-WD5e3
```

**Run 2** (CUDA 1): lr=8e-4 + gc=0.5
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 8e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-aggressive --wandb-name airfrans-3L256d-lr8e4-gc05
```

**Run 3** (CUDA 2): lr=8e-4 + gc=0.5 + WD=5e-3
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 8e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 5e-3 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb-group airfrans-3L256d-aggressive --wandb-name airfrans-3L256d-lr8e4-gc05-WD5e3
```

## Expected Outcome
val_primary/surface_mse < **0.001479**

Report best val_primary/surface_mse per run. A clean win at lr=8e-4+gc=0.5 vs lr=7e-4+gc=1.0 would confirm the directional value of both higher LR and tighter clipping. If lr=1.2e-3 diverges, report the last stable checkpoint metric.