### PR TITLE
wave3: Label Smoothing for Regression Regularization (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -164,6 +164,8 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    label_smoothing: float = 0.0
+    label_smooth_mode: str = "batch-mean"
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -731,20 +733,49 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def apply_label_smoothing(
+    targets: torch.Tensor,
+    epsilon: float,
+    smooth_mode: str = "batch-mean",
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if epsilon == 0:
+        return targets
+    if smooth_mode == "zero":
+        smooth_target = torch.zeros_like(targets)
+    else:
+        if mask is not None:
+            valid = targets[mask]
+            smooth_val = valid.mean(dim=0, keepdim=True)
+            smooth_target = smooth_val.expand_as(targets[mask])
+            result = targets.clone()
+            result[mask] = (1 - epsilon) * targets[mask] + epsilon * smooth_target
+            return result
+        else:
+            smooth_target = targets.mean(dim=1, keepdim=True).expand_as(targets)
+    return (1 - epsilon) * targets + epsilon * smooth_target
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    label_smoothing: float = 0.0,
+    label_smooth_mode: str = "batch-mean",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
+        if label_smoothing > 0:
+            target = apply_label_smoothing(target, label_smoothing, label_smooth_mode, batch.surface_mask)
         surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
+        if label_smoothing > 0:
+            target = apply_label_smoothing(target, label_smoothing, label_smooth_mode, batch.volume_mask)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
@@ -755,15 +786,23 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    label_smoothing: float = 0.0,
+    label_smooth_mode: str = "batch-mean",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
     if outputs["surface_preds"] is not None:
-        surf_loss = F.mse_loss(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask])
+        surf_target = prepared.surface_target
+        if label_smoothing > 0:
+            surf_target = apply_label_smoothing(surf_target, label_smoothing, label_smooth_mode, prepared.surface_mask)
+        surf_loss = F.mse_loss(outputs["surface_preds"][prepared.surface_mask], surf_target[prepared.surface_mask])
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
-        vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
+        vol_target = prepared.volume_target
+        if label_smoothing > 0:
+            vol_target = apply_label_smoothing(vol_target, label_smoothing, label_smooth_mode, prepared.volume_mask)
+        vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], vol_target[prepared.volume_mask])
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -774,16 +813,22 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    label_smoothing: float = 0.0,
+    label_smooth_mode: str = "batch-mean",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
     if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
         surf_target = transform.apply(batch.surface_anchor_target)
+        if label_smoothing > 0:
+            surf_target = apply_label_smoothing(surf_target, label_smoothing, label_smooth_mode)
         surf_loss = F.mse_loss(outputs["surface_preds"], surf_target)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
+        if label_smoothing > 0:
+            vol_target = apply_label_smoothing(vol_target, label_smoothing, label_smooth_mode)
         vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
@@ -1194,6 +1239,8 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    label_smoothing: float = 0.0,
+    label_smooth_mode: str = "batch-mean",
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1227,7 +1274,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, label_smoothing, label_smooth_mode)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1240,7 +1287,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, label_smoothing, label_smooth_mode)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1249,7 +1296,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, label_smoothing, label_smooth_mode)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1462,6 +1509,8 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            label_smoothing=config.label_smoothing,
+            label_smooth_mode=config.label_smooth_mode,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Apply label smoothing as a form of soft target regularization for regression. Standard label smoothing (Szegedy et al. 2016) is used in classification to prevent overconfidence by mixing hard targets with a uniform distribution. For regression, the analogous idea is to mix the true target values with a smoothed version: instead of training on exact ground-truth CFD field values, train on a convex combination of the true values and a local/global smoothed estimate.

**Regression label smoothing variants:**
1. **Global smooth:** Mix targets with the training set mean: `y_smooth = (1 - eps) * y_true + eps * y_mean`
2. **Gaussian smooth:** Convolve targets with a small Gaussian kernel (local spatial smoothing)
3. **Neighbor smooth:** Mix with spatially nearest-neighbor target values

The intuition: CFD field values have physically meaningful spatial coherence. Ground-truth labels computed by a numerical solver have a specific precision that may over-specify fine-grained details the surrogate doesn't need to reproduce exactly. Soft labels may improve generalization by preventing the model from memorizing exact solver artifacts.

