### PR TITLE
Best-checkpoint saving: save best val checkpoint instead of final epoch

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1534,6 +1534,17 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
+    if bundle.spec.name == "tandemfoilset":
+        primary_metric_key = "val_primary/surface_pressure_mae"
+    else:
+        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_metric = float("inf")
+    best_epoch = 0
+    best_model_state: dict[str, torch.Tensor] | None = None
+    best_anp_state: dict[str, torch.Tensor] | None = None
+    best_ema_shadow: dict[str, torch.Tensor] | None = None
+    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
+
     run = None
     if config.wandb_name:
         run_config = asdict(config)
@@ -1598,16 +1609,32 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
+        current_val = eval_metrics.get(primary_metric_key)
+        if current_val is not None and current_val < best_val_metric:
+            best_val_metric = current_val
+            best_epoch = epoch
+            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+            if anp_head is not None:
+                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+            if ema is not None:
+                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+            if anp_ema is not None:
+                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
         if ema is not None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        epoch_metrics["best_val_metric"] = best_val_metric
+        epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
+            run.summary["best_epoch"] = best_epoch
+            run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1656,7 +1683,9 @@ def main() -> None:
         if run is not None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
-        print(json.dumps({"final_test_metrics": final_test_metrics}, sort_keys=True), flush=True)
+            run.summary["best_epoch"] = best_epoch
+            run.summary["best_val_metric"] = best_val_metric
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)


### PR DESCRIPTION
## Hypothesis

The trainer currently saves the **final epoch** checkpoint, not the **best validation checkpoint**. This means transient best results during training are permanently lost on restart or at the end of training.

Evidence from PR #2895 (mugen): TandemFoil reached **25.459** and AirfRANS reached **0.000371** transiently during training — significantly better than the final-epoch metrics that were reported. Both improvements were lost because the trainer saved the terminal checkpoint rather than the best-validation checkpoint.

This is the **single highest-leverage code change** available. It costs nothing in compute and may unlock multiple record improvements across all datasets simultaneously.

## Task

Modify `target/icml2026/train.py` to:

1. Track `best_val_metric` across all epochs (initialized to `+inf`)
2. After each validation, if `current_val_metric < best_val_metric`:
   - Update `best_val_metric`
   - Save checkpoint to `best_checkpoint.pt` (in addition to or instead of `last_checkpoint.pt`)
3. At the end of training (or on SIGTERM/timeout), load `best_checkpoint.pt` and use those weights for final metric reporting
4. The final metrics logged to W&B should reflect the **best checkpoint**, not the terminal epoch

The primary validation metric to track per dataset:
- **TandemFoil**: `val_primary/surface_pressure_mae` (lower is better)
- **AirfRANS**: `val_primary/surface_mse` (lower is better)
- **DrivAerML**: `val_primary/surface_rel_l2_pct` (lower is better)
- **TandemFoil Paper**: `val_primary/field_mse` (lower is better)

## Run ALL four datasets

Run on all 4 datasets with the current best configurations:

### TandemFoil
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group best-ckpt-saving
```

### AirfRANS
```bash
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb_group best-ckpt-saving
```

### DrivAerML
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb_group best-ckpt-saving
```

### TandemFoil Paper
```bash
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group best-ckpt-saving
```

## Current Baselines (targets to beat)

| Dataset | Metric | Current Best | PR |
|---------|--------|-------------|-----|
| TandemFoil | `val_primary/surface_pressure_mae` | **26.06** | #2887 |
| AirfRANS | `val_primary/surface_mse` | **0.000627** | #2902 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 |
| TandemFoil Paper | `val_primary/field_mse` | *no baseline yet* | — |

## Expected Outcome

- TandemFoil: ~25.4 (recovering transient best from #2895)
- AirfRANS: ~0.000371 (recovering transient best from #2895)
- DrivAerML: ≤3.997% (or better if best epoch occurred mid-training)
- TandemFoil Paper: establishes a new baseline using the best-checkpoint approach from the start

## Notes

- This is a **code change**, not a hyperparameter sweep — the existing best configs are used
- If the trainer already has a `--save-best` flag or similar, confirm it is active and working; if not, implement it
- Use `--wandb_group best-ckpt-saving` across all runs so they appear together in W&B