### PR TITLE
Add paper-faithful TandemFoilSet benchmark variant

### DIFF
--- a/target/icml2026/core/datasets.py
+++ b/target/icml2026/core/datasets.py
@@ -25,11 +25,15 @@ from core.contracts import (
 from core.features import augment_case_sample, stable_hash32
 from drivaerml.data import prepare_drivaerml
 from tandemfoil.data import prepare_multi
+from tandemfoil_paper.data import prepare_multi as paper_prepare_multi
+from tandemfoil_paper.data import split_paper_experiment4
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_TANDEM_MANIFEST = ROOT_DIR / "tandemfoil/data/split_manifest_tandemfoilset_v2.json"
 DEFAULT_TANDEM_STATS = ROOT_DIR / "tandemfoil/data/split_stats.json"
+DEFAULT_TANDEM_PAPER_MANIFEST = ROOT_DIR / "tandemfoil_paper/data/split_manifest_tandemfoil_paper_experiment4.json"
+DEFAULT_TANDEM_PAPER_STATS = ROOT_DIR / "tandemfoil_paper/data/split_stats_tandemfoil_paper_experiment4.json"
 DEFAULT_AIRFRANS_MANIFEST = ROOT_DIR / "airfrans/data/split_manifest_airfrans.json"
 DEFAULT_DRIVAERML_MANIFEST = ROOT_DIR / "drivaerml/data/split_manifest_drivaerml.json"
 RUNTIME_CACHE_CASES = 16
@@ -95,6 +99,62 @@ class TandemFoilCaseDataset(Dataset):
             metadata={"base_idx": base_idx},
         )
         return sample
+
+
+class PaperTandemFoilCaseDataset(Dataset):
+    def __init__(
+        self,
+        split_indices: list[int],
+        pickle_files: list[str],
+        *,
+        root_candidates: list[str] | None = None,
+        debug: bool = False,
+        task_name: str,
+        enable_fourier: bool = False,
+        enable_wake_deficit: bool = False,
+        enable_wake_angle: bool = False,
+    ):
+        task_spec = split_paper_experiment4.TASK_SPECS[task_name]
+        candidates = list(root_candidates or split_paper_experiment4.DEFAULT_ROOT_CANDIDATES)
+        self.pickle_paths = split_paper_experiment4._resolve_task_pickle_paths(task_spec, candidates)
+        cache_size = -1 if debug else RUNTIME_CACHE_CASES
+        self.base = paper_prepare_multi.MultiFieldDataset(self.pickle_paths, cache_size=cache_size)
+        self.indices = list(split_indices)
+        self.task_name = task_name
+        self.augment = dict(
+            enable_fourier=enable_fourier,
+            enable_cp_panel=False,
+            enable_wake_deficit=enable_wake_deficit,
+            enable_wake_angle=enable_wake_angle,
+        )
+        expected_files = [path.name for path in self.pickle_paths]
+        if list(pickle_files) != expected_files:
+            raise ValueError(
+                f"Manifest pickle files for {task_name} do not match resolved files: "
+                f"{pickle_files} vs {expected_files}"
+            )
+
+    def __len__(self) -> int:
+        return len(self.indices)
+
+    def __getitem__(self, idx: int) -> CaseSample:
+        base_idx = self.indices[idx]
+        x, y, is_surface = self.base[base_idx]
+        surface_x = x[is_surface]
+        volume_x = x[~is_surface]
+        surface_y = y[is_surface]
+        volume_y = y[~is_surface]
+        sample = CaseSample(
+            case_id=f"{self.task_name}_{base_idx}",
+            dataset_name="tandemfoilset_paper",
+            space_dim=2,
+            surface_x=surface_x,
+            surface_y=surface_y,
+            volume_x=volume_x,
+            volume_y=volume_y,
+            metadata={"base_idx": base_idx, "task": self.task_name},
+        )
+        return augment_case_sample(sample, **self.augment)
 
 
 class AirfRANSCaseDataset(Dataset):
@@ -566,6 +626,94 @@ def build_airfrans_bundle(
     )
 
 
