### PR TITLE
Wave3: Stochastic Depth (DropPath) Regularization — cross-dataset

### DIFF
--- a/target/icml2026/core/architectures/transolver_reference.py
+++ b/target/icml2026/core/architectures/transolver_reference.py
@@ -72,6 +72,18 @@ class MLP(nn.Module):
         return self.net(x)
 
 
+class DropPath(nn.Module):
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = drop_prob
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not self.training or self.drop_prob == 0.0:
+            return x
+        keep = (torch.rand(x.shape[0], *([1] * (x.ndim - 1)), device=x.device) >= self.drop_prob).to(x.dtype)
+        return x * keep / (1.0 - self.drop_prob)
+
+
 class UpActDownMlp(nn.Module):
     def __init__(self, hidden_dim: int, mlp_hidden_dim: int):
         super().__init__()
@@ -139,6 +151,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -151,10 +164,11 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.drop_path = DropPath(drop_path_rate) if drop_path_rate > 0.0 else nn.Identity()
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        x = x + self.drop_path(self.attention(self.norm1(x), attn_mask=attn_mask))
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
         return x
 
 
@@ -167,8 +181,10 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
+        dpr = [drop_path_rate * i / max(depth - 1, 1) for i in range(depth)]
         self.blocks = nn.ModuleList(
             [
                 TransformerBlock(
@@ -177,8 +193,9 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    drop_path_rate=dpr[i],
                 )
-                for _ in range(depth)
+                for i in range(depth)
             ]
         )
 
@@ -205,6 +222,7 @@ class ReferenceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,6 +251,7 @@ class ReferenceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            drop_path_rate=drop_path_rate,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.out = LinearProjection(n_hidden, surface_output_dim + volume_output_dim)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -106,6 +106,7 @@ class TrainConfig:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    drop_path_rate: float = 0.0
     drivaerml_train_surface_points: int = 0
     drivaerml_eval_surface_points: int = 0
     drivaerml_train_volume_points: int = 0
@@ -480,6 +481,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
+        "drop_path_rate": config.drop_path_rate,
     }
     if config.model == "reference_transolver":
         return ReferenceTransolver(


### PR DESCRIPTION
## Hypothesis

Stochastic Depth (DropPath) randomly drops entire residual blocks during training, acting as a powerful regularizer. Originally proposed for ResNets and adopted in ViT/DeiT/Swin, it forces the network to learn redundant representations by randomly bypassing blocks. For CFD surrogates, where overfitting to training flow configurations is a risk, this could improve generalization on OOD geometries. We test `drop_path_rate` at 0.1 and 0.2 with a linear schedule (deeper blocks have higher drop probability).

## DropPath Implementation

Add `--drop_path_rate` flag. Apply linearly-scaled drop probabilities across layers (layer i gets `drop_prob = drop_path_rate * i / (num_layers - 1)`):

```python
class DropPath(nn.Module):
    def __init__(self, drop_prob=0.0):
        super().__init__()
        self.drop_prob = drop_prob

    def forward(self, x):
        if not self.training or self.drop_prob == 0.0:
            return x
        keep_prob = 1 - self.drop_prob
        # Shape: [batch_size, 1, 1] for 3D tensors; adjust for your tensor shape
        shape = (x.shape[0],) + (1,) * (x.ndim - 1)
        random_tensor = torch.rand(shape, dtype=x.dtype, device=x.device)
        random_tensor = torch.floor(random_tensor + keep_prob)
        return x / keep_prob * random_tensor
```

Apply this to each residual connection in the transformer blocks. Layer 0 gets `drop_prob=0`, layer L-1 gets `drop_prob=drop_path_rate`.

## Training Instructions — All 4 Datasets

Test 2 values of `drop_path_rate`: 0.1 and 0.2. Use `--wandb_group violet-droppath`.

### TandemFoil
```bash
cd target/icml2026

# drop_path_rate=0.1
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --drop_path_rate 0.1 --wandb_group violet-droppath

# drop_path_rate=0.2
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --drop_path_rate 0.2 --wandb_group violet-droppath
```

### TandemFoil Paper (use EMA)
```bash
# drop_path_rate=0.1
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --drop_path_rate 0.1 --wandb_group violet-droppath

# drop_path_rate=0.2
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 \
  --drop_path_rate 0.2 --wandb_group violet-droppath
```

### AirfRANS
```bash
# drop_path_rate=0.1
python train.py --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 \
  --drop_path_rate 0.1 --wandb_group violet-droppath

# drop_path_rate=0.2
python train.py --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 \
  --model-heads 4 --epochs 999 \
  --drop_path_rate 0.2 --wandb_group violet-droppath
```

### DrivAerML
```bash
# drop_path_rate=0.1
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --drop_path_rate 0.1 --wandb_group violet-droppath

# drop_path_rate=0.2
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --drop_path_rate 0.2 --wandb_group violet-droppath
```

## Current Baselines (targets to beat)

| Dataset | Metric | Current Best | PR |
|---------|--------|-------------|-----|
| TandemFoil | `val_primary/surface_pressure_mae` | **26.06** | #2887 (gohan) |
| TandemFoil Paper | `val_primary/field_mse` | TBD (establishing via #2947-2949) |
| AirfRANS | `val_primary/surface_mse` | **0.000627** | #2902 (stark) |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 (piccolo) |

## Expected Outcome

drop_path_rate=0.1 is a mild regularizer — likely safe for all datasets. drop_path_rate=0.2 is stronger and may cause instability on DrivAerML (small dataset, 4L model). If 0.2 diverges, 0.1 is the candidate to merge. Report metrics for both values on all 4 datasets from the best validation checkpoint.