### PR TITLE
SDF wall-distance as physics input feature — cross-dataset geometry encoding

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -148,6 +148,7 @@ class TrainConfig:
     enable_vortex_panel_velocity: bool = False
     vortex_panel_scale: float = 0.1
     vortex_panel_n: int = 64
+    enable_wall_distance: bool = False
     enable_pressure_prior_addition: bool = False
     surface_refine: bool = True
     surface_refine_hidden: int = 128
@@ -226,6 +227,66 @@ class TargetTransform:
         if self.asinh_pressure and self.pressure_index is not None:
             out[..., self.pressure_index] = torch.sinh(out[..., self.pressure_index]) / max(self.asinh_scale, 1e-6)
         return out
+
+
+@torch.no_grad()
+def _compute_wall_distance_cases(
+    coords: torch.Tensor,
+    surface_coords: torch.Tensor,
+    mask: torch.Tensor,
+    surface_mask: torch.Tensor,
+    chunk_size: int = 4096,
+) -> torch.Tensor:
+    """Compute log-normalized wall distance per case in a batch.
+
+    Args:
+        coords: [B, N, D] coordinates of all query points
+        surface_coords: [B, M, D] coordinates of surface (wall) points
+        mask: [B, N] valid-point mask for query points
+        surface_mask: [B, M] valid-point mask for surface points
+        chunk_size: chunk size for cdist to avoid OOM
+
+    Returns:
+        [B, N, 1] log-normalized wall distance feature
+    """
+    B, N, D = coords.shape
+    result = coords.new_zeros(B, N, 1)
+    for b in range(B):
+        valid_surf = surface_coords[b][surface_mask[b].bool()]
+        if valid_surf.shape[0] == 0:
+            continue
+        dists = []
+        for i in range(0, N, chunk_size):
+            chunk = coords[b, i : i + chunk_size]
+            d = torch.cdist(chunk.unsqueeze(0).float(), valid_surf.unsqueeze(0).float())[0]
+            dists.append(d.min(dim=-1).values)
+        wd = torch.cat(dists, dim=0)
+        valid_wd = wd[mask[b].bool()]
+        mean_dist = valid_wd.mean().clamp(min=1e-8) if valid_wd.numel() > 0 else wd.new_tensor(1.0)
+        result[b, :, 0] = torch.log1p(wd / mean_dist)
+    return result
+
+
+def augment_batch_wall_distance(batch: "GroupedBatch") -> "GroupedBatch":
+    """Append wall-distance feature to surface_x (and volume_x if present).
+
+    Surface points are on the wall so their wall distance is 0.
+    Volume points get actual distance to nearest surface point.
+    """
+    space_dim = batch.space_dim
+    surf_coords = batch.surface_x[..., :space_dim]
+
+    surf_wd = batch.surface_x.new_zeros(*batch.surface_x.shape[:-1], 1)
+    batch.surface_x = torch.cat([batch.surface_x, surf_wd], dim=-1)
+
+    if batch.volume_x is not None and batch.volume_mask is not None:
+        vol_coords = batch.volume_x[..., :space_dim]
+        vol_wd = _compute_wall_distance_cases(
+            vol_coords, surf_coords, batch.volume_mask, batch.surface_mask,
+        )
+        batch.volume_x = torch.cat([batch.volume_x, vol_wd.to(batch.volume_x.dtype)], dim=-1)
+
+    return batch
 
 
 class TandemTargetTransform:
@@ -323,6 +384,11 @@ class TandemTargetTransform:
                 include_angle=self.config.enable_wake_angle,
             )
             x = torch.cat([x, wake_feats], dim=-1)
+        if self.config.enable_wall_distance:
+            wall_dist = _compute_wall_distance_cases(
+                raw_xy, raw_xy, full_mask, full_is_surface.bool(),
+            )
+            x = torch.cat([x, wall_dist.to(x.dtype)], dim=-1)
         if self.config.enable_fourier:
             x = append_batched_fourier_features(x)
 
@@ -829,6 +895,7 @@ def evaluate_grouped(
     *,
     amp_mode: str = "none",
     max_batches: int = 0,
+    enable_wall_distance: bool = False,
 ) -> dict[str, float]:
     model.eval()
     if anp_head is not None:
