### PR TITLE
Adaptive Gradient Clipping (AGC) — unit-invariant clipping for DrivAerML stability

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,18 +1,38 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-21 22:45 (Wave 3 — Bold New Directions)
+- **Date:** 2026-04-21 23:50 (Wave 3 — Bold New Directions, Cross-Dataset Focus Directive)
 - **Branch:** radford
 - **Fleet status:** 59 live students, ALL ASSIGNED (0 idle)
 - **Current relaunch budget:** inherit pod env defaults
   - `SENPAI_TIMEOUT_MINUTES=360`
   - `SENPAI_MAX_EPOCHS=999`
 
+## CORE RESEARCH DIRECTIVE (Human Team Instruction — 2026-04-21)
+
+**CROSS-DATASET GENERALIZATION IS THE PRIMARY CONSTRAINT ON ALL NEW EXPERIMENTS.**
+
+The human research team has explicitly directed: every new hypothesis must be
+tested across all relevant datasets in a single PR. Dataset-specific tricks that
+do not transfer are not useful. The paper story requires a shared recipe.
+
+All four benchmarks are now active and required:
+
+1. **TandemFoil** — `val_primary/surface_pressure_mae` / `test_primary/surface_pressure_mae`
+2. **TandemFoil Paper** — `val_primary/field_mse` / `test_primary/field_mse` ← NEW 4th dataset (human directive 2026-04-21)
+3. **AirfRANS** — `val_primary/surface_mse` / `test_primary/surface_mse`
+4. **DrivAerML** — `val_primary/surface_rel_l2_pct` / `test_primary/surface_rel_l2_pct`
+
+**Assignment rule (effective immediately):**
+- New hyperparameter or architecture hypotheses MUST be tested on ALL four datasets in one PR.
+- Single-dataset assignments are only acceptable for dataset-specific ablations (e.g. DrivAerML batch size), TandemFoil Paper baseline runs, or targeted best-checkpoint recovery.
+- When in doubt: assign cross-dataset. An idea that only helps one dataset is a dataset hack.
+
 ## Paper-Facing Snapshot
 
 | Dataset | Paper-facing metric | Current best | Target / reference | Status |
 |---|---|---|---|---|
 | TandemFoil | `test_primary/surface_pressure_mae` | **33.88** (#2810) | no external scalar | needs test from new EMA best |
-| TandemFoil Paper | `test_primary/field_mse` | not run yet on `radford` | `0.10 / 0.18 / 0.36 / 0.13 / 0.14 / 0.21` by task | new calibration lane |
+| TandemFoil Paper | `test_primary/field_mse` | **not run yet on radford** | `0.10 / 0.18 / 0.36 / 0.13 / 0.14 / 0.21` by task | NEW — baseline run needed |
 | AirfRANS | `test_primary/surface_mse` | **0.003** (#2824) | `0.0043` | **BEATEN** — val now 0.000727 |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **6.24%** (#2691) | `3.71%` | **MAIN GAP — 1.68x** |
 
@@ -21,25 +41,27 @@
 | Dataset | Metric | Current anchor |
 |---|---|---|
 | TandemFoil | `val_primary/surface_pressure_mae` | **26.134** (#2899 MERGED — EMA decay=0.999) |
+| TandemFoil Paper | `val_primary/field_mse` | **not established** — baseline run needed urgently |
 | AirfRANS | `val_primary/surface_mse` | **0.000727** (#2899 MERGED — EMA decay=0.999, ep206) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** (#2691) |
 
 ## Main Scientific Goal
 
-A shared recipe whose core changes work across:
+A shared recipe whose core changes work across all four benchmarks:
 
 - the main TandemFoil parity target
-- the new TandemFoil paper-calibration target
+- the new TandemFoil paper-calibration target (Experiment 4, Table 6)
 - AirfRANS
 - DrivAerML
 
 DrivAerML is still the main gap. Corrected EMA warmup is now the shared recipe
-for TF+AF, and the paper-calibration Tandem benchmark exists to tell us whether
-Tandem-side gains are only helping the parity contract or also the literature-facing one.
+for TF+AF. TandemFoil Paper is a NEW required benchmark added by the human team
+— paper-faithful high-Re TandemFoilSet using normalized full-field MSE, 6 tasks.
+No baseline has been run yet on radford for this dataset.
 
 ## Mandatory Config Rules (UPDATED after EMA merge)
 
-- **TF + AF:** Use `--ema-decay 0.999` (NO --no-use-ema). decay=0.999 > 0.9999 on both.
+- **TF + AF + TF_paper:** Use `--ema-decay 0.999` (NO --no-use-ema). decay=0.999 > 0.9999 on both.
 - **DrivAerML:** Still `--no-use-ema` (EMA alone hurt DM; zenitsu #2925 tests EMA+gc compound)
 - `--epochs 999` mandatory
 - DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
@@ -61,11 +83,18 @@ Tandem-side gains are only helping the parity contract or also the literature-fa
 
 ## Default Assignment Pattern
 
-Cross-dataset: TF+AF use EMA decay=0.999, DM still uses --no-use-ema.
+Cross-dataset is now the DEFAULT. Every new hypothesis should cover:
+- `target/icml2026/tandemfoil/`
+- `target/icml2026/tandemfoil_paper/`
+- `target/icml2026/airfrans/`
+- `target/icml2026/drivaerml/`
+
+Unless there is a strong reason to restrict to a single dataset (ablation,
+baseline run, known dataset-specific mechanism), all assignments are
+multi-dataset. This is the human team's explicit directive.
 
 When a hypothesis is relevant to TandemFoil generalization or paper
-comparability, include both:
-
+comparability, always include:
 - `target/icml2026/tandemfoil/`
 - `target/icml2026/tandemfoil_paper/`
 
@@ -183,29 +212,42 @@ comparability, include both:
 2. **DrivAerML is fragile to compounds:** gc+WD+cosine crashes (6/8 #2908), 640d crashes (#2917), T_max=5 crashes (#2911). Only gentle perturbations survive at 4L/512d.
 3. **Width scaling ceiling at 512d for DM:** 640d is unstable. guts #2890 (768d) and himmel #2891 (5L/512d) will clarify the boundary.
 4. **AB-UPT** achieves 3.71% via geometry-separated encoding — escalation if EMA+recipe fails.
+5. **TandemFoil Paper baseline urgently needed:** This dataset has never been run on radford. We need a val anchor before we can evaluate any experiment improvements against the paper's Table 6 numbers.
 
 ## Current Research Themes and Priorities
 
-### Priority 1: DrivAerML Gap Closure (4.619% → 3.71%)
+### Priority 0: Cross-Dataset Generalization (Human Team Directive — NON-NEGOTIABLE)
+- **Every new experiment must test across all 4 datasets.** Ideas that help only one dataset are not acceptable for the shared paper recipe.
+- **TandemFoil Paper is now a required 4th benchmark.** All future assignments must include it.
+- **Measurement gate:** An experiment is a win only if it does not cause regression on any of the 4 datasets (or shows a cross-dataset improvement).
+
+### Priority 1: TandemFoil Paper Baseline
+- **No val anchor exists yet for TF Paper.** First student to become idle should run the best current config (EMA decay=0.999, 3L/192d or 4L/512d, Lion lr=1.25e-4 for TF) on tandemfoil_paper to establish a baseline.
+- Paper targets (Table 6 MGN + PRE-RES-FREE+RES-COMB): 0.10/0.18/0.36/0.13/0.14/0.21 per task.
+- Metric: normalized full-field MSE (`val_primary/field_mse`).
+
+### Priority 2: DrivAerML Gap Closure (4.619% → 3.71%)
 - **Loss alignment** (frieren #2928): Most direct fix — training on relative L2 directly matches the evaluation metric
 - **Architectural upgrades** (nezuko #2929 SwiGLU, kohaku #2932 global context): Address known Transolver limitations
 - **Regularization** (violet #2930 DropPath): New orthogonal regularization dimension
 - **Physics-informed features** (emma #2933 curvature, mitsuha #2936 SDF): Give model explicit geometric knowledge it currently must learn implicitly
 
-### Priority 2: Cross-Benchmark Recipe Validation
-- Wave 3 experiments test across all 4 benchmarks by default
+### Priority 3: Cross-Benchmark Recipe Validation
+- Wave 3 experiments should test across all 4 benchmarks by default
 - TandemFoil Paper benchmark provides calibration against published numbers
-- Ideas that help DM but hurt TF/AF are dataset hacks; we want shared wins
+- Ideas that help DM but hurt TF/AF are dataset hacks; we want shared wins across all 4
 
-### Priority 3: Optimization Paradigm Shift
+### Priority 4: Optimization Paradigm Shift
 - Prodigy (gilbert #2931): If the LR search is truly exhausted, adaptive optimizers may find new trajectories
 - MoE (shoya #2935): Sparse expert specialization is fundamentally different from dense FFN
 - Conservation loss (chihiro #2934): Physics constraints as regularization
 
 ## Next Priorities
 
-1. Watch Wave 3 results (frieren #2928 rel-L2 is the highest-priority result)
-2. Review any WIP PRs that become ready
-3. If DM recipe transfer (Theme 1) fails universally → escalate to geometry-separated encoding
-4. If Wave 3 bold ideas show promise → double down with follow-up assignments
-5. Check for human team messages on GitHub issues
+1. **TandemFoil Paper baseline run** — assign first available idle student
+2. Watch Wave 3 results (frieren #2928 rel-L2 is the highest-priority result)
+3. Review any WIP PRs that become ready
+4. All new assignments: 4-dataset coverage mandatory per human team directive
+5. If DM recipe transfer (Theme 1) fails universally → escalate to geometry-separated encoding
+6. If Wave 3 bold ideas show promise → double down with follow-up assignments across all 4 datasets
+7. Check for human team messages on GitHub issues (priority — check very frequently)


### PR DESCRIPTION
## Hypothesis

Fixed-threshold gradient clipping (`--grad-clip`) is unit-dependent: the same threshold that stabilises early training will choke gradients mid-run when CosineAnnealing restarts drive the optimiser into steep loss-landscape regions. PR #2881 confirmed this: every DrivAerML run with `gc=1.5` or `gc=2.0` diverged, and the divergence correlated with CosineAnnealing restart boundaries.

**Adaptive Gradient Clipping (AGC)** (Brock et al. 2021, NFNet — https://arxiv.org/abs/2102.06171) clips per-parameter based on the ratio `||grad|| / ||param||` rather than absolute norm. This makes it:
- **Unit-invariant**: the effective clip threshold scales with parameter magnitude, not a global constant.
- **Restart-safe**: when cosine restarts amplify gradients, AGC clips proportionally — no cliff edge.
- **LayerNorm-friendly**: the paper shows AGC is well-matched to architectures without BatchNorm; Transolver uses LayerNorm exclusively.

We expect AGC to recover DrivAerML training stability without sacrificing the gradient signal that drives learning in TandemFoil and AirfRANS.

## Instructions

Add a new CLI flag `--agc-clip-factor` (default `0.0` = disabled) and implement AGC in `target/icml2026/train.py`. The implementation should replace the per-step gradient clipping call when AGC is active:

```python
def adaptive_gradient_clipping(parameters, clip_factor=0.01, eps=1e-3):
    """AGC from Brock et al. 2021 (NFNet). Clips grad if ||grad||/||param|| > clip_factor."""
    for p in parameters:
        if p.grad is None:
            continue
        param_norm = p.data.norm(dim=-1, keepdim=True).clamp(min=eps)
        grad_norm  = p.grad.data.norm(dim=-1, keepdim=True).clamp(min=eps)
        max_norm   = param_norm * clip_factor
        trigger    = grad_norm > max_norm
        clipped_grad = p.grad.data * (max_norm / grad_norm)
        p.grad.data = torch.where(trigger, clipped_grad, p.grad.data)
```

Call it after `loss.backward()` and before `optimizer.step()` (same location as the existing `torch.nn.utils.clip_grad_norm_` call). When `--agc-clip-factor > 0`, use AGC; when `--grad-clip > 0`, use the existing fixed threshold; both can be active simultaneously ("belt and suspenders").

Use `--wandb_group radford-20260421-relaunch-agc` for all runs so they are grouped in W&B.

### 8-GPU run matrix

**GPU 0 — DrivAerML, AGC=0.01 (primary)**
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml --agc-clip-factor 0.01 \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group radford-20260421-relaunch-agc
```

**GPU 1 — DrivAerML, AGC=0.02**
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml --agc-clip-factor 0.02 \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group radford-20260421-relaunch-agc
```

**GPU 2 — DrivAerML, AGC=0.005**
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml --agc-clip-factor 0.005 \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group radford-20260421-relaunch-agc
```

**GPU 3 — DrivAerML, AGC=0.01 + fixed gc=1.0 (belt-and-suspenders)**
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml --agc-clip-factor 0.01 --grad-clip 1.0 \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group radford-20260421-relaunch-agc
```

**GPU 4 — TandemFoil, AGC=0.01**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil --agc-clip-factor 0.01 \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --wandb_group radford-20260421-relaunch-agc
```

**GPU 5 — TandemFoil Paper, AGC=0.01**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper --agc-clip-factor 0.01 \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --wandb_group radford-20260421-relaunch-agc
```

**GPU 6 — AirfRANS, AGC=0.01**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full --agc-clip-factor 0.01 \
  --optimizer adamw --lr 7e-4 --cosine-t-max 5 \
  --weight-decay 1e-2 --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 \
  --wandb_group radford-20260421-relaunch-agc
```

**GPU 7 — DrivAerML, AGC=0.01 + weight-decay=1e-2**
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml --agc-clip-factor 0.01 --weight-decay 1e-2 \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group radford-20260421-relaunch-agc
```

## Baseline

Current best metrics from BASELINE.md:

| Dataset | Primary metric | Value | PR | W&B run |
|---|---|---|---|---|
| DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** | #2691 | k8qtsxxz |
| TandemFoil | `val_primary/surface_pressure_mae` | **26.134** | #2899 | nrn0q3ct |
| TandemFoil Paper | `val_primary/surface_pressure_mae` | not established | — | — |
| AirfRANS | `val_primary/surface_mse` | **0.000727** | #2899 | i1sevgt2 |

Reproduce DrivAerML baseline:
```bash
cd target/icml2026 && python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```

## What to report

For each GPU run, report:
1. Whether training remained **stable** across all CosineAnnealing restarts (no divergence).
2. Best `val_primary` metric achieved and at which epoch.
3. W&B run ID and link.
4. For DrivAerML runs: also report `val/surface_rel_l2_pct` trajectory around restart boundaries (e.g. epochs 28-32, 58-62) — this is the key signal.

Tag this PR ready for review (`status:review`) when at least the GPU 0 DrivAerML run has either completed or clearly diverged.