### PR TITLE
[canute] Slice assignment temperature sweep (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    slice_temperature: float = 0.5
 
 
 @dataclass
@@ -1407,6 +1408,10 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.slice_temperature != 0.5:
+        for module in model.modules():
+            if hasattr(module, "temperature") and isinstance(module.temperature, torch.nn.Parameter):
+                module.temperature.data.fill_(config.slice_temperature)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

The Transolver slice-assignment attention uses a hardcoded temperature of \`self.temperature = 0.5\` in every attention layer. This temperature controls the sharpness of the physics-partition softmax: lower values create sharper, more exclusive slice assignments; higher values produce softer, more distributed assignments.

This parameter has **never been ablated** in our research. We don't know whether 0.5 is the right value, or whether different datasets benefit from different temperatures. This PR sweeps 4 temperature values across all 4 datasets.

## Implementation

Add a \`--slice-temperature\` flag to \`train.py\` (default \`0.5\` to match current behavior). Pass through to the model constructor, which replaces the hardcoded \`self.temperature = 0.5\` in all Transolver attention layers.

Look for all occurrences of \`self.temperature = 0.5\` or \`temperature=0.5\` in \`core/\` and make them configurable via this flag.

## Values to test

Per dataset, run 4 experiments:
- \`temperature=0.25\` — sharper/more exclusive slice assignments
- \`temperature=0.5\` — **baseline (current hardcoded default)**
- \`temperature=1.0\` — softer/more distributed
- \`temperature=2.0\` — very soft (nearly uniform slice assignment)

## Training commands

Use \`--wandb_group canute-slice-temperature\` on all runs.

### TandemFoil (4 runs)

```bash
# temperature=0.25
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 0.25 --wandb_group canute-slice-temperature

# temperature=0.5 (baseline control)
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 0.5 --wandb_group canute-slice-temperature

# temperature=1.0
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 1.0 --wandb_group canute-slice-temperature

# temperature=2.0
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 2.0 --wandb_group canute-slice-temperature
```

### TandemFoil Paper (4 runs)

```bash
# temperature=0.25
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 0.25 --wandb_group canute-slice-temperature

# temperature=0.5 (baseline control)
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 0.5 --wandb_group canute-slice-temperature

# temperature=1.0
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 1.0 --wandb_group canute-slice-temperature

# temperature=2.0
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --slice-temperature 2.0 --wandb_group canute-slice-temperature
```

### AirfRANS (4 runs)

```bash
# temperature=0.25
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --slice-temperature 0.25 --wandb_group canute-slice-temperature

# temperature=0.5 (baseline control)
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --slice-temperature 0.5 --wandb_group canute-slice-temperature

# temperature=1.0
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --slice-temperature 1.0 --wandb_group canute-slice-temperature

# temperature=2.0
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --slice-temperature 2.0 --wandb_group canute-slice-temperature
```

### DrivAerML (4 runs)

```bash
# temperature=0.25
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --slice-temperature 0.25 --wandb_group canute-slice-temperature

# temperature=0.5 (baseline control)
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --slice-temperature 0.5 --wandb_group canute-slice-temperature

# temperature=1.0
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --slice-temperature 1.0 --wandb_group canute-slice-temperature

# temperature=2.0
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --slice-temperature 2.0 --wandb_group canute-slice-temperature
```

## Current baselines to beat

| Dataset | Metric | Current best |
|---------|--------|-------------|
| TandemFoil | val_primary/surface_pressure_mae | 26.06 (PR #2887) |
| TandemFoil Paper | val_primary/field_mse | TBD (no baseline yet) |
| AirfRANS | val_primary/surface_mse | 0.000598 (PR #2906) |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% (PR #2898) |

## Success criteria

1. Identify whether any temperature value consistently beats 0.5 across datasets.
2. If 0.25 or 1.0 beats the baseline on any dataset, that's a win worth merging.
3. If results vary across datasets, report the per-dataset best — a dataset-specific optimal temperature is still useful information.

## Notes for implementation

- The temperature should be a scalar multiplied into the dot-product before the softmax in the slice-assignment attention: \`attn = softmax(QK^T / temperature)\` — equivalent to dividing by temperature or multiplying by 1/temperature.
- Make sure the same temperature is applied consistently to ALL layers' slice attention, not just the first layer.
- No other hyperparameters should be changed from the baseline golden configs above.