### PR TITLE
Cross-dataset: gc=1.5/gc=2.0 — higher gradient clipping for DrivAerML

### DIFF
--- a/target/icml2026/experiments/casca-gc-1.5-gc-2.0-drivaer.md
+++ b/target/icml2026/experiments/casca-gc-1.5-gc-2.0-drivaer.md
@@ -1,0 +1,4 @@
+# Experiment: gc=1.5/gc=2.0 — higher gradient clipping for DrivAerML
+Student: casca
+Branch: casca/gc-1.5-gc-2.0-drivaer
+Wandb group: gc-high-sweep


### PR DESCRIPTION
## Hypothesis

AirfRANS achieved its best result at gc=1.0, which was a significant win over the no-clipping baseline. TandemFoil also benefits from gc=1.0. The question is whether DrivAerML (currently using no gradient clipping in the golden baseline) would benefit from more aggressive clipping — and specifically whether gc=1.5 or gc=2.0 (higher than the AirfRANS winner) is optimal for the larger, more complex 3D automotive case. Higher gradient clipping values may provide better regularization for the noisier, higher-dimensional DrivAerML gradients while still allowing larger gradient steps than gc=1.0.

## Instructions

Run 8 GPU jobs: 4 for gc=1.5, 4 for gc=2.0. Use `--wandb-group gc-high-sweep` so all runs are grouped.

**DrivAerML gc=1.5 runs (GPUs 0-3):**

```bash
# GPU 0
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 1.5 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc1.5-seed0 \
  --seed 0 2>&1 | tee /tmp/casca-drivaer-gc1.5-gpu0.log &

# GPU 1
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 1.5 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc1.5-seed1 \
  --seed 1 2>&1 | tee /tmp/casca-drivaer-gc1.5-gpu1.log &

# GPU 2
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 1.5 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc1.5-seed2 \
  --seed 2 2>&1 | tee /tmp/casca-drivaer-gc1.5-gpu2.log &

# GPU 3
cd target/icml2026 && CUDA_VISIBLE_DEVICES=3 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 1.5 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc1.5-seed3 \
  --seed 3 2>&1 | tee /tmp/casca-drivaer-gc1.5-gpu3.log &
```

**DrivAerML gc=2.0 runs (GPUs 4-7):**

```bash
# GPU 4
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 2.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc2.0-seed0 \
  --seed 0 2>&1 | tee /tmp/casca-drivaer-gc2.0-gpu4.log &

# GPU 5
cd target/icml2026 && CUDA_VISIBLE_DEVICES=5 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 2.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc2.0-seed1 \
  --seed 1 2>&1 | tee /tmp/casca-drivaer-gc2.0-gpu5.log &

# GPU 6
cd target/icml2026 && CUDA_VISIBLE_DEVICES=6 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 2.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc2.0-seed2 \
  --seed 2 2>&1 | tee /tmp/casca-drivaer-gc2.0-gpu6.log &

# GPU 7
cd target/icml2026 && CUDA_VISIBLE_DEVICES=7 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 2.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group gc-high-sweep \
  --wandb-name drivaer-4L-512d-gc2.0-seed3 \
  --seed 3 2>&1 | tee /tmp/casca-drivaer-gc2.0-gpu7.log &
```

Wait for all 8 runs to finish, then report the best `val_primary/surface_rel_l2_pct` for gc=1.5 (best across seeds 0-3) and gc=2.0 (best across seeds 4-7).

## Baseline

- **DrivAerML best**: `val_primary/surface_rel_l2_pct = 4.619%` (epoch 256, PR #2691)
  - Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, **no gradient clipping**, no WD
  - Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --num-layers 4 --hidden-dim 512 --num-heads 8 --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- **AirfRANS best**: `val_primary/surface_mse = 0.001236` (epoch 349, PR #2828); 2L/256d/4H, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5
- **TandemFoil best**: `val_primary/surface_pressure_mae = 30.10` (epoch 157, PR #2810); 3L/192d/3H, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10