### PR TITLE
LR warmup + cosine annealing cross-dataset (code change required)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -102,6 +102,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    warmup_epochs: int = 0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1251,10 +1252,18 @@ def main() -> None:
     if anp_head is not None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
+    steps_per_epoch = min(len(train_loader), config.max_train_batches) if config.max_train_batches > 0 else len(train_loader)
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            from torch.optim.lr_scheduler import LinearLR, SequentialLR, CosineAnnealingLR
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup = LinearLR(base_optimizer, start_factor=0.01, total_iters=warmup_steps)
+            cosine = CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+            scheduler = SequentialLR(base_optimizer, [warmup, cosine], milestones=[warmup_steps])
+        else:
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis
Starting with a very small learning rate and linearly ramping up before the cosine decay phase can stabilize early training, reduce gradient noise during the critical first epochs, and allow the cosine annealing to work from a better initialization. This is a standard technique (e.g., BERT, ViT) that has not yet been tested in this project. We hypothesize that warmup will particularly benefit DrivAerML where early instability is a known risk, and TandemFoil where Lion optimizer is used. This is a cross-dataset sweep of warmup durations (5, 10, 20, 30 epochs).

## Code Change Required

**You must add `--warmup-epochs` support to `target/icml2026/train.py` before running.**

Add the argument parser entry:
```python
parser.add_argument('--warmup-epochs', type=int, default=0,
                    help='Number of linear LR warmup epochs before cosine annealing')
```

Replace the scheduler construction block (find where `CosineAnnealingLR` is instantiated) with:
```python
from torch.optim.lr_scheduler import LinearLR, SequentialLR, CosineAnnealingLR

if args.warmup_epochs > 0:
    warmup = LinearLR(optimizer, start_factor=0.01, total_iters=args.warmup_epochs)
    cosine = CosineAnnealingLR(optimizer, T_max=args.cosine_t_max)
    scheduler = SequentialLR(optimizer, [warmup, cosine], milestones=[args.warmup_epochs])
else:
    scheduler = CosineAnnealingLR(optimizer, T_max=args.cosine_t_max)
```

## Instructions

After implementing the code change above, run the following 8 experiments. **Do not hardcode SENPAI_TIMEOUT_MINUTES or SENPAI_MAX_EPOCHS.** Use `--epochs 999` and let the environment control the budget.

**Golden configs (baselines for each dataset):**

DAM base:
```
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```

AF base:
```
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999
```

TF base:
```
python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999
```

**Run assignments (all use `--wandb_group warmup-cosine`):**

- GPU 0: TF base + `--warmup-epochs 10`
- GPU 1: AF base + `--warmup-epochs 5`
- GPU 2: DAM base + `--warmup-epochs 5`
- GPU 3: DAM base + `--warmup-epochs 10`
- GPU 4: DAM base + `--warmup-epochs 20`
- GPU 5: DAM base + `--warmup-epochs 30`
- GPU 6: DAM base + `--warmup-epochs 10 --grad-clip 1.0 --weight-decay 1e-2`
- GPU 7: DAM base + `--warmup-epochs 20 --grad-clip 1.0 --weight-decay 1e-2`

Run all 8 in parallel, one per GPU. Report `val_primary/surface_rel_l2_pct` for DrivAerML, `val_primary/surface_mse` for AirfRANS, and `val_primary/surface_pressure_mae` for TandemFoil.

## Baseline

**DrivAerML:** `val_primary/surface_rel_l2_pct = 4.619%` (PR #2691, epoch 256, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

**AirfRANS:** `val_primary/surface_mse = 0.001236` (PR #2828, epoch 349, 2L/256d/4H, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5)
Reproduce: `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999`

**TandemFoil:** `val_primary/surface_pressure_mae = 30.10` (PR #2810, epoch 157, 3L/192d/3H, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10)
Reproduce: `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999`