### PR TITLE
AirfRANS: 2L/256d + T_max=10 LR sweep — optimal LR at 2-layer depth

### DIFF
--- a/.experiment
+++ b/.experiment
@@ -1,1 +1,1 @@
-airfrans-2L-depth-frontier
+airfrans-2L256d-Tmax10-lr-sweep


### PR DESCRIPTION
## Hypothesis

The optimal learning rate may shift at 2L vs 3L. lr=7e-4 is optimal for 3L/256d (confirmed by winry's sweep). At 2L with fewer parameters, the loss landscape is different — a higher or lower LR may converge to deeper basins. This LR sweep at 2L/256d + T_max=10 complements itachi's #2872 (gc sweep) and inosuke's #2874 (gc sweep + 1L test).

## Instructions

Run from `cd target/icml2026`. Use `CUDA_VISIBLE_DEVICES=X` to assign GPUs.

**Run 1 — lr=5e-4 (lower than golden)** (`CUDA_VISIBLE_DEVICES=0`):
```bash
SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 5e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --wandb-group airfrans-2L256d-Tmax10-lr \
  --wandb-name airfrans-2L256d-Tmax10-lr5e4
```

**Run 2 — lr=1e-3 (higher than golden)** (`CUDA_VISIBLE_DEVICES=1`):
Same as Run 1 but `--lr 1e-3 --wandb-name airfrans-2L256d-Tmax10-lr1e3`

**Run 3 — lr=3e-4 (much lower)** (`CUDA_VISIBLE_DEVICES=2`):
Same as Run 1 but `--lr 3e-4 --wandb-name airfrans-2L256d-Tmax10-lr3e4`

## Baseline

- **val_primary/surface_mse: 0.001236** (PR #2828, 2L/256d + T_max=5 + gc=1.0 + lr=7e-4, W&B: libpwryz)
- Also compare: 0.001095 (kakashi, 3L/256d + T_max=10, pending merge)
- Reproduce: `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 SENPAI_TIMEOUT_MINUTES=180 python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999`

## Expected Outcome

val_primary/surface_mse < 0.001236