### PR TITLE
DrivAerML: LR headroom above 5e-4 without gc interference (6e-4, 5.5e-4, 4.5e-4)

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-# airfrans-3L256d-golden
+# drivaerml-lr6e4-no-gc


### PR DESCRIPTION
## Hypothesis

All DrivAerML gc=0.5 experiments crashed. The golden config at lr=5e-4 + no gc (i.e., gc=1.0 default) works. The question is: **is there any LR headroom above 5e-4 when gc interference is removed?**

- lr=6e-4 is a minimal 20% increase above baseline — the smallest meaningful step
- lr=5.5e-4 is an even tinier 10% increase to narrow the window
- lr=4.5e-4 tests slightly below baseline to confirm whether 5e-4 is already at the optimum

This is chrome's own suggestion after observing that gc=0.5 destabilized all prior DrivAerML runs.

## Baseline

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **4.619%** |

## Runs

Base command:
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=X SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --cosine-t-max 30
```

### Run 1 (CUDA 0): lr=6e-4 — minimal increase, no gc
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 6e-4 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --cosine-t-max 30 --wandb-group drivaerml-lr-headroom --wandb-name drivaerml-lr6e4-nogc
```

### Run 2 (CUDA 1): lr=5.5e-4 — tiny increase
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 5.5e-4 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --cosine-t-max 30 --wandb-group drivaerml-lr-headroom --wandb-name drivaerml-lr55e4-nogc
```

### Run 3 (CUDA 2): lr=4.5e-4 — slightly below baseline LR
```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset drivaerml --optimizer adamw --lr 4.5e-4 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --cosine-t-max 30 --wandb-group drivaerml-lr-headroom --wandb-name drivaerml-lr45e4-nogc
```

NOTE: Run 3 tests slightly below the baseline LR to confirm whether 5e-4 is already at the optimum or whether there is still room below it.

## Expected Outcome

`val_primary/surface_rel_l2_pct < 4.619%`

If any of the above-baseline LRs (6e-4 or 5.5e-4) beat the baseline, it opens the door to a larger LR sweep. If 4.5e-4 is also worse, this confirms 5e-4 is very close to optimal for the no-gc configuration.

## Reporting

Please report `val_primary/surface_rel_l2_pct` for each run. Report from the best validation checkpoint, not terminal epoch. Include W&B run IDs. If any run diverges (loss spikes, NaN), report at what epoch and the approximate loss value.