### PR TITLE
AirfRANS: 2L/256d + T_max=10 compound — depth floor meets long cycles

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-airfrans-2L-depth-frontier
+airfrans-2L256d-Tmax10-gc-sweep


### PR DESCRIPTION
## Hypothesis

Two independent breakthroughs have not yet been compounded:
1. **2L/256d achieves 0.001236** (PR #2828, T_max=5) — depth reduction 3L→2L gives 16.4% improvement
2. **3L/256d + T_max=10 achieves 0.001095** (kakashi #2823, pending) — longer cosine cycles give 26% improvement

Neither uses both changes together. 2L/256d + T_max=10 could be the new frontier.

Also test **1L/256d** — the depth floor. If 4L→3L→2L all helped, does 1L help further or does the model lose minimum capacity?

## Instructions

Run from `cd target/icml2026`. Use `CUDA_VISIBLE_DEVICES=X` to assign GPUs.

**Run 1 — PRIMARY: 2L/256d + T_max=10 + gc=1.0** (`CUDA_VISIBLE_DEVICES=0`):
```bash
SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 7e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-2L256d-Tmax10 \
  --wandb-name airfrans-2L256d-Tmax10-gc10
```

**Run 2 — gc comparison: 2L/256d + T_max=10 + gc=0.5** (`CUDA_VISIBLE_DEVICES=1`):
Same as Run 1 but `--grad-clip 0.5 --wandb-name airfrans-2L256d-Tmax10-gc05`

**Run 3 — DEPTH FLOOR: 1L/256d + T_max=10 + gc=1.0** (`CUDA_VISIBLE_DEVICES=2`):
Same as Run 1 but `--model-layers 1 --wandb-name airfrans-1L256d-Tmax10-gc10`

Run all three in parallel. Monitor for divergence. If 1L diverges early, note the epoch.

## Baseline

- **val_primary/surface_mse: 0.001236** (PR #2828, 2L/256d + T_max=5 + gc=1.0, W&B: libpwryz)
- Also compare against: 0.001095 (kakashi, 3L/256d + T_max=10, pending merge)
- Reproduce baseline: `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999`

## Expected Outcome

val_primary/surface_mse < 0.001236 (ideally < 0.001095 to beat both pending bests)