### PR TITLE
[codex] sync DrivAerML split contract

### DIFF
--- a/target/icml2026/core/datasets.py
+++ b/target/icml2026/core/datasets.py
@@ -32,6 +32,22 @@ DEFAULT_TANDEM_MANIFEST = ROOT_DIR / "tandemfoil/data/split_manifest_tandemfoils
 DEFAULT_TANDEM_STATS = ROOT_DIR / "tandemfoil/data/split_stats.json"
 DEFAULT_AIRFRANS_MANIFEST = ROOT_DIR / "airfrans/data/split_manifest_airfrans.json"
 DEFAULT_DRIVAERML_MANIFEST = ROOT_DIR / "drivaerml/data/split_manifest_drivaerml.json"
+EXPECTED_DRIVAERML_SURFACE_SPLIT_COUNTS = {"train": 400, "val": 34, "test": 50}
+EXPECTED_DRIVAERML_EXCLUDED_CASE_COUNT = 0
+REQUIRED_DRIVAERML_CASE_IDS = frozenset(
+    {
+        "run_44",
+        "run_133",
+        "run_158",
+        "run_184",
+        "run_203",
+        "run_226",
+        "run_249",
+        "run_310",
+        "run_416",
+        "run_484",
+    }
+)
 RUNTIME_CACHE_CASES = 16
 
 
@@ -56,6 +72,59 @@ def _stats_from_json(stats_path: str | Path) -> TargetTransformStats:
         y_mean=torch.tensor(raw["y_mean"], dtype=torch.float32),
         y_std=torch.tensor(raw["y_std"], dtype=torch.float32),
     )
+
+
+def _validate_drivaerml_manifest(manifest: dict, manifest_path: str | Path) -> None:
+    surface_splits = manifest.get("surface_splits")
+    if not isinstance(surface_splits, dict):
+        raise ValueError(f"DrivAerML manifest {manifest_path} is missing surface_splits")
+
+    missing_splits = sorted(set(EXPECTED_DRIVAERML_SURFACE_SPLIT_COUNTS) - set(surface_splits))
+    if missing_splits:
+        raise ValueError(f"DrivAerML manifest {manifest_path} is missing surface splits: {missing_splits}")
+
+    actual_counts = {
+        split: len(surface_splits[split])
+        for split in EXPECTED_DRIVAERML_SURFACE_SPLIT_COUNTS
+    }
+    if actual_counts != EXPECTED_DRIVAERML_SURFACE_SPLIT_COUNTS:
+        raise ValueError(
+            "DrivAerML manifest does not match the repaired public benchmark split: "
+            f"{actual_counts} vs {EXPECTED_DRIVAERML_SURFACE_SPLIT_COUNTS} ({manifest_path})"
+        )
+
+    split_sets = {
+        split: set(surface_splits[split])
+        for split in EXPECTED_DRIVAERML_SURFACE_SPLIT_COUNTS
+    }
+    surface_case_ids = set().union(*split_sets.values())
+    if len(surface_case_ids) != sum(actual_counts.values()):
+        raise ValueError(f"DrivAerML manifest {manifest_path} has overlapping surface splits")
+
+    excluded_case_count = int(
+        manifest.get("excluded_case_count", len(manifest.get("excluded_case_ids", [])))
+    )
+    if excluded_case_count != EXPECTED_DRIVAERML_EXCLUDED_CASE_COUNT:
+        raise ValueError(
+            "DrivAerML manifest still excludes repaired public cases: "
+            f"{excluded_case_count} excluded in {manifest_path}"
+        )
+
+    missing_required = sorted(REQUIRED_DRIVAERML_CASE_IDS - surface_case_ids)
+    if missing_required:
+        raise ValueError(
+            f"DrivAerML manifest {manifest_path} is missing restored public cases: {missing_required}"
+        )
+
+    volume_splits = manifest.get("volume_splits", {})
+    if isinstance(volume_splits, dict):
+        for split_name, case_ids in volume_splits.items():
+            extra_case_ids = sorted(set(case_ids) - split_sets.get(split_name, set()))
+            if extra_case_ids:
+                raise ValueError(
+                    "DrivAerML volume split must stay aligned with the same surface split: "
+                    f"{split_name} has extras {extra_case_ids} in {manifest_path}"
+                )
 
 
 class TandemFoilCaseDataset(Dataset):
@@ -578,6 +647,7 @@ def build_drivaerml_bundle(
     eval_volume_points: int = 0,
 ) -> DatasetBundle:
     manifest = _read_json(manifest_path)
