### PR TITLE
Cross-dataset: gradient noise injection — flat minima at zero extra cost

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -107,6 +107,8 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
+    grad_noise_eta: float = 0.0
+    grad_noise_gamma: float = 0.55
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1051,6 +1053,9 @@ def train_one_epoch(
     amp_mode: str = "none",
     max_batches: int = 0,
     grad_clip: float = 0.0,
+    grad_noise_eta: float = 0.0,
+    grad_noise_gamma: float = 0.55,
+    epoch: int = 1,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1058,7 +1063,8 @@ def train_one_epoch(
     running = {"loss": 0.0}
     steps = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
-    for batch in batches:
+    steps_per_epoch = max_batches if max_batches > 0 else len(loader)
+    for batch_idx, batch in enumerate(batches):
         optimizer.zero_grad(set_to_none=True)
         if model_name == "reference_abupt":
             batch = batch.to(device)
@@ -1103,6 +1109,14 @@ def train_one_epoch(
         if grad_clip > 0 and float(grad_norm) > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
+        if grad_noise_eta > 0:
+            step_count = (epoch - 1) * steps_per_epoch + batch_idx
+            sigma = grad_noise_eta / (1 + step_count) ** grad_noise_gamma
+            for param in all_params:
+                if param.grad is not None:
+                    param.grad.add_(torch.randn_like(param.grad) * sigma)
+            running.setdefault("grad_noise_sigma", 0.0)
+            running["grad_noise_sigma"] += sigma
         optimizer.step()
         if scheduler is not None:
             scheduler.step()
@@ -1115,6 +1129,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "grad_noise_sigma" in running:
+        running["grad_noise_sigma"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
@@ -1291,6 +1307,9 @@ def main() -> None:
             amp_mode=config.amp_mode,
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
+            grad_noise_eta=config.grad_noise_eta,
+            grad_noise_gamma=config.grad_noise_gamma,
+            epoch=epoch,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Gradient noise injection (Neelakantan et al. 2015, "Adding Gradient Noise Improves Learning for Very Deep Networks") adds Gaussian noise with decaying variance to gradients during training. The noise schedule is: `sigma_t = eta / (1 + t)^gamma` where t is the step count, eta controls initial noise magnitude, and gamma controls decay rate. This encourages escape from sharp minima early in training while allowing convergence late. Unlike MSAM (which we just proved costs 2x), gradient noise adds ~0% compute overhead — just one noise tensor addition per parameter after the backward pass.

This addresses the late-training instability pattern we see on DrivAerML: gradient explosions at cosine LR peaks (epoch 200+). The noise acts as a continuous implicit regularizer that smooths the loss landscape traversal without requiring a second forward-backward pass.

## Instructions

**CODE CHANGE REQUIRED.** Add gradient noise injection to `target/icml2026/train.py`.

### Implementation

1. Add two config flags:
   - `grad_noise_eta: float = 0.01` (initial noise magnitude)
   - `grad_noise_gamma: float = 0.55` (decay exponent, 0.55 is the Neelakantan default)

2. After `loss.backward()` and before `optimizer.step()`, add:
```python
if config.grad_noise_eta > 0:
    step_count = epoch * len(train_loader) + batch_idx
    sigma = config.grad_noise_eta / (1 + step_count) ** config.grad_noise_gamma
    for param in model.parameters():
        if param.grad is not None:
            param.grad.add_(torch.randn_like(param.grad) * sigma)
```

3. Log `grad_noise_sigma` to wandb each step so we can see the decay curve.

### Runs

**Run 1** — DrivAerML eta=0.01, gamma=0.55 + gc=1.0 + WD=1e-2:
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --grad-noise-eta 0.01 --grad-noise-gamma 0.55 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group usopp-grad-noise
```

**Run 2** — DrivAerML eta=0.001, gamma=0.55 + gc=1.0 (lower noise):
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --grad-clip 1.0 \
  --grad-noise-eta 0.001 --grad-noise-gamma 0.55 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group usopp-grad-noise
```

**Run 3** — DrivAerML eta=0.1, gamma=0.55 + gc=1.0 + WD=1e-2 (higher noise):
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw \
  --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --grad-noise-eta 0.1 --grad-noise-gamma 0.55 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb-group usopp-grad-noise
```

**Run 4** — AirfRANS eta=0.01, gamma=0.55 + gc=1.0 + WD=1e-2 (cross-dataset):
```bash
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 \
  --grad-noise-eta 0.01 --grad-noise-gamma 0.55 \
  --wandb-group usopp-grad-noise
```

**Run 5** — TandemFoil eta=0.01, gamma=0.55 + gc=1.0 + WD=1e-2 (cross-dataset):
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion \
  --lr 1.25e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --grad-noise-eta 0.01 --grad-noise-gamma 0.55 \
  --wandb-group usopp-grad-noise
```

Report `val_primary/surface_rel_l2_pct` for DrivAerML, `val_primary/surface_mse` for AirfRANS, and `val_primary/surface_pressure_mae` for TandemFoil.

## Baseline

- **DrivAerML val_primary/surface_rel_l2_pct:** 4.619% (PR #2691, epoch 256)
- **AirfRANS val_primary/surface_mse:** 0.001236 (PR #2828, epoch 349)
- **TandemFoil val_primary/surface_pressure_mae:** 30.10 (PR #2810, epoch 157)
- **DrivAerML external target:** 3.71% (AB-UPT)

## Reference

- Neelakantan et al. 2015: "Adding Gradient Noise Improves Learning for Very Deep Networks" (arxiv 1511.06807)
- Default eta=0.01, gamma=0.55 from the paper