### PR TITLE
wave3: Linear Warmup + SGDR Cosine Restarts (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -158,6 +158,9 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    lr_schedule: str = "cosine"
+    warmup_epochs: int = 5
+    sgdr_t_mult: int = 2
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -525,6 +528,42 @@ def build_optimizer(params, config: TrainConfig):
     if config.use_lookahead:
         optimizer = Lookahead(optimizer)
     return optimizer
+
+
+def build_scheduler(base_optimizer, config: TrainConfig):
+    """Returns (step_scheduler, epoch_scheduler). At most one is non-None."""
+    if config.cosine_t_max <= 0:
+        return None, None
+    if config.lr_schedule == "sgdr":
+        from torch.optim.lr_scheduler import (
+            CosineAnnealingWarmRestarts,
+            LinearLR,
+            SequentialLR,
+        )
+        if config.warmup_epochs > 0:
+            warmup = LinearLR(
+                base_optimizer, start_factor=0.1, end_factor=1.0,
+                total_iters=config.warmup_epochs,
+            )
+            restarts = CosineAnnealingWarmRestarts(
+                base_optimizer, T_0=config.cosine_t_max,
+                T_mult=config.sgdr_t_mult, eta_min=config.lr * 1e-3,
+            )
+            sched = SequentialLR(
+                base_optimizer, schedulers=[warmup, restarts],
+                milestones=[config.warmup_epochs],
+            )
+        else:
+            sched = CosineAnnealingWarmRestarts(
+                base_optimizer, T_0=config.cosine_t_max,
+                T_mult=config.sgdr_t_mult, eta_min=config.lr * 1e-3,
+            )
+        return None, sched
+    else:
+        sched = torch.optim.lr_scheduler.CosineAnnealingLR(
+            base_optimizer, T_max=config.cosine_t_max,
+        )
+        return sched, None
 
 
 def resolve_num_workers(config: TrainConfig, dataset_name: str) -> int:
@@ -1419,10 +1458,8 @@ def main() -> None:
     if anp_head is not None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
-    scheduler = None
-    if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+    step_scheduler, epoch_scheduler = build_scheduler(base_optimizer, config)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
@@ -1452,7 +1489,7 @@ def main() -> None:
             anp_head=anp_head,
             loader=train_loader,
             optimizer=optimizer,
-            scheduler=scheduler,
+            scheduler=step_scheduler,
             ema=ema,
             anp_ema=anp_ema,
             transform=transform,
@@ -1463,6 +1500,10 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
         )
+
+        train_metrics["train/lr"] = base_optimizer.param_groups[0]["lr"]
+        if epoch_scheduler is not None:
+            epoch_scheduler.step()
 
         if ema is not None:
             ema.store(model)


### PR DESCRIPTION
## Hypothesis

Replace fixed-period cosine annealing with SGDR (Stochastic Gradient Descent with Warm Restarts, Loshchilov & Hutter 2017). The current golden config uses `--cosine-t-max 10` with no restarts. SGDR adds periodic restarts where LR jumps back to the initial value, which can help escape local minima and explore a wider loss landscape. Combined with T_mult>1 (each cycle is longer than the previous), this provides a natural curriculum: early fast cycles explore broadly, later long cycles refine deeply. Also add a short linear warmup (5 epochs) to stabilize early training before the first cosine cycle begins.

**Key innovation:** T_mult=2 means cycles grow: 10 → 20 → 40 → 80 epochs. By epoch 150 the model has seen 4 full warm-restart cycles. This is architecturally different from our current single-period cosine and has not been tested in this research programme.

**Expected outcome:** Improved generalization across all 4 datasets by escaping early local minima that fixed cosine may converge to prematurely.

## Implementation

Add `--lr-schedule [cosine|sgdr]`, `--warmup-epochs`, `--sgdr-t-mult` flags to `train.py`:

```python
import math
from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts, LinearLR, SequentialLR

def build_scheduler(optimizer, args, steps_per_epoch=1):
    if args.lr_schedule == 'sgdr':
        warmup = LinearLR(optimizer, start_factor=0.1, end_factor=1.0,
                          total_iters=args.warmup_epochs)
        restarts = CosineAnnealingWarmRestarts(
            optimizer,
            T_0=args.cosine_t_max,
            T_mult=args.sgdr_t_mult,
            eta_min=args.lr * 1e-3
        )
        scheduler = SequentialLR(optimizer, schedulers=[warmup, restarts],
                                 milestones=[args.warmup_epochs])
    else:
        # existing cosine annealing
        scheduler = CosineAnnealingLR(optimizer, T_max=args.cosine_t_max,
                                      eta_min=args.lr * 1e-3)
    return scheduler
```

Add to argparse:
```python
parser.add_argument('--lr-schedule', type=str, default='cosine',
                    choices=['cosine', 'sgdr'],
                    help='LR schedule: cosine (default) or sgdr (warm restarts)')
parser.add_argument('--warmup-epochs', type=int, default=5,
                    help='Linear warmup epochs before main schedule (default: 5)')
parser.add_argument('--sgdr-t-mult', type=int, default=2,
                    help='T_mult for SGDR restarts (default: 2)')
```

## Training Commands

### TandemFoil (golden config + SGDR)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --lr-schedule sgdr --warmup-epochs 5 --sgdr-t-mult 2 \
  --epochs 999 \
  --wandb_group wave3-warmup-cosine-restarts
```

### TandemFoil Paper (EMA enabled)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --lr-schedule sgdr --warmup-epochs 5 --sgdr-t-mult 2 \
  --epochs 999 \
  --wandb_group wave3-warmup-cosine-restarts
```

### AirfRANS (golden config + SGDR)
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --enable-fourier \
  --lr-schedule sgdr --warmup-epochs 5 --sgdr-t-mult 2 \
  --epochs 999 \
  --wandb_group wave3-warmup-cosine-restarts
```

### DrivAerML (golden config + SGDR)
```bash
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --lr-schedule sgdr --warmup-epochs 5 --sgdr-t-mult 2 \
  --epochs 999 \
  --wandb_group wave3-warmup-cosine-restarts
```

**Note for DrivAerML:** Use T_0=30 (same as current cosine-t-max) so the first cycle matches the existing config. The growth factor T_mult=2 means cycles 30 → 60 → 120 epochs, which fits within the ~467 epoch budget from best PR #2898.

## Current Baselines

| Dataset | Metric | Baseline | Best PR |
|---------|--------|----------|---------|
| TandemFoil | `val_primary/surface_pressure_mae` | 26.06 | #2887 |
| TandemFoil Paper | `val_primary/field_mse` | TBD | #2947/#2948/#2949 |
| AirfRANS | `val_primary/surface_mse` | 0.000627 | #2902 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | 3.997% | #2898 |

## Notes

- SGDR with T_mult=2 is a classic technique — broadly used in vision models (ResNet, ViT) and often overlooked for PDE surrogate work
- Linear warmup (5 epochs) prevents instability at training start when LR jumps immediately to max
- `CosineAnnealingWarmRestarts` and `LinearLR` are both natively in PyTorch — no external dependencies
- `SequentialLR` chains the warmup and SGDR phases cleanly
- If this works well, follow-up: test T_mult=1 (fixed-period restarts) vs T_mult=2 to understand the curriculum effect