### PR TITLE
GeGLU FFN activation — cross-dataset TF/TFP/AF/DM

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -33,6 +33,34 @@ from core.features import (
 from core.optim import Lion, Lookahead
 
 
+class GeGLUFFN(torch.nn.Module):
+    """GeGLU feed-forward: FFN(x) = (xW_up) * GELU(xW_gate) @ W_down (Shazeer 2020)."""
+
+    def __init__(self, hidden_dim: int, ffn_dim: int):
+        super().__init__()
+        self.W_gate = torch.nn.Linear(hidden_dim, ffn_dim, bias=False)
+        self.W_up = torch.nn.Linear(hidden_dim, ffn_dim, bias=False)
+        self.W_down = torch.nn.Linear(ffn_dim, hidden_dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.W_down(F.gelu(self.W_gate(x)) * self.W_up(x))
+
+
+def _replace_ffn_with_geglu(model: torch.nn.Module) -> int:
+    """Walk model tree and replace all UpActDownMlp instances with GeGLUFFN."""
+    from core.architectures.transolver_reference import UpActDownMlp
+
+    count = 0
+    for name, module in model.named_modules():
+        for child_name, child in module.named_children():
+            if isinstance(child, UpActDownMlp):
+                hidden_dim = child.fc1.in_features
+                ffn_dim = child.fc1.out_features
+                setattr(module, child_name, GeGLUFFN(hidden_dim, ffn_dim))
+                count += 1
+    return count
+
+
 class EMAWithWarmup:
     """EMA with timm-style adaptive decay warmup: min(target, (1+step)/(10+step))."""
 
@@ -165,6 +193,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
+    geglu: bool = False
     seed: int = 0
 
 
@@ -1506,7 +1535,11 @@ def main() -> None:
         )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
-    model = build_model(config, bundle).to(device)
+    model = build_model(config, bundle)
+    if config.geglu:
+        n_replaced = _replace_ffn_with_geglu(model)
+        print(f"[GeGLU] Replaced {n_replaced} FFN blocks with GeGLU")
+    model = model.to(device)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1538,6 +1571,7 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        run_config["model_params"] = sum(p.numel() for p in model.parameters())
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),


### PR DESCRIPTION
## Hypothesis

GeGLU (Dauphin et al. 2017, Shazeer 2020) replaces the standard two-matrix FFN with a gated variant:

```
FFN_GeGLU(x) = (x W_1) * GELU(x W_3) * W_2
```

where W_1, W_3 are up-projection matrices and W_2 is the down-projection. The GELU gate smoothly suppresses small activations near zero — a property directly useful in CFD surrogate models, where many mesh nodes have near-zero physical quantities (far-field pressure, low-velocity regions).

This is distinct from SwiGLU tested in PR #2938 (nezuko), which uses SiLU as the gate function. GELU has heavier tails and is smoother near zero compared to SiLU. In CFD regimes where node features span many decades, GELU's behavior at small magnitudes may better preserve gradient signal for low-intensity physics regions.

Key properties:
- GELU gate is differentiable everywhere, including near zero
- Heavier tails than SiLU: less aggressive suppression of mid-range activations
- Standard in many modern transformers (GPT-J, Falcon, CodeGen)
- No change to model depth or attention — pure FFN swap

Papers:
- Dauphin et al., Language Modeling with Gated Convolutional Networks (2017): https://arxiv.org/abs/1612.08083
- Shazeer, GLU Variants Improve Transformer (2020): https://arxiv.org/abs/2002.05202

## Instructions

Add a `--geglu` flag to `train.py`. When enabled, replace the FFN activation in all transformer blocks with GeGLU.

Implementation pattern:

```python
import torch
import torch.nn as nn
import torch.nn.functional as F

class GeGLUFFN(nn.Module):
    """
    GeGLU feed-forward block.
    FFN(x) = (x W_1) * GELU(x W_3) @ W_2
    Shazeer 2020: https://arxiv.org/abs/2002.05202
    """
    def __init__(self, hidden_dim: int, ffn_dim: int, dropout: float = 0.0):
        super().__init__()
        # Two parallel up-projections: one for value, one for gate
        self.W_gate = nn.Linear(hidden_dim, ffn_dim, bias=False)
        self.W_up   = nn.Linear(hidden_dim, ffn_dim, bias=False)
        self.W_down = nn.Linear(ffn_dim, hidden_dim, bias=False)
        self.dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()

    def forward(self, x):
        gate = F.gelu(self.W_gate(x))
        up   = self.W_up(x)
        return self.dropout(self.W_down(gate * up))
```

Replace the standard FFN block in every transformer layer with `GeGLUFFN`. Keep `ffn_dim` consistent with the existing FFN hidden dimension (typically `4 * hidden_dim`). The parameter count increases modestly due to the extra W_gate matrix.

**Run all four datasets in a single W&B group:**

```bash
# TandemFoil (Lion, EMA=0.999, 3L/192d)
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --ema-decay 0.999 \
  --epochs 999 \
  --geglu \
  --wandb_group wave11-geglu

# TandemFoil Paper (Lion, EMA=0.999, same arch)
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --ema-decay 0.999 \
  --epochs 999 \
  --geglu \
  --wandb_group wave11-geglu

# AirfRANS (AdamW, no-EMA, 2L/256d)
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --geglu \
  --wandb_group wave11-geglu

# DrivAerML (AdamW, no-EMA, 4L/512d)
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --geglu \
  --wandb_group wave11-geglu
```

Run all four in parallel across your 8 GPUs. Report W&B run IDs for all four runs.

**Note on parameter count:** GeGLU adds one extra up-projection matrix per FFN (W_gate). If you want to maintain strict parameter parity with the baseline, reduce ffn_dim to approximately `ffn_dim * 2/3` (as recommended by Shazeer). This is optional — try the default ffn_dim first and note whether increased capacity helps or hurts.

## Baseline

Current best metrics (from BASELINE.md):

| Dataset | Primary Metric | Value | PR | W&B Run |
|---------|---------------|-------|-----|---------|
| TandemFoil | `val_primary/surface_pressure_mae` | **22.537** | #2924 | 0lv7fnun |
| AirfRANS | `val_primary/surface_mse` | **0.000482** | #2951 | pr4wsbfm |
| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** | #2898 | bht6h42t |

**TandemFoil reproduce command:**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```

**AirfRANS reproduce command:**
```bash
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999
```

**DrivAerML reproduce command:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200
```

## Relationship to SwiGLU (PR #2938)

PR #2938 (nezuko) tested SwiGLU (`FFN(x) = (xW_1) * SiLU(xW_3) @ W_2`) and is currently WIP. This PR tests GeGLU independently. The two hypotheses differ in gate activation: SiLU vs GELU. If both beat baseline, the results should be compared directly to pick the better gate function. If only one wins, the winning gate type becomes part of the standard recipe.