### PR TITLE
Cross-dataset: Huber loss — robust to outlier mesh nodes at stagnation points and trailing edges (CODE CHANGE)

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -3,11 +3,20 @@
 ## TandemFoilSet
 
 - **Primary metric:** `val_primary/surface_pressure_mae` (= `val_eq4/surface_pressure_mae`)
-- **Current best:** 30.10 (val) at epoch 157
-- **Best PR:** #2810 (gilbert — T_max=10, 3L/192d, Fourier + physics + no-EMA, slices=64, Lion **lr=1.25e-4**, gc=1.0, WD=1e-2, 180-min)
-- **Key insight:** Lower LR KEEPS WINNING. lr=1.25e-4 at 3L/192d (30.10 at ep157) beats lr=1.5e-4 (44.72). **32.8% improvement in one step!** gc=1.0 provides critical stability — gradient clipping is now confirmed essential for TandemFoil. Also: gc=0.5 at lr=1.5e-4 (sasuke, 30.11) nearly identical to gc=1.0 at lr=1.25e-4. gc and LR interact — both paths reach ~30.1. Still descending at ep161 timeout. Next: lr=1e-4 + gc, 3L/256d width scaling at lr=1.25e-4.
+- **Current best:** 26.134 (val) at epoch 123
+- **Best PR:** #2899 (robin — corrected EMA warmup decay=0.999 at 3L/192d, Fourier + physics, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10)
+- **Key insight:** CORRECTED EMA BREAKS THROUGH. timm-style EMA warmup (min(decay, (1+step)/(10+step))) gives 13.2% improvement over no-EMA (26.134 vs 30.10). The old EMA was bugged (corrupted by early random weights) — the fix restores EMA's regularization benefit. With proper warmup, decay=0.999 > decay=0.9999 > no-EMA. The shared recipe now includes --ema-decay 0.999 (without --no-use-ema) for TandemFoil and AirfRANS.
 
-### 2026-04-21 — PR #2810: TandemFoil: lr=1.25e-4 + gc=1.0 — NEW BEST
+### 2026-04-21 — PR #2899: TandemFoil: Corrected EMA warmup (decay=0.999) — NEW BEST
+
+- **val_primary/surface_pressure_mae:** 26.134 (-13.2% vs 30.10) at epoch 123
+- **decay=0.9999:** 26.903 at epoch 113 (also beats baseline — 10.6% improvement)
+- **W&B run:** nrn0q3ct (decay=0.999, still running at ep125, still improving)
+- **Key insight:** EMAWithWarmup replaces bugged EMA. Timm formula `min(target_decay, (1+step)/(10+step))` ramps decay from 0 to target, preventing random-init dominance of EMA weights. Both decay values beat baseline significantly. decay=0.999 is the winner. DrivAerML did NOT benefit (9.749% at 60 eps).
+- **Config:** Lion lr=1.25e-4, T_max=10, gc=1.0, WD=1e-2, 3L/192d, Fourier+physics, EMA decay=0.999 (WITHOUT --no-use-ema)
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+
+### 2026-04-21 — PR #2810: TandemFoil: lr=1.25e-4 + gc=1.0 — PREVIOUS BEST
 
 - **val_primary/surface_pressure_mae:** 30.10 (-32.8% vs 44.72) at epoch 157
 - **W&B run:** v6amjkh7 (157+ epochs, 180-min budget, still descending at cutoff)
@@ -121,11 +130,19 @@
 ## AirfRANS
 
 - **Primary metric:** `val_primary/surface_mse`
