### PR TITLE
RMSNorm in place of LayerNorm across all 4 CFD benchmarks

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -33,6 +33,27 @@ from core.features import (
 from core.optim import Lion, Lookahead
 
 
+class RMSNorm(torch.nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.g = torch.nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        norm = torch.norm(x, dim=-1, keepdim=True) * (x.shape[-1] ** -0.5)
+        return x / norm.clamp(min=self.eps) * self.g
+
+
+def _replace_layernorm_in_transformer_blocks(model: torch.nn.Module) -> None:
+    for module in model.modules():
+        for attr_name in ("norm1", "norm2"):
+            sub = getattr(module, attr_name, None)
+            if isinstance(sub, torch.nn.LayerNorm):
+                dim = sub.normalized_shape[0]
+                new_norm = RMSNorm(dim).to(device=sub.weight.device, dtype=sub.weight.dtype)
+                setattr(module, attr_name, new_norm)
+
+
 class EMAWithWarmup:
     """EMA with timm-style adaptive decay warmup: min(target, (1+step)/(10+step))."""
 
@@ -166,6 +187,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    rmsnorm: bool = False
 
 
 @dataclass
@@ -1507,6 +1529,8 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.rmsnorm:
+        _replace_layernorm_in_transformer_blocks(model)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:


### PR DESCRIPTION
## Hypothesis

RMSNorm (Root Mean Square Layer Normalization) replaces LayerNorm by dropping the mean-centering step, computing only the RMS scale. It has fewer parameters, slightly lower compute, and empirically matches or exceeds LayerNorm on many transformer tasks. In physics surrogate models where features span large dynamic ranges (e.g. pressure fields), the centering step in LayerNorm may add noise. Replacing it with RMSNorm could improve training stability and final accuracy.

**Cross-dataset scope:** TandemFoil · TandemFoil Paper · AirfRANS · DrivAerML

---

## Instructions to the Student

Add a `--rmsnorm` boolean flag (default `False`) to `train.py`. When active, replace every `nn.LayerNorm` instance in the Transolver transformer blocks with `RMSNorm`:

```python
class RMSNorm(nn.Module):
    def __init__(self, dim, eps=1e-8):
        super().__init__()
        self.scale = dim ** 0.5
        self.eps = eps
        self.g = nn.Parameter(torch.ones(dim))

    def forward(self, x):
        norm = torch.norm(x, dim=-1, keepdim=True) * (x.shape[-1] ** -0.5)
        return x / norm.clamp(min=self.eps) * self.g
```

Apply consistently to every normalization layer in every transformer block. Do not change LayerNorm instances outside the transformer blocks (e.g. input/output projections) unless you find a strong reason to.

Use `--wandb_group rmsnorm-layer-norm` on all runs.

---

### TandemFoil

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame \
  --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --rmsnorm \
  --wandb_group rmsnorm-layer-norm
```

### TandemFoil Paper

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 150 --no-use-ema \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --epochs 999 \
  --rmsnorm \
  --wandb_group rmsnorm-layer-norm
```

### AirfRANS

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --rmsnorm \
  --wandb_group rmsnorm-layer-norm
```

### DrivAerML

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --no-use-ema \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --rmsnorm \
  --wandb_group rmsnorm-layer-norm
```

---

## Current Baselines (lower is better)

| Dataset | Metric | Current Best | PR |
|---|---|---|---|
| TandemFoil | `val_primary/surface_pressure_mae` | 22.537 | #2924 |
| TandemFoil Paper | `val_primary/field_mse` | 0.00434 | #2979 |
| AirfRANS | `val_primary/surface_mse` | 0.000482 | #2951 |
| DrivAerML | `val_primary/surface_rel_l2_pct` | 3.997% | #2898 |

---

## Reporting

When done, post results as a PR comment with:
- W&B run IDs for all runs
- Best val metric per dataset (RMSNorm vs LayerNorm baseline)
- Whether RMSNorm beat baseline on each dataset
- Any observations on training stability or convergence speed