### PR TITLE
LayerScale on Transolver residuals — cross-dataset stability

### DIFF
--- a/target/icml2026/core/architectures/transolver_reference.py
+++ b/target/icml2026/core/architectures/transolver_reference.py
@@ -139,6 +139,7 @@ class TransformerBlock(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        layer_scale_init: float = 0.0,
     ):
         super().__init__()
         mlp_hidden_dim = int(math.ceil(hidden_dim * mlp_expansion_factor))
@@ -151,10 +152,18 @@ class TransformerBlock(nn.Module):
         )
         self.norm2 = nn.LayerNorm(hidden_dim, eps=1e-6)
         self.mlp = UpActDownMlp(hidden_dim=hidden_dim, mlp_hidden_dim=mlp_hidden_dim)
+        self.use_layer_scale = layer_scale_init > 0.0
+        if self.use_layer_scale:
+            self.layer_scale_1 = nn.Parameter(layer_scale_init * torch.ones(hidden_dim))
+            self.layer_scale_2 = nn.Parameter(layer_scale_init * torch.ones(hidden_dim))
 
     def forward(self, x: torch.Tensor, attn_mask: torch.Tensor | None = None) -> torch.Tensor:
-        x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
-        x = x + self.mlp(self.norm2(x))
+        if self.use_layer_scale:
+            x = x + self.layer_scale_1 * self.attention(self.norm1(x), attn_mask=attn_mask)
+            x = x + self.layer_scale_2 * self.mlp(self.norm2(x))
+        else:
+            x = x + self.attention(self.norm1(x), attn_mask=attn_mask)
+            x = x + self.mlp(self.norm2(x))
         return x
 
 
@@ -167,6 +176,7 @@ class Transformer(nn.Module):
         mlp_expansion_factor: int | float,
         num_slices: int,
         dropout: float = 0.0,
+        layer_scale_init: float = 0.0,
     ):
         super().__init__()
         self.blocks = nn.ModuleList(
@@ -177,6 +187,7 @@ class Transformer(nn.Module):
                     mlp_expansion_factor=mlp_expansion_factor,
                     num_slices=num_slices,
                     dropout=dropout,
+                    layer_scale_init=layer_scale_init,
                 )
                 for _ in range(depth)
             ]
@@ -205,6 +216,7 @@ class ReferenceTransolver(nn.Module):
         n_head: int = 3,
         mlp_ratio: int = 4,
         slice_num: int = 96,
+        layer_scale_init: float = 0.0,
     ):
         super().__init__()
         self.space_dim = space_dim
@@ -233,6 +245,7 @@ class ReferenceTransolver(nn.Module):
             mlp_expansion_factor=mlp_ratio,
             num_slices=slice_num,
             dropout=dropout,
+            layer_scale_init=layer_scale_init,
         )
         self.norm = nn.LayerNorm(n_hidden, eps=1e-6)
         self.out = LinearProjection(n_hidden, surface_output_dim + volume_output_dim)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -164,6 +164,7 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    layer_scale_init: float = 0.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -486,6 +487,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
+        "layer_scale_init": config.layer_scale_init,
     }
     if config.model == "reference_transolver":
         return ReferenceTransolver(
@@ -1604,6 +1606,11 @@ def main() -> None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        if config.layer_scale_init > 0.0:
+            for block_idx, block in enumerate(model.backbone.blocks):
+                if hasattr(block, "layer_scale_1"):
+                    epoch_metrics[f"layer_scale/block{block_idx}_attn_mean"] = float(block.layer_scale_1.data.mean().item())
+                    epoch_metrics[f"layer_scale/block{block_idx}_ffn_mean"] = float(block.layer_scale_2.data.mean().item())
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

LayerScale (Touvron et al., 2021 — CaiT) initializes per-channel learnable scalars (α, init=1e-4) on each residual branch output before the skip connection. This makes residual branches near-zero at init, effectively letting the model start as a near-linear function and gradually activate each layer's contribution as training proceeds.

For CFD surrogates with structured physics priors (pressure fields, boundary layers), this should help in two ways:
1. **Stability**: Early training oscillations in Lion-optimized TandemFoil runs (gc needed to prevent divergence) may reflect large residual magnitudes destabilizing the skip connections — LayerScale dampens this automatically.
2. **Depth utilization**: DrivAerML's 4L/512d model may not be fully utilizing all 4 layers at current hyperparameters. LayerScale lets deeper layers activate more selectively.

Paper: https://arxiv.org/abs/2103.17239 (CaiT, Touvron et al. 2021)

## Instructions

Add LayerScale to `target/icml2026/train.py` in the Transolver transformer block. Specifically:

In the `TransolverBlock` (or equivalent residual block), after each sub-layer output (attention + FFN), multiply by a learnable per-channel scalar initialized to `1e-4`:

```python
# In the block __init__:
self.layer_scale_1 = nn.Parameter(1e-4 * torch.ones(hidden_dim))
self.layer_scale_2 = nn.Parameter(1e-4 * torch.ones(hidden_dim))

# In forward, replace:
#   x = x + self.attn(self.norm1(x))
#   x = x + self.ffn(self.norm2(x))
# With:
x = x + self.layer_scale_1.unsqueeze(0).unsqueeze(0) * self.attn(self.norm1(x))
x = x + self.layer_scale_2.unsqueeze(0).unsqueeze(0) * self.ffn(self.norm2(x))
```

Run with `--wandb_group layerscale-cross-dataset` across all 3 datasets using their best known configs:

**Run 1 — TandemFoil (Lion, EMA, gc=0.5):**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999 \
  --wandb_group layerscale-cross-dataset
```

**Run 2 — AirfRANS (AdamW, T_max=50):**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw \
  --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema --enable-fourier --model-layers 2 \
  --model-hidden-dim 256 --model-heads 4 --epochs 999 \
  --wandb_group layerscale-cross-dataset
```

**Run 3 — DrivAerML (AdamW, 4L/512d, T_max=30):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 \
  --batch-size 1 --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group layerscale-cross-dataset
```

Distribute across available GPUs. Report val_primary metric for each dataset at best checkpoint.

## Baseline

| Dataset | Metric | Current Best | Best PR |
|---------|--------|-------------|---------|
| TandemFoil | val_primary/surface_pressure_mae | **22.537** | #2924 (Lion lr=1.25e-4, gc=0.5, EMA=0.999) |
| AirfRANS | val_primary/surface_mse | **0.000482** | #2951 (AdamW lr=6e-4, T_max=50) |
| DrivAerML | val_primary/surface_rel_l2_pct | **3.997%** | #2898 (AdamW lr=5e-4, 4L/512d, T_max=30) |

Lower is better on all metrics.