### PR TITLE
wave3: Point/Node Dropout Spatial Augmentation (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -86,6 +86,27 @@ class EMAWithWarmup:
         self.backup = None
 
 
+class PointDropout(torch.nn.Module):
+    """Spatial point-level dropout: randomly zero node features during training."""
+
+    def __init__(self, p: float = 0.1, mode: str = "feature"):
+        super().__init__()
+        self.p = p
+        self.mode = mode
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not self.training or self.p == 0:
+            return x
+        B, N, D = x.shape
+        if self.mode == "feature":
+            mask = torch.bernoulli(torch.ones(B, N, D, device=x.device) * (1 - self.p))
+            return x * mask / (1 - self.p)
+        elif self.mode == "point":
+            mask = torch.bernoulli(torch.ones(B, N, 1, device=x.device) * (1 - self.p))
+            return x * mask
+        return x
+
+
 LEGACY_VAL_ALIAS = {
     "val_in_dist": "p_in",
     "val_ood_cond": "p_oodc",
@@ -166,6 +187,8 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    point_dropout: float = 0.0
+    point_dropout_mode: str = "feature"
 
 
 @dataclass
@@ -1194,6 +1217,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    point_dropout: PointDropout | None = None,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1232,6 +1256,10 @@ def train_one_epoch(
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
                     prepared = transform.prepare_batch(batch)
+                    if point_dropout is not None:
+                        prepared.surface_x = point_dropout(prepared.surface_x)
+                        if prepared.volume_x is not None:
+                            prepared.volume_x = point_dropout(prepared.volume_x)
                     with autocast_context(device, amp_mode):
                         outputs = model(
                             surface_x=prepared.surface_x,
@@ -1242,6 +1270,10 @@ def train_one_epoch(
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
                         loss, _ = loss_grouped_tandem(prepared, outputs)
                 else:
+                    if point_dropout is not None:
+                        batch.surface_x = point_dropout(batch.surface_x)
+                        if batch.volume_x is not None:
+                            batch.volume_x = point_dropout(batch.volume_x)
                     with autocast_context(device, amp_mode):
                         outputs = model(
                             surface_x=batch.surface_x,
@@ -1426,6 +1458,11 @@ def main() -> None:
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+    point_dropout_module = (
+        PointDropout(p=config.point_dropout, mode=config.point_dropout_mode)
+        if config.point_dropout > 0.0
+        else None
+    )
     history: list[dict[str, float]] = []
 
     run = None
@@ -1462,6 +1499,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            point_dropout=point_dropout_module,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Apply random point dropout as a spatial data augmentation: during training, randomly zero out a fraction of point/node features (not entire points, but their feature values) to force the model to be more robust to missing or noisy sensor readings. This is analogous to DropPath/Stochastic Depth for transformers but applied at the input point cloud level rather than the network depth.

**Two variants to test:**
1. **Feature dropout:** For each point, independently zero its feature vector with probability p (like node-level dropout in GNNs)  
2. **Point masking:** Randomly mask entire points (set all features to zero) — closer to masked autoencoding but applied as augmentation not pretraining

In CFD datasets, real sensor placements are often non-uniform and some measurement locations may be unreliable. Training with point dropout teaches the model to aggregate information robustly, which should help generalization to test geometries with different point distributions.

**Expected outcome:** Better OOD generalization, especially on DrivAerML where test cases have different surface point distributions than training. Target: <3.997% on DrivAerML, <26.06 on TandemFoil.

## Implementation

```python
class PointDropout(nn.Module):
    """Spatial point-level dropout: randomly zero node features during training."""
    def __init__(self, p=0.1, mode='feature'):
        """
        Args:
            p: dropout probability per point (default 0.1 = 10% of points)
            mode: 'feature' (zero feature vector) or 'point' (zero entire point)
        """
        super().__init__()
        self.p = p
        self.mode = mode
    
    def forward(self, x):
        """
        Args:
            x: point features [B, N, D]
        Returns:
            x with random points or features zeroed out
        """
        if not self.training or self.p == 0:
            return x
        B, N, D = x.shape
        if self.mode == 'feature':
            # Per-feature dropout (standard)
            mask = torch.bernoulli(torch.ones(B, N, D, device=x.device) * (1 - self.p))
            return x * mask / (1 - self.p)  # scale to preserve expected value
        elif self.mode == 'point':
            # Per-point masking (entire node zeroed)
            mask = torch.bernoulli(torch.ones(B, N, 1, device=x.device) * (1 - self.p))
            return x * mask  # no scaling for point masking (structural dropout)
        return x

# In model forward pass, apply after initial projection / before transformer blocks:
# if args.point_dropout > 0:
#     x = self.point_dropout(x)  # PointDropout applied at input embedding stage

# Or apply as input augmentation during data loading:
if args.point_dropout > 0 and mode == 'train':
    features = point_dropout_augment(features, p=args.point_dropout)
```

Add to argparse:
```python
parser.add_argument('--point-dropout', type=float, default=0.0,
                    help='Point feature dropout probability during training (default: 0.0, try 0.05-0.2)')
parser.add_argument('--point-dropout-mode', type=str, default='feature',
                    choices=['feature', 'point'],
                    help='Dropout mode: feature (per-feature) or point (per-node, default: feature)')
```

## Training Commands

### TandemFoil — Run A: p=0.1 (feature dropout)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --point-dropout 0.1 --point-dropout-mode feature \
  --epochs 999 \
  --wandb_group wave3-point-dropout
```

### TandemFoil — Run B: p=0.05 (lighter dropout)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --point-dropout 0.05 --point-dropout-mode feature \
  --epochs 999 \
  --wandb_group wave3-point-dropout
```

### TandemFoil Paper (EMA + point dropout)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --point-dropout 0.1 --point-dropout-mode feature \
  --epochs 999 \
  --wandb_group wave3-point-dropout
```

### AirfRANS (point dropout p=0.1)
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --enable-fourier \
  --point-dropout 0.1 --point-dropout-mode feature \
  --epochs 999 \
  --wandb_group wave3-point-dropout
```

### DrivAerML (point dropout p=0.1)
```bash
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --point-dropout 0.1 --point-dropout-mode feature \
  --epochs 999 \
  --wandb_group wave3-point-dropout
```

## Current Baselines

| Dataset | Metric | Baseline | Best PR |
|---------|--------|----------|---------|
| TandemFoil | `val_primary/surface_pressure_mae` | 26.06 | #2887 |
| TandemFoil Paper | `val_primary/field_mse` | TBD | #2947/#2948/#2949 |
| AirfRANS | `val_primary/surface_mse` | 0.000627 | #2902 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | 3.997% | #2898 |

## Notes

- Point dropout is a data augmentation, not a model architecture change — it's applied during training only, not inference
- p=0.1 means 10% of point features are zeroed per forward pass — this is mild augmentation, start here
- Scale factor `1/(1-p)` preserves expected feature magnitude (standard inverted dropout)
- If point-mode (full node masking) shows promise, it's a step toward masked point cloud pretraining
- Inspired by: PointDrop (Wang et al. 2022), DropEdge (Rong et al. 2020) for GNNs, and MAE (He et al. 2022) for point clouds
- **Do not confuse** with Dropout layers inside the network — this is augmentation at the input data level