### PR TITLE
[codex] Update model references to 4.7

### DIFF
--- a/.agents/skills/alphaxiv-paper-lookup/SKILL.md
+++ b/.agents/skills/alphaxiv-paper-lookup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: alphaxiv-paper-lookup
 description: Look up any arxiv paper on alphaxiv.org to get a structured AI-generated overview. This is faster and more reliable than trying to read a raw PDF.
-model: Codex-opus-4-6
+model: Codex-opus-4-7
 effort: high
 ---
 

--- a/.agents/skills/rlm/SKILL.md
+++ b/.agents/skills/rlm/SKILL.md
@@ -173,7 +173,7 @@ if __name__ == "__main__":
 |---|---|---|
 | `Codex-sonnet-4-6` | 30 | Default — good balance of speed and cost |
 | `Codex-haiku-4-5` | 50 | Use for cheap, high-volume sub-calls |
-| `Codex-opus-4-6` | 5 | Heavy model; use only for root-level synthesis |
+| `Codex-opus-4-7` | 5 | Heavy model; use only for root-level synthesis |
 
 Use a **second semaphore** for downstream rate-limited APIs (e.g. W&B, GitHub):
 

--- a/.agents/skills/web-search-advanced-research-paper/SKILL.md
+++ b/.agents/skills/web-search-advanced-research-paper/SKILL.md
@@ -2,7 +2,7 @@
 name: web-search-advanced-research-paper
 description: Search for research papers and academic content using Exa advanced search. Full filter support including date ranges and text filtering. Use when searching for academic papers, arXiv preprints, or scientific research.
 context: fork
-model: Codex-opus-4-6
+model: Codex-opus-4-7
 effort: high
 ---
 

--- a/.claude/skills/alphaxiv-paper-lookup/SKILL.md
+++ b/.claude/skills/alphaxiv-paper-lookup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: alphaxiv-paper-lookup
 description: Look up any arxiv paper on alphaxiv.org to get a structured AI-generated overview. This is faster and more reliable than trying to read a raw PDF.
-model: claude-opus-4-6
+model: claude-opus-4-7
 effort: high
 ---
 

--- a/.claude/skills/web-search-advanced-research-paper/SKILL.md
+++ b/.claude/skills/web-search-advanced-research-paper/SKILL.md
@@ -2,7 +2,7 @@
 name: web-search-advanced-research-paper
 description: Search for research papers and academic content using Exa advanced search. Full filter support including date ranges and text filtering. Use when searching for academic papers, arXiv preprints, or scientific research.
 context: fork
-model: claude-opus-4-6
+model: claude-opus-4-7
 effort: high
 ---
 

--- a/k8s/run-senpai-claude.sh
+++ b/k8s/run-senpai-claude.sh
@@ -15,7 +15,7 @@ run_senpai_claude() {
     # embeds the prompt (which mentions train.py) in the cmdline, causing the
     # agent to accidentally kill its own Claude Code process.
     printf '%s' "$user_prompt" | claude "$@" -p - \
-        --model "claude-opus-4-6[1m]" \
+        --model "claude-opus-4-7[1m]" \
         --effort "max" \
         --max-turns "$max_turns" \
         --output-format stream-json --verbose \

--- a/plugins/senpai/skills/check-human-issues/SKILL.md
+++ b/plugins/senpai/skills/check-human-issues/SKILL.md
@@ -12,7 +12,7 @@ description: >
   "check issues", "respond to humans".
 argument-hint: "<name> <ADVISOR|STUDENT>"
 context: fork
-model: claude-opus-4-6
+model: claude-opus-4-7
 effort: high
 ---
 

--- a/plugins/senpai/skills/senpai-gh/SKILL.md
+++ b/plugins/senpai/skills/senpai-gh/SKILL.md
@@ -13,7 +13,7 @@ description: >
   student", "close this PR", "mark for review", "check human issues",
   "list review-ready PRs", "idle students".
 user-invocable: false
-model: claude-opus-4-6
+model: claude-opus-4-7
 effort: high
 ---
 


### PR DESCRIPTION
## Summary
- update Codex skill model references from `*-4-6` to `*-4-7`
- update Claude skill model references from `claude-opus-4-6` to `claude-opus-4-7`
- keep `k8s/run-senpai-claude.sh` aligned with the new Claude model version

## Why
These staged changes move the repo's skill metadata and launcher configuration to the 4.7 model naming.

## Validation
- `git diff --cached --check`
- `bash -n k8s/run-senpai-claude.sh`