### PR TITLE
wave3: Divergence Conservation Auxiliary Loss (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    div_loss_weight: float = 0.0
 
 
 @dataclass
@@ -1194,6 +1195,8 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    div_loss_weight: float = 0.0,
+    velocity_channels: int = 0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1251,6 +1254,22 @@ def train_one_epoch(
                         )
                         loss, _ = loss_grouped(batch, outputs, transform)
 
+            if div_loss_weight > 0.0 and velocity_channels > 0:
+                div_reg = torch.tensor(0.0, device=loss.device)
+                n_terms = 0
+                sp = outputs.get("surface_preds")
+                if sp is not None and sp.shape[-1] >= velocity_channels:
+                    div_reg = div_reg + sp[..., :velocity_channels].var(dim=-2).mean()
+                    n_terms += 1
+                vp = outputs.get("volume_preds")
+                if vp is not None and vp.shape[-1] >= velocity_channels:
+                    div_reg = div_reg + vp[..., :velocity_channels].var(dim=-2).mean()
+                    n_terms += 1
+                if n_terms > 0:
+                    loss = loss + div_loss_weight * div_reg
+                    running.setdefault("div_reg", 0.0)
+                    running["div_reg"] += float(div_reg.detach())
+
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
             micro_count += 1
@@ -1282,6 +1301,8 @@ def train_one_epoch(
     running["loss"] /= max(steps, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
+    if "div_reg" in running:
+        running["div_reg"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
     if scheduler is not None:
@@ -1462,6 +1483,8 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            div_loss_weight=config.div_loss_weight,
+            velocity_channels=bundle.spec.pressure_output_index or 0,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Adding a physics-informed divergence conservation auxiliary loss will regularize the velocity field predictions to satisfy approximate incompressibility (∇·u ≈ 0), improving generalization across all four datasets. The regularization loss penalizes non-zero velocity divergence at predicted surface/field points.

## Implementation

Add to `train.py`:

```python
# After computing data_loss, add divergence regularization
if args.div_loss_weight > 0 and pred has velocity components:
    # Assuming pred[:, :3] are velocity components (u, v, w)
    # Approximate divergence using finite differences on batched point cloud
    u_pred = pred_field[:, 0]  # x-velocity
    v_pred = pred_field[:, 1]  # y-velocity
    # For 3D: w_pred = pred_field[:, 2]
    
    # Divergence loss: penalize |∇·u|^2 using central differences
    # or simply penalize the L2 norm of (du/dx + dv/dy + dw/dz)
    # Simpler: use the divergence of output velocity predictions
    div_loss = (u_pred.pow(2) + v_pred.pow(2)).mean()  # proxy regularization
    total_loss = data_loss + args.div_loss_weight * div_loss
```

More precisely, implement as a soft physics constraint:
```python
# Add new CLI argument:
parser.add_argument('--div-loss-weight', type=float, default=0.0,
    help='Weight for divergence conservation auxiliary loss')

# In training loop, after computing predictions:
if args.div_loss_weight > 0.0:
    # pred shape: [B, N, C] where C includes velocity components
    # Compute approximate divergence regularization
    vel_pred = pred[..., :3]  # velocity (u,v,w)
    # L2 regularization on velocity magnitude variance as proxy
    div_reg = vel_pred.var(dim=1).mean()  # penalize non-smooth velocity fields
    total_loss = primary_loss + args.div_loss_weight * div_reg
```

Use `--wandb_group wave3-div-conservation-loss` for grouping related runs.

## Training Commands

### TandemFoil
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --div-loss-weight 0.01 \
  --epochs 999 --wandb_group wave3-div-conservation-loss
```

### TandemFoil Paper
```bash
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --div-loss-weight 0.01 \
  --epochs 999 --wandb_group wave3-div-conservation-loss
```

### AirfRANS
```bash
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4--cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --div-loss-weight 0.01 \
  --epochs 999 --wandb_group wave3-div-conservation-loss
```

### DrivAerML
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --div-loss-weight 0.01 \
  --wandb_group wave3-div-conservation-loss
```

Also test `--div-loss-weight 0.001` and `--div-loss-weight 0.1` on at least one dataset to find the optimal weight.

## Current Baselines

| Dataset | Metric | Best Value | PR |
|---------|--------|-----------|-----|
| TandemFoil | val_primary/surface_pressure_mae | 26.06 | #2887 |
| TandemFoil Paper | val_primary/field_mse | TBD | #2947/2948/2949 |
| AirfRANS | val_primary/surface_mse | 0.000627 | #2902 |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% | #2898 |

## Expected Outcome

The divergence constraint should act as a physics-informed regularizer that prevents the model from learning non-physical velocity fields. On AirfRANS (incompressible CFD) and DrivAerML (external aerodynamics), this constraint is most physically motivated. Expect 1-3% improvement where the velocity field is predicted. The auxiliary loss weight of 0.01 provides gentle regularization without overwhelming the data loss.