### PR TITLE
[shoya] Sparse top-k slice attention — cross-dataset

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -11,6 +11,7 @@ import math
 import os
 import random
 import time
+import types
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -166,6 +167,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    topk_attention: int = 0
 
 
 @dataclass
@@ -472,6 +474,37 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
     return None
 
 
+def _apply_topk_attention(model: torch.nn.Module, topk: int) -> None:
+    from core.architectures.transolver_reference import TransolverAttention
+
+    def _make_forward(k: int):
+        def _forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+            slice_tokens, slice_weights = self.create_slices(x, attn_mask=attn_mask)
+            qkv = self.qkv(slice_tokens)
+            q, key, v = qkv.chunk(3, dim=-1)
+            scale = q.shape[-1] ** -0.5
+            scores = torch.matmul(q, key.transpose(-2, -1)) * scale
+            if k < scores.shape[-1]:
+                topk_vals, topk_idx = torch.topk(scores, k=k, dim=-1)
+                sparse_mask = torch.full_like(scores, float("-inf"))
+                sparse_mask.scatter_(-1, topk_idx, topk_vals)
+                scores = sparse_mask
+            attn = torch.softmax(scores, dim=-1)
+            drop_p = self.dropout if self.training else 0.0
+            if drop_p > 0:
+                attn = F.dropout(attn, p=drop_p)
+            out_slice = torch.matmul(attn, v)
+            out_x = torch.einsum("bhsc,bhns->bhnc", out_slice, slice_weights)
+            out_x = out_x.permute(0, 2, 1, 3).contiguous().view(x.shape[0], x.shape[1], self.hidden_dim)
+            return self.proj_dropout(self.proj(out_x))
+
+        return _forward
+
+    for module in model.modules():
+        if isinstance(module, TransolverAttention):
+            module.forward = types.MethodType(_make_forward(topk), module)
+
+
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
@@ -482,7 +515,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "slice_num": config.model_slices,
     }
     if config.model == "reference_transolver":
-        return ReferenceTransolver(
+        model = ReferenceTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -490,9 +523,9 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
             **transolver_kwargs,
         )
-    if config.model == "senpai_transolver":
+    elif config.model == "senpai_transolver":
         prior_idx = cp_panel_prior_index(config, bundle)
