### PR TITLE
DrivAerML: Tight grad clip sweep (gc=0.7/0.8/0.9)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+drivaerml-gc-tight


### PR DESCRIPTION
## Hypothesis

DrivAerML's natural gradient norms are ~0.76-0.85. The golden gc=1.0 barely clips anything. gc=0.5 was too aggressive and crashed. The unexplored sweet spot is gc values just below the natural norm range: gc=0.8 clips only peaks above 0.8 (the top ~20-30% of gradient events), gc=0.9 clips only extreme peaks (top ~5-10%), and gc=0.7 clips more aggressively but stays well above the destructive gc=0.5 level. This is a precision gradient shaping experiment — we're not trying to suppress gradients, just trim the outlier steps that may cause DrivAerML's characteristic instability. Student taki is separately testing gc=0.25/0.1 (very tight).

## Baseline
val_primary/surface_rel_l2_pct = **4.619%** (PR #2691, 4L/512d/8H, T_max=30, lr=5e-4, AdamW, WD=1e-2, gc=1.0)

## Context
- Natural grad norms on DrivAerML: ~0.76-0.85
- gc=1.0 (baseline): rarely activates
- gc=0.5: crashed (too aggressive)
- gc=1.5: diverged
- gc=0.25/0.1: being tested by taki (PR #2814)

## Runs

All runs keep golden config values: 4L/512d/8H, lr=5e-4, WD=1e-2, T_max=30, AdamW, no-use-ema, enable-fourier, 50k surface points.

**Run 1 (CUDA 0): gc=0.8**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.8 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-gc-tight --wandb-name drivaerml-gc08
```

**Run 2 (CUDA 1): gc=0.9**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.9 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-gc-tight --wandb-name drivaerml-gc09
```

**Run 3 (CUDA 2): gc=0.7**
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.7 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb-group drivaerml-gc-tight --wandb-name drivaerml-gc07
```

## Expected Outcome
val_primary/surface_rel_l2_pct < **4.619%**

Report val_primary/surface_rel_l2_pct for each run. Also note whether any run shows instability (spikes in train loss) that might indicate the clipping threshold is too tight. Together with taki's gc=0.25/0.1 results, this will give us a full picture of the gc landscape.