### PR TITLE
Cross-dataset: gradient accumulation — larger effective batch size across all three datasets (CODE CHANGE)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -107,6 +107,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
+    grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1051,49 +1052,71 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    grad_accum_steps: int = 1,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
         anp_head.train()
     running = {"loss": 0.0}
     steps = 0
+    micro_batches_total = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
-    for batch in batches:
+    batch_iter = iter(batches)
+    exhausted = False
+
+    while not exhausted:
         optimizer.zero_grad(set_to_none=True)
-        if model_name == "reference_abupt":
-            batch = batch.to(device)
-            with autocast_context(device, amp_mode):
-                outputs = model(
-                    geometry_position=batch.geometry_position,
-                    geometry_supernode_idx=batch.geometry_supernode_idx,
-                    geometry_batch_idx=batch.geometry_batch_idx,
-                    surface_anchor_position=batch.surface_anchor_position,
-                    volume_anchor_position=batch.volume_anchor_position,
-                )
-                loss, _ = loss_abupt(batch, outputs, transform)
-        else:
-            batch = batch.to(device)
-            if isinstance(transform, TandemTargetTransform):
-                prepared = transform.prepare_batch(batch)
+        accum_loss = 0.0
+        micro_count = 0
+
+        for _ in range(grad_accum_steps):
+            try:
+                batch = next(batch_iter)
+            except StopIteration:
+                exhausted = True
+                break
+
+            if model_name == "reference_abupt":
+                batch = batch.to(device)
                 with autocast_context(device, amp_mode):
                     outputs = model(
-                        surface_x=prepared.surface_x,
-                        surface_mask=prepared.surface_mask,
-                        volume_x=prepared.volume_x,
-                        volume_mask=prepared.volume_mask,
+                        geometry_position=batch.geometry_position,
+                        geometry_supernode_idx=batch.geometry_supernode_idx,
+                        geometry_batch_idx=batch.geometry_batch_idx,
+                        surface_anchor_position=batch.surface_anchor_position,
+                        volume_anchor_position=batch.volume_anchor_position,
                     )
-                    outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                    loss, _ = loss_grouped_tandem(prepared, outputs)
+                    loss, _ = loss_abupt(batch, outputs, transform)
             else:
-                with autocast_context(device, amp_mode):
-                    outputs = model(
-                        surface_x=batch.surface_x,
-                        surface_mask=batch.surface_mask,
-                        volume_x=batch.volume_x,
-                        volume_mask=batch.volume_mask,
-                    )
-                    loss, _ = loss_grouped(batch, outputs, transform)
-        loss.backward()
+                batch = batch.to(device)
+                if isinstance(transform, TandemTargetTransform):
+                    prepared = transform.prepare_batch(batch)
+                    with autocast_context(device, amp_mode):
+                        outputs = model(
+                            surface_x=prepared.surface_x,
+                            surface_mask=prepared.surface_mask,
+                            volume_x=prepared.volume_x,
+                            volume_mask=prepared.volume_mask,
+                        )
+                        outputs = maybe_apply_anp(outputs, prepared, anp_head)
+                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                else:
+                    with autocast_context(device, amp_mode):
+                        outputs = model(
+                            surface_x=batch.surface_x,
+                            surface_mask=batch.surface_mask,
+                            volume_x=batch.volume_x,
+                            volume_mask=batch.volume_mask,
+                        )
+                        loss, _ = loss_grouped(batch, outputs, transform)
+
+            accum_loss += float(loss.detach().cpu().item())
+            (loss / grad_accum_steps).backward()
+            micro_count += 1
+
+        if micro_count == 0:
+            break
+
         all_params = list(model.parameters())
         if anp_head is not None:
             all_params += list(anp_head.parameters())
@@ -1110,12 +1133,15 @@ def train_one_epoch(
             ema.update(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.update(anp_head)
-        running["loss"] += float(loss.detach().cpu().item())
+        running["loss"] += accum_loss / micro_count
+        micro_batches_total += micro_count
         steps += 1
+
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
     running["train_steps"] = float(steps)
+    running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
     return running
@@ -1262,12 +1288,14 @@ def main() -> None:
 
     run = None
     if config.wandb_name:
+        run_config = asdict(config)
+        run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),
             name=config.wandb_name,
             group=config.wandb_group or None,
-            config=asdict(config),
+            config=run_config,
             tags=[config.dataset, config.model],
         )
 
