### PR TITLE
Cosine annealing warm restarts (T_mult) cross-dataset (code change required)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -102,6 +102,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_t_mult: int = 1
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1253,8 +1254,12 @@ def main() -> None:
     optimizer = build_optimizer(params, config)
     scheduler = None
     if config.cosine_t_max > 0:
+        from torch.optim.lr_scheduler import CosineAnnealingLR, CosineAnnealingWarmRestarts
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.cosine_t_mult > 1:
+            scheduler = CosineAnnealingWarmRestarts(base_optimizer, T_0=config.cosine_t_max, T_mult=config.cosine_t_mult)
+        else:
+            scheduler = CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
     anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis
Standard CosineAnnealingLR uses a fixed period T_max. CosineAnnealingWarmRestarts (SGDR) restarts the cosine cycle at increasing intervals (T_0, T_0*T_mult, T_0*T_mult^2, ...), allowing the model to escape sharp minima repeatedly while the restart intervals grow to permit finer convergence. This technique has shown strong results in vision and NLP tasks. We hypothesize it will improve over fixed-period cosine on DrivAerML and TandemFoil, especially with longer-period restarts (T_mult=2–3) that give progressively longer exploration windows.

## Code Change Required

**You must add `--cosine-t-mult` support to `target/icml2026/train.py` before running.**

Add the argument parser entry:
```python
parser.add_argument('--cosine-t-mult', type=int, default=1,
                    help='T_mult multiplier for CosineAnnealingWarmRestarts (1 = standard CosineAnnealingLR)')
```

Replace the scheduler construction block (find where `CosineAnnealingLR` is instantiated) with:
```python
from torch.optim.lr_scheduler import CosineAnnealingLR, CosineAnnealingWarmRestarts

if hasattr(args, 'cosine_t_mult') and args.cosine_t_mult > 1:
    scheduler = CosineAnnealingWarmRestarts(optimizer, T_0=args.cosine_t_max, T_mult=args.cosine_t_mult)
else:
    scheduler = CosineAnnealingLR(optimizer, T_max=args.cosine_t_max)
```

## Instructions

After implementing the code change above, run the following 8 experiments. **Do not hardcode SENPAI_TIMEOUT_MINUTES or SENPAI_MAX_EPOCHS.** Use `--epochs 999` and let the environment control the budget.

**Golden configs (baselines for each dataset):**

DAM base:
```
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```

AF base:
```
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999
```

TF base:
```
python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999
```

**Run assignments (all use `--wandb_group warm-restarts`):**

- GPU 0: TF base + `--cosine-t-max 10 --cosine-t-mult 2`
- GPU 1: AF base + `--cosine-t-max 5 --cosine-t-mult 2`
- GPU 2: DAM base + `--cosine-t-max 5 --cosine-t-mult 2`
- GPU 3: DAM base + `--cosine-t-max 10 --cosine-t-mult 2`
- GPU 4: DAM base + `--cosine-t-max 15 --cosine-t-mult 2`
- GPU 5: DAM base + `--cosine-t-max 30 --cosine-t-mult 2`
- GPU 6: DAM base + `--cosine-t-max 5 --cosine-t-mult 3`
- GPU 7: DAM base + `--cosine-t-max 10 --cosine-t-mult 3`

Run all 8 in parallel, one per GPU. Report `val_primary/surface_rel_l2_pct` for DrivAerML, `val_primary/surface_mse` for AirfRANS, and `val_primary/surface_pressure_mae` for TandemFoil.

## Baseline

**DrivAerML:** `val_primary/surface_rel_l2_pct = 4.619%` (PR #2691, epoch 256, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
Reproduce: `cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

**AirfRANS:** `val_primary/surface_mse = 0.001236` (PR #2828, epoch 349, 2L/256d/4H, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5)
Reproduce: `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999`

**TandemFoil:** `val_primary/surface_pressure_mae = 30.10` (PR #2810, epoch 157, 3L/192d/3H, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10)
Reproduce: `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999`