+def build_tandem_paper_bundle(
+    *,
+    task: str,
+    manifest_path: str | Path = DEFAULT_TANDEM_PAPER_MANIFEST,
+    stats_path: str | Path = DEFAULT_TANDEM_PAPER_STATS,
+    debug: bool = False,
+    enable_fourier: bool = False,
+    enable_wake_deficit: bool = False,
+    enable_wake_angle: bool = False,
+) -> DatasetBundle:
+    manifest_path = Path(manifest_path)
+    stats_path = Path(stats_path)
+    if not manifest_path.exists() or not stats_path.exists():
+        split_paper_experiment4.materialize_default_artifacts(
+            manifest_path=manifest_path,
+            stats_path=stats_path,
+        )
+    manifest = _read_json(manifest_path)
+    task_manifest = manifest["tasks"].get(task)
+    if task_manifest is None:
+        available = ", ".join(sorted(manifest["tasks"]))
+        raise ValueError(f"Unknown tandemfoil paper task {task!r}; available tasks: {available}")
+    task_stats = _read_json(stats_path)["tasks"].get(task)
+    if task_stats is None:
+        raise ValueError(f"Missing stats for tandemfoil paper task {task!r}")
+
+    train_dataset = PaperTandemFoilCaseDataset(
+        list(task_manifest["splits"]["train"]),
+        task_manifest["pickle_files"],
+        root_candidates=manifest.get("data_root_candidates"),
+        debug=debug,
+        task_name=task,
+        enable_fourier=enable_fourier,
+        enable_wake_deficit=enable_wake_deficit,
+        enable_wake_angle=enable_wake_angle,
+    )
+    val_dataset = PaperTandemFoilCaseDataset(
+        list(task_manifest["splits"]["val"]),
+        task_manifest["pickle_files"],
+        root_candidates=manifest.get("data_root_candidates"),
+        debug=debug,
+        task_name=task,
+        enable_fourier=enable_fourier,
+        enable_wake_deficit=enable_wake_deficit,
+        enable_wake_angle=enable_wake_angle,
+    )
+    test_dataset = PaperTandemFoilCaseDataset(
+        list(task_manifest["splits"]["test"]),
+        task_manifest["pickle_files"],
+        root_candidates=manifest.get("data_root_candidates"),
+        debug=debug,
+        task_name=task,
+        enable_fourier=enable_fourier,
+        enable_wake_deficit=enable_wake_deficit,
+        enable_wake_angle=enable_wake_angle,
+    )
+    augmented_dim = (
+        paper_prepare_multi.X_DIM
+        + (16 if enable_fourier else 0)
+        + (2 if enable_wake_deficit else 0)
+        + (1 if enable_wake_angle else 0)
+    )
+    return DatasetBundle(
+        train_dataset=train_dataset,
+        val_datasets={"val": val_dataset},
+        test_datasets={"test": test_dataset},
+        spec=DatasetSpec(
+            name="tandemfoilset_paper",
+            space_dim=2,
+            surface_input_dim=augmented_dim,
+            surface_output_dim=3,
+            volume_input_dim=augmented_dim,
+            volume_output_dim=3,
+            pressure_output_index=2,
+            default_metric="field_mse",
+            notes=[
+                "Paper-faithful high-Re TandemFoilSet benchmark using Experiment 4 split semantics.",
+                "Primary comparison metric is normalized full-field MSE, matching the paper contract.",
+            ],
+        ),
+        target_stats=TargetTransformStats(
+            y_mean=torch.tensor(task_stats["y_mean"], dtype=torch.float32),
+            y_std=torch.tensor(task_stats["y_std"], dtype=torch.float32),
+        ),
+        sample_weights=torch.ones(len(train_dataset), dtype=torch.float32),
+    )
+
+
 def build_drivaerml_bundle(
     *,
     manifest_path: str | Path = DEFAULT_DRIVAERML_MANIFEST,
@@ -652,6 +800,9 @@ def build_dataset_bundle(
     debug: bool = False,
     tandem_manifest: str | Path = DEFAULT_TANDEM_MANIFEST,
     tandem_stats: str | Path = DEFAULT_TANDEM_STATS,
+    tandemfoil_paper_task: str = "cruise_random_uniform",
+    tandemfoil_paper_manifest: str | Path = DEFAULT_TANDEM_PAPER_MANIFEST,
+    tandemfoil_paper_stats: str | Path = DEFAULT_TANDEM_PAPER_STATS,
     airfrans_manifest: str | Path = DEFAULT_AIRFRANS_MANIFEST,
     airfrans_root: str | Path | None = None,
     airfrans_task: str = "full",
@@ -680,6 +831,16 @@ def build_dataset_bundle(
             enable_wake_deficit=enable_wake_deficit,
             enable_wake_angle=enable_wake_angle,
             enable_vortex_panel_velocity=enable_vortex_panel_velocity,
+        )
+    if dataset_name in {"tandemfoil_paper", "tandemfoilset_paper"}:
+        return build_tandem_paper_bundle(
+            task=tandemfoil_paper_task,
+            manifest_path=tandemfoil_paper_manifest,
+            stats_path=tandemfoil_paper_stats,
+            debug=debug,
+            enable_fourier=enable_fourier,
+            enable_wake_deficit=enable_wake_deficit,
+            enable_wake_angle=enable_wake_angle,
         )
     if dataset_name == "airfrans":
         return build_airfrans_bundle(

--- a/target/icml2026/core/features.py
+++ b/target/icml2026/core/features.py
@@ -279,7 +279,7 @@ def augment_case_sample(
         full_x = append_fourier_features(full_x, sample.space_dim, fourier_freqs)
     if enable_cp_panel and sample.dataset_name == "airfrans":
         appended_full.append(_compute_airfrans_cp_panel(full_x))
-    if enable_wake_deficit and sample.dataset_name == "tandemfoilset":
+    if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):
         appended_full.append(_compute_tandem_wake_deficit(full_x, include_angle=enable_wake_angle))
     if appended_full:
         full_x = torch.cat([full_x, *appended_full], dim=1)

--- a/target/icml2026/data/README.md
+++ b/target/icml2026/data/README.md
@@ -5,7 +5,7 @@ Shared helpers for the multi-dataset ICML 2026 target.
 ## Layout
 
 - `split_utils.py` — shared manifest helpers used by the dataset-local split scripts
-- `smoke_test_datasets.py` — PVC-backed smoke test for all three dataset loaders
+- `smoke_test_datasets.py` — PVC-backed smoke test for the shared ICML dataset loaders
 
 The actual dataset pipelines live under their benchmark directories:
 

--- a/target/icml2026/instructions/additional_advisor_guidance.md
+++ b/target/icml2026/instructions/additional_advisor_guidance.md
@@ -15,6 +15,12 @@ recipe whose core changes more or less work across:
 It is fine if some hyperparameters differ by dataset. It is not fine if the
 story only works because every dataset needs a completely different core idea.
 
+For TandemFoilSet, remember there are now two useful views of the problem:
+
+- `target/icml2026/tandemfoil/` for the main parity / ICML sprint contract
+- `target/icml2026/tandemfoil_paper/` for a paper-faithful Experiment 4
+  high-Re MSE comparison
+
 ## Benchmark-facing priorities
 
 - `tandemfoil`
@@ -23,6 +29,15 @@ story only works because every dataset needs a completely different core idea.
   - current sprint anchor at time of writing (`2026-04-21`):
     - `val_primary/surface_pressure_mae = 44.72`
     - reported test from that lane: `50.77`
+- `tandemfoil_paper`
+  - paper-facing metric: `test_primary/field_mse`
+  - published paper reference numbers from Experiment 4 / Table 6:
+    - `cruise_random_uniform = 0.10`
+    - `cruise_random_aoa_extrap = 0.18`
+    - `cruise_random_re_extrap = 0.36`
+    - `cruise_random_stagger_extrap = 0.13`
+    - `cruise_random_gap_extrap = 0.14`
+    - `racecar_uniform = 0.21`
 - `airfrans`
   - paper-facing metric: `test_primary/surface_mse`
   - external targets:
@@ -50,15 +65,19 @@ Always keep the target or reference beside the reported test metric.
 ## Assignment guidance
 
 When a large fleet is available, default to assigning a hypothesis family across
-all three datasets to the same student.
+the relevant datasets to the same student.
 
 - A student has `8` GPUs.
 - Use those GPUs as a matrix across datasets and nearby variants.
 - A good default is:
-  - at least one run per dataset
+  - at least one run on `airfrans`
+  - at least one run on `drivaerml`
+  - at least one run on either `tandemfoil` or `tandemfoil_paper`
+  - include both Tandem variants when the question is about Tandem comparability
+    or transfer
   - remaining GPUs used for the most decision-critical nearby variants
-- The resulting PR should report metrics across all three datasets so the same
-  student can judge whether the idea transferred or was too dataset-specific.
+- The resulting PR should report metrics across the assigned benchmarks so the
+  same student can judge whether the idea transferred or was too dataset-specific.
 
 Single-dataset assignments are still appropriate for:
 

--- a/target/icml2026/instructions/additional_advisor_guidance_tandemfoil_paper_2026-04-21.md
+++ b/target/icml2026/instructions/additional_advisor_guidance_tandemfoil_paper_2026-04-21.md
@@ -1,0 +1,134 @@
+# Additional Advisor Guidance For The TandemFoil Paper-Calibration Expansion
+
+This file is intended to be passed via `k8s/launch.py --extra_instructions ...`
+for the next advisor restart or fleet expansion after adding the fourth
+benchmark under `target/icml2026/tandemfoil_paper/`.
+
+## Why The Fourth Benchmark Exists
+
+We currently have two TandemFoilSet views:
+
+- `target/icml2026/tandemfoil/`
+  - the main parity / ICML sprint benchmark
+  - useful for noam-lineage progress and the shared sprint story
+- `target/icml2026/tandemfoil_paper/`
+  - a paper-faithful high-Re Experiment 4 benchmark
+  - useful for answering a simpler question:
+    - are we actually good relative to the published TandemFoilSet paper?
+
+Do not confuse them.
+
+## Scientific Goal
+
+The goal is still a shared recipe, not a collection of unrelated per-benchmark
+tricks.
+
+The core question is now whether one broad recipe can survive across:
+
+- `target/icml2026/tandemfoil/`
+- `target/icml2026/tandemfoil_paper/`
+- `target/icml2026/airfrans/`
+- `target/icml2026/drivaerml/`
+
+It is fine if LR, schedule length, or regularization strength differ somewhat.
+It is not fine if every benchmark needs a different core idea.
+
+## Benchmark-Facing Priorities
+
+- `tandemfoil`
+  - paper-facing summary metric: `test_primary/surface_pressure_mae`
+  - this is the ICML sprint parity target, not the original paper contract
+- `tandemfoil_paper`
+  - paper-facing metric: `test_primary/field_mse`
+  - published Experiment 4 references:
+    - `cruise_random_uniform = 0.10`
+    - `cruise_random_aoa_extrap = 0.18`
+    - `cruise_random_re_extrap = 0.36`
+    - `cruise_random_stagger_extrap = 0.13`
+    - `cruise_random_gap_extrap = 0.14`
+    - `racecar_uniform = 0.21`
+- `airfrans`
+  - paper-facing metric: `test_primary/surface_mse`
+  - targets:
+    - `surface_mse = 0.0043`
+    - `volume_mse = 0.0017`
+- `drivaerml`
+  - paper-facing metric: `test_primary/surface_rel_l2_pct`
+  - nominal reference:
+    - `3.71`
+
+Always keep the reported test metric beside the target or reference.
+
+## Current Strategic Read
+
+- AirfRANS is already strong enough that it should stay narrow.
+- DrivAerML is still the weakest benchmark and remains the main rescue lane.
+- The new `tandemfoil_paper` benchmark is not a license to reopen huge Tandem
+  local sweeps.
+- Its job is calibration:
+  - tell us whether our Tandem-related ideas are merely improving the internal
+    parity target
+  - or are also competitive against the original paper contract
+
+## Assignment Guidance
+
+When a student is assigned a cross-benchmark hypothesis family, treat the `8`
+GPUs as a small matrix.
+
+Strong default:
+
+- `1` run on `airfrans`
+- `2-3` runs on `drivaerml`
+- `1` run on `tandemfoil`
+- `1` run on `tandemfoil_paper` if the idea is relevant to TandemFoil
+- remaining GPUs used for the most decision-critical nearby variants
+
+Use both Tandem benchmarks together when the hypothesis is about:
+
+- Tandem transfer
+- Tandem generalization
+- whether a Tandem-side change is only helping the noam/parity contract
+- whether a Tandem-side change also helps the original paper-style benchmark
+
+Single-dataset work is still appropriate for:
+
+- best-checkpoint cleanup
+- preserving the AirfRANS frontier
+- a clearly justified DrivAerML rescue lane
+- one-off Tandem paper calibration checks
+
+## What To Emphasize
+
+- DrivAerML-centered ideas that can also be checked on AirfRANS and both Tandem
+  views
+- simple transferable recipe changes
+- hypotheses that tell us whether an idea is globally useful or too
+  dataset-specific
+- test metrics at the best validation checkpoint
+
+## What To De-Emphasize
+
+- broad AirfRANS local mapping
+- broad Tandem local mapping on only one Tandem benchmark
+- speculative code-change branches unless they are clearly high value
+- architecture proliferation without a strong transfer rationale
+
+## Operational Reminder
+
+- The run budget is inherited from the pod environment.
+- Do not hardcode obsolete `180`-minute run budgets in PR bodies.
+- If a stale `CURRENT_RESEARCH_STATE.md` on the branch conflicts with this
+  benchmark expansion, overwrite it immediately.
+
+## Sharp Summary
+
+The fourth benchmark is a calibration tool, not the new center of gravity.
+
+Use it to answer:
+
+- is our Tandem recipe actually paper-competitive?
+
+But keep the overall queue aimed at the harder global question:
+
+- can one shared recipe work across AirfRANS, DrivAerML, the Tandem parity
+  target, and the Tandem paper-style target?

--- a/target/icml2026/instructions/prompt-advisor.md
+++ b/target/icml2026/instructions/prompt-advisor.md
@@ -20,19 +20,24 @@ You're the senpai advisor. Your students run experiments; your job is to direct 
 
 Read CLAUDE.md for the full workflow and `$PROBLEM_DIR/program.md` for research context.
 
-The active problem directory contains three benchmark subtargets:
+The active problem directory contains four benchmark subtargets:
 
 - `$PROBLEM_DIR/tandemfoil/`
+- `$PROBLEM_DIR/tandemfoil_paper/`
 - `$PROBLEM_DIR/airfrans/`
 - `$PROBLEM_DIR/drivaerml/`
 
 When you write a hypothesis PR, specify the dataset explicitly and keep the
 benchmark contract tied to that dataset's `program.md`.
 
-When feasible, default to hypothesis families that are tested across all three
-benchmarks rather than only one. Use single-dataset assignments mainly for
-frontier closure, best-checkpoint test recovery, or another clearly justified
-reason.
+When feasible, default to hypothesis families that are tested across the active
+benchmarks rather than only one. In particular:
+
+- use `tandemfoil_paper/` when you need a literature-facing TandemFoilSet
+  comparison point
+- use `tandemfoil/` when you need the main parity / ICML-sprint Tandem anchor
+- use single-dataset assignments mainly for frontier closure, best-checkpoint
+  test recovery, or another clearly justified reason
 
 ### Git branch to use
 Its very important that all your work always lives on the `$ADVISOR_BRANCH` branch, not main — PRs target it as base, new branches check out from it, and merges squash into it. This keeps the research track clean and separate from the main codebase.
@@ -42,5 +47,6 @@ Its very important that all your work always lives on the `$ADVISOR_BRANCH` bran
 Survey the current state: check student's metrics on wandb (use the /wandb-primary skill if helpful), list existing PRs (using the /list-experiments skill if helpful), and identify what needs attention next.
 
 In this ICML target, prefer a common-recipe story over benchmark-specific hacks:
-aim for core changes that survive across TandemFoilSet, AirfRANS, and
-DrivAerML, even if final LR, scheduler, or regularization settings differ.
+aim for core changes that survive across `tandemfoil/`,
+`tandemfoil_paper/`, AirfRANS, and DrivAerML, even if final LR, scheduler, or
+regularization settings differ.

--- a/target/icml2026/instructions/prompt-student.md
+++ b/target/icml2026/instructions/prompt-student.md
@@ -11,7 +11,7 @@ You're $STUDENT_NAME, a senpai research student. The advisor assigns hypotheses 
 ## Setup
 
 - **You:** $STUDENT_NAME
-- **Datasets:** TandemFoilSet, AirfRANS, and DrivAerML. Exact roots and split contracts live under `$PROBLEM_DIR/tandemfoil/`, `$PROBLEM_DIR/airfrans/`, and `$PROBLEM_DIR/drivaerml/`.
+- **Datasets:** the main TandemFoilSet parity target, the paper-faithful TandemFoilSet high-Re target, AirfRANS, and DrivAerML. Exact roots and split contracts live under `$PROBLEM_DIR/tandemfoil/`, `$PROBLEM_DIR/tandemfoil_paper/`, `$PROBLEM_DIR/airfrans/`, and `$PROBLEM_DIR/drivaerml/`.
 - **GPUs:** 8 on this node. Use all 8 across experiment variations where it makes sense — `CUDA_VISIBLE_DEVICES` lets you pin a training to a specific GPU.
 - **Target branch:** `$ADVISOR_BRANCH`
 
@@ -25,8 +25,10 @@ cd "$PROBLEM_DIR" && python train.py --dataset <dataset> --agent $STUDENT_NAME -
 ```
 
 When the advisor assigns a cross-dataset hypothesis family, use your 8 GPUs as a
-small run matrix across TandemFoilSet, AirfRANS, and DrivAerML, then report the
-metrics together so the transfer signal is easy to interpret.
+small run matrix across the relevant benchmarks, then report the metrics
+together so the transfer signal is easy to interpret. If the hypothesis is
+about TandemFoil generalization or paper comparability, include both
+`tandemfoil/` and `tandemfoil_paper/`.
 
 Try and use sub-agents where possible, for example specialised agents like researcher-agent for research, Explore agent for checking log files or generic sub-agents for other repetitive tasks like polling for work.
 

--- a/target/icml2026/program.md
+++ b/target/icml2026/program.md
@@ -10,20 +10,28 @@ Autonomous research target for the ICML 2026 AI for Science workshop sprint.
 
 ## Problem
 
-This target packages the experiments for the ICML paper around three CFD surrogate
+This target packages the experiments for the ICML paper around four CFD surrogate
 benchmarks under one harness-compatible problem directory:
 
 - `tandemfoil/` — TandemFoilSet, the load-bearing benchmark and current strongest evidence
+- `tandemfoil_paper/` — paper-faithful high-Re TandemFoilSet calibration tasks
 - `airfrans/` — AirfRANS, the 2D transfer benchmark
 - `drivaerml/` — DrivAerML, the 3D surface-first transfer benchmark
 
-The goal is to compare a clean shared training stack across the three datasets,
+The goal is to compare a clean shared training stack across the four benchmark
+views,
 with reference comparisons against a vanilla grouped-domain Transolver and an
 AB-UPT-style anchor model where appropriate.
 
-The ideal paper story is not three unrelated benchmark-specific wins. It is a
-shared recipe whose core ideas transfer across TandemFoilSet, AirfRANS, and
-DrivAerML, even if the best final hyperparameters differ somewhat by dataset.
+The ideal paper story is not four unrelated benchmark-specific wins. It is a
+shared recipe whose core ideas transfer across:
+
+- the main `tandemfoil/` parity benchmark
+- the paper-faithful `tandemfoil_paper/` calibration benchmark
+- `airfrans/`
+- `drivaerml/`
+
+Hyperparameters may differ somewhat by dataset, but the core recipe should not.
 
 For TandemFoilSet specifically, this target should become the reproduction and
 extension path for the merged noam lineage through `#2379`, while AirfRANS and
@@ -34,7 +42,8 @@ explicitly requested.
 
 - `train.py` — shared ICML sprint trainer and model selector. **Primary editable entrypoint.**
 - `core/` — shared dataset contract, features, optimizers, and model definitions.
-- `tandemfoil/` — TandemFoilSet-specific data pipeline and benchmark docs.
+- `tandemfoil/` — TandemFoilSet-specific parity target and benchmark docs.
+- `tandemfoil_paper/` — paper-faithful TandemFoilSet high-Re benchmark docs.
 - `airfrans/` — AirfRANS-specific data pipeline and benchmark docs.
 - `drivaerml/` — DrivAerML-specific data pipeline and benchmark docs.
 - `data/` — shared split helpers and smoke tests for the multi-dataset target.
@@ -49,6 +58,11 @@ most decision-relevant metric for the selected benchmark:
   - `legacy_noam/*` for the denormalized historical `p_*` contract
   - `icml2026_v2/*` for the packaged `kagent` split contract
   - pressure and surface fidelity remain the decision-driving quantities
+- `tandemfoil_paper`
+  - prioritize normalized full-field MSE on the paper-faithful Experiment 4
+    tasks
+  - use this benchmark to decide whether our shared stack is actually
+    competitive against the published TandemFoilSet paper numbers
 - `airfrans`
   - prioritize surface and volume error on the official task split
   - compare against literature-reported Transolver and newer baselines
@@ -100,6 +114,8 @@ Primary harness metric aliases:
 
 - `tandemfoil`: `val_primary/surface_pressure_mae` and
   `test_primary/surface_pressure_mae`
+- `tandemfoil_paper`: `val_primary/field_mse` and
+  `test_primary/field_mse`
 - `airfrans`: `val_primary/surface_mse` and `test_primary/surface_mse`
 - `drivaerml`: `val_primary/surface_rel_l2_pct` and
   `test_primary/surface_rel_l2_pct`
@@ -109,6 +125,7 @@ Primary harness metric aliases:
 Read the dataset-specific subprogram before making dataset-specific claims:
 
 - `tandemfoil/program.md`
+- `tandemfoil_paper/program.md`
 - `airfrans/program.md`
 - `drivaerml/program.md`
 

--- a/target/icml2026/tandemfoil_paper/__init__.py
+++ b/target/icml2026/tandemfoil_paper/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-faithful TandemFoilSet high-Re benchmark tasks."""
+

--- a/target/icml2026/tandemfoil_paper/data/README.md
+++ b/target/icml2026/tandemfoil_paper/data/README.md
@@ -1,0 +1,62 @@
+# Paper TandemFoil Tasks
+
+This directory defines a paper-faithful benchmark variant for the high-Re
+TandemFoilSet experiments in Experiment 4 of the TandemFoilSet paper.
+
+## Supported Tasks
+
+The following task names are available through:
+
+```bash
+cd target/icml2026
+python train.py --dataset tandemfoil_paper --tandemfoil-paper-task <task>
+```
+
+Supported tasks:
+
+- `cruise_random_uniform`
+- `cruise_random_aoa_extrap`
+- `cruise_random_re_extrap`
+- `cruise_random_stagger_extrap`
+- `cruise_random_gap_extrap`
+- `racecar_uniform`
+
+## Split Rules
+
+Uniform tasks:
+
+- deterministic `80/10/10` train/val/test split
+- RNG seed `42`
+
+Extrapolation tasks:
+
+- lowest `5%` and highest `5%` of the selected variable become `test`
+- the middle `90%` is split uniformly into:
+  - `train = 80%` of the full dataset
+  - `val = 10%` of the full dataset
+- RNG seed `42` for the middle-90% train/val shuffle
+
+## Artifacts
+
+The generator writes:
+
+- `split_manifest_tandemfoil_paper_experiment4.json`
+- `split_stats_tandemfoil_paper_experiment4.json`
+
+These files are auto-materialized on first use if they are missing and the raw
+TandemFoil pickles are available under the mounted PVC.
+
+Manual generation:
+
+```bash
+cd target/icml2026
+python tandemfoil_paper/data/split_paper_experiment4.py
+```
+
+## Implementation Note
+
+This benchmark uses the shared tandem pickle loader and the same 24-feature
+dual-foil preprocessing as `tandemfoil/`. The difference is the split contract
+and the metric contract: this benchmark evaluates normalized full-field MSE,
+matching the paper’s Experiment 4 reporting style.
+

--- a/target/icml2026/tandemfoil_paper/data/__init__.py
+++ b/target/icml2026/tandemfoil_paper/data/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-faithful TandemFoilSet task artifacts."""
+

--- a/target/icml2026/tandemfoil_paper/data/prepare.py
+++ b/target/icml2026/tandemfoil_paper/data/prepare.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-variant TandemFoilSet re-exports the shared tandem pickle loader."""
+
+from tandemfoil.data.prepare import *  # noqa: F401,F403
+

--- a/target/icml2026/tandemfoil_paper/data/prepare_multi.py
+++ b/target/icml2026/tandemfoil_paper/data/prepare_multi.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Paper-variant TandemFoilSet re-exports the shared 24-feature preprocessing."""
+
+from tandemfoil.data.prepare_multi import *  # noqa: F401,F403
+

--- a/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
+++ b/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-PackageName: senpai
+
+"""Materialize paper-faithful TandemFoilSet Experiment 4 tasks.
+
+This generator targets the unambiguous high-Re tasks from the paper:
+
+- Cruise Random, uniform 8:1:1
+- Cruise Random extrapolation on AOA / Re / Stagger / Gap
+- Race Car, uniform 8:1:1
+
+The paper does not publish an exact split RNG seed, so this repo pins seed 42
+for the uniform train/val sampling and uses stable rank order for tail
+selection.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+
+try:
+    from data.split_utils import first_existing, write_json
+    from tandemfoil.data.prepare import load_pickle
+    from tandemfoil.data.prepare_multi import MultiFieldDataset
+except ModuleNotFoundError:
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parents[2]))
+    from data.split_utils import first_existing, write_json
+    from tandemfoil.data.prepare import load_pickle
+    from tandemfoil.data.prepare_multi import MultiFieldDataset
+
+
+SEED = 42
+TRAIN_FRACTION = 0.80
+VAL_FRACTION = 0.10
+TAIL_FRACTION = 0.05
+DEFAULT_ROOT_CANDIDATES = [
+    "/mnt/pvc/datasets/tandemfoil",
+    "/mnt/new-pvc/datasets/tandemfoil",
+]
+DEFAULT_MANIFEST = Path(__file__).with_name("split_manifest_tandemfoil_paper_experiment4.json")
+DEFAULT_STATS = Path(__file__).with_name("split_stats_tandemfoil_paper_experiment4.json")
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    dataset_group: str
+    split_style: str
+    variable: str | None
+    pickle_files: tuple[str, ...]
+    paper_table6_baseline: float
+    paper_table6_best: float
+    paper_table6_best_std: float
+    notes: tuple[str, ...]
+
+
+TASK_SPECS: dict[str, TaskSpec] = {
+    "cruise_random_uniform": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="uniform",
+        variable=None,
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=1.79,
+        paper_table6_best=0.10,
+        paper_table6_best_std=0.13,
+        notes=(
+            "Experiment 4 Cruise Random uniform split.",
+            "Paper states 8:1:1 train/val/test unless otherwise stated.",
+        ),
+    ),
+    "cruise_random_aoa_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="aoa0",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=2.03,
+        paper_table6_best=0.18,
+        paper_table6_best_std=0.24,
+        notes=(
+            "Experiment 4 Cruise Random AOA extrapolation split.",
+            "Test set is the highest and lowest 5% of AOA.",
+        ),
+    ),
+    "cruise_random_re_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="re",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=4.85,
+        paper_table6_best=0.36,
+        paper_table6_best_std=0.53,
+        notes=(
+            "Experiment 4 Cruise Random Reynolds extrapolation split.",
+            "Test set is the highest and lowest 5% of Reynolds number.",
+        ),
+    ),
+    "cruise_random_stagger_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="stagger",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=1.74,
+        paper_table6_best=0.13,
+        paper_table6_best_std=0.17,
+        notes=(
+            "Experiment 4 Cruise Random stagger extrapolation split.",
+            "Test set is the highest and lowest 5% of stagger.",
+        ),
+    ),
+    "cruise_random_gap_extrap": TaskSpec(
+        dataset_group="cruise_random",
+        split_style="tail_extrapolation",
+        variable="gap",
+        pickle_files=(
+            "cruise_randomFields_mgn_Part1.pickle",
+            "cruise_randomFields_mgn_Part2.pickle",
+            "cruise_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=1.95,
+        paper_table6_best=0.14,
+        paper_table6_best_std=0.20,
+        notes=(
+            "Experiment 4 Cruise Random gap extrapolation split.",
+            "Test set is the highest and lowest 5% of gap.",
+        ),
+    ),
+    "racecar_uniform": TaskSpec(
+        dataset_group="racecar",
+        split_style="uniform",
+        variable=None,
+        pickle_files=(
+            "raceCar_randomFields_mgn_Part1.pickle",
+            "raceCar_randomFields_mgn_Part2.pickle",
+            "raceCar_randomFields_mgn_Part3.pickle",
+        ),
+        paper_table6_baseline=0.61,
+        paper_table6_best=0.21,
+        paper_table6_best_std=0.29,
+        notes=(
+            "Experiment 4 Race Car uniform split.",
+            "Paper uses uniform sampling on Race Car rather than an extrapolation split.",
+        ),
+    ),
+}
+
+
+def _resolve_task_pickle_paths(task: TaskSpec, root_candidates: list[str]) -> list[Path]:
+    root = first_existing(root_candidates)
+    if root is None:
+        raise FileNotFoundError(
+            "Could not find TandemFoilSet root. Checked: "
+            + ", ".join(root_candidates)
+        )
+    return [root / name for name in task.pickle_files]
+
+
+def _extract_records(pickle_paths: list[Path]) -> list[dict]:
+    records: list[dict] = []
+    task_local_idx = 0
+    for file_idx, path in enumerate(pickle_paths):
+        raw = load_pickle(path)
+        for local_idx, sample in enumerate(raw):
+            aoa = sample.AoA
+            if isinstance(aoa, list):
+                aoa0 = float(aoa[0])
+                aoa1 = float(aoa[1])
+                if abs(aoa0 - aoa1) > 1e-6:
+                    raise ValueError(
+                        f"Expected paper-style tandem AoA to be shared, got {aoa0} vs {aoa1} "
+                        f"for {path.name}:{local_idx}"
+                    )
+            else:
+                aoa0 = float(aoa)
+                aoa1 = None
+
+            gap = getattr(sample, "gap", None)
+            stagger = getattr(sample, "stagger", None)
+            if gap is None or stagger is None:
+                raise ValueError(f"Expected tandem metadata gap/stagger in {path.name}:{local_idx}")
+
+            records.append(
+                {
+                    "task_local_idx": task_local_idx,
+                    "file_idx": file_idx,
+                    "local_idx": local_idx,
+                    "re": float(sample.flowState["Re"]),
+                    "aoa0": aoa0,
+                    "aoa1": aoa1,
+                    "gap": float(gap),
+                    "stagger": float(stagger),
+                }
+            )
+            task_local_idx += 1
+        del raw
+    return records
+
+
+def split_uniform_indices(total: int, *, seed: int = SEED) -> dict[str, list[int]]:
+    if total <= 0:
+        raise ValueError("Uniform split requires at least one sample")
+    rng = np.random.default_rng(seed)
+    order = np.arange(total)
+    rng.shuffle(order)
+    n_test = max(1, round(total * VAL_FRACTION))
+    n_val = max(1, round(total * VAL_FRACTION))
+    n_train = total - n_val - n_test
+    if n_train <= 0:
+        raise ValueError(f"Invalid split sizes for total={total}")
+    train = sorted(order[:n_train].tolist())
+    val = sorted(order[n_train : n_train + n_val].tolist())
+    test = sorted(order[n_train + n_val :].tolist())
+    return {"train": train, "val": val, "test": test}
+
+
+def split_tail_extrapolation_indices(values: list[float], *, seed: int = SEED) -> dict[str, list[int]]:
+    total = len(values)
+    if total <= 0:
+        raise ValueError("Tail extrapolation requires at least one sample")
+    n_tail = max(1, round(total * TAIL_FRACTION))
+    order = sorted(range(total), key=lambda idx: (values[idx], idx))
+    test_set = set(order[:n_tail]) | set(order[-n_tail:])
+    if len(test_set) != n_tail * 2:
+        raise ValueError("Tail extrapolation test set unexpectedly overlapped")
+
+    middle = [idx for idx in range(total) if idx not in test_set]
+    rng = np.random.default_rng(seed)
+    rng.shuffle(middle)
+    n_val = max(1, round(total * VAL_FRACTION))
+    n_train = len(middle) - n_val
+    if n_train <= 0:
+        raise ValueError(f"Invalid tail split sizes for total={total}")
+    train = sorted(middle[:n_train])
+    val = sorted(middle[n_train:])
+    test = sorted(test_set)
+    return {"train": train, "val": val, "test": test}
+
+
+def _compute_y_stats(pickle_paths: list[Path], train_indices: list[int]) -> dict[str, float | list[float]]:
+    dataset = MultiFieldDataset(pickle_paths, cache_size=-1)
+    train_sorted = sorted(train_indices, key=lambda idx: dataset.index[idx])
+
+    sum_y = torch.zeros(3, dtype=torch.float64)
+    total_nodes = 0
+    for idx in train_sorted:
+        _, y, _ = dataset[idx]
+        sum_y += y.double().sum(dim=0)
+        total_nodes += y.shape[0]
+    if total_nodes <= 1:
+        raise ValueError("Need at least two nodes to compute y statistics")
+    mean_y = sum_y / total_nodes
+
+    sq_y = torch.zeros(3, dtype=torch.float64)
+    for idx in train_sorted:
+        _, y, _ = dataset[idx]
+        sq_y += ((y.double() - mean_y) ** 2).sum(dim=0)
+    std_y = (sq_y / (total_nodes - 1)).sqrt().clamp(min=1e-6)
+    return {
+        "n_train_samples": len(train_indices),
+        "n_train_nodes": int(total_nodes),
+        "y_mean": mean_y.float().tolist(),
+        "y_std": std_y.float().tolist(),
+    }
+
+
+def build_artifacts(root_candidates: list[str]) -> tuple[dict, dict]:
+    manifest = {
+        "dataset": "TandemFoilSet",
+        "benchmark_variant": "paper_experiment4",
+        "paper_source": "https://openreview.net/pdf?id=4Z0P4Nbosn",
+        "seed": SEED,
+        "train_fraction": TRAIN_FRACTION,
+        "val_fraction": VAL_FRACTION,
+        "tail_fraction": TAIL_FRACTION,
+        "data_root_candidates": list(root_candidates),
+        "tasks": {},
+    }
+    stats = {
+        "dataset": "TandemFoilSet",
+        "benchmark_variant": "paper_experiment4",
+        "seed": SEED,
+        "tasks": {},
+    }
+
+    for task_name, task in TASK_SPECS.items():
+        pickle_paths = _resolve_task_pickle_paths(task, root_candidates)
+        records = _extract_records(pickle_paths)
+        if task.split_style == "uniform":
+            splits = split_uniform_indices(len(records), seed=SEED)
+        elif task.split_style == "tail_extrapolation":
+            if task.variable is None:
+                raise ValueError(f"Task {task_name} is missing its extrapolation variable")
+            splits = split_tail_extrapolation_indices(
+                [float(record[task.variable]) for record in records],
+                seed=SEED,
+            )
+        else:
+            raise ValueError(f"Unknown split style: {task.split_style}")
+
+        manifest["tasks"][task_name] = {
+            "dataset_group": task.dataset_group,
+            "split_style": task.split_style,
+            "variable": task.variable,
+            "pickle_files": [path.name for path in pickle_paths],
+            "n_cases": len(records),
+            "split_counts": {name: len(indices) for name, indices in splits.items()},
+            "splits": {name: sorted(indices) for name, indices in splits.items()},
+            "paper_targets": {
+                "table": "Table 6",
+                "mgn_baseline_field_mse": task.paper_table6_baseline,
+                "mgn_pre_res_free_res_comb_field_mse": task.paper_table6_best,
+                "mgn_pre_res_free_res_comb_field_mse_std": task.paper_table6_best_std,
+            },
+            "notes": list(task.notes),
+        }
+        stats["tasks"][task_name] = _compute_y_stats(pickle_paths, splits["train"])
+    return manifest, stats
+
+
+def materialize_default_artifacts(
+    *,
+    manifest_path: str | Path = DEFAULT_MANIFEST,
+    stats_path: str | Path = DEFAULT_STATS,
+    root_candidates: list[str] | None = None,
+) -> tuple[Path, Path]:
+    manifest_path = Path(manifest_path)
+    stats_path = Path(stats_path)
+    if manifest_path.exists() and stats_path.exists():
+        return manifest_path, stats_path
+    resolved_candidates = list(root_candidates or DEFAULT_ROOT_CANDIDATES)
+    manifest, stats = build_artifacts(resolved_candidates)
+    write_json(manifest_path, manifest)
+    write_json(stats_path, stats)
+    return manifest_path, stats_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Materialize TandemFoilSet paper Experiment 4 artifacts")
+    parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--stats-out", default=str(DEFAULT_STATS))
+    parser.add_argument(
+        "--data-root-candidate",
+        action="append",
+        default=[],
+        help="Override/add TandemFoilSet root candidates.",
+    )
+    args = parser.parse_args()
+
+    root_candidates = args.data_root_candidate or DEFAULT_ROOT_CANDIDATES
+    manifest, stats = build_artifacts(root_candidates)
+    write_json(args.manifest_out, manifest)
+    write_json(args.stats_out, stats)
+
+    print(f"Wrote {args.manifest_out}")
+    print(f"Wrote {args.stats_out}")
+    for task_name, task_manifest in manifest["tasks"].items():
+        counts = task_manifest["split_counts"]
+        print(
+            f"  {task_name:30s} train={counts['train']:4d} "
+            f"val={counts['val']:4d} test={counts['test']:4d}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/target/icml2026/tandemfoil_paper/program.md
+++ b/target/icml2026/tandemfoil_paper/program.md
@@ -1,0 +1,120 @@
+<!--
+SPDX-FileCopyrightText: 2026 CoreWeave, Inc.
+SPDX-License-Identifier: Apache-2.0
+SPDX-PackageName: senpai
+-->
+
+# TandemFoilSet Paper Variant
+
+This subtarget adds a fourth benchmark inside `target/icml2026`: a
+paper-faithful high-Re TandemFoilSet variant built around the unambiguous split
+rules from Experiment 4 of the TandemFoilSet paper.
+
+## Why This Exists
+
+The main `tandemfoil/` benchmark in this target is intentionally pinned to the
+later `kagent` / noam-style parity contract. That is useful for the ICML sprint,
+but it does **not** give us a clean literature-facing scalar from the original
+TandemFoilSet paper.
+
+This variant exists to answer a simpler question:
+
+- on the paper’s own high-Re `Cruise Random` / `Race Car` tasks, is our model
+  actually competitive or not?
+
+## Scope
+
+Only the paper splits that are reasonably unambiguous are included here:
+
+- `cruise_random_uniform`
+- `cruise_random_aoa_extrap`
+- `cruise_random_re_extrap`
+- `cruise_random_stagger_extrap`
+- `cruise_random_gap_extrap`
+- `racecar_uniform`
+
+We intentionally do **not** treat the low-Re curriculum experiments in Tables
+3–5 as this benchmark’s primary contract, because those results depend on the
+paper’s curriculum procedure and multi-network decomposition in a way that is
+less cleanly comparable to our shared ICML trainer.
+
+## Published Contract
+
+Primary source:
+
+- TandemFoilSet paper: [OpenReview PDF](https://openreview.net/pdf?id=4Z0P4Nbosn)
+
+Paper statements we are reproducing here:
+
+- “the datasets are uniformly sampled in a `8:1:1` ratio for training,
+  validation, and test sets, respectively, unless otherwise stated”
+- for Cruise Random extrapolation:
+  - “the highest and lowest `5%` of the `AOA`, `Re`, `Stagger`, or `Gap` value
+    range is used as the test set”
+  - “the training and validation sets are uniformly sampled from the middle
+    `90%` range”
+
+The paper does **not** publish an exact RNG seed or tie-break rule for samples
+on the extrapolation boundary. For reproducibility, this repo uses:
+
+- deterministic RNG seed `42` for uniform train/val sampling
+- stable rank ordering by `(value, case_index)` when selecting the top/bottom
+  `5%` tails
+
+This preserves the paper’s split semantics even though the exact hidden sample
+IDs cannot be recovered from the PDF alone.
+
+## Metrics
+
+The paper reports **normalized full-field MSE** after z-score normalization with
+training-set statistics.
+
+This subtarget therefore uses:
+
+- `field_mse`
+  - mean squared error over **all valid nodes and all three channels**
+    `[Ux, Uy, p]`
+  - computed in normalized target space using task-local training-set mean/std
+- `surface_mse`
+  - normalized-space MSE on surface nodes only
+- `volume_mse`
+  - normalized-space MSE on non-surface nodes only
+
+Lower is better.
+
+Primary harness aliases:
+
+- `val_primary/field_mse`
+- `test_primary/field_mse`
+
+## Paper Reference Numbers
+
+Experiment 4, Table 6:
+
+| Task | MGN baseline | MGN + PRE-RES-FREE + RES-COMB |
+|---|---:|---:|
+| `cruise_random_uniform` | `1.79 ± 1.38` | `0.10 ± 0.13` |
+| `cruise_random_aoa_extrap` | `2.03 ± 1.96` | `0.18 ± 0.24` |
+| `cruise_random_re_extrap` | `4.85 ± 1.82` | `0.36 ± 0.53` |
+| `cruise_random_stagger_extrap` | `1.74 ± 1.66` | `0.13 ± 0.17` |
+| `cruise_random_gap_extrap` | `1.95 ± 1.68` | `0.14 ± 0.20` |
+| `racecar_uniform` | `0.61 ± 0.51` | `0.21 ± 0.29` |
+
+Those are the numbers to compare against when deciding whether our shared ICML
+stack is competitive on the paper-style TandemFoil evaluation.
+
+## Codebase
+
+- `../train.py` — shared trainer
+- `data/split_paper_experiment4.py` — deterministic split and stats generator
+- `data/prepare.py` — shared tandem pickle loading re-export
+- `data/prepare_multi.py` — shared 24-feature TandemFoil preprocessing re-export
+- `data/README.md` — task definitions and artifact materialization details
+
+## Notes
+
+- This variant uses the same TandemFoil raw pickles and 24-feature preprocessing
+  stack as `tandemfoil/`, but **not** the noam-style pressure-denorm contract.
+- It is a benchmark-calibration target, not a replacement for the main
+  `tandemfoil/` ICML sprint target.
+

--- a/target/icml2026/tests/test_tandemfoil_paper.py
+++ b/target/icml2026/tests/test_tandemfoil_paper.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.contracts import GroupedBatch  # noqa: E402
+from tandemfoil_paper.data.split_paper_experiment4 import (  # noqa: E402
+    split_tail_extrapolation_indices,
+    split_uniform_indices,
+)
+from train import TargetTransform, evaluate_grouped  # noqa: E402
+
+
+class _IdentityPaperModel(torch.nn.Module):
+    def eval(self):
+        return self
+
+    def forward(self, *, surface_x, surface_mask, volume_x, volume_mask):
+        del surface_mask, volume_mask
+        return {
+            "surface_preds": surface_x[..., :3],
+            "volume_preds": None if volume_x is None else volume_x[..., :3],
+        }
+
+
+def test_uniform_split_uses_80_10_10_counts():
+    splits = split_uniform_indices(900, seed=42)
+    assert len(splits["train"]) == 720
+    assert len(splits["val"]) == 90
+    assert len(splits["test"]) == 90
+    assert set(splits["train"]).isdisjoint(splits["val"])
+    assert set(splits["train"]).isdisjoint(splits["test"])
+    assert set(splits["val"]).isdisjoint(splits["test"])
+
+
+def test_tail_extrapolation_split_uses_5_percent_tails():
+    values = list(range(900))
+    splits = split_tail_extrapolation_indices(values, seed=42)
+    assert len(splits["train"]) == 720
+    assert len(splits["val"]) == 90
+    assert len(splits["test"]) == 90
+    assert set(splits["test"][:45]) == set(range(45))
+    assert set(splits["test"][45:]) == set(range(855, 900))
+
+
+def test_paper_eval_reports_normalized_field_mse():
+    surface_target = torch.tensor([[[1.0, 2.0, 3.0], [1.0, 1.0, 1.0]]], dtype=torch.float32)
+    volume_target = torch.tensor([[[2.0, 2.0, 2.0]]], dtype=torch.float32)
+    surface_pred = torch.tensor([[[2.0, 2.0, 3.0], [0.0, 1.0, 2.0]]], dtype=torch.float32)
+    volume_pred = torch.tensor([[[3.0, 1.0, 2.0]]], dtype=torch.float32)
+    batch = GroupedBatch(
+        case_ids=["paper-case"],
+        dataset_name="tandemfoilset_paper",
+        space_dim=2,
+        surface_x=torch.cat([surface_pred, torch.zeros(1, 2, 1)], dim=-1),
+        surface_y=surface_target,
+        surface_mask=torch.ones(1, 2, dtype=torch.bool),
+        volume_x=torch.cat([volume_pred, torch.zeros(1, 1, 1)], dim=-1),
+        volume_y=volume_target,
+        volume_mask=torch.ones(1, 1, dtype=torch.bool),
+        metadata=[],
+    )
+    metrics = evaluate_grouped(
+        _IdentityPaperModel(),
+        None,
+        [batch],
+        TargetTransform(pressure_index=2, stats_mean=torch.zeros(3), stats_std=torch.ones(3)),
+        torch.device("cpu"),
+    )
+
+    surface_sq = 3.0
+    volume_sq = 2.0
+    expected_surface = surface_sq / (2 * 3)
+    expected_volume = volume_sq / (1 * 3)
+    expected_field = (surface_sq + volume_sq) / (3 * 3)
+
+    assert math.isclose(metrics["surface_mse"], expected_surface, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(metrics["volume_mse"], expected_volume, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(metrics["field_mse"], expected_field, rel_tol=1e-6, abs_tol=1e-6)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -39,6 +39,7 @@ LEGACY_VAL_ALIAS = {
     "val_ood_re": "p_re",
 }
 AIRFRANS_FIELD_NAMES = ("Ux", "Uy", "p", "nut")
+TANDEM_FIELD_NAMES = ("Ux", "Uy", "p")
 
 
 @dataclass
@@ -81,6 +82,9 @@ class TrainConfig:
     airfrans_task: str = "full"
     tandem_manifest: str = ""
     tandem_stats: str = ""
+    tandemfoil_paper_task: str = "cruise_random_uniform"
+    tandemfoil_paper_manifest: str = ""
+    tandemfoil_paper_stats: str = ""
     enable_fourier: bool = False
     enable_te_coord_frame: bool = False
     enable_cp_panel: bool = False
@@ -375,6 +379,7 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
     bundle_kwargs = {
         "dataset_name": config.dataset,
         "debug": config.debug,
+        "tandemfoil_paper_task": config.tandemfoil_paper_task,
         "airfrans_task": config.airfrans_task,
         "drivaerml_surface_only": config.surface_only_drivaerml,
         "drivaerml_train_surface_points": config.drivaerml_train_surface_points,
@@ -392,6 +397,10 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
         bundle_kwargs["tandem_manifest"] = config.tandem_manifest
     if config.tandem_stats:
         bundle_kwargs["tandem_stats"] = config.tandem_stats
+    if config.tandemfoil_paper_manifest:
+        bundle_kwargs["tandemfoil_paper_manifest"] = config.tandemfoil_paper_manifest
+    if config.tandemfoil_paper_stats:
+        bundle_kwargs["tandemfoil_paper_stats"] = config.tandemfoil_paper_stats
     return build_dataset_bundle(**bundle_kwargs)
 
 
@@ -742,6 +751,10 @@ def evaluate_grouped(
     n_vol = torch.zeros(3, device=device)
     surf_channel_sum = None
     vol_channel_sum = None
+    paper_surface_sq_sum = None
+    paper_volume_sq_sum = None
+    paper_surface_nodes = 0
+    paper_volume_nodes = 0
     drivaer_surface_case_sums: dict[str, list[float]] = {}
     drivaer_volume_case_sums: dict[str, list[float]] = {}
 
@@ -815,6 +828,25 @@ def evaluate_grouped(
                         if vol_channel_sum is None:
                             vol_channel_sum = torch.zeros(channel_mean.shape[0], device=device)
                         vol_channel_sum += channel_mean.to(device)
+            continue
+
+        if dataset_name == "tandemfoilset_paper":
+            if batch.surface_y is not None and outputs["surface_preds"] is not None:
+                target = transform.apply(batch.surface_y)
+                case_values = (outputs["surface_preds"] - target).square()
+                valid = batch.surface_mask.unsqueeze(-1)
+                if paper_surface_sq_sum is None:
+                    paper_surface_sq_sum = torch.zeros(case_values.shape[-1], device=device)
+                paper_surface_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device)
+                paper_surface_nodes += int(batch.surface_mask.sum().detach().cpu().item())
+            if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
+                target = transform.apply(batch.volume_y)
+                case_values = (outputs["volume_preds"] - target).square()
+                valid = batch.volume_mask.unsqueeze(-1)
+                if paper_volume_sq_sum is None:
+                    paper_volume_sq_sum = torch.zeros(case_values.shape[-1], device=device)
+                paper_volume_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device)
+                paper_volume_nodes += int(batch.volume_mask.sum().detach().cpu().item())
             continue
 
         pred_surface = None
@@ -900,6 +932,25 @@ def evaluate_grouped(
             metrics["volume_rel_l2"] = volume_rel_l2
             metrics["volume_rel_l2_pct"] = volume_rel_l2 * 100.0
         return metrics
+    if dataset_name == "tandemfoilset_paper":
+        metrics: dict[str, float] = {}
+        total_sq_sum = 0.0
+        total_nodes = 0
+        if paper_surface_sq_sum is not None and paper_surface_nodes > 0:
+            surface_channel = paper_surface_sq_sum / paper_surface_nodes
+            metrics["surface_mse"] = float(surface_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("surface_mse", surface_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_surface_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_surface_nodes
+        if paper_volume_sq_sum is not None and paper_volume_nodes > 0:
+            volume_channel = paper_volume_sq_sum / paper_volume_nodes
+            metrics["volume_mse"] = float(volume_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("volume_mse", volume_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_volume_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_volume_nodes
+        if total_nodes > 0:
+            metrics["field_mse"] = total_sq_sum / (total_nodes * len(TANDEM_FIELD_NAMES))
+        return metrics
     metrics = {
         "surface_mae": total_surface / max(count_surface, 1),
         "volume_mae": total_volume / max(count_volume, 1),
@@ -937,6 +988,10 @@ def evaluate_abupt(
     count_volume = 0
     surf_channel_sum = None
     vol_channel_sum = None
+    paper_surface_sq_sum = None
+    paper_volume_sq_sum = None
+    paper_surface_nodes = 0
+    paper_volume_nodes = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
     for batch in batches:
         batch = batch.to(device)
@@ -967,6 +1022,21 @@ def evaluate_abupt(
                 if vol_channel_sum is None:
                     vol_channel_sum = torch.zeros(channel_mean.shape[0], device=device)
                 vol_channel_sum += channel_mean.to(device)
+            continue
+
+        if dataset_name == "tandemfoilset_paper":
+            if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
+                target = transform.apply(batch.surface_anchor_target)
+                if paper_surface_sq_sum is None:
+                    paper_surface_sq_sum = torch.zeros(target.shape[-1], device=device)
+                paper_surface_sq_sum += (outputs["surface_preds"] - target).square().sum(dim=(0, 1)).to(device)
+                paper_surface_nodes += batch.surface_anchor_target.shape[0] * batch.surface_anchor_target.shape[1]
+            if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
+                target = transform.apply(batch.volume_anchor_target)
+                if paper_volume_sq_sum is None:
+                    paper_volume_sq_sum = torch.zeros(target.shape[-1], device=device)
+                paper_volume_sq_sum += (outputs["volume_preds"] - target).square().sum(dim=(0, 1)).to(device)
+                paper_volume_nodes += batch.volume_anchor_target.shape[0] * batch.volume_anchor_target.shape[1]
             continue
 
         if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
@@ -1015,6 +1085,25 @@ def evaluate_abupt(
             volume_rel_l2 = total_volume / count_volume
             metrics["volume_rel_l2"] = volume_rel_l2
             metrics["volume_rel_l2_pct"] = volume_rel_l2 * 100.0
+        return metrics
+    if dataset_name == "tandemfoilset_paper":
+        metrics: dict[str, float] = {}
+        total_sq_sum = 0.0
+        total_nodes = 0
+        if paper_surface_sq_sum is not None and paper_surface_nodes > 0:
+            surface_channel = paper_surface_sq_sum / paper_surface_nodes
+            metrics["surface_mse"] = float(surface_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("surface_mse", surface_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_surface_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_surface_nodes
+        if paper_volume_sq_sum is not None and paper_volume_nodes > 0:
+            volume_channel = paper_volume_sq_sum / paper_volume_nodes
+            metrics["volume_mse"] = float(volume_channel.mean().detach().cpu().item())
+            metrics.update(_named_channel_metrics("volume_mse", volume_channel, TANDEM_FIELD_NAMES))
+            total_sq_sum += float(paper_volume_sq_sum.sum().detach().cpu().item())
+            total_nodes += paper_volume_nodes
+        if total_nodes > 0:
+            metrics["field_mse"] = total_sq_sum / (total_nodes * len(TANDEM_FIELD_NAMES))
         return metrics
     return {"surface_mae": total_surface / max(count_surface, 1), "volume_mae": total_volume / max(count_volume, 1)}
 


### PR DESCRIPTION
## Summary
- add a fourth `target/icml2026` benchmark view, `tandemfoil_paper`, for paper-faithful high-Re TandemFoilSet calibration
- add deterministic Experiment 4 split generation for `Cruise Random` uniform/extrapolation tasks and `Race Car` uniform
- wire the shared trainer and dataset bundle builder to support `--dataset tandemfoil_paper --tandemfoil-paper-task ...`
- update ICML target docs, prompts, and launch-time advisor guidance to treat the new benchmark as a calibration tool alongside the existing parity Tandem target

## Why
The current `tandemfoil/` target is useful for the noam / `kagent` parity story, but it does not give us a clean literature-facing scalar from the original TandemFoilSet paper. This PR adds that missing benchmark view so we can answer a simpler question: are we actually competitive against the paper's published high-Re TandemFoil results?

## Benchmark contract
This PR only implements the paper splits that are reasonably unambiguous from Experiment 4:
- `cruise_random_uniform`
- `cruise_random_aoa_extrap`
- `cruise_random_re_extrap`
- `cruise_random_stagger_extrap`
- `cruise_random_gap_extrap`
- `racecar_uniform`

The new subtarget uses normalized full-field MSE as its primary metric, matching the paper's Table 6 reporting style.

## Notes
- the raw TandemFoil pickles are not present in this desktop worktree, so the new paper manifests/stats are materialized on first real pod run if missing
- the main `tandemfoil/` parity benchmark is intentionally kept separate from the new `tandemfoil_paper/` calibration benchmark
- the project env here does not include a `pytest` module, so verification used `python -m py_compile`, `uv run python train.py --help`, and a direct `uv run python` harness for the split logic and paper-style MSE aggregation checks
