### PR TITLE
Attention temperature scaling: learnable per-head temperature sweep (all 4 datasets)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -21,6 +21,7 @@ import wandb
 from torch.utils.data import DataLoader, WeightedRandomSampler
 
 from core.architectures import ABUPTReference, ANPSurfaceDecoder, ReferenceTransolver, SenpaiTransolver
+from core.architectures.transolver_reference import TransolverAttention
 from core.contracts import ABUPTBatch, DatasetBundle, GroupedBatch, TargetTransformStats
 from core.datasets import ABUPTCollate, build_dataset_bundle, collate_grouped
 from core.features import (
@@ -166,6 +167,8 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    learnable_attn_temperature: bool = False
+    attn_temperature_scale: float = 1.0
 
 
 @dataclass
@@ -470,6 +473,53 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+def _attn_forward_with_temperature(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+    """TransolverAttention.forward with per-head temperature scaling on QKV attention."""
+    slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+    qkv = self.qkv(slice_tokens)
+    q, k, v = qkv.chunk(3, dim=-1)
+    if hasattr(self, "log_attn_temperature"):
+        q = q * torch.exp(-self.log_attn_temperature).view(1, -1, 1, 1)
+    elif hasattr(self, "fixed_attn_temp_scale"):
+        q = q / self.fixed_attn_temp_scale
+    out_slice = F.scaled_dot_product_attention(
+        q, k, v, dropout_p=self.dropout if self.training else 0.0,
+    )
+    out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
+    out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
+    return self.proj_dropout(self.proj(out_x))
+
+
+def apply_attn_temperature(model: torch.nn.Module, config: TrainConfig) -> None:
+    """Add learnable or fixed temperature scaling to all TransolverAttention modules."""
+    TransolverAttention.forward = _attn_forward_with_temperature
+    for module in model.modules():
+        if isinstance(module, TransolverAttention):
+            device = next(module.parameters()).device
+            if config.learnable_attn_temperature:
+                module.log_attn_temperature = torch.nn.Parameter(
+                    torch.zeros(module.num_heads, device=device)
+                )
+            elif config.attn_temperature_scale != 1.0:
+                module.register_buffer(
+                    "fixed_attn_temp_scale",
+                    torch.tensor(config.attn_temperature_scale, device=device),
+                )
+
+
+def get_attn_temperature_stats(model: torch.nn.Module) -> dict[str, float]:
+    """Extract learned temperature statistics for W&B logging."""
+    stats: dict[str, float] = {}
+    for i, module in enumerate(m for m in model.modules() if isinstance(m, TransolverAttention)):
+        if hasattr(module, "log_attn_temperature"):
+            temps = torch.exp(module.log_attn_temperature).detach().cpu()
+            stats[f"attn_temp/layer{i}_mean"] = temps.mean().item()
+            stats[f"attn_temp/layer{i}_std"] = temps.std().item()
+            for h in range(temps.numel()):
+                stats[f"attn_temp/layer{i}_head{h}"] = temps[h].item()
+    return stats
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -1407,6 +1457,8 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.learnable_attn_temperature or config.attn_temperature_scale != 1.0:
+        apply_attn_temperature(model, config)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1514,6 +1566,8 @@ def main() -> None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        if config.learnable_attn_temperature:
+            epoch_metrics.update(get_attn_temperature_stats(model))
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

Standard scaled dot-product attention uses a fixed temperature of `1/sqrt(d_k)`. This uniform scaling can be suboptimal: some attention heads may benefit from sharper distributions (lower temperature → more peaked softmax → strong focus on a few neighbours) while others benefit from softer distributions (higher temperature → more uniform attention → global aggregation).

**Hypothesis**: Adding **learnable per-head temperature scalars** (one scalar per head per layer, initialized to `1.0`, learned during training) will allow the model to discover the optimal attention sharpness per head, improving both local geometric reasoning (TF panel pressure) and global field prediction (DM, AF).

This is a minimal architectural change: adds `n_layers * n_heads` scalar parameters (e.g. 3*3=9 for TF, 2*4=8 for AF, 4*8=32 for DM) with no other modifications.

## Implementation

In the attention module, replace the fixed `sqrt(d_k)` scaling with a learnable parameter:

```python
# Before (standard):
attn_weights = torch.matmul(q, k.transpose(-2, -1)) / math.sqrt(self.head_dim)

# After (learnable temperature per head):
# self.log_temperature = nn.Parameter(torch.zeros(num_heads))  # log-space for positivity
temperature = self.head_dim ** 0.5 * torch.exp(self.log_temperature)  # shape: (num_heads,)
attn_weights = torch.matmul(q, k.transpose(-2, -1)) / temperature.unsqueeze(-1).unsqueeze(-1)
```

- Initialize `log_temperature = zeros` (equivalent to standard scaling at init)
- Use log-space parameterization to ensure temperature stays positive
- One `log_temperature` parameter per attention layer (not shared across layers)
- Add flag `--learnable-attn-temperature` to enable this

**Also run a fixed temperature sweep as ablation**: try `--attn-temperature-scale 0.5` and `--attn-temperature-scale 2.0` (fixed global scaling, not learnable) as fast ablations on TF and AF only.

## Run ALL four datasets (learnable temperature)

### TandemFoil
```bash
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --learnable-attn-temperature --epochs 999 --wandb_group attn-temperature
```

### AirfRANS
```bash
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --learnable-attn-temperature --epochs 999 --wandb_group attn-temperature
```

### DrivAerML
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --learnable-attn-temperature --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb_group attn-temperature
```

### TandemFoil Paper
```bash
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --learnable-attn-temperature --epochs 999 --wandb_group attn-temperature
```

## Ablation (TF + AF only, fixed temperature sweep)

If time permits after the main runs, do a quick fixed-temp ablation:

```bash
# TF with temperature=0.5x (sharper attention)
python train.py --dataset tandemfoil [same flags as above] --attn-temperature-scale 0.5 --wandb_group attn-temperature-ablation

# AF with temperature=2.0x (softer attention)
python train.py --dataset airfrans [same flags as above] --attn-temperature-scale 2.0 --wandb_group attn-temperature-ablation
```

## Current Baselines (targets to beat)

| Dataset | Metric | Current Best | PR |
|---------|--------|-------------|-----|
| TandemFoil | `val_primary/surface_pressure_mae` | **26.06** | #2887 |
| AirfRANS | `val_primary/surface_mse` | **0.000627** | #2902 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 |
| TandemFoil Paper | `val_primary/field_mse` | *no baseline yet* | — |

## Expected Outcome

Learnable temperature has shown 1-2% improvements in graph transformer settings. The model may learn: sharp temperatures for panel-boundary heads (TF), soft temperatures for global pressure heads (DM). Expected: modest improvement (~1%) on TF and AF; DM harder to predict given its 3D complexity.

## Notes

- Please log the learned temperature values (mean/std across heads per layer) to W&B at end of training so we can analyze what the model learned
- Prior Zenitsu experiments: #2853 (DM T_max neighbourhood), #2911 (DM T_max+gc+WD, closed as dead end) — both DrivAerML-only; this is cross-dataset
- Zenitsu is NOT assigned to any Wave 3 technique