**Note:** Usopp's previous experiment (PR #2920, gradient noise injection) caused all 5 runs to diverge. Label smoothing is a fundamentally different, and much safer, regularization approach — it modifies targets, not gradients.

**Expected outcome:** Small but consistent improvement across all 4 datasets by reducing overfitting to solver-specific artifacts. Target: <26.06 on TandemFoil, <0.000627 on AirfRANS, <3.997% on DrivAerML.

## Implementation

```python
def apply_label_smoothing(targets, epsilon=0.05, smooth_mode='global', y_mean=None):
    """
    Regression label smoothing.
    
    Args:
        targets: ground truth targets [B, N, C]
        epsilon: smoothing weight (0 = no smoothing, 1 = all smooth)
        smooth_mode: 'global' (mix with batch mean) or 'zero' (mix with zero)
        y_mean: precomputed training set mean (for global mode)
    Returns:
        Smoothed targets of same shape
    """
    if epsilon == 0:
        return targets
    
    if smooth_mode == 'global' and y_mean is not None:
        # Mix targets with training set mean (per-channel)
        smooth_target = y_mean.view(1, 1, -1).expand_as(targets)
    elif smooth_mode == 'zero':
        # Mix targets with zero (zero-biased regularization)
        smooth_target = torch.zeros_like(targets)
    else:
        # Mix targets with batch mean (simple approximation)
        smooth_target = targets.mean(dim=1, keepdim=True).expand_as(targets)
    
    return (1 - epsilon) * targets + epsilon * smooth_target

# In training loop, apply before computing loss:
if args.label_smoothing > 0:
    targets_smooth = apply_label_smoothing(targets, epsilon=args.label_smoothing,
                                           smooth_mode=args.label_smooth_mode)
    loss = criterion(predictions, targets_smooth)
else:
    loss = criterion(predictions, targets)
```

Add to argparse:
```python
parser.add_argument('--label-smoothing', type=float, default=0.0,
                    help='Label smoothing epsilon for regression (default: 0.0, try 0.05)')
parser.add_argument('--label-smooth-mode', type=str, default='batch-mean',
                    choices=['batch-mean', 'zero', 'global'],
                    help='Label smoothing mode (default: batch-mean)')
```

## Training Commands

### TandemFoil — Run A: eps=0.05, batch-mean
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --label-smoothing 0.05 --label-smooth-mode batch-mean \
  --epochs 999 \
  --wandb_group wave3-label-smoothing
```

### TandemFoil — Run B: eps=0.02, batch-mean (gentler smoothing)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --label-smoothing 0.02 --label-smooth-mode batch-mean \
  --epochs 999 \
  --wandb_group wave3-label-smoothing
```

### TandemFoil Paper (EMA enabled, eps=0.05)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --label-smoothing 0.05 --label-smooth-mode batch-mean \
  --epochs 999 \
  --wandb_group wave3-label-smoothing
```

### AirfRANS (eps=0.05, batch-mean)
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --enable-fourier \
  --label-smoothing 0.05 --label-smooth-mode batch-mean \
  --epochs 999 \
  --wandb_group wave3-label-smoothing
```

### DrivAerML (eps=0.05, batch-mean)
```bash
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --label-smoothing 0.05 --label-smooth-mode batch-mean \
  --epochs 999 \
  --wandb_group wave3-label-smoothing
```

## Current Baselines

| Dataset | Metric | Baseline | Best PR |
|---------|--------|----------|---------|
| TandemFoil | `val_primary/surface_pressure_mae` | 26.06 | #2887 |
| TandemFoil Paper | `val_primary/field_mse` | TBD | #2947/#2948/#2949 |
| AirfRANS | `val_primary/surface_mse` | 0.000627 | #2902 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | 3.997% | #2898 |

## Notes

- Label smoothing is applied at training time only — validation/test uses unsmoothed targets
- eps=0.05 means 5% of the target comes from the smooth component — very gentle regularization
- This is **safe** — no gradient modifications, no architecture changes, no risk of divergence
- The batch-mean mode is the simplest: smooth toward the batch's own mean, requiring no precomputed statistics
- If eps=0.05 shows no improvement, try eps=0.01 (nearly zero effect) to confirm the direction before trying eps=0.1
- Inspired by: "Rethinking the Value of Labels for Improving Class-Imbalanced Learning" (Yang et al. 2020) and regression label smoothing in protein structure prediction