### PR TITLE
Cross-dataset: OneCycleLR — built-in warmup + annealing schedule (CODE CHANGE)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -102,6 +102,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    use_one_cycle: bool = False
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1252,8 +1253,15 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
-    if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+    if config.use_one_cycle:
+        batches_per_epoch = len(train_loader) if config.max_train_batches <= 0 else min(len(train_loader), config.max_train_batches)
+        total_steps = config.epochs * batches_per_epoch
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            base_optimizer, max_lr=config.lr, total_steps=total_steps,
+            pct_start=0.1, anneal_strategy='cos',
+        )
+    elif config.cosine_t_max > 0:
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMA(model, decay=config.ema_decay, start_step=config.ema_start_step) if config.use_ema else None


### PR DESCRIPTION
## Hypothesis

OneCycleLR provides linear warmup, cosine decay, AND momentum scheduling in one integrated package. Proven in modern training recipes (fastai, timm). Could replace our cosine+no-warmup default with a more robust, self-contained schedule. The built-in warmup phase helps early training escape poor local optima before the model commits, while the final annealing phase enables tighter convergence. Multiple max_lr variants will identify the optimal peak.

## Instructions

**CODE CHANGE REQUIRED:** Add `--use-one-cycle` flag to `target/icml2026/train.py`. When set, replace the cosine scheduler with OneCycleLR:

```python
if args.use_one_cycle:
    scheduler = torch.optim.lr_scheduler.OneCycleLR(
        optimizer, max_lr=args.lr, total_steps=total_training_steps,
        pct_start=0.1, anneal_strategy='cos'
    )
    # Step per batch, not per epoch!
else:
    scheduler = CosineAnnealingLR(optimizer, T_max=args.cosine_t_max)
```

**CRITICAL:** OneCycleLR steps per batch, not per epoch. The `total_steps` must be computed as `epochs × batches_per_epoch`. When `--use-one-cycle` is set, the `--cosine-t-max` flag is unused (but `--lr` is still used as `max_lr`).

All runs use: `--no-use-ema --epochs 999 --enable-fourier`

DrivAerML extra flags: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

TandemFoil extra flags: `--optimizer lion --model-slices 64 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition`

**Runs (use `--wandb_group one-cycle-lr`):**

- **GPU 0:** TF base + `--use-one-cycle` (max_lr=1.25e-4)
  ```
  python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --use-one-cycle --wandb_group one-cycle-lr
  ```

- **GPU 1:** AF base + `--use-one-cycle` (max_lr=7e-4)
  ```
  python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 7e-4 --cosine-t-max 5 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --use-one-cycle --wandb_group one-cycle-lr
  ```

- **GPU 2:** DAM base + `--use-one-cycle` (max_lr=5e-4)
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-one-cycle --wandb_group one-cycle-lr
  ```

- **GPU 3:** DAM base + `--use-one-cycle --lr 1e-3` (max_lr=1e-3)
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 1e-3 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-one-cycle --wandb_group one-cycle-lr
  ```

- **GPU 4:** DAM base + `--use-one-cycle --lr 3e-4` (max_lr=3e-4)
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 3e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-one-cycle --wandb_group one-cycle-lr
  ```

- **GPU 5:** DAM base + `--use-one-cycle --grad-clip 1.0` (max_lr=5e-4)
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 1.0 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-one-cycle --wandb_group one-cycle-lr
  ```

- **GPU 6:** DAM base + `--use-one-cycle --lr 7e-4` (max_lr=7e-4)
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 7e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-one-cycle --wandb_group one-cycle-lr
  ```

- **GPU 7:** DAM base + `--use-one-cycle --weight-decay 1e-2` (max_lr=5e-4)
  ```
  python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --use-one-cycle --wandb_group one-cycle-lr
  ```

## Baseline

Current best metrics:
- **DrivAerML:** `val_primary/surface_rel_l2_pct` = **4.619%** (PR #2691, 4L/512d/8H, AdamW lr=5e-4, T_max=30). Target: 3.71%
- **AirfRANS:** `val_primary/surface_mse` = **0.001236** (PR #2828, 2L/256d/4H, AdamW lr=7e-4, gc=1.0, WD=1e-2, T_max=5). Target: 0.0043
- **TandemFoil:** `val_primary/surface_pressure_mae` = **30.10** (PR #2810, 3L/192d/3H, Lion lr=1.25e-4, gc=1.0, WD=1e-2, T_max=10)