### PR TITLE
sigma-Reparam attention projections — cross-dataset TF/TFP/AF/DM

### DIFF
--- a/target/icml2026/core/architectures/transolver_reference.py
+++ b/target/icml2026/core/architectures/transolver_reference.py
@@ -18,6 +18,29 @@ def _init_linear(module: nn.Module, std: float = 0.02) -> None:
             nn.init.zeros_(module.bias)
 
 
+class SigmaReparam(nn.Module):
+    """
+    Reparameterize a linear layer as W = g * (V / ||V||_sigma).
+
+    Zhai et al., ICML 2023 (https://arxiv.org/abs/2301.09578).
+    Spectral norm of the effective weight is bounded to |g| throughout training.
+    No hooks, no auxiliary state — compatible with torch.compile and any optimizer.
+    """
+
+    def __init__(self, linear: nn.Linear):
+        super().__init__()
+        self.V = nn.Parameter(linear.weight.data.clone())
+        with torch.no_grad():
+            sigma_init = torch.linalg.matrix_norm(self.V, ord=2)
+        self.g = nn.Parameter(sigma_init.reshape(1))
+        self.bias = linear.bias  # shared reference (may be None)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        sigma = torch.linalg.matrix_norm(self.V, ord=2)
+        W = self.g * self.V / sigma
+        return F.linear(x, W, self.bias)
+
+
 class LinearProjection(nn.Module):
     def __init__(self, input_dim: int, output_dim: int, bias: bool = True):
         super().__init__()
@@ -85,7 +108,7 @@ class UpActDownMlp(nn.Module):
 
 
 class TransolverAttention(nn.Module):
-    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0):
+    def __init__(self, hidden_dim: int, num_heads: int, num_slices: int, dropout: float = 0.0, sigma_reparam: bool = False):
         super().__init__()
         if hidden_dim % num_heads != 0:
             raise ValueError("hidden_dim must be divisible by num_heads")
@@ -102,6 +125,9 @@ class TransolverAttention(nn.Module):
         self.qkv = LinearProjection(self.dim_head, self.dim_head * 3, bias=False)
         self.proj = LinearProjection(hidden_dim, hidden_dim)
         self.proj_dropout = nn.Dropout(dropout)
+        if sigma_reparam:
+            self.qkv.project = SigmaReparam(self.qkv.project)
+            self.proj.project = SigmaReparam(self.proj.project)
 
     def create_slices(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size, num_tokens, _ = x.shape
@@ -139,6 +165,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        sigma_reparam: bool = False,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -148,6 +175,7 @@ class TransformerBlock(nn.Module):
             num_heads=num_heads,
             num_slices=num_slices,
             dropout=dropout,
+            sigma_reparam=sigma_reparam,
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
@@ -167,6 +195,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        sigma_reparam: bool = False,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -177,6 +206,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    sigma_reparam=sigma_reparam,
                 )
                 for _ in range(depth)
             ]
@@ -205,6 +235,7 @@ class ReferenceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        sigma_reparam: bool = False,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,6 +264,7 @@ class ReferenceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            sigma_reparam=sigma_reparam,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.out = LinearProjection(n_hidden, surface_output_dim + volume_output_dim)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    sigma_reparam: bool = False
 
 
 @dataclass
@@ -200,6 +201,20 @@ class TargetTransform:
         asinh_scale: float = 1.0,
     ):
         self.pressure_index = pressure_index
+        # FIX (Bug 4): sanitize stats tensors — if the stats JSON was computed on
+        # data whose pressure channel is entirely NaN (e.g. tandemfoilset_paper
+        # cruise tasks), y_mean/y_std contain NaN for that channel.  Replace NaN/inf
+        # in the mean with 0 (identity shift) and in the std with 1 (identity scale)
+        # so those channels pass through unnormalised rather than propagating NaN
+        # into every training loss value.
+        if stats_mean is not None:
+            safe_mean = stats_mean.clone().float()
+            safe_mean[~torch.isfinite(safe_mean)] = 0.0
+            stats_mean = safe_mean
+        if stats_std is not None:
+            safe_std = stats_std.clone().float()
+            safe_std[~torch.isfinite(safe_std)] = 1.0
+            stats_std = safe_std
         self.stats_mean = stats_mean
         self.stats_std = stats_std
         self.asinh_pressure = asinh_pressure
