### PR TITLE
cross-dataset: coordinate noise augmentation for physics-invariant representations

### DIFF
--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-22 (Wave 3 + TF Paper baseline wave + DM Lion + AF LR sweep + cross-dataset spatial/physics budget sweeps + Wave 4 cross-dataset code/arch innovations)
+- **Date:** 2026-04-22 (Wave 3 + TF Paper baseline wave + DM Lion + AF LR sweep + cross-dataset spatial/physics budget sweeps + Wave 4 cross-dataset code/arch innovations + Wave 5 cross-dataset code/arch innovations)
 - **Branch:** radford
-- **Fleet status:** 60 live students, ALL ASSIGNED (0 idle) — Wave 4 launched 2026-04-22
+- **Fleet status:** 60 live students, ALL ASSIGNED (0 idle) — Wave 5 launched 2026-04-22
 - **Current relaunch budget:** inherit pod env defaults
   - `SENPAI_TIMEOUT_MINUTES=360`
   - `SENPAI_MAX_EPOCHS=999`
@@ -188,9 +188,21 @@ Paper targets (Experiment 4, Table 6 — MGN best / paper best per task):
 | edward | #2916 | lr=6e-4+gc=1.0+WD=1e-2+T_max=10 |
 | ~~wolfwood~~ | ~~#2919~~ | ~~T_max=40/50+gc=1.0+WD=1e-2 (longer cycling)~~ CLOSED — failed; reassigned to #2973 cross-dataset spatial sweep |
 
-### Theme 11: Wave 4 — Cross-Dataset Code/Architecture Innovations (NEW — 2026-04-22)
+### Theme 12: Wave 5 — Cross-Dataset Code/Architecture Innovations (NEW — 2026-04-22)
 
