### PR TITLE
Hypernetwork condition encoding for flow-regime-aware slice computation (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,8 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    enable_flow_hypernet: bool = False
+    flow_hypernet_hidden: int = 64
 
 
 @dataclass
@@ -472,6 +474,73 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
     return None
 
 
+class FlowCondHyperNet(torch.nn.Module):
+    def __init__(self, cond_dim: int, target_dim: int, hidden: int = 64):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(cond_dim, hidden),
+            torch.nn.SiLU(),
+            torch.nn.Linear(hidden, hidden),
+            torch.nn.SiLU(),
+            torch.nn.Linear(hidden, target_dim * 2),
+        )
+        torch.nn.init.zeros_(self.net[-1].weight)
+        torch.nn.init.zeros_(self.net[-1].bias)
+
+    def forward(self, cond: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        out = self.net(cond)
+        scale, bias = out.chunk(2, dim=-1)
+        return 1.0 + scale, bias
+
+
+class FiLMTransformerBackbone(torch.nn.Module):
+    def __init__(self, backbone: torch.nn.Module, hypernet: FlowCondHyperNet):
+        super().__init__()
+        self.inner = backbone
+        self.hypernet = hypernet
+        self._cond: torch.Tensor | None = None
+
+    @property
+    def blocks(self):
+        return self.inner.blocks
+
+    def set_cond(self, cond: torch.Tensor | None) -> None:
+        self._cond = cond
+
+    def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
+        if self._cond is not None:
+            scale, bias = self.hypernet(self._cond)
+            x = x * scale.unsqueeze(1) + bias.unsqueeze(1)
+            self._cond = None
+        return self.inner(x, attn_mask=attn_mask)
+
+
+def _flow_cond_dim(config_dataset: str) -> int:
+    if config_dataset in ("tandemfoil", "tandemfoil_paper"):
+        return 2
+    if config_dataset == "airfrans":
+        return 2
+    return 0
+
+
+def extract_flow_cond(batch: GroupedBatch) -> torch.Tensor | None:
+    name = batch.dataset_name
+    if name in ("tandemfoilset", "tandemfoilset_paper"):
+        return torch.cat([
+            batch.surface_x[:, 0, 13:14],
+            batch.surface_x[:, 0, 14:15],
+        ], dim=-1)
+    if name == "airfrans":
+        return batch.surface_x[:, 0, 2:4]
+    return None
+
+
+def _set_backbone_cond(model: torch.nn.Module, cond: torch.Tensor | None) -> None:
+    backbone = getattr(model, "backbone", None)
+    if backbone is not None and isinstance(backbone, FiLMTransformerBackbone):
+        backbone.set_cond(cond)
+
+
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
@@ -513,6 +582,20 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
             volume_output_dim=bundle.spec.volume_output_dim,
         )
     raise ValueError(f"Unknown model: {config.model}")
+
+
+def _maybe_wrap_flow_hypernet(model: torch.nn.Module, config: TrainConfig) -> torch.nn.Module:
+    if not config.enable_flow_hypernet:
+        return model
+    cond_dim = _flow_cond_dim(config.dataset)
+    if cond_dim == 0:
+        return model
+    backbone = getattr(model, "backbone", None)
+    if backbone is None:
+        return model
+    hypernet = FlowCondHyperNet(cond_dim, model.n_hidden, config.flow_hypernet_hidden)
+    model.backbone = FiLMTransformerBackbone(backbone, hypernet)
+    return model
 
 
 def build_optimizer(params, config: TrainConfig):