+    _validate_drivaerml_manifest(manifest, manifest_path)
     train_sampling_mode = "train_random" if train_surface_points > 0 or train_volume_points > 0 else "full"
     eval_sampling_mode = "eval_chunk" if eval_surface_points > 0 or eval_volume_points > 0 else "full"
     train_dataset = DrivAerMLCaseDataset(
@@ -634,7 +704,7 @@ def build_drivaerml_bundle(
             pressure_output_index=0,
             default_metric="surface_rel_l2_pct",
             notes=[
-                "DrivAerML defaults to the packaged public surface split for the paper sprint.",
+                "DrivAerML defaults to the repaired public 400/34/50 surface split for the paper sprint.",
                 "Surface-first mode is the default; the volume subset stays optional.",
                 "Paper-facing evaluation follows AB-UPT's average per-case relative-L2 contract on unnormalized targets.",
                 "When DrivAerML train point limits are set, each epoch repeats a case ceil(N / points_per_view) times.",

--- a/target/icml2026/drivaerml/data/README.md
+++ b/target/icml2026/drivaerml/data/README.md
@@ -12,6 +12,9 @@ Repo-local DrivAerML benchmark assets for the ICML 2026 target.
 
 The committed split follows the packaged public processed manifest on the PVC and
 keeps the surface-first public benchmark contract that matches the packaged data.
+The current public surface split is `400 train / 34 val / 50 test`, the volume
+subset is `15 train / 1 val`, and `train.py` records the exact committed split
+in each DrivAerML run summary.
 
 ## Running
 

--- a/target/icml2026/drivaerml/data/split_drivaerml.py
+++ b/target/icml2026/drivaerml/data/split_drivaerml.py
@@ -40,10 +40,14 @@ def build_manifest(
     volume_manifest_path: str,
     case_root: str,
     case_root_candidates: list[str],
+    *,
+    surface_manifest_read_path: str | None = None,
+    surface_full_manifest_read_path: str | None = None,
+    volume_manifest_read_path: str | None = None,
 ) -> dict:
-    surface_rows = _read_csv_rows(surface_manifest_path)
-    surface_full_rows = _read_csv_rows(surface_full_manifest_path)
-    volume_rows = _read_csv_rows(volume_manifest_path)
+    surface_rows = _read_csv_rows(surface_manifest_read_path or surface_manifest_path)
+    surface_full_rows = _read_csv_rows(surface_full_manifest_read_path or surface_full_manifest_path)
+    volume_rows = _read_csv_rows(volume_manifest_read_path or volume_manifest_path)
 
     surface_splits = {
         split: [row["case_id"] for row in surface_rows if row["split"] == split]
@@ -57,6 +61,19 @@ def build_manifest(
     current_ids = {row["case_id"] for row in surface_rows}
     full_ids = {row["case_id"] for row in surface_full_rows}
     excluded_case_ids = sorted(full_ids - current_ids)
+
+    notes = [
+        "Surface splits come directly from the current preprocessed manifest.csv on the PVC.",
+        "Volume splits come from volume_manifest.csv and are a strict subset of the surface cases.",
+    ]
+    if excluded_case_ids:
+        notes.append(
+            "manifest_full_failed10_included.csv is used to identify cases excluded from the current processed manifest."
+        )
+    else:
+        notes.append(
+            "manifest.csv and manifest_full_failed10_included.csv currently agree on all packaged processed surface cases."
+        )
 
     return {
         "dataset": "DrivAerML",
@@ -72,17 +89,13 @@ def build_manifest(
         "volume_split_counts": {k: len(v) for k, v in volume_splits.items()},
         "excluded_case_ids": excluded_case_ids,
         "excluded_case_count": len(excluded_case_ids),
-        "notes": [
-            "Surface splits come directly from the current preprocessed manifest.csv on the PVC.",
-            "Volume splits come from volume_manifest.csv and are a strict subset of the surface cases.",
-            "manifest_full_failed10_included.csv is used to identify cases excluded from the current processed manifest.",
-        ],
+        "notes": notes,
     }
 
 
 def verify_manifest(manifest: dict) -> None:
     surface_counts = manifest["surface_split_counts"]
-    if surface_counts != {"train": 394, "val": 34, "test": 46}:
+    if surface_counts != {"train": 400, "val": 34, "test": 50}:
         raise ValueError(f"Unexpected DrivAerML surface split counts: {surface_counts}")
 
     ensure_disjoint(manifest["surface_splits"])
@@ -105,8 +118,8 @@ def verify_manifest(manifest: dict) -> None:
                     f"Volume case {case_id} split {split} mismatches surface split {surface_by_case.get(case_id)}"
                 )
 
-    if manifest["excluded_case_count"] != 10:
-        raise ValueError(f"Expected 10 excluded DrivAerML cases, got {manifest['excluded_case_count']}")
+    if manifest["excluded_case_count"] != 0:
+        raise ValueError(f"Expected 0 excluded DrivAerML cases, got {manifest['excluded_case_count']}")
 
 
 def main() -> None:
@@ -125,12 +138,19 @@ def main() -> None:
     args = parser.parse_args()
 
     case_root_candidates = args.case_root_candidate or DEFAULT_CASE_ROOT_CANDIDATES
+    surface_manifest_path = str(args.surface_manifest)
+    surface_full_manifest_path = str(args.surface_manifest_full)
+    volume_manifest_path = str(args.volume_manifest)
+    case_root = str(args.case_root)
     manifest = build_manifest(
-        surface_manifest_path=str(rewrite_under_pvc_mount(args.surface_manifest)),
-        surface_full_manifest_path=str(rewrite_under_pvc_mount(args.surface_manifest_full)),
-        volume_manifest_path=str(rewrite_under_pvc_mount(args.volume_manifest)),
-        case_root=str(rewrite_under_pvc_mount(args.case_root)),
+        surface_manifest_path=surface_manifest_path,
+        surface_full_manifest_path=surface_full_manifest_path,
+        volume_manifest_path=volume_manifest_path,
+        case_root=case_root,
         case_root_candidates=expand_pvc_candidates(case_root_candidates),
+        surface_manifest_read_path=str(rewrite_under_pvc_mount(surface_manifest_path)),
+        surface_full_manifest_read_path=str(rewrite_under_pvc_mount(surface_full_manifest_path)),
+        volume_manifest_read_path=str(rewrite_under_pvc_mount(volume_manifest_path)),
     )
     verify_manifest(manifest)
     write_json(args.out, manifest)

--- a/target/icml2026/drivaerml/data/split_manifest_drivaerml.json
+++ b/target/icml2026/drivaerml/data/split_manifest_drivaerml.json
@@ -5,6 +5,10 @@
   "source_surface_manifest_full": "/mnt/pvc/Processed/drivaerml_processed/manifest_full_failed10_included.csv",
   "source_volume_manifest": "/mnt/pvc/Processed/drivaerml_processed/volume_manifest.csv",
   "case_root": "/mnt/pvc/Processed/drivaerml_processed",
+  "case_root_candidates": [
+    "/mnt/pvc/Processed/drivaerml_processed",
+    "/mnt/new-pvc/Processed/drivaerml_processed"
+  ],
   "surface_splits": {
     "train": [
       "run_1",
@@ -40,6 +44,7 @@
       "run_40",
       "run_42",
       "run_43",
+      "run_44",
       "run_45",
       "run_46",
       "run_47",
@@ -163,6 +168,7 @@
       "run_181",
       "run_182",
       "run_183",
+      "run_184",
       "run_185",
       "run_186",
       "run_189",
@@ -206,6 +212,7 @@
       "run_244",
       "run_245",
       "run_246",
+      "run_249",
       "run_250",
       "run_251",
       "run_254",
@@ -251,6 +258,7 @@
       "run_307",
       "run_308",
       "run_309",
+      "run_310",
       "run_312",
       "run_313",
       "run_314",
@@ -329,6 +337,7 @@
       "run_413",
       "run_414",
       "run_415",
+      "run_416",
       "run_417",
       "run_418",
       "run_419",
@@ -386,6 +395,7 @@
       "run_481",
       "run_482",
       "run_483",
+      "run_484",
       "run_485",
       "run_486",
       "run_488",
@@ -452,19 +462,23 @@
       "run_108",
       "run_124",
       "run_127",
+      "run_133",
       "run_142",
+      "run_158",
       "run_173",
       "run_180",
       "run_187",
       "run_188",
       "run_197",
       "run_199",
+      "run_203",
       "run_205",
       "run_207",
       "run_208",
       "run_210",
       "run_215",
       "run_222",
+      "run_226",
       "run_258",
       "run_263",
       "run_280",
@@ -488,9 +502,9 @@
     ]
   },
   "surface_split_counts": {
-    "train": 394,
+    "train": 400,
     "val": 34,
-    "test": 46
+    "test": 50
   },
   "volume_splits": {
     "train": [
@@ -518,22 +532,11 @@
     "train": 15,
     "val": 1
   },
-  "excluded_case_ids": [
-    "run_133",
-    "run_158",
-    "run_184",
-    "run_203",
-    "run_226",
-    "run_249",
-    "run_310",
-    "run_416",
-    "run_44",
-    "run_484"
-  ],
-  "excluded_case_count": 10,
+  "excluded_case_ids": [],
+  "excluded_case_count": 0,
   "notes": [
     "Surface splits come directly from the current preprocessed manifest.csv on the PVC.",
     "Volume splits come from volume_manifest.csv and are a strict subset of the surface cases.",
-    "manifest_full_failed10_included.csv is used to identify cases excluded from the current processed manifest."
+    "manifest.csv and manifest_full_failed10_included.csv currently agree on all packaged processed surface cases."
   ]
 }

--- a/target/icml2026/drivaerml/program.md
+++ b/target/icml2026/drivaerml/program.md
@@ -50,16 +50,15 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
 
 - **Split contract**
   - Default split for this repo target:
-    - `394 train / 34 val / 46 test`
+    - `400 train / 34 val / 50 test`
   - This is the packaged public processed split present on the PVC.
-  - It is slightly smaller than the nominal public split discussed in AB-UPT because `10` processed public cases are absent from the packaged PVC.
+  - The packaged surface manifests now match the public AB-UPT train/val/test case counts on the processed PVC.
 
 - **Important comparison note**
-  - The packaged PVC split is not identical to the nominal AB-UPT public split because `10` processed public cases are missing.
-  - That split discrepancy must be disclosed whenever we compare against AB-UPT, PhysicsNeMo, or Transolver-3 tables.
+  - The packaged public processed split now aligns with the public AB-UPT `400 / 34 / 50` train/val/test partition.
+  - AB-UPT also tracks a separate `16`-case hidden validation bucket that is not part of the public processed PVC contract used here.
   - The local `reference_abupt` model path should be treated as an **AB-UPT-style reference architecture**, not a byte-for-byte reproduction of the published AB-UPT DrivAerML setup.
   - The main remaining differences are:
-    - **split**: this target uses the packaged processed split `394 / 34 / 46`, whereas AB-UPT reports the nominal public split `400 / 34 effective val / 50 test`
     - **targets**: the packaged sprint path is surface-first and predicts packaged `surface_cp`, whereas AB-UPT predicts 4 surface variables and 7 volume variables on the full task
     - **token counts**: the AB-UPT paper uses `16384` geometry supernodes, `16384` surface anchors, and `16384` volume anchors for DrivAerML; the local sprint defaults are smaller and configurable for practicality
     - **architecture depth / recipe**: the paper uses the full published AB-UPT block schedule and training recipe (`500` epochs, `bs=1`, Lion with warmup+cosine, mixed precision). The local sprint trainer exposes a shared training loop and does not yet hard-pin every AB-UPT hyperparameter to those paper values
@@ -68,7 +67,7 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
 ## Published reference targets
 
 - **Exact local contract used by this target**
-  - packaged processed split: `394 train / 34 val / 46 test`
+  - packaged processed split: `400 train / 34 val / 50 test`
   - packaged target: `surface_cp`
   - paper-facing metric:
     - `test_primary/surface_rel_l2_pct`
@@ -77,10 +76,10 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
 
 - **What we found in the literature**
   - We did **not** find a published paper that reports the exact packaged
-    `394 / 34 / 46` `surface_cp` contract used in this repo.
-  - The closest published surface-pressure references use the nominal public
-    DrivAerML benchmark rather than the packaged PVC subset:
-    - `Transolver-3` (Table 4, random `400 train / 34 effective val / 50 test`):
+    `surface_cp` sprint target and shared-trainer implementation used in this repo.
+  - The closest published surface-pressure references use the same nominal
+    public DrivAerML train/val/test counts:
+    - `Transolver-3` (Table 4, `400 train / 34 effective val / 50 test`):
       - `p_s = 3.71`
     - `AB-UPT` (same table):
       - `p_s = 3.82`
@@ -94,8 +93,11 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
     `surface_rel_l2_pct`, that is approximately `3.88`.
 
 - **Implication for this repo**
-  - There is no exact published apples-to-apples number for our packaged split,
-    so the paper should disclose that clearly.
+  - The split counts now align with the public AB-UPT benchmark, so split-size
+    disclosure is no longer the main caveat.
+  - There is still no exact published apples-to-apples number for our packaged
+    `surface_cp` sprint target and trainer path, so the paper should disclose
+    that clearly.
   - The right external target band for `surface_rel_l2_pct` is nevertheless
     low-single-digit surface-pressure error, with `3.71` from `Transolver-3`
     as the strongest nominal DrivAerML reference we found.

--- a/target/icml2026/program.md
+++ b/target/icml2026/program.md
@@ -76,8 +76,9 @@ Alignment policy:
 - when model selection is done on validation, paper-facing test numbers should
   be evaluated from the best validation checkpoint rather than the terminal
   training state whenever possible
-- document any remaining irreducible discrepancy, such as the packaged
-  DrivAerML case set being smaller than the nominal public split in AB-UPT
+- document any remaining irreducible discrepancy, such as unavailable
+  hidden-validation cases or differences between packaged sprint targets and
+  published full-task targets
 - pin TandemFoilSet parity work to concrete source refs rather than a floating
   branch head:
   - transform, metric, residual, and merged feature-stack contract:

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -56,6 +56,8 @@ class TrainConfig:
     drivaerml_eval_surface_points: int = 0
     drivaerml_train_volume_points: int = 0
     drivaerml_eval_volume_points: int = 0
+    drivaerml_manifest: str = ""
+    drivaerml_root: str = ""
     agent: str = ""
     wandb_name: str = ""
     wandb_group: str = ""
@@ -395,6 +397,10 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
         bundle_kwargs["tandem_manifest"] = config.tandem_manifest
     if config.tandem_stats:
         bundle_kwargs["tandem_stats"] = config.tandem_stats
+    if config.drivaerml_manifest:
+        bundle_kwargs["drivaerml_manifest"] = config.drivaerml_manifest
+    if config.drivaerml_root:
+        bundle_kwargs["drivaerml_root"] = config.drivaerml_root
     return build_dataset_bundle(**bundle_kwargs)
 
 
@@ -1145,7 +1151,29 @@ def write_run_summary(
         "history": history,
         "final_test_metrics": final_test_metrics or {},
     }
+    drivaerml_split = drivaerml_split_summary(bundle)
+    if drivaerml_split is not None:
+        payload["drivaerml_split"] = drivaerml_split
     path.write_text(json.dumps(payload, indent=2))
+
+
+def drivaerml_split_summary(bundle: DatasetBundle) -> dict[str, object] | None:
+    if bundle.spec.name != "drivaerml":
+        return None
+    store = getattr(bundle.train_dataset, "store", None)
+    manifest = getattr(store, "manifest", None)
+    if not isinstance(manifest, dict):
+        return None
+    return {
+        "manifest_path": str(store.manifest_path),
+        "case_root": str(store.root),
+        "surface_split_counts": manifest.get("surface_split_counts", {}),
+        "surface_splits": manifest.get("surface_splits", {}),
+        "volume_split_counts": manifest.get("volume_split_counts", {}),
+        "volume_splits": manifest.get("volume_splits", {}),
+        "excluded_case_count": manifest.get("excluded_case_count"),
+        "excluded_case_ids": manifest.get("excluded_case_ids", []),
+    }
 
 
 def compute_tandem_phys_stats(


### PR DESCRIPTION
## Summary
- regenerate the committed DrivAerML manifest to the repaired public `400/34/50` surface split and `15/1` volume subset
- make the ICML trainer validate that repaired split at runtime and record the exact manifest-backed DrivAerML split in run summaries
- update the DrivAerML benchmark docs to reflect the AB-UPT-aligned public split

## Why
The processed DrivAerML PVC now includes the previously missing public cases. The `radford` branch was still encoding the older `394/34/46` contract, which would keep training and eval/test out of sync with the latest corrected benchmark split.

## Validation
- `python -m py_compile target/icml2026/train.py target/icml2026/core/datasets.py target/icml2026/drivaerml/data/split_drivaerml.py target/icml2026/drivaerml/data/prepare_drivaerml.py`
- `.venv/bin/python` manifest validation against the committed DrivAerML manifest
- confirmed the committed manifest contains `400/34/50` surface counts, `15/1` volume counts, `0` excluded cases, and the restored case IDs
- full dataset-root smoke could not run in this environment because `/mnt/pvc/...` and `/mnt/new-pvc/...` are not mounted on this host