### PR TITLE
Relative L2 training loss to align DrivAerML objective with eval metric

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -165,6 +165,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
+    loss: str = "mse"
     seed: int = 0
 
 
@@ -737,21 +738,37 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def _rel_l2_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    return ((pred - target).norm(dim=-1) / (target.norm(dim=-1) + 1e-8)).mean()
+
+
+def _compute_loss(pred: torch.Tensor, target: torch.Tensor, loss_mode: str) -> torch.Tensor:
+    if loss_mode == "mse":
+        return F.mse_loss(pred, target)
+    elif loss_mode == "rel_l2":
+        return _rel_l2_loss(pred, target)
+    elif loss_mode == "mixed":
+        return 0.5 * F.mse_loss(pred, target) + 0.5 * _rel_l2_loss(pred, target)
+    else:
+        raise ValueError(f"Unknown loss mode: {loss_mode}")
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    loss_mode: str = "mse",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        surf_loss = _compute_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask], loss_mode)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
-        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
+        vol_loss = _compute_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask], loss_mode)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -761,15 +778,16 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    loss_mode: str = "mse",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
     if outputs["surface_preds"] is not None:
-        surf_loss = F.mse_loss(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask])
+        surf_loss = _compute_loss(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask], loss_mode)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
-        vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
+        vol_loss = _compute_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask], loss_mode)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -780,17 +798,18 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    loss_mode: str = "mse",
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
     if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
         surf_target = transform.apply(batch.surface_anchor_target)
-        surf_loss = F.mse_loss(outputs["surface_preds"], surf_target)
+        surf_loss = _compute_loss(outputs["surface_preds"], surf_target, loss_mode)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
-        vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
+        vol_loss = _compute_loss(outputs["volume_preds"], vol_target, loss_mode)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -1200,6 +1219,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    loss_mode: str = "mse",
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1233,7 +1253,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, loss_mode)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1246,7 +1266,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, loss_mode)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1255,7 +1275,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, loss_mode)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1568,6 +1588,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            loss_mode=config.loss,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The DrivAerML primary eval metric is `surface_rel_l2_pct` — a **relative** L2 error (normalized by target magnitude). However, training currently uses absolute MSE. This objective mismatch is a known source of degradation in surrogate regression: the model is penalized equally for errors on low-pressure and high-pressure regions, whereas the eval metric cares more about relative fidelity on each point.

Replacing MSE with a relative-L2 loss directly aligns the training signal with the evaluation signal and may also help TandemFoil because pressure variation across cases is large and absolute errors on high-Re regions dominate gradient updates.

Supporting reference: SMART paper (arxiv 2601.18707) shows relative-L2 objective alignment consistently outperforms MSE on surface regression tasks.

## Instructions

Add a `--loss` flag to `target/icml2026/train.py` supporting three modes:

- `mse` (default, existing behavior — do not change)
- `rel_l2`: replace training loss with `((pred - target).norm(dim=-1) / (target.norm(dim=-1) + 1e-8)).mean()`
- `mixed`: `0.5 * mse_loss + 0.5 * rel_l2_loss`

Run **four experiments** using `--wandb_group wave4-rel-l2-loss`:

### DrivAerML — two variants

**DM-rel_l2** — pure relative L2 loss:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --loss rel_l2 \
  --wandb_group wave4-rel-l2-loss
```

**DM-mixed** — 0.5 MSE + 0.5 rel_L2:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --loss mixed \
  --wandb_group wave4-rel-l2-loss
```

### TandemFoil — two variants

**TF-rel_l2** — pure relative L2 loss:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --loss rel_l2 \
  --wandb_group wave4-rel-l2-loss
```

**TF-mixed** — 0.5 MSE + 0.5 rel_L2:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure \
  --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --loss mixed \
  --wandb_group wave4-rel-l2-loss
```

## Implementation notes

- The `rel_l2` norm should be computed per-output-point, then averaged: `((pred - target).norm(dim=-1) / (target.norm(dim=-1) + 1e-8)).mean()`. The `dim=-1` is the feature/channel dimension.
- For `mixed`: compute both losses independently then average — do not scale or reweight further.
- eps = `1e-8` to avoid divide-by-zero on zero-valued target points.
- The `--loss` flag should only affect the **training** loss. All validation/test metrics should remain unchanged.
- If DrivAerML training diverges on `rel_l2` (loss > 10x initial value after 20 epochs), stop that run and try adding `--grad-clip 1.0`.

## Reporting

Please report for each run:
- Best `val_primary/surface_rel_l2_pct` (DrivAerML) and best epoch
- Best `val_primary/surface_pressure_mae` (TandemFoil) and best epoch
- W&B run IDs for all four runs
- Any training instability observations

## Baseline

### DrivAerML
- **Best**: `val_primary/surface_rel_l2_pct` = **3.997%** at epoch 467 (PR #2898, piccolo)
- External target: <3.71% (AB-UPT)

### TandemFoil
- **Best**: `val_primary/surface_pressure_mae` = **22.537** at epoch 336 (PR #2924, robin)