### PR TITLE
Cross-dataset: SWA from cosine troughs — flat minima generalization (CODE CHANGE)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -31,6 +31,7 @@ from core.features import (
     compute_wake_deficit_features,
 )
 from core.optim import Lion, Lookahead
+from torch.optim.swa_utils import AveragedModel, update_bn
 
 
 class EMAWithWarmup:
@@ -166,6 +167,8 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    use_swa: bool = False
+    swa_start_epoch: int = 50
 
 
 @dataclass
@@ -1426,6 +1429,9 @@ def main() -> None:
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+
+    swa_model = AveragedModel(model) if config.use_swa else None
+    swa_n_averaged = 0
     history: list[dict[str, float]] = []
 
     run = None
@@ -1464,18 +1470,28 @@ def main() -> None:
             grad_accum_steps=config.grad_accum_steps,
         )
 
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
+        if swa_model is not None and epoch >= config.swa_start_epoch:
+            swa_model.update_parameters(model)
+            swa_n_averaged += 1
+
+        swa_active = swa_model is not None and swa_n_averaged > 0
+        if swa_active:
+            update_bn(train_loader, swa_model, device=device)
+            eval_model = swa_model
+        else:
+            if ema is not None:
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
+            eval_model = forward_model
 
         eval_metrics: dict[str, float] = {}
         for split_name, loader in val_loaders.items():
             if config.model == "reference_abupt":
                 split_metrics = evaluate_abupt(
-                    forward_model,
+                    eval_model,
                     loader,
                     transform,
                     device,
@@ -1484,7 +1500,7 @@ def main() -> None:
                 )
             else:
                 split_metrics = evaluate_grouped(
-                    forward_model,
+                    eval_model,
                     anp_head,
                     loader,
                     transform,
@@ -1507,11 +1523,14 @@ def main() -> None:
             if len(eq4_values) == 4:
                 eval_metrics["val_eq4/surface_pressure_mae"] = sum(eq4_values) / 4.0
         eval_metrics = add_primary_metric_aliases(bundle, eval_metrics, phase="val")
+        if swa_active:
+            eval_metrics["swa/n_averaged"] = float(swa_n_averaged)
 
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
+        if not swa_active:
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         history.append(epoch_metrics)
@@ -1521,18 +1540,24 @@ def main() -> None:
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     final_test_metrics: dict[str, float] = {}
+    swa_active = swa_model is not None and swa_n_averaged > 0
     if test_loaders:
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
+        if swa_active:
+            update_bn(train_loader, swa_model, device=device)
+            test_eval_model = swa_model
+        else:
+            if ema is not None:
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
+            test_eval_model = forward_model
 
         for split_name, loader in test_loaders.items():
             if config.model == "reference_abupt":
                 split_metrics = evaluate_abupt(
-                    forward_model,
+                    test_eval_model,
                     loader,
                     transform,
                     device,
@@ -1541,7 +1566,7 @@ def main() -> None:
                 )
             else:
                 split_metrics = evaluate_grouped(
-                    forward_model,
+                    test_eval_model,
                     anp_head,
                     loader,
                     transform,
@@ -1561,11 +1586,14 @@ def main() -> None:
             if len(eq4_values) == 4:
                 final_test_metrics["test_eq4/surface_pressure_mae"] = sum(eq4_values) / 4.0
         final_test_metrics = add_primary_metric_aliases(bundle, final_test_metrics, phase="test")
+        if swa_active:
+            final_test_metrics["swa/n_averaged"] = float(swa_n_averaged)
 
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
+        if not swa_active:
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
         if run is not None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -169,6 +169,7 @@ class TrainConfig:
     seed: int = 0
     use_swa: bool = False
     swa_start_epoch: int = 50
+    swa_trough_only: bool = False
 
 
 @dataclass
@@ -1471,8 +1472,12 @@ def main() -> None:
         )
 
         if swa_model is not None and epoch >= config.swa_start_epoch:
-            swa_model.update_parameters(model)
-            swa_n_averaged += 1
+            do_swa_update = True
+            if config.swa_trough_only and config.cosine_t_max > 0:
+                do_swa_update = epoch % config.cosine_t_max == 0
+            if do_swa_update:
+                swa_model.update_parameters(model)
+                swa_n_averaged += 1
 
         swa_active = swa_model is not None and swa_n_averaged > 0
         if swa_active:
@@ -1525,6 +1530,7 @@ def main() -> None:
         eval_metrics = add_primary_metric_aliases(bundle, eval_metrics, phase="val")
         if swa_active:
             eval_metrics["swa/n_averaged"] = float(swa_n_averaged)
+            eval_metrics["swa/trough_only"] = float(config.swa_trough_only)
 
         if not swa_active:
             if ema is not None:


### PR DESCRIPTION
## Hypothesis

Stochastic Weight Averaging (SWA) averages model weights collected from multiple cosine LR cycle troughs. The averaged weights lie in flatter, wider loss basins that generalize better than any single checkpoint. Our val→test gap (TF: 30.10→33.88 = 12.5%) suggests the current optima are too sharp. SWA should reduce this gap by finding broader, more robust minima. Prior work shows SWA reliably improves generalization with almost no additional compute cost.

## Instructions

**CODE CHANGE REQUIRED:** Add `--use-swa` flag and `--swa-start-epoch N` argument to `target/icml2026/train.py`. Use PyTorch native SWA utilities:

```python
from torch.optim.swa_utils import AveragedModel, SWALR, update_bn

swa_model = AveragedModel(model)
# After swa_start_epoch, at each epoch end:
swa_model.update_parameters(model)
# Before evaluation:
update_bn(train_loader, swa_model)  # CRITICAL — must update BN stats
# Evaluate swa_model instead of model
```

**CRITICAL:** `update_bn()` is mandatory before evaluation. Without it, batch norm statistics are stale and SWA appears to not work. Also ensure you evaluate `swa_model` (not the base `model`) when `--use-swa` is active.

All runs use: `--no-use-ema --epochs 999 --enable-fourier`

DrivAerML extra flags: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

TandemFoil extra flags: `--optimizer lion --model-slices 64 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition`

**Runs (use `--wandb_group swa-troughs`):**

- **GPU 0:** TF base + `--use-swa --swa-start-epoch 50`
  ```
  python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --use-swa --swa-start-epoch 50 --wandb_group swa-troughs
  ```

- **GPU 1:** AF base + `--use-swa --swa-start-epoch 100`
  ```
  python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --use-swa --swa-start-epoch 100 --wandb_group swa-troughs
  ```

- **GPU 2:** DAM base + `--use-swa --swa-start-epoch 200`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-swa --swa-start-epoch 200 --wandb_group swa-troughs
  ```

- **GPU 3:** DAM base + `--use-swa --swa-start-epoch 300`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-swa --swa-start-epoch 300 --wandb_group swa-troughs
  ```

- **GPU 4:** DAM base + `--use-swa --swa-start-epoch 100`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-swa --swa-start-epoch 100 --wandb_group swa-troughs
  ```

- **GPU 5:** DAM base + `--use-swa --swa-start-epoch 200 --grad-clip 1.0`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-swa --swa-start-epoch 200 --wandb_group swa-troughs
  ```

- **GPU 6:** DAM base + `--use-swa --swa-start-epoch 200 --weight-decay 1e-2`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-swa --swa-start-epoch 200 --wandb_group swa-troughs
  ```

- **GPU 7:** DAM base + `--use-swa --swa-start-epoch 200 --grad-clip 1.0 --weight-decay 1e-2`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-swa --swa-start-epoch 200 --wandb_group swa-troughs
  ```

## Baseline

Current best metrics:
- **DrivAerML:** `val_primary/surface_rel_l2_pct` = **4.619%** (PR #2691, 4L/512d/8H, AdamW lr=5e-4, T_max=30). Target: 3.71%
- **AirfRANS:** `val_primary/surface_mse` = **0.001236** (PR #2828, 2L/256d/4H, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5). Target: 0.0043
- **TandemFoil:** `val_primary/surface_pressure_mae` = **30.10** (PR #2810, 3L/192d/3H, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10)