### PR TITLE
Cross-dataset: Corrected EMA warmup (timm-style) — fix decay=0.999 at step 750 bug (CODE CHANGE)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -30,7 +30,60 @@ from core.features import (
     compute_vortex_panel_velocity,
     compute_wake_deficit_features,
 )
-from core.optim import EMA, Lion, Lookahead
+from core.optim import Lion, Lookahead
+
+
+class EMAWithWarmup:
+    """EMA with timm-style adaptive decay warmup: min(target, (1+step)/(10+step))."""
+
+    def __init__(self, model: torch.nn.Module, decay: float = 0.9999):
+        self.decay = decay
+        self.step_counter = 0
+        self.shadow = {
+            self._clean(name): param.detach().clone()
+            for name, param in model.named_parameters()
+            if param.requires_grad
+        }
+        self.backup: dict[str, torch.Tensor] | None = None
+
+    @staticmethod
+    def _clean(name: str) -> str:
+        return name.replace("_orig_mod.", "")
+
+    @torch.no_grad()
+    def update(self, model: torch.nn.Module) -> None:
+        self.step_counter += 1
+        actual_decay = min(self.decay, (1 + self.step_counter) / (10 + self.step_counter))
+        for name, param in model.named_parameters():
+            key = self._clean(name)
+            if not param.requires_grad or key not in self.shadow:
+                continue
+            self.shadow[key].mul_(actual_decay).add_(param.detach(), alpha=1 - actual_decay)
+
+    @torch.no_grad()
+    def store(self, model: torch.nn.Module) -> None:
+        self.backup = {
+            self._clean(name): param.detach().clone()
+            for name, param in model.named_parameters()
+            if param.requires_grad and self._clean(name) in self.shadow
+        }
+
+    @torch.no_grad()
+    def copy_to(self, model: torch.nn.Module) -> None:
+        for name, param in model.named_parameters():
+            key = self._clean(name)
+            if param.requires_grad and key in self.shadow:
+                param.data.copy_(self.shadow[key])
+
+    @torch.no_grad()
+    def restore(self, model: torch.nn.Module) -> None:
+        if self.backup is None:
+            return
+        for name, param in model.named_parameters():
+            key = self._clean(name)
+            if param.requires_grad and key in self.backup:
+                param.data.copy_(self.backup[key])
+        self.backup = None
 
 
 LEGACY_VAL_ALIAS = {
@@ -67,8 +120,7 @@ class TrainConfig:
     optimizer: str = "lion"
     use_lookahead: bool = True
     use_ema: bool = True
-    ema_decay: float = 0.999
-    ema_start_step: int = 50
+    ema_decay: float = 0.9999
     num_workers: int = -1
     pin_memory: bool = True
     persistent_workers: bool = True
@@ -1042,8 +1094,8 @@ def train_one_epoch(
     loader: DataLoader,
     optimizer,
     scheduler,
-    ema: EMA | None,
-    anp_ema: EMA | None,
+    ema: EMAWithWarmup | None,
+    anp_ema: EMAWithWarmup | None,
     transform: TargetTransform | TandemTargetTransform,
     device: torch.device,
     model_name: str,
@@ -1108,6 +1160,7 @@ def train_one_epoch(
             scheduler.step()
         if ema is not None:
             ema.update(model)
+            running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
         if anp_head is not None and anp_ema is not None:
             anp_ema.update(anp_head)
         running["loss"] += float(loss.detach().cpu().item())
@@ -1256,8 +1309,8 @@ def main() -> None:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
-    anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None
+    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
+    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
 
     run = None


### PR DESCRIPTION
## Hypothesis

The current EMA implementation uses a fixed `decay=0.9999` from step 0. At step 750 (early training), the effective weight on the EMA model is 0.9999^750 ≈ 0.928, meaning the EMA is already 93% of current weights — but the model hasn't converged yet, so the EMA is accumulating early-training noise from the very first steps.

The timm-style EMA warmup fix uses an adaptive decay schedule:

```
actual_decay = min(target_decay, (1 + step) / (10 + step))
```

At step 1: actual_decay = 2/11 ≈ 0.18 (EMA tracks current model closely)
At step 100: actual_decay = 101/110 ≈ 0.918
At step 1000: actual_decay = 1001/1010 ≈ 0.991
At step 10000+: actual_decay ≈ target_decay = 0.9999

This prevents the EMA from being "poisoned" by early random-ish weights and lets it converge to a proper ensemble of late-training checkpoints. The current codebase uses `--no-use-ema` in all baselines precisely because EMA was broken; this fix should make EMA useful again.

## Instructions

**CODE CHANGE REQUIRED** — replace the EMA class in `train.py` with the warmup-corrected version.

### Step 1: Replace the EMA class

Find the existing EMA class (search for `class EMA` or `ema_decay`) and replace with:

```python
import copy

class EMAWithWarmup:
    def __init__(self, model, decay=0.9999):
        self.model = copy.deepcopy(model)
        self.decay = decay
        self.step = 0

    def update(self, model):
        self.step += 1
        actual_decay = min(self.decay, (1 + self.step) / (10 + self.step))
        with torch.no_grad():
            for ema_p, p in zip(self.model.parameters(), model.parameters()):
                ema_p.mul_(actual_decay).add_(p, alpha=1 - actual_decay)

    def state_dict(self):
        return self.model.state_dict()
```

### Step 2: Remove `--no-use-ema` from runs — use EMA for all experiments

Use `--wandb_group ema-warmup` for all runs.

**DrivAerML — EMA warmup decay=0.9999:**
```bash
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb_group ema-warmup
```

**DrivAerML — EMA warmup decay=0.999:**
```bash
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.999 --wandb_group ema-warmup
```

**AirfRANS — EMA warmup decay=0.9999:**
```bash
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb_group ema-warmup
```

**AirfRANS — EMA warmup decay=0.999:**
```bash
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --wandb_group ema-warmup
```

**TandemFoil — EMA warmup decay=0.9999:**
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group ema-warmup
```

**TandemFoil — EMA warmup decay=0.999:**
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999 --wandb_group ema-warmup
```

Note: if the `--ema-decay` flag doesn't exist yet, add it:
```python
parser.add_argument('--ema-decay', type=float, default=0.9999)
```

Run 6 experiments total (2 per dataset: decay 0.9999 and 0.999). Use the remaining 2 GPU slots to run the two most promising datasets again if one clearly outperforms.

## Baseline

Current best metrics (all using `--no-use-ema`):
- **TandemFoil**: val/loss = 30.10 (epoch 157, PR #2810, W&B run v6amjkh7)
- **AirfRANS**: val/loss = 0.001236 (epoch 349, PR #2828, W&B run libpwryz)
- **DrivAerML**: val/loss = 4.619% (epoch 256, PR #2691, W&B run k8qtsxxz)

Reproduce commands:
```bash
# TandemFoil baseline
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999

# AirfRANS baseline
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999

# DrivAerML baseline
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```