### PR TITLE
wave3: Adaptive Gradient Clipping AGC NFNet-style (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -164,6 +164,8 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    agc: bool = False
+    agc_clip_factor: float = 0.01
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -1178,6 +1180,25 @@ def evaluate_abupt(
     return {"surface_mae": total_surface / max(count_surface, 1), "volume_mae": total_volume / max(count_volume, 1)}
 
 
+def adaptive_gradient_clip(parameters, clip_factor: float = 0.01, eps: float = 1e-3) -> tuple[int, float]:
+    clipped = 0
+    total_grad_norm_sq = 0.0
+    for p in parameters:
+        if p.grad is None:
+            continue
+        g = p.grad.detach()
+        total_grad_norm_sq += g.norm(2).item() ** 2
+        if p.ndim < 2:
+            continue
+        p_norm = p.detach().norm(2).clamp_(min=eps)
+        g_norm = g.norm(2)
+        max_norm = clip_factor * p_norm
+        if g_norm > max_norm:
+            g.mul_(max_norm / g_norm.clamp(min=1e-8))
+            clipped += 1
+    return clipped, total_grad_norm_sq ** 0.5
+
+
 def train_one_epoch(
     model: torch.nn.Module,
     anp_head: ANPSurfaceDecoder | None,
@@ -1194,6 +1215,8 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    agc: bool = False,
+    agc_clip_factor: float = 0.01,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1261,12 +1284,18 @@ def train_one_epoch(
         all_params = list(model.parameters())
         if anp_head is not None:
             all_params += list(anp_head.parameters())
-        grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+        if agc:
+            agc_clipped, grad_norm_val = adaptive_gradient_clip(all_params, clip_factor=agc_clip_factor)
+            grad_norm = torch.tensor(grad_norm_val)
+            running.setdefault("agc_clip_events", 0.0)
+            running["agc_clip_events"] += float(agc_clipped)
+        else:
+            grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+            if grad_clip > 0 and float(grad_norm) > grad_clip:
+                running.setdefault("grad_clip_events", 0.0)
+                running["grad_clip_events"] += 1.0
         running.setdefault("grad_norm_mean", 0.0)
         running["grad_norm_mean"] += float(grad_norm)
-        if grad_clip > 0 and float(grad_norm) > grad_clip:
-            running.setdefault("grad_clip_events", 0.0)
-            running["grad_clip_events"] += 1.0
         optimizer.step()
         if scheduler is not None:
             scheduler.step()
@@ -1462,6 +1491,8 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            agc=config.agc,
+            agc_clip_factor=config.agc_clip_factor,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Adaptive Gradient Clipping (AGC), as introduced in NFNets (Brock et al. 2021), clips gradients based on the ratio of the gradient norm to the parameter norm rather than using a fixed global clip threshold. This is more stable than fixed gradient clipping — it prevents very large updates relative to parameter scale while allowing larger updates where parameters are small. Replacing fixed `--grad-clip 1.0` with AGC may enable faster convergence and better final accuracy across all four datasets.

## Implementation

Add to `train.py`:

```python
def adaptive_gradient_clip(parameters, clip_factor=0.01, eps=1e-3):
    """
    Adaptive Gradient Clipping (AGC) as in NFNet.
    Clips grad norm to clip_factor * param_norm for each layer.
    
    Args:
        parameters: model parameters (iterable)
        clip_factor: AGC clipping factor (default 0.01)
        eps: minimum parameter norm floor to prevent instability
    """
    for p in parameters:
        if p.grad is None:
            continue
        # Compute norms per parameter tensor
        p_norm = torch.norm(p.detach(), p=2).clamp(min=eps)
        g_norm = torch.norm(p.grad.detach(), p=2)
        
        # Clip grad if g_norm > clip_factor * p_norm
        max_norm = clip_factor * p_norm
        clip_coef = max_norm / g_norm.clamp(min=1e-8)
        if clip_coef < 1.0:
            p.grad.detach().mul_(clip_coef)

# Add CLI arguments:
parser.add_argument('--agc', action='store_true',
    help='Use Adaptive Gradient Clipping (NFNet-style) instead of fixed clip')
parser.add_argument('--agc-clip-factor', type=float, default=0.01,
    help='AGC clipping factor (default 0.01 as in NFNet paper)')

# In training loop, replace:
#   torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
# With:
if args.agc:
    adaptive_gradient_clip(model.parameters(), clip_factor=args.agc_clip_factor)
else:
    torch.nn.utils.clip_grad_norm_(model.parameters(), args.grad_clip)
```

Test two values: `--agc-clip-factor 0.01` (NFNet default) and `--agc-clip-factor 0.03`.

Use `--wandb_group wave3-adaptive-grad-clipping` for grouping.

## Training Commands

### TandemFoil (AGC clip_factor=0.01)
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --agc --agc-clip-factor 0.01 \
  --epochs 999 --wandb_group wave3-adaptive-grad-clipping
```

Note: do NOT pass `--grad-clip` when using `--agc`.

### TandemFoil Paper
```bash
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --agc --agc-clip-factor 0.01 \
  --epochs 999 --wandb_group wave3-adaptive-grad-clipping
```

### AirfRANS
```bash
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --weight-decay 1e-2 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --agc --agc-clip-factor 0.01 \
  --epochs 999 --wandb_group wave3-adaptive-grad-clipping
```

### DrivAerML
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --agc --agc-clip-factor 0.01 \
  --wandb_group wave3-adaptive-grad-clipping
```

Also run a variant with `--agc-clip-factor 0.03` on DrivAerML (DrivAerML has the most complex gradient landscape).

## Current Baselines

| Dataset | Metric | Best Value | PR |
|---------|--------|-----------|-----|
| TandemFoil | val_primary/surface_pressure_mae | 26.06 | #2887 |
| TandemFoil Paper | val_primary/field_mse | TBD | #2947/2948/2949 |
| AirfRANS | val_primary/surface_mse | 0.000627 | #2902 |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% | #2898 |

## Expected Outcome

AGC provides layer-wise gradient normalization that is more adaptive than the global fixed clip. In the NFNet paper, AGC enabled training without BatchNorm at high learning rates. In our point-cloud transformers, AGC should prevent the common issue of gradient explosion in the attention layers (large query/key inner products) while still allowing the FFN layers to update aggressively. Expected: 1-3% improvement, especially beneficial on DrivAerML where gradient instability is more common (complex 3D geometry with surface normal discontinuities).