### PR TITLE
[levi] Flash Attention + torch.compile — cross-dataset

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -128,6 +128,8 @@ class TrainConfig:
     prefetch_factor: int = 4
     amp_mode: str = "bf16"
     compile_model: bool = True
+    flash_attention: bool = False
+    torch_compile: bool = False
     debug: bool = False
     max_train_batches: int = 0
     max_eval_batches: int = 0
@@ -1407,7 +1409,16 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
-    forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
+    if config.flash_attention and device.type == "cuda":
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(True)
+        torch.backends.cuda.enable_math_sdp(False)
+    if config.torch_compile and device.type == "cuda":
+        forward_model = torch.compile(model, mode="reduce-overhead", fullgraph=False)
+    elif config.compile_model and device.type == "cuda":
+        forward_model = torch.compile(model)
+    else:
+        forward_model = model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
         anp_head = ANPSurfaceDecoder(
@@ -1447,6 +1458,8 @@ def main() -> None:
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
+        epoch_t0 = time.monotonic()
+        train_t0 = time.monotonic()
         train_metrics = train_one_epoch(
             model=forward_model,
             anp_head=anp_head,
@@ -1463,6 +1476,7 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
         )
+        train_elapsed = time.monotonic() - train_t0
 
         if ema is not None:
             ema.store(model)
@@ -1513,7 +1527,13 @@ def main() -> None:
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
-        epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        epoch_elapsed = time.monotonic() - epoch_t0
+        train_steps = train_metrics.get("train_steps", 0)
+        throughput = {"epoch_seconds": epoch_elapsed, "train_seconds": train_elapsed}
+        if train_steps > 0 and train_elapsed > 0:
+            throughput["train_steps_per_sec"] = train_steps / train_elapsed
+
+        epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics, **throughput}
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

Modern attention kernels (FlashAttention-2/3) and `torch.compile` with `mode='reduce-overhead'` together eliminate memory-bandwidth bottlenecks and kernel-launch overhead that dominate small-batch CFD surrogate training. The combined optimization should allow larger effective batch sizes or more epochs within the fixed time budget — and on DrivAerML where every epoch costs heavily, faster per-step iteration directly translates to more training signal. This is a **throughput hypothesis** that is orthogonal to all architecture and loss changes made so far, meaning it should compose with any other improvement.

## Prior Art / Why Now

FlashAttention has been the standard transformer implementation for 2+ years, but has never been tested in this programme. `torch.compile` was introduced in PyTorch 2.0 and is known to reduce Python overhead by 20–50% on small models. The Transolver architecture with its attention-heavy slice mechanism is an ideal candidate — the per-slice cross-attention computes small K×V matrices repeatedly per forward pass.

## Implementation

If `--flash-attention` and `--torch-compile` flags already exist, use them. If not, the student should implement:

1. **FlashAttention**: In the Transolver attention module, replace `torch.nn.functional.scaled_dot_product_attention` calls (or manual `Q @ K.T / sqrt(d)` matmul + softmax) with `torch.nn.functional.scaled_dot_product_attention` with `enable_flash=True, enable_math=False, enable_mem_efficient=True` via the `sdpa_kernel` context manager:
   ```python
   from torch.backends.cuda.sdp_kernel import SDPBackend, sdpa_kernel
   with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
       out = F.scaled_dot_product_attention(q, k, v)
   ```

2. **torch.compile**: Wrap the model after construction with:
   ```python
   model = torch.compile(model, mode='reduce-overhead', fullgraph=False)
   ```
   Note: `fullgraph=False` allows graph breaks for dataset-specific branches.

3. **Measurement**: Log `train_steps_per_sec` or `epoch_duration_seconds` to W&B alongside the normal metrics so we can isolate throughput gains from quality gains.

## Baselines to Beat

| Dataset | Metric | Current Best | Best PR |
|---|---|---|---|
| TandemFoil | val_primary/surface_pressure_mae | **26.06** | #2887 |
| TandemFoil Paper | val_primary/surface_pressure_mae | not yet established | — |
| AirfRANS | val_primary/surface_pressure_mae | **0.000598** | #2906 |
| DrivAerML | val_primary/surface_drag_coefficient_error | **3.997%** | #2898 |

## Training Commands

### TandemFoil (establish throughput baseline, then add compile/flash)
```bash
# Config: 3L/192d/3H, Lion lr=1e-4, T_max=10, gc=1.0, no-EMA
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --flash-attention --torch-compile \
  --epochs 999 \
  --wandb_group flash-compile-cross-dataset
```

### TandemFoil Paper
```bash
# Config: 3L/192d/3H, Lion lr=1e-4, T_max=10, gc=1.0, no-EMA
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --flash-attention --torch-compile \
  --epochs 999 \
  --wandb_group flash-compile-cross-dataset
```

### AirfRANS
```bash
# Config: 3L/192d/4H, AdamW lr=5e-4, T_max=50, EMA 0.999
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 5e-4 --cosine-t-max 50 --weight-decay 1e-4 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 4 \
  --enable-fourier \
  --flash-attention --torch-compile \
  --epochs 999 \
  --wandb_group flash-compile-cross-dataset
```

### DrivAerML
```bash
# Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, no-EMA, Fourier
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --flash-attention --torch-compile \
  --epochs 999 \
  --wandb_group flash-compile-cross-dataset
```

## If --flash-attention / --torch-compile flags don't exist

**FlashAttention**: Find the attention module in `train.py` or the model code. Locate any `torch.nn.functional.softmax(scores, dim=-1)` or manual attention computation. Wrap the attention computation:
```python
import torch.nn.functional as F
from torch.backends.cuda import sdp_kernel, SDPBackend
# Replace manual attention with:
with sdp_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
    attn_output = F.scaled_dot_product_attention(q, k, v, dropout_p=0.0)
```

**torch.compile**: After model construction (before training loop), add:
```python
model = torch.compile(model, mode='reduce-overhead', fullgraph=False)
```
This is safe to add even if the model has dataset-specific branches since `fullgraph=False` allows graph breaks.

## What to Measure

In your results comment, please include:
1. Primary validation metric per dataset (lower is better)
2. Approximate training throughput (steps/sec or epochs/min) **with vs without** the optimizations if you can measure it
3. Whether torch.compile caused any graph breaks or errors (these will appear as warnings in stdout)
4. W&B run IDs for all 4 datasets

## Suggested Follow-ups

If flash+compile gives throughput gains:
- Combine with GQA/MQA to see if reduced KV materialization + flash further improves memory
- Test with `mode='max-autotune'` on DrivAerML (longer compile time but potentially higher peak throughput)
- If DrivAerML epochs/min improves, re-run the baseline for 600 minutes to test depth-of-training ceiling