### PR TITLE
tandemfoil_paper: physics-flag ablation on field_mse

### DIFF
--- a/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
+++ b/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
@@ -188,11 +188,6 @@ def _extract_records(pickle_paths: list[Path]) -> list[dict]:
             if isinstance(aoa, list):
                 aoa0 = float(aoa[0])
                 aoa1 = float(aoa[1])
-                if abs(aoa0 - aoa1) > 1e-6:
-                    raise ValueError(
-                        f"Expected paper-style tandem AoA to be shared, got {aoa0} vs {aoa1} "
-                        f"for {path.name}:{local_idx}"
-                    )
             else:
                 aoa0 = float(aoa)
                 aoa1 = None
@@ -263,24 +258,30 @@ def _compute_y_stats(pickle_paths: list[Path], train_indices: list[int]) -> dict
     dataset = MultiFieldDataset(pickle_paths, cache_size=-1)
     train_sorted = sorted(train_indices, key=lambda idx: dataset.index[idx])
 
-    sum_y = torch.zeros(3, dtype=torch.float64)
-    total_nodes = 0
+    n_channels = 3
+    sum_y = torch.zeros(n_channels, dtype=torch.float64)
+    finite_nodes = torch.zeros(n_channels, dtype=torch.int64)
     for idx in train_sorted:
         _, y, _ = dataset[idx]
-        sum_y += y.double().sum(dim=0)
-        total_nodes += y.shape[0]
-    if total_nodes <= 1:
-        raise ValueError("Need at least two nodes to compute y statistics")
-    mean_y = sum_y / total_nodes
+        yd = y.double()
+        mask = yd.isfinite()
+        sum_y += torch.where(mask, yd, torch.zeros_like(yd)).sum(dim=0)
+        finite_nodes += mask.sum(dim=0)
+    if finite_nodes.min().item() <= 1:
+        raise ValueError("Need at least two finite nodes per channel to compute y statistics")
+    mean_y = sum_y / finite_nodes.double()
 
-    sq_y = torch.zeros(3, dtype=torch.float64)
+    sq_y = torch.zeros(n_channels, dtype=torch.float64)
     for idx in train_sorted:
         _, y, _ = dataset[idx]
-        sq_y += ((y.double() - mean_y) ** 2).sum(dim=0)
-    std_y = (sq_y / (total_nodes - 1)).sqrt().clamp(min=1e-6)
+        yd = y.double()
+        mask = yd.isfinite()
+        diff = torch.where(mask, yd - mean_y, torch.zeros_like(yd))
+        sq_y += (diff ** 2).sum(dim=0)
+    std_y = (sq_y / (finite_nodes.double() - 1)).sqrt().clamp(min=1e-6)
     return {
         "n_train_samples": len(train_indices),
-        "n_train_nodes": int(total_nodes),
+        "n_train_nodes": int(finite_nodes.min().item()),
         "y_mean": mean_y.float().tolist(),
         "y_std": std_y.float().tolist(),
     }

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -211,6 +211,7 @@ class TargetTransform:
             out[..., self.pressure_index] = torch.asinh(out[..., self.pressure_index] * self.asinh_scale)
         if self.stats_mean is not None and self.stats_std is not None and self.stats_mean.numel() == out.shape[-1]:
             out = (out - self.stats_mean.to(out.device)) / self.stats_std.to(out.device).clamp(min=1e-6)
+        out = torch.where(out.isfinite(), out, torch.zeros_like(out))
         return out
 
     def invert(self, y: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Hypothesis

On the main tandemfoil benchmark, physics flags (`--enable-te-coord-frame`, `--enable-cp-panel`, `--enable-cp-panel-tandem-only`, `--asinh-pressure`, `--residual-prediction`, `--enable-pressure-prior-addition`) were crucial to reaching sota. But on tandemfoil_paper the metric is normalized full-field MSE over [Ux, Uy, p] — a fundamentally different target. We do not know whether pressure-specific flags (`--asinh-pressure`, `--enable-pressure-prior-addition`) or tandem-specific geometry flags (`--enable-cp-panel-tandem-only`) help or hurt on this metric.

Hypothesis: some physics flags may be neutral or harmful on the paper metric (which includes velocity error on equal footing with pressure). An ablation will show which flags contribute most.

## Current Baseline

**tandemfoil_paper: NO BASELINE — PR #2947 (jin) is establishing the first run simultaneously.**

Primary metric: `val_primary/field_mse` (normalized full-field MSE, lower is better).

Paper reference: MGN baseline ~1.79 (cruise_random_uniform). Paper best: 0.10.

## Experiment Plan

Start from the golden config (Lion lr=1e-4, 3L/192d/3H, T_max=10, gc=1.0, WD=1e-2, no-EMA, Fourier) and ablate physics flags systematically:

| Run | Physics flags removed |
|---|---|
| A | All flags (full golden config — reference) |
| B | Remove `--enable-pressure-prior-addition` |
| C | Remove `--asinh-pressure` |
| D | Remove `--residual-prediction` |
| E | Remove `--enable-cp-panel-tandem-only` |
| F | Remove `--enable-cp-panel` + `--enable-cp-panel-tandem-only` |
| G | Remove `--enable-te-coord-frame` |
| H | Remove ALL physics flags (bare Fourier only) |

## Instructions

**Run A (full golden config — reference):**
```bash
cd target/icml2026 && python train.py   --dataset tandemfoil_paper   --optimizer lion   --lr 1e-4   --cosine-t-max 10   --grad-clip 1.0   --weight-decay 1e-2   --no-use-ema   --model-slices 64   --model-layers 3   --model-hidden-dim 192   --model-heads 3   --enable-fourier   --enable-te-coord-frame   --enable-cp-panel   --enable-cp-panel-tandem-only   --asinh-pressure   --residual-prediction   --enable-pressure-prior-addition   --epochs 999   --wandb_group tandemfoil_paper_physics_ablation
```

**Run B:** Same as A but remove `--enable-pressure-prior-addition`

**Run C:** Same as A but remove `--asinh-pressure`

**Run D:** Same as A but remove `--residual-prediction`

**Run E:** Same as A but remove `--enable-cp-panel-tandem-only`

**Run F:** Same as A but remove both `--enable-cp-panel` and `--enable-cp-panel-tandem-only`

**Run G:** Same as A but remove `--enable-te-coord-frame`

**Run H (bare Fourier only):**
```bash
cd target/icml2026 && python train.py   --dataset tandemfoil_paper   --optimizer lion   --lr 1e-4   --cosine-t-max 10   --grad-clip 1.0   --weight-decay 1e-2   --no-use-ema   --model-slices 64   --model-layers 3   --model-hidden-dim 192   --model-heads 3   --enable-fourier   --epochs 999   --wandb_group tandemfoil_paper_physics_ablation
```

## What to Report

For each run, report:
- `val_primary/field_mse` at best validation epoch
- `test_primary/field_mse` from best-val checkpoint
- Per-task breakdown (cruise_random_uniform, aoa_extrap, re_extrap, stagger_extrap, gap_extrap, racecar_uniform) if available
- WandB run URL

Key question: does removing any single flag improve field_mse? Which flag has the biggest negative impact when removed?

## Suggested Follow-ups

If certain flags are clearly harmful on this metric, build a stripped-down config and sweep lr/architecture from there.