-Five novel hypotheses, all covering all 4 datasets. None overlap Wave 3.
+Five novel hypotheses, all covering all 4 datasets. Wave 5 re-runs Wave 4 ideas as TRUE cross-dataset PRs (the Wave 4 assignments #2974-#2978 were single-dataset; Wave 5 is the corrected multi-dataset version).
+
+| Student | PR | Experiment | Risk |
+|---|---|---|---|
+| mugen | #2980 | **PCGrad Gradient Surgery** — project conflicting surface/volume gradients using PCGrad (Yu et al. 2020); `pcgrad_backward()` helper; all 4 datasets | MED |
+| spike | #2981 | **Learnable Attention Temperature** — per-head log-space temperature scalar `self.log_temperature = nn.Parameter(torch.zeros(n_heads))`; scale=`exp(-log_temp)/sqrt(d_k)`; all 4 datasets | LOW-MED |
+| taki | #2982 | **Z-Score Pressure Normalization** — replace `--asinh-pressure` with `LearnedPressureNorm` using running_mean/running_var buffers (momentum=0.01); all 4 datasets | LOW |
+| zenitsu | #2983 | **RoPE Positional Embeddings** — rotary positional encoding on QK using 3D node coordinates; alongside `--enable-fourier`; all 4 datasets | LOW-MED |
+| frieren | #2984 | **LLRD (Layer-wise Learning Rate Decay)** — `get_llrd_param_groups(model, base_lr, decay=0.8)`, test decay=0.8 and 0.9 on TF first; all 4 datasets | LOW |
+
+### Theme 11: Wave 4 — Cross-Dataset Code/Architecture Innovations (2026-04-22, SUPERSEDED by Wave 5)
+
+NOTE: These PRs (#2974-#2978) were originally framed as cross-dataset but were single-dataset implementations. Wave 5 (#2980-#2984) is the corrected multi-dataset version. These PRs may still complete and should be reviewed individually.
 
 | Student | PR | Experiment | Risk |
 |---|---|---|---|
@@ -334,7 +346,7 @@ Their old PRs remain in-flight but are now listed under their new assignments in
 
 ## Next Priorities
 
-1. ~~**URGENT: Best-checkpoint saving code change**~~ — **IN PROGRESS (#2974 mugen).** The T_mult experiment (#2895) proved TF=25.459 and AF=0.000371 exist in the landscape. mugen is implementing `checkpoint_best.pt` saving across all 4 datasets.
+1. ~~**URGENT: Best-checkpoint saving code change**~~ — **IN PROGRESS (#2974 mugen Wave 4).** The T_mult experiment (#2895) proved TF=25.459 and AF=0.000371 exist in the landscape. mugen implementing `checkpoint_best.pt` saving. **Wave 5 launched: #2980-#2984 (PCGrad/AttnTemp/ZScore/RoPE/LLRD) — all true cross-dataset.**
 2. **Monitor TF Paper baseline wave** (#2947 jin, #2948 guts, #2949 vash) — update BASELINE.md with new section once first results arrive
 3. **Monitor DrivAerML Lion** (#2950 piccolo) — first Lion run on DrivAerML; could be significant
 4. **Monitor AirfRANS LR ceiling** (#2951 stark) — tests whether lr>6e-4 helps AF


### PR DESCRIPTION
## Hypothesis

Coordinate noise augmentation — adding small Gaussian noise to input 3D node positions during training — forces the model to learn representations that are robust to geometric perturbations. This is fundamentally different from point dropout (nami #2970, which removes entire nodes) and acts instead in the continuous coordinate space.

In CFD, the underlying physics is continuous and smooth. A model that over-fits to exact mesh coordinates learns spuriously sharp features tied to mesh topology rather than fluid physics. Coordinate noise acts as a geometric regularizer: the model must predict the same pressure/velocity field even when node positions shift by epsilon, which encourages it to learn physics-invariant feature extraction.

This technique is standard in 3D point cloud literature (PointNet, DGCNN) but has not been applied in our CFD surrogate pipeline. The hypothesis is that sigma=0.005–0.01 (relative to mesh coordinate scale) will improve generalization without distorting the geometry enough to change the physics.

## Instructions

Run all 4 datasets. Add coordinate noise augmentation in `train.py`: during training, after loading a batch, add `torch.randn_like(coords) * sigma` to the node coordinate tensor before passing to the model. Do NOT apply noise during validation/evaluation. Try sigma=0.01 as the primary run. Use `--wandb_group coord-noise-cross-dataset`.

Specifically:
- Locate where node coordinates (positions/mesh points) are extracted from the batch in the training loop
- Add: `if self.training: coords = coords + torch.randn_like(coords) * 0.01`
- Do not modify validation code paths
- Set `--wandb_group coord-noise-cross-dataset`

**Dataset 1 — TandemFoil:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --wandb_group coord-noise-cross-dataset
```

**Dataset 2 — TandemFoil Paper:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper --optimizer lion --lr 1e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --wandb_group coord-noise-cross-dataset
```

**Dataset 3 — AirfRANS:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 10 --grad-clip 1.0 \
  --ema-decay 0.999 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --wandb_group coord-noise-cross-dataset
```

**Dataset 4 — DrivAerML:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --no-use-ema \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group coord-noise-cross-dataset
```

Note: DrivAerML coordinates are in meters (car geometry ~4m long), so sigma=0.01m is about 1cm noise — physically meaningful. If DrivAerML diverges, try sigma=0.005.

If results look promising, suggested follow-ups: sigma=0.005, sigma=0.02, or annealing the noise from sigma_max to 0 over training.

## Baseline

Current best metrics:
- TandemFoil `val_primary/surface_pressure_mae`: **26.06** at ep300 (PR #2887, gohan)
- TandemFoil Paper `val_primary/field_mse`: TBD (racing jin #2947, guts #2948, vash #2949)
- AirfRANS `val_primary/surface_mse`: **0.000627** at ep661 (PR #2902, stark)
- DrivAerML `val_primary/surface_rel_l2_pct`: **3.997%** at ep467 (PR #2898, piccolo)

Report best-checkpoint metric per dataset. Note whether the noise helped most on TandemFoil (smallest dataset, most regularization benefit expected) vs AirfRANS/DrivAerML (larger, may be less regularization-constrained).