### PR TITLE
wave3: Spectral Normalization on Attention Weights (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -164,6 +164,8 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    spectral_norm_attn: bool = False
+    spectral_norm_ffn: bool = False
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -470,6 +472,18 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+def apply_spectral_norm(model: torch.nn.Module, attn: bool = True, ffn: bool = False) -> torch.nn.Module:
+    from torch.nn.utils import spectral_norm
+    for block in model.backbone.blocks:
+        if attn:
+            spectral_norm(block.attention.qkv.project)
+            spectral_norm(block.attention.proj.project)
+        if ffn:
+            spectral_norm(block.mlp.fc1)
+            spectral_norm(block.mlp.fc2)
+    return model
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -1407,6 +1421,8 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.spectral_norm_attn or config.spectral_norm_ffn:
+        apply_spectral_norm(model, attn=config.spectral_norm_attn, ffn=config.spectral_norm_ffn)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

Apply spectral normalization to the Q, K, V, and output projection matrices in the transformer attention layers. Spectral normalization constrains the Lipschitz constant of these matrices to ≤1 (or a tunable value), improving training stability and generalization. This is related to NFNet (Aghajanyan et al.) and GAN literature where SN controls gradient explosion and prevents feature collapse.

In CFD surrogates, attention matrices that learn physically structured patterns (e.g. near-wall vs far-field correlations) may benefit from the implicit regularization that SN provides — keeping the attention weight matrices well-conditioned prevents the model from over-fitting to specific pressure gradients in the training set.

**Key insight:** Unlike weight decay (which penalizes magnitude globally), spectral normalization constrains singular values specifically, preserving the rank structure of learned attention patterns. This is a fundamentally different regularization than what we've tested so far.

**Expected outcome:** Improved generalization, especially on OOD test cases. Target: <26.06 on TandemFoil, <0.000627 on AirfRANS, <3.997% on DrivAerML.

## Implementation

Use `torch.nn.utils.parametrize.register_parametrization` with spectral normalization on attention projection layers:

```python
from torch.nn.utils import spectral_norm

def apply_spectral_norm_to_attention(model, apply_to=('q', 'k', 'v', 'out')):
    """Apply spectral normalization to attention weight matrices."""
    for name, module in model.named_modules():
        # Target attention projection layers by name pattern
        if hasattr(module, 'q_proj') and 'q' in apply_to:
            module.q_proj = spectral_norm(module.q_proj)
        if hasattr(module, 'k_proj') and 'k' in apply_to:
            module.k_proj = spectral_norm(module.k_proj)
        if hasattr(module, 'v_proj') and 'v' in apply_to:
            module.v_proj = spectral_norm(module.v_proj)
        if hasattr(module, 'out_proj') and 'out' in apply_to:
            module.out_proj = spectral_norm(module.out_proj)
    return model

# Alternative: wrap the combined QKV projection if the model uses a single qkv matrix:
def apply_spectral_norm_attention_blocks(model):
    for name, module in model.named_modules():
        # Match any Linear layer whose name contains 'attn' or 'attention'
        if isinstance(module, nn.Linear):
            parent_name = name.rsplit('.', 1)[0] if '.' in name else ''
            parent = dict(model.named_modules()).get(parent_name)
            if parent is not None and 'attn' in parent_name.lower():
                spectral_norm(module)
    return model
```

Add flag `--spectral-norm-attn` to enable this. After building the model:
```python
if args.spectral_norm_attn:
    model = apply_spectral_norm_attention_blocks(model)
```

Add to argparse:
```python
parser.add_argument('--spectral-norm-attn', action='store_true',
                    help='Apply spectral normalization to attention projection matrices')
parser.add_argument('--spectral-norm-ffn', action='store_true',
                    help='Also apply spectral normalization to FFN layers (optional, test separately)')
```

**Implementation note:** Inspect the actual attention module structure in `core/` to find the correct layer names. PyTorch's `spectral_norm()` wraps a layer in-place and adds a power iteration step to the forward pass — minimal overhead.

## Training Commands

### TandemFoil (golden config + spectral norm)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --spectral-norm-attn \
  --epochs 999 \
  --wandb_group wave3-spectral-norm-attention
```

### TandemFoil Paper (EMA enabled)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --spectral-norm-attn \
  --epochs 999 \
  --wandb_group wave3-spectral-norm-attention
```

### AirfRANS (golden config + spectral norm)
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --enable-fourier \
  --spectral-norm-attn \
  --epochs 999 \
  --wandb_group wave3-spectral-norm-attention
```

### DrivAerML (golden config + spectral norm)
```bash
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --spectral-norm-attn \
  --epochs 999 \
  --wandb_group wave3-spectral-norm-attention
```

## Current Baselines

| Dataset | Metric | Baseline | Best PR |
|---------|--------|----------|---------|
| TandemFoil | `val_primary/surface_pressure_mae` | 26.06 | #2887 |
| TandemFoil Paper | `val_primary/field_mse` | TBD | #2947/#2948/#2949 |
| AirfRANS | `val_primary/surface_mse` | 0.000627 | #2902 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | 3.997% | #2898 |

## Notes

- `torch.nn.utils.spectral_norm` is a PyTorch built-in — no dependencies
- The power iteration adds ~1 forward pass per layer per step, minimal overhead on 96GB GPUs
- Start with attention-only (`--spectral-norm-attn`); test `--spectral-norm-ffn` only if attention shows promise
- If the model uses a combined `qkv` projection (single Linear layer for Q+K+V), apply SN to that combined matrix
- SN may slow convergence early (more conservative weight updates) but should improve final generalization
- If training diverges, try combining with slightly lower grad-clip (0.5) or omitting grad-clip entirely when using SN