### PR TITLE
AirfRANS: 3L/256d MLP ratio sweep (ratio=2, ratio=8)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+airfrans-3L256d-mlp-ratio


### PR DESCRIPTION
## Hypothesis

The MLP ratio (feed-forward expansion factor) is fixed at the default of 4 (hidden_dim * 4 in each transformer MLP block) and has never been ablated. For CFD surrogate tasks, the optimal capacity allocation between attention and MLP blocks may differ from language modeling defaults. MLP ratio=2 compresses the MLP sublayers, reducing overfitting risk and focusing capacity on attention. MLP ratio=8 expands MLP capacity dramatically, potentially improving function approximation if the current bottleneck is in the feed-forward layers rather than attention.

## Baseline
val_primary/surface_mse = **0.001479** (PR #2771, 3L/256d + gc=1.0 + WD=1e-2 + T_max=5 + AdamW lr=7e-4, default mlp-ratio=4)

## Runs

**Run 1** (CUDA 0): mlp-ratio=2 + gc=1.0
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --model-mlp-ratio 2 --epochs 999 --wandb-group airfrans-3L256d-mlp --wandb-name airfrans-3L256d-mlp2-gc10
```

**Run 2** (CUDA 1): mlp-ratio=2 + gc=0.5
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 0.5 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --model-mlp-ratio 2 --epochs 999 --wandb-group airfrans-3L256d-mlp --wandb-name airfrans-3L256d-mlp2-gc05
```

**Run 3** (CUDA 2): mlp-ratio=8 + gc=1.0
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 3 --model-hidden-dim 256 --model-heads 4 --model-mlp-ratio 8 --epochs 999 --wandb-group airfrans-3L256d-mlp --wandb-name airfrans-3L256d-mlp8-gc10
```

## Expected Outcome
val_primary/surface_mse < **0.001479**

Report best val_primary/surface_mse per run. If mlp-ratio=2 beats the default ratio=4, it suggests MLP over-parameterization is harming generalization at 3L/256d. If mlp-ratio=8 wins, feed-forward capacity is the current bottleneck. Either result is highly informative for architecture design.