@@ -853,6 +936,7 @@ def evaluate_grouped(
         batch = batch.to(device)
         dataset_name = batch.dataset_name
 
+        _set_backbone_cond(model, extract_flow_cond(batch))
         if isinstance(transform, TandemTargetTransform):
             prepared = transform.prepare_batch(batch)
             with autocast_context(device, amp_mode):
@@ -1230,6 +1314,7 @@ def train_one_epoch(
                     loss, _ = loss_abupt(batch, outputs, transform)
             else:
                 batch = batch.to(device)
+                _set_backbone_cond(model, extract_flow_cond(batch))
                 if isinstance(transform, TandemTargetTransform):
                     prepared = transform.prepare_batch(batch)
                     with autocast_context(device, amp_mode):
@@ -1406,8 +1491,14 @@ def main() -> None:
         )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
-    model = build_model(config, bundle).to(device)
-    forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
+    model = _maybe_wrap_flow_hypernet(build_model(config, bundle), config).to(device)
+    total_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    print(f"Model parameters: {total_params:,}", flush=True)
+    if config.enable_flow_hypernet:
+        cond_dim = _flow_cond_dim(config.dataset)
+        print(f"Flow hypernet: cond_dim={cond_dim}, hidden={config.flow_hypernet_hidden}, active={cond_dim > 0}", flush=True)
+    use_compile = config.compile_model and device.type == "cuda" and not config.enable_flow_hypernet
+    forward_model = torch.compile(model) if use_compile else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
         anp_head = ANPSurfaceDecoder(
@@ -1432,6 +1523,8 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        run_config["flow_hypernet_cond_dim"] = _flow_cond_dim(config.dataset) if config.enable_flow_hypernet else 0
+        run_config["flow_hypernet_active"] = config.enable_flow_hypernet and _flow_cond_dim(config.dataset) > 0
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),


### PR DESCRIPTION
## Hypothesis

Current slice-based models compute the same functional transformation regardless of the flow regime (Reynolds number, angle of attack, Mach number). This is suboptimal: a flow at Re=1e6 with AoA=15° is physically very different from Re=1e4 with AoA=2°, and a well-tuned surrogate should allocate computational capacity differently across regimes.

**Proposal:** Add a small hypernetwork that reads the global flow condition scalars (Re, AoA, Mach, or whatever global conditioning variables are available in each dataset) and generates per-layer weight *offsets* (scale+bias parameters) that modulate the main slice network's computation. The hypernetwork is tiny (2-3 FC layers, ~4k parameters) so it adds negligible cost but gives the model explicit regime-awareness.

This is orthogonal to every current experiment (head-dim scaling, MQA/GQA, SWA, Flash attention, sparse attention, Fourier features, TE coord frame). It targets the conditioning pathway rather than the attention mechanism or loss.

**Why this should work:**
- Each dataset already passes global scalars to the model; the hypernetwork simply makes the model's use of those scalars more expressive
- Physics intuition: different flow regimes have qualitatively different boundary layer dynamics; a single fixed-weight network is forced to average over these modes
- Hypernetworks for parameter modulation are a well-established technique (HyperNetworks, FiLM conditioning, Ha et al.) with strong empirical track records in conditional generation

## Implementation Instructions

In `target/icml2026/train.py`, implement the following:

1. **Identify the condition scalars**: Find where Re, AoA, Mach (and any other global flow scalars) enter the model. These are likely concatenated into a condition vector before or alongside the slice processing.

2. **Add a FlowCondHyperNet module** (inside `train.py`):
   ```python
   class FlowCondHyperNet(nn.Module):
       def __init__(self, cond_dim, target_dim, hidden=64):
           super().__init__()
           self.net = nn.Sequential(
               nn.Linear(cond_dim, hidden),
               nn.SiLU(),
               nn.Linear(hidden, hidden),
               nn.SiLU(),
               nn.Linear(hidden, target_dim * 2),  # scale + bias
           )
           # Init to identity (scale=1, bias=0) so it starts as a no-op
           nn.init.zeros_(self.net[-1].weight)
           nn.init.zeros_(self.net[-1].bias)

       def forward(self, cond):
           out = self.net(cond)  # (B, target_dim*2)
           scale, bias = out.chunk(2, dim=-1)
           return 1.0 + scale, bias   # residual scale around 1
   ```

3. **Apply the hypernetwork** at the slice hidden representation level: after the initial embedding of each slice but before the attention blocks, apply:
   ```python
   scale, bias = hypernet(cond)  # cond = normalized global flow scalars, shape (B, cond_dim)
   h = h * scale.unsqueeze(1) + bias.unsqueeze(1)  # h shape (B, num_slices, hidden_dim)
   ```
   Start with a single application at the entry to the transformer stack. If time allows and results look good, try applying it at each layer.

4. Add a CLI flag `--enable-flow-hypernet` to gate the feature (default off so baseline is preserved).

5. Normalize the condition vector `cond` using dataset statistics (same normalization already applied to global scalars in the dataloader).

## Training Commands

Run all four datasets. Use `--wandb_group hypernet-cond-enc-cross` to group all runs.

### TandemFoil
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --enable-flow-hypernet \
  --epochs 999 \
  --wandb_group hypernet-cond-enc-cross
```

### AirfRANS
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 \
  --grad-clip 1.0 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --enable-flow-hypernet \
  --epochs 999 \
  --wandb_group hypernet-cond-enc-cross
```

### DrivAerML
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 10 \
  --grad-clip 1.0 \
  --no-use-ema \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --enable-flow-hypernet \
  --epochs 999 \
  --wandb_group hypernet-cond-enc-cross
```

### TandemFoil Paper
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --enable-flow-hypernet \
  --epochs 999 \
  --wandb_group hypernet-cond-enc-cross
```

## Current Baselines (targets to beat)

| Dataset | Metric | Current Best | PR |
|---|---|---|---|
| TandemFoil | `val_primary/surface_pressure_mae` | **26.06** | #2887 |
| TandemFoil Paper | `val_primary/field_mse` | no baseline yet | — |
| AirfRANS | `val_primary/surface_mse` | **0.000598** | #2906 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **4.619%** | #2691 |

## Mandatory Config Rules

- TandemFoil, AirfRANS, TandemFoil Paper: `--ema-decay 0.999`
- DrivAerML: `--no-use-ema`
- TandemFoil: Lion optimizer; AirfRANS + DrivAerML: AdamW
- All runs: `--epochs 999`
- DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`

## Success Criteria

Report `val_primary` metric for each dataset at best validation checkpoint. Even a single dataset showing >1% improvement validates the approach. If TandemFoil Paper gives a first `val_primary/field_mse` reading, report it even without a baseline — it is valuable data.

## Suggested Follow-ups (if positive)

1. Apply the hypernetwork at every transformer layer rather than once at entry
2. Try predicting per-head attention temperature in addition to hidden-dim scale/bias
3. Condition on additional derived scalars (e.g., normalized pressure coefficient range)