### PR TITLE
Cross-dataset: T_max=15+gc=1.0+WD=1e-2 — intermediate cycling with regularization

### DIFF
--- a/target/icml2026/experiments/chopper-tmax-15-gc-wd-drivaer.md
+++ b/target/icml2026/experiments/chopper-tmax-15-gc-wd-drivaer.md
@@ -1,0 +1,4 @@
+# Experiment: T_max=15+gc=1.0+WD=1e-2 — intermediate cycling with regularization for DrivAerML
+Student: chopper
+Branch: chopper/tmax-15-gc-wd-drivaer
+Wandb group: tmax-15-compound


### PR DESCRIPTION
## Hypothesis

The AirfRANS golden recipe uses T_max=5 and TandemFoil uses T_max=10. DrivAerML currently uses T_max=30 (the full cycle). An intermediate cosine cycle length of T_max=15, combined with the regularization package (gc=1.0, WD=1e-2) that worked on both other datasets, may give DrivAerML the best of both worlds: shorter, more focused cosine annealing cycles that reset momentum more frequently, plus the gradient stability from gradient clipping and weight decay that helped AirfRANS and TandemFoil. This compound test covers T_max=15 as a midpoint between the AirfRANS (T_max=5) and DrivAerML (T_max=30) extremes, with the winning cross-dataset regularization recipe.

Run 4 seeds so we can distinguish a real signal from noise.

## Instructions

Run 8 GPU jobs with `--wandb-group tmax-15-compound` (4 seeds for T_max=15+compound, 4 seeds without WD for ablation).

**T_max=15 + gc=1.0 + WD=1e-2 (GPUs 0-3):**

```bash
# GPU 0
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-wd1e2-seed0 \
  --seed 0 2>&1 | tee /tmp/chopper-drivaer-tmax15-gpu0.log &

# GPU 1
cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-wd1e2-seed1 \
  --seed 1 2>&1 | tee /tmp/chopper-drivaer-tmax15-gpu1.log &

# GPU 2
cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-wd1e2-seed2 \
  --seed 2 2>&1 | tee /tmp/chopper-drivaer-tmax15-gpu2.log &

# GPU 3
cd target/icml2026 && CUDA_VISIBLE_DEVICES=3 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-wd1e2-seed3 \
  --seed 3 2>&1 | tee /tmp/chopper-drivaer-tmax15-gpu3.log &
```

**T_max=15 + gc=1.0, no WD — ablation (GPUs 4-7):**

```bash
# GPU 4
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-nowd-seed0 \
  --seed 0 2>&1 | tee /tmp/chopper-drivaer-tmax15-nowd-gpu4.log &

# GPU 5
cd target/icml2026 && CUDA_VISIBLE_DEVICES=5 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-nowd-seed1 \
  --seed 1 2>&1 | tee /tmp/chopper-drivaer-tmax15-nowd-gpu5.log &

# GPU 6
cd target/icml2026 && CUDA_VISIBLE_DEVICES=6 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-nowd-seed2 \
  --seed 2 2>&1 | tee /tmp/chopper-drivaer-tmax15-nowd-gpu6.log &

# GPU 7
cd target/icml2026 && CUDA_VISIBLE_DEVICES=7 python train.py \
  --dataset drivaerml \
  --num-layers 4 --hidden-dim 512 --num-heads 8 \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 15 \
  --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb-group tmax-15-compound \
  --wandb-name drivaer-4L-512d-tmax15-gc1.0-nowd-seed3 \
  --seed 3 2>&1 | tee /tmp/chopper-drivaer-tmax15-nowd-gpu7.log &
```

Wait for all 8 runs to finish. Report best `val_primary/surface_rel_l2_pct` for both groups (with WD vs without WD), and confirm which variant performs better.

## Baseline

- **DrivAerML best**: `val_primary/surface_rel_l2_pct = 4.619%` (epoch 256, PR #2691)
  - Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, no gradient clipping, no WD
  - Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --num-layers 4 --hidden-dim 512 --num-heads 8 --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
- **AirfRANS best**: `val_primary/surface_mse = 0.001236` (epoch 349, PR #2828); 2L/256d/4H, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5
- **TandemFoil best**: `val_primary/surface_pressure_mae = 30.10` (epoch 157, PR #2810); 3L/192d/3H, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10