-- **Current best:** 0.001236 (val) at epoch 349
-- **Best PR:** #2828 (inosuke — **2L/256d**/4H + gc=1.0 + Fourier + no-EMA + T_max=5 + WD=1e-2, AdamW lr=7e-4, 388 epochs, 180-min budget, SENPAI_MAX_EPOCHS=9999)
-- **Key insight:** DEPTH REDUCTION CONTINUES. 2L/256d beats 3L/256d by 16.4% (0.001236 vs 0.001479). 4L→3L was 46.6%, 3L→2L is 16.4% — diminishing but real. Width 256d is the sweet spot at every depth level (2L/384d diverged, 2L/512d never converged). gc=1.0 still optimal. **Beats external target 0.0043 by 71.3%.** PENDING: T_max=10 at 2L/256d (itachi #2872) may push further given kakashi's T_max=10 breakthrough at 3L.
+- **Current best:** 0.000727 (val) at epoch 206
+- **Best PR:** #2899 (robin — corrected EMA decay=0.999, 2L/256d + gc=1.0 + Fourier + T_max=5 + WD=1e-2, AdamW lr=7e-4)
+- **Key insight:** CORRECTED EMA SHATTERS THE BASELINE. EMAWithWarmup at decay=0.999 gives 0.000727 — a 41.2% improvement over 0.001236. The timm-style warmup prevents EMA from being dominated by random early weights. **Beats external target 0.0043 by 83.1%.** Both EMA decay values beat old baseline (0.9999 → 0.001123, 8.7% improvement; 0.999 → 0.000727, 41.2%). The EMA model is evaluated by swapping weights at validation time. Best checkpoint at ep206, late-training oscillation from T_max=5.
 
-### 2026-04-21 — PR #2828: AirfRANS: 2L/256d depth frontier — NEW BEST
+### 2026-04-21 — PR #2899: AirfRANS: Corrected EMA warmup (decay=0.999) — NEW BEST
+
+- **val_primary/surface_mse:** 0.000727 (-41.2% vs 0.001236) at epoch 206 (W&B run i1sevgt2)
+- **decay=0.9999:** 0.001123 (-8.7% vs 0.001236) at epoch 275 (W&B run bz00wego — also beats baseline)
+- **Key insight:** EMA with timm warmup recovers the regularization benefit that was broken by the bugged EMA. Best checkpoint at ep206; late epochs oscillate due to T_max=5 cycling. decay=0.999 massively outperforms decay=0.9999 on AirfRANS.
+- **Config:** 2L/256d, AdamW lr=7e-4, T_max=5, gc=1.0, WD=1e-2, Fourier, EMA decay=0.999 (WITHOUT --no-use-ema)
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999`
+
+### 2026-04-21 — PR #2828: AirfRANS: 2L/256d depth frontier — PREVIOUS BEST
 
 - **val_primary/surface_mse:** 0.001236 (-16.4% vs 0.001479) at epoch 349
 - **2L/256d gc=0.5:** 0.001405 (-5.1% vs 0.001479) at epoch 366 (also beats baseline)

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -3,11 +3,18 @@
 ## TandemFoilSet
 
 - **Primary metric:** `val_primary/surface_pressure_mae` (= `val_eq4/surface_pressure_mae`)
-- **Current best:** 26.134 (val) at epoch 123
-- **Best PR:** #2899 (robin — corrected EMA warmup decay=0.999 at 3L/192d, Fourier + physics, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10)
-- **Key insight:** CORRECTED EMA BREAKS THROUGH. timm-style EMA warmup (min(decay, (1+step)/(10+step))) gives 13.2% improvement over no-EMA (26.134 vs 30.10). The old EMA was bugged (corrupted by early random weights) — the fix restores EMA's regularization benefit. With proper warmup, decay=0.999 > decay=0.9999 > no-EMA. The shared recipe now includes --ema-decay 0.999 (without --no-use-ema) for TandemFoil and AirfRANS.
+- **Current best:** 26.06 (val) at epoch 300
+- **Best PR:** #2887 (gohan — lr=1e-4 no-EMA LR scan, 3L/192d, Lion lr=1e-4, gc=1.0, WD=1e-2, T_max=10)
+- **Note:** This beats 26.134 (#2899 with EMA) using no-EMA + lower LR. The EMA recipe (#2899) is still the recommended shared recipe — the 26.06 result is a marginal improvement from longer training at lower LR.
 
-### 2026-04-21 — PR #2899: TandemFoil: Corrected EMA warmup (decay=0.999) — NEW BEST
+### 2026-04-22 — PR #2887: TandemFoil: lr=1e-4 gc=1.0 LR scan — NEW BEST
+
+- **val_primary/surface_pressure_mae:** 26.06 (-0.3% vs 26.134) at epoch 300
+- **W&B run:** pbq4kgdk
+- **Config:** Lion lr=1e-4, T_max=10, gc=1.0, WD=1e-2, 3L/192d, Fourier+physics, no-EMA
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999`
+
+### 2026-04-21 — PR #2899: TandemFoil: Corrected EMA warmup (decay=0.999) — PREVIOUS BEST
 
 - **val_primary/surface_pressure_mae:** 26.134 (-13.2% vs 30.10) at epoch 123
 - **decay=0.9999:** 26.903 at epoch 113 (also beats baseline — 10.6% improvement)
@@ -130,11 +137,18 @@
 ## AirfRANS
 
 - **Primary metric:** `val_primary/surface_mse`
-- **Current best:** 0.000727 (val) at epoch 206
-- **Best PR:** #2899 (robin — corrected EMA decay=0.999, 2L/256d + gc=1.0 + Fourier + T_max=5 + WD=1e-2, AdamW lr=7e-4)
-- **Key insight:** CORRECTED EMA SHATTERS THE BASELINE. EMAWithWarmup at decay=0.999 gives 0.000727 — a 41.2% improvement over 0.001236. The timm-style warmup prevents EMA from being dominated by random early weights. **Beats external target 0.0043 by 83.1%.** Both EMA decay values beat old baseline (0.9999 → 0.001123, 8.7% improvement; 0.999 → 0.000727, 41.2%). The EMA model is evaluated by swapping weights at validation time. Best checkpoint at ep206, late-training oscillation from T_max=5.
+- **Current best:** 0.000699 (val) at epoch 653
+- **Best PR:** #2887 (gohan — AirfRANS lr=6e-4 gc=1.0 T_max=10, 2L/256d, no-EMA)
+- **Key insight:** Slightly lower LR (6e-4 vs 7e-4) with longer training (653 epochs) at T_max=10 pushes below EMA baseline. **Beats external target 0.0043 by 83.7%.** Note: this uses no-EMA while the previous best (#2899) used EMA. Next step is applying EMA to lr=6e-4 T_max=10.
 
-### 2026-04-21 — PR #2899: AirfRANS: Corrected EMA warmup (decay=0.999) — NEW BEST
+### 2026-04-22 — PR #2887: AirfRANS: lr=6e-4 gc=1.0 T_max=10 LR scan — NEW BEST
+
+- **val_primary/surface_mse:** 0.000699 (-3.6% vs 0.000727) at epoch 653
+- **W&B run:** 7m6c1ydk
+- **Config:** 2L/256d, AdamW lr=6e-4, T_max=10, gc=1.0, WD=1e-2, no-EMA, Fourier
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999`
+
+### 2026-04-21 — PR #2899: AirfRANS: Corrected EMA warmup (decay=0.999) — PREVIOUS BEST
 
 - **val_primary/surface_mse:** 0.000727 (-41.2% vs 0.001236) at epoch 206 (W&B run i1sevgt2)
 - **decay=0.9999:** 0.001123 (-8.7% vs 0.001236) at epoch 275 (W&B run bz00wego — also beats baseline)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 23:50 (Wave 3 — Bold New Directions, Cross-Dataset Focus Directive)
+- **Date:** 2026-04-22 00:15 (Wave 3 Reassigned + casca AGC)
 - **Branch:** radford
-- **Fleet status:** 59 live students, ALL ASSIGNED (0 idle)
+- **Fleet status:** 60 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
   - `SENPAI_TIMEOUT_MINUTES=360`
   - `SENPAI_MAX_EPOCHS=999`
@@ -80,6 +80,7 @@ No baseline has been run yet on radford for this dataset.
 - **4L/640d at lr=5e-4+gc=1.0** (#2917): all 3 DM runs crashed (ep90-153)
 - **T_max=5 on DrivAerML** (#2911): all 3 runs diverged — too rapid for 4L/512d scale
 - **EMA alone on DrivAerML** (#2899): 9.749% (worse than 4.619% baseline) — EMA+gc compound now being tested
+- **gc=1.5/gc=2.0 on DrivAerML** (#2881): all 8 runs diverged. gc=1.5 best 6.066% (+31%), gc=2.0 best 8.834% (+91%). CosineAnnealing restarts amplify instability
 
 ## Default Assignment Pattern
 
@@ -100,21 +101,22 @@ comparability, always include:
 
 ## ACTIVE EXPERIMENTS — 59 WIP PRs
 
-### Theme 7: Bold New Directions (Wave 3, 2026-04-21 22:45)
+### Theme 7: Bold New Directions (Wave 3 — recreated after accidental merge of #2928-2936)
 
-9 new hypothesis families testing genuinely new mechanisms — loss reformulation, architecture innovations, optimization paradigm shifts, and physics-informed features.
+10 hypothesis families: loss reformulation, architecture innovations, optimization shifts, physics-informed features, unit-invariant clipping.
 
 | Student | PR | Experiment | Risk |
 |---|---|---|---|
-| frieren | #2928 | **Relative L2 Training Loss** — align DM training loss with eval metric | LOW |
-| nezuko | #2929 | **SwiGLU FFN Replacement** — gated linear units for all Transolver blocks | LOW |
-| violet | #2930 | **Stochastic Depth (DropPath)** — layer-level regularization 0.1/0.2 | LOW |
-| gilbert | #2931 | **Prodigy Optimizer** — parameter-free LR adaptation | LOW-MED |
-| kohaku | #2932 | **Global Context Token** — break slice-local attention bottleneck | MEDIUM |
-| emma | #2933 | **Surface Normals + Curvature** — differential geometry input features | MEDIUM |
-| chihiro | #2934 | **Conservation Auxiliary Loss** — div(u)=0 physics regularization | MED-HIGH |
-| shoya | #2935 | **MoE FFN Layers** — sparse expert routing for physics-regime specialization | MED-HIGH |
-| mitsuha | #2936 | **SDF Wall-Distance Feature** — signed distance field geometry embedding | MEDIUM |
+| frieren | #2937 | **Relative L2 Training Loss** — align DM training loss with eval metric | LOW |
+| nezuko | #2938 | **SwiGLU FFN Replacement** — gated linear units for all Transolver blocks | LOW |
+| violet | #2939 | **Stochastic Depth (DropPath)** — layer-level regularization 0.1/0.2 | LOW |
+| gilbert | #2940 | **Prodigy Optimizer** — parameter-free LR adaptation | LOW-MED |
+| kohaku | #2941 | **Global Context Token** — break slice-local attention bottleneck | MEDIUM |
+| emma | #2942 | **Surface Normals + Curvature** — differential geometry input features | MEDIUM |
+| chihiro | #2943 | **Conservation Auxiliary Loss** — div(u)=0 physics regularization | MED-HIGH |
+| shoya | #2944 | **MoE FFN Layers** — sparse expert routing for physics-regime specialization | MED-HIGH |
+| mitsuha | #2945 | **SDF Wall-Distance Feature** — signed distance field geometry embedding | MEDIUM |
+| casca | #2946 | **Adaptive Gradient Clipping (AGC)** — NFNet-style unit-invariant clipping | LOW-MED |
 
 ### Theme 0: EMA Refinement
 
@@ -144,7 +146,7 @@ comparability, always include:
 | franky | #2886 | lr=4e-4+gc=1.0 |
 | gohan | #2887 | gc=1.0+T_max=10 LR scan |
 | gojo | #2888 | gc=0.5+T_max=10 |
-| casca | #2881 | gc=1.5/gc=2.0 |
+| ~~casca~~ | ~~#2881~~ | ~~gc=1.5/gc=2.0~~ CLOSED — dead end. Reassigned to #2946 AGC |
 | jin | #2893 | lr=1e-3+gc=1.0 |
 | shinobu | #2912 | WD=3e-2/5e-2+gc=1.0 (heavy regularization) |
 | sanji | #2918 | gc=0.5+WD=1e-2 (softer clip + regularization compound) |

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 21:30 (DrivAerML Refocus — Wave 2, All Students Assigned)
+- **Date:** 2026-04-21 22:00 (DrivAerML Refocus — Wave 2, EMA BREAKTHROUGH)
 - **Branch:** radford
 - **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
@@ -11,26 +11,27 @@
 
 | Dataset | Paper-facing metric | Current best | Target / reference | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **33.88** (#2810) | no single packaged external scalar | strong, no longer bottleneck |
-| AirfRANS | `test_primary/surface_mse` | **0.003** (#2824) | `0.0043` | **BEATEN** |
+| TandemFoil | `test_primary/surface_pressure_mae` | **33.88** (#2810) | no external scalar | needs test from new EMA best |
+| AirfRANS | `test_primary/surface_mse` | **0.003** (#2824) | `0.0043` | **BEATEN** — val now 0.000727 |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **6.24%** (#2691) | `3.71%` | **MAIN GAP — 1.68x** |
 
 ## Steering Anchors (validation, for experiment decisions)
 
 | Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **30.10** (#2810) |
-| AirfRANS | `val_primary/surface_mse` | **0.001236** merged (#2828), **0.001095** pending (#2823 — unstable) |
+| TandemFoil | `val_primary/surface_pressure_mae` | **26.134** (#2899 MERGED — EMA decay=0.999) |
+| AirfRANS | `val_primary/surface_mse` | **0.000727** (#2899 MERGED — EMA decay=0.999, ep206) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** (#2691) |
 
 ## Main Scientific Goal
 
 A shared recipe whose core changes work across TandemFoil, AirfRANS, and DrivAerML.
-DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
+DrivAerML is the main gap. Corrected EMA warmup is now the shared recipe for TF+AF.
 
-## Mandatory Config Rules
+## Mandatory Config Rules (UPDATED after EMA merge)
 
-- `--no-use-ema` mandatory everywhere (robin #2899 tests a fix)
+- **TF + AF:** Use `--ema-decay 0.999` (NO --no-use-ema). decay=0.999 > 0.9999 on both.
+- **DrivAerML:** Still `--no-use-ema` (EMA alone hurt DM; zenitsu #2925 tests EMA+gc compound)
 - `--epochs 999` mandatory
 - DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
 - Lion for TandemFoil; AdamW for AirfRANS/DrivAerML
@@ -39,34 +40,41 @@ DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 
 - **No-Lookahead** (#2834): fatal across all datasets — diverges AF/DM, TF regresses
 - **3L/192d on TF or DM** (#2825): too shallow at current scale
-- **Pressure-weighted loss at wrong architecture** (#2801): pressure weighting hurts if applied at non-golden depth
+- **Pressure-weighted loss at wrong architecture** (#2801): pressure weighting hurts at non-golden depth
 - **LR above 5e-4 on DrivAerML** (#2873): 6e-4/5.5e-4/4.5e-4 all worse, LR optimum firmly at 5e-4
-- **surface_only_drivaerml is already default** (#2900): don't re-test; use --no-surface-only-drivaerml to test volume inclusion
-- **lr=8e-4 + Lion on DrivAerML** (#2907): confounded by wrong optimizer/architecture. Lion competitive at 3L but untested at 4L/512d (nami #2896 testing)
-- **lr=9e-4 is above DrivAerML ceiling** (#2907): both runs diverged catastrophically
-- **Momentum-SAM (MSAM)** (#2904): 3.7-22.7x worse everywhere. Cost is 2x (not ~0%), Lion momentum anti-adversarial on TF
-- **gc=1.0+WD=1e-2+cosine compound** (#2908): 6/8 runs crashed. gc=1.0 permits spikes at cosine LR peaks that cascade with WD
-- **4L/640d at lr=5e-4+gc=1.0** (#2917): all 3 DM runs crashed (ep90-153). Width above 512d needs lower LR or tighter gc
+- **surface_only_drivaerml is already default** (#2900): use --no-surface-only-drivaerml to test volume
+- **lr=9e-4 is above DrivAerML ceiling** (#2907): diverged catastrophically
+- **Momentum-SAM (MSAM)** (#2904): 3.7-22.7x worse everywhere; cost is actually 2x
+- **gc=1.0+WD=1e-2+cosine compound on DM** (#2908): 6/8 runs crashed
+- **4L/640d at lr=5e-4+gc=1.0** (#2917): all 3 DM runs crashed (ep90-153)
+- **T_max=5 on DrivAerML** (#2911): all 3 runs diverged — too rapid for 4L/512d scale
+- **EMA alone on DrivAerML** (#2899): 9.749% (worse than 4.619% baseline) — EMA+gc compound now being tested
 
 ## Default Assignment Pattern
 
-Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per student.
+Cross-dataset: TF+AF use EMA decay=0.999, DM still uses --no-use-ema.
 
 ## ACTIVE EXPERIMENTS — 50 WIP PRs
+
+### Theme 0: EMA Refinement (NEW HIGHEST PRIORITY — push new TF/AF bests)
+
+| Student | PR | Experiment |
+|---|---|---|
+| robin | #2924 | TF lr=1e-4+EMA, TF gc=0.5+EMA, AF T_max=10+EMA, AF seed=43 |
+| zenitsu | #2925 | DrivAerML EMA+gc=1.0, EMA+gc+WD, EMA decay=0.9999, pure gc control |
 
 ### Theme 1: AirfRANS Recipe Transfer to DrivAerML (HIGHEST PRIORITY)
 
 | Student | PR | Experiment |
 |---|---|---|
-| brook | #2878 | gc=1.0+WD=1e-2 (flagship compound) |
+| brook | #2878 | gc=1.0+WD=1e-2 (flagship compound, no EMA) |
 | bulma | #2879 | T_max=10+gc=1.0 |
 | canute | #2880 | Full recipe: lr=7e-4+gc=1.0+WD=1e-2 |
 | chopper | #2882 | T_max=15+gc=1.0+WD=1e-2 |
 | einar | #2883 | gc=1.0+T_max=20+WD=1e-2 |
 | yuji | #2922 | WD=5e-3+gc=1.0 moderate, pure gc ablation, WD alone |
-| zenitsu | #2911 | T_max=5+gc=1.0+WD=1e-2 (AirfRANS golden scheduler) |
-| edward | #2916 | lr=6e-4+gc=1.0+WD=1e-2+T_max=10 (intermediate LR) |
-| wolfwood | #2919 | T_max=40/50+gc=1.0+WD=1e-2 (longer cosine cycling) |
+| edward | #2916 | lr=6e-4+gc=1.0+WD=1e-2+T_max=10 |
+| wolfwood | #2919 | T_max=40/50+gc=1.0+WD=1e-2 (longer cycling) |
 
 ### Theme 2: DrivAerML LR+gc Exploration
 
@@ -77,7 +85,6 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | gohan | #2887 | gc=1.0+T_max=10 LR scan |
 | gojo | #2888 | gc=0.5+T_max=10 |
 | casca | #2881 | gc=1.5/gc=2.0 |
-| wolfwood | #2907 | lr=8e-4+gc=1.0 |
 | jin | #2893 | lr=1e-3+gc=1.0 |
 | shinobu | #2912 | WD=3e-2/5e-2+gc=1.0 (heavy regularization) |
 | sanji | #2918 | gc=0.5+WD=1e-2 (softer clip + regularization compound) |
@@ -92,7 +99,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | jet | #2892 | 3L/768d shallow+wide |
 | shouko | #2909 | heads=16/4 ablation + gc=1.0 |
 | askeladd | #2914 | MLP ratio=6/2 + gc=1.0+WD=1e-2 |
-| chrome | #2923 | torch.compile + gc=1.0 (throughput + stability compound) |
+| chrome | #2923 | torch.compile + gc=1.0 (throughput + stability) |
 
 ### Theme 4: Scheduler Innovations (CODE CHANGES)
 
@@ -102,12 +109,11 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | mugen | #2895 | CosineAnnealingWarmRestarts T_mult |
 | vash | #2905 | OneCycleLR |
 
-### Theme 5: Optimizer + Training Recipe Innovations (CODE CHANGES)
+### Theme 5: Training Innovations (CODE CHANGES)
 
 | Student | PR | Experiment |
 |---|---|---|
 | nobara | #2897 | LLRD (layer-wise LR decay) |
-| robin | #2899 | Corrected EMA with warmup |
 | usopp | #2920 | Gradient noise injection (Neelakantan 2015) |
 | sukuna | #2903 | SWA at cosine troughs |
 | spike | #2901 | Huber/log-cosh loss |
@@ -117,8 +123,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 
 | Student | PR | Experiment |
 |---|---|---|
-| piccolo | #2898 | torch.compile throughput |
-| sanji | #2900 | surface-only DrivAerML |
+| piccolo | #2898 | torch.compile throughput (baseline) |
 | vegeta | #2906 | 360min multi-seed replication |
 | nami | #2896 | Lion higher LR on DrivAerML |
 | eren | #2910 | max-train-batches=788 (2x data/epoch) |
@@ -129,45 +134,37 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 
 | Student | PR | Dataset | Focus |
 |---|---|---|---|
-| chrome | #2873 | DrivAerML | LR headroom 4.5-6e-4 |
 | zoro | #2870 | DrivAerML | Lower LR 2-3e-4 |
 | shinji | #2869 | DrivAerML | gc=0.5/0.7+T_max=25/30 |
 | norman | #2868 | DrivAerML | 2L/512d+3L/512d |
 | historia | #2867 | DrivAerML | 3L/256d+3L/384d |
 | kaneda | #2858 | DrivAerML | gc=0.7/0.8/0.9 |
-| kakashi | #2823 | AirfRANS | gc=1.0+T_max=10 stabilization (lr=5e-4 + reproduce) |
+| kakashi | #2823 | AirfRANS | gc=1.0+T_max=10 stabilization |
 | inosuke | #2874 | AirfRANS | 2L+T_max=10 compound |
-| thorfinn | #2786 | AirfRANS | gc=1.0+T_max=7 extended budget |
+| thorfinn | #2786 | AirfRANS | gc=1.0+T_max=7 extended |
 | taki | #2814 | DrivAerML | Mild regularization |
+| tanjiro | #2842 | TandemFoil | 3L/192d+lr=1e-4+gc=0.5 (sent back) |
 | Various | #2835-2876 | TandemFoil | LR/depth/gc fine-tuning |
 
-## Research Insights from Literature
+## Research Insights
 
-1. **Corrected EMA** (robin #2899): no-EMA was a bug fix, not a design choice. timm-style warmup fixes it.
-2. **SWA** (sukuna #2903): weight averaging at cosine troughs → flatter minima.
-3. **MSAM** (usopp #2904): flat-minima bias without SAM's 2x cost.
-4. **LLRD** (nobara #2897): 1-3% improvement in <10 epoch regime.
-5. **AB-UPT** achieves 3.71% via geometry-separated encoding — next escalation if recipe transfer fails.
-6. **Transolver-3** (arxiv 2602.04940): amortized mesh subset training for throughput.
-7. **Lookahead is load-bearing**: removing it causes catastrophic divergence on AF/DM (confirmed #2834).
-
-## Human Guidance
-
-Issue #2545: Focus on DrivAerML and cross-dataset evidence. No new directives.
+1. **Corrected EMA (MERGED #2899):** timm-style warmup `min(decay, (1+step)/(10+step))` gives -13.2% TF and -41.2% AF. **This is the shared recipe change.** decay=0.999 > 0.9999 on both datasets.
+2. **DrivAerML is fragile to compounds:** gc+WD+cosine crashes (6/8 #2908), 640d crashes (#2917), T_max=5 crashes (#2911). Only gentle perturbations survive at 4L/512d.
+3. **Width scaling ceiling at 512d for DM:** 640d is unstable. guts #2890 (768d) and himmel #2891 (5L/512d) will clarify the boundary.
+4. **AB-UPT** achieves 3.71% via geometry-separated encoding — escalation if EMA+recipe fails.
 
 ## Next Priorities
 
-1. Review PRs as results come in (~30-360 min)
-2. **brook #2878** (gc+WD transfer) = THE paper question — first to report
-3. **bulma #2879** (T_max=10+gc) = second priority
-4. **kakashi #2823** (AirfRANS 0.001095 reproducibility) = AirfRANS question
-5. Watch for code-change PRs (robin #2899, megumi #2894, sukuna #2903, usopp #2904) — these need careful review
-6. If recipe transfer fails → escalate to geometry-separated encoding (AB-UPT approach)
+1. EMA refinement (robin #2924) — can we push below TF 26 and AF 0.0007?
+2. DrivAerML EMA+gc test (zenitsu #2925) — the key 3-of-3 question
+3. Review brook #2878 (gc+WD) when ready — flagship recipe transfer result
+4. Watch bulma #2879, canute #2880, chopper #2882 — T_max cycle results
+5. If DM recipe transfer fails universally → escalate to geometry-separated encoding
 
-## Potential Next Research Directions
+## Potential Next Directions
 
-- **Residual prediction on DrivAerML**: works for TandemFoil (--residual-prediction), untested on DM
-- **Geometry-separated encoding**: AB-UPT approach — encode surface geometry separately from flow fields
-- **Mesh decimation / adaptive sampling**: sample more points near high-curvature regions
-- **Ensemble of 4L/512d seeds**: if variance is ±0.2% and we ensemble 3 seeds, could get deterministic improvement
-- **Amortized subset training** (Transolver-3): alternate between subsets of the mesh per step
+- **TF+AF: EMA + lower LR** (robin #2924 covers this)
+- **DM: EMA+gc+WD compound** (zenitsu #2925 covers this)
+- **Test set evaluation from EMA best checkpoint** — ensure paper metrics reflect EMA model
+- **EMA with arch variants** — does EMA help on 5L/512d or 3L/768d DM configs?
+- **Residual prediction on DrivAerML** — works for TF (--residual-prediction), untested on DM

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 17:30 (DrivAerML Refocus Relaunch — Wave 2)
+- **Date:** 2026-04-21 18:15 (DrivAerML Refocus Relaunch — Wave 2, All Students Assigned)
 - **Branch:** radford
 - **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
@@ -20,7 +20,7 @@
 | Dataset | Metric | Current anchor |
 |---|---|---|
 | TandemFoil | `val_primary/surface_pressure_mae` | **30.10** (#2810) |
-| AirfRANS | `val_primary/surface_mse` | **0.001236** merged (#2828), **0.001095** pending (#2823) |
+| AirfRANS | `val_primary/surface_mse` | **0.001236** merged (#2828), **0.001095** pending (#2823 — unstable) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** (#2691) |
 
 ## Main Scientific Goal
@@ -35,11 +35,17 @@ DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 - DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
 - Lion for TandemFoil; AdamW for AirfRANS/DrivAerML
 
+## Negative Results (Do Not Repeat)
+
+- **No-Lookahead** (#2834): fatal across all datasets — diverges AF/DM, TF regresses
+- **3L/192d on TF or DM** (#2825): too shallow at current scale
+- **Pressure-weighted loss at wrong architecture** (#2801): pressure weighting hurts if applied at non-golden depth
+
 ## Default Assignment Pattern
 
 Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per student.
 
-## ACTIVE EXPERIMENTS — 79 WIP PRs
+## ACTIVE EXPERIMENTS — 50 WIP PRs
 
 ### Theme 1: AirfRANS Recipe Transfer to DrivAerML (HIGHEST PRIORITY)
 
@@ -51,6 +57,8 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | chopper | #2882 | T_max=15+gc=1.0+WD=1e-2 |
 | einar | #2883 | gc=1.0+T_max=20+WD=1e-2 |
 | yuji | #2908 | Compound gc=1.0+WD=1e-2+T_max=15 |
+| zenitsu | #2911 | T_max=5+gc=1.0+WD=1e-2 (AirfRANS golden scheduler) |
+| edward | #2916 | lr=6e-4+gc=1.0+WD=1e-2+T_max=10 (intermediate LR) |
 
 ### Theme 2: DrivAerML LR+gc Exploration
 
@@ -63,6 +71,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | casca | #2881 | gc=1.5/gc=2.0 |
 | wolfwood | #2907 | lr=8e-4+gc=1.0 |
 | jin | #2893 | lr=1e-3+gc=1.0 |
+| shinobu | #2912 | WD=3e-2/5e-2+gc=1.0 (heavy regularization) |
 
 ### Theme 3: DrivAerML Architecture
 
@@ -72,6 +81,8 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | guts | #2890 | 4L/768d ultra-wide |
 | himmel | #2891 | 5L/512d deeper |
 | jet | #2892 | 3L/768d shallow+wide |
+| shouko | #2909 | heads=16/4 ablation + gc=1.0 |
+| askeladd | #2914 | MLP ratio=6/2 + gc=1.0+WD=1e-2 |
 
 ### Theme 4: Scheduler Innovations (CODE CHANGES)
 
@@ -92,7 +103,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | spike | #2901 | Huber/log-cosh loss |
 | stark | #2902 | Gradient accumulation |
 
-### Theme 6: Throughput + Seeds + Surface-Only
+### Theme 6: Throughput + Seeds + Ablations
 
 | Student | PR | Experiment |
 |---|---|---|
@@ -100,6 +111,9 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | sanji | #2900 | surface-only DrivAerML |
 | vegeta | #2906 | 360min multi-seed replication |
 | nami | #2896 | Lion higher LR on DrivAerML |
+| eren | #2910 | max-train-batches=788 (2x data/epoch) |
+| rei | #2913 | surface-points=75k resolution scaling |
+| levi | #2915 | no-Fourier ablation (faster epochs) |
 
 ### Continuing from Previous Wave (~20 students)
 
@@ -111,17 +125,10 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | norman | #2868 | DrivAerML | 2L/512d+3L/512d |
 | historia | #2867 | DrivAerML | 3L/256d+3L/384d |
 | kaneda | #2858 | DrivAerML | gc=0.7/0.8/0.9 |
-| shouko | #2857 | DrivAerML | MLP ratio 2/3/6 |
-| eren | #2855 | DrivAerML | Seed replication |
-| zenitsu | #2853 | DrivAerML | T_max=20/25/35 |
-| shinobu | #2851 | DrivAerML | WD ablation |
-| ymir | #2847 | DrivAerML | Lion 5e-5/1e-4/2e-4 |
-| rei | #2849 | DrivAerML | Conservative LR |
-| taki | #2814 | DrivAerML | Mild regularization |
-| kakashi | #2823 | AirfRANS | T_max=10 (0.001095 pending rebase) |
+| kakashi | #2823 | AirfRANS | gc=1.0+T_max=10 stabilization (lr=5e-4 + reproduce) |
 | inosuke | #2874 | AirfRANS | 2L+T_max=10 compound |
-| askeladd | #2834 | Cross | No-Lookahead ablation |
-| levi | #2825 | Cross | 3L architecture transfer |
+| thorfinn | #2786 | AirfRANS | gc=1.0+T_max=7 extended budget |
+| taki | #2814 | DrivAerML | Mild regularization |
 | Various | #2835-2876 | TandemFoil | LR/depth/gc fine-tuning |
 
 ## Research Insights from Literature
@@ -132,6 +139,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 4. **LLRD** (nobara #2897): 1-3% improvement in <10 epoch regime.
 5. **AB-UPT** achieves 3.71% via geometry-separated encoding — next escalation if recipe transfer fails.
 6. **Transolver-3** (arxiv 2602.04940): amortized mesh subset training for throughput.
+7. **Lookahead is load-bearing**: removing it causes catastrophic divergence on AF/DM (confirmed #2834).
 
 ## Human Guidance
 
@@ -140,7 +148,16 @@ Issue #2545: Focus on DrivAerML and cross-dataset evidence. No new directives.
 ## Next Priorities
 
 1. Review PRs as results come in (~30-360 min)
-2. **brook #2878** (gc+WD transfer) = THE paper question
+2. **brook #2878** (gc+WD transfer) = THE paper question — first to report
 3. **bulma #2879** (T_max=10+gc) = second priority
-4. Merge kakashi #2823 once rebased
-5. If recipe transfer fails → escalate to geometry-separated encoding (AB-UPT approach)
+4. **kakashi #2823** (AirfRANS 0.001095 reproducibility) = AirfRANS question
+5. Watch for code-change PRs (robin #2899, megumi #2894, sukuna #2903, usopp #2904) — these need careful review
+6. If recipe transfer fails → escalate to geometry-separated encoding (AB-UPT approach)
+
+## Potential Next Research Directions
+
+- **Residual prediction on DrivAerML**: works for TandemFoil (--residual-prediction), untested on DM
+- **Geometry-separated encoding**: AB-UPT approach — encode surface geometry separately from flow fields
+- **Mesh decimation / adaptive sampling**: sample more points near high-curvature regions
+- **Ensemble of 4L/512d seeds**: if variance is ±0.2% and we ensemble 3 seeds, could get deterministic improvement
+- **Amortized subset training** (Transolver-3): alternate between subsets of the mesh per step

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,165 +1,146 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 (post-prune relaunch refocus)
+- **Date:** 2026-04-21 17:30 (DrivAerML Refocus Relaunch — Wave 2)
 - **Branch:** radford
-- **Fleet status:** 50 live students after the relaunch reset
-- **Queue hygiene:** 29 open PRs from retired students were closed on 2026-04-21; treat those lanes as historical only
-- **Current relaunch budget:** inherit the pod env defaults
+- **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
+- **Current relaunch budget:** inherit pod env defaults
   - `SENPAI_TIMEOUT_MINUTES=360`
   - `SENPAI_MAX_EPOCHS=999`
-  - do not hardcode `180` minute runs
-  - do not hardcode `9999` epoch caps
 
 ## Paper-Facing Snapshot
 
-| Dataset | Paper-facing metric | Current best | Target / reference | Current read |
+| Dataset | Paper-facing metric | Current best | Target / reference | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **33.88** from #2810 | no single packaged external scalar | strong enough that Tandem is no longer the main bottleneck |
-| AirfRANS | `test_primary/surface_mse` | **0.003** from #2824 | `0.0043` | surface test target is already beaten |
-| AirfRANS full contract | `surface_mse + volume_mse` view | surface good, volume still around **0.0076+** | `volume_mse < 0.0017` | still not clean on the full published surface+volume pair |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **6.24%–6.29%** | `3.71%` nominal reference | still the weakest benchmark and the main empirical gap |
+| TandemFoil | `test_primary/surface_pressure_mae` | **33.88** (#2810) | no single packaged external scalar | strong, no longer bottleneck |
+| AirfRANS | `test_primary/surface_mse` | **0.003** (#2824) | `0.0043` | **BEATEN** |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **6.24%** (#2691) | `3.71%` | **MAIN GAP — 1.68x** |
 
-## Steering Anchors
+## Steering Anchors (validation, for experiment decisions)
 
-These are still useful for choosing the next experiments, even though test is the paper-facing number.
-
-| Dataset | Steering metric | Current anchor |
+| Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **30.10** from #2810 |
-| AirfRANS | `val_primary/surface_mse` | **0.001095** pending in #2823 |
-| DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** from #2691 |
+| TandemFoil | `val_primary/surface_pressure_mae` | **30.10** (#2810) |
+| AirfRANS | `val_primary/surface_mse` | **0.001236** merged (#2828), **0.001095** pending (#2823) |
+| DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** (#2691) |
 
 ## Main Scientific Goal
 
-The goal is **not** three unrelated benchmark-specific wins.
-
-The goal is a shared recipe whose core changes more or less work across:
-
-- `target/icml2026/tandemfoil/`
-- `target/icml2026/airfrans/`
-- `target/icml2026/drivaerml/`
-
-It is fine if LR, scheduler, WD, or point-budget differ by dataset.
-It is not fine if the abstract only works because every dataset needs a different core idea.
-
-Because AirfRANS surface test is already over the line and Tandem is healthy, the next wave should be:
-
-- **DrivAerML-weighted**
-- **cross-dataset by default**
-- **test-aware when reporting**
+A shared recipe whose core changes work across TandemFoil, AirfRANS, and DrivAerML.
+DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 
 ## Mandatory Config Rules
 
-- `--no-use-ema` is mandatory everywhere
-- `--epochs 999` is mandatory because the default epoch count is too small
-- inherit `SENPAI_TIMEOUT_MINUTES=360` from the pod env unless there is a clearly justified shorter run
-- inherit `SENPAI_MAX_EPOCHS=999` from the pod env unless there is a clearly justified override
-- for DrivAerML keep:
-  - `--batch-size 1`
-  - `--drivaerml-train-surface-points 50000`
-  - `--drivaerml-eval-surface-points 50000`
-  - `--max-train-batches 394`
-  - `--max-eval-batches 200`
-- when reporting benchmark-facing results, always keep the reported **test** metric beside its target or reference
+- `--no-use-ema` mandatory everywhere (robin #2899 tests a fix)
+- `--epochs 999` mandatory
+- DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
+- Lion for TandemFoil; AdamW for AirfRANS/DrivAerML
 
 ## Default Assignment Pattern
 
-When a student is free, default to a **single hypothesis family across all three datasets** in one PR.
+Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per student.
 
-Use the student's 8 GPUs roughly like this:
+## ACTIVE EXPERIMENTS — 79 WIP PRs
 
-- `1` TandemFoil run
-- `1` AirfRANS run
-- `2-4` DrivAerML runs
-- remaining GPUs for the most decision-critical nearby variants
+### Theme 1: AirfRANS Recipe Transfer to DrivAerML (HIGHEST PRIORITY)
 
-The resulting PR should let the same student answer:
+| Student | PR | Experiment |
+|---|---|---|
+| brook | #2878 | gc=1.0+WD=1e-2 (flagship compound) |
+| bulma | #2879 | T_max=10+gc=1.0 |
+| canute | #2880 | Full recipe: lr=7e-4+gc=1.0+WD=1e-2 |
+| chopper | #2882 | T_max=15+gc=1.0+WD=1e-2 |
+| einar | #2883 | gc=1.0+T_max=20+WD=1e-2 |
+| yuji | #2908 | Compound gc=1.0+WD=1e-2+T_max=15 |
 
-- did this transfer broadly?
-- did it help AirfRANS and TandemFoil but fail on DrivAerML?
-- is it too dataset-specific to support the abstract story?
+### Theme 2: DrivAerML LR+gc Exploration
 
-Single-dataset PRs are still acceptable only for:
+| Student | PR | Experiment |
+|---|---|---|
+| faye | #2885 | lr=7e-4+gc=1.0 |
+| franky | #2886 | lr=4e-4+gc=1.0 |
+| gohan | #2887 | gc=1.0+T_max=10 LR scan |
+| gojo | #2888 | gc=0.5+T_max=10 |
+| casca | #2881 | gc=1.5/gc=2.0 |
+| wolfwood | #2907 | lr=8e-4+gc=1.0 |
+| jin | #2893 | lr=1e-3+gc=1.0 |
 
-- AirfRANS benchmark cleanup or best-checkpoint / test cleanup
-- a clearly justified DrivAerML rescue lane
-- minimal Tandem anchor locking
+### Theme 3: DrivAerML Architecture
 
-## Keep And Prioritize
+| Student | PR | Experiment |
+|---|---|---|
+| griffith | #2889 | 3L/512d+gc=1.0 |
+| guts | #2890 | 4L/768d ultra-wide |
+| himmel | #2891 | 5L/512d deeper |
+| jet | #2892 | 3L/768d shallow+wide |
 
-### 1. Cross-dataset transfer evidence
+### Theme 4: Scheduler Innovations (CODE CHANGES)
 
-These are the clearest matches to the abstract story and should stay live:
+| Student | PR | Experiment |
+|---|---|---|
+| megumi | #2894 | Linear warmup+cosine |
+| mugen | #2895 | CosineAnnealingWarmRestarts T_mult |
+| vash | #2905 | OneCycleLR |
 
-- `#2834` askeladd — no-Lookahead ablation
-- `#2825` levi — 3L architecture transfer
+### Theme 5: Optimizer + Training Recipe Innovations (CODE CHANGES)
 
-New PRs should look more like these.
+| Student | PR | Experiment |
+|---|---|---|
+| nobara | #2897 | LLRD (layer-wise LR decay) |
+| robin | #2899 | Corrected EMA with warmup |
+| usopp | #2904 | Momentum-SAM |
+| sukuna | #2903 | SWA at cosine troughs |
+| spike | #2901 | Huber/log-cosh loss |
+| stark | #2902 | Gradient accumulation |
 
-### 2. DrivAerML rescue lanes
+### Theme 6: Throughput + Seeds + Surface-Only
 
-These are the highest-value single-benchmark lanes because DrivAerML is now the main gap:
+| Student | PR | Experiment |
+|---|---|---|
+| piccolo | #2898 | torch.compile throughput |
+| sanji | #2900 | surface-only DrivAerML |
+| vegeta | #2906 | 360min multi-seed replication |
+| nami | #2896 | Lion higher LR on DrivAerML |
 
-- `#2873` chrome — LR headroom above `5e-4`
-- `#2868` norman — `2L/512d` and `3L/512d`
-- `#2867` historia — `3L/256d` and `3L/384d`
-- `#2855` eren — seed replication
-- `#2853` zenitsu — `T_max` neighborhood
-- `#2851` shinobu — WD ablation
-- `#2849` rei — conservative LR neighborhood
-- `#2814` taki — mild regularization (`WD=1e-3 + gc=0.5`) if still behaving sanely
+### Continuing from Previous Wave (~20 students)
 
-### 3. Minimal Tandem anchor lanes
+| Student | PR | Dataset | Focus |
+|---|---|---|---|
+| chrome | #2873 | DrivAerML | LR headroom 4.5-6e-4 |
+| zoro | #2870 | DrivAerML | Lower LR 2-3e-4 |
+| shinji | #2869 | DrivAerML | gc=0.5/0.7+T_max=25/30 |
+| norman | #2868 | DrivAerML | 2L/512d+3L/512d |
+| historia | #2867 | DrivAerML | 3L/256d+3L/384d |
+| kaneda | #2858 | DrivAerML | gc=0.7/0.8/0.9 |
+| shouko | #2857 | DrivAerML | MLP ratio 2/3/6 |
+| eren | #2855 | DrivAerML | Seed replication |
+| zenitsu | #2853 | DrivAerML | T_max=20/25/35 |
+| shinobu | #2851 | DrivAerML | WD ablation |
+| ymir | #2847 | DrivAerML | Lion 5e-5/1e-4/2e-4 |
+| rei | #2849 | DrivAerML | Conservative LR |
+| taki | #2814 | DrivAerML | Mild regularization |
+| kakashi | #2823 | AirfRANS | T_max=10 (0.001095 pending rebase) |
+| inosuke | #2874 | AirfRANS | 2L+T_max=10 compound |
+| askeladd | #2834 | Cross | No-Lookahead ablation |
+| levi | #2825 | Cross | 3L architecture transfer |
+| Various | #2835-2876 | TandemFoil | LR/depth/gc fine-tuning |
 
-Keep only a small Tandem lane alive:
+## Research Insights from Literature
 
-- `#2864` senku — 2-layer depth frontier
-- `#2840` alphonse — `lr=1e-4` multi-seed replication
-- `#2837` fern — `3L/256d` width check
-- `#2842` tanjiro — compound lane only if it is already near a useful readout
+1. **Corrected EMA** (robin #2899): no-EMA was a bug fix, not a design choice. timm-style warmup fixes it.
+2. **SWA** (sukuna #2903): weight averaging at cosine troughs → flatter minima.
+3. **MSAM** (usopp #2904): flat-minima bias without SAM's 2x cost.
+4. **LLRD** (nobara #2897): 1-3% improvement in <10 epoch regime.
+5. **AB-UPT** achieves 3.71% via geometry-separated encoding — next escalation if recipe transfer fails.
+6. **Transolver-3** (arxiv 2602.04940): amortized mesh subset training for throughput.
 
-### 4. Minimal AirfRANS lane
+## Human Guidance
 
-AirfRANS should now be narrow:
+Issue #2545: Focus on DrivAerML and cross-dataset evidence. No new directives.
 
-- `#2823` kakashi — preserve / rebase / merge the current best validation anchor
-- `#2801` edward — only if it yields a broadly useful transferable lesson rather than another benchmark-specific trick
+## Next Priorities
 
-## Retask Or De-Emphasize
-
-These open lanes are **not** central to the new plan and should be retasked if they are not already very close to a useful answer:
-
-- `#2820` haku — AirfRANS local stability line
-- `#2786` thorfinn — AirfRANS `T_max=7`
-- `#2770` hinata — AirfRANS `WD=5e-3`
-- `#2801` edward — de-emphasize unless it is near review and clearly transferable
-- `#2842` tanjiro — de-emphasize if it is turning into another Tandem-only local sweep
-- `#2857` shouko — DrivAer MLP-ratio lane is lower value than LR / depth / seeds / scheduler
-
-Do **not** recreate the following families by default:
-
-- broad AirfRANS WD / LR / MLP-ratio neighborhoods around already-strong lines
-- broad Tandem LR / WD / `T_max` neighborhood mapping
-- DrivAerML Lion sweeps
-- DrivAerML clipping-heavy compounds that repeat already weak signals
-
-## Queue Notes
-
-- 29 PRs owned by retired students were closed during this refocus; if old notes mention them, they are no longer active
-- do not assign work to retired students
-- if many newly relaunched students are idle, assign cross-dataset matrices first, not more one-benchmark local sweeps
-
-## Immediate Priorities
-
-1. Keep DrivAerML as the main destination for fresh capacity
-2. Prefer cross-dataset PRs over single-benchmark PRs whenever possible
-3. Preserve the minimal AirfRANS and Tandem anchors without letting them dominate the queue
-4. Report test metrics beside SOTA targets / references when summarizing progress
-
-## Most Recent Human Guidance
-
-The current human direction is:
-
-- close stale dead-student PRs
-- focus the next wave on DrivAerML and cross-dataset evidence
-- keep pushing toward an ICML abstract story based on a shared recipe, not three disconnected wins
+1. Review PRs as results come in (~30-360 min)
+2. **brook #2878** (gc+WD transfer) = THE paper question
+3. **bulma #2879** (T_max=10+gc) = second priority
+4. Merge kakashi #2823 once rebased
+5. If recipe transfer fails → escalate to geometry-separated encoding (AB-UPT approach)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 19:30 (DrivAerML Refocus — Wave 2, All Students Assigned)
+- **Date:** 2026-04-21 20:10 (DrivAerML Refocus — Wave 2, All Students Assigned)
 - **Branch:** radford
 - **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
@@ -44,6 +44,7 @@ DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 - **surface_only_drivaerml is already default** (#2900): don't re-test; use --no-surface-only-drivaerml to test volume inclusion
 - **lr=8e-4 + Lion on DrivAerML** (#2907): confounded by wrong optimizer/architecture. Lion competitive at 3L but untested at 4L/512d (nami #2896 testing)
 - **lr=9e-4 is above DrivAerML ceiling** (#2907): both runs diverged catastrophically
+- **Momentum-SAM (MSAM)** (#2904): 3.7-22.7x worse everywhere. Cost is 2x (not ~0%), Lion momentum anti-adversarial on TF
 
 ## Default Assignment Pattern
 
@@ -105,7 +106,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 |---|---|---|
 | nobara | #2897 | LLRD (layer-wise LR decay) |
 | robin | #2899 | Corrected EMA with warmup |
-| usopp | #2904 | Momentum-SAM |
+| usopp | #2920 | Gradient noise injection (Neelakantan 2015) |
 | sukuna | #2903 | SWA at cosine troughs |
 | spike | #2901 | Huber/log-cosh loss |
 | stark | #2902 | Gradient accumulation |

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 20:30 (DrivAerML Refocus — Wave 2, All Students Assigned)
+- **Date:** 2026-04-21 21:30 (DrivAerML Refocus — Wave 2, All Students Assigned)
 - **Branch:** radford
 - **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
@@ -46,6 +46,7 @@ DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 - **lr=9e-4 is above DrivAerML ceiling** (#2907): both runs diverged catastrophically
 - **Momentum-SAM (MSAM)** (#2904): 3.7-22.7x worse everywhere. Cost is 2x (not ~0%), Lion momentum anti-adversarial on TF
 - **gc=1.0+WD=1e-2+cosine compound** (#2908): 6/8 runs crashed. gc=1.0 permits spikes at cosine LR peaks that cascade with WD
+- **4L/640d at lr=5e-4+gc=1.0** (#2917): all 3 DM runs crashed (ep90-153). Width above 512d needs lower LR or tighter gc
 
 ## Default Assignment Pattern
 
@@ -91,7 +92,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | jet | #2892 | 3L/768d shallow+wide |
 | shouko | #2909 | heads=16/4 ablation + gc=1.0 |
 | askeladd | #2914 | MLP ratio=6/2 + gc=1.0+WD=1e-2 |
-| chrome | #2917 | 4L/640d mid-width + gc=1.0 (between 512d and 768d) |
+| chrome | #2923 | torch.compile + gc=1.0 (throughput + stability compound) |
 
 ### Theme 4: Scheduler Innovations (CODE CHANGES)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 19:00 (DrivAerML Refocus — Wave 2, All Students Assigned)
+- **Date:** 2026-04-21 19:30 (DrivAerML Refocus — Wave 2, All Students Assigned)
 - **Branch:** radford
 - **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
@@ -42,6 +42,8 @@ DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 - **Pressure-weighted loss at wrong architecture** (#2801): pressure weighting hurts if applied at non-golden depth
 - **LR above 5e-4 on DrivAerML** (#2873): 6e-4/5.5e-4/4.5e-4 all worse, LR optimum firmly at 5e-4
 - **surface_only_drivaerml is already default** (#2900): don't re-test; use --no-surface-only-drivaerml to test volume inclusion
+- **lr=8e-4 + Lion on DrivAerML** (#2907): confounded by wrong optimizer/architecture. Lion competitive at 3L but untested at 4L/512d (nami #2896 testing)
+- **lr=9e-4 is above DrivAerML ceiling** (#2907): both runs diverged catastrophically
 
 ## Default Assignment Pattern
 
@@ -61,6 +63,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | yuji | #2908 | Compound gc=1.0+WD=1e-2+T_max=15 |
 | zenitsu | #2911 | T_max=5+gc=1.0+WD=1e-2 (AirfRANS golden scheduler) |
 | edward | #2916 | lr=6e-4+gc=1.0+WD=1e-2+T_max=10 (intermediate LR) |
+| wolfwood | #2919 | T_max=40/50+gc=1.0+WD=1e-2 (longer cosine cycling) |
 
 ### Theme 2: DrivAerML LR+gc Exploration
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 18:15 (DrivAerML Refocus Relaunch — Wave 2, All Students Assigned)
+- **Date:** 2026-04-21 19:00 (DrivAerML Refocus — Wave 2, All Students Assigned)
 - **Branch:** radford
 - **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
@@ -40,6 +40,8 @@ DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 - **No-Lookahead** (#2834): fatal across all datasets — diverges AF/DM, TF regresses
 - **3L/192d on TF or DM** (#2825): too shallow at current scale
 - **Pressure-weighted loss at wrong architecture** (#2801): pressure weighting hurts if applied at non-golden depth
+- **LR above 5e-4 on DrivAerML** (#2873): 6e-4/5.5e-4/4.5e-4 all worse, LR optimum firmly at 5e-4
+- **surface_only_drivaerml is already default** (#2900): don't re-test; use --no-surface-only-drivaerml to test volume inclusion
 
 ## Default Assignment Pattern
 
@@ -72,6 +74,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | wolfwood | #2907 | lr=8e-4+gc=1.0 |
 | jin | #2893 | lr=1e-3+gc=1.0 |
 | shinobu | #2912 | WD=3e-2/5e-2+gc=1.0 (heavy regularization) |
+| sanji | #2918 | gc=0.5+WD=1e-2 (softer clip + regularization compound) |
 
 ### Theme 3: DrivAerML Architecture
 
@@ -83,6 +86,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | jet | #2892 | 3L/768d shallow+wide |
 | shouko | #2909 | heads=16/4 ablation + gc=1.0 |
 | askeladd | #2914 | MLP ratio=6/2 + gc=1.0+WD=1e-2 |
+| chrome | #2917 | 4L/640d mid-width + gc=1.0 (between 512d and 768d) |
 
 ### Theme 4: Scheduler Innovations (CODE CHANGES)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -12,6 +12,7 @@
 | Dataset | Paper-facing metric | Current best | Target / reference | Status |
 |---|---|---|---|---|
 | TandemFoil | `test_primary/surface_pressure_mae` | **33.88** (#2810) | no external scalar | needs test from new EMA best |
+| TandemFoil Paper | `test_primary/field_mse` | not run yet on `radford` | `0.10 / 0.18 / 0.36 / 0.13 / 0.14 / 0.21` by task | new calibration lane |
 | AirfRANS | `test_primary/surface_mse` | **0.003** (#2824) | `0.0043` | **BEATEN** — val now 0.000727 |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **6.24%** (#2691) | `3.71%` | **MAIN GAP — 1.68x** |
 
@@ -25,8 +26,16 @@
 
 ## Main Scientific Goal
 
-A shared recipe whose core changes work across TandemFoil, AirfRANS, and DrivAerML.
-DrivAerML is the main gap. Corrected EMA warmup is now the shared recipe for TF+AF.
+A shared recipe whose core changes work across:
+
+- the main TandemFoil parity target
+- the new TandemFoil paper-calibration target
+- AirfRANS
+- DrivAerML
+
+DrivAerML is still the main gap. Corrected EMA warmup is now the shared recipe
+for TF+AF, and the paper-calibration Tandem benchmark exists to tell us whether
+Tandem-side gains are only helping the parity contract or also the literature-facing one.
 
 ## Mandatory Config Rules (UPDATED after EMA merge)
 
@@ -53,6 +62,12 @@ DrivAerML is the main gap. Corrected EMA warmup is now the shared recipe for TF+
 ## Default Assignment Pattern
 
 Cross-dataset: TF+AF use EMA decay=0.999, DM still uses --no-use-ema.
+
+When a hypothesis is relevant to TandemFoil generalization or paper
+comparability, include both:
+
+- `target/icml2026/tandemfoil/`
+- `target/icml2026/tandemfoil_paper/`
 
 ## ACTIVE EXPERIMENTS — 50 WIP PRs
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,18 +1,38 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 22:45 (Wave 3 — Bold New Directions)
+- **Date:** 2026-04-21 23:50 (Wave 3 — Bold New Directions, Cross-Dataset Focus Directive)
 - **Branch:** radford
 - **Fleet status:** 59 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
   - `SENPAI_TIMEOUT_MINUTES=360`
   - `SENPAI_MAX_EPOCHS=999`
 
+## CORE RESEARCH DIRECTIVE (Human Team Instruction — 2026-04-21)
+
+**CROSS-DATASET GENERALIZATION IS THE PRIMARY CONSTRAINT ON ALL NEW EXPERIMENTS.**
+
+The human research team has explicitly directed: every new hypothesis must be
+tested across all relevant datasets in a single PR. Dataset-specific tricks that
+do not transfer are not useful. The paper story requires a shared recipe.
+
+All four benchmarks are now active and required:
+
+1. **TandemFoil** — `val_primary/surface_pressure_mae` / `test_primary/surface_pressure_mae`
+2. **TandemFoil Paper** — `val_primary/field_mse` / `test_primary/field_mse` ← NEW 4th dataset (human directive 2026-04-21)
+3. **AirfRANS** — `val_primary/surface_mse` / `test_primary/surface_mse`
+4. **DrivAerML** — `val_primary/surface_rel_l2_pct` / `test_primary/surface_rel_l2_pct`
+
+**Assignment rule (effective immediately):**
+- New hyperparameter or architecture hypotheses MUST be tested on ALL four datasets in one PR.
+- Single-dataset assignments are only acceptable for dataset-specific ablations (e.g. DrivAerML batch size), TandemFoil Paper baseline runs, or targeted best-checkpoint recovery.
+- When in doubt: assign cross-dataset. An idea that only helps one dataset is a dataset hack.
+
 ## Paper-Facing Snapshot
 
 | Dataset | Paper-facing metric | Current best | Target / reference | Status |
 |---|---|---|---|---|
 | TandemFoil | `test_primary/surface_pressure_mae` | **33.88** (#2810) | no external scalar | needs test from new EMA best |
-| TandemFoil Paper | `test_primary/field_mse` | not run yet on `radford` | `0.10 / 0.18 / 0.36 / 0.13 / 0.14 / 0.21` by task | new calibration lane |
+| TandemFoil Paper | `test_primary/field_mse` | **not run yet on radford** | `0.10 / 0.18 / 0.36 / 0.13 / 0.14 / 0.21` by task | NEW — baseline run needed |
 | AirfRANS | `test_primary/surface_mse` | **0.003** (#2824) | `0.0043` | **BEATEN** — val now 0.000727 |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **6.24%** (#2691) | `3.71%` | **MAIN GAP — 1.68x** |
 
@@ -21,25 +41,27 @@
 | Dataset | Metric | Current anchor |
 |---|---|---|
 | TandemFoil | `val_primary/surface_pressure_mae` | **26.134** (#2899 MERGED — EMA decay=0.999) |
+| TandemFoil Paper | `val_primary/field_mse` | **not established** — baseline run needed urgently |
 | AirfRANS | `val_primary/surface_mse` | **0.000727** (#2899 MERGED — EMA decay=0.999, ep206) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** (#2691) |
 
 ## Main Scientific Goal
 
-A shared recipe whose core changes work across:
+A shared recipe whose core changes work across all four benchmarks:
 
 - the main TandemFoil parity target
-- the new TandemFoil paper-calibration target
+- the new TandemFoil paper-calibration target (Experiment 4, Table 6)
 - AirfRANS
 - DrivAerML
 
 DrivAerML is still the main gap. Corrected EMA warmup is now the shared recipe
-for TF+AF, and the paper-calibration Tandem benchmark exists to tell us whether
-Tandem-side gains are only helping the parity contract or also the literature-facing one.
+for TF+AF. TandemFoil Paper is a NEW required benchmark added by the human team
+— paper-faithful high-Re TandemFoilSet using normalized full-field MSE, 6 tasks.
+No baseline has been run yet on radford for this dataset.
 
 ## Mandatory Config Rules (UPDATED after EMA merge)
 
-- **TF + AF:** Use `--ema-decay 0.999` (NO --no-use-ema). decay=0.999 > 0.9999 on both.
+- **TF + AF + TF_paper:** Use `--ema-decay 0.999` (NO --no-use-ema). decay=0.999 > 0.9999 on both.
 - **DrivAerML:** Still `--no-use-ema` (EMA alone hurt DM; zenitsu #2925 tests EMA+gc compound)
 - `--epochs 999` mandatory
 - DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
@@ -61,11 +83,18 @@ Tandem-side gains are only helping the parity contract or also the literature-fa
 
 ## Default Assignment Pattern
 
-Cross-dataset: TF+AF use EMA decay=0.999, DM still uses --no-use-ema.
+Cross-dataset is now the DEFAULT. Every new hypothesis should cover:
+- `target/icml2026/tandemfoil/`
+- `target/icml2026/tandemfoil_paper/`
+- `target/icml2026/airfrans/`
+- `target/icml2026/drivaerml/`
+
+Unless there is a strong reason to restrict to a single dataset (ablation,
+baseline run, known dataset-specific mechanism), all assignments are
+multi-dataset. This is the human team's explicit directive.
 
 When a hypothesis is relevant to TandemFoil generalization or paper
-comparability, include both:
-
+comparability, always include:
 - `target/icml2026/tandemfoil/`
 - `target/icml2026/tandemfoil_paper/`
 
@@ -183,29 +212,42 @@ comparability, include both:
 2. **DrivAerML is fragile to compounds:** gc+WD+cosine crashes (6/8 #2908), 640d crashes (#2917), T_max=5 crashes (#2911). Only gentle perturbations survive at 4L/512d.
 3. **Width scaling ceiling at 512d for DM:** 640d is unstable. guts #2890 (768d) and himmel #2891 (5L/512d) will clarify the boundary.
 4. **AB-UPT** achieves 3.71% via geometry-separated encoding — escalation if EMA+recipe fails.
+5. **TandemFoil Paper baseline urgently needed:** This dataset has never been run on radford. We need a val anchor before we can evaluate any experiment improvements against the paper's Table 6 numbers.
 
 ## Current Research Themes and Priorities
 
-### Priority 1: DrivAerML Gap Closure (4.619% → 3.71%)
+### Priority 0: Cross-Dataset Generalization (Human Team Directive — NON-NEGOTIABLE)
+- **Every new experiment must test across all 4 datasets.** Ideas that help only one dataset are not acceptable for the shared paper recipe.
+- **TandemFoil Paper is now a required 4th benchmark.** All future assignments must include it.
+- **Measurement gate:** An experiment is a win only if it does not cause regression on any of the 4 datasets (or shows a cross-dataset improvement).
+
+### Priority 1: TandemFoil Paper Baseline
+- **No val anchor exists yet for TF Paper.** First student to become idle should run the best current config (EMA decay=0.999, 3L/192d or 4L/512d, Lion lr=1.25e-4 for TF) on tandemfoil_paper to establish a baseline.
+- Paper targets (Table 6 MGN + PRE-RES-FREE+RES-COMB): 0.10/0.18/0.36/0.13/0.14/0.21 per task.
+- Metric: normalized full-field MSE (`val_primary/field_mse`).
+
+### Priority 2: DrivAerML Gap Closure (4.619% → 3.71%)
 - **Loss alignment** (frieren #2928): Most direct fix — training on relative L2 directly matches the evaluation metric
 - **Architectural upgrades** (nezuko #2929 SwiGLU, kohaku #2932 global context): Address known Transolver limitations
 - **Regularization** (violet #2930 DropPath): New orthogonal regularization dimension
 - **Physics-informed features** (emma #2933 curvature, mitsuha #2936 SDF): Give model explicit geometric knowledge it currently must learn implicitly
 
-### Priority 2: Cross-Benchmark Recipe Validation
-- Wave 3 experiments test across all 4 benchmarks by default
+### Priority 3: Cross-Benchmark Recipe Validation
+- Wave 3 experiments should test across all 4 benchmarks by default
 - TandemFoil Paper benchmark provides calibration against published numbers
-- Ideas that help DM but hurt TF/AF are dataset hacks; we want shared wins
+- Ideas that help DM but hurt TF/AF are dataset hacks; we want shared wins across all 4
 
-### Priority 3: Optimization Paradigm Shift
+### Priority 4: Optimization Paradigm Shift
 - Prodigy (gilbert #2931): If the LR search is truly exhausted, adaptive optimizers may find new trajectories
 - MoE (shoya #2935): Sparse expert specialization is fundamentally different from dense FFN
 - Conservation loss (chihiro #2934): Physics constraints as regularization
 
 ## Next Priorities
 
-1. Watch Wave 3 results (frieren #2928 rel-L2 is the highest-priority result)
-2. Review any WIP PRs that become ready
-3. If DM recipe transfer (Theme 1) fails universally → escalate to geometry-separated encoding
-4. If Wave 3 bold ideas show promise → double down with follow-up assignments
-5. Check for human team messages on GitHub issues
+1. **TandemFoil Paper baseline run** — assign first available idle student
+2. Watch Wave 3 results (frieren #2928 rel-L2 is the highest-priority result)
+3. Review any WIP PRs that become ready
+4. All new assignments: 4-dataset coverage mandatory per human team directive
+5. If DM recipe transfer (Theme 1) fails universally → escalate to geometry-separated encoding
+6. If Wave 3 bold ideas show promise → double down with follow-up assignments across all 4 datasets
+7. Check for human team messages on GitHub issues (priority — check very frequently)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 22:00 (DrivAerML Refocus — Wave 2, EMA BREAKTHROUGH)
+- **Date:** 2026-04-21 22:45 (Wave 3 — Bold New Directions)
 - **Branch:** radford
-- **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
+- **Fleet status:** 59 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
   - `SENPAI_TIMEOUT_MINUTES=360`
   - `SENPAI_MAX_EPOCHS=999`
@@ -69,16 +69,32 @@ comparability, include both:
 - `target/icml2026/tandemfoil/`
 - `target/icml2026/tandemfoil_paper/`
 
-## ACTIVE EXPERIMENTS — 50 WIP PRs
+## ACTIVE EXPERIMENTS — 59 WIP PRs
 
-### Theme 0: EMA Refinement (NEW HIGHEST PRIORITY — push new TF/AF bests)
+### Theme 7: Bold New Directions (Wave 3, 2026-04-21 22:45)
+
+9 new hypothesis families testing genuinely new mechanisms — loss reformulation, architecture innovations, optimization paradigm shifts, and physics-informed features.
+
+| Student | PR | Experiment | Risk |
+|---|---|---|---|
+| frieren | #2928 | **Relative L2 Training Loss** — align DM training loss with eval metric | LOW |
+| nezuko | #2929 | **SwiGLU FFN Replacement** — gated linear units for all Transolver blocks | LOW |
+| violet | #2930 | **Stochastic Depth (DropPath)** — layer-level regularization 0.1/0.2 | LOW |
+| gilbert | #2931 | **Prodigy Optimizer** — parameter-free LR adaptation | LOW-MED |
+| kohaku | #2932 | **Global Context Token** — break slice-local attention bottleneck | MEDIUM |
+| emma | #2933 | **Surface Normals + Curvature** — differential geometry input features | MEDIUM |
+| chihiro | #2934 | **Conservation Auxiliary Loss** — div(u)=0 physics regularization | MED-HIGH |
+| shoya | #2935 | **MoE FFN Layers** — sparse expert routing for physics-regime specialization | MED-HIGH |
+| mitsuha | #2936 | **SDF Wall-Distance Feature** — signed distance field geometry embedding | MEDIUM |
+
+### Theme 0: EMA Refinement
 
 | Student | PR | Experiment |
 |---|---|---|
 | robin | #2924 | TF lr=1e-4+EMA, TF gc=0.5+EMA, AF T_max=10+EMA, AF seed=43 |
 | zenitsu | #2925 | DrivAerML EMA+gc=1.0, EMA+gc+WD, EMA decay=0.9999, pure gc control |
 
-### Theme 1: AirfRANS Recipe Transfer to DrivAerML (HIGHEST PRIORITY)
+### Theme 1: AirfRANS Recipe Transfer to DrivAerML
 
 | Student | PR | Experiment |
 |---|---|---|
@@ -145,21 +161,21 @@ comparability, include both:
 | rei | #2913 | surface-points=75k resolution scaling |
 | levi | #2915 | no-Fourier ablation (faster epochs) |
 
-### Continuing from Previous Wave (~20 students)
+### Continuing from Previous Wave
 
 | Student | PR | Dataset | Focus |
 |---|---|---|---|
-| zoro | #2870 | DrivAerML | Lower LR 2-3e-4 |
-| shinji | #2869 | DrivAerML | gc=0.5/0.7+T_max=25/30 |
 | norman | #2868 | DrivAerML | 2L/512d+3L/512d |
 | historia | #2867 | DrivAerML | 3L/256d+3L/384d |
-| kaneda | #2858 | DrivAerML | gc=0.7/0.8/0.9 |
 | kakashi | #2823 | AirfRANS | gc=1.0+T_max=10 stabilization |
-| inosuke | #2874 | AirfRANS | 2L+T_max=10 compound |
 | thorfinn | #2786 | AirfRANS | gc=1.0+T_max=7 extended |
 | taki | #2814 | DrivAerML | Mild regularization |
 | tanjiro | #2842 | TandemFoil | 3L/192d+lr=1e-4+gc=0.5 (sent back) |
-| Various | #2835-2876 | TandemFoil | LR/depth/gc fine-tuning |
+| alphonse | #2840 | TandemFoil | lr=1e-4+gc=1.0 multi-seed |
+| fern | #2837 | TandemFoil | 3L/256d at lr=1.25e-4 |
+| senku | #2864 | TandemFoil | 2L/192d+2L/256d depth reduction |
+| haku | #2820 | AirfRANS | gc=0.5+lr=5e-4 extended |
+| hinata | #2770 | AirfRANS | 4L/256d WD=5e-3 |
 
 ## Research Insights
 
@@ -168,18 +184,28 @@ comparability, include both:
 3. **Width scaling ceiling at 512d for DM:** 640d is unstable. guts #2890 (768d) and himmel #2891 (5L/512d) will clarify the boundary.
 4. **AB-UPT** achieves 3.71% via geometry-separated encoding — escalation if EMA+recipe fails.
 
+## Current Research Themes and Priorities
+
+### Priority 1: DrivAerML Gap Closure (4.619% → 3.71%)
+- **Loss alignment** (frieren #2928): Most direct fix — training on relative L2 directly matches the evaluation metric
+- **Architectural upgrades** (nezuko #2929 SwiGLU, kohaku #2932 global context): Address known Transolver limitations
+- **Regularization** (violet #2930 DropPath): New orthogonal regularization dimension
+- **Physics-informed features** (emma #2933 curvature, mitsuha #2936 SDF): Give model explicit geometric knowledge it currently must learn implicitly
+
+### Priority 2: Cross-Benchmark Recipe Validation
+- Wave 3 experiments test across all 4 benchmarks by default
+- TandemFoil Paper benchmark provides calibration against published numbers
+- Ideas that help DM but hurt TF/AF are dataset hacks; we want shared wins
+
+### Priority 3: Optimization Paradigm Shift
+- Prodigy (gilbert #2931): If the LR search is truly exhausted, adaptive optimizers may find new trajectories
+- MoE (shoya #2935): Sparse expert specialization is fundamentally different from dense FFN
+- Conservation loss (chihiro #2934): Physics constraints as regularization
+
 ## Next Priorities
 
-1. EMA refinement (robin #2924) — can we push below TF 26 and AF 0.0007?
-2. DrivAerML EMA+gc test (zenitsu #2925) — the key 3-of-3 question
-3. Review brook #2878 (gc+WD) when ready — flagship recipe transfer result
-4. Watch bulma #2879, canute #2880, chopper #2882 — T_max cycle results
-5. If DM recipe transfer fails universally → escalate to geometry-separated encoding
-
-## Potential Next Directions
-
-- **TF+AF: EMA + lower LR** (robin #2924 covers this)
-- **DM: EMA+gc+WD compound** (zenitsu #2925 covers this)
-- **Test set evaluation from EMA best checkpoint** — ensure paper metrics reflect EMA model
-- **EMA with arch variants** — does EMA help on 5L/512d or 3L/768d DM configs?
-- **Residual prediction on DrivAerML** — works for TF (--residual-prediction), untested on DM
+1. Watch Wave 3 results (frieren #2928 rel-L2 is the highest-priority result)
+2. Review any WIP PRs that become ready
+3. If DM recipe transfer (Theme 1) fails universally → escalate to geometry-separated encoding
+4. If Wave 3 bold ideas show promise → double down with follow-up assignments
+5. Check for human team messages on GitHub issues

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 20:10 (DrivAerML Refocus — Wave 2, All Students Assigned)
+- **Date:** 2026-04-21 20:30 (DrivAerML Refocus — Wave 2, All Students Assigned)
 - **Branch:** radford
 - **Fleet status:** 50 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
@@ -45,6 +45,7 @@ DrivAerML is the main gap. All new work is DrivAerML-weighted and cross-dataset.
 - **lr=8e-4 + Lion on DrivAerML** (#2907): confounded by wrong optimizer/architecture. Lion competitive at 3L but untested at 4L/512d (nami #2896 testing)
 - **lr=9e-4 is above DrivAerML ceiling** (#2907): both runs diverged catastrophically
 - **Momentum-SAM (MSAM)** (#2904): 3.7-22.7x worse everywhere. Cost is 2x (not ~0%), Lion momentum anti-adversarial on TF
+- **gc=1.0+WD=1e-2+cosine compound** (#2908): 6/8 runs crashed. gc=1.0 permits spikes at cosine LR peaks that cascade with WD
 
 ## Default Assignment Pattern
 
@@ -61,7 +62,7 @@ Cross-dataset by default: 1 TF + 1 AF + 2-4 DrivAerML + nearby variants per stud
 | canute | #2880 | Full recipe: lr=7e-4+gc=1.0+WD=1e-2 |
 | chopper | #2882 | T_max=15+gc=1.0+WD=1e-2 |
 | einar | #2883 | gc=1.0+T_max=20+WD=1e-2 |
-| yuji | #2908 | Compound gc=1.0+WD=1e-2+T_max=15 |
+| yuji | #2922 | WD=5e-3+gc=1.0 moderate, pure gc ablation, WD alone |
 | zenitsu | #2911 | T_max=5+gc=1.0+WD=1e-2 (AirfRANS golden scheduler) |
 | edward | #2916 | lr=6e-4+gc=1.0+WD=1e-2+T_max=10 (intermediate LR) |
 | wolfwood | #2919 | T_max=40/50+gc=1.0+WD=1e-2 (longer cosine cycling) |

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,23 @@
 # SENPAI Research Results
 
+## 2026-04-21 19:30 — Wave 2 Review Round 3: 1 PR closed, 1 new assignment
+
+### PR Closed
+
+| PR | Student | Dataset | Best Val | Baseline | Reason |
+|---|---|---|---|---|---|
+| #2907 | wolfwood | Cross (DM/AF/TF) | DM=19.67% (best), AF=0.2654, TF=185.36 | DM=4.619%, AF=0.001236, TF=30.10 | Confounded: all runs used Lion (not AdamW) at default 3L/192d (not golden architectures). One signal: Lion+gc=1.0 at 3L/192d (19.67%) beats AdamW at same capacity (33.65%). |
+
+**Key insight:** Lion + lr=8e-4 + gc=1.0 is competitive with AdamW at equivalent architecture capacity (3L/192d). nami #2896 is testing Lion at 4L/512d.
+
+### New Assignment
+
+| PR | Student | Focus | Key Config |
+|---|---|---|---|
+| #2919 | wolfwood | DrivAerML longer cosine cycling | T_max=40/50 + gc=1.0 + WD=1e-2 (above-baseline T_max) |
+
+---
+
 ## 2026-04-21 19:00 — Wave 2 Review Round 2: 2 more PRs closed, 2 new assignments
 
 ### PRs Closed

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,39 @@
 # SENPAI Research Results
 
+## 2026-04-21 22:00 — BREAKTHROUGH: Corrected EMA warmup MERGED — TF -13.2%, AF -41.2%
+
+### PR #2899 (robin): Corrected EMA Warmup — MERGED, DUAL NEW BEST
+
+| Metric | EMA decay=0.999 | EMA decay=0.9999 | Previous Baseline | Delta (best) |
+|---|---|---|---|---|
+| TF val_primary/surface_pressure_mae | **26.134** (ep123) | 26.903 (ep113) | 30.10 | **-13.2%** |
+| AF val_primary/surface_mse | **0.000727** (ep206) | 0.001123 (ep275) | 0.001236 | **-41.2%** |
+| DM val_primary/surface_rel_l2_pct | 9.749% (ep60, diverged) | — | 4.619% | +111% (WORSE) |
+| W&B runs | nrn0q3ct (TF), i1sevgt2 (AF) | 3xi6cgx1 (TF), bz00wego (AF) | — | — |
+
+**Implementation:** EMAWithWarmup replaces bugged EMA. Formula: `actual_decay = min(target_decay, (1+step)/(10+step))`. Handles _orig_mod prefix (compile compat), store/copy_to/restore for val swap. Clean code.
+
+**Paper story implications:**
+- Corrected EMA is a SHARED RECIPE change — one code change benefits 2 of 3 datasets simultaneously
+- The new TF anchor is 26.134; the new AF anchor is 0.000727 (83.1% below external target 0.0043)
+- DrivAerML still needs --no-use-ema or EMA+gc compound testing (zenitsu #2925)
+
+### Other Reviews This Round
+
+| PR | Student | Action | Key Finding |
+|---|---|---|---|
+| #2911 | zenitsu | CLOSED | T_max=5 fatal for DM 4L/512d — all 3 runs crashed |
+| #2842 | tanjiro | SENT BACK | TF 30.23 at 3L/256d (near-miss). Try 3L/192d+lr=1e-4+gc=0.5 |
+
+### New Assignments
+
+| PR | Student | Focus |
+|---|---|---|
+| #2924 | robin | TF lr=1e-4+EMA, TF gc=0.5+EMA, AF T_max=10+EMA, AF seed=43 reproduce |
+| #2925 | zenitsu | DrivAerML EMA+gc=1.0, EMA+gc+WD, EMA decay=0.9999, control pure gc |
+
+---
+
 ## 2026-04-21 21:30 — Wave 2 Review Round 6: 640d unstable, AirfRANS near-beat
 
 ### PR Closed

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,28 @@
 # SENPAI Research Results
 
+## 2026-04-21 21:30 — Wave 2 Review Round 6: 640d unstable, AirfRANS near-beat
+
+### PR Closed
+
+| PR | Student | Dataset | Best Val | Baseline | Reason |
+|---|---|---|---|---|---|
+| #2917 | chrome | DrivAerML (primary) | 6.52% (ep125) | 4.619% | 4L/640d unstable: all 3 DM runs crashed (ep90-153). 512d→640d crosses stability boundary at lr=5e-4+gc=1.0. |
+
+**AirfRANS side result:** Run 4 (AF golden at seed=45) hit 0.001193 at ep237 — 3.5% below baseline 0.001236. But oscillating badly in late epochs (0.004-0.009). Not merged — fragile seed result, still running.
+
+**Key insights:**
+- **640d is unstable** at lr=5e-4+gc=1.0 on DrivAerML — WD=1e-2 delays crash by ~57 epochs but can't prevent it
+- **Width scaling above 512d needs lower LR or tighter gc** to stay stable
+- AirfRANS golden config seed variance reaches 0.001193 — near-beat but not robust
+
+### New Assignment
+
+| PR | Student | Focus | Key Config |
+|---|---|---|---|
+| #2923 | chrome | DrivAerML compile + gc=1.0 | torch.compile + gc=1.0 (throughput + stability), with and without WD |
+
+---
+
 ## 2026-04-21 20:30 — Wave 2 Review Round 5: compound crash, moderate WD next
 
 ### PR Closed

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,26 @@
 # SENPAI Research Results
 
+## 2026-04-21 20:10 — Wave 2 Review Round 4: MSAM dead end, gradient noise next
+
+### PR Closed
+
+| PR | Student | Dataset | Best Val | Baseline | Reason |
+|---|---|---|---|---|---|
+| #2904 | usopp | Cross (DM/AF/TF) | DM=29.84%, AF=0.0256, TF=110.25 | DM=4.619%, AF=0.001236, TF=30.10 | MSAM catastrophically worse everywhere (3.7-22.7x). Core premise false: actual cost was 2x compute (same as SAM). Lion momentum direction is anti-adversarial on TF. |
+
+**Key insights:**
+- MSAM is definitively dead for this codebase — do not retry
+- Lion optimizer's momentum buffer does NOT align with loss ascent direction (negative msam_loss_increase on TF)
+- The `_forward_and_loss()` code refactor was clean; could cherry-pick if needed
+
+### New Assignment
+
+| PR | Student | Focus | Key Config |
+|---|---|---|---|
+| #2920 | usopp | Gradient noise injection (code change) | Neelakantan 2015: eta=0.01/0.001/0.1, gamma=0.55, zero extra cost |
+
+---
+
 ## 2026-04-21 19:30 — Wave 2 Review Round 3: 1 PR closed, 1 new assignment
 
 ### PR Closed

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,43 @@
 # SENPAI Research Results
 
+## 2026-04-21 18:00 — Wave 2 Review Round: 5 PRs disposed, 8 new assignments
+
+### PRs Closed (Dead Ends)
+
+| PR | Student | Dataset | Best Val | Baseline | Reason |
+|---|---|---|---|---|---|
+| #2834 | askeladd | Cross (AF/DM/TF) | TF=33.51, AF/DM diverged | TF=30.10 | No-Lookahead ablation CONFIRMED: Lookahead is essential — catastrophic divergence on AF/DM without it |
+| #2825 | levi | Cross (TF/DM) | TF=30.99, DM=6.53% | TF=30.10, DM=4.619% | 3L/192d architecture too shallow — both datasets regressed |
+| #2801 | edward | AirfRANS (3L/256d) | 0.003261 | 0.001236 | Pressure-weighted loss (20x) at wrong architecture (3L/256d wrong depth vs golden 2L/256d) |
+
+### PRs Sent Back (Promising, Needs Stabilization)
+
+| PR | Student | Dataset | Best Val | Guidance |
+|---|---|---|---|---|
+| #2823 | kakashi | AirfRANS | 0.001095 (original), 0.001881 (rebase) | Instability between runs. Sent back to test lr=5e-4 stabilization + reproduce original result |
+| #2786 | thorfinn | AirfRANS | 0.001330 (gc=1.0+T_max=7) | Still converging at timeout. Sent back with extended budget + lr=5e-4 stability variant |
+
+**Key findings from Round:**
+- Lookahead removal is definitively fatal (askeladd #2834): not worth retesting
+- 3L/192d is too small for either TF or DM at current scale — confirmed dead end
+- kakashi's original 0.001095 on AirfRANS (if reproducible) would be ~11% below baseline 0.001236
+- thorfinn's 0.001330 with T_max=7 suggests mid-range scheduler values still have headroom
+
+### New Assignments (Wave 2, 8 students)
+
+| PR | Student | Focus | Key Config |
+|---|---|---|---|
+| #2909 | shouko | DrivAerML heads ablation | 16 heads vs 4 heads + gc=1.0 at 4L/512d |
+| #2910 | eren | DrivAerML data throughput | max-train-batches=788/600 + gc=1.0 |
+| #2911 | zenitsu | DrivAerML T_max=5 transfer | AirfRANS golden scheduler on DrivAerML |
+| #2912 | shinobu | DrivAerML heavy WD | WD=3e-2/5e-2 + gc=1.0 |
+| #2913 | rei | DrivAerML resolution | surface-points=75k train+eval + gc=1.0 |
+| #2914 | askeladd | DrivAerML MLP ratio | mlp-ratio=6/2 + gc=1.0 + WD=1e-2 |
+| #2915 | levi | DrivAerML Fourier ablation | no-Fourier + gc=1.0 (faster epochs) |
+| #2916 | edward | DrivAerML compound sweep | lr=6e-4 + gc=1.0 + WD=1e-2 + T_max=10 |
+
+---
+
 ## 2026-04-21 ~15:45 — Round 37 (continued): TandemFoil BREAKTHROUGH + Massive Review Wave
 
 ### PR #2810 (gilbert): TandemFoil lr=1.25e-4 + gc=1.0 — MERGED, NEW BEST

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,28 @@
 # SENPAI Research Results
 
+## 2026-04-21 19:00 — Wave 2 Review Round 2: 2 more PRs closed, 2 new assignments
+
+### PRs Closed
+
+| PR | Student | Dataset | Best Val | Baseline | Reason |
+|---|---|---|---|---|---|
+| #2900 | sanji | DrivAerML | 11.065% (ep49) | 4.619% | Surface-only flag was already default (hypothesis untested). GA hurt due to T_max not scaled. 6 concurrent runs on 1 node = 45x slowdown. Student's follow-up insights were good. |
+| #2873 | chrome | DrivAerML | 5.240% (ep229) | 4.619% | LR headroom above 5e-4 definitively falsified: 6e-4=5.24%, 5.5e-4=5.39%, 4.5e-4=DIVERGED. LR optimum firmly at 5e-4 with gc=1.0 |
+
+**Key insights:**
+- DrivAerML LR is locked at 5e-4 — any deviation (even ±10%) degrades results
+- surface_only_drivaerml=True is already the default — future tests of volume inclusion need explicit `--no-surface-only-drivaerml`
+- GA requires T_max scaling (T_max/GA_factor) to equalize cosine cycles
+
+### New Assignments
+
+| PR | Student | Focus | Key Config |
+|---|---|---|---|
+| #2917 | chrome | DrivAerML 4L/640d mid-width | 640d/10 heads + gc=1.0 (between 512d and 768d) |
+| #2918 | sanji | DrivAerML gc=0.5 + WD=1e-2 | Softer clip from AirfRANS 4L recipe + regularization |
+
+---
+
 ## 2026-04-21 18:00 — Wave 2 Review Round: 5 PRs disposed, 8 new assignments
 
 ### PRs Closed (Dead Ends)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,27 @@
 # SENPAI Research Results
 
+## 2026-04-21 20:30 — Wave 2 Review Round 5: compound crash, moderate WD next
+
+### PR Closed
+
+| PR | Student | Dataset | Best Val | Baseline | Reason |
+|---|---|---|---|---|---|
+| #2908 | yuji | Cross (DM/AF/TF) | DM=6.19%, AF=0.001421, TF=36.33 | DM=4.619%, AF=0.001236, TF=30.10 | gc=1.0+WD=1e-2+cosine compound crashes: 6/8 runs exploded via gradient cascades at cosine LR peaks. Compound components interact destructively. |
+
+**Key insights:**
+- gc=1.0+WD=1e-2+aggressive cosine is UNSTABLE on DrivAerML — LR peaks cause gradient explosions
+- AF T_max=10 got 0.001421 before crashing — tantalizingly close to 0.001236 baseline
+- DM T_max=15 survived longest (6.19% at ep206) but still 34% worse and regressing
+- WD=1e-2 from AirfRANS may be too aggressive for DM's larger 4L/512d model
+
+### New Assignment
+
+| PR | Student | Focus | Key Config |
+|---|---|---|---|
+| #2922 | yuji | DrivAerML moderate WD + pure gc ablation | WD=5e-3+gc=1.0, WD=5e-3 alone, gc=1.0 alone, all at T_max=30 |
+
+---
+
 ## 2026-04-21 20:10 — Wave 2 Review Round 4: MSAM dead end, gradient noise next
 
 ### PR Closed

--- a/research/RESEARCH_IDEAS_2026-04-21_22:30.md
+++ b/research/RESEARCH_IDEAS_2026-04-21_22:30.md
@@ -1,0 +1,557 @@
+<!--
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: senpai
+-->
+
+# Research Ideas — 2026-04-21 22:30
+
+Generated after reviewing 507 experiment PRs (68 merged, 285 ran, 168 never ran)
+and a targeted literature search on ML for CFD surrogates, 2024–2026.
+
+## Context and Search Space Summary
+
+### What Has Been Exhaustively Saturated
+
+The following search spaces have been thoroughly explored and should not be
+revisited without a compelling new rationale:
+
+- **Learning rate:** 1e-4 to 1e-3, all standard values
+- **T_max (cosine annealing period):** 5 to 1000 epochs
+- **Architecture depth/width:** 2L–5L, 192d–768d; 4L/640d+ crashes on DrivAerML
+- **Gradient clipping:** 0.5–2.0
+- **Weight decay:** 1e-4–5e-2; weight_decay=0 tried on DrivAerML (#2630)
+- **Surface point count:** 25k–200k for DrivAerML (#2566 tried 100k)
+- **Optimizer family:** AdamW, Lion, MSAM (3.7–22.7x worse), SGD with momentum
+- **Physics features on DrivAerML:** TE coord frame, Cp panel, asinh pressure,
+  residual prediction — all tried on DrivAerML (#2522), showed no gain
+- **Attention variants:** Multi-query attention (#2560), surface cross-attention
+  (#2559), Kutta condition constraint (#2562)
+- **Regularization:** Dropout (already tried on multiple benchmarks), no-EMA
+  versus EMA tuning
+
+### What Is Currently In-Flight (Do Not Duplicate)
+
+- SWA (stochastic weight averaging)
+- Gradient accumulation
+- Huber loss
+- LLRD (layer-wise learning rate decay)
+- Gradient noise injection
+- OneCycleLR
+- Cosine warm restarts
+- LR warmup + cosine
+- torch.compile
+- Dropout=0.1
+- Pressure-weighted loss
+
+### Key Findings From Literature
+
+- **AB-UPT (TMLR 2025):** Standard self-attention outperforms linear Transolver
+  on automotive CFD; their DrivAerML result is 3.71% surface rel-L2, which is
+  our target
+- **MoE-POT (NeurIPS 2025):** Mixture-of-experts operator transformer yields
+  40% error reduction on PDE benchmarks; MoE FFN layers are a drop-in
+- **GeoTransolver (arxiv 2512.20399):** GALE attention — cross-attention to
+  explicit geometry points plus a global context token — beats Transolver on
+  CFD benchmarks
+- **SDF + derivative constraints (arxiv 2503.17289):** Signed distance field
+  as geometry embedding + continuity loss boosts aerodynamic predictions
+- **Prodigy optimizer (ICML 2024):** Parameter-free learning rate adaptation,
+  matches or beats hand-tuned Adam/AdamW without any LR search
+- **SMART (arxiv 2601.18707):** Mesh-free point-cloud transformer using
+  relative L2 as training loss, demonstrating strong DrivAerML results
+- **SwiGLU (Noam Shazeer, 2020; adopted by LLaMA-2, Mistral, PaLM-2):**
+  Gated linear units universally improve transformer FFN training dynamics with
+  zero architectural overhead
+
+---
+
+## Hypotheses Ranked by Expected Value (Impact × Probability)
+
+### Rank 1 — Relative L2 Training Loss
+
+**One-line summary:** Replace MAE/MSE training loss with the relative L2 norm
+`||y_pred - y_true||_2 / (||y_true||_2 + eps)` to directly align training
+with the DrivAerML evaluation metric.
+
+**Scientific rationale:** DrivAerML's primary metric is `surface_rel_l2_pct`,
+but the model currently trains on absolute MAE or MSE. This is a known
+objective mismatch — training on MAE penalizes absolute error uniformly,
+which over-weights low-magnitude regions (wake, far-field) and under-weights
+the high-pressure stagnation zones and suction peaks that drive the relative
+metric. A model trained with relative L2 will naturally allocate capacity
+toward regions with large signal-to-noise ratio in the normalized target,
+which is exactly what the benchmark measures. This is the most direct fix for
+the metric-training alignment gap and requires no architectural change. SMART
+(2601.18707) explicitly uses this loss for point-cloud CFD and reports strong
+results on DrivAerML-class benchmarks.
+
+**Code changes needed:**
+- In `train.py` or `core/`, add a new loss option e.g. `--loss rel_l2` or
+  `--loss_type rel_l2`
+- Loss implementation:
+  ```python
+  def relative_l2_loss(pred, target, eps=1e-8):
+      return (pred - target).norm(dim=-1) / (target.norm(dim=-1) + eps)
+  ```
+  Average over batch. Can also compute per-field (pressure, velocity
+  separately) and sum, or use a single global norm across all output
+  channels.
+- DrivAerML-only initially; AirfRANS can keep MSE as it's already well below
+  target.
+
+**Specific hyperparameters:**
+- eps=1e-8 (standard; ablate 1e-6 if training is unstable)
+- Compare three variants: (a) global relative L2, (b) per-point relative L2
+  (normalize each node independently), (c) mixed: 0.5 * MSE + 0.5 * rel_L2
+- Keep all other hyperparameters at DrivAerML defaults (AdamW, lr=5e-4,
+  T_max=20, gc=1.0, wd=1e-2, no EMA)
+
+**GPU allocation:**
+- DrivAerML: 4 GPUs (primary target, run variants a/b/c in parallel)
+- TandemFoil: 2 GPUs (test if relative L2 also helps TF surface pressure MAE)
+- AirfRANS: 0 GPUs (already solved; skip)
+- DrivAerML ablation (per-field vs. global): remaining 2 GPUs
+
+**Risk:** LOW. Pure loss change, no architecture modification. Worst case it
+matches baseline. Most likely direction of improvement given metric alignment.
+
+---
+
+### Rank 2 — SwiGLU FFN Replacement
+
+**One-line summary:** Replace the standard ReLU/GELU feed-forward network in
+every Transolver layer with a SwiGLU gated linear unit.
+
+**Scientific rationale:** SwiGLU (Shazeer 2020) is now the default FFN in
+LLaMA-2, Mistral, PaLM-2, and most frontier LLMs — it consistently
+outperforms GELU with no increase in parameter count if the hidden dimension
+is scaled by 2/3 to compensate for the extra gate projection. The mechanism
+is a multiplicative gating: `FFN(x) = (xW_1) * sigmoid(xW_3) * W_2` which
+produces smoother gradient flow and is empirically more data-efficient. In
+scientific ML, SwiGLU has been adopted in protein structure prediction (ESMFold
+derivative work) and weather forecasting transformers. The Transolver FFN is
+currently a bottleneck that SwiGLU can improve without touching the physics-
+encoding slice attention mechanism. This is likely beneficial across all four
+benchmarks.
+
+**Code changes needed:**
+- In `core/model/` (or wherever the Transolver FFN is defined), add a
+  `SwiGLUBlock` class:
+  ```python
+  class SwiGLUFFN(nn.Module):
+      def __init__(self, dim, hidden_dim=None):
+          super().__init__()
+          hidden_dim = hidden_dim or int(dim * 4 * 2/3)
+          self.w1 = nn.Linear(dim, hidden_dim, bias=False)
+          self.w2 = nn.Linear(hidden_dim, dim, bias=False)
+          self.w3 = nn.Linear(dim, hidden_dim, bias=False)
+      def forward(self, x):
+          return self.w2(F.silu(self.w1(x)) * self.w3(x))
+  ```
+- Add `--ffn_type swiglu` flag to `train.py`; default remains `gelu` for
+  backward compatibility
+- Note: with 2/3 hidden scaling, parameter count stays close to original;
+  alternatively use same hidden_dim as GELU FFN and accept slight parameter
+  increase (~0.3M for 3L/384d)
+
+**Specific hyperparameters:**
+- hidden_dim = 4 * dim * 2/3 (standard SwiGLU recipe)
+- No other changes needed; use standard recipe for each benchmark
+- If instability is seen in early training, add 1e-5 weight decay on gate
+  projections (w1, w3) separately
+
+**GPU allocation:**
+- DrivAerML: 3 GPUs
+- TandemFoil: 3 GPUs
+- AirfRANS: 1 GPU (low priority — already solved)
+- TandemFoil Paper: 1 GPU
+
+**Risk:** LOW. Drop-in replacement with strong empirical backing across many
+domains. Worst case: negligible change. The mechanism is well-understood.
+
+---
+
+### Rank 3 — Surface Normals and Principal Curvature as Input Features
+
+**One-line summary:** Augment DrivAerML point features with precomputed surface
+normal vectors and two principal curvature values at each surface node.
+
+**Scientific rationale:** The largest prediction errors on DrivAerML surface
+pressure are consistently found at high-curvature geometric regions — the
+A-pillar, wheel arch leading edges, and roof-windshield junction. These are
+exactly the regions where pressure gradients are largest and where the model
+has the least geometric context from raw XYZ coordinates alone. Surface
+normals provide the local surface orientation (essential for pressure recovery:
+`Cp ~ f(n · v_inf)` at first order), while principal curvatures encode the
+rate of geometric change — a feature the Transolver's point attention has no
+other way to infer. This is not the same as the TF-specific TE coordinate
+frame (#2522): curvature is a local differential geometry quantity computable
+from the mesh at preprocessing time, not a flow-physics heuristic. Literature
+in shape analysis and mesh processing consistently shows that normal + curvature
+features reduce surface reconstruction error on high-curvature regions.
+
+**Code changes needed:**
+- Precompute normals and principal curvatures from the DrivAerML mesh during
+  dataset loading. Libraries: `open3d` (fast) or `trimesh` (already likely
+  available). For a triangle mesh, per-vertex normals are trivial; principal
+  curvatures require fitting a local quadric (see `trimesh.curvature`).
+- Add the 5 new features per surface node: `[nx, ny, nz, k1, k2]` (or 4 if
+  using mean and Gaussian curvature: `[nx, ny, nz, H, K]`)
+- In `train.py` or the DrivAerML data pipeline, add `--drivaerml_surface_curvature`
+  flag that activates the augmented feature set
+- Optionally normalize curvature values (they span large ranges): apply
+  `arcsinh(k)` scaling analogous to the TF asinh pressure transform
+
+**Specific hyperparameters:**
+- Curvature normalization: arcsinh scaling with scale=1.0 (ablate 0.1, 10.0)
+- Normal vectors: already unit-normalized, no scaling needed
+- Keep all other DrivAerML defaults unchanged
+- Run with 3L/384d architecture (the current best stable DrivAerML config)
+
+**GPU allocation:**
+- DrivAerML: 4 GPUs (main target)
+- TandemFoil: 2 GPUs (test curvature on airfoil surfaces — trailing edge
+  curvature is physically meaningful)
+- AirfRANS: 2 GPUs (2D surface curvature = 1D scalar; easy to add)
+
+**Risk:** MEDIUM. Preprocessing code needs to be written and validated. If
+curvature estimates are noisy (common with non-uniform triangle meshes), the
+features could add noise rather than signal. Validate by checking curvature
+values at known high-curvature regions before training.
+
+---
+
+### Rank 4 — Prodigy / D-Adaptation Optimizer
+
+**One-line summary:** Replace AdamW with Prodigy — a parameter-free optimizer
+that adapts its own learning rate, eliminating the LR search that has been
+exhausted for DrivAerML.
+
+**Scientific rationale:** The DrivAerML LR sweep has been run extensively
+(1e-4 to 1e-3) and shows a frustratingly flat landscape — no single LR value
+has broken through. Prodigy (Mishchenko and Defazio, ICML 2024) learns the
+effective step size online using a D-Adaptation rule, converging to near-
+optimal LR without any grid search. The key advantage here is that Prodigy
+does not assume a fixed LR but instead maintains a per-parameter effective
+learning rate that adapts to the local loss landscape curvature. On the
+DrivAerML objective — which may have extremely ill-conditioned geometry due
+to the 3D surface topology — this adaptive scaling could find a better descent
+direction than any fixed LR schedule. Prodigy has been validated across vision
+transformers, LLMs, and diffusion models at ICML 2024; it consistently matches
+or beats hand-tuned Adam within the same epoch budget.
+
+**Code changes needed:**
+- `pip install prodigyopt` (lightweight, no non-standard dependencies)
+- Add `--optimizer prodigy` branch in the optimizer factory in `train.py`
+- Prodigy usage:
+  ```python
+  from prodigyopt import Prodigy
+  optimizer = Prodigy(
+      model.parameters(),
+      lr=1.0,  # Prodigy ignores this; set to 1.0 by convention
+      weight_decay=1e-2,
+      safeguard_warmup=True,  # critical: prevents early divergence
+      use_bias_correction=True,
+  )
+  ```
+- Keep EMA and gradient clipping at DrivAerML defaults; they are orthogonal
+
+**Specific hyperparameters:**
+- `lr=1.0` (conventional placeholder)
+- `weight_decay=1e-2` (keep matching AdamW baseline)
+- `safeguard_warmup=True` (required for stable early training)
+- `use_bias_correction=True`
+- `d_coef=1.0` (default; ablate 0.1 if Prodigy diverges)
+- Run for the same epoch budget as baseline
+
+**GPU allocation:**
+- DrivAerML: 3 GPUs (primary; this is a pure optimizer swap)
+- TandemFoil: 3 GPUs (also worth testing given TF's LR sensitivity)
+- AirfRANS: 1 GPU
+- TandemFoil Paper: 1 GPU
+
+**Risk:** LOW-MEDIUM. Prodigy is well-validated. The main risk is that
+`safeguard_warmup` may interact poorly with the cosine schedule — monitor
+the effective LR reported by Prodigy and check it is not too large in the
+first 10 epochs.
+
+---
+
+### Rank 5 — Global Context Token (GeoTransolver-style)
+
+**One-line summary:** Inject a single learned global-geometry summary token
+into the Transolver's slice attention mechanism, giving every slice cross-
+attention access to a compact global descriptor.
+
+**Scientific rationale:** The Transolver processes points in slices — groups
+of physically similar points attend to each other. This is effective for local
+physics but has a fundamental limitation: there is no mechanism for global
+information flow across slices without deep layer stacking. In automotive CFD,
+global flow features (vehicle frontal area, blockage ratio, overall drag
+classification) modulate local pressure everywhere. GeoTransolver (arxiv
+2512.20399) addresses this with GALE attention: a learnable global-context
+token is updated via cross-attention to geometry points, then injected into
+each slice's attention as an additional key-value pair. The result is that
+every point in every slice can attend to the global geometry summary, breaking
+the locality constraint. This is architecturally motivated by the known
+limitation of pure slice-local attention for 3D automotive bodies where far-
+field and near-field pressures are correlated. The AB-UPT paper's superior
+performance on DrivAerML (they report 3.71%) may partly be attributed to their
+standard global self-attention rather than the slice-local Transolver design.
+
+**Code changes needed:**
+- Add a `GlobalContextToken` module to the Transolver encoder
+- At each attention layer, update the global token via cross-attention to
+  the current slice embeddings, then concatenate the global token as an
+  additional key-value pair in slice self-attention
+- Minimal version: a single trainable `nn.Parameter` of shape `[1, 1, dim]`
+  that is updated via a lightweight cross-attention head before each slice
+  attention layer
+- Add `--global_context_token` flag to `train.py`
+
+**Specific hyperparameters:**
+- Global token dimension: same as model dim (dim=384 for 3L/384d)
+- Cross-attention heads for global update: 4 (or half of main attention heads)
+- Learnable token initialization: zeros or small random normal (N(0, 0.02))
+- No change to LR, optimizer, or regularization
+
+**GPU allocation:**
+- DrivAerML: 4 GPUs (primary motivation)
+- TandemFoil: 3 GPUs (tandem foil interaction is also a global effect)
+- AirfRANS: 1 GPU
+
+**Risk:** MEDIUM. Requires non-trivial attention module modification. The key
+implementation risk is that the global token adds to VRAM at every layer —
+verify no OOM on DrivAerML before scaling. The mechanism is well-motivated
+and directly addresses a known architectural gap.
+
+---
+
+### Rank 6 — Mass Conservation Auxiliary Loss (DrivAerML Volume)
+
+**One-line summary:** Add a soft continuity-equation penalty to the DrivAerML
+volume prediction — penalize the divergence of the predicted velocity field
+at training time.
+
+**Scientific rationale:** Incompressible flow satisfies div(u) = 0 everywhere.
+The DrivAerML volume prediction (u, v, w, p) is currently supervised only with
+a data-fit loss — the model has no explicit incentive to produce a physically
+consistent velocity field. Adding a continuity penalty `lambda * ||div(u_pred)||^2`
+forces the model to learn divergence-free velocity fields, which is a strong
+physical prior that reduces the solution space. The arxiv 2503.17289 paper
+(DeepONet + SDF + continuity loss) demonstrates that even a soft continuity
+penalty (lambda=0.01) measurably improves accuracy on aerodynamic volume fields
+without requiring an exact solve. On DrivAerML, the surface pressure is
+ultimately a function of the volume flow field, so volume fidelity improvements
+cascade to the surface metric.
+
+**Code changes needed:**
+- During training, compute finite-difference or learned-divergence estimate of
+  the predicted velocity field. Simplest: for each batch of volume points,
+  use the predicted (u, v, w) and their approximate spatial Jacobian.
+  Since points are scattered (not on a grid), use a local polynomial fit or
+  a KNN-based finite difference approximation.
+- Alternatively, use automatic differentiation if the model can compute
+  `d(u_pred)/dx` via `torch.autograd.grad` — this is exact but adds backward
+  pass overhead.
+- Loss: `total_loss = data_loss + lambda_div * mean(div_u_pred^2)`
+- Add `--div_loss_weight` flag (default 0.0 for backward compat)
+
+**Specific hyperparameters:**
+- lambda_div: 0.01 (start small; ablate 0.001, 0.1)
+- Divergence estimation: KNN with k=8 neighbors for finite difference
+- Only apply to volume predictions (not surface); surface pressure is a
+  boundary condition not directly constrained by continuity
+
+**GPU allocation:**
+- DrivAerML: 4 GPUs (volume prediction target)
+- TandemFoil Paper: 2 GPUs (TF also has velocity field predictions)
+- AirfRANS: 2 GPUs (2D: div(u,v)=0 is exact for incompressible 2D flow)
+
+**Risk:** MEDIUM-HIGH. The scattered-point divergence estimation is
+non-trivial — finite differences on unstructured point clouds can be noisy.
+Recommend starting with autograd if the backward pass overhead is acceptable
+(typically 20-30% extra compute). If too expensive, use the soft KNN version.
+This is a more complex change than the other ideas here and should be staffed
+to a strong student.
+
+---
+
+### Rank 7 — Stochastic Depth (DropPath) Regularization
+
+**One-line summary:** Apply layer-level stochastic depth (DropPath) with
+probability 0.1–0.2 across all Transolver blocks instead of node-level dropout.
+
+**Scientific rationale:** Standard dropout randomly zeros individual activations,
+which is known to interact poorly with LayerNorm and attention mechanisms in
+transformers (the normalized residual stream is corrupted in a way that hurts
+training). Stochastic depth (Huang et al., 2016; adopted widely in ViT, DeiT,
+Swin) instead drops entire residual blocks with probability p_drop, effectively
+training an ensemble of different-depth networks and providing strong implicit
+regularization. For DrivAerML, where the model has shown flat improvement
+despite extensive hyperparameter tuning, stochastic depth is a form of
+regularization that operates at a different level of abstraction than weight
+decay or dropout — it regularizes the function class rather than individual
+weights. This has not been tried on any benchmark in our experiment history.
+The `timm` library has a battle-tested DropPath implementation.
+
+**Code changes needed:**
+- Import `timm.models.layers.DropPath` or implement the trivial version:
+  ```python
+  class DropPath(nn.Module):
+      def __init__(self, drop_prob=0.0):
+          super().__init__()
+          self.drop_prob = drop_prob
+      def forward(self, x):
+          if not self.training or self.drop_prob == 0.0:
+              return x
+          keep = torch.rand(x.shape[0], 1, 1, device=x.device) > self.drop_prob
+          return x / (1 - self.drop_prob) * keep
+  ```
+- Wrap each Transolver block's residual output with DropPath
+- Use linear stochastic depth schedule: block i gets
+  `p_i = p_max * i / (num_blocks - 1)` (earlier blocks survive more often)
+- Add `--drop_path_rate` flag (default 0.0)
+
+**Specific hyperparameters:**
+- drop_path_rate: 0.1 (start), 0.2 (higher regularization if 0.1 insufficient)
+- Linear depth schedule across blocks (standard practice)
+- No other changes needed
+
+**GPU allocation:**
+- DrivAerML: 3 GPUs (0.1 and 0.2 rates + one reference)
+- TandemFoil: 3 GPUs
+- AirfRANS: 1 GPU
+- TandemFoil Paper: 1 GPU
+
+**Risk:** LOW. Minimal code change, well-understood mechanism, no interaction
+with existing architecture. Worst case: slight training slowdown with no
+metric change. This is the lowest-risk "big-regularization" idea available.
+
+---
+
+### Rank 8 — Mixture-of-Experts FFN Layers (MoE-POT style)
+
+**One-line summary:** Replace the dense FFN in the final 1-2 Transolver layers
+with a sparse MoE FFN — multiple expert networks with a learned gating function
+that routes each token to its top-2 experts.
+
+**Scientific rationale:** MoE-POT (NeurIPS 2025, arxiv 2510.25803) demonstrated
+40% error reduction on PDE surrogate benchmarks by replacing dense FFN layers
+with sparse MoE. The intuition is that different experts specialize in different
+physical regimes: one expert handles high-pressure stagnation regions, another
+handles attached boundary layer flow, another handles separated wake. This
+specialization is emergent and not manually programmed. For DrivAerML, where
+the 3D surface spans dramatically different physics (stagnation zone, attached
+flow, separated wake, underbody tunnel), MoE routing could capture
+cross-regime variation that a single dense FFN cannot. The key implementation
+detail from MoE-POT is that MoE is applied only to the later layers (where
+features are already physics-informed) — applying it to early layers (where
+geometric encoding is still forming) tends to destabilize routing.
+
+**Code changes needed:**
+- Implement a `SparseMoEFFN` class with:
+  - `n_experts=8` expert networks (each a standard FFN)
+  - Top-2 routing via a learned `nn.Linear(dim, n_experts)` gate
+  - Auxiliary load-balancing loss (standard: `lambda_lb * sum(f_i * p_i)`)
+- Replace the FFN in the last 1-2 Transolver blocks with SparseMoEFFN
+- Add `--moe_layers 0` (default 0 = no MoE, 1 = last layer, 2 = last 2 layers)
+- Add `--moe_n_experts 8` and `--moe_load_balance_weight 0.01`
+
+**Specific hyperparameters:**
+- n_experts: 8 (MoE-POT default; ablate 4 and 16)
+- top-k: 2 (standard; higher k reduces sparsity benefit)
+- load_balance_weight: 0.01
+- Apply to last 1 layer first; escalate to 2 if improvement is seen
+- Keep all other hyperparameters at DrivAerML defaults
+
+**GPU allocation:**
+- DrivAerML: 4 GPUs (primary target; high VRAM headroom at 3L/384d)
+- TandemFoil: 2 GPUs
+- AirfRANS: 2 GPUs
+
+**Risk:** MEDIUM-HIGH. MoE implementation is more complex than other ideas
+here. The load-balancing loss weight is a sensitive hyperparameter — too low
+causes expert collapse, too high dominates the primary loss. Monitor expert
+utilization during training (fraction of tokens routed to each expert should
+be roughly uniform). Recommend staffing to a student with strong PyTorch
+skills.
+
+---
+
+### Rank 9 — SDF Wall-Distance Feature (3D Geometry Embedding)
+
+**One-line summary:** Add the signed distance from the vehicle surface (SDF)
+as a precomputed scalar feature at every volume and surface point in DrivAerML.
+
+**Scientific rationale:** Wall distance is the single most physically meaningful
+geometric input for RANS-based flow solvers — the turbulence model (k-omega,
+k-epsilon) explicitly depends on it. The DrivAerML volume points currently
+only have raw XYZ coordinates; the model must implicitly learn wall proximity
+from the distribution of neighboring points. Adding a precomputed SDF gives
+the model direct access to this physical prior, which is known to govern
+boundary layer development, turbulent viscosity, and near-wall pressure
+recovery. The arxiv 2503.17289 paper (DeepONet + SDF) shows that even a
+simple global SDF feature improves aerodynamic predictions by ~15% on their
+benchmark. For DrivAerML specifically, the underbody tunnel and wheel arch
+are regions where wall proximity effects are strong and errors are high.
+
+**Code changes needed:**
+- Precompute SDF at every volume and surface point using the vehicle mesh.
+  Libraries: `igl` (libigl Python bindings) for exact mesh SDF, or
+  `pysdf` for fast approximate SDF computation.
+  ```python
+  from pysdf import SDF
+  sdf_fn = SDF(mesh.vertices, mesh.faces)
+  wall_dist = sdf_fn(points)  # shape [N]
+  ```
+- Append `arcsinh(wall_dist / scale)` as a feature (scale=0.01 for car-scale
+  geometry in meters)
+- Add `--drivaerml_sdf_feature` flag; precompute and cache as `.npy` file
+  alongside the dataset
+
+**Specific hyperparameters:**
+- SDF scale: 0.01 m (car-scale; ablate 0.001 and 0.1)
+- arcsinh transformation (prevents large values from dominating)
+- Cache precomputed SDF to avoid per-epoch overhead
+
+**GPU allocation:**
+- DrivAerML: 4 GPUs (volume and surface variants)
+- TandemFoil: 2 GPUs (SDF to airfoil chord is physically meaningful)
+- AirfRANS: 2 GPUs (2D: exact SDF to airfoil contour is trivial)
+
+**Risk:** MEDIUM. The preprocessing step requires a mesh-based SDF library
+and will add to dataset preparation time. The feature itself is low-risk —
+a monotone scalar that is easy to validate visually. The main technical risk
+is correctness of the SDF sign convention (inside/outside the vehicle body).
+
+---
+
+## Assignment Recommendation
+
+Given 9 idle students and these 9 hypotheses, suggested initial assignment:
+
+| Rank | Hypothesis | Primary Benchmark | Risk |
+|------|-----------|------------------|------|
+| 1 | Relative L2 Training Loss | DrivAerML | LOW |
+| 2 | SwiGLU FFN Replacement | DrivAerML + TandemFoil | LOW |
+| 3 | Surface Normals + Curvature | DrivAerML | MEDIUM |
+| 4 | Prodigy Optimizer | DrivAerML + TandemFoil | LOW-MED |
+| 5 | Global Context Token | DrivAerML + TandemFoil | MEDIUM |
+| 6 | Mass Conservation Loss | DrivAerML volume | MED-HIGH |
+| 7 | Stochastic Depth | DrivAerML + TandemFoil | LOW |
+| 8 | MoE FFN Layers | DrivAerML | MED-HIGH |
+| 9 | SDF Wall-Distance Feature | DrivAerML | MEDIUM |
+
+All 9 ideas have been verified as not currently in-flight and not previously
+run in the 507-PR experiment history. Ideas 1, 2, 4, and 7 can be coded
+and launched by a typical student in under an hour. Ideas 3, 5, 6, 8, 9
+require more careful implementation but are all motivated by specific gaps in
+the current model identified through both experiment history analysis and
+targeted literature review.
+
+The highest-probability quick win for the DrivAerML gap (4.619% → 3.71%) is
+**Rank 1 (Relative L2 Loss)** — it requires fewer than 20 lines of code and
+directly addresses the metric-training misalignment that is the most obvious
+remaining structural flaw in the current approach.

--- a/target/icml2026/core/datasets.py
+++ b/target/icml2026/core/datasets.py
@@ -25,11 +25,15 @@ from core.contracts import (
 from core.features import augment_case_sample, stable_hash32
 from drivaerml.data import prepare_drivaerml
 from tandemfoil.data import prepare_multi
+from tandemfoil_paper.data import prepare_multi as paper_prepare_multi
+from tandemfoil_paper.data import split_paper_experiment4
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_TANDEM_MANIFEST = ROOT_DIR / "tandemfoil/data/split_manifest_tandemfoilset_v2.json"
 DEFAULT_TANDEM_STATS = ROOT_DIR / "tandemfoil/data/split_stats.json"
+DEFAULT_TANDEM_PAPER_MANIFEST = ROOT_DIR / "tandemfoil_paper/data/split_manifest_tandemfoil_paper_experiment4.json"
+DEFAULT_TANDEM_PAPER_STATS = ROOT_DIR / "tandemfoil_paper/data/split_stats_tandemfoil_paper_experiment4.json"
 DEFAULT_AIRFRANS_MANIFEST = ROOT_DIR / "airfrans/data/split_manifest_airfrans.json"
 DEFAULT_DRIVAERML_MANIFEST = ROOT_DIR / "drivaerml/data/split_manifest_drivaerml.json"
 RUNTIME_CACHE_CASES = 16
@@ -95,6 +99,62 @@ class TandemFoilCaseDataset(Dataset):
             metadata={"base_idx": base_idx},
         )
         return sample
+
+
+class PaperTandemFoilCaseDataset(Dataset):
+    def __init__(
+        self,
+        split_indices: list[int],
+        pickle_files: list[str],
+        *,
+        root_candidates: list[str] | None = None,
+        debug: bool = False,
+        task_name: str,
+        enable_fourier: bool = False,
+        enable_wake_deficit: bool = False,
+        enable_wake_angle: bool = False,
+    ):
+        task_spec = split_paper_experiment4.TASK_SPECS[task_name]
+        candidates = list(root_candidates or split_paper_experiment4.DEFAULT_ROOT_CANDIDATES)
+        self.pickle_paths = split_paper_experiment4._resolve_task_pickle_paths(task_spec, candidates)
+        cache_size = -1 if debug else RUNTIME_CACHE_CASES
+        self.base = paper_prepare_multi.MultiFieldDataset(self.pickle_paths, cache_size=cache_size)
+        self.indices = list(split_indices)
+        self.task_name = task_name
+        self.augment = dict(
+            enable_fourier=enable_fourier,
+            enable_cp_panel=False,
+            enable_wake_deficit=enable_wake_deficit,
+            enable_wake_angle=enable_wake_angle,
+        )
+        expected_files = [path.name for path in self.pickle_paths]
+        if list(pickle_files) != expected_files:
+            raise ValueError(
+                f"Manifest pickle files for {task_name} do not match resolved files: "
+                f"{pickle_files} vs {expected_files}"
+            )
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+    def __getitem__(self, idx: int) -> CaseSample:
+        base_idx = self.indices[idx]
+        x, y, is_surface = self.base[base_idx]
+        surface_x = x[is_surface]
+        volume_x = x[~is_surface]
+        surface_y = y[is_surface]
+        volume_y = y[~is_surface]
+        sample = CaseSample(
+            case_id=f"{self.task_name}_{base_idx}",
+            dataset_name="tandemfoilset_paper",
+            space_dim=2,
+            surface_x=surface_x,
+            surface_y=surface_y,
+            volume_x=volume_x,
+            volume_y=volume_y,
+            metadata={"base_idx": base_idx, "task": self.task_name},
+        )
+        return augment_case_sample(sample, **self.augment)
 
 
 class AirfRANSCaseDataset(Dataset):
@@ -566,6 +626,94 @@ def build_airfrans_bundle(
     )
 
 
+def build_tandem_paper_bundle(
+    *,
+    task: str,
+    manifest_path: str | Path = DEFAULT_TANDEM_PAPER_MANIFEST,
+    stats_path: str | Path = DEFAULT_TANDEM_PAPER_STATS,
+    debug: bool = False,
+    enable_fourier: bool = False,
+    enable_wake_deficit: bool = False,
+    enable_wake_angle: bool = False,
+) -> DatasetBundle:
+    manifest_path = Path(manifest_path)
+    stats_path = Path(stats_path)
+    if not manifest_path.exists() or not stats_path.exists():
+        split_paper_experiment4.materialize_default_artifacts(
+            manifest_path=manifest_path,
+            stats_path=stats_path,
+        )
+    manifest = _read_json(manifest_path)
+    task_manifest = manifest["tasks"].get(task)
+    if task_manifest is None:
+        available = ", ".join(sorted(manifest["tasks"]))
+        raise ValueError(f"Unknown tandemfoil paper task {task!r}; available tasks: {available}")
+    task_stats = _read_json(stats_path)["tasks"].get(task)
+    if task_stats is None:
+        raise ValueError(f"Missing stats for tandemfoil paper task {task!r}")
+
+    train_dataset = PaperTandemFoilCaseDataset(
+        list(task_manifest["splits"]["train"]),
+        task_manifest["pickle_files"],
+        root_candidates=manifest.get("data_root_candidates"),
+        debug=debug,
+        task_name=task,
+        enable_fourier=enable_fourier,
+        enable_wake_deficit=enable_wake_deficit,
+        enable_wake_angle=enable_wake_angle,
+    )
+    val_dataset = PaperTandemFoilCaseDataset(
+        list(task_manifest["splits"]["val"]),
+        task_manifest["pickle_files"],
+        root_candidates=manifest.get("data_root_candidates"),
+        debug=debug,
+        task_name=task,
+        enable_fourier=enable_fourier,
+        enable_wake_deficit=enable_wake_deficit,
+        enable_wake_angle=enable_wake_angle,
+    )
+    test_dataset = PaperTandemFoilCaseDataset(
+        list(task_manifest["splits"]["test"]),
+        task_manifest["pickle_files"],
+        root_candidates=manifest.get("data_root_candidates"),
+        debug=debug,
+        task_name=task,
+        enable_fourier=enable_fourier,
+        enable_wake_deficit=enable_wake_deficit,
+        enable_wake_angle=enable_wake_angle,
+    )
+    augmented_dim = (
+        paper_prepare_multi.X_DIM
+        + (16 if enable_fourier else 0)
+        + (2 if enable_wake_deficit else 0)
+        + (1 if enable_wake_angle else 0)
+    )
+    return DatasetBundle(
+        train_dataset=train_dataset,
+        val_datasets={"val": val_dataset},
+        test_datasets={"test": test_dataset},
+        spec=DatasetSpec(
+            name="tandemfoilset_paper",
+            space_dim=2,
+            surface_input_dim=augmented_dim,
+            surface_output_dim=3,
+            volume_input_dim=augmented_dim,
+            volume_output_dim=3,
+            pressure_output_index=2,
+            default_metric="field_mse",
+            notes=[
+                "Paper-faithful high-Re TandemFoilSet benchmark using Experiment 4 split semantics.",
+                "Primary comparison metric is normalized full-field MSE, matching the paper contract.",
+            ],
+        ),
+        target_stats=TargetTransformStats(
+            y_mean=torch.tensor(task_stats["y_mean"], dtype=torch.float32),
+            y_std=torch.tensor(task_stats["y_std"], dtype=torch.float32),
+        ),
+        sample_weights=torch.ones(len(train_dataset), dtype=torch.float32),
+    )
+
+
 def build_drivaerml_bundle(
     *,
     manifest_path: str | Path = DEFAULT_DRIVAERML_MANIFEST,
@@ -652,6 +800,9 @@ def build_dataset_bundle(
     debug: bool = False,
     tandem_manifest: str | Path = DEFAULT_TANDEM_MANIFEST,
     tandem_stats: str | Path = DEFAULT_TANDEM_STATS,
+    tandemfoil_paper_task: str = "cruise_random_uniform",
+    tandemfoil_paper_manifest: str | Path = DEFAULT_TANDEM_PAPER_MANIFEST,
+    tandemfoil_paper_stats: str | Path = DEFAULT_TANDEM_PAPER_STATS,
     airfrans_manifest: str | Path = DEFAULT_AIRFRANS_MANIFEST,
     airfrans_root: str | Path | None = None,
     airfrans_task: str = "full",
@@ -680,6 +831,16 @@ def build_dataset_bundle(
             enable_wake_deficit=enable_wake_deficit,
             enable_wake_angle=enable_wake_angle,
             enable_vortex_panel_velocity=enable_vortex_panel_velocity,
+        )
+    if dataset_name in {"tandemfoil_paper", "tandemfoilset_paper"}:
+        return build_tandem_paper_bundle(
+            task=tandemfoil_paper_task,
+            manifest_path=tandemfoil_paper_manifest,
+            stats_path=tandemfoil_paper_stats,
+            debug=debug,
+            enable_fourier=enable_fourier,
+            enable_wake_deficit=enable_wake_deficit,
+            enable_wake_angle=enable_wake_angle,
         )
     if dataset_name == "airfrans":
         return build_airfrans_bundle(

--- a/target/icml2026/core/features.py
+++ b/target/icml2026/core/features.py
@@ -279,7 +279,7 @@ def augment_case_sample(
         full_x = append_fourier_features(full_x, sample.space_dim, fourier_freqs)
     if enable_cp_panel and sample.dataset_name == "airfrans":
         appended_full.append(_compute_airfrans_cp_panel(full_x))
-    if enable_wake_deficit and sample.dataset_name == "tandemfoilset":
+    if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):
         appended_full.append(_compute_tandem_wake_deficit(full_x, include_angle=enable_wake_angle))
     if appended_full:
         full_x = torch.cat([full_x, *appended_full], dim=1)

--- a/target/icml2026/data/README.md
+++ b/target/icml2026/data/README.md
@@ -5,7 +5,7 @@ Shared helpers for the multi-dataset ICML 2026 target.
 ## Layout
 
 - `split_utils.py` — shared manifest helpers used by the dataset-local split scripts
-- `smoke_test_datasets.py` — PVC-backed smoke test for all three dataset loaders
+- `smoke_test_datasets.py` — PVC-backed smoke test for the shared ICML dataset loaders
 
 The actual dataset pipelines live under their benchmark directories:
 

--- a/target/icml2026/instructions/additional_advisor_guidance.md
+++ b/target/icml2026/instructions/additional_advisor_guidance.md
@@ -15,6 +15,12 @@ recipe whose core changes more or less work across:
 It is fine if some hyperparameters differ by dataset. It is not fine if the
 story only works because every dataset needs a completely different core idea.
 
+For TandemFoilSet, remember there are now two useful views of the problem:
+
+- `target/icml2026/tandemfoil/` for the main parity / ICML sprint contract
+- `target/icml2026/tandemfoil_paper/` for a paper-faithful Experiment 4
+  high-Re MSE comparison
+
 ## Benchmark-facing priorities
 
 - `tandemfoil`
@@ -23,6 +29,15 @@ story only works because every dataset needs a completely different core idea.
   - current sprint anchor at time of writing (`2026-04-21`):
     - `val_primary/surface_pressure_mae = 44.72`
     - reported test from that lane: `50.77`
+- `tandemfoil_paper`
+  - paper-facing metric: `test_primary/field_mse`
+  - published paper reference numbers from Experiment 4 / Table 6:
+    - `cruise_random_uniform = 0.10`
+    - `cruise_random_aoa_extrap = 0.18`
+    - `cruise_random_re_extrap = 0.36`
+    - `cruise_random_stagger_extrap = 0.13`
+    - `cruise_random_gap_extrap = 0.14`
+    - `racecar_uniform = 0.21`
 - `airfrans`
   - paper-facing metric: `test_primary/surface_mse`
   - external targets:
@@ -50,15 +65,19 @@ Always keep the target or reference beside the reported test metric.
 ## Assignment guidance
 
 When a large fleet is available, default to assigning a hypothesis family across
-all three datasets to the same student.
+the relevant datasets to the same student.
 
 - A student has `8` GPUs.
 - Use those GPUs as a matrix across datasets and nearby variants.
 - A good default is:
-  - at least one run per dataset
+  - at least one run on `airfrans`
+  - at least one run on `drivaerml`
+  - at least one run on either `tandemfoil` or `tandemfoil_paper`
+  - include both Tandem variants when the question is about Tandem comparability
+    or transfer
   - remaining GPUs used for the most decision-critical nearby variants
-- The resulting PR should report metrics across all three datasets so the same
-  student can judge whether the idea transferred or was too dataset-specific.
+- The resulting PR should report metrics across the assigned benchmarks so the
+  same student can judge whether the idea transferred or was too dataset-specific.
 
 Single-dataset assignments are still appropriate for:
 

--- a/target/icml2026/instructions/additional_advisor_guidance_tandemfoil_paper_2026-04-21.md
+++ b/target/icml2026/instructions/additional_advisor_guidance_tandemfoil_paper_2026-04-21.md
@@ -1,0 +1,134 @@
+# Additional Advisor Guidance For The TandemFoil Paper-Calibration Expansion
+
+This file is intended to be passed via `k8s/launch.py --extra_instructions ...`
+for the next advisor restart or fleet expansion after adding the fourth
+benchmark under `target/icml2026/tandemfoil_paper/`.
+
+## Why The Fourth Benchmark Exists
+
+We currently have two TandemFoilSet views:
+
+- `target/icml2026/tandemfoil/`
+  - the main parity / ICML sprint benchmark
+  - useful for noam-lineage progress and the shared sprint story
+- `target/icml2026/tandemfoil_paper/`
+  - a paper-faithful high-Re Experiment 4 benchmark
+  - useful for answering a simpler question:
+    - are we actually good relative to the published TandemFoilSet paper?
+
+Do not confuse them.
+
+## Scientific Goal
+
+The goal is still a shared recipe, not a collection of unrelated per-benchmark
+tricks.
+
+The core question is now whether one broad recipe can survive across:
+
+- `target/icml2026/tandemfoil/`
+- `target/icml2026/tandemfoil_paper/`
+- `target/icml2026/airfrans/`
+- `target/icml2026/drivaerml/`
+
+It is fine if LR, schedule length, or regularization strength differ somewhat.
+It is not fine if every benchmark needs a different core idea.
+
+## Benchmark-Facing Priorities
+
+- `tandemfoil`
+  - paper-facing summary metric: `test_primary/surface_pressure_mae`
+  - this is the ICML sprint parity target, not the original paper contract
+- `tandemfoil_paper`
+  - paper-facing metric: `test_primary/field_mse`
+  - published Experiment 4 references:
+    - `cruise_random_uniform = 0.10`
+    - `cruise_random_aoa_extrap = 0.18`
+    - `cruise_random_re_extrap = 0.36`
+    - `cruise_random_stagger_extrap = 0.13`
+    - `cruise_random_gap_extrap = 0.14`
+    - `racecar_uniform = 0.21`
+- `airfrans`
+  - paper-facing metric: `test_primary/surface_mse`
+  - targets:
+    - `surface_mse = 0.0043`
+    - `volume_mse = 0.0017`
+- `drivaerml`
+  - paper-facing metric: `test_primary/surface_rel_l2_pct`
+  - nominal reference:
+    - `3.71`
+
+Always keep the reported test metric beside the target or reference.
+
+## Current Strategic Read
+
+- AirfRANS is already strong enough that it should stay narrow.
+- DrivAerML is still the weakest benchmark and remains the main rescue lane.
+- The new `tandemfoil_paper` benchmark is not a license to reopen huge Tandem
+  local sweeps.
+- Its job is calibration:
+  - tell us whether our Tandem-related ideas are merely improving the internal
+    parity target
+  - or are also competitive against the original paper contract
+
+## Assignment Guidance
+
+When a student is assigned a cross-benchmark hypothesis family, treat the `8`
+GPUs as a small matrix.
+
+Strong default:
+
+- `1` run on `airfrans`
+- `2-3` runs on `drivaerml`
+- `1` run on `tandemfoil`
+- `1` run on `tandemfoil_paper` if the idea is relevant to TandemFoil
+- remaining GPUs used for the most decision-critical nearby variants
+
+Use both Tandem benchmarks together when the hypothesis is about:
+
+- Tandem transfer
+- Tandem generalization
+- whether a Tandem-side change is only helping the noam/parity contract
+- whether a Tandem-side change also helps the original paper-style benchmark
+
+Single-dataset work is still appropriate for:
+
+- best-checkpoint cleanup
+- preserving the AirfRANS frontier
+- a clearly justified DrivAerML rescue lane
+- one-off Tandem paper calibration checks
+
+## What To Emphasize
+
+- DrivAerML-centered ideas that can also be checked on AirfRANS and both Tandem
+  views
+- simple transferable recipe changes
+- hypotheses that tell us whether an idea is globally useful or too
+  dataset-specific
+- test metrics at the best validation checkpoint
+
+## What To De-Emphasize
+
+- broad AirfRANS local mapping
+- broad Tandem local mapping on only one Tandem benchmark
+- speculative code-change branches unless they are clearly high value
+- architecture proliferation without a strong transfer rationale
+
+## Operational Reminder
+
+- The run budget is inherited from the pod environment.
+- Do not hardcode obsolete `180`-minute run budgets in PR bodies.
+- If a stale `CURRENT_RESEARCH_STATE.md` on the branch conflicts with this
+  benchmark expansion, overwrite it immediately.
+
+## Sharp Summary
+
+The fourth benchmark is a calibration tool, not the new center of gravity.
+
+Use it to answer:
+
+- is our Tandem recipe actually paper-competitive?
+
+But keep the overall queue aimed at the harder global question:
+
+- can one shared recipe work across AirfRANS, DrivAerML, the Tandem parity
+  target, and the Tandem paper-style target?

--- a/target/icml2026/instructions/prompt-advisor.md
+++ b/target/icml2026/instructions/prompt-advisor.md
@@ -20,19 +20,24 @@ You're the senpai advisor. Your students run experiments; your job is to direct 
 
 Read CLAUDE.md for the full workflow and `$PROBLEM_DIR/program.md` for research context.
 
-The active problem directory contains three benchmark subtargets:
+The active problem directory contains four benchmark subtargets:
 
 - `$PROBLEM_DIR/tandemfoil/`
+- `$PROBLEM_DIR/tandemfoil_paper/`
 - `$PROBLEM_DIR/airfrans/`
 - `$PROBLEM_DIR/drivaerml/`
 
 When you write a hypothesis PR, specify the dataset explicitly and keep the
 benchmark contract tied to that dataset's `program.md`.
 
-When feasible, default to hypothesis families that are tested across all three
-benchmarks rather than only one. Use single-dataset assignments mainly for
-frontier closure, best-checkpoint test recovery, or another clearly justified
-reason.
+When feasible, default to hypothesis families that are tested across the active
+benchmarks rather than only one. In particular:
+
+- use `tandemfoil_paper/` when you need a literature-facing TandemFoilSet
+  comparison point
+- use `tandemfoil/` when you need the main parity / ICML-sprint Tandem anchor
+- use single-dataset assignments mainly for frontier closure, best-checkpoint
+  test recovery, or another clearly justified reason
 
 ### Git branch to use
 Its very important that all your work always lives on the `$ADVISOR_BRANCH` branch, not main — PRs target it as base, new branches check out from it, and merges squash into it. This keeps the research track clean and separate from the main codebase.
@@ -42,5 +47,6 @@ Its very important that all your work always lives on the `$ADVISOR_BRANCH` bran
 Survey the current state: check student's metrics on wandb (use the /wandb-primary skill if helpful), list existing PRs (using the /list-experiments skill if helpful), and identify what needs attention next.
 
 In this ICML target, prefer a common-recipe story over benchmark-specific hacks:
-aim for core changes that survive across TandemFoilSet, AirfRANS, and
-DrivAerML, even if final LR, scheduler, or regularization settings differ.
+aim for core changes that survive across `tandemfoil/`,
+`tandemfoil_paper/`, AirfRANS, and DrivAerML, even if final LR, scheduler, or
+regularization settings differ.

--- a/target/icml2026/instructions/prompt-student.md
+++ b/target/icml2026/instructions/prompt-student.md
@@ -11,7 +11,7 @@ You're $STUDENT_NAME, a senpai research student. The advisor assigns hypotheses 
 ## Setup
 
 - **You:** $STUDENT_NAME
-- **Datasets:** TandemFoilSet, AirfRANS, and DrivAerML. Exact roots and split contracts live under `$PROBLEM_DIR/tandemfoil/`, `$PROBLEM_DIR/airfrans/`, and `$PROBLEM_DIR/drivaerml/`.
+- **Datasets:** the main TandemFoilSet parity target, the paper-faithful TandemFoilSet high-Re target, AirfRANS, and DrivAerML. Exact roots and split contracts live under `$PROBLEM_DIR/tandemfoil/`, `$PROBLEM_DIR/tandemfoil_paper/`, `$PROBLEM_DIR/airfrans/`, and `$PROBLEM_DIR/drivaerml/`.
 - **GPUs:** 8 on this node. Use all 8 across experiment variations where it makes sense — `CUDA_VISIBLE_DEVICES` lets you pin a training to a specific GPU.
 - **Target branch:** `$ADVISOR_BRANCH`
 
@@ -25,8 +25,10 @@ cd "$PROBLEM_DIR" && python train.py --dataset <dataset> --agent $STUDENT_NAME -
 ```
 
 When the advisor assigns a cross-dataset hypothesis family, use your 8 GPUs as a
-small run matrix across TandemFoilSet, AirfRANS, and DrivAerML, then report the
-metrics together so the transfer signal is easy to interpret.
+small run matrix across the relevant benchmarks, then report the metrics
+together so the transfer signal is easy to interpret. If the hypothesis is
+about TandemFoil generalization or paper comparability, include both
+`tandemfoil/` and `tandemfoil_paper/`.
 
 Try and use sub-agents where possible, for example specialised agents like researcher-agent for research, Explore agent for checking log files or generic sub-agents for other repetitive tasks like polling for work.
 

--- a/target/icml2026/program.md
+++ b/target/icml2026/program.md
@@ -10,20 +10,28 @@ Autonomous research target for the ICML 2026 AI for Science workshop sprint.
 
 ## Problem
 
-This target packages the experiments for the ICML paper around three CFD surrogate
+This target packages the experiments for the ICML paper around four CFD surrogate
 benchmarks under one harness-compatible problem directory:
 
 - `tandemfoil/` — TandemFoilSet, the load-bearing benchmark and current strongest evidence
+- `tandemfoil_paper/` — paper-faithful high-Re TandemFoilSet calibration tasks
 - `airfrans/` — AirfRANS, the 2D transfer benchmark
 - `drivaerml/` — DrivAerML, the 3D surface-first transfer benchmark
 
-The goal is to compare a clean shared training stack across the three datasets,
+The goal is to compare a clean shared training stack across the four benchmark
+views,
 with reference comparisons against a vanilla grouped-domain Transolver and an
 AB-UPT-style anchor model where appropriate.
 
-The ideal paper story is not three unrelated benchmark-specific wins. It is a
-shared recipe whose core ideas transfer across TandemFoilSet, AirfRANS, and
-DrivAerML, even if the best final hyperparameters differ somewhat by dataset.
+The ideal paper story is not four unrelated benchmark-specific wins. It is a
+shared recipe whose core ideas transfer across:
+
+- the main `tandemfoil/` parity benchmark
+- the paper-faithful `tandemfoil_paper/` calibration benchmark
+- `airfrans/`
+- `drivaerml/`
+
+Hyperparameters may differ somewhat by dataset, but the core recipe should not.
 
 For TandemFoilSet specifically, this target should become the reproduction and
 extension path for the merged noam lineage through `#2379`, while AirfRANS and
@@ -34,7 +42,8 @@ explicitly requested.
 
 - `train.py` — shared ICML sprint trainer and model selector. **Primary editable entrypoint.**
 - `core/` — shared dataset contract, features, optimizers, and model definitions.
-- `tandemfoil/` — TandemFoilSet-specific data pipeline and benchmark docs.
+- `tandemfoil/` — TandemFoilSet-specific parity target and benchmark docs.
+- `tandemfoil_paper/` — paper-faithful TandemFoilSet high-Re benchmark docs.
 - `airfrans/` — AirfRANS-specific data pipeline and benchmark docs.
 - `drivaerml/` — DrivAerML-specific data pipeline and benchmark docs.
 - `data/` — shared split helpers and smoke tests for the multi-dataset target.
@@ -49,6 +58,11 @@ most decision-relevant metric for the selected benchmark:
   - `legacy_noam/*` for the denormalized historical `p_*` contract
   - `icml2026_v2/*` for the packaged `kagent` split contract
   - pressure and surface fidelity remain the decision-driving quantities
+- `tandemfoil_paper`
+  - prioritize normalized full-field MSE on the paper-faithful Experiment 4
+    tasks
+  - use this benchmark to decide whether our shared stack is actually
+    competitive against the published TandemFoilSet paper numbers
 - `airfrans`
   - prioritize surface and volume error on the official task split
   - compare against literature-reported Transolver and newer baselines
@@ -100,6 +114,8 @@ Primary harness metric aliases:
 
 - `tandemfoil`: `val_primary/surface_pressure_mae` and
   `test_primary/surface_pressure_mae`
+- `tandemfoil_paper`: `val_primary/field_mse` and
+  `test_primary/field_mse`
 - `airfrans`: `val_primary/surface_mse` and `test_primary/surface_mse`
 - `drivaerml`: `val_primary/surface_rel_l2_pct` and
   `test_primary/surface_rel_l2_pct`
@@ -109,6 +125,7 @@ Primary harness metric aliases:
 Read the dataset-specific subprogram before making dataset-specific claims:
 
 - `tandemfoil/program.md`
+- `tandemfoil_paper/program.md`
 - `airfrans/program.md`
 - `drivaerml/program.md`
 

--- a/target/icml2026/tandemfoil_paper/__init__.py
+++ b/target/icml2026/tandemfoil_paper/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-faithful TandemFoilSet high-Re benchmark tasks."""
+

--- a/target/icml2026/tandemfoil_paper/data/README.md
+++ b/target/icml2026/tandemfoil_paper/data/README.md
@@ -1,0 +1,62 @@
+# Paper TandemFoil Tasks
+
+This directory defines a paper-faithful benchmark variant for the high-Re
+TandemFoilSet experiments in Experiment 4 of the TandemFoilSet paper.
+
+## Supported Tasks
+
+The following task names are available through:
+
+```bash
+cd target/icml2026
+python train.py --dataset tandemfoil_paper --tandemfoil-paper-task <task>
+```
+
+Supported tasks:
+
+- `cruise_random_uniform`
+- `cruise_random_aoa_extrap`
+- `cruise_random_re_extrap`
+- `cruise_random_stagger_extrap`
+- `cruise_random_gap_extrap`
+- `racecar_uniform`
+
+## Split Rules
+
+Uniform tasks:
+
+- deterministic `80/10/10` train/val/test split
+- RNG seed `42`
+
+Extrapolation tasks:
+
+- lowest `5%` and highest `5%` of the selected variable become `test`
+- the middle `90%` is split uniformly into:
+  - `train = 80%` of the full dataset
+  - `val = 10%` of the full dataset
+- RNG seed `42` for the middle-90% train/val shuffle
+
+## Artifacts
+
+The generator writes:
+
+- `split_manifest_tandemfoil_paper_experiment4.json`
+- `split_stats_tandemfoil_paper_experiment4.json`
+
+These files are auto-materialized on first use if they are missing and the raw
+TandemFoil pickles are available under the mounted PVC.
+
+Manual generation:
+
+```bash
+cd target/icml2026
+python tandemfoil_paper/data/split_paper_experiment4.py
+```
+
+## Implementation Note
+
+This benchmark uses the shared tandem pickle loader and the same 24-feature
+dual-foil preprocessing as `tandemfoil/`. The difference is the split contract
+and the metric contract: this benchmark evaluates normalized full-field MSE,
+matching the paper’s Experiment 4 reporting style.
+

--- a/target/icml2026/tandemfoil_paper/data/__init__.py
+++ b/target/icml2026/tandemfoil_paper/data/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-faithful TandemFoilSet task artifacts."""
+

--- a/target/icml2026/tandemfoil_paper/data/prepare.py
+++ b/target/icml2026/tandemfoil_paper/data/prepare.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-variant TandemFoilSet re-exports the shared tandem pickle loader."""
+
+from tandemfoil.data.prepare import *  # noqa: F401,F403
+

--- a/target/icml2026/tandemfoil_paper/data/prepare_multi.py
+++ b/target/icml2026/tandemfoil_paper/data/prepare_multi.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-variant TandemFoilSet re-exports the shared 24-feature preprocessing."""
+
+from tandemfoil.data.prepare_multi import *  # noqa: F401,F403
+

--- a/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
+++ b/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Materialize paper-faithful TandemFoilSet Experiment 4 tasks.
+
+This generator targets the unambiguous high-Re tasks from the paper:
+
+- Cruise Random, uniform 8:1:1
+- Cruise Random extrapolation on AOA / Re / Stagger / Gap
+- Race Car, uniform 8:1:1
+
+The paper does not publish an exact split RNG seed, so this repo pins seed 42
+for the uniform train/val sampling and uses stable rank order for tail
+selection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+
+try:
+    from data.split_utils import first_existing, write_json
+    from tandemfoil.data.prepare import load_pickle
+    from tandemfoil.data.prepare_multi import MultiFieldDataset
+except ModuleNotFoundError:
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from data.split_utils import first_existing, write_json
+    from tandemfoil.data.prepare import load_pickle
+    from tandemfoil.data.prepare_multi import MultiFieldDataset
+
+
+SEED = 42
+TRAIN_FRACTION = 0.80
+VAL_FRACTION = 0.10
+TAIL_FRACTION = 0.05
+DEFAULT_ROOT_CANDIDATES = [
+    "/mnt/pvc/datasets/tandemfoil",
+    "/mnt/new-pvc/datasets/tandemfoil",
+]
+DEFAULT_MANIFEST = Path(__file__).with_name("split_manifest_tandemfoil_paper_experiment4.json")
+DEFAULT_STATS = Path(__file__).with_name("split_stats_tandemfoil_paper_experiment4.json")
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    dataset_group: str
+    split_style: str
+    variable: str | None
+    pickle_files: tuple[str, ...]
+    paper_table6_baseline: float
+    paper_table6_best: float
+    paper_table6_best_std: float
+    notes: tuple[str, ...]
+
+
+TASK_SPECS: dict[str, TaskSpec] = {
+    "cruise_random_uniform": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="uniform",
+        variable=None,
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=1.79,
+        paper_table6_best=0.10,
+        paper_table6_best_std=0.13,
+        notes=(
+            "Experiment 4 Cruise Random uniform split.",
+            "Paper states 8:1:1 train/val/test unless otherwise stated.",
+        ),
+    ),
+    "cruise_random_aoa_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="aoa0",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=2.03,
+        paper_table6_best=0.18,
+        paper_table6_best_std=0.24,
+        notes=(
+            "Experiment 4 Cruise Random AOA extrapolation split.",
+            "Test set is the highest and lowest 5% of AOA.",
+        ),
+    ),
+    "cruise_random_re_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="re",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=4.85,
+        paper_table6_best=0.36,
+        paper_table6_best_std=0.53,
+        notes=(
+            "Experiment 4 Cruise Random Reynolds extrapolation split.",
+            "Test set is the highest and lowest 5% of Reynolds number.",
+        ),
+    ),
+    "cruise_random_stagger_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="stagger",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=1.74,
+        paper_table6_best=0.13,
+        paper_table6_best_std=0.17,
+        notes=(
+            "Experiment 4 Cruise Random stagger extrapolation split.",
+            "Test set is the highest and lowest 5% of stagger.",
+        ),
+    ),
+    "cruise_random_gap_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="gap",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=1.95,
+        paper_table6_best=0.14,
+        paper_table6_best_std=0.20,
+        notes=(
+            "Experiment 4 Cruise Random gap extrapolation split.",
+            "Test set is the highest and lowest 5% of gap.",
+        ),
+    ),
+    "racecar_uniform": TaskSpec(
+        dataset_group="racecar",
+        split_style="uniform",
+        variable=None,
+        pickle_files=(
+            "raceCar_randomFields_mgn_Part1.pickle",
+            "raceCar_randomFields_mgn_Part2.pickle",
+            "raceCar_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=0.61,
+        paper_table6_best=0.21,
+        paper_table6_best_std=0.29,
+        notes=(
+            "Experiment 4 Race Car uniform split.",
+            "Paper uses uniform sampling on Race Car rather than an extrapolation split.",
+        ),
+    ),
+}
+
+
+def _resolve_task_pickle_paths(task: TaskSpec, root_candidates: list[str]) -> list[Path]:
+    root = first_existing(root_candidates)
+    if root is None:
+        raise FileNotFoundError(
+            "Could not find TandemFoilSet root. Checked: "
+            + ", ".join(root_candidates)
+        )
+    return [root / name for name in task.pickle_files]
+
+
+def _extract_records(pickle_paths: list[Path]) -> list[dict]:
+    records: list[dict] = []
+    task_local_idx = 0
+    for file_idx, path in enumerate(pickle_paths):
+        raw = load_pickle(path)
+        for local_idx, sample in enumerate(raw):
+            aoa = sample.AoA
+            if isinstance(aoa, list):
+                aoa0 = float(aoa[0])
+                aoa1 = float(aoa[1])
+                if abs(aoa0 - aoa1) > 1e-6:
+                    raise ValueError(
+                        f"Expected paper-style tandem AoA to be shared, got {aoa0} vs {aoa1} "
+                        f"for {path.name}:{local_idx}"
+                    )
+            else:
+                aoa0 = float(aoa)
+                aoa1 = None
+
+            gap = getattr(sample, "gap", None)
+            stagger = getattr(sample, "stagger", None)
+            if gap is None or stagger is None:
+                raise ValueError(f"Expected tandem metadata gap/stagger in {path.name}:{local_idx}")
+
+            records.append(
+                {
+                    "task_local_idx": task_local_idx,
+                    "file_idx": file_idx,
+                    "local_idx": local_idx,
+                    "re": float(sample.flowState["Re"]),
+                    "aoa0": aoa0,
+                    "aoa1": aoa1,
+                    "gap": float(gap),
+                    "stagger": float(stagger),
+                }
+            )
+            task_local_idx += 1
+        del raw
+    return records
+
+
+def split_uniform_indices(total: int, *, seed: int = SEED) -> dict[str, list[int]]:
+    if total <= 0:
+        raise ValueError("Uniform split requires at least one sample")
+    rng = np.random.default_rng(seed)
+    order = np.arange(total)
+    rng.shuffle(order)
+    n_test = max(1, round(total * VAL_FRACTION))
+    n_val = max(1, round(total * VAL_FRACTION))
+    n_train = total - n_val - n_test
+    if n_train <= 0:
+        raise ValueError(f"Invalid split sizes for total={total}")
+    train = sorted(order[:n_train].tolist())
+    val = sorted(order[n_train : n_train + n_val].tolist())
+    test = sorted(order[n_train + n_val :].tolist())
+    return {"train": train, "val": val, "test": test}
+
+
+def split_tail_extrapolation_indices(values: list[float], *, seed: int = SEED) -> dict[str, list[int]]:
+    total = len(values)
+    if total <= 0:
+        raise ValueError("Tail extrapolation requires at least one sample")
+    n_tail = max(1, round(total * TAIL_FRACTION))
+    order = sorted(range(total), key=lambda idx: (values[idx], idx))
+    test_set = set(order[:n_tail]) | set(order[-n_tail:])
+    if len(test_set) != n_tail * 2:
+        raise ValueError("Tail extrapolation test set unexpectedly overlapped")
+
+    middle = [idx for idx in range(total) if idx not in test_set]
+    rng = np.random.default_rng(seed)
+    rng.shuffle(middle)
+    n_val = max(1, round(total * VAL_FRACTION))
+    n_train = len(middle) - n_val
+    if n_train <= 0:
+        raise ValueError(f"Invalid tail split sizes for total={total}")
+    train = sorted(middle[:n_train])
+    val = sorted(middle[n_train:])
+    test = sorted(test_set)
+    return {"train": train, "val": val, "test": test}
+
+
+def _compute_y_stats(pickle_paths: list[Path], train_indices: list[int]) -> dict[str, float | list[float]]:
+    dataset = MultiFieldDataset(pickle_paths, cache_size=-1)
+    train_sorted = sorted(train_indices, key=lambda idx: dataset.index[idx])
+
+    sum_y = torch.zeros(3, dtype=torch.float64)
+    total_nodes = 0
+    for idx in train_sorted:
+        _, y, _ = dataset[idx]
+        sum_y += y.double().sum(dim=0)
+        total_nodes += y.shape[0]
+    if total_nodes <= 1:
+        raise ValueError("Need at least two nodes to compute y statistics")
+    mean_y = sum_y / total_nodes
+
+    sq_y = torch.zeros(3, dtype=torch.float64)
+    for idx in train_sorted:
+        _, y, _ = dataset[idx]
+        sq_y += ((y.double() - mean_y) ** 2).sum(dim=0)
+    std_y = (sq_y / (total_nodes - 1)).sqrt().clamp(min=1e-6)
+    return {
+        "n_train_samples": len(train_indices),
+        "n_train_nodes": int(total_nodes),
+        "y_mean": mean_y.float().tolist(),
+        "y_std": std_y.float().tolist(),
+    }
+
+
+def build_artifacts(root_candidates: list[str]) -> tuple[dict, dict]:
+    manifest = {
+        "dataset": "TandemFoilSet",
+        "benchmark_variant": "paper_experiment4",
+        "paper_source": "https://openreview.net/pdf?id=4Z0P4Nbosn",
+        "seed": SEED,
+        "train_fraction": TRAIN_FRACTION,
+        "val_fraction": VAL_FRACTION,
+        "tail_fraction": TAIL_FRACTION,
+        "data_root_candidates": list(root_candidates),
+        "tasks": {},
+    }
+    stats = {
+        "dataset": "TandemFoilSet",
+        "benchmark_variant": "paper_experiment4",
+        "seed": SEED,
+        "tasks": {},
+    }
+
+    for task_name, task in TASK_SPECS.items():
+        pickle_paths = _resolve_task_pickle_paths(task, root_candidates)
+        records = _extract_records(pickle_paths)
+        if task.split_style == "uniform":
+            splits = split_uniform_indices(len(records), seed=SEED)
+        elif task.split_style == "tail_extrapolation":
+            if task.variable is None:
+                raise ValueError(f"Task {task_name} is missing its extrapolation variable")
+            splits = split_tail_extrapolation_indices(
+                [float(record[task.variable]) for record in records],
+                seed=SEED,
+            )
+        else:
+            raise ValueError(f"Unknown split style: {task.split_style}")
+
+        manifest["tasks"][task_name] = {
+            "dataset_group": task.dataset_group,
+            "split_style": task.split_style,
+            "variable": task.variable,
+            "pickle_files": [path.name for path in pickle_paths],
+            "n_cases": len(records),
+            "split_counts": {name: len(indices) for name, indices in splits.items()},
+            "splits": {name: sorted(indices) for name, indices in splits.items()},
+            "paper_targets": {
+                "table": "Table 6",
+                "mgn_baseline_field_mse": task.paper_table6_baseline,
+                "mgn_pre_res_free_res_comb_field_mse": task.paper_table6_best,
+                "mgn_pre_res_free_res_comb_field_mse_std": task.paper_table6_best_std,
+            },
+            "notes": list(task.notes),
+        }
+        stats["tasks"][task_name] = _compute_y_stats(pickle_paths, splits["train"])
+    return manifest, stats
+
+
+def materialize_default_artifacts(
+    *,
+    manifest_path: str | Path = DEFAULT_MANIFEST,
+    stats_path: str | Path = DEFAULT_STATS,
+    root_candidates: list[str] | None = None,
+) -> tuple[Path, Path]:
+    manifest_path = Path(manifest_path)
+    stats_path = Path(stats_path)
+    if manifest_path.exists() and stats_path.exists():
+        return manifest_path, stats_path
+    resolved_candidates = list(root_candidates or DEFAULT_ROOT_CANDIDATES)
+    manifest, stats = build_artifacts(resolved_candidates)
+    write_json(manifest_path, manifest)
+    write_json(stats_path, stats)
+    return manifest_path, stats_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Materialize TandemFoilSet paper Experiment 4 artifacts")
+    parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--stats-out", default=str(DEFAULT_STATS))
+    parser.add_argument(
+        "--data-root-candidate",
+        action="append",
+        default=[],
+        help="Override/add TandemFoilSet root candidates.",
+    )
+    args = parser.parse_args()
+
+    root_candidates = args.data_root_candidate or DEFAULT_ROOT_CANDIDATES
+    manifest, stats = build_artifacts(root_candidates)
+    write_json(args.manifest_out, manifest)
+    write_json(args.stats_out, stats)
+
+    print(f"Wrote {args.manifest_out}")
+    print(f"Wrote {args.stats_out}")
+    for task_name, task_manifest in manifest["tasks"].items():
+        counts = task_manifest["split_counts"]
+        print(
+            f"  {task_name:30s} train={counts['train']:4d} "
+            f"val={counts['val']:4d} test={counts['test']:4d}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/target/icml2026/tandemfoil_paper/program.md
+++ b/target/icml2026/tandemfoil_paper/program.md
@@ -1,0 +1,120 @@
+<!--
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: senpai
+-->
+
+# TandemFoilSet Paper Variant
+
+This subtarget adds a fourth benchmark inside `target/icml2026`: a
+paper-faithful high-Re TandemFoilSet variant built around the unambiguous split
+rules from Experiment 4 of the TandemFoilSet paper.
+
+## Why This Exists
+
+The main `tandemfoil/` benchmark in this target is intentionally pinned to the
+later `kagent` / noam-style parity contract. That is useful for the ICML sprint,
+but it does **not** give us a clean literature-facing scalar from the original
+TandemFoilSet paper.
+
+This variant exists to answer a simpler question:
+
+- on the paper’s own high-Re `Cruise Random` / `Race Car` tasks, is our model
+  actually competitive or not?
+
+## Scope
+
+Only the paper splits that are reasonably unambiguous are included here:
+
+- `cruise_random_uniform`
+- `cruise_random_aoa_extrap`
+- `cruise_random_re_extrap`
+- `cruise_random_stagger_extrap`
+- `cruise_random_gap_extrap`
+- `racecar_uniform`
+
+We intentionally do **not** treat the low-Re curriculum experiments in Tables
+3–5 as this benchmark’s primary contract, because those results depend on the
+paper’s curriculum procedure and multi-network decomposition in a way that is
+less cleanly comparable to our shared ICML trainer.
+
+## Published Contract
+
+Primary source:
+
+- TandemFoilSet paper: [OpenReview PDF](https://openreview.net/pdf?id=4Z0P4Nbosn)
+
+Paper statements we are reproducing here:
+
+- “the datasets are uniformly sampled in a `8:1:1` ratio for training,
+  validation, and test sets, respectively, unless otherwise stated”
+- for Cruise Random extrapolation:
+  - “the highest and lowest `5%` of the `AOA`, `Re`, `Stagger`, or `Gap` value
+    range is used as the test set”
+  - “the training and validation sets are uniformly sampled from the middle
+    `90%` range”
+
+The paper does **not** publish an exact RNG seed or tie-break rule for samples
+on the extrapolation boundary. For reproducibility, this repo uses:
+
+- deterministic RNG seed `42` for uniform train/val sampling
+- stable rank ordering by `(value, case_index)` when selecting the top/bottom
+  `5%` tails
+
+This preserves the paper’s split semantics even though the exact hidden sample
+IDs cannot be recovered from the PDF alone.
+
+## Metrics
+
+The paper reports **normalized full-field MSE** after z-score normalization with
+training-set statistics.
+
+This subtarget therefore uses:
+
+- `field_mse`
+  - mean squared error over **all valid nodes and all three channels**
+    `[Ux, Uy, p]`
+  - computed in normalized target space using task-local training-set mean/std
+- `surface_mse`
+  - normalized-space MSE on surface nodes only
+- `volume_mse`
+  - normalized-space MSE on non-surface nodes only
+
+Lower is better.
+
+Primary harness aliases:
+
+- `val_primary/field_mse`
+- `test_primary/field_mse`
+
+## Paper Reference Numbers
+
+Experiment 4, Table 6:
+
+| Task | MGN baseline | MGN + PRE-RES-FREE + RES-COMB |
+|---|---:|---:|
+| `cruise_random_uniform` | `1.79 ± 1.38` | `0.10 ± 0.13` |
+| `cruise_random_aoa_extrap` | `2.03 ± 1.96` | `0.18 ± 0.24` |
+| `cruise_random_re_extrap` | `4.85 ± 1.82` | `0.36 ± 0.53` |
+| `cruise_random_stagger_extrap` | `1.74 ± 1.66` | `0.13 ± 0.17` |
+| `cruise_random_gap_extrap` | `1.95 ± 1.68` | `0.14 ± 0.20` |
+| `racecar_uniform` | `0.61 ± 0.51` | `0.21 ± 0.29` |
+
+Those are the numbers to compare against when deciding whether our shared ICML
+stack is competitive on the paper-style TandemFoil evaluation.
+
+## Codebase
+
+- `../train.py` — shared trainer
+- `data/split_paper_experiment4.py` — deterministic split and stats generator
+- `data/prepare.py` — shared tandem pickle loading re-export
+- `data/prepare_multi.py` — shared 24-feature TandemFoil preprocessing re-export
+- `data/README.md` — task definitions and artifact materialization details
+
+## Notes
+
+- This variant uses the same TandemFoil raw pickles and 24-feature preprocessing
+  stack as `tandemfoil/`, but **not** the noam-style pressure-denorm contract.
+- It is a benchmark-calibration target, not a replacement for the main
+  `tandemfoil/` ICML sprint target.
+

--- a/target/icml2026/tests/test_tandemfoil_paper.py
+++ b/target/icml2026/tests/test_tandemfoil_paper.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.contracts import GroupedBatch  # noqa: E402
+from tandemfoil_paper.data.split_paper_experiment4 import (  # noqa: E402
+    split_tail_extrapolation_indices,
+    split_uniform_indices,
+)
+from train import TargetTransform, evaluate_grouped  # noqa: E402
+
+
+class _IdentityPaperModel(torch.nn.Module):
+    def eval(self):
+        return self
+
+    def forward(self, *, surface_x, surface_mask, volume_x, volume_mask):
+        del surface_mask, volume_mask
+        return {
+            "surface_preds": surface_x[..., :3],
+            "volume_preds": None if volume_x is None else volume_x[..., :3],
+        }
+
+
+def test_uniform_split_uses_80_10_10_counts():
+    splits = split_uniform_indices(900, seed=42)
+    assert len(splits["train"]) == 720
+    assert len(splits["val"]) == 90
+    assert len(splits["test"]) == 90
+    assert set(splits["train"]).isdisjoint(splits["val"])
+    assert set(splits["train"]).isdisjoint(splits["test"])
+    assert set(splits["val"]).isdisjoint(splits["test"])
+
+
+def test_tail_extrapolation_split_uses_5_percent_tails():
+    values = list(range(900))
+    splits = split_tail_extrapolation_indices(values, seed=42)
+    assert len(splits["train"]) == 720
+    assert len(splits["val"]) == 90
+    assert len(splits["test"]) == 90
+    assert set(splits["test"][:45]) == set(range(45))
+    assert set(splits["test"][45:]) == set(range(855, 900))
+
+
+def test_paper_eval_reports_normalized_field_mse():
+    surface_target = torch.tensor([[[1.0, 2.0, 3.0], [1.0, 1.0, 1.0]]], dtype=torch.float32)
+    volume_target = torch.tensor([[[2.0, 2.0, 2.0]]], dtype=torch.float32)
+    surface_pred = torch.tensor([[[2.0, 2.0, 3.0], [0.0, 1.0, 2.0]]], dtype=torch.float32)
+    volume_pred = torch.tensor([[[3.0, 1.0, 2.0]]], dtype=torch.float32)
+    batch = GroupedBatch(
+        case_ids=["paper-case"],
+        dataset_name="tandemfoilset_paper",
+        space_dim=2,
+        surface_x=torch.cat([surface_pred, torch.zeros(1, 2, 1)], dim=-1),
+        surface_y=surface_target,
+        surface_mask=torch.ones(1, 2, dtype=torch.bool),
+        volume_x=torch.cat([volume_pred, torch.zeros(1, 1, 1)], dim=-1),
+        volume_y=volume_target,
+        volume_mask=torch.ones(1, 1, dtype=torch.bool),
+        metadata=[],
+    )
+    metrics = evaluate_grouped(
+        _IdentityPaperModel(),
+        None,
+        [batch],
+        TargetTransform(pressure_index=2, stats_mean=torch.zeros(3), stats_std=torch.ones(3)),
+        torch.device("cpu"),
+    )
+
+    surface_sq = 3.0
+    volume_sq = 2.0
+    expected_surface = surface_sq / (2 * 3)
+    expected_volume = volume_sq / (1 * 3)
+    expected_field = (surface_sq + volume_sq) / (3 * 3)
+
+    assert math.isclose(metrics["surface_mse"], expected_surface, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(metrics["volume_mse"], expected_volume, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(metrics["field_mse"], expected_field, rel_tol=1e-6, abs_tol=1e-6)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -30,7 +30,60 @@ from core.features import (
     compute_vortex_panel_velocity,
     compute_wake_deficit_features,
 )
-from core.optim import EMA, Lion, Lookahead
+from core.optim import Lion, Lookahead
+
+
+class EMAWithWarmup:
+    """EMA with timm-style adaptive decay warmup: min(target, (1+step)/(10+step))."""
+
+    def __init__(self, model: torch.nn.Module, decay: float = 0.9999):
+        self.decay = decay
+        self.step_counter = 0
+        self.shadow = {
+            self._clean(name): param.detach().clone()
+            for name, param in model.named_parameters()
+            if param.requires_grad
+        }
+        self.backup: dict[str, torch.Tensor] | None = None
+
+    @staticmethod
+    def _clean(name: str) -> str:
+        return name.replace("_orig_mod.", "")
+
+    @torch.no_grad()
+    def update(self, model: torch.nn.Module) -> None:
+        self.step_counter += 1
+        actual_decay = min(self.decay, (1 + self.step_counter) / (10 + self.step_counter))
+        for name, param in model.named_parameters():
+            key = self._clean(name)
+            if not param.requires_grad or key not in self.shadow:
+                continue
+            self.shadow[key].mul_(actual_decay).add_(param.detach(), alpha=1 - actual_decay)
+
+    @torch.no_grad()
+    def store(self, model: torch.nn.Module) -> None:
+        self.backup = {
+            self._clean(name): param.detach().clone()
+            for name, param in model.named_parameters()
+            if param.requires_grad and self._clean(name) in self.shadow
+        }
+
+    @torch.no_grad()
+    def copy_to(self, model: torch.nn.Module) -> None:
+        for name, param in model.named_parameters():
+            key = self._clean(name)
+            if param.requires_grad and key in self.shadow:
+                param.data.copy_(self.shadow[key])
+
+    @torch.no_grad()
+    def restore(self, model: torch.nn.Module) -> None:
+        if self.backup is None:
+            return
+        for name, param in model.named_parameters():
+            key = self._clean(name)
+            if param.requires_grad and key in self.backup:
+                param.data.copy_(self.backup[key])
+        self.backup = None
 
 
 LEGACY_VAL_ALIAS = {
@@ -67,8 +120,7 @@ class TrainConfig:
     optimizer: str = "lion"
     use_lookahead: bool = True
     use_ema: bool = True
-    ema_decay: float = 0.999
-    ema_start_step: int = 50
+    ema_decay: float = 0.9999
     num_workers: int = -1
     pin_memory: bool = True
     persistent_workers: bool = True
@@ -1042,8 +1094,8 @@ def train_one_epoch(
     loader: DataLoader,
     optimizer,
     scheduler,
-    ema: EMA | None,
-    anp_ema: EMA | None,
+    ema: EMAWithWarmup | None,
+    anp_ema: EMAWithWarmup | None,
     transform: TargetTransform | TandemTargetTransform,
     device: torch.device,
     model_name: str,
@@ -1108,6 +1160,7 @@ def train_one_epoch(
             scheduler.step()
         if ema is not None:
             ema.update(model)
+            running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
         if anp_head is not None and anp_ema is not None:
             anp_ema.update(anp_head)
         running["loss"] += float(loss.detach().cpu().item())
@@ -1256,8 +1309,8 @@ def main() -> None:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
-    ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None
-    anp_ema = EMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema and anp_head is not None else None
+    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
+    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
 
     run = None

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -165,6 +165,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
+    loss_type: str = "mse"
+    huber_delta: float = 1.0
 
 
 @dataclass
@@ -730,21 +732,33 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def _compute_loss(pred: torch.Tensor, target: torch.Tensor, loss_type: str = "mse", huber_delta: float = 1.0) -> torch.Tensor:
+    if loss_type == "huber":
+        return F.huber_loss(pred, target, delta=huber_delta)
+    if loss_type == "log_cosh":
+        diff = pred - target
+        abs_diff = diff.abs()
+        return torch.mean(abs_diff + F.softplus(-2.0 * abs_diff) - math.log(2.0))
+    return F.mse_loss(pred, target)
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    loss_type: str = "mse",
+    huber_delta: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        surf_loss = _compute_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask], loss_type, huber_delta)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
-        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
+        vol_loss = _compute_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask], loss_type, huber_delta)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -754,15 +768,17 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    loss_type: str = "mse",
+    huber_delta: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
     if outputs["surface_preds"] is not None:
-        surf_loss = F.mse_loss(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask])
+        surf_loss = _compute_loss(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask], loss_type, huber_delta)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
-        vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
+        vol_loss = _compute_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask], loss_type, huber_delta)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -773,17 +789,19 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    loss_type: str = "mse",
+    huber_delta: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
     if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
         surf_target = transform.apply(batch.surface_anchor_target)
-        surf_loss = F.mse_loss(outputs["surface_preds"], surf_target)
+        surf_loss = _compute_loss(outputs["surface_preds"], surf_target, loss_type, huber_delta)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
-        vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
+        vol_loss = _compute_loss(outputs["volume_preds"], vol_target, loss_type, huber_delta)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -1192,6 +1210,8 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    loss_type: str = "mse",
+    huber_delta: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1211,7 +1231,7 @@ def train_one_epoch(
                     surface_anchor_position=batch.surface_anchor_position,
                     volume_anchor_position=batch.volume_anchor_position,
                 )
-                loss, _ = loss_abupt(batch, outputs, transform)
+                loss, _ = loss_abupt(batch, outputs, transform, loss_type, huber_delta)
         else:
             batch = batch.to(device)
             if isinstance(transform, TandemTargetTransform):
@@ -1224,7 +1244,7 @@ def train_one_epoch(
                         volume_mask=prepared.volume_mask,
                     )
                     outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                    loss, _ = loss_grouped_tandem(prepared, outputs)
+                    loss, _ = loss_grouped_tandem(prepared, outputs, loss_type, huber_delta)
             else:
                 with autocast_context(device, amp_mode):
                     outputs = model(
@@ -1233,7 +1253,7 @@ def train_one_epoch(
                         volume_x=batch.volume_x,
                         volume_mask=batch.volume_mask,
                     )
-                    loss, _ = loss_grouped(batch, outputs, transform)
+                    loss, _ = loss_grouped(batch, outputs, transform, loss_type, huber_delta)
         loss.backward()
         all_params = list(model.parameters())
         if anp_head is not None:
@@ -1433,6 +1453,8 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            loss_type=config.loss_type,
+            huber_delta=config.huber_delta,
         )
 
         if ema is not None:

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -93,6 +93,7 @@ LEGACY_VAL_ALIAS = {
     "val_ood_re": "p_re",
 }
 AIRFRANS_FIELD_NAMES = ("Ux", "Uy", "p", "nut")
+TANDEM_FIELD_NAMES = ("Ux", "Uy", "p")
 
 
 @dataclass
@@ -134,6 +135,9 @@ class TrainConfig:
     airfrans_task: str = "full"
     tandem_manifest: str = ""
     tandem_stats: str = ""
+    tandemfoil_paper_task: str = "cruise_random_uniform"
+    tandemfoil_paper_manifest: str = ""
+    tandemfoil_paper_stats: str = ""
     enable_fourier: bool = False
     enable_te_coord_frame: bool = False
     enable_cp_panel: bool = False
@@ -430,6 +434,7 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
     bundle_kwargs = {
         "dataset_name": config.dataset,
         "debug": config.debug,
+        "tandemfoil_paper_task": config.tandemfoil_paper_task,
         "airfrans_task": config.airfrans_task,
         "drivaerml_surface_only": config.surface_only_drivaerml,
         "drivaerml_train_surface_points": config.drivaerml_train_surface_points,
@@ -447,6 +452,10 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
         bundle_kwargs["tandem_manifest"] = config.tandem_manifest
     if config.tandem_stats:
         bundle_kwargs["tandem_stats"] = config.tandem_stats
+    if config.tandemfoil_paper_manifest:
+        bundle_kwargs["tandemfoil_paper_manifest"] = config.tandemfoil_paper_manifest
+    if config.tandemfoil_paper_stats:
+        bundle_kwargs["tandemfoil_paper_stats"] = config.tandemfoil_paper_stats
     return build_dataset_bundle(**bundle_kwargs)
 
 
@@ -831,6 +840,10 @@ def evaluate_grouped(
     n_vol = torch.zeros(3, device=device)
     surf_channel_sum = None
     vol_channel_sum = None
+    paper_surface_sq_sum = None
+    paper_volume_sq_sum = None
+    paper_surface_nodes = 0
+    paper_volume_nodes = 0
     drivaer_surface_case_sums: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
     drivaer_volume_case_sums: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
@@ -906,6 +919,25 @@ def evaluate_grouped(
                         vol_channel_sum += channel_mean.to(device)
             continue
 
+        if dataset_name == "tandemfoilset_paper":
+            if batch.surface_y is not None and outputs["surface_preds"] is not None:
+                target = transform.apply(batch.surface_y)
+                case_values = (outputs["surface_preds"] - target).square()
+                valid = batch.surface_mask.unsqueeze(-1)
+                if paper_surface_sq_sum is None:
+                    paper_surface_sq_sum = torch.zeros(case_values.shape[-1], device=device)
+                paper_surface_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device)
+                paper_surface_nodes += int(batch.surface_mask.sum().detach().cpu().item())
+            if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
+                target = transform.apply(batch.volume_y)
+                case_values = (outputs["volume_preds"] - target).square()
+                valid = batch.volume_mask.unsqueeze(-1)
+                if paper_volume_sq_sum is None:
+                    paper_volume_sq_sum = torch.zeros(case_values.shape[-1], device=device)
+                paper_volume_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device)
+                paper_volume_nodes += int(batch.volume_mask.sum().detach().cpu().item())
+            continue
+
         pred_surface = None
         pred_volume = None
         if batch.surface_y is not None and outputs["surface_preds"] is not None:
@@ -969,6 +1001,25 @@ def evaluate_grouped(
             metrics["volume_rel_l2"] = volume_rel_l2
             metrics["volume_rel_l2_pct"] = volume_rel_l2 * 100.0
         return metrics
+    if dataset_name == "tandemfoilset_paper":
+        metrics: dict[str, float] = {}
+        total_sq_sum = 0.0
+        total_nodes = 0
+        if paper_surface_sq_sum is not None and paper_surface_nodes > 0:
+            surface_channel = paper_surface_sq_sum / paper_surface_nodes
+            metrics["surface_mse"] = float(surface_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("surface_mse", surface_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_surface_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_surface_nodes
+        if paper_volume_sq_sum is not None and paper_volume_nodes > 0:
+            volume_channel = paper_volume_sq_sum / paper_volume_nodes
+            metrics["volume_mse"] = float(volume_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("volume_mse", volume_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_volume_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_volume_nodes
+        if total_nodes > 0:
+            metrics["field_mse"] = total_sq_sum / (total_nodes * len(TANDEM_FIELD_NAMES))
+        return metrics
     metrics = {
         "surface_mae": total_surface / max(count_surface, 1),
         "volume_mae": total_volume / max(count_volume, 1),
@@ -1006,6 +1057,10 @@ def evaluate_abupt(
     count_volume = 0
     surf_channel_sum = None
     vol_channel_sum = None
+    paper_surface_sq_sum = None
+    paper_volume_sq_sum = None
+    paper_surface_nodes = 0
+    paper_volume_nodes = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
     for batch in batches:
         batch = batch.to(device)
@@ -1036,6 +1091,21 @@ def evaluate_abupt(
                 if vol_channel_sum is None:
                     vol_channel_sum = torch.zeros(channel_mean.shape[0], device=device)
                 vol_channel_sum += channel_mean.to(device)
+            continue
+
+        if dataset_name == "tandemfoilset_paper":
+            if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
+                target = transform.apply(batch.surface_anchor_target)
+                if paper_surface_sq_sum is None:
+                    paper_surface_sq_sum = torch.zeros(target.shape[-1], device=device)
+                paper_surface_sq_sum += (outputs["surface_preds"] - target).square().sum(dim=(0, 1)).to(device)
+                paper_surface_nodes += batch.surface_anchor_target.shape[0] * batch.surface_anchor_target.shape[1]
+            if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
+                target = transform.apply(batch.volume_anchor_target)
+                if paper_volume_sq_sum is None:
+                    paper_volume_sq_sum = torch.zeros(target.shape[-1], device=device)
+                paper_volume_sq_sum += (outputs["volume_preds"] - target).square().sum(dim=(0, 1)).to(device)
+                paper_volume_nodes += batch.volume_anchor_target.shape[0] * batch.volume_anchor_target.shape[1]
             continue
 
         if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
@@ -1084,6 +1154,25 @@ def evaluate_abupt(
             volume_rel_l2 = total_volume / count_volume
             metrics["volume_rel_l2"] = volume_rel_l2
             metrics["volume_rel_l2_pct"] = volume_rel_l2 * 100.0
+        return metrics
+    if dataset_name == "tandemfoilset_paper":
+        metrics: dict[str, float] = {}
+        total_sq_sum = 0.0
+        total_nodes = 0
+        if paper_surface_sq_sum is not None and paper_surface_nodes > 0:
+            surface_channel = paper_surface_sq_sum / paper_surface_nodes
+            metrics["surface_mse"] = float(surface_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("surface_mse", surface_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_surface_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_surface_nodes
+        if paper_volume_sq_sum is not None and paper_volume_nodes > 0:
+            volume_channel = paper_volume_sq_sum / paper_volume_nodes
+            metrics["volume_mse"] = float(volume_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("volume_mse", volume_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_volume_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_volume_nodes
+        if total_nodes > 0:
+            metrics["field_mse"] = total_sq_sum / (total_nodes * len(TANDEM_FIELD_NAMES))
         return metrics
     return {"surface_mae": total_surface / max(count_surface, 1), "volume_mae": total_volume / max(count_volume, 1)}
 


### PR DESCRIPTION
## Hypothesis

MSE loss treats all prediction errors equally, but CFD meshes have high-error outlier nodes at stagnation points, trailing edges, and separation zones. These outliers disproportionately dominate the MSE gradient, pulling the model away from good predictions on the majority of well-behaved nodes. Huber loss (and optionally log-cosh) clips the gradient contribution from large-error nodes, providing robustness while remaining convex and smooth. We hypothesize this will improve mean surface metrics across all three datasets by reducing the distortion caused by outlier nodes.

Reference: Huber (1964), "Robust Estimation of a Location Parameter"; log-cosh is a smooth approximation with similar robustness properties.

## Code Change Required

Add the following to `target/icml2026/train.py`:

```python
# Add CLI args near other loss/training args:
parser.add_argument('--loss-type', type=str, default='mse',
                    choices=['mse', 'huber', 'log_cosh'],
                    help='Loss function type. mse=default, huber=robust to outliers, log_cosh=smooth robust.')
parser.add_argument('--huber-delta', type=float, default=1.0,
                    help='Delta threshold for Huber loss (only used when --loss-type huber).')

# Replace the loss function instantiation (wherever criterion/loss is set up):
if args.loss_type == 'huber':
    criterion = nn.HuberLoss(delta=args.huber_delta)
elif args.loss_type == 'log_cosh':
    def log_cosh_loss(pred, target):
        return torch.mean(torch.log(torch.cosh(pred - target)))
    criterion = log_cosh_loss
else:
    criterion = nn.MSELoss()
```

Make sure the new `criterion` is used wherever the loss is computed during training and validation.

## Instructions

Run the following matrix across all three datasets. Use `--wandb_group huber-loss-cross` on all runs so they are grouped in W&B.

**AirfRANS — golden config baseline + Huber/log-cosh variants:**

```bash
# AF control (MSE — confirm baseline)
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --loss-type mse \
  --wandb_group huber-loss-cross --wandb_run_name af-mse-control

# AF Huber delta=1.0
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --loss-type huber --huber-delta 1.0 \
  --wandb_group huber-loss-cross --wandb_run_name af-huber-d1

# AF Huber delta=0.1
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --loss-type huber --huber-delta 0.1 \
  --wandb_group huber-loss-cross --wandb_run_name af-huber-d01
```

**TandemFoil — golden config baseline + Huber/log-cosh variants:**

```bash
# TF control (MSE — confirm baseline)
python train.py --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --loss-type mse \
  --wandb_group huber-loss-cross --wandb_run_name tf-mse-control

# TF Huber delta=1.0
python train.py --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --loss-type huber --huber-delta 1.0 \
  --wandb_group huber-loss-cross --wandb_run_name tf-huber-d1

# TF log-cosh
python train.py --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --loss-type log_cosh \
  --wandb_group huber-loss-cross --wandb_run_name tf-log-cosh
```

**DrivAerML — golden config baseline + Huber/log-cosh variants:**

```bash
# DAM control (MSE — confirm baseline)
python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --loss-type mse \
  --wandb_group huber-loss-cross --wandb_run_name dam-mse-control

# DAM Huber delta=1.0
python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --loss-type huber --huber-delta 1.0 \
  --wandb_group huber-loss-cross --wandb_run_name dam-huber-d1

# DAM log-cosh
python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --loss-type log_cosh \
  --wandb_group huber-loss-cross --wandb_run_name dam-log-cosh
```

Report best val/loss for each run and the W&B run ID. Compare each variant against the MSE control.

## Baseline

Current best metrics:

| Dataset | val/loss | PR | W&B Run |
|---------|----------|----|---------|
| AirfRANS | 0.001236 | #2828 | libpwryz |
| TandemFoil | 30.10 | #2810 | v6amjkh7 |
| DrivAerML | 4.619% | #2691 | k8qtsxxz |

**AirfRANS reproduce:**
```bash
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999
```

**TandemFoil reproduce:**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999
```

**DrivAerML reproduce:**
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```