### PR TITLE
wave3: LayerScale Initialization for Transformer Stability (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,37 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    layer_scale_init: float = 0.0
+
+
+class LayerScale(torch.nn.Module):
+    def __init__(self, dim: int, init_value: float = 1e-4):
+        super().__init__()
+        self.gamma = torch.nn.Parameter(init_value * torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.gamma
+
+
+def apply_layer_scale(model: torch.nn.Module, init_value: float) -> None:
+    from core.architectures.transolver_reference import TransformerBlock
+
+    for block in model.modules():
+        if not isinstance(block, TransformerBlock):
+            continue
+        dim = block.norm1.normalized_shape[0]
+        block.layer_scale_1 = LayerScale(dim, init_value)
+        block.layer_scale_2 = LayerScale(dim, init_value)
+        _orig_forward = block.forward.__func__ if hasattr(block.forward, '__func__') else None
+
+        def _make_forward(blk):
+            def forward(self, x, attn_mask=None):
+                x = x + self.layer_scale_1(self.attention(self.norm1(x), attn_mask=attn_mask))
+                x = x + self.layer_scale_2(self.mlp(self.norm2(x)))
+                return x
+            return forward.__get__(blk, type(blk))
+
+        block.forward = _make_forward(block)
 
 
 @dataclass
@@ -1406,7 +1437,10 @@ def main() -> None:
         )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
-    model = build_model(config, bundle).to(device)
+    model = build_model(config, bundle)
+    if config.layer_scale_init > 0:
+        apply_layer_scale(model, config.layer_scale_init)
+    model = model.to(device)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1514,6 +1548,10 @@ def main() -> None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        if config.layer_scale_init > 0:
+            for i, block in enumerate(m for m in model.modules() if hasattr(m, 'layer_scale_1')):
+                epoch_metrics[f"layer_scale/block{i}_attn_mean"] = block.layer_scale_1.gamma.data.mean().item()
+                epoch_metrics[f"layer_scale/block{i}_ffn_mean"] = block.layer_scale_2.gamma.data.mean().item()
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

LayerScale (Touvron et al. 2021, CaiT) adds a learnable per-channel scalar initialized to a very small value (e.g. 1e-4) to the output of each transformer block's attention and FFN sublayers. This dramatically improves training stability for deep transformers by preventing the residual branches from dominating early in training, allowing the model to gradually increase their contribution as training progresses. This should particularly help our deeper DrivAerML model (4 layers) and improve convergence across all datasets.

## Implementation

Add to `train.py`:

```python
class LayerScale(nn.Module):
    """
    LayerScale: per-channel learnable scalar applied after each transformer sublayer.
    From CaiT (Touvron et al. 2021): https://arxiv.org/abs/2103.17239
    """
    def __init__(self, dim, init_value=1e-4):
        super().__init__()
        self.gamma = nn.Parameter(init_value * torch.ones(dim))
    
    def forward(self, x):
        return x * self.gamma

# In each transformer block, modify the residual connections:
# Before (standard):
#   x = x + self.attn(self.norm1(x))
#   x = x + self.ffn(self.norm2(x))
#
# After (with LayerScale):
#   x = x + self.layer_scale_1(self.attn(self.norm1(x)))
#   x = x + self.layer_scale_2(self.ffn(self.norm2(x)))
#
# Where layer_scale_1 and layer_scale_2 are LayerScale(dim, init_value=init_value)

# Add to each TransformerBlock:
class TransformerBlock(nn.Module):
    def __init__(self, dim, num_heads, ..., layer_scale_init=1e-4):
        ...
        self.layer_scale_1 = LayerScale(dim, layer_scale_init)
        self.layer_scale_2 = LayerScale(dim, layer_scale_init)
    
    def forward(self, x, ...):
        x = x + self.layer_scale_1(self.attn(self.norm1(x)))
        x = x + self.layer_scale_2(self.ffn(self.norm2(x)))
        return x
```

Add CLI argument:
```python
parser.add_argument('--layer-scale-init', type=float, default=0.0,
    help='LayerScale init value. 0.0 = disabled. Try 1e-4 or 1e-5.')
```

Test two values: `--layer-scale-init 1e-4` (standard CaiT) and `--layer-scale-init 1e-5` (more conservative).

Use `--wandb_group wave3-layerscale-init` for grouping.

## Training Commands

### TandemFoil (LayerScale init=1e-4)
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --layer-scale-init 1e-4 \
  --epochs 999 --wandb_group wave3-layerscale-init
```

### TandemFoil Paper
```bash
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --layer-scale-init 1e-4 \
  --epochs 999 --wandb_group wave3-layerscale-init
```

### AirfRANS
```bash
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --layer-scale-init 1e-4 \
  --epochs 999 --wandb_group wave3-layerscale-init
```

### DrivAerML (test both 1e-4 and 1e-5 since it's 4 layers deep)
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --layer-scale-init 1e-4 \
  --wandb_group wave3-layerscale-init
```

## Current Baselines

| Dataset | Metric | Best Value | PR |
|---------|--------|-----------|-----|
| TandemFoil | val_primary/surface_pressure_mae | 26.06 | #2887 |
| TandemFoil Paper | val_primary/field_mse | TBD | #2947/2948/2949 |
| AirfRANS | val_primary/surface_mse | 0.000627 | #2902 |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% | #2898 |

## Expected Outcome

LayerScale is a simple, well-validated technique from vision transformers that has been shown to improve training stability without adding significant computation. The initialization at 1e-4 ensures the residual branches start near-zero, forcing the model to learn through the main path first. Expect improved convergence speed (fewer epochs to reach good performance) and potentially better final accuracy, especially for DrivAerML (deepest model). Expected: 1-3% improvement.