### PR TITLE
hotfix: TF Paper pipeline bugs 1-3 — AoA assertion, non-finite stats, inf normalization

### DIFF
--- a/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
+++ b/target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py
@@ -188,11 +188,8 @@ def _extract_records(pickle_paths: list[Path]) -> list[dict]:
             if isinstance(aoa, list):
                 aoa0 = float(aoa[0])
                 aoa1 = float(aoa[1])
-                if abs(aoa0 - aoa1) > 1e-6:
-                    raise ValueError(
-                        f"Expected paper-style tandem AoA to be shared, got {aoa0} vs {aoa1} "
-                        f"for {path.name}:{local_idx}"
-                    )
+                # NOTE: racecar data has independently-varied AoA per foil;
+                # cruise_random may also differ slightly — do NOT assert equality.
             else:
                 aoa0 = float(aoa)
                 aoa1 = None
@@ -263,24 +260,38 @@ def _compute_y_stats(pickle_paths: list[Path], train_indices: list[int]) -> dict
     dataset = MultiFieldDataset(pickle_paths, cache_size=-1)
     train_sorted = sorted(train_indices, key=lambda idx: dataset.index[idx])
 
-    sum_y = torch.zeros(3, dtype=torch.float64)
-    total_nodes = 0
+    # FIX (Bug 2): some cruise_random samples contain ±inf pressure values from
+    # float16 overflow in the raw pickles.  Accumulate per-channel finite counts
+    # and sums to prevent NaN/inf from poisoning the statistics.
+    n_channels = 3
+    sum_y = torch.zeros(n_channels, dtype=torch.float64)
+    finite_nodes = torch.zeros(n_channels, dtype=torch.int64)
     for idx in train_sorted:
         _, y, _ = dataset[idx]
-        sum_y += y.double().sum(dim=0)
-        total_nodes += y.shape[0]
-    if total_nodes <= 1:
-        raise ValueError("Need at least two nodes to compute y statistics")
-    mean_y = sum_y / total_nodes
+        yd = y.double()
+        mask = torch.isfinite(yd)  # (N, C)
+        sum_y += (yd * mask).sum(dim=0)
+        finite_nodes += mask.sum(dim=0)
+    if finite_nodes.min() <= 1:
+        raise ValueError(
+            f"Need at least two finite nodes per channel to compute y statistics; "
+            f"got finite_nodes={finite_nodes.tolist()}"
+        )
+    mean_y = sum_y / finite_nodes.double()
 
-    sq_y = torch.zeros(3, dtype=torch.float64)
+    sq_y = torch.zeros(n_channels, dtype=torch.float64)
+    finite_nodes2 = torch.zeros(n_channels, dtype=torch.int64)
     for idx in train_sorted:
         _, y, _ = dataset[idx]
-        sq_y += ((y.double() - mean_y) ** 2).sum(dim=0)
-    std_y = (sq_y / (total_nodes - 1)).sqrt().clamp(min=1e-6)
+        yd = y.double()
+        mask = torch.isfinite(yd)
+        sq_y += (mask * (yd - mean_y) ** 2).sum(dim=0)
+        finite_nodes2 += mask.sum(dim=0)
+    std_y = (sq_y / (finite_nodes2.double() - 1)).sqrt().clamp(min=1e-6)
+    total_nodes = int(finite_nodes.min().item())  # report minimum across channels
     return {
         "n_train_samples": len(train_indices),
-        "n_train_nodes": int(total_nodes),
+        "n_train_nodes": total_nodes,
         "y_mean": mean_y.float().tolist(),
         "y_std": std_y.float().tolist(),
     }

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -207,6 +207,12 @@ class TargetTransform:
 
     def apply(self, y: torch.Tensor) -> torch.Tensor:
         out = y.clone()
+        # FIX (Bug 3): clamp non-finite input values before normalization so that
+        # ±inf from float16 overflow in raw TandemFoil Paper pickles do not
+        # propagate as NaN through the normalization arithmetic.
+        if not out.is_floating_point():
+            out = out.float()
+        out = torch.where(torch.isfinite(out), out, torch.zeros_like(out))
         if self.asinh_pressure and self.pressure_index is not None:
             out[..., self.pressure_index] = torch.asinh(out[..., self.pressure_index] * self.asinh_scale)
         if self.stats_mean is not None and self.stats_std is not None and self.stats_mean.numel() == out.shape[-1]:


### PR DESCRIPTION
## Critical Hotfix — Three bugs blocking 100% of TF Paper runs

These bugs were discovered independently by multiple students (jin, guts, vash) who each applied fixes locally in their containers but **never committed them**. Every container restart lost the fixes. This PR makes them permanent in radford.

---

### Bug 1 — AoA strict equality assertion crashes on racecar data

**File:** `target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py` — `_extract_records()`

**Symptom:** `ValueError: Expected paper-style tandem AoA to be shared, got -0.94 vs -2.36`

**Root cause:** Strict `assert abs(aoa0 - aoa1) < 1e-6` fails immediately for racecar configurations where each foil has an independently-varied AoA.

**Fix:** Remove the assertion entirely. The record dict already stores `aoa0` and `aoa1` independently — no information is lost.

---

### Bug 2 — Non-finite pressure values poison normalization statistics

**File:** `target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py` — `_compute_y_stats()`

**Symptom:** Stats JSON contains `y_mean=[-inf]` and `y_std=[nan]`

**Root cause:** Some cruise_random pickles contain ±inf pressure values from float16 range overflow. The old unmasked accumulation propagated those infinities directly into the mean/std.

**Fix:** Per-channel `torch.isfinite()` masking before accumulating sums and counts. Tracks `finite_nodes` per channel so no channel can poison another.

---

### Bug 3 — ±inf targets propagate through TargetTransform as NaN loss

**File:** `target/icml2026/train.py` — `TargetTransform.apply()`

**Symptom:** `loss=nan` from the very first training batch

**Root cause:** Raw ±inf target values survive from the pickles into the normalization `(x - mean) / std`, producing NaN.

**Fix:** `torch.where(torch.isfinite(out), out, torch.zeros_like(out))` at the top of `apply()`, before any normalization arithmetic.

---

## Validation

jin (#2947) confirmed these fixes in their container: a 2-epoch debug run completed successfully with `val_primary/field_mse = 0.243`, establishing the first TF Paper baseline. All three fixes are required together for any TF Paper run to complete.

## Relationship to shoya PR #3013

The fix commit was first pushed on `shoya/fourier-ablation-cross-dataset` to unblock TF Paper runs in that ablation. This PR is a clean cherry-pick of just the bug fixes onto radford so they land independently of the ablation result.