### PR TITLE
wave3: SDF Wall Distance Feature as Input (cross-dataset)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "weave",
     "tqdm",
     "matplotlib",
+    "scikit-learn",
 ]
 
 [tool.setuptools.packages.find]

--- a/target/icml2026/core/datasets.py
+++ b/target/icml2026/core/datasets.py
@@ -485,6 +485,8 @@ def build_tandem_bundle(
     enable_wake_deficit: bool = False,
     enable_wake_angle: bool = False,
     enable_vortex_panel_velocity: bool = False,
+    sdf_wall_distance: bool = False,
+    sdf_cache_dir: str = ".sdf_cache",
 ) -> DatasetBundle:
     manifest = _read_json(manifest_path)
     train_indices = list(manifest["splits"]["train"])
@@ -528,6 +530,7 @@ def build_tandem_bundle(
         + (16 if enable_fourier else 0)
         + (1 if enable_cp_panel else 0)
         + (4 if enable_vortex_panel_velocity else 0)
+        + (1 if sdf_wall_distance else 0)
     )
     return DatasetBundle(
         train_dataset=train_dataset,
@@ -560,6 +563,8 @@ def build_airfrans_bundle(
     debug: bool = False,
     enable_fourier: bool = False,
     enable_cp_panel: bool = False,
+    sdf_wall_distance: bool = False,
+    sdf_cache_dir: str = ".sdf_cache",
 ) -> DatasetBundle:
     manifest = _read_json(manifest_path)
     train_name = f"{task}_train"
@@ -601,7 +606,7 @@ def build_airfrans_bundle(
         cache_size=-1 if debug else RUNTIME_CACHE_CASES,
     )
     base_dim = prepare_airfrans.X_DIM
-    augmented_dim = base_dim + (16 if enable_fourier else 0) + (1 if enable_cp_panel else 0)
+    augmented_dim = base_dim + (16 if enable_fourier else 0) + (1 if enable_cp_panel else 0) + (1 if sdf_wall_distance else 0)
     return DatasetBundle(
         train_dataset=train_dataset,
         val_datasets={val_name: val_dataset},
@@ -635,6 +640,8 @@ def build_tandem_paper_bundle(
     enable_fourier: bool = False,
     enable_wake_deficit: bool = False,
     enable_wake_angle: bool = False,
+    sdf_wall_distance: bool = False,
+    sdf_cache_dir: str = ".sdf_cache",
 ) -> DatasetBundle:
     manifest_path = Path(manifest_path)
     stats_path = Path(stats_path)
@@ -687,6 +694,7 @@ def build_tandem_paper_bundle(
         + (16 if enable_fourier else 0)
         + (2 if enable_wake_deficit else 0)
         + (1 if enable_wake_angle else 0)
+        + (1 if sdf_wall_distance else 0)
     )
     return DatasetBundle(
         train_dataset=train_dataset,
@@ -724,6 +732,8 @@ def build_drivaerml_bundle(
     eval_surface_points: int = 0,
     train_volume_points: int = 0,
     eval_volume_points: int = 0,
+    sdf_wall_distance: bool = False,
+    sdf_cache_dir: str = ".sdf_cache",
 ) -> DatasetBundle:
     manifest = _read_json(manifest_path)
     train_sampling_mode = "train_random" if train_surface_points > 0 or train_volume_points > 0 else "full"
@@ -768,6 +778,7 @@ def build_drivaerml_bundle(
     base_surface_dim = prepare_drivaerml.SURFACE_X_DIM
     base_volume_dim = 0 if surface_only else prepare_drivaerml.VOLUME_X_DIM
     fourier_extra = 24 if enable_fourier else 0
+    sdf_extra = 1 if sdf_wall_distance else 0
     return DatasetBundle(
         train_dataset=train_dataset,
         val_datasets={"val_surface": val_dataset},
@@ -775,9 +786,9 @@ def build_drivaerml_bundle(
         spec=DatasetSpec(
             name="drivaerml",
             space_dim=3,
-            surface_input_dim=base_surface_dim + fourier_extra,
+            surface_input_dim=base_surface_dim + fourier_extra + sdf_extra,
             surface_output_dim=prepare_drivaerml.SURFACE_Y_DIM,
-            volume_input_dim=base_volume_dim + fourier_extra if base_volume_dim else 0,
+            volume_input_dim=(base_volume_dim + fourier_extra + sdf_extra) if base_volume_dim else 0,
             volume_output_dim=0 if surface_only else prepare_drivaerml.VOLUME_Y_DIM,
             pressure_output_index=0,
             default_metric="surface_rel_l2_pct",
@@ -819,6 +830,8 @@ def build_dataset_bundle(
     enable_wake_deficit: bool = False,
     enable_wake_angle: bool = False,
     enable_vortex_panel_velocity: bool = False,
+    sdf_wall_distance: bool = False,
+    sdf_cache_dir: str = ".sdf_cache",
 ) -> DatasetBundle:
     if dataset_name in {"tandemfoil", "tandemfoilset"}:
         return build_tandem_bundle(
@@ -831,6 +844,8 @@ def build_dataset_bundle(
             enable_wake_deficit=enable_wake_deficit,
             enable_wake_angle=enable_wake_angle,
             enable_vortex_panel_velocity=enable_vortex_panel_velocity,
+            sdf_wall_distance=sdf_wall_distance,
+            sdf_cache_dir=sdf_cache_dir,
         )
     if dataset_name in {"tandemfoil_paper", "tandemfoilset_paper"}:
         return build_tandem_paper_bundle(
@@ -841,6 +856,8 @@ def build_dataset_bundle(
             enable_fourier=enable_fourier,
             enable_wake_deficit=enable_wake_deficit,
             enable_wake_angle=enable_wake_angle,
+            sdf_wall_distance=sdf_wall_distance,
+            sdf_cache_dir=sdf_cache_dir,
         )
     if dataset_name == "airfrans":
         return build_airfrans_bundle(
@@ -850,6 +867,8 @@ def build_dataset_bundle(
             debug=debug,
             enable_fourier=enable_fourier,
             enable_cp_panel=enable_cp_panel,
+            sdf_wall_distance=sdf_wall_distance,
+            sdf_cache_dir=sdf_cache_dir,
         )
     if dataset_name == "drivaerml":
         return build_drivaerml_bundle(
@@ -861,5 +880,7 @@ def build_dataset_bundle(
             eval_surface_points=drivaerml_eval_surface_points,
             train_volume_points=drivaerml_train_volume_points,
             eval_volume_points=drivaerml_eval_volume_points,
+            sdf_wall_distance=sdf_wall_distance,
+            sdf_cache_dir=sdf_cache_dir,
         )
     raise ValueError(f"Unknown dataset: {dataset_name}")

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,8 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    sdf_wall_distance: bool = False
+    sdf_cache_dir: str = ".sdf_cache"
 
 
 @dataclass
@@ -341,6 +343,18 @@ class TandemTargetTransform:
                 vortex = vortex * self.config.vortex_panel_scale
             x = torch.cat([x, vortex], dim=-1)
 
+        if self.config.sdf_wall_distance:
+            import numpy as np
+            sdf_feats = []
+            for b in range(raw_xy.shape[0]):
+                pts = raw_xy[b].detach().cpu().numpy()
+                surf_mask_b = full_is_surface[b].detach().cpu().numpy().astype(bool)
+                surf_pts = pts[surf_mask_b]
+                wall_dist = compute_sdf_wall_distance(pts, surf_pts)
+                sdf_feats.append(torch.from_numpy(wall_dist))
+            sdf_tensor = torch.stack(sdf_feats, dim=0).unsqueeze(-1).to(x.device, dtype=x.dtype)
+            x = torch.cat([x, sdf_tensor], dim=-1)
+
         umag, q = self._umag_q(full_y_raw, full_mask)
         y_phys = self._phys_norm(full_y_raw, umag, q)
         if self.config.asinh_pressure:
@@ -448,6 +462,8 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
         "enable_wake_deficit": config.enable_wake_deficit,
         "enable_wake_angle": config.enable_wake_angle,
         "enable_vortex_panel_velocity": config.enable_vortex_panel_velocity,
+        "sdf_wall_distance": config.sdf_wall_distance,
+        "sdf_cache_dir": config.sdf_cache_dir,
     }
     if config.tandem_manifest:
         bundle_kwargs["tandem_manifest"] = config.tandem_manifest
@@ -470,6 +486,138 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+def compute_sdf_wall_distance(
+    points: "np.ndarray",
+    surface_points: "np.ndarray",
+    cache_path=None,
+) -> "np.ndarray":
+    """Compute wall distance (SDF) for each point to the nearest surface point.
+
+    Distances are normalized via arcsinh(d / 0.01) matching the pressure
+    normalization convention used elsewhere in this stack. Results are cached
+    to disk as .npy files to avoid repeated KDTree queries across epochs.
+    """
+    import numpy as np
+    from pathlib import Path as _Path
+
+    if cache_path is not None and _Path(cache_path).exists():
+        return np.load(cache_path)
+
+    try:
+        from sklearn.neighbors import KDTree
+
+        tree = KDTree(surface_points)
+        dist, _ = tree.query(points, k=1)
+        wall_dist = dist.squeeze(-1).astype(np.float32)
+    except ImportError:
+        chunks = []
+        for i in range(0, len(points), 1000):
+            chunk = points[i : i + 1000]
+            d = np.linalg.norm(chunk[:, None] - surface_points[None], axis=-1)
+            chunks.append(d.min(axis=1))
+        wall_dist = np.concatenate(chunks).astype(np.float32)
+
+    wall_dist_normalized = np.arcsinh(wall_dist / 0.01).astype(np.float32)
+
+    if cache_path is not None:
+        _Path(cache_path).parent.mkdir(parents=True, exist_ok=True)
+        np.save(cache_path, wall_dist_normalized)
+
+    return wall_dist_normalized
+
+
+def _augment_batch_with_sdf(
+    batch,
+    *,
+    sdf_cache_dir: str = ".sdf_cache",
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Return (augmented_surface_x, augmented_volume_x) with wall-distance appended.
+
+    Works for 2-D (space_dim=2) and 3-D (space_dim=3) batches.  The surface
+    positions are the first ``space_dim`` columns of ``batch.surface_x``.
+    Each point's distance to the nearest surface point is arcsinh-normalised
+    and appended as a single channel.
+
+    Caching is per-(dataset, case-id) so the KDTree is only built once.
+
+    NOTE: SDF values are computed and cached for the **valid (unmasked) points
+    only** — independent of the per-batch padding length.  They are then placed
+    into a zero-padded buffer of the current batch's padded size so that
+    ``torch.stack`` always produces tensors of identical shape regardless of
+    which cases are co-batched.
+    """
+    import numpy as np
+    from pathlib import Path as _Path
+
+    space_dim = batch.space_dim
+    device = batch.surface_x.device
+    dtype = batch.surface_x.dtype
+    B = batch.surface_x.shape[0]
+    S_padded = batch.surface_x.shape[1]
+
+    sdf_surf_list = []
+    sdf_vol_list = []
+
+    has_volume = batch.volume_x is not None and batch.volume_mask is not None
+    V_padded = batch.volume_x.shape[1] if has_volume else 0
+
+    for b in range(B):
+        # --- surface positions --------------------------------------------------
+        s_mask_np = batch.surface_mask[b].bool().cpu().numpy()
+        surf_pos_full = batch.surface_x[b, :, :space_dim].detach().cpu().numpy()
+        surf_pts = surf_pos_full[s_mask_np]            # valid (unpadded) surface pts
+        valid_surf_pos = surf_pos_full[s_mask_np]      # same: points for which we compute SDF
+
+        # determine a stable cache key — independent of padding
+        case_id = batch.case_ids[b] if hasattr(batch, "case_ids") and batch.case_ids else str(b)
+        ds_name = getattr(batch, "dataset_name", "unknown")
+
+        # cache stores only the unpadded valid-point values
+        surf_cache = (
+            _Path(sdf_cache_dir) / ds_name / f"{case_id}_surface.npy"
+            if sdf_cache_dir
+            else None
+        )
+        # compute SDF for the valid surface points only (wall dist to nearest surf pt)
+        sdf_valid_surf = compute_sdf_wall_distance(valid_surf_pos, surf_pts, cache_path=surf_cache)
+
+        # scatter into a padded buffer matching the current batch's S_padded
+        sdf_surf_padded = np.zeros(S_padded, dtype=np.float32)
+        sdf_surf_padded[s_mask_np] = sdf_valid_surf
+        sdf_surf_list.append(torch.from_numpy(sdf_surf_padded))
+
+        # volume points SDF (optional)
+        if has_volume:
+            v_mask_np = batch.volume_mask[b].bool().cpu().numpy()
+            vol_pos_full = batch.volume_x[b, :, :space_dim].detach().cpu().numpy()
+            valid_vol_pos = vol_pos_full[v_mask_np]
+
+            vol_cache = (
+                _Path(sdf_cache_dir) / ds_name / f"{case_id}_volume.npy"
+                if sdf_cache_dir
+                else None
+            )
+            sdf_valid_vol = compute_sdf_wall_distance(valid_vol_pos, surf_pts, cache_path=vol_cache)
+
+            sdf_vol_padded = np.zeros(V_padded, dtype=np.float32)
+            sdf_vol_padded[v_mask_np] = sdf_valid_vol
+            sdf_vol_list.append(torch.from_numpy(sdf_vol_padded))
+
+    sdf_surf_tensor = (
+        torch.stack(sdf_surf_list, dim=0).unsqueeze(-1).to(device=device, dtype=dtype)
+    )
+    aug_surface_x = torch.cat([batch.surface_x, sdf_surf_tensor], dim=-1)
+
+    aug_volume_x = batch.volume_x
+    if sdf_vol_list:
+        sdf_vol_tensor = (
+            torch.stack(sdf_vol_list, dim=0).unsqueeze(-1).to(device=device, dtype=dtype)
+        )
+        aug_volume_x = torch.cat([batch.volume_x, sdf_vol_tensor], dim=-1)
+
+    return aug_surface_x, aug_volume_x
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -823,6 +971,8 @@ def evaluate_grouped(
     *,
     amp_mode: str = "none",
     max_batches: int = 0,
+    sdf_wall_distance: bool = False,
+    sdf_cache_dir: str = ".sdf_cache",
 ) -> dict[str, float]:
     model.eval()
     if anp_head is not None:
@@ -887,11 +1037,17 @@ def evaluate_grouped(
                 count_volume += 1
             continue
 
+        eval_surface_x = batch.surface_x
+        eval_volume_x = batch.volume_x
+        if sdf_wall_distance:
+            eval_surface_x, eval_volume_x = _augment_batch_with_sdf(
+                batch, sdf_cache_dir=sdf_cache_dir
+            )
         with autocast_context(device, amp_mode):
             outputs = model(
-                surface_x=batch.surface_x,
+                surface_x=eval_surface_x,
                 surface_mask=batch.surface_mask,
-                volume_x=batch.volume_x,
+                volume_x=eval_volume_x,
                 volume_mask=batch.volume_mask,
             )
         outputs = float_outputs(outputs)
@@ -1194,6 +1350,8 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    sdf_wall_distance: bool = False,
+    sdf_cache_dir: str = ".sdf_cache",
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1242,11 +1400,17 @@ def train_one_epoch(
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
                         loss, _ = loss_grouped_tandem(prepared, outputs)
                 else:
+                    train_surface_x = batch.surface_x
+                    train_volume_x = batch.volume_x
+                    if sdf_wall_distance:
+                        train_surface_x, train_volume_x = _augment_batch_with_sdf(
+                            batch, sdf_cache_dir=sdf_cache_dir
+                        )
                     with autocast_context(device, amp_mode):
                         outputs = model(
-                            surface_x=batch.surface_x,
+                            surface_x=train_surface_x,
                             surface_mask=batch.surface_mask,
-                            volume_x=batch.volume_x,
+                            volume_x=train_volume_x,
                             volume_mask=batch.volume_mask,
                         )
                         loss, _ = loss_grouped(batch, outputs, transform)
@@ -1462,6 +1626,8 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            sdf_wall_distance=config.sdf_wall_distance,
+            sdf_cache_dir=config.sdf_cache_dir,
         )
 
         if ema is not None:
@@ -1491,6 +1657,8 @@ def main() -> None:
                     device,
                     amp_mode=config.amp_mode,
                     max_batches=config.max_eval_batches,
+                    sdf_wall_distance=config.sdf_wall_distance,
+                    sdf_cache_dir=config.sdf_cache_dir,
                 )
             eval_metrics.update({f"{split_name}/{name}": value for name, value in split_metrics.items()})
             if split_name in LEGACY_VAL_ALIAS and "mae_surf_p" in split_metrics:
@@ -1548,6 +1716,8 @@ def main() -> None:
                     device,
                     amp_mode=config.amp_mode,
                     max_batches=config.max_eval_batches,
+                    sdf_wall_distance=config.sdf_wall_distance,
+                    sdf_cache_dir=config.sdf_cache_dir,
                 )
             final_test_metrics.update({f"{split_name}/{name}": value for name, value in split_metrics.items()})
         if bundle.spec.name == "tandemfoilset":

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -345,13 +345,24 @@ class TandemTargetTransform:
 
         if self.config.sdf_wall_distance:
             import numpy as np
+            from pathlib import Path as _Path
             sdf_feats = []
             for b in range(raw_xy.shape[0]):
-                pts = raw_xy[b].detach().cpu().numpy()
-                surf_mask_b = full_is_surface[b].detach().cpu().numpy().astype(bool)
-                surf_pts = pts[surf_mask_b]
-                wall_dist = compute_sdf_wall_distance(pts, surf_pts)
-                sdf_feats.append(torch.from_numpy(wall_dist))
+                pts_full = raw_xy[b].detach().cpu().numpy()
+                valid_mask_b = full_mask[b].detach().cpu().numpy().astype(bool)
+                surf_is_valid_b = full_is_surface[b].detach().cpu().numpy().astype(bool)
+                surf_pts = pts_full[surf_is_valid_b]       # valid surface (wall) points only
+                valid_pts = pts_full[valid_mask_b]         # all valid (non-padded) points
+                case_id = batch.case_ids[b] if hasattr(batch, "case_ids") and batch.case_ids else str(b)
+                cache_path = (
+                    _Path(self.config.sdf_cache_dir) / "tandemfoilset" / f"{case_id}.npy"
+                    if self.config.sdf_cache_dir
+                    else None
+                )
+                sdf_valid = compute_sdf_wall_distance(valid_pts, surf_pts, cache_path=cache_path)
+                sdf_full = np.zeros(pts_full.shape[0], dtype=np.float32)
+                sdf_full[valid_mask_b] = sdf_valid
+                sdf_feats.append(torch.from_numpy(sdf_full))
             sdf_tensor = torch.stack(sdf_feats, dim=0).unsqueeze(-1).to(x.device, dtype=x.dtype)
             x = torch.cat([x, sdf_tensor], dim=-1)
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -514,7 +514,10 @@ def compute_sdf_wall_distance(
     from pathlib import Path as _Path
 
     if cache_path is not None and _Path(cache_path).exists():
-        return np.load(cache_path)
+        cached = np.load(cache_path)
+        if len(cached) == len(points):
+            return cached
+        # length mismatch — stale cache, fall through to recompute
 
     try:
         from sklearn.neighbors import KDTree


### PR DESCRIPTION
## Hypothesis

Adding a signed distance function (SDF) / wall distance feature as an additional input channel provides the model with explicit geometric context about proximity to walls and surfaces. In CFD, wall distance is critical for boundary layer physics — the model currently must implicitly learn this from coordinates. Making it explicit should improve surface pressure and field predictions across all datasets.

## Implementation

Add to `train.py` / data loading:

```python
import numpy as np
from pathlib import Path

def compute_sdf_wall_distance(points, surface_points, cache_path=None):
    """
    Compute approximate wall distance for each field point.
    Uses brute-force nearest neighbor to surface.
    Cache results to .npy to avoid recomputation.
    """
    if cache_path and Path(cache_path).exists():
        return np.load(cache_path)
    
    # Simple nearest-neighbor wall distance (no sign needed for positive distance)
    # points: [N, 3], surface_points: [M, 3]
    try:
        from sklearn.neighbors import KDTree
        tree = KDTree(surface_points)
        dist, _ = tree.query(points, k=1)
        wall_dist = dist.squeeze(-1).astype(np.float32)
    except ImportError:
        # Fallback: compute pairwise distances in chunks
        chunks = []
        for i in range(0, len(points), 1000):
            chunk = points[i:i+1000]
            d = np.linalg.norm(chunk[:, None] - surface_points[None], axis=-1)
            chunks.append(d.min(axis=1))
        wall_dist = np.concatenate(chunks).astype(np.float32)
    
    # arcsinh normalization (similar to pressure treatment)
    wall_dist_normalized = np.arcsinh(wall_dist / 0.01)
    
    if cache_path:
        np.save(cache_path, wall_dist_normalized)
    
    return wall_dist_normalized

# In dataset loading, add wall distance as additional feature channel:
# node_features = np.concatenate([
#     existing_features,
#     wall_dist_normalized[:, None]  # [N, 1]
# ], axis=-1)
```

Add CLI argument:
```python
parser.add_argument('--sdf-wall-distance', action='store_true',
    help='Add SDF wall distance as additional input feature (arcsinh normalized)')
parser.add_argument('--sdf-cache-dir', type=str, default='.sdf_cache',
    help='Directory to cache precomputed SDF wall distances')
```

Cache files should be stored as `<sdf_cache_dir>/<dataset>_<split>_wall_dist.npy`.

Use `--wandb_group wave3-sdf-wall-distance` for grouping.

## Training Commands

### TandemFoil
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --sdf-wall-distance \
  --epochs 999 --wandb_group wave3-sdf-wall-distance
```

### TandemFoil Paper
```bash
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --sdf-wall-distance \
  --epochs 999 --wandb_group wave3-sdf-wall-distance
```

### AirfRANS
```bash
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --sdf-wall-distance \
  --epochs 999 --wandb_group wave3-sdf-wall-distance
```

### DrivAerML
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --sdf-wall-distance \
  --wandb_group wave3-sdf-wall-distance
```

Note: First run will compute and cache SDF distances. Subsequent runs will load from cache (fast). Expect first epoch to be slower due to SDF precomputation.

## Current Baselines

| Dataset | Metric | Best Value | PR |
|---------|--------|-----------|-----|
| TandemFoil | val_primary/surface_pressure_mae | 26.06 | #2887 |
| TandemFoil Paper | val_primary/field_mse | TBD | #2947/2948/2949 |
| AirfRANS | val_primary/surface_mse | 0.000627 | #2902 |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% | #2898 |

## Expected Outcome

Wall distance is one of the most physically meaningful features in CFD — turbulence models like k-ω SST and Spalart-Allmaras explicitly use wall distance. Providing it as an input should help the model understand boundary layer behavior without having to infer it from raw coordinates. Expect largest gains on AirfRANS (complex wake + boundary layer interactions) and DrivAerML (complex 3D geometry). TandemFoil gains may be moderate since it's primarily surface pressure. Estimated improvement: 2-5% on AirfRANS and DrivAerML.