-        return SenpaiTransolver(
+        model = SenpaiTransolver(
             space_dim=bundle.spec.space_dim,
             surface_input_dim=bundle.spec.surface_input_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
@@ -506,13 +539,17 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_pressure_prior_idx=prior_idx,
             **transolver_kwargs,
         )
-    if config.model == "reference_abupt":
-        return ABUPTReference(
+    elif config.model == "reference_abupt":
+        model = ABUPTReference(
             space_dim=bundle.spec.space_dim,
             surface_output_dim=bundle.spec.surface_output_dim,
             volume_output_dim=bundle.spec.volume_output_dim,
         )
-    raise ValueError(f"Unknown model: {config.model}")
+    else:
+        raise ValueError(f"Unknown model: {config.model}")
+    if config.topk_attention > 0:
+        _apply_topk_attention(model, config.topk_attention)
+    return model
 
 
 def build_optimizer(params, config: TrainConfig):


### PR DESCRIPTION
## Hypothesis

The Transolver architecture uses all-pairs attention across physics-informed slice tokens. For large meshes (DrivAerML: 50 000 surface points → many slices), most slice-to-slice attention weights are near-zero — only spatially proximate or physically coupled slices meaningfully interact. By keeping only the top-k attention connections per query (sparse attention), we reduce the quadratic O(S²) attention cost to O(S·k), allowing either more slices per forward pass or more layers within the same compute budget. Better slice coverage → better spatial resolution of flow features → lower surface error.

## Prior Art / Why Now

Sparse attention (Longformer, BigBird, Routing Transformers) has been extensively studied for sequences, but has not been tested in this programme on slice tokens. The key insight here is that physics-informed slices cluster geometrically — the leading edge slices are not strongly coupled to wake slices — making top-k sparsity a physically motivated approximation, not just a compute trick.

## Implementation

If `--topk-attention K` flag exists, use it. Otherwise implement as follows:

In the Transolver slice attention module, after computing attention logits `scores = Q @ K.T / sqrt(d_k)` (shape `[B, H, S, S]`), apply top-k masking before softmax:

```python
def topk_sparse_attention(q, k, v, topk=16):
    """Replace full softmax attention with top-k sparse attention."""
    scale = q.shape[-1] ** -0.5
    scores = torch.matmul(q, k.transpose(-2, -1)) * scale  # [B, H, S, S]
    
    # Keep only top-k logits per query, mask the rest to -inf
    if topk < scores.shape[-1]:
        topk_vals, topk_idx = torch.topk(scores, k=topk, dim=-1)
        mask = torch.full_like(scores, float('-inf'))
        mask.scatter_(-1, topk_idx, topk_vals)
        scores = mask
    
    attn = torch.softmax(scores, dim=-1)
    return torch.matmul(attn, v)
```

## Baselines to Beat

| Dataset | Metric | Current Best | Best PR |
|---|---|---|---|
| TandemFoil | val_primary/surface_pressure_mae | **26.06** | #2887 |
| TandemFoil Paper | val_primary/surface_pressure_mae | not yet established | — |
| AirfRANS | val_primary/surface_pressure_mae | **0.000598** | #2906 |
| DrivAerML | val_primary/surface_drag_coefficient_error | **3.997%** | #2898 |

## Ablation Plan

Test **two values of k** per dataset to find the sweet spot. Use the same base config as current best for each dataset:

- **k=16**: aggressive sparsity — only 16 slices per query attend to each other
- **k=32**: moderate sparsity — 50% density (baseline uses 64 slices = full attention = k=64)

### TandemFoil

```bash
# k=16 (aggressive)
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --topk-attention 16 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset

# k=32 (moderate)
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --topk-attention 32 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset
```

### TandemFoil Paper

```bash
# k=16
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --topk-attention 16 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset

# k=32
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --topk-attention 32 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset
```

### AirfRANS

```bash
# k=16
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 5e-4 --cosine-t-max 50 --weight-decay 1e-4 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 4 \
  --enable-fourier \
  --topk-attention 16 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset

# k=32
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 5e-4 --cosine-t-max 50 --weight-decay 1e-4 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 4 \
  --enable-fourier \
  --topk-attention 32 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset
```

### DrivAerML

```bash
# k=32 (DrivAerML has 50k surface points → more slices, need more connectivity)
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --topk-attention 32 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset

# k=64 (moderate — DrivAerML baseline uses 8H so full-attention would be S×S, k=64 is aggressive cut)
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --topk-attention 64 \
  --epochs 999 \
  --wandb_group sparse-topk-cross-dataset
```

## If --topk-attention flag doesn't exist

Implement the `topk_sparse_attention` function above and integrate it into the Transolver attention module. Locate the slice attention computation (likely a method called `attention`, `slice_attention`, or `physics_attention` in the model code). Replace the softmax call with the top-k masked version. Make k a command-line argument via `argparse`:

```python
parser.add_argument('--topk-attention', type=int, default=None,
    help='If set, restrict slice attention to top-k keys per query (sparse attention)')
```

Pass `topk=args.topk_attention` through to the model constructor so it can use the value in the attention module. If `--topk-attention` is not set (None), fall back to standard full attention — this ensures backward compatibility.

## What to Report

In your results comment, please include:
1. Best primary validation metric per dataset for each k value tested
2. Whether sparsity improved or degraded performance vs full attention (k=64)
3. W&B run IDs for all runs
4. If possible: memory usage comparison (sparse vs dense) — useful for future experiments combining sparsity with larger models

## Suggested Follow-ups

If top-k sparsity helps on DrivAerML:
- Try using sparsity to enable more slices (e.g., increase `--model-slices` from 64 to 128 or 256 while keeping k=32)
- Combine with MQA/GQA (PRs #2988/#2989) — shared KV heads + sparse attention is doubly memory-efficient
- Try learned sparsity patterns (e.g., routing top-k based on geometric proximity of slice centroids)