### PR TITLE
Spectral norm on attention Q/K/V/O projections — cross-dataset (TF/TF-paper/AF/DM)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    spectral_norm_attn: bool = False
 
 
 @dataclass
@@ -496,6 +497,18 @@ def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | No
         base_dim -= 1
         return base_dim
     return None
+
+
+def apply_spectral_norm_attn(model: torch.nn.Module) -> None:
+    from torch.nn.utils import spectral_norm
+    from core.architectures.transolver_reference import TransolverAttention
+    count = 0
+    for module in model.modules():
+        if isinstance(module, TransolverAttention):
+            spectral_norm(module.qkv.project)
+            spectral_norm(module.proj.project)
+            count += 1
+    print(f"[spectral-norm-attn] Applied to {count} TransolverAttention layers (qkv + proj)")
 
 
 def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
@@ -1610,6 +1623,8 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.spectral_norm_attn:
+        apply_spectral_norm_attn(model)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

Spectral Normalization (Miyato et al., 2018; Brock et al., 2018) constrains the Lipschitz constant of weight matrices by normalising each matrix by its largest singular value σ(W). Applied to the Q, K, V, and O projection matrices in attention layers, this:

1. Bounds the sensitivity of attention logits to input perturbations — important for meshes with irregular point density.
2. Prevents gradient explosion through attention layers without requiring explicit gradient clipping to compensate.
3. Acts as an implicit regulariser orthogonal to weight decay, learning rate, and EMA.

Physics surrogate models with irregular-mesh inputs (like Transolver) often suffer from attention maps collapsing onto a small region of the mesh. Spectral norm forces a Lipschitz-bounded map from queries to attention logits, which should yield more distributed attention patterns and better generalisation across the split.

This has never been tested in this pipeline. It is low-risk (no new hyperparameters) and orthogonal to all current recipe ingredients.

References:
- https://arxiv.org/abs/1802.05957 (Spectral Normalization for GANs, Miyato 2018)
- https://arxiv.org/abs/1809.11096 (Large Scale GAN Training, Brock 2018, applied to attn)

## Instructions

Apply `torch.nn.utils.spectral_norm` to the Q, K, V, and output projection matrices of every Transolver attention layer in `target/icml2026/train.py`:

1. In the attention module `__init__`, wrap each projection with spectral_norm **after** constructing the linear layers:
   ```python
   from torch.nn.utils import spectral_norm as sn
   
   self.q_proj = sn(nn.Linear(hidden_dim, hidden_dim))
   self.k_proj = sn(nn.Linear(hidden_dim, hidden_dim))
   self.v_proj = sn(nn.Linear(hidden_dim, hidden_dim))
   self.o_proj = sn(nn.Linear(hidden_dim, hidden_dim))
   ```
   If the existing code uses a single `in_proj` that concatenates Q/K/V, split it into three separate projections before applying spectral norm — or apply spectral norm to `in_proj` and `out_proj` as the minimum viable version.

2. Add a CLI flag `--spectral-norm-attn` (boolean, default False) to enable/disable this feature.

3. Run all **four datasets** with the golden config plus `--spectral-norm-attn`. Do NOT change gradient clipping — we want to isolate the Lipschitz constraint effect. Use `--wandb_group spectral-norm-attn-cross-dataset` for all runs.

### TandemFoil run
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --spectral-norm-attn \
  --epochs 999 \
  --wandb_group spectral-norm-attn-cross-dataset
```

### TandemFoil Paper run
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 \
  --ema-decay 0.999 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --spectral-norm-attn \
  --epochs 999 \
  --wandb_group spectral-norm-attn-cross-dataset
```

### AirfRANS run
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 \
  --ema-decay 0.999 \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --enable-fourier \
  --spectral-norm-attn \
  --epochs 999 \
  --wandb_group spectral-norm-attn-cross-dataset
```

### DrivAerML run
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --enable-fourier \
  --spectral-norm-attn \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --epochs 999 \
  --wandb_group spectral-norm-attn-cross-dataset
```

Note: DrivAerML uses `--no-use-ema` (not `--ema-decay 0.999`) — EMA hurts on DM per PR #2899.

## Baseline

Current best validation metrics:

| Dataset | Metric | Best val | Best PR |
|---|---|---|---|
| TandemFoil | `val_primary/surface_pressure_mae` | **26.06** | #2887 |
| TandemFoil Paper | `val_primary/field_mse` | not yet established | — |
| AirfRANS | `val_primary/surface_mse` | **0.000598** | #2906 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 |

Reproduce TandemFoil baseline:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999
```

Reproduce AirfRANS baseline:
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 \
  --cosine-t-max 10 --grad-clip 1.0 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999
```

Reproduce DrivAerML baseline:
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```

## Expected outcome

Spectral norm is a zero-hyperparameter regulariser that constrains the Lipschitz constant of attention maps. On irregular-mesh physics problems, this should improve generalisation to out-of-distribution geometries (TF OOD splits, AirfRANS test cases). The main risk is a slight slow-down in convergence due to the bounded gradient — this is acceptable given the fixed epoch budget. Expected: 1–5% improvement on TF OOD metrics and DM gap closure, or at minimum no regression.

Report `val_primary/surface_pressure_mae` for TF, `val_primary/field_mse` for TF-paper, `val_primary/surface_mse` for AF, and `val_primary/surface_rel_l2_pct` for DM in your results comment. Also report W&B run IDs for all four runs.

Note: if the existing code uses a fused `in_proj` matrix that combines Q, K, V into one Linear layer, apply spectral norm to `in_proj` as the minimum viable version, and mention this in the results comment. The three-separate-projections version is preferred for maximum Lipschitz control.