### PR TITLE
DrivAerML: gc=1.0+T_max=20+WD=1e-2 — regularized intermediate cycling

### DIFF
--- a/target/icml2026/experiments/einar-gc-1.0-tmax-20-wd-compound.md
+++ b/target/icml2026/experiments/einar-gc-1.0-tmax-20-wd-compound.md
@@ -1,0 +1,4 @@
+# Experiment: gc=1.0+T_max=20+WD=1e-2 — regularized intermediate cycling for DrivAerML
+Student: einar
+Branch: einar/gc-1.0-tmax-20-wd-compound
+Wandb group: tmax-20-compound


### PR DESCRIPTION
## Hypothesis

The DrivAerML baseline uses T_max=30 with no gc or WD (best: 4.619% at 4L/512d). Meanwhile, AirfRANS benefited from gc=1.0+WD=1e-2 regularization, and chopper is currently testing T_max=15 with gc=1.0+WD=1e-2. This PR tests T_max=20 — the midpoint between T_max=15 and T_max=30 — combined with the gc=1.0+WD=1e-2 compound that proved effective on AirfRANS.

The hypothesis: T_max=20 allows faster cosine cycling than the baseline T_max=30 (fewer restarts get stuck at plateau), while gc=1.0 prevents gradient spikes at cosine peaks and WD=1e-2 provides regularization. Together these may produce a better loss landscape than the current bare T_max=30 setting.

We also test the WD ablation (gc=1.0 only, no WD) to disentangle the contributions.

## Instructions

You have 8 GPUs. Run 4 seeds with the full compound (gc=1.0+WD=1e-2+T_max=20) on GPUs 0-3, and 4 seeds with the gc=1.0-only ablation (no WD, T_max=20) on GPUs 4-7. Use `--wandb-group tmax-20-compound` for all runs.

**GPUs 0-3 — Full compound: gc=1.0 + WD=1e-2 + T_max=20 (seeds 0-3)**

```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=0 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 0 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-wd1e2-seed0 &

cd target/icml2026 && CUDA_VISIBLE_DEVICES=1 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 1 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-wd1e2-seed1 &

cd target/icml2026 && CUDA_VISIBLE_DEVICES=2 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 2 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-wd1e2-seed2 &

cd target/icml2026 && CUDA_VISIBLE_DEVICES=3 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 3 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-wd1e2-seed3 &
```

**GPUs 4-7 — Ablation: gc=1.0 only, no WD, T_max=20 (seeds 0-3)**

```bash
cd target/icml2026 && CUDA_VISIBLE_DEVICES=4 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 0 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-nowd-seed0 &

cd target/icml2026 && CUDA_VISIBLE_DEVICES=5 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 1 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-nowd-seed1 &

cd target/icml2026 && CUDA_VISIBLE_DEVICES=6 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 2 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-nowd-seed2 &

cd target/icml2026 && CUDA_VISIBLE_DEVICES=7 SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 20 --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 --seed 3 \
  --wandb-group tmax-20-compound --wandb-name drivaer-4L-512d-tmax20-gc1.0-nowd-seed3 &

wait
```

**Important:** The DrivAerML baseline does NOT use `--grad-clip` or `--weight-decay`. This run adds both gc=1.0 and WD=1e-2 (full compound, GPUs 0-3) and gc=1.0 alone (ablation, GPUs 4-7). Please report best val_primary/surface_rel_l2_pct (from best checkpoint, not terminal epoch) for all 8 runs separately, organized by seed.

## Baseline

- **DrivAerML val_primary/surface_rel_l2_pct:** 4.619% at epoch 256 (PR #2691)
- **Architecture:** 4L/512d/8H, AdamW lr=5e-4, T_max=30, no gc, no WD, Fourier, no-EMA
- **External target:** <3.71% (AB-UPT, ~500 epochs) — 1.24x gap remaining
- **W&B run:** k8qtsxxz
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

**Companion experiments:** casca (gc=1.5/gc=2.0 at T_max=30), chopper (T_max=15+gc=1.0+WD=1e-2).