### PR TITLE
cross-dataset: per-step SGDR restarts preserving oscillation regularizer

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-22 (Wave 3 + TF Paper baseline wave + DM Lion + AF LR sweep + cross-dataset spatial/physics budget sweeps + Wave 4 cross-dataset code/arch innovations)
+- **Date:** 2026-04-22 (Wave 3 + TF Paper baseline wave + DM Lion + AF LR sweep + cross-dataset spatial/physics budget sweeps + Wave 4 cross-dataset code/arch innovations + Wave 5 cross-dataset code/arch innovations)
 - **Branch:** radford
-- **Fleet status:** 60 live students, ALL ASSIGNED (0 idle) — Wave 4 launched 2026-04-22
+- **Fleet status:** 60 live students, ALL ASSIGNED (0 idle) — Wave 5 launched 2026-04-22
 - **Current relaunch budget:** inherit pod env defaults
   - `SENPAI_TIMEOUT_MINUTES=360`
   - `SENPAI_MAX_EPOCHS=999`
@@ -188,9 +188,21 @@ Paper targets (Experiment 4, Table 6 — MGN best / paper best per task):
 | edward | #2916 | lr=6e-4+gc=1.0+WD=1e-2+T_max=10 |
 | ~~wolfwood~~ | ~~#2919~~ | ~~T_max=40/50+gc=1.0+WD=1e-2 (longer cycling)~~ CLOSED — failed; reassigned to #2973 cross-dataset spatial sweep |
 
-### Theme 11: Wave 4 — Cross-Dataset Code/Architecture Innovations (NEW — 2026-04-22)
+### Theme 12: Wave 5 — Cross-Dataset Code/Architecture Innovations (NEW — 2026-04-22)
 
