### PR TITLE
DrivAerML: MLP ratio sweep (ratio=2/3/6)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+drivaerml-mlp-ratio


### PR DESCRIPTION
## Hypothesis

The MLP ratio (controlling the feedforward expansion factor inside each transformer block) has never been ablated on DrivAerML. The default value of 4 means the MLP hidden dimension is 4×512=2048. With only 394 training batches, this MLP capacity may be creating unnecessary overfitting pressure. Reducing to mlp-ratio=2 (MLP dim=1024) or mlp-ratio=3 (MLP dim=1536) cuts parameters by 25-50% while keeping attention capacity unchanged. Conversely, mlp-ratio=6 (MLP dim=3072) tests whether more MLP capacity helps DrivAerML's complex 3D surface geometry. This is a pure capacity knob that hasn't been pulled and costs nothing in attention compute.

## Baseline
val_primary/surface_rel_l2_pct = **4.619%** (PR #2691, 4L/512d/8H, T_max=30, lr=5e-4, AdamW, WD=1e-2, mlp-ratio=4 default)

## Runs

All runs keep golden config values: 4L/512d/8H, lr=5e-4, WD=1e-2, gc=1.0, T_max=30, AdamW, no-use-ema, enable-fourier, 50k surface points. Only the MLP ratio changes.

**Run 1 (CUDA 0): mlp-ratio=2**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-mlp-ratio 2 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-mlp --wandb-name drivaerml-mlp2
```

**Run 2 (CUDA 1): mlp-ratio=3**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-mlp-ratio 3 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-mlp --wandb-name drivaerml-mlp3
```

**Run 3 (CUDA 2): mlp-ratio=6**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --model-mlp-ratio 6 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-mlp --wandb-name drivaerml-mlp6
```

## Expected Outcome
val_primary/surface_rel_l2_pct < **4.619%**

Report val_primary/surface_rel_l2_pct for each run. If --model-mlp-ratio is not a recognized flag, report the error and try --mlp-ratio instead.