### PR TITLE
Wave3: Relative L2 Training Loss — cross-dataset

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    relative_l2_loss: str = ""
 
 
 @dataclass
@@ -731,21 +732,44 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def _relative_l2(pred: torch.Tensor, target: torch.Tensor, mode: str) -> torch.Tensor:
+    eps = 1e-8
+    diff = pred - target
+    if mode == "global":
+        return (diff.pow(2).sum() / (target.pow(2).sum() + eps)).sqrt()
+    if mode == "per-point":
+        return (diff.pow(2).sum(-1) / (target.pow(2).sum(-1) + eps)).sqrt().mean()
+    global_loss = (diff.pow(2).sum() / (target.pow(2).sum() + eps)).sqrt()
+    per_pt_loss = (diff.pow(2).sum(-1) / (target.pow(2).sum(-1) + eps)).sqrt().mean()
+    return 0.5 * global_loss + 0.5 * per_pt_loss
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    relative_l2_loss: str = "",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        pred_masked = outputs["surface_preds"][batch.surface_mask]
+        tgt_masked = target[batch.surface_mask]
+        if relative_l2_loss:
+            surf_loss = _relative_l2(pred_masked, tgt_masked, relative_l2_loss)
+        else:
+            surf_loss = F.mse_loss(pred_masked, tgt_masked)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
-        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
+        pred_masked = outputs["volume_preds"][batch.volume_mask]
+        tgt_masked = target[batch.volume_mask]
+        if relative_l2_loss:
+            vol_loss = _relative_l2(pred_masked, tgt_masked, relative_l2_loss)
+        else:
+            vol_loss = F.mse_loss(pred_masked, tgt_masked)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -755,15 +779,26 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    relative_l2_loss: str = "",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
     if outputs["surface_preds"] is not None:
-        surf_loss = F.mse_loss(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask])
+        pred_masked = outputs["surface_preds"][prepared.surface_mask]
+        tgt_masked = prepared.surface_target[prepared.surface_mask]
+        if relative_l2_loss:
+            surf_loss = _relative_l2(pred_masked, tgt_masked, relative_l2_loss)
+        else:
+            surf_loss = F.mse_loss(pred_masked, tgt_masked)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
-        vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
+        pred_masked = outputs["volume_preds"][prepared.volume_mask]
+        tgt_masked = prepared.volume_target[prepared.volume_mask]
+        if relative_l2_loss:
+            vol_loss = _relative_l2(pred_masked, tgt_masked, relative_l2_loss)
+        else:
+            vol_loss = F.mse_loss(pred_masked, tgt_masked)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -774,17 +809,24 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    relative_l2_loss: str = "",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
     if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
         surf_target = transform.apply(batch.surface_anchor_target)
-        surf_loss = F.mse_loss(outputs["surface_preds"], surf_target)
+        if relative_l2_loss:
+            surf_loss = _relative_l2(outputs["surface_preds"], surf_target, relative_l2_loss)
+        else:
+            surf_loss = F.mse_loss(outputs["surface_preds"], surf_target)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
-        vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
+        if relative_l2_loss:
+            vol_loss = _relative_l2(outputs["volume_preds"], vol_target, relative_l2_loss)
+        else:
+            vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -1194,6 +1236,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    relative_l2_loss: str = "",
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1227,7 +1270,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, relative_l2_loss)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1240,7 +1283,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, relative_l2_loss)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1249,7 +1292,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, relative_l2_loss)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1462,6 +1505,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            relative_l2_loss=config.relative_l2_loss,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Standard MSE loss treats all nodes equally, but CFD targets have wildly different magnitudes (stagnation pressure vs. wake velocity). Replacing MSE with a relative L2 loss — normalizing the squared error by the squared norm of the ground truth — should make the optimizer pay proportionally equal attention to low-magnitude regions (e.g. wake, suction side) and high-magnitude regions, improving surface pressure and field accuracy across all four datasets.

## Relative L2 Loss Formulation

```
L_rel = ||y_pred - y_true||_2 / (||y_true||_2 + eps),   eps = 1e-8
```

Three variants to try in one sweep (use `--wandb_group frieren-rel-l2`):
- **global**: normalize by the full-batch norm (single scalar)
- **per-point**: normalize per-node (divide each node error by its ground-truth norm)
- **mixed**: 0.5 * L_global + 0.5 * L_per_point

Implement by adding a `--relative-l2-loss {global,per-point,mixed}` flag in `train.py`. Leave the existing loss path fully intact so the baseline still runs unchanged.

Core change (global variant):
```python
# In your loss computation block, after getting pred and target tensors:
if args.relative_l2_loss == 'global':
    diff = pred - target
    loss = (diff.pow(2).sum() / (target.pow(2).sum() + 1e-8)).sqrt()
elif args.relative_l2_loss == 'per-point':
    diff = pred - target
    loss = (diff.pow(2).sum(-1) / (target.pow(2).sum(-1) + 1e-8)).sqrt().mean()
elif args.relative_l2_loss == 'mixed':
    global_loss = (diff.pow(2).sum() / (target.pow(2).sum() + 1e-8)).sqrt()
    per_pt_loss = (diff.pow(2).sum(-1) / (target.pow(2).sum(-1) + 1e-8)).sqrt().mean()
    loss = 0.5 * global_loss + 0.5 * per_pt_loss
```

## Training Instructions — All 4 Datasets

Run all 4 datasets. Use 8 GPUs (one per run) for maximum throughput. Use `--wandb_group frieren-rel-l2`.

### TandemFoil (3 variants × 1 run = 3 runs, share 1-2 GPUs sequentially)
```bash
cd target/icml2026

# global
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --relative-l2-loss global --wandb_group frieren-rel-l2

# per-point
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --relative-l2-loss per-point --wandb_group frieren-rel-l2

# mixed
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --relative-l2-loss mixed --wandb_group frieren-rel-l2
```

### TandemFoil Paper (same 3 variants — uses TF pickles, full-field MSE metric)
```bash
# global
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --relative-l2-loss global --wandb_group frieren-rel-l2

# per-point
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --relative-l2-loss per-point --wandb_group frieren-rel-l2

# mixed
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --relative-l2-loss mixed --wandb_group frieren-rel-l2
```

### AirfRANS (3 variants)
```bash
# global
python train.py --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 \
  --relative-l2-loss global --wandb_group frieren-rel-l2

# per-point
python train.py --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 \
  --relative-l2-loss per-point --wandb_group frieren-rel-l2

# mixed
python train.py --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 \
  --relative-l2-loss mixed --wandb_group frieren-rel-l2
```

### DrivAerML (3 variants)
```bash
# global
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --relative-l2-loss global --wandb_group frieren-rel-l2

# per-point
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --relative-l2-loss per-point --wandb_group frieren-rel-l2

# mixed
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --relative-l2-loss mixed --wandb_group frieren-rel-l2
```

## Current Baselines (targets to beat)

| Dataset | Metric | Current Best | PR |
|---------|--------|-------------|-----|
| TandemFoil | `val_primary/surface_pressure_mae` | **26.06** | #2887 (gohan) |
| TandemFoil Paper | `val_primary/field_mse` | TBD (establishing via #2947-2949) |
| AirfRANS | `val_primary/surface_mse` | **0.000627** | #2902 (stark) |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 (piccolo) |

## Expected Outcome

Relative L2 loss should benefit datasets with high dynamic range (DrivAerML pressure fields, TandemFoil wake regions). Per-point variant risks over-fitting to near-zero nodes — mixed variant is the safest bet. Report best checkpoint metrics for all 4 datasets and all 3 variants.