### PR TITLE
[franky] Extended Fourier frequency bands sweep (cross-dataset)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -33,6 +33,15 @@ from core.features import (
 from core.optim import Lion, Lookahead
 
 
+def _make_fourier_freqs(n_features: int) -> tuple[float, ...]:
+    n_values = max(1, n_features // 4)
+    if n_values == 1:
+        return (4.0,)
+    return tuple(
+        0.5 * (64.0 ** (i / (n_values - 1))) for i in range(n_values)
+    )
+
+
 class EMAWithWarmup:
     """EMA with timm-style adaptive decay warmup: min(target, (1+step)/(10+step))."""
 
@@ -139,6 +148,7 @@ class TrainConfig:
     tandemfoil_paper_manifest: str = ""
     tandemfoil_paper_stats: str = ""
     enable_fourier: bool = False
+    fourier_freqs: int = 16
     enable_te_coord_frame: bool = False
     enable_cp_panel: bool = False
     enable_cp_panel_tandem_only: bool = False
@@ -318,7 +328,9 @@ class TandemTargetTransform:
             )
             x = torch.cat([x, wake_feats], dim=-1)
         if self.config.enable_fourier:
-            x = append_batched_fourier_features(x)
+            x = append_batched_fourier_features(
+                x, freqs=_make_fourier_freqs(self.config.fourier_freqs)
+            )
 
         cp_panel_unscaled = None
         if self.config.enable_cp_panel:
@@ -1381,6 +1393,21 @@ def main() -> None:
         _ds.TandemFoilCaseDataset.__init__ = _patched_init
 
     bundle = build_bundle(config)
+
+    if config.enable_fourier and config.fourier_freqs != 16:
+        _custom_freqs = _make_fourier_freqs(config.fourier_freqs)
+        _n_vals = len(_custom_freqs)
+        _sd = bundle.spec.space_dim
+        _delta = (_n_vals - 4) * _sd * 2
+        bundle.spec.surface_input_dim += _delta
+        if bundle.spec.volume_input_dim > 0:
+            bundle.spec.volume_input_dim += _delta
+        _orig_augment = _ds.augment_case_sample
+        def _patched_augment(sample, _freqs=_custom_freqs, _orig=_orig_augment, **kwargs):
+            kwargs["fourier_freqs"] = _freqs
+            return _orig(sample, **kwargs)
+        _ds.augment_case_sample = _patched_augment
+
     resolved_num_workers = resolve_num_workers(config, bundle.spec.name)
     if bundle.spec.name == "tandemfoilset":
         phys_stats = compute_tandem_phys_stats(
@@ -1432,6 +1459,8 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        if config.enable_fourier:
+            run_config["fourier_freq_values"] = list(_make_fourier_freqs(config.fourier_freqs))
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),


### PR DESCRIPTION
## Hypothesis

The current Fourier feature encoding uses a default number of frequency bands (`--fourier-freqs`). Higher-frequency Fourier features allow the model to represent finer spatial structure in the flow field — potentially capturing sharp pressure gradients around leading edges, separation points, and wake interactions. This is especially relevant for TandemFoil where inter-foil interactions create complex interference patterns.

This PR sweeps `--fourier-freqs` at values 8, 16 (default), and 32 across all 4 datasets to determine whether more frequency bands improve accuracy.

## Implementation

The `--fourier-freqs` flag should already exist or be easy to add to `train.py`. The flag controls how many random Fourier frequency vectors are used in positional encoding. Check the current default value in `core/` and verify it — this experiment assumes the current default is **16**. If the default is different, adjust the "baseline control" run accordingly.

## Values to test

- `--fourier-freqs 8` — fewer bands, coarser spatial encoding
- `--fourier-freqs 16` — **current default (baseline control)**
- `--fourier-freqs 32` — double the default, finer spatial resolution
- `--fourier-freqs 64` — 4x the default (only if 8 GPUs allow; otherwise skip this and run 3 values)

Run across all 4 datasets with `--wandb_group franky-fourier-bands`.

## Training commands

### TandemFoil (3-4 runs)

```bash
# fourier-freqs=8
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --fourier-freqs 8 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group franky-fourier-bands

# fourier-freqs=16 (baseline control — verify this matches current default)
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --fourier-freqs 16 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group franky-fourier-bands

# fourier-freqs=32
python train.py --dataset tandemfoil --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --fourier-freqs 32 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group franky-fourier-bands
```

### TandemFoil Paper (3 runs)

```bash
# fourier-freqs=8
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --fourier-freqs 8 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group franky-fourier-bands

# fourier-freqs=16 (baseline control)
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --fourier-freqs 16 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group franky-fourier-bands

# fourier-freqs=32
python train.py --dataset tandemfoil_paper --optimizer lion --lr 1e-4 --cosine-t-max 10 --grad-clip 1.0 --weight-decay 1e-2 --ema-decay 0.999 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --fourier-freqs 32 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --wandb_group franky-fourier-bands
```

### AirfRANS (3 runs)

```bash
# fourier-freqs=8
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema --enable-fourier --fourier-freqs 8 --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb_group franky-fourier-bands

# fourier-freqs=16 (baseline control)
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema --enable-fourier --fourier-freqs 16 --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb_group franky-fourier-bands

# fourier-freqs=32
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 10 --grad-clip 1.0 --no-use-ema --enable-fourier --fourier-freqs 32 --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --wandb_group franky-fourier-bands
```

### DrivAerML (3 runs)

```bash
# fourier-freqs=8
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --fourier-freqs 8 --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb_group franky-fourier-bands

# fourier-freqs=16 (baseline control)
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --fourier-freqs 16 --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb_group franky-fourier-bands

# fourier-freqs=32
python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --fourier-freqs 32 --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --wandb_group franky-fourier-bands
```

## Current baselines to beat

| Dataset | Metric | Current best |
|---------|--------|-------------|
| TandemFoil | val_primary/surface_pressure_mae | 26.06 (PR #2887) |
| TandemFoil Paper | val_primary/field_mse | TBD (no baseline yet) |
| AirfRANS | val_primary/surface_mse | 0.000598 (PR #2906) |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% (PR #2898) |

## Success criteria

1. If `--fourier-freqs 32` beats default on any dataset, merge as improvement.
2. If `--fourier-freqs 8` is competitive, the model can be made lighter without accuracy loss — also useful for paper.
3. Report min val metric for each run. Identify whether a single best value works across all 4 datasets or whether datasets prefer different band counts.

## Implementation note

If `--fourier-freqs` is not yet a command-line argument, implement it as a passthrough to the Fourier feature encoder. The random frequency matrix should be resampled at each training run (not fixed), so results will have some variance — run the best value twice if you have a spare GPU slot and want to confirm.