@@ -486,6 +501,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
+        "sigma_reparam": config.sigma_reparam,
     }
     if config.model == "reference_transolver":
         return ReferenceTransolver(


### PR DESCRIPTION
## Hypothesis

σ-Reparameterization (Zhai et al., ICML 2023) replaces each attention weight matrix W with:

```
W = g * (V / ||V||_sigma)
```

where `g` is a learned per-layer scalar, `V` is an unconstrained matrix of the same shape, and `||V||_sigma` is the spectral norm of V. This constrains the spectral norm of the effective weight to exactly `|g|`, providing stable spectral norm control natively in the forward pass — no hook API or extra backward passes needed.

This is directly motivated by griffith's own review comment in PR #2968 (Spectral Norm via hooks), which showed that externally imposing spectral norm constraints caused training divergence. σ-Reparam achieves the same regularization effect purely through reparameterization.

Benefits for CFD surrogates:
- Spectral norm of Q, K, V, O projections is bounded throughout training by a learned scalar
- Gradient flow is well-conditioned because g absorbs the scale separately from V
- Unlike hook-based spectral norm (PR #2968), there is no conflict with torch.compile or optimizer state
- The extra cost is one matrix norm per projection per forward step — negligible

Paper: https://arxiv.org/abs/2301.09578

## Instructions

Add a `--sigma-reparam` flag to `train.py`. When enabled, wrap the Q, K, V, and output projection `nn.Linear` layers inside the attention modules with σ-Reparameterization.

Implementation pattern:

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

class SigmaReparam(nn.Module):
    """
    Reparameterize a linear layer as W = g * (V / ||V||_sigma).
    Zhai et al., ICML 2023 (https://arxiv.org/abs/2301.09578).
    """
    def __init__(self, linear: nn.Linear):
        super().__init__()
        # Initialize V from the existing weight
        self.V = nn.Parameter(linear.weight.data.clone())
        # g initialized to the current spectral norm so W starts equal to the original weight
        with torch.no_grad():
            sigma_init = torch.linalg.matrix_norm(self.V, ord=2)
        self.g = nn.Parameter(sigma_init.reshape(1))
        self.bias = linear.bias  # shared reference or None

    def forward(self, x):
        sigma = torch.linalg.matrix_norm(self.V, ord=2)
        W = self.g * self.V / sigma
        return F.linear(x, W, self.bias)
```

Apply `SigmaReparam` to each Q, K, V, and output projection `nn.Linear` in every attention block in the model. Leave all FFN layers and embedding layers untouched.

**Run all four datasets in a single W&B group:**

```bash
# TandemFoil (Lion, EMA=0.999, 3L/192d)
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --ema-decay 0.999 \
  --epochs 999 \
  --sigma-reparam \
  --wandb_group wave11-sigma-reparam

# TandemFoil Paper (Lion, EMA=0.999, same arch)
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --ema-decay 0.999 \
  --epochs 999 \
  --sigma-reparam \
  --wandb_group wave11-sigma-reparam

# AirfRANS (AdamW, no-EMA, 2L/256d)
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --sigma-reparam \
  --wandb_group wave11-sigma-reparam

# DrivAerML (AdamW, no-EMA, 4L/512d)
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --sigma-reparam \
  --wandb_group wave11-sigma-reparam
```

Run all four in parallel across your 8 GPUs. Report W&B run IDs for all four runs.

## Baseline

Current best metrics (from BASELINE.md):

| Dataset | Primary Metric | Value | PR | W&B Run |
|---------|---------------|-------|-----|---------|
| TandemFoil | `val_primary/surface_pressure_mae` | **22.537** | #2924 | 0lv7fnun |
| AirfRANS | `val_primary/surface_mse` | **0.000482** | #2951 | pr4wsbfm |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 | bht6h42t |

**TandemFoil reproduce command:**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```

**AirfRANS reproduce command:**
```bash
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999
```

**DrivAerML reproduce command:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```

## Background: Why sigma-Reparam instead of hook-based spectral norm

PR #2968 (griffith) tested spectral norm constraints via PyTorch's `torch.nn.utils.spectral_norm` hook API. The run diverged early on TandemFoil. Root cause identified in review: hook-based spectral norm injects auxiliary singular vector state that conflicts with AdamW/Lion optimizer state and torch.compile graph capture.

sigma-Reparam avoids this entirely: the reparameterization is a pure weight transformation in the forward pass. The optimizer sees `V` and `g` as ordinary parameters. No hooks, no auxiliary state, no graph capture conflict.

The expected benefit is the same: stable attention dynamics through bounded spectral norm of projection matrices — but via a cleaner mechanism proven to work at scale (ViT-22B used this approach).