@@ -893,6 +960,8 @@ def evaluate_grouped(
                 count_volume += 1
             continue
 
+        if enable_wall_distance:
+            augment_batch_wall_distance(batch)
         with autocast_context(device, amp_mode):
             outputs = model(
                 surface_x=batch.surface_x,
@@ -1200,6 +1269,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    enable_wall_distance: bool = False,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1248,6 +1318,8 @@ def train_one_epoch(
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
                         loss, _ = loss_grouped_tandem(prepared, outputs)
                 else:
+                    if enable_wall_distance:
+                        augment_batch_wall_distance(batch)
                     with autocast_context(device, amp_mode):
                         outputs = model(
                             surface_x=batch.surface_x,
@@ -1385,6 +1457,7 @@ def evaluate_phase_metrics(
                 device,
                 amp_mode=config.amp_mode,
                 max_batches=config.max_eval_batches,
+                enable_wall_distance=config.enable_wall_distance,
             )
         metrics.update({f"{split_name}/{name}": value for name, value in split_metrics.items()})
         if phase == "val" and split_name in LEGACY_VAL_ALIAS and "mae_surf_p" in split_metrics:
@@ -1481,6 +1554,10 @@ def main() -> None:
         _ds.TandemFoilCaseDataset.__init__ = _patched_init
 
     bundle = build_bundle(config)
+    if config.enable_wall_distance:
+        bundle.spec.surface_input_dim += 1
+        if bundle.spec.volume_input_dim > 0:
+            bundle.spec.volume_input_dim += 1
     resolved_num_workers = resolve_num_workers(config, bundle.spec.name)
     if bundle.spec.name == "tandemfoilset":
         phys_stats = compute_tandem_phys_stats(
@@ -1568,6 +1645,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            enable_wall_distance=config.enable_wall_distance,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

**Signed Distance Function (SDF) / wall-distance as an explicit physics-informed input feature across CFD benchmarks.**

All current models rely on Fourier embeddings of raw coordinates. However, in CFD, the wall-distance (distance to the nearest solid boundary) is a physically fundamental quantity:

1. It governs boundary layer thickness and turbulence intensity (wall-distance appears explicitly in RANS turbulence models like k-ω SST)
2. It encodes geometry proximity in a way that polynomial/Fourier coordinates do not
3. It has been successfully used in Graph Neural Network CFD surrogates (MeshGraphNet variants) as a physics-informed feature

For 2D airfoil cases (TandemFoil, AirfRANS), wall distance can be computed as the minimum distance from each mesh point to the airfoil surface points. For 3D DrivAerML, the same applies to the car surface.

## Implementation

Compute wall-distance as a per-point feature during data loading and append it to the input feature vector:

```python
# During dataset preprocessing / feature construction:
# For each mesh point, compute minimum distance to any boundary/surface point.
# surface_points: [N_surf, 3] — the solid body surface coordinates
# volume_points:  [N_vol, 3]  — all mesh points

import torch

def compute_wall_distance(volume_points, surface_points):
    """
    Compute minimum distance from each volume point to any surface point.
    Returns wall_dist: [N_vol, 1]
    """
    # Chunked to avoid OOM on large meshes
    chunk_size = 4096
    dists = []
    for i in range(0, len(volume_points), chunk_size):
        chunk = volume_points[i:i+chunk_size]  # [chunk, 3]
        d = torch.cdist(chunk.unsqueeze(0), surface_points.unsqueeze(0))[0]  # [chunk, N_surf]
        dists.append(d.min(dim=-1).values)  # [chunk]
    wall_dist = torch.cat(dists, dim=0).unsqueeze(-1)  # [N_vol, 1]
    return wall_dist
```

Then concatenate `wall_dist` to the input features alongside coordinates and Fourier embeddings. Apply optional log-normalization since wall-distance has long-tail distribution: `log(1 + wall_dist / mean_dist)`.

## Runs (3 datasets)

Run these 3 jobs using `--wandb_group sdf-wall-distance-cross-dataset` on all runs.

### Run 1 — TandemFoil

```bash
python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.5 \
  --weight-decay 1e-2 \
  --model-slices 64 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --ema-decay 0.999 \
  --wandb_group sdf-wall-distance-cross-dataset
```

### Run 2 — AirfRANS

```bash
python train.py \
  --dataset airfrans \
  --airfrans-task full \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 2 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --epochs 999 \
  --wandb_group sdf-wall-distance-cross-dataset
```

### Run 3 — DrivAerML

```bash
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group sdf-wall-distance-cross-dataset
```

## Current Baselines

| Dataset | Metric | Current Best | Best PR |
|---------|--------|-------------|---------|
| TandemFoil | val_primary/surface_pressure_mae | 22.537 | #2924 |
| AirfRANS | val_primary/surface_mse | 0.000482 | #2951 |
| DrivAerML | val_primary/surface_rel_l2_pct | 3.997% | #2898 |

## Expected outcome

Wall-distance is a direct physical signal for boundary layer behavior. It should help most on AirfRANS and TandemFoil where wake/surface pressure gradients dominate error. DrivAerML will be an interesting test — if the 3D geometry is already well-captured by Fourier coordinates, the gain may be smaller.

**Key diagnostic**: Check whether the model error maps correlate with distance from the wall — if they do, this feature should help directly.

## Reporting

Please report:
1. W&B run IDs for all 3 datasets
2. Best val_primary metric for each dataset  
3. Whether implementation required log-normalization or raw wall-distance worked better
4. Error map plots comparing baseline vs this model near-wall vs far-field (if available)