@@ -1291,6 +1319,7 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            grad_accum_steps=config.grad_accum_steps,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Gradient accumulation simulates a larger effective batch size by accumulating gradients over multiple micro-steps before calling `optimizer.step()`. For AirfRANS and TandemFoil, where batch sizes are already moderate, this allows exploration of a higher effective batch regime that may smooth the loss landscape and improve generalization. For DrivAerML, which is forced to `batch-size 1` by VRAM constraints, gradient accumulation is the only path to larger effective batches, potentially stabilizing training significantly. We hypothesize that `--grad-accum-steps 4` (effective batch size ×4) will lower val/loss across all three datasets, with the largest gain on DrivAerML where the effective batch is currently the smallest.

## Code Change Required

Add the following to `target/icml2026/train.py`:

```python
# Add CLI arg near other training args:
parser.add_argument('--grad-accum-steps', type=int, default=1,
                    help='Number of gradient accumulation steps. Effective batch size = batch_size * grad_accum_steps.')
```

Replace the existing per-batch training loop with an accumulation-aware version:

```python
optimizer.zero_grad()
for micro_step in range(args.grad_accum_steps):
    batch = next(train_iter)
    loss = model(batch) / args.grad_accum_steps
    loss.backward()
optimizer.step()
scheduler.step()
```

Note: `args.grad_accum_steps=1` should reproduce the original behavior exactly (one micro-step, no accumulation). Make sure the train iterator (`train_iter`) is set up to support repeated `next()` calls per optimizer step.

## Instructions

Run the following matrix across all three datasets. Use `--wandb_group grad-accum-cross` on all runs.

**AirfRANS — golden config + grad accumulation variants:**

```bash
# AF control (accum=1, confirm baseline)
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --grad-accum-steps 1 \
  --wandb_group grad-accum-cross --wandb_run_name af-accum1-control

# AF accum=4 (effective batch ×4)
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --grad-accum-steps 4 \
  --wandb_group grad-accum-cross --wandb_run_name af-accum4

# AF accum=8 (effective batch ×8)
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --grad-accum-steps 8 \
  --wandb_group grad-accum-cross --wandb_run_name af-accum8
```

**TandemFoil — golden config + grad accumulation variants:**

```bash
# TF control (accum=1, confirm baseline)
python train.py --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --grad-accum-steps 1 \
  --wandb_group grad-accum-cross --wandb_run_name tf-accum1-control

# TF accum=4
python train.py --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --grad-accum-steps 4 \
  --wandb_group grad-accum-cross --wandb_run_name tf-accum4
```

**DrivAerML — golden config + grad accumulation variants (highest priority — currently batch_size=1):**

```bash
# DAM control (accum=1, effective batch=1)
python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --grad-accum-steps 1 \
  --wandb_group grad-accum-cross --wandb_run_name dam-accum1-control

# DAM accum=4 (effective batch=4)
python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --grad-accum-steps 4 \
  --wandb_group grad-accum-cross --wandb_run_name dam-accum4

# DAM accum=8 (effective batch=8)
python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --grad-accum-steps 8 \
  --wandb_group grad-accum-cross --wandb_run_name dam-accum8
```

Report best val/loss and W&B run ID for each variant. For DrivAerML, also report the epoch at which each run's best val/loss was achieved — we want to know if accumulation also speeds convergence.

## Baseline

Current best metrics:

| Dataset | val/loss | PR | W&B Run |
|---------|----------|----|---------|
| AirfRANS | 0.001236 | #2828 | libpwryz |
| TandemFoil | 30.10 | #2810 | v6amjkh7 |
| DrivAerML | 4.619% | #2691 | k8qtsxxz |

**AirfRANS reproduce:**
```bash
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999
```

**TandemFoil reproduce:**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999
```

**DrivAerML reproduce:**
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```