-Five novel hypotheses, all covering all 4 datasets. None overlap Wave 3.
+Five novel hypotheses, all covering all 4 datasets. Wave 5 re-runs Wave 4 ideas as TRUE cross-dataset PRs (the Wave 4 assignments #2974-#2978 were single-dataset; Wave 5 is the corrected multi-dataset version).
+
+| Student | PR | Experiment | Risk |
+|---|---|---|---|
+| mugen | #2980 | **PCGrad Gradient Surgery** — project conflicting surface/volume gradients using PCGrad (Yu et al. 2020); `pcgrad_backward()` helper; all 4 datasets | MED |
+| spike | #2981 | **Learnable Attention Temperature** — per-head log-space temperature scalar `self.log_temperature = nn.Parameter(torch.zeros(n_heads))`; scale=`exp(-log_temp)/sqrt(d_k)`; all 4 datasets | LOW-MED |
+| taki | #2982 | **Z-Score Pressure Normalization** — replace `--asinh-pressure` with `LearnedPressureNorm` using running_mean/running_var buffers (momentum=0.01); all 4 datasets | LOW |
+| zenitsu | #2983 | **RoPE Positional Embeddings** — rotary positional encoding on QK using 3D node coordinates; alongside `--enable-fourier`; all 4 datasets | LOW-MED |
+| frieren | #2984 | **LLRD (Layer-wise Learning Rate Decay)** — `get_llrd_param_groups(model, base_lr, decay=0.8)`, test decay=0.8 and 0.9 on TF first; all 4 datasets | LOW |
+
+### Theme 11: Wave 4 — Cross-Dataset Code/Architecture Innovations (2026-04-22, SUPERSEDED by Wave 5)
+
+NOTE: These PRs (#2974-#2978) were originally framed as cross-dataset but were single-dataset implementations. Wave 5 (#2980-#2984) is the corrected multi-dataset version. These PRs may still complete and should be reviewed individually.
 
 | Student | PR | Experiment | Risk |
 |---|---|---|---|
@@ -334,7 +346,7 @@ Their old PRs remain in-flight but are now listed under their new assignments in
 
 ## Next Priorities
 
-1. ~~**URGENT: Best-checkpoint saving code change**~~ — **IN PROGRESS (#2974 mugen).** The T_mult experiment (#2895) proved TF=25.459 and AF=0.000371 exist in the landscape. mugen is implementing `checkpoint_best.pt` saving across all 4 datasets.
+1. ~~**URGENT: Best-checkpoint saving code change**~~ — **IN PROGRESS (#2974 mugen Wave 4).** The T_mult experiment (#2895) proved TF=25.459 and AF=0.000371 exist in the landscape. mugen implementing `checkpoint_best.pt` saving. **Wave 5 launched: #2980-#2984 (PCGrad/AttnTemp/ZScore/RoPE/LLRD) — all true cross-dataset.**
 2. **Monitor TF Paper baseline wave** (#2947 jin, #2948 guts, #2949 vash) — update BASELINE.md with new section once first results arrive
 3. **Monitor DrivAerML Lion** (#2950 piccolo) — first Lion run on DrivAerML; could be significant
 4. **Monitor AirfRANS LR ceiling** (#2951 stark) — tests whether lr>6e-4 helps AF


### PR DESCRIPTION
## Hypothesis

Per-epoch SGDR (PR #2967) caused catastrophic divergence across all 4 datasets. The failure mechanism is clear: with ~750 steps/epoch, each cosine restart stretched over an entire epoch — LR monotonically decreased for 750 steps, model settled into a sharp basin, then the LR spike at the next restart destabilized it. This broke the rapid oscillation regularizer that per-step T_max=10 provides.

Per-step SGDR — where T_0 is measured in optimizer steps, not epochs — preserves the rapid oscillation cycle while adding warm restarts. T_0=1000 steps means the full cosine cycle completes in about 1.3 epochs, T_mult=2 progressively lengthens subsequent cycles. This tests whether warm restarts help when the oscillation pattern is intact.

This is the correct scientific follow-up to #2967.

## Instructions

Run all 4 datasets in parallel. Use 8 GPUs across the datasets with the configurations below.

**Key change:** Use `CosineAnnealingWarmRestarts` scheduler configured with step-level T_0 (total optimizer steps), not epoch-level. Implement in `train.py`: replace the `CosineAnnealingLR` scheduler with `CosineAnnealingWarmRestarts(optimizer, T_0=1000, T_mult=2, eta_min=1e-7)` and call `scheduler.step()` at every optimizer step (not epoch). Keep `--cosine-t-max 10` in the command (it will be overridden in code for this experiment). Set `--wandb_group sgdr-per-step-cross-dataset`.

**Dataset 1 — TandemFoil:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --wandb_group sgdr-per-step-cross-dataset
```

**Dataset 2 — TandemFoil Paper:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --wandb_group sgdr-per-step-cross-dataset
```

**Dataset 3 — AirfRANS:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 10 --grad-clip 1.0 \
  --ema-decay 0.999 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --wandb_group sgdr-per-step-cross-dataset
```

**Dataset 4 — DrivAerML:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --no-use-ema \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group sgdr-per-step-cross-dataset
```

Note on DrivAerML T_0: With 394 steps/epoch, T_0=1000 steps ≈ 2.5 epochs. Use T_mult=2 throughout. For DrivAerML, set `T_0=1000` in the scheduler just like the other datasets.

## Baseline

Current best metrics:
- TandemFoil `val_primary/surface_pressure_mae`: **26.06** at ep300 (PR #2887, gohan)
- TandemFoil Paper `val_primary/field_mse`: TBD (racing jin #2947, guts #2948, vash #2949)
- AirfRANS `val_primary/surface_mse`: **0.000627** at ep661 (PR #2902, stark)
- DrivAerML `val_primary/surface_rel_l2_pct`: **3.997%** at ep467 (PR #2898, piccolo)

Report the best checkpoint metric (not last epoch) for all datasets. If per-step SGDR helps or hurts, note at which restart the divergence/convergence shifted.