### PR TITLE
[faye] Grouped-query attention (GQA) intermediate — cross-dataset

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -16,6 +16,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 import wandb
 from torch.utils.data import DataLoader, WeightedRandomSampler
@@ -105,6 +106,7 @@ class TrainConfig:
     model_heads: int = 3
     model_mlp_ratio: int = 4
     model_slices: int = 96
+    num_kv_heads: int = 0
     model_dropout: float = 0.0
     drivaerml_train_surface_points: int = 0
     drivaerml_eval_surface_points: int = 0
@@ -470,6 +472,78 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+class GQATransolverAttention(nn.Module):
+    def __init__(self, hidden_dim: int, num_heads: int, num_kv_heads: int, num_slices: int, dropout: float = 0.0):
+        super().__init__()
+        if hidden_dim % num_heads != 0:
+            raise ValueError("hidden_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.hidden_dim = hidden_dim
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.dim_head = hidden_dim // num_heads
+        self.num_slices = num_slices
+        self.dropout = dropout
+        self.heads_per_group = num_heads // num_kv_heads
+
+        self.temperature = nn.Parameter(torch.full((1, num_heads, 1, 1), 0.5))
+        self.in_project_x = nn.Linear(hidden_dim, hidden_dim)
+        self.in_project_fx = nn.Linear(hidden_dim, hidden_dim)
+        self.in_project_slice = nn.Linear(self.dim_head, num_slices)
+        self.q_proj = nn.Linear(self.dim_head, self.dim_head, bias=False)
+        self.kv_proj = nn.Linear(self.dim_head, self.dim_head * 2, bias=False)
+        self.proj = nn.Linear(hidden_dim, hidden_dim)
+        self.proj_dropout = nn.Dropout(dropout)
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.trunc_normal_(m.weight, std=0.02)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+        B, N, _ = x.shape
+        H, KV_H, G = self.num_heads, self.num_kv_heads, self.heads_per_group
+        S, D = self.num_slices, self.dim_head
+
+        fx_mid = self.in_project_fx(x).view(B, N, H, D).permute(0, 2, 1, 3)
+        x_mid = self.in_project_x(x).view(B, N, H, D).permute(0, 2, 1, 3)
+        slice_logits = self.in_project_slice(x_mid) / self.temperature
+        slice_weights = F.softmax(slice_logits, dim=-1)
+        if attn_mask is not None:
+            mask = attn_mask[:, None, :, None].float()
+            slice_weights = slice_weights * mask
+        slice_norm = slice_weights.sum(dim=2, keepdim=False).unsqueeze(-1)
+        slice_tokens = torch.einsum("bhnc,bhns->bhsc", fx_mid, slice_weights) / (slice_norm + 1e-5)
+
+        q = self.q_proj(slice_tokens)
+        kv_tokens = slice_tokens.view(B, KV_H, G, S, D).mean(dim=2)
+        kv = self.kv_proj(kv_tokens)
+        k, v = kv.chunk(2, dim=-1)
+        k = k.unsqueeze(2).expand(B, KV_H, G, S, D).reshape(B, H, S, D)
+        v = v.unsqueeze(2).expand(B, KV_H, G, S, D).reshape(B, H, S, D)
+
+        out_slice = F.scaled_dot_product_attention(q, k, v, dropout_p=self.dropout if self.training else 0.0)
+        out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
+        out_x = out_x.permute(0, 2, 1, 3).contiguous().view(B, N, self.hidden_dim)
+        return self.proj_dropout(self.proj(out_x))
+
+
+def apply_gqa_to_model(model: nn.Module, num_kv_heads: int) -> None:
+    for block in model.backbone.blocks:
+        old = block.attention
+        block.attention = GQATransolverAttention(
+            hidden_dim=old.hidden_dim,
+            num_heads=old.num_heads,
+            num_kv_heads=num_kv_heads,
+            num_slices=old.num_slices,
+            dropout=old.dropout,
+        )
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -1406,7 +1480,12 @@ def main() -> None:
         )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
-    model = build_model(config, bundle).to(device)
+    model = build_model(config, bundle)
+    if config.num_kv_heads > 0 and config.num_kv_heads < config.model_heads:
+        apply_gqa_to_model(model, config.num_kv_heads)
+    model = model.to(device)
+    total_params = sum(p.numel() for p in model.parameters())
+    print(f"Model parameters: {total_params:,} (num_kv_heads={config.num_kv_heads or config.model_heads})", flush=True)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1432,6 +1511,7 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        run_config["total_params"] = total_params
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),


### PR DESCRIPTION
## Hypothesis

Test **grouped-query attention (GQA)** with `num_kv_heads=2` as a middle ground between standard multi-head attention (MHA, num_kv_heads=num_heads) and multi-query attention (MQA, num_kv_heads=1). GQA groups query heads so that each group shares one K/V pair, retaining more representational diversity than MQA while cutting KV computation roughly in half.

This runs in parallel with chrome's MQA (num_kv_heads=1) experiment to find the optimal KV-sharing level. Together they bracket the design space: if chrome finds MQA too aggressive (degraded quality), GQA provides the sweet spot. If both beat baseline, the best config can be merged and further tuned.

**Architecture:** For each dataset architecture:
- TandemFoil/TF-paper: 3H → set `num_kv_heads=1` (GQA with 3 groups of 1 query each = effectively MQA for 3-head models; try this as the baseline and also try `num_kv_heads=3` (MHA) vs `num_kv_heads=1` (MQA) to find which wins)
- AirfRANS: 4H → set `num_kv_heads=2` (2 groups of 2 queries each)
- DrivAerML: 8H → set `num_kv_heads=4` (4 groups of 2 queries each — true GQA midpoint)

Use `--wandb_group gqa-cross-dataset` for all runs.

## Instructions

Run the following 4 experiments. Report val and test primary metrics for each.

### 1. TandemFoil — GQA (num_kv_heads=1, ablate vs MHA)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --num-kv-heads 1 \
  --epochs 999 \
  --wandb_group gqa-cross-dataset
```

### 2. TandemFoil Paper — GQA (num_kv_heads=1)
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --num-kv-heads 1 \
  --epochs 999 \
  --wandb_group gqa-cross-dataset
```

### 3. AirfRANS — GQA (num_kv_heads=2, 4 heads total)
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --num-kv-heads 2 \
  --epochs 999 \
  --wandb_group gqa-cross-dataset
```

### 4. DrivAerML — GQA (num_kv_heads=4, 8 heads total)
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --num-kv-heads 4 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group gqa-cross-dataset
```

**Note:** If `--num-kv-heads` is not supported, implement GQA directly: divide query heads into G groups; each group shares one K/V projection. For G=2 groups with 4 query heads: 2 K/V projections of size `(hidden_dim // num_heads)`, each shared by 2 query heads. The overall memory reduction is `num_kv_heads / num_heads` of the original KV params.

## Current Baselines (targets to beat)

| Dataset | Metric | Current Best | PR |
|---------|--------|-------------|-----|
| TandemFoil | val primary (lower is better) | 26.06 | #2887 |
| TandemFoil Paper | val primary | not yet established | — |
| AirfRANS | val_primary/surface_mse | 0.000598 | #2906 |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% | #2898 |

Report val and test metrics for all 4 datasets. Include W&B run IDs.