### PR TITLE
DrivAerML: surface-only training + gradient accumulation — focus compute on surface metrics

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -107,6 +107,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
+    grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1051,15 +1052,18 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    grad_accum_steps: int = 1,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
         anp_head.train()
     running = {"loss": 0.0}
-    steps = 0
+    micro_steps = 0
+    optimizer_steps = 0
+    accum = max(1, grad_accum_steps)
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
+    optimizer.zero_grad(set_to_none=True)
     for batch in batches:
-        optimizer.zero_grad(set_to_none=True)
         if model_name == "reference_abupt":
             batch = batch.to(device)
             with autocast_context(device, amp_mode):
@@ -1093,29 +1097,50 @@ def train_one_epoch(
                         volume_mask=batch.volume_mask,
                     )
                     loss, _ = loss_grouped(batch, outputs, transform)
-        loss.backward()
+        scaled_loss = loss / accum
+        scaled_loss.backward()
+        running["loss"] += float(loss.detach().cpu().item())
+        micro_steps += 1
+        if micro_steps % accum == 0:
+            all_params = list(model.parameters())
+            if anp_head is not None:
+                all_params += list(anp_head.parameters())
+            grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+            running.setdefault("grad_norm_mean", 0.0)
+            running["grad_norm_mean"] += float(grad_norm)
+            if grad_clip > 0 and float(grad_norm) > grad_clip:
+                running.setdefault("grad_clip_events", 0.0)
+                running["grad_clip_events"] += 1.0
+            optimizer.step()
+            if scheduler is not None:
+                scheduler.step()
+            if ema is not None:
+                ema.update(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.update(anp_head)
+            optimizer_steps += 1
+            optimizer.zero_grad(set_to_none=True)
+    if micro_steps % accum != 0:
         all_params = list(model.parameters())
         if anp_head is not None:
             all_params += list(anp_head.parameters())
         grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
         running.setdefault("grad_norm_mean", 0.0)
         running["grad_norm_mean"] += float(grad_norm)
-        if grad_clip > 0 and float(grad_norm) > grad_clip:
-            running.setdefault("grad_clip_events", 0.0)
-            running["grad_clip_events"] += 1.0
         optimizer.step()
+        optimizer_steps += 1
         if scheduler is not None:
             scheduler.step()
         if ema is not None:
             ema.update(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.update(anp_head)
-        running["loss"] += float(loss.detach().cpu().item())
-        steps += 1
-    running["loss"] /= max(steps, 1)
+        optimizer.zero_grad(set_to_none=True)
+    running["loss"] /= max(micro_steps, 1)
     if "grad_norm_mean" in running:
-        running["grad_norm_mean"] /= max(steps, 1)
-    running["train_steps"] = float(steps)
+        running["grad_norm_mean"] /= max(optimizer_steps, 1)
+    running["train_steps"] = float(micro_steps)
+    running["optimizer_steps"] = float(optimizer_steps)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
     return running
@@ -1291,6 +1316,7 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            grad_accum_steps=config.grad_accum_steps,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

DrivAerML has both volume and surface nodes. The benchmark metric (val/loss = 4.619%) is the surface-averaged pressure/velocity error. Volume nodes are required for physics consistency but may be diluting the loss signal: with ~50k surface points and ~500k+ volume points, the surface loss is ~10x less weighted in a joint training scheme.

Two orthogonal changes:
1. **`--surface-only-drivaerml`**: trains only on surface predictions, removing volume overhead entirely. This focuses all model capacity and gradient signal on the surface fields that matter for the metric.
2. **Gradient accumulation**: DrivAerML is forced to batch_size=1 by memory. Gradient accumulation with steps=2 or 4 simulates batch_size=2 or 4, smoothing gradient noise without additional memory.

We test these independently and combined to isolate their effects.

## Instructions

Use `--wandb_group surface-gc-dam` for all runs.

**DrivAerML — surface-only (no grad accum):**
```bash
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --surface-only-drivaerml --wandb_group surface-gc-dam
```

**DrivAerML — grad accum 2 (no surface-only):**
```bash
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --grad-accum-steps 2 --wandb_group surface-gc-dam
```

**DrivAerML — grad accum 4 (no surface-only):**
```bash
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --grad-accum-steps 4 --wandb_group surface-gc-dam
```

**DrivAerML — surface-only + grad accum 2:**
```bash
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --surface-only-drivaerml --grad-accum-steps 2 --wandb_group surface-gc-dam
```

**DrivAerML — surface-only + grad accum 4:**
```bash
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --surface-only-drivaerml --grad-accum-steps 4 --wandb_group surface-gc-dam
```

**CODE CHANGE REQUIRED for gradient accumulation** — if `--grad-accum-steps` doesn't exist, add it:

```python
parser.add_argument('--grad-accum-steps', type=int, default=1,
                    help='Gradient accumulation steps. Simulates batch_size * grad_accum_steps effective batch.')
```

Then modify the training loop to accumulate gradients:

```python
optimizer.zero_grad()
for micro_step in range(args.grad_accum_steps):
    batch = next(train_iter)
    loss = model(batch) / args.grad_accum_steps
    loss.backward()
optimizer.step()
scheduler.step()
```

Use the 6th GPU for a control run (baseline config, no changes) to confirm reproducibility.

## Baseline

Current best metrics:
- **DrivAerML**: val/loss = 4.619% (epoch 256, PR #2691, W&B run k8qtsxxz)

Reproduce command:
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```