### PR TITLE
Wave3: SwiGLU FFN Replacement — cross-dataset

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -33,6 +33,25 @@ from core.features import (
 from core.optim import Lion, Lookahead
 
 
+class SwiGLUFFN(torch.nn.Module):
+    def __init__(self, dim: int, hidden_dim: int | None = None):
+        super().__init__()
+        hidden_dim = hidden_dim or int(dim * 4 * 2 / 3)
+        hidden_dim = ((hidden_dim + 63) // 64) * 64
+        self.w1 = torch.nn.Linear(dim, hidden_dim, bias=False)
+        self.w2 = torch.nn.Linear(hidden_dim, dim, bias=False)
+        self.w3 = torch.nn.Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+def _replace_ffn_with_swiglu(model: torch.nn.Module) -> None:
+    for block in model.backbone.blocks:
+        dim = block.mlp.fc1.in_features
+        block.mlp = SwiGLUFFN(dim)
+
+
 class EMAWithWarmup:
     """EMA with timm-style adaptive decay warmup: min(target, (1+step)/(10+step))."""
 
@@ -166,6 +185,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    ffn_type: str = "gelu"
 
 
 @dataclass
@@ -481,8 +501,9 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
     }
+    model: torch.nn.Module
     if config.model == "reference_transolver":
-        return ReferenceTransolver(
+        model = ReferenceTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -490,9 +511,9 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
             **transolver_kwargs,
         )
-    if config.model == "senpai_transolver":
+    elif config.model == "senpai_transolver":
         prior_idx = cp_panel_prior_index(config, bundle)
-        return SenpaiTransolver(
+        model = SenpaiTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -506,13 +527,19 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_pressure_prior_idx=prior_idx,
             **transolver_kwargs,
         )
-    if config.model == "reference_abupt":
-        return ABUPTReference(
+    elif config.model == "reference_abupt":
+        model = ABUPTReference(
             space_dim=bundle.spec.space_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
             volume_output_dim=bundle.spec.volume_output_dim,
         )
-    raise ValueError(f"Unknown model: {config.model}")
+    else:
+        raise ValueError(f"Unknown model: {config.model}")
+
+    if config.ffn_type == "swiglu" and hasattr(model, "backbone"):
+        _replace_ffn_with_swiglu(model)
+
+    return model
 
 
 def build_optimizer(params, config: TrainConfig):
@@ -1407,6 +1434,9 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    total_params = sum(p.numel() for p in model.parameters())
+    trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    print(f"Model params: {total_params:,} total, {trainable_params:,} trainable (ffn_type={config.ffn_type})")
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1432,6 +1462,8 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        run_config["total_params"] = total_params
+        run_config["trainable_params"] = trainable_params
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),


### PR DESCRIPTION
## Hypothesis

Standard transformer FFNs use GeLU/ReLU activations. SwiGLU — used in LLaMA, PaLM, and Mistral — replaces the single activation with a gated product: `silu(W1*x) * W3*x`. This gating mechanism allows the FFN to selectively suppress or amplify features, which may help the model focus on physically meaningful CFD features (pressure gradients, boundary layer signatures) while suppressing noise. SwiGLU typically provides 1-3% improvement in NLP tasks with the same parameter count if hidden dim is scaled to 2/3 * 4d.

## SwiGLU FFN Implementation

Add a `--ffn_type swiglu` flag. When set, replace the standard FFN in every transformer block with `SwiGLUFFN`:

```python
import torch.nn.functional as F

class SwiGLUFFN(nn.Module):
    def __init__(self, dim, hidden_dim=None):
        super().__init__()
        # Scale hidden dim to 2/3 * 4d to keep parameter count equal to standard 4d FFN
        hidden_dim = hidden_dim or int(dim * 4 * 2 / 3)
        # Round up to nearest multiple of 64 for GPU efficiency
        hidden_dim = ((hidden_dim + 63) // 64) * 64
        self.w1 = nn.Linear(dim, hidden_dim, bias=False)
        self.w2 = nn.Linear(hidden_dim, dim, bias=False)
        self.w3 = nn.Linear(dim, hidden_dim, bias=False)

    def forward(self, x):
        return self.w2(F.silu(self.w1(x)) * self.w3(x))
```

The standard FFN hidden dim is typically `4 * dim`. SwiGLU with `2/3 * 4 * dim` ≈ `2.67 * dim` keeps params similar (3 matrices at 2.67d vs 2 matrices at 4d).

## Training Instructions — All 4 Datasets

Run 2 variants per dataset: `--ffn_type swiglu` vs. baseline (no flag). Use `--wandb_group nezuko-swiglu`.

### TandemFoil
```bash
cd target/icml2026

# SwiGLU variant
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --ffn_type swiglu --wandb_group nezuko-swiglu
```

### TandemFoil Paper (full-field MSE metric, use EMA)
```bash
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --ffn_type swiglu --wandb_group nezuko-swiglu
```

### AirfRANS
```bash
python train.py --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 \
  --ffn_type swiglu --wandb_group nezuko-swiglu
```

### DrivAerML
```bash
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ffn_type swiglu --wandb_group nezuko-swiglu
```

## Current Baselines (targets to beat)

| Dataset | Metric | Current Best | PR |
|---------|--------|-------------|-----|
| TandemFoil | `val_primary/surface_pressure_mae` | **26.06** | #2887 (gohan) |
| TandemFoil Paper | `val_primary/field_mse` | TBD (establishing via #2947-2949) |
| AirfRANS | `val_primary/surface_mse` | **0.000627** | #2902 (stark) |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 (piccolo) |

## Expected Outcome

SwiGLU often generalizes better than GeLU in attention-based architectures due to its gating mechanism. In CFD surrogate models, where the model must learn to selectively attend to boundary layer physics vs. freestream regions, gating should help. Run all 4 datasets and report best checkpoint metrics.