### PR TITLE
Cross-dataset: Momentum-SAM (MSAM) — flat minima without 2x compute (CODE CHANGE)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -109,6 +109,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
+    use_msam: bool = False
+    msam_rho: float = 0.02
 
 
 @dataclass
@@ -1036,6 +1038,65 @@ def evaluate_abupt(
     return {"surface_mae": total_surface / max(count_surface, 1), "volume_mae": total_volume / max(count_volume, 1)}
 
 
+def _forward_and_loss(model, model_name, batch, transform, anp_head, device, amp_mode):
+    if model_name == "reference_abupt":
+        with autocast_context(device, amp_mode):
+            outputs = model(
+                geometry_position=batch.geometry_position,
+                geometry_supernode_idx=batch.geometry_supernode_idx,
+                geometry_batch_idx=batch.geometry_batch_idx,
+                surface_anchor_position=batch.surface_anchor_position,
+                volume_anchor_position=batch.volume_anchor_position,
+            )
+            loss, _ = loss_abupt(batch, outputs, transform)
+    elif isinstance(transform, TandemTargetTransform):
+        prepared = transform.prepare_batch(batch)
+        with autocast_context(device, amp_mode):
+            outputs = model(
+                surface_x=prepared.surface_x,
+                surface_mask=prepared.surface_mask,
+                volume_x=prepared.volume_x,
+                volume_mask=prepared.volume_mask,
+            )
+            outputs = maybe_apply_anp(outputs, prepared, anp_head)
+            loss, _ = loss_grouped_tandem(prepared, outputs)
+    else:
+        with autocast_context(device, amp_mode):
+            outputs = model(
+                surface_x=batch.surface_x,
+                surface_mask=batch.surface_mask,
+                volume_x=batch.volume_x,
+                volume_mask=batch.volume_mask,
+            )
+            loss, _ = loss_grouped(batch, outputs, transform)
+    return loss
+
+
+def _msam_perturb(base_optimizer, rho):
+    deltas = {}
+    with torch.no_grad():
+        for group in base_optimizer.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                state = base_optimizer.state[p]
+                if "exp_avg" not in state:
+                    continue
+                momentum = state["exp_avg"]
+                norm = momentum.norm()
+                if norm > 0:
+                    delta = rho * momentum / norm
+                    deltas[p] = delta
+                    p.data.add_(delta)
+    return deltas
+
+
+def _msam_unperturb(deltas):
+    with torch.no_grad():
+        for p, delta in deltas.items():
+            p.data.sub_(delta)
+
+
 def train_one_epoch(
     model: torch.nn.Module,
     anp_head: ANPSurfaceDecoder | None,
@@ -1051,6 +1112,8 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    use_msam: bool = False,
+    msam_rho: float = 0.02,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1058,42 +1121,26 @@ def train_one_epoch(
     running = {"loss": 0.0}
     steps = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
+
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+
     for batch in batches:
         optimizer.zero_grad(set_to_none=True)
-        if model_name == "reference_abupt":
-            batch = batch.to(device)
-            with autocast_context(device, amp_mode):
-                outputs = model(
-                    geometry_position=batch.geometry_position,
-                    geometry_supernode_idx=batch.geometry_supernode_idx,
-                    geometry_batch_idx=batch.geometry_batch_idx,
-                    surface_anchor_position=batch.surface_anchor_position,
-                    volume_anchor_position=batch.volume_anchor_position,
-                )
-                loss, _ = loss_abupt(batch, outputs, transform)
-        else:
-            batch = batch.to(device)
-            if isinstance(transform, TandemTargetTransform):
-                prepared = transform.prepare_batch(batch)
-                with autocast_context(device, amp_mode):
-                    outputs = model(
-                        surface_x=prepared.surface_x,
-                        surface_mask=prepared.surface_mask,
-                        volume_x=prepared.volume_x,
-                        volume_mask=prepared.volume_mask,
-                    )
-                    outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                    loss, _ = loss_grouped_tandem(prepared, outputs)
-            else:
-                with autocast_context(device, amp_mode):
-                    outputs = model(
-                        surface_x=batch.surface_x,
-                        surface_mask=batch.surface_mask,
-                        volume_x=batch.volume_x,
-                        volume_mask=batch.volume_mask,
-                    )
-                    loss, _ = loss_grouped(batch, outputs, transform)
+        batch = batch.to(device)
+        loss = _forward_and_loss(model, model_name, batch, transform, anp_head, device, amp_mode)
         loss.backward()
+        original_loss = float(loss.detach().cpu().item())
+
+        if use_msam:
+            deltas = _msam_perturb(base_optimizer, msam_rho)
+            if deltas:
+                optimizer.zero_grad(set_to_none=True)
+                loss_perturbed = _forward_and_loss(model, model_name, batch, transform, anp_head, device, amp_mode)
+                loss_perturbed.backward()
+                _msam_unperturb(deltas)
+                running.setdefault("msam_loss_increase", 0.0)
+                running["msam_loss_increase"] += float(loss_perturbed.detach().cpu().item()) - original_loss
+
         all_params = list(model.parameters())
         if anp_head is not None:
             all_params += list(anp_head.parameters())
@@ -1110,11 +1157,13 @@ def train_one_epoch(
             ema.update(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.update(anp_head)
-        running["loss"] += float(loss.detach().cpu().item())
+        running["loss"] += original_loss
         steps += 1
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "msam_loss_increase" in running:
+        running["msam_loss_increase"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
@@ -1291,6 +1340,8 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            use_msam=config.use_msam,
+            msam_rho=config.msam_rho,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Standard SAM costs 2x compute (unacceptable at our epoch budget). Momentum-SAM (MSAM) perturbs weights in the momentum buffer direction instead — same flat-minima bias at ~0.1% overhead. At 2-11 epochs for shorter datasets, pushing toward broad basins from the first step amplifies each gradient step's value. The momentum direction is more stable than raw gradient direction, so the perturbation rho can be larger without instability. Prior work shows SAM-style methods improve generalization by finding flatter loss basins.

## Instructions

**CODE CHANGE REQUIRED:** Add `--use-msam` flag and `--msam-rho` argument (default 0.02) to `target/icml2026/train.py`. Implementation:

```python
# At each optimizer.step(), before clearing gradients:
if args.use_msam:
    with torch.no_grad():
        for group in optimizer.param_groups:
            for p in group['params']:
                if p.grad is None: continue
                state = optimizer.state[p]
                if 'exp_avg' not in state: continue  # skip if no momentum yet
                momentum = state['exp_avg']
                norm = momentum.norm()
                if norm > 0:
                    delta = args.msam_rho * momentum / norm
                    p.data.add_(delta)
        # Recompute loss and grad at perturbed point (use same batch)
        loss_perturbed = compute_loss(model, batch)
        loss_perturbed.backward()
        # Remove perturbation
        for group in optimizer.param_groups:
            for p in group['params']:
                if p.grad is None: continue
                state = optimizer.state[p]
                if 'exp_avg' not in state: continue
                momentum = state['exp_avg']
                norm = momentum.norm()
                if norm > 0:
                    delta = args.msam_rho * momentum / norm
                    p.data.sub_(delta)
    optimizer.step()
```

**Note:** This DOES require 2 forward-backward passes per step (same as regular SAM). The advantage of MSAM is that the perturbation direction (momentum) is more stable than the raw gradient direction, so rho can be larger. If this is too expensive, try with `--msam-rho 0.01` and only apply MSAM every 2nd step.

All runs use: `--no-use-ema --epochs 999 --enable-fourier`

DrivAerML extra flags: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

TandemFoil extra flags: `--optimizer lion --model-slices 64 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition`

**Runs (use `--wandb_group msam-optimizer`):**

- **GPU 0:** TF base + `--use-msam --msam-rho 0.02`
  ```
  python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --use-msam --msam-rho 0.02 --wandb_group msam-optimizer
  ```

- **GPU 1:** AF base + `--use-msam --msam-rho 0.02`
  ```
  python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --use-msam --msam-rho 0.02 --wandb_group msam-optimizer
  ```

- **GPU 2:** DAM base + `--use-msam --msam-rho 0.02`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-msam --msam-rho 0.02 --wandb_group msam-optimizer
  ```

- **GPU 3:** DAM base + `--use-msam --msam-rho 0.05`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-msam --msam-rho 0.05 --wandb_group msam-optimizer
  ```

- **GPU 4:** DAM base + `--use-msam --msam-rho 0.01`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-msam --msam-rho 0.01 --wandb_group msam-optimizer
  ```

- **GPU 5:** DAM base + `--use-msam --msam-rho 0.02 --grad-clip 1.0`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-msam --msam-rho 0.02 --wandb_group msam-optimizer
  ```

- **GPU 6:** DAM base + `--use-msam --msam-rho 0.02 --weight-decay 1e-2`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-msam --msam-rho 0.02 --wandb_group msam-optimizer
  ```

- **GPU 7:** DAM base + `--use-msam --msam-rho 0.02 --lr 4e-4`
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 4e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-msam --msam-rho 0.02 --wandb_group msam-optimizer
  ```

## Baseline

Current best metrics:
- **DrivAerML:** `val_primary/surface_rel_l2_pct` = **4.619%** (PR #2691, 4L/512d/8H, AdamW lr=5e-4, T_max=30). Target: 3.71%
- **AirfRANS:** `val_primary/surface_mse` = **0.001236** (PR #2828, 2L/256d/4H, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5). Target: 0.0043
- **TandemFoil:** `val_primary/surface_pressure_mae` = **30.10** (PR #2810, 3L/192d/3H, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10)