### PR TITLE
Align TandemFoil benchmark contracts

### DIFF
--- a/analysis/AIRFRANS_BENCHMARK.md
+++ b/analysis/AIRFRANS_BENCHMARK.md
@@ -1,0 +1,366 @@
+# AirfRANS Benchmark History and Comparison Contract
+
+This note is aligned with the repo's current `STATUS_*` files and `analysis/ICML_2026_ABSTRACTS_PLAN.md`: for a paper-facing AirfRANS claim, the safe comparison contract is the official normalized-target `Surf MSE` plus `Vol MSE` on the official test split, not a surface-only number.
+
+## Executive Summary
+
+For a new paper on the official AirfRANS `full` task, the clean post-Transolver comparison set is narrower than a generic "AirfRANS papers" list, but it is not just two rows. The safe full-task apples-to-apples chain is `Transolver -> GeoANF -> SpiderSolver`.
+
+| Paper | Venue | Split / eval contract | Metric family | Surface reported? | Volume reported? | Apples-to-apples to official `Surf MSE` / `Vol MSE`? | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Transolver | ICML 2024 | Official `full` task; code follows AirfRANS split logic and scores on official test set | Official AirfRANS MSE family | Yes | Yes | Yes | Original published row is `Vol = 0.0037`, `Surf = 0.0142`. Repo README corrects the metric name: these are MSE, not Relative L2. |
+| SpiderSolver | NeurIPS 2025 | Official `full` task; code inherits the same split / test protocol | Official AirfRANS MSE family | Yes | Yes | Yes | Strongest clearly documented full-task result I found: `Vol = 0.0017`, `Surf = 0.0043`. |
+| GeoANF | Appl. Sci. 2024 | Explicitly says data configuration and metrics are aligned with AirfRANS; reports `full`, `reynolds`, and `aoa` tables | Official AirfRANS-style MSE family | Yes | Yes | Yes, with one wording caveat | Table 5 gives a directly comparable `full` row: `Vol = 0.0062`, `Surf = 0.0089`. The abstract also quotes `volume flow field MSE = 0.0038`, which should not be mixed with the aggregate `Vol MSE` row. |
+| GLOBE | arXiv 2025 | AirfRANS `full` and `scarce`, but headline tables are on validation set | Per-field z-score MSE, plus physically nondimensionalized MAE | Surface pressure only | Per-field volume only | No | Strong paper, but not a leaderboard-style `Surf MSE` / `Vol MSE` comparison. |
+| MARIO | 2025 | AirfRANS `scarce` task | Per-field MSE on normalized outputs | Surface pressure only | Per-field volume only | No for `full` benchmark; partial for `scarce` per-field comparisons | Commonly cited, but not the same benchmark target as full-task `Surf MSE` / `Vol MSE`. |
+| FLOW-GLIDE | Appl. Sci. 2025 | AirfRANS full / OOD tasks | Relative-L2 for `Volume` and `Surface` | Yes | Yes | No | Explicitly changes metric family away from official AirfRANS MSE. |
+
+If we want the safest apples-to-apples comparison in our paper, the main full-task table should include:
+
+- `Transolver`: `Surf MSE = 0.0142`, `Vol MSE = 0.0037` as the original published row.
+- `GeoANF`: `Surf MSE = 0.0089`, `Vol MSE = 0.0062` from the paper's AirfRANS-aligned full-task table.
+- `SpiderSolver`: `Surf MSE = 0.0043`, `Vol MSE = 0.0017`.
+
+If we want to mention the stronger `Transolver = 0.0080 / 0.0025` pair that appears in later citations and in our local AirfRANS notes, we should label it as a later cited / corrected Transolver baseline, not as the original ICML 2024 published row.
+
+## Official Benchmark Contract
+
+These are the details that have to match before two AirfRANS numbers are really comparable.
+
+### Tasks and splits
+
+From the official AirfRANS paper / repo:
+
+- `full`: 800 train, 200 test.
+- `scarce`: 200 train, same test set as `full`.
+- `reynolds`: train on mid-range Reynolds numbers, test on out-of-range Reynolds numbers.
+- `aoa`: train on mid-range angles of attack, test on out-of-range angles of attack.
+
+From the official code and the later Transolver / SpiderSolver codebases:
+
+- Training starts from the official task-specific train manifest.
+- The last 10% of that train manifest is carved out as validation.
+- Evaluation uses the official task test split.
+- Special case: `scarce` evaluates on `full_test`.
+
+So for the `full` task, the effective training recipe used by AirfRANS-style code is usually:
+
+- 720 training cases
+- 80 validation cases
+- 200 official test cases
+
+### Normalization
+
+The official AirfRANS `dataset.py` computes z-score normalization coefficients on the training data only:
+
+- input normalization: `mean_in`, `std_in`
+- output normalization: `mean_out`, `std_out`
+
+Then validation / test targets are normalized with those training-set coefficients.
+
+This matters because several later papers still use z-score-normalized targets, but not always with the same reporting format.
+
+### Metric aggregation
+
+The official AirfRANS `metrics.py` computes:
+
+- MSE separately on surface nodes and non-surface volume nodes
+- mean over output channels
+- then average over cases in the test loader
+
+So the official benchmark-style scalar metrics are:
+
+- `Surf MSE`: surface-node MSE on normalized targets
+- `Vol MSE`: non-surface-node MSE on normalized targets
+
+One source of historical confusion is that the original AirfRANS literature often reports per-field normalized MSEs such as `u_x`, `u_y`, `p`, `nu_t`, and `p_s`, while Transolver / SpiderSolver-style practical-design tables compress this into aggregate `Vol` and `Surf` scalars. Those two reporting styles should not be mixed without saying so explicitly.
+
+This is the contract our own repo notes are implicitly enforcing when they warn that surface-only numbers are not enough for a full benchmark claim.
+
+## Directly Comparable Post-Transolver Results
+
+These are the rows I would treat as genuinely valid full-task benchmark comparators.
+
+### 1. Transolver (ICML 2024)
+
+- Source: Transolver paper / AirfRANS repo.
+- Split / protocol: follows the AirfRANS task manifests, 10% validation carve-out, official test scoring.
+- Metric family: official AirfRANS MSE family.
+- Surface + volume: yes.
+
+Original published AirfRANS full-task row:
+
+- `Vol = 0.0037`
+- `Surf = 0.0142`
+- `C_L error = 0.1030`
+- `rho_L = 0.9978`
+
+Important caveat:
+
+- The Transolver AirfRANS README explicitly says the paper has a typo: the physics-field metrics are `MSE`, not `Relative L2`.
+
+### 2. GeoANF (Applied Sciences 2024)
+
+- Source: Applied Sciences 2024 paper.
+- Split / protocol: the paper states that the data configuration and metrics are fully aligned with the AirfRANS benchmark.
+- Metric family: official AirfRANS-style normalized-field MSE family.
+- Surface + volume: yes.
+
+The directly comparable full-task row in Table 5 is:
+
+- `Vol = 0.0062`
+- `Surf = 0.0089`
+- `C_L error = 0.1042`
+- `rho_L = 0.9998`
+
+Important caveat:
+
+- The abstract also quotes `volume flow field MSE = 0.0038` together with `surface pressure MSE = 0.0089`.
+- For benchmark history, the safer row to use is the paper's AirfRANS-aligned `Volume / Surface` table, not the abstract shorthand.
+
+### 3. SpiderSolver (NeurIPS 2025)
+
+- Source: NeurIPS 2025 poster plus released code.
+- Split / protocol: same AirfRANS-style split logic as Transolver, including the `scarce -> full_test` convention.
+- Metric family: official AirfRANS MSE family.
+- Surface + volume: yes.
+
+AirfRANS full-task row:
+
+- `Vol = 0.0017`
+- `Surf = 0.0043`
+- `C_L error = 0.0741`
+- `rho_L = 0.9988`
+
+This is the strongest clean full-task `Surf` / `Vol` result I found with clearly matching benchmark semantics.
+
+## Partially Comparable or Not Directly Comparable Papers
+
+These papers are still useful to mention in related work, but I would not mix their numbers into the main full-task `Surf MSE` / `Vol MSE` leaderboard without a caveat.
+
+### GLOBE (arXiv 2025 / PhysicsNeMo example)
+
+What matches:
+
+- Uses AirfRANS `full`, `scarce`, `reynolds`, and `aoa`.
+- Uses z-score-normalized field MSE in headline tables.
+
+Why it is not directly comparable to the Transolver / SpiderSolver full-task row:
+
+- The headline AirfRANS tables are validation-set tables, not official test-set leaderboard rows.
+- Reporting is per field: `u_x`, `u_y`, `p`, and `p_s`.
+- The paper also introduces physically nondimensionalized MAE tables, which are more interpretable but again a different contract.
+
+How I would use it:
+
+- Strong recent related work.
+- Do not place it in the same table as official full-test `Surf MSE` / `Vol MSE`.
+- It is reasonable to build a separate auxiliary table for `surface pressure` or per-field AirfRANS metrics, but only if we compare like-for-like:
+  - same split family
+  - same normalization
+  - same field (`p_s` or surface pressure only)
+  - same aggregation rule
+
+One concrete auxiliary comparison we can now justify is:
+
+| Method | Split / reporting contract | `p_s` z-score MSE | Safe to place in a GLOBE-style auxiliary table? | Notes |
+| --- | --- | --- | --- | --- |
+| GLOBE | `full` validation; per-field z-score MSE | `0.0039` | Yes | From GLOBE Table 3. |
+| Our repo, PR `#2771` / run `q4hytsr6` | `full` validation at best-val epoch; per-field normalized `p_s` MSE | `0.00588` | Yes | The PR comment explicitly labels this as the best-validation checkpoint surface-pressure breakdown. |
+| Transolver | `full` validation; per-field z-score MSE | `1.4200` | Yes | From the same GLOBE Table 3. |
+
+Important caveat:
+
+- this auxiliary table is useful for a `surface pressure only` comparison
+- it is **not** a substitute for the official full-test `Surf MSE` / `Vol MSE` table
+- the newer PR `#2824` comment also reports `surface_mse_p = 6.53e-3`, but its split labeling is less explicit than PR `#2771`, so `0.00588` is the cleaner field-level citation unless we re-pull the exact W&B summary
+
+### AB-UPT, Transolver++, and Transolver-3
+
+These are relevant CFD baselines, but not additional AirfRANS benchmark rows.
+
+- `AB-UPT` benchmarks `ShapeNet-Car`, `AhmedML`, and `DrivAerML`, then later `SHIFT-SUV` and `SHIFT-Wing`; I did not find an AirfRANS benchmark in the original paper or the automotive / aerospace follow-up.
+- `Transolver++` improves Transolver on six standard PDE benchmarks plus two industrial datasets, but the listed benchmarks are things like `Elasticity`, `Plasticity`, `Airfoil`, `Pipe`, `NS2d`, and `Darcy`, not AirfRANS.
+- `Transolver-3` benchmarks `NASA-CRM`, `AhmedML`, and `DrivAerML`, and compares against `AB-UPT` and `Transolver++` there, not on AirfRANS.
+
+### MARIO (2025)
+
+What matches:
+
+- Uses AirfRANS.
+- Uses MSE on normalized outputs.
+
+Why it is not a full-task benchmark comparator:
+
+- The main AirfRANS comparison is on the `scarce` task, not `full`.
+- Reporting is per field (`u_x`, `u_y`, `p`, `nu_t`, `p_s`), not official aggregate `Surf MSE` / `Vol MSE`.
+
+Useful recovered scarce-task values:
+
+- MARIO: `u_x = 0.152e-2`, `u_y = 0.113e-2`, `p = 0.240e-2`, `p_s = 2.700e-2`
+- Transolver in the same scarce-style table: `u_x = 2.105e-2`, `u_y = 2.108e-2`, `p = 4.434e-2`, `p_s = 23.670e-2`
+
+How I would use it:
+
+- Good for a scarce-task subsection.
+- Not valid as a replacement for full-task `Surf` / `Vol` benchmark rows.
+
+### FLOW-GLIDE (Applied Sciences 2025)
+
+Why I would exclude it from official benchmark comparison:
+
+- The paper explicitly defines `Volume` and `Surface` as relative-L2 errors.
+- That is not the official AirfRANS MSE family.
+
+How I would use it:
+
+- Mention only in a separate "different metric family" paragraph, or omit from a strict comparison table.
+- Do not try to back-compute official `Surf MSE` from the published relative-L2 number alone. That conversion is not identifiable without extra information such as raw predictions or the exact target norms and aggregation statistics used in evaluation.
+
+## Transolver Number Drift
+
+I found two different Transolver AirfRANS full-task rows in the literature:
+
+1. Original Transolver published row:
+   - `Vol = 0.0037`
+   - `Surf = 0.0142`
+
+2. Later cited row that appears in SpiderSolver and in our local AirfRANS notes:
+   - `Vol = 0.0025`
+   - `Surf = 0.0080`
+
+What I could verify directly:
+
+- The Transolver README corrects the metric type from `Relative L2` to `MSE`.
+- I did not find a first-party Transolver artifact in this pass that explains the numeric jump from `0.0037 / 0.0142` to `0.0025 / 0.0080`.
+
+Recommendation:
+
+- For a strict historical citation, use the original published Transolver row.
+- If we also mention the later `0.0025 / 0.0080` row because it appears in follow-on work and in our repo notes, we should label it explicitly as a later cited / corrected Transolver baseline.
+
+## Recommendation for Our Paper
+
+If our model is evaluated on the official AirfRANS `full` task and we compute the official normalized-target benchmark metrics, then:
+
+- headline comparison should use both `Surf MSE` and `Vol MSE`
+- the safest external baselines are `Transolver`, `GeoANF`, and `SpiderSolver`
+- `GLOBE`, `MARIO`, and `FLOW-GLIDE` should not be mixed into the same main comparison table without an explicit note about different split / aggregation / metric contracts
+
+Concretely, the cleanest paper table for us is probably:
+
+- `Our model`
+- `Transolver`
+- `GeoANF`
+- `SpiderSolver`
+- optional footnote for later cited `Transolver = 0.0080 / 0.0025`
+
+And the repo's current status notes are right about one important thing:
+
+- a surface-only score is not enough to claim a full AirfRANS benchmark win
+
+## Are Our Repo Metrics Comparable?
+
+Short answer:
+
+- **split comparability:** yes
+- **metric-family comparability:** yes on the current AirfRANS scorer
+- **current scientific status:** yes on `Surf MSE`, no on the full `Surf MSE + Vol MSE` pair
+
+Why the split is comparable:
+
+- `target/icml2026/airfrans/data/split_airfrans.py` is generated from the official AirfRANS `manifest.json`
+- it preserves the official task train/test lists
+- it uses the same deterministic tail-10% validation carve-out as the official AirfRANS / Transolver / SpiderSolver code
+- it preserves the benchmark rule `scarce_test = full_test`
+
+Why the metric calculation is comparable:
+
+- `target/icml2026/airfrans/data/prepare_airfrans.py` computes target stats from the AirfRANS training split only
+- `target/icml2026/train.py` now evaluates AirfRANS in an explicit official-metric space:
+  - model outputs are decoded back to raw target space
+  - benchmark metrics are then recomputed with the official train-stat z-score transform
+  - per-case channel means are averaged into `surface_mse` and `volume_mse`
+- that means paper-facing AirfRANS metrics stay benchmark-faithful even if training uses a different target transform
+
+Important repo caveat, now addressed in code:
+
+- the shared trainer supports an optional `asinh_pressure` transform
+- training may still use that flag
+- benchmark reporting should not
+- the repo scorer now enforces this separation for AirfRANS evaluation, so `surface_mse` and `volume_mse` stay on the official contract
+- for historical runs logged before this fix, we should still verify the config before citing a number in the paper
+
+Follow-up verification on the cited frontier run:
+
+- PR `#2824`'s published command for run `3e0ce368` does **not** include `--asinh_pressure`, so that specific cited run was already on the benchmark-faithful target path
+- the same PR comment also exposes a per-field row at the best checkpoint, including `surface_mse_p = 6.53e-3`
+- that means the repo does have the ingredients for a GLOBE-style auxiliary `surface pressure` table
+- however, the status memos still headline aggregate `surface_mse`, not the exact validation-side `surface_mse_p` number needed for a fully like-for-like GLOBE comparison table
+
+## Current Repo Numbers
+
+The latest status memo family gives two slightly different things:
+
+- the **newest status memo** gives the latest surface headline
+- the **most recent status memo that still reports the full pair** gives the latest explicit `surface + volume` comparison
+
+| Source | Provenance | `Surf MSE` | `Vol MSE` | Fully comparable to official full-task literature table? | Interpretation |
+| --- | --- | --- | --- | --- | --- |
+| Repo latest surface headline | `STATUS_2026-04-22-0923` and `STATUS_2026-04-22-0008`, run `3e0ce368` / PR `#2824` | `0.002999` | not reported in newest memo | Surface-only: yes. Full pair: not enough evidence from that memo alone. | Strong latest surface result; better than SpiderSolver's `0.0043` on surface alone. |
+| Repo latest explicit full pair | `STATUS_2026-04-21-1759`, PR `#2824` | `0.003` | `0.00764` | Yes, assuming default AirfRANS target transform was used. | Beats the external surface target but misses the external volume target badly. |
+| Repo multi-seed follow-up | `STATUS_2026-04-21-1759`, PR `#2831` | `0.00333 / 0.00668 / 0.00857` | `0.00886 / 0.00901 / 0.01709` | Yes for metric family, again assuming default transform. | Confirms the surface win is real, but also confirms volume is still the blocker. |
+
+So the current paper-safe summary of our own AirfRANS position is:
+
+- **surface:** competitive and apparently better than the published `0.0043` reference
+- **volume:** still far from the published `0.0017` reference
+- **full benchmark claim:** not yet
+
+If we want one compact comparison table for the paper draft right now, this is the honest version:
+
+| Method | `Surf MSE` | `Vol MSE` | Status |
+| --- | --- | --- | --- |
+| Transolver (published row) | `0.0142` | `0.0037` | baseline |
+| SpiderSolver | `0.0043` | `0.0017` | strongest clean published full-task reference |
+| Ours (latest surface headline) | `0.002999` | `—` | surface-only headline, not enough for full-pair claim |
+| Ours (latest explicit full pair) | `0.003` | `0.00764` | better on surface, much worse on volume |
+
+## Sources
+
+- Local repo context:
+  - `analysis/ICML_2026_ABSTRACTS_PLAN.md`
+  - `analysis/STATUS_*`
+  - `target/icml2026/airfrans/program.md`
+- Official AirfRANS:
+  - [AirfRANS README](https://github.com/Extrality/AirfRANS)
+  - [AirfRANS paper (arXiv)](https://arxiv.org/abs/2212.07564)
+  - [AirfRANS NeurIPS / paper PDF](https://papers.nips.cc/paper_files/paper/2022/file/94ab7b23a345f93333eac8748a66c763-Paper-Datasets_and_Benchmarks.pdf)
+  - [AirfRANS main.py](https://raw.githubusercontent.com/Extrality/AirfRANS/main/main.py)
+  - [AirfRANS dataset.py](https://raw.githubusercontent.com/Extrality/AirfRANS/main/dataset.py)
+  - [AirfRANS metrics.py](https://raw.githubusercontent.com/Extrality/AirfRANS/main/metrics.py)
+- Transolver:
+  - [Transolver paper](https://arxiv.org/abs/2402.02366)
+  - [Transolver AirfRANS README](https://raw.githubusercontent.com/thuml/Transolver/main/Airfoil-Design-AirfRANS/README.md)
+  - [Transolver AirfRANS main.py](https://raw.githubusercontent.com/thuml/Transolver/main/Airfoil-Design-AirfRANS/main.py)
+- SpiderSolver:
+  - [SpiderSolver README](https://raw.githubusercontent.com/Kai-Qi/SpiderSolver/main/README.md)
+  - [SpiderSolver poster](https://neurips.cc/media/PosterPDFs/NeurIPS%202025/116641.png)
+  - [SpiderSolver AirfRANS training script](https://raw.githubusercontent.com/Kai-Qi/SpiderSolver/main/AirfRANS/main_SpiderSolver_Airfoil.py)
+  - [SpiderSolver AirfRANS evaluation script](https://raw.githubusercontent.com/Kai-Qi/SpiderSolver/main/AirfRANS/main_evaluation.py)
+- GeoANF:
+  - [GeoANF paper](https://www.mdpi.com/2076-3417/14/22/10685)
+- MARIO:
+  - [MARIO paper](https://arxiv.org/abs/2505.14704)
+  - [ar5iv HTML](https://ar5iv.labs.arxiv.org/html/2505.14704v1)
+- GLOBE:
+  - [GLOBE paper](https://arxiv.org/abs/2511.15856)
+  - [GLOBE HTML](https://arxiv.org/html/2511.15856)
+  - [PhysicsNeMo AirFRANS example](https://docs.nvidia.com/physicsnemo/latest/physicsnemo/examples/cfd/external_aerodynamics/globe/airfrans/README.html)
+- FLOW-GLIDE:
+  - [FLOW-GLIDE paper](https://www.mdpi.com/2076-3417/15/19/10834)
+- Other related CFD surrogate families:
+  - [AB-UPT paper](https://arxiv.org/abs/2502.09692)
+  - [AB-UPT for Automotive and Aerospace Applications](https://arxiv.org/abs/2510.15808)
+  - [Transolver++ paper](https://arxiv.org/abs/2502.02414)
+  - [Transolver-3 paper](https://arxiv.org/abs/2602.04940)

--- a/analysis/DRIVAERML_BENCHMARK.md
+++ b/analysis/DRIVAERML_BENCHMARK.md
@@ -1,0 +1,400 @@
+# DrivAerML Benchmark History and Comparison Contract
+
+This note mirrors `AIRFRANS_BENCHMARK.md`, but DrivAerML needs a stricter caveat up front:
+there is no single canonical public scalar in the literature analogous to AirfRANS
+`Surf MSE` / `Vol MSE`. Instead, papers report a family of per-field relative-L2 metrics,
+usually on surface pressure, wall shear stress, velocity, and volume pressure.
+
+For our current repo, the only paper-safe direct comparison object is:
+
+- **surface pressure relative-L2 (%)**
+- averaged **per case**
+- on the public `400 train / 34 effective val / 50 test` split family
+- computed on **unnormalized** predictions and targets
+
+That means DrivAerML should currently be written as a **surface-pressure transfer benchmark**,
+not as a full multi-field benchmark win.
+
+## Executive Summary
+
+The clean literature history is not a single ladder. It breaks into three tiers:
+
+1. **Early / broader DrivAerML context**
+   - `X-MeshGraphNet`
+   - `DoMINO`
+   - `A Benchmarking Framework for AI models in Automotive Aerodynamics`
+2. **Direct public-split surface-pressure comparators**
+   - `AB-UPT`
+   - `Transolver-3`
+3. **Our current repo position**
+   - best provenanced test: `6.244%`
+   - best provenanced validation: `4.6190%`
+
+If we want the safest paper table right now, it should be:
+
+| Method | `p_s` relative-L2 (%) | Directly comparable to our current repo? | Notes |
+| --- | --- | --- | --- |
+| AB-UPT | `3.82` | Yes | First strong public-split benchmark row. |
+| Transolver-3 | `3.71` | Yes | Strongest directly comparable published `p_s` row I found. |
+| Ours | `6.244` | Yes | Current best provenanced test result in local status / PR history. |
+
+If we want extra historical context, we can add later baseline rows recovered from
+the later `AB-UPT` / `Transolver-3` comparison family:
+
+- `Transolver`: `4.81`
+- `Transolver++`: `4.12`
+
+But those two should be labeled as **secondary-provenance baseline rows**, not as the
+canonical standalone DrivAerML benchmark publications.
+
+## Literature Map
+
+| Paper / result | Venue | Split / eval contract | Surface pressure reported? | Surface + volume coverage? | Directly comparable to our current repo `surface_rel_l2_pct`? | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| X-MeshGraphNet | arXiv 2024 | DrivAerML surface-field study, but not a clean public `400 / 34 / 50` benchmark row | not a stable paper-facing scalar to cite | surface only | No | Important early DrivAerML surrogate paper, but not the row I would use in a comparison table. |
+| DoMINO | arXiv 2025 | Relative-L2 on DrivAerML, with a different split story and strong OOD emphasis | Yes: `p_s = 15.05%` (`11.81%` area-weighted) | Yes | No | First strong quantitative surface+volume DrivAerML field baseline I found. |
+| Benchmarking Framework | arXiv 2025 | common validation benchmark inside PhysicsNeMo-CFD; different split and metric suite | Yes | Yes | No | Best apples-to-apples multi-model paper, but not the same public `400 / 34 / 50` test contract. |
+| Transolver baseline inside AB-UPT | TMLR 2025 | public `400 train / 34 effective val / 50 test`; mean per-case relative-L2 on unnormalized targets | Yes: `p_s = 4.81%` | partial in main table | Yes | Best direct provenance I found for a non-Transolver-paper DrivAerML `Transolver` row. |
+| AB-UPT | TMLR 2025 | public `400 train / 34 effective val / 50 test`; mean per-case relative-L2 on unnormalized targets | Yes: `p_s = 3.82%` | Yes | Yes | First strong directly comparable public-split row. |
+| Transolver-3 | arXiv 2026 | same `400 / 34 / 50` public contract; mean per-case relative-L2 on unnormalized targets | Yes: `p_s = 3.71%` | Yes | Yes | Strongest directly comparable surface-pressure reference I found. |
+| Ours, latest best reported test | local status / PR ledger | repaired public split; mean per-case relative-L2 on unnormalized `surface_cp` | Yes: `6.244%` | No benchmark-comparable volume story | Yes, on surface pressure only | Still behind the published public-split benchmark band. |
+
+## What Counts As A Valid Comparison?
+
+These pieces need to line up before two DrivAerML numbers are honestly comparable.
+
+### Split protocol
+
+From the later public-split literature used by `AB-UPT` and `Transolver-3`:
+
+- total cases: `500`
+- training: `400`
+- test: `50`
+- validation: `50`, but `16` are hidden / unavailable
+- effective public validation: `34`
+
+Our packaged public processed split now matches that repaired public contract:
+
+- `400 train`
+- `34 val`
+- `50 test`
+- `0` excluded repaired public cases
+
+Relevant local files:
+
+- `target/icml2026/drivaerml/data/split_drivaerml.py`
+- `target/icml2026/drivaerml/data/split_manifest_drivaerml.json`
+- `target/icml2026/core/datasets.py`
+
+### Metric family
+
+The directly relevant DrivAerML papers use:
+
+- per-case relative-L2 on **unnormalized** targets and predictions
+- averaged across cases
+- reported on the percent scale
+
+Formally:
+
+- `rel_l2_case = 100 * ||Y_hat - Y||_2 / ||Y||_2`
+- dataset score = arithmetic mean of `rel_l2_case` over the evaluation split
+
+Important details:
+
+- this is **not** an MSE benchmark like AirfRANS
+- this is **not** a pooled-all-points global relative-L2
+- chunked inference is allowed only if the full case is reconstructed before computing
+  the case-level ratio
+
+### Target family
+
+The literature is broader than our current repo target.
+
+Common published DrivAerML quantities:
+
+- surface pressure `p_s`
+- wall shear stress `tau`
+- volume velocity `u`
+- volume pressure `p_v`
+- sometimes vorticity `omega`
+
+Our current repo target is narrower:
+
+- packaged `surface_cp.npy`
+- surface-first by default
+- optional small processed volume subset only
+
+So the paper-safe statement is:
+
+- **surface pressure comparison:** yes
+- **full multi-field DrivAerML comparison:** not yet
+
+## Literature History
+
+### Is there an original Transolver DrivAerML benchmark?
+
+Not as a clean standalone benchmark row that I would cite.
+
+What I could verify:
+
+- the original `Transolver` paper says the method excels on large-scale industrial
+  simulations including car design
+- but I did **not** find a published DrivAerML table row in that original paper
+- the original automotive benchmark associated with `Transolver` is the earlier car-design
+  family, not the later public DrivAerML benchmark contract
+
+So for DrivAerML specifically, the correct citation pattern is:
+
+- **not** "original Transolver paper benchmarked DrivAerML"
+- **yes** "later papers trained / evaluated Transolver on DrivAerML as a baseline"
+
+### 1. X-MeshGraphNet (arXiv 2024)
+
+This is the earliest DrivAerML surrogate paper in the chain I found.
+
+Why it matters:
+
+- it establishes DrivAerML as a serious ML surrogate benchmark
+- it predicts surface pressure and wall-shear-related fields
+
+Why I would not use it as a main numeric baseline:
+
+- I did not find a clean public-split `400 / 34 / 50` benchmark row to cite in the same
+  paper-facing way as `AB-UPT` or `Transolver-3`
+- it is better treated as early context than as the benchmark anchor for our table
+
+### 2. DoMINO (arXiv 2025)
+
+This is the first strong quantitative DrivAerML **surface + volume** field baseline I found.
+
+Reported test metrics include:
+
+- surface pressure `p_s = 0.1505` (`15.05%`)
+- area-weighted surface pressure `0.1181` (`11.81%`)
+- volume pressure `p_v = 0.2193` (`21.93%`)
+- volume velocity:
+  - `u_x = 0.2397`
+  - `u_y = 0.5025`
+  - `u_z = 0.4567`
+
+Why it is only partial context for us:
+
+- it is not the same clean public benchmark split story used later by `AB-UPT` and
+  `Transolver-3`
+- `AB-UPT` explicitly notes that the DoMINO comparison split contains a `20%` OOD subset
+  chosen by drag-force range
+
+So I would cite DoMINO as:
+
+- the first strong multi-field DrivAerML baseline
+- **not** the main apples-to-apples comparator for our current repo table
+
+### 3. A Benchmarking Framework for AI models in Automotive Aerodynamics (arXiv 2025)
+
+This is the best multi-model DrivAerML benchmarking paper I found.
+
+What it adds:
+
+- common evaluation of `DoMINO`, `X-MeshGraphNet`, and `FIGConvNet`
+- both surface and volume metrics
+- additional engineering metrics such as drag / lift correlations
+
+Representative validation metrics from the paper:
+
+- surface pressure relative-L2:
+  - `X-MeshGraphNet = 0.14`
+  - `FIGConvNet = 0.21`
+  - `DoMINO = 0.10`
+- area-weighted surface pressure relative-L2:
+  - `X-MeshGraphNet = 0.14`
+  - `FIGConvNet = 0.14`
+  - `DoMINO = 0.08`
+- volume pressure relative-L2 for `DoMINO`:
+  - `0.1042`
+
+Why it is not our main table:
+
+- it uses a different split / benchmark harness (`436 train / 48 validation` in the paper)
+- it is a **validation benchmark**, not the later public `400 / 34 / 50` test contract
+
+So I would use it as:
+
+- the best broader-literature context section
+- not the primary direct comparison table for our current repo
+
+### 4. AB-UPT (TMLR 2025)
+
+This is the first strong DrivAerML paper that lines up well with our current repo metric.
+
+Importantly for your question, `AB-UPT` does **not** only compare against abstract
+families; it explicitly benchmarks a `Transolver` baseline on DrivAerML.
+
+Public DrivAerML row:
+
+- `p_s = 3.82`
+- `u = 5.93`
+- `omega = 35.1`
+- `tau = 7.29`
+- `p_v = 6.08`
+
+Why it is directly relevant:
+
+- split is the public `400 / 34 / 50` family
+- metric is mean per-case relative-L2 on unnormalized predictions / targets
+- it reports the exact surface pressure quantity we can currently compare
+
+Important nuance:
+
+- AB-UPT is a **full surface + volume** model
+- our current repo is only directly comparable on `p_s`
+
+AB-UPT also provides the cleanest direct-provenance `Transolver` baseline row I found on
+DrivAerML:
+
+- `Transolver` on DrivAerML:
+  - `p_s = 4.81`
+  - `u = 6.78`
+  - `omega = 38.4`
+
+Why this matters:
+
+- this is not just a row copied from another paper; AB-UPT states that it benchmarks
+  `Transolver` against the other neural surrogates on the same public-split DrivAerML
+  contract
+- AB-UPT also states that it does **not** include `Transolver++` there because of
+  reproducibility issues
+
+So if we want to include a `Transolver` DrivAerML row in our paper, the strongest
+provenance is:
+
+- cite `AB-UPT` for the `Transolver` baseline
+- label it as a later benchmarked baseline, not as an original Transolver-paper result
+
+### 5. Transolver-3 (arXiv 2026)
+
+This is the strongest directly comparable DrivAerML surface-pressure reference I found.
+
+DrivAerML Table 4 row:
+
+- `p_s = 3.71`
+- `u = 4.14`
+- `tau = 5.85`
+- `p_v = 5.72`
+
+Why it matters:
+
+- same public `400 / 34 / 50` split family
+- same per-case relative-L2 on unnormalized targets
+- strongest surface-pressure row among the directly comparable papers I found
+
+It also gives useful secondary-provenance baseline rows:
+
+| Method | `p_s` | `u` | `tau` | `p_v` | How to use it |
+| --- | --- | --- | --- | --- | --- |
+| Transolver | `4.81` | `6.78` | `8.95` | `7.74` | Historical context only; same surface-pressure / velocity baseline family, with additional field coverage in the later paper. |
+| Transolver++ | `4.12` | `4.70` | `6.42` | `6.70` | Historical context only; recovered from later comparison table. |
+
+This gives us a clean provenance story:
+
+- `Transolver` baseline on DrivAerML exists in `AB-UPT`
+- `Transolver-3` later extends the comparison family and adds a broader field table
+- `Transolver++` only appears in the later `Transolver-3` comparison table, not in the
+  original `AB-UPT` benchmark table
+
+## Are Our Repo Metrics Comparable?
+
+Short answer:
+
+- **split comparability:** yes
+- **metric comparability:** yes, for surface pressure
+- **full-task comparability:** no, because our repo is still surface-first on DrivAerML
+
+Why the split is comparable:
+
+- `target/icml2026/drivaerml/data/split_drivaerml.py` enforces the repaired public
+  `400 / 34 / 50` contract
+- `target/icml2026/core/datasets.py` validates the manifest against the restored public
+  case IDs and requires `excluded_case_count = 0`
+
+Why the metric is comparable:
+
+- `target/icml2026/train.py` computes DrivAerML paper-facing metrics on
+  **unnormalized** targets and predictions
+- when point-limited evaluation is enabled, the trainer stores numerator /
+  denominator pieces per case and reconstructs the exact full-case relative-L2 before
+  averaging
+- that matches the `AB-UPT` / `Transolver-3` metric contract for `p_s`
+
+Where the repo still diverges from the broader literature:
+
+- the packaged sprint path is surface-first
+- the processed volume subset is tiny (`15 train / 1 val`) and has no benchmark-grade
+  public test contract
+- so we should not imply a multi-field DrivAerML comparison yet
+
+## Current Repo Position
+
+The latest `STATUS_*` files and PR ledger give a consistent picture:
+
+- best provenanced validation: `4.618963354953193`
+  - run `k8qtsxxz`
+  - PR `#2691`
+- best provenanced test: `6.244070498131545`
+  - run `qx7z7if3`
+  - PR `#2648`
+
+There is also a same-day advisor issue draft that mentions a stronger approximate line
+around `3.997%` validation and `5.93%` final test for a "no-compile AdamW" family, but
+it does not currently have the same run-level provenance, so I would **not** use that in
+the paper table without confirming the exact run / PR first.
+
+| Source | Provenance | `surface_rel_l2_pct` | Directly comparable to published `p_s` rows? | Interpretation |
+| --- | --- | --- | --- | --- |
+| Repo best reported test | `STATUS_2026-04-22-0923` and `STATUS_2026-04-22-0008`, run `qx7z7if3`, PR `#2648` | `6.244%` | Yes | Current best reportable test result, but still well above `3.71%` / `3.82%`. |
+| Repo best reported validation | `STATUS_2026-04-22-0008`, run `k8qtsxxz`, PR `#2691` | `4.6190%` | Not directly, because it is validation not test | Shows the stack can enter the mid-4% regime, but the test story did not move with it. |
+| PR `#2691` best-checkpoint test | run `k8qtsxxz` | `6.29%` | Yes | Better validation than older runs, but not a new test breakthrough. |
+
+So the honest current paper summary is:
+
+- **surface pressure:** benchmark-comparable metric, but still behind the published frontier
+- **volume / wall shear / integrated quantities:** not yet a valid repo-level comparison story
+- **DrivAerML role in the paper today:** transfer evidence with caveats, not a benchmark win
+
+## Recommendation For Our Paper
+
+If we write DrivAerML with the same discipline as AirfRANS, the safest approach is:
+
+- compare **only** `surface pressure relative-L2 (%)`
+- use `AB-UPT` and `Transolver-3` as the main published anchors
+- optionally add `Transolver` and `Transolver++` as later-table historical baselines
+- keep `DoMINO` and the `Benchmarking Framework` in a broader-context subsection, not in
+  the same main benchmark table
+- state explicitly that our current repo target is **surface-first**, not the full
+  multi-field DrivAerML task
+
+The cleanest direct-comparison table right now is:
+
+| Method | `p_s` relative-L2 (%) | Note |
+| --- | --- | --- |
+| Transolver baseline (reported by AB-UPT) | `4.81` | later benchmarked baseline, not an original Transolver-paper DrivAerML row |
+| AB-UPT | `3.82` | first strong public-split benchmark anchor |
+| Transolver-3 | `3.71` | strongest directly comparable published row I found |
+| Ours | `6.244` | current best provenanced test |
+
+## Sources
+
+- Local repo context:
+  - `analysis/STATUS_2026-04-22-0008_radford_post_restart_metric_update.md`
+  - `analysis/STATUS_2026-04-22-0923_radford_live_status_after_cross_dataset_wave.md`
+  - `analysis/ADVISOR_ISSUE_2026-04-22_drivaerml_sampling_and_tandem_debugging.md`
+  - `target/icml2026/drivaerml/program.md`
+- DrivAerML dataset:
+  - [DrivAerML paper](https://arxiv.org/abs/2408.11969)
+- Early / broader DrivAerML surrogate papers:
+  - [X-MeshGraphNet](https://arxiv.org/abs/2411.17164)
+  - [DoMINO](https://arxiv.org/abs/2501.13350)
+  - [A Benchmarking Framework for AI models in Automotive Aerodynamics](https://arxiv.org/abs/2507.10747)
+- Direct public-split comparators:
+  - [AB-UPT (OpenReview)](https://openreview.net/forum?id=nwQ8nitlTZ)
+  - [AB-UPT (arXiv)](https://arxiv.org/abs/2502.09692)
+  - [Transolver-3](https://arxiv.org/abs/2602.04940)

--- a/analysis/TANDEMFOILSET_BENCHMARK.md
+++ b/analysis/TANDEMFOILSET_BENCHMARK.md
@@ -1,0 +1,194 @@
+# TandemFoilSet Benchmark Notes
+
+This repo now has **two distinct TandemFoilSet benchmark contracts**. They are
+both useful, but they are **not numerically interchangeable**.
+
+## Executive summary
+
+- The **original TandemFoilSet paper** benchmark relevant to our repo is
+  Experiment 4 / Table 6.
+- That paper-facing contract uses **test MSE on the full flow field**, not a
+  surface-only metric.
+- Our literature-facing reproduction target is
+  [`target/icml2026/tandemfoil_paper/`](../target/icml2026/tandemfoil_paper/program.md).
+  Its primary metric is `field_mse`.
+- Our main ICML sprint target is
+  [`target/icml2026/tandemfoil/`](../target/icml2026/tandemfoil/program.md).
+  It intentionally uses a different split family and a different metric:
+  denormalized `surface_pressure_mae` on the public `kagent` v2 split design.
+- Do **not** compare `tandemfoil/ surface_pressure_mae` directly against the
+  paper’s Table 6 `field_mse`.
+
+## 1. Original paper contract
+
+Primary source:
+
+- TandemFoilSet paper: [OpenReview PDF](https://openreview.net/pdf?id=4Z0P4Nbosn)
+
+### What the paper actually reports
+
+The relevant paper statements are:
+
+- datasets are “uniformly sampled in a `8:1:1` ratio for training, validation,
+  and test sets, respectively, unless otherwise stated”
+- Experiment 4 uses:
+  - uniform sampling for `cruise_random_uniform` and `racecar_uniform`
+  - top and bottom `5%` tails of a selected variable as `test` for the
+    extrapolation tasks
+  - the middle `90%` uniformly split into train/val
+- the training appendix says the model predicts three fields:
+  `[Ux, Uy, p]`
+- the training appendix also says a “standard z-score style normalisation” is
+  used with the **training-set mean and standard deviation**
+- Experiment 4 says “Table 6 shows that the `MSE` test losses are higher...”
+- later, the appendix introduces **boundary MSE** separately for the
+  three-airfoil extension, which supports reading Table 6 as the overall
+  full-field metric rather than a surface-only one
+
+### Paper tasks and reference numbers
+
+| Task | Split style | Paper baseline | Paper best |
+| --- | --- | ---: | ---: |
+| `cruise_random_uniform` | uniform `8:1:1` | `1.79 ± 1.38` | `0.10 ± 0.13` |
+| `cruise_random_aoa_extrap` | lowest/highest `5%` AOA tails to test | `2.03 ± 1.96` | `0.18 ± 0.24` |
+| `cruise_random_re_extrap` | lowest/highest `5%` Re tails to test | `4.85 ± 1.82` | `0.36 ± 0.53` |
+| `cruise_random_stagger_extrap` | lowest/highest `5%` stagger tails to test | `1.74 ± 1.66` | `0.13 ± 0.17` |
+| `cruise_random_gap_extrap` | lowest/highest `5%` gap tails to test | `1.95 ± 1.68` | `0.14 ± 0.20` |
+| `racecar_uniform` | uniform `8:1:1` | `0.61 ± 0.51` | `0.21 ± 0.29` |
+
+### Repo reproduction target: `tandemfoil_paper`
+
+Relevant local docs:
+
+- [`target/icml2026/tandemfoil_paper/program.md`](../target/icml2026/tandemfoil_paper/program.md)
+- [`target/icml2026/tandemfoil_paper/data/README.md`](../target/icml2026/tandemfoil_paper/data/README.md)
+- [`target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py`](../target/icml2026/tandemfoil_paper/data/split_paper_experiment4.py)
+
+Repo contract:
+
+- primary metric: `field_mse`
+- definition: normalized full-field MSE over all valid nodes and all three
+  channels `[Ux, Uy, p]`
+- normalization: task-local train-set `y_mean` / `y_std`
+- auxiliary diagnostics:
+  - `surface_mse`
+  - `volume_mse`
+- if training enables an extra target transform such as `--asinh-pressure`,
+  paper-facing evaluation must still decode predictions back to raw target space
+  and recompute `field_mse` in the paper’s plain z-score space
+
+Current status:
+
+- no clean literature-facing benchmark result yet
+- latest memo:
+  [`STATUS_2026-04-22-0923_radford_live_status_after_cross_dataset_wave.md`](./STATUS_2026-04-22-0923_radford_live_status_after_cross_dataset_wave.md)
+  says the lane is still immature
+- best visible debug check there is `test_primary/field_mse = 0.151`
+
+## 2. Packaged parity contract
+
+Primary local docs:
+
+- [`target/icml2026/tandemfoil/program.md`](../target/icml2026/tandemfoil/program.md)
+- [`target/icml2026/tandemfoil/data/README.md`](../target/icml2026/tandemfoil/data/README.md)
+- [`target/icml2026/tandemfoil/data/split_manifest_tandemfoilset_v2.json`](../target/icml2026/tandemfoil/data/split_manifest_tandemfoilset_v2.json)
+- public split rationale:
+  [`kagent` SPLITS.md](https://github.com/tcapelle/kagent/blob/main/cfd-competition/organizer/SPLITS.md)
+
+This is the active `tandemfoil/` target used for the ICML sprint parity story.
+It follows the public `kagent` split design, not the original paper’s Experiment
+4 split family.
+
+### Active split family
+
+Balanced validation and test tracks:
+
+| Split | Cases | What it tests |
+| --- | ---: | --- |
+| `val_single_in_dist` / `test_single_in_dist` | `100 / 200` | single-foil interpolation sanity check |
+| `val_geom_camber_rc` / `test_geom_camber_rc` | `100 / 200` | race-car tandem geometry generalization to unseen front-foil camber |
+| `val_geom_camber_cruise` / `test_geom_camber_cruise` | `100 / 200` | cruise tandem geometry generalization to unseen front-foil camber |
+| `val_re_rand` / `test_re_rand` | `100 / 200` | Reynolds-number generalization across tandem training domains |
+
+Train / val / test totals:
+
+- train: `1499`
+- val: `400`
+- test: `800`
+
+High-level rationale:
+
+- full-file geometry holdouts give clean unseen-foil-family tests
+- a stratified Reynolds-number holdout checks cross-regime generalization
+- a random single-foil holdout provides an easier sanity-check track
+- all four tracks are balanced so one split does not dominate the summary metric
+
+### Active metric family
+
+Primary metric:
+
+- `val_primary/surface_pressure_mae`
+- `test_primary/surface_pressure_mae`
+
+Definition:
+
+- pressure-channel MAE on all valid surface nodes in a split
+- computed **after full denormalization back to the original target space**
+- aggregated globally over valid surface nodes, not by averaging per-case MAEs
+
+Summary metric:
+
+- `val_eq4/surface_pressure_mae`
+- `test_eq4/surface_pressure_mae`
+
+This is the equal-weight mean of:
+
+- `single_in_dist`
+- `geom_camber_rc`
+- `geom_camber_cruise`
+- `re_rand`
+
+Historical note:
+
+- the old legacy split family still exists in the repo as `split_manifest.json`
+  and `legacy_noam/p_in`, `p_oodc`, `p_tan`, `p_re`
+- those are still useful for historical noam-lineage interpretation
+- they are not the same thing as the active v2 manifest
+
+### Current parity status
+
+Latest strong anchor:
+
+- [`STATUS_2026-04-22-0923_radford_live_status_after_cross_dataset_wave.md`](./STATUS_2026-04-22-0923_radford_live_status_after_cross_dataset_wave.md)
+  reports `test_primary/surface_pressure_mae = 24.581` for run `nrn0q3ct`
+
+Earlier anchor:
+
+- [`STATUS_2026-04-21-1759_radford_relaunch_status_and_refocus.md`](./STATUS_2026-04-21-1759_radford_relaunch_status_and_refocus.md)
+  reported `test_primary/surface_pressure_mae = 33.88`
+
+Interpretation:
+
+- `tandemfoil/` is currently our strongest **internal** TandemFoil story
+- but it is not the clean literature-facing Table 6 comparison contract
+
+## 3. What to compare against
+
+Use this rule of thumb:
+
+- if the claim is “how do we compare to the original TandemFoilSet paper?” use
+  `tandemfoil_paper/` and compare `field_mse` only
+- if the claim is “how strong is our current TandemFoil parity target inside the
+  ICML sprint?” use `tandemfoil/` and report `surface_pressure_mae`
+- if a table mixes `surface_pressure_mae` and Table 6 `field_mse` without
+  relabeling the contracts, it is scientifically misleading
+
+## 4. Bottom line
+
+- The original paper contract is **full-field normalized MSE** on Experiment 4
+  tasks.
+- The active repo parity contract is **denormalized surface-pressure MAE** on
+  the public `kagent` split family.
+- Both are worth keeping.
+- They must stay clearly separated in the paper, in status memos, and in agent
+  instructions.

--- a/target/icml2026/airfrans/program.md
+++ b/target/icml2026/airfrans/program.md
@@ -34,6 +34,7 @@ Use the **official AirfRANS benchmark metric family**. For literature comparison
     - `loss_vol = loss_vol_var.mean()`
   - Finally average those case-level scalars over the evaluation split.
   - In the original AirfRANS training / scoring code, these MSEs are computed on the **normalized target tensors** produced by the official `Dataset(...)` loader using the training-set normalization coefficients, not on denormalized physical-unit fields.
+  - If training uses any extra target transform beyond that official z-score normalization, the paper-facing scorer must first map predictions back to raw target space and then recompute metrics with the official AirfRANS normalization only.
   - In the shared trainer, validation metrics are logged on `*_val` splits for model selection, while paper-facing comparison numbers come from the matching `*_test` split. The harness aliases these as `val_primary/surface_mse` and `test_primary/surface_mse`.
 
 - **Official target-field contract**
@@ -56,6 +57,7 @@ Use the **official AirfRANS benchmark metric family**. For literature comparison
     - the task name: `full`, `scarce`, `reynolds`, or `aoa`
     - `Surf MSE`
     - `Vol MSE`
+  - Always report both `Surf MSE` and `Vol MSE` together for paper-facing AirfRANS claims.
   - Do not relabel these as MAE or relative L2.
   - If a run is selected on validation, the final paper number must still be recomputed on the official task test split before citing it.
 

--- a/target/icml2026/drivaerml/program.md
+++ b/target/icml2026/drivaerml/program.md
@@ -79,14 +79,14 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
     `surface_cp` sprint target and shared-trainer implementation used in this repo.
   - The closest published surface-pressure references use the same nominal
     public DrivAerML train/val/test counts:
-    - `Transolver-3` (Table 4, `400 train / 34 effective val / 50 test`):
-      - `p_s = 3.71`
     - `AB-UPT` (same table):
       - `p_s = 3.82`
-    - `Transolver++` (same table):
-      - `p_s = 4.12`
-    - `Transolver` (same table):
+    - `Transolver` baseline reported by `AB-UPT` on the same DrivAerML contract:
       - `p_s = 4.81`
+    - `Transolver-3` (Table 4, same public split family):
+      - `p_s = 3.71`
+    - `Transolver++` (later baseline row inside `Transolver-3` Table 4):
+      - `p_s = 4.12`
   - A separate `NeuralCFD` benchmark table reports `Transolver` at raw
     `L2 = 0.0388` on its own random `80/10/10` DrivAerML split with 40k sampled
     surface points. Interpreted on the percent scale used by
@@ -105,9 +105,10 @@ Use the **DrivAerML relative-L2 contract** used by AB-UPT and continued in later
 ## Sources
 
 - AB-UPT paper: <https://openreview.net/pdf?id=nwQ8nitlTZ>
+- AB-UPT arXiv mirror: <https://arxiv.org/abs/2502.09692>
 - `milieu_cfd` common evaluator: `scripts/eval_drivaerml.py` and `nn_cfd/noether/callbacks.py`
 - Transolver-3 paper: <https://arxiv.org/abs/2602.04940>
-- NeuralCFD paper: <https://arxiv.org/abs/2502.09692>
+- DrivAerML dataset paper: <https://arxiv.org/abs/2408.11969>
 
 ## Training schedules in related work
 

--- a/target/icml2026/instructions/additional_advisor_guidance.md
+++ b/target/icml2026/instructions/additional_advisor_guidance.md
@@ -31,6 +31,8 @@ For TandemFoilSet, remember there are now two useful views of the problem:
     - reported test from that lane: `50.77`
 - `tandemfoil_paper`
   - paper-facing metric: `test_primary/field_mse`
+  - this is normalized full-field MSE, not a surface-only metric
+  - `surface_mse` / `volume_mse` are diagnostics, not the comparison scalar
   - published paper reference numbers from Experiment 4 / Table 6:
     - `cruise_random_uniform = 0.10`
     - `cruise_random_aoa_extrap = 0.18`

--- a/target/icml2026/instructions/additional_advisor_guidance_tandemfoil_paper_2026-04-21.md
+++ b/target/icml2026/instructions/additional_advisor_guidance_tandemfoil_paper_2026-04-21.md
@@ -40,6 +40,8 @@ It is not fine if every benchmark needs a different core idea.
   - this is the ICML sprint parity target, not the original paper contract
 - `tandemfoil_paper`
   - paper-facing metric: `test_primary/field_mse`
+  - this is normalized full-field MSE over `[Ux, Uy, p]`, not a surface-only metric
+  - `surface_mse` / `volume_mse` are diagnostics only
   - published Experiment 4 references:
     - `cruise_random_uniform = 0.10`
     - `cruise_random_aoa_extrap = 0.18`

--- a/target/icml2026/instructions/prompt-advisor.md
+++ b/target/icml2026/instructions/prompt-advisor.md
@@ -34,8 +34,9 @@ When feasible, default to hypothesis families that are tested across the active
 benchmarks rather than only one. In particular:
 
 - use `tandemfoil_paper/` when you need a literature-facing TandemFoilSet
-  comparison point
+  comparison point with paper-facing `field_mse`
 - use `tandemfoil/` when you need the main parity / ICML-sprint Tandem anchor
+  with `surface_pressure_mae`
 - use single-dataset assignments mainly for frontier closure, best-checkpoint
   test recovery, or another clearly justified reason
 

--- a/target/icml2026/instructions/prompt-student.md
+++ b/target/icml2026/instructions/prompt-student.md
@@ -28,7 +28,8 @@ When the advisor assigns a cross-dataset hypothesis family, use your 8 GPUs as a
 small run matrix across the relevant benchmarks, then report the metrics
 together so the transfer signal is easy to interpret. If the hypothesis is
 about TandemFoil generalization or paper comparability, include both
-`tandemfoil/` and `tandemfoil_paper/`.
+`tandemfoil/` and `tandemfoil_paper/`, and keep their metrics distinct:
+`surface_pressure_mae` for `tandemfoil/`, `field_mse` for `tandemfoil_paper/`.
 
 Try and use sub-agents where possible, for example specialised agents like researcher-agent for research, Explore agent for checking log files or generic sub-agents for other repetitive tasks like polling for work.
 

--- a/target/icml2026/program.md
+++ b/target/icml2026/program.md
@@ -58,9 +58,13 @@ most decision-relevant metric for the selected benchmark:
   - `legacy_noam/*` for the denormalized historical `p_*` contract
   - `icml2026_v2/*` for the packaged `kagent` split contract
   - pressure and surface fidelity remain the decision-driving quantities
+  - this is intentionally **not** the original TandemFoilSet paper’s Table 6
+    MSE contract
 - `tandemfoil_paper`
   - prioritize normalized full-field MSE on the paper-faithful Experiment 4
     tasks
+  - the paper-facing scalar is `field_mse`; `surface_mse` / `volume_mse` are
+    diagnostics only
   - use this benchmark to decide whether our shared stack is actually
     competitive against the published TandemFoilSet paper numbers
 - `airfrans`
@@ -85,6 +89,9 @@ Alignment policy:
 - use the benchmark metric calculation exactly, including whether evaluation is
   done on normalized or unnormalized targets and whether aggregation is
   per-case or global over the split
+- when training uses an auxiliary target transform but the benchmark contract
+  does not, decode predictions back to raw target space and recompute the
+  paper-facing metric in the official metric space
 - keep hyperparameter-tuning metrics on validation splits, but reserve
   literature-facing comparison numbers for the matching test split
 - when model selection is done on validation, paper-facing test numbers should
@@ -104,6 +111,11 @@ Alignment policy:
   - historical best merged single-seed anchor in the report: `#2319`
   - merged parity lineage this target should reproduce and extend:
     `#2319 -> #2350 -> #2357 -> #2379`
+- keep the two TandemFoil benchmark contracts distinct:
+  - `tandemfoil/` = packaged parity target on the `kagent` split family with
+    denormalized surface-pressure MAE
+  - `tandemfoil_paper/` = paper-faithful Experiment 4 tasks with normalized
+    full-field `field_mse`
 - emit both TandemFoil metric regimes explicitly instead of silently mixing
   them:
   - `legacy_noam/p_in`, `legacy_noam/p_oodc`, `legacy_noam/p_tan`,

--- a/target/icml2026/tandemfoil/data/README.md
+++ b/target/icml2026/tandemfoil/data/README.md
@@ -1,77 +1,126 @@
 # data
 
-Data preparation, benchmark splits, and normalization stats for the TandemFoilSet
-subtarget inside `target/icml2026`.
+Data preparation, benchmark splits, and normalization stats for the packaged
+TandemFoilSet parity target inside `target/icml2026`.
 
 The shared trainer lives at `../../train.py`.
 
+This README documents the **active `tandemfoil/` contract**:
+
+- split manifest: `split_manifest_tandemfoilset_v2.json`
+- metrics: denormalized surface-pressure MAE on the balanced `kagent` split
+  family
+
+It is intentionally **not** the original TandemFoilSet paper’s Experiment 4 MSE
+contract. For that literature-facing benchmark, see `../../tandemfoil_paper/`.
+
 ---
 
-## Why a structured benchmark?
+## Why this split design?
 
-A naive random 90/10 split mostly tests **interpolation**: the model sees the same
-airfoil families, nearby (Re, α, gap, stagger) values, and often the same front/rear
-shapes in both train and test. That hides the paper's central question — whether
-single-airfoil pretraining actually helps on unseen tandem configurations.
+The active `tandemfoil/` target uses the public `kagent` TandemFoilSet split
+design (v2), which was built to answer four concrete questions with balanced
+validation and test tracks.
 
-The structured split instead tests four orthogonal failure modes:
+All val/test tracks are balanced:
 
-| Track | What it tests | Why it matters |
-|-------|--------------|----------------|
-| `val_in_dist` | Interpolation on seen shapes and conditions | Sanity check; should be easy |
-| `val_tandem_transfer` | Tandem pair with a front foil (NACA6416) absent from tandem training | Core claim: does single-foil data transfer to unseen tandem front shapes? |
-| `val_ood_cond` | Cruise cases in the frontier 20% of the joint (AoA, gap, stagger) space | Condition extrapolation — far from the training distribution centroid |
-| `val_ood_re` | All cruise Part2 cases (Re=4.445M, entirely outside training Re range) | Reynolds-number extrapolation — a clean OOD physics shift |
+- `100` validation cases per track
+- `200` test cases per track
+- paper-facing summary = equal-weight average surface-pressure MAE across the four tracks
 
-These four tracks map directly onto the paper's evaluation axes: **composition**,
-**transfer**, **condition OOD**, and **physics OOD**. Reporting each separately
-prevents a single global MSE from masking failures on harder sub-tasks (e.g. near-wall
-regions, wake prediction on novel pairs).
+### Validation / test tracks
 
-### Split assignment rules
+| Split | Source | Selection | What it tests |
+|-------|--------|-----------|---------------|
+| `val_single_in_dist` / `test_single_in_dist` | file `0` | random holdout | Sanity check on single-foil interpolation |
+| `val_geom_camber_rc` / `test_geom_camber_rc` | file `2` | full file holdout | Race-car tandem geometry generalization to unseen front-foil camber `M=6-8` |
+| `val_geom_camber_cruise` / `test_geom_camber_cruise` | file `5` | full file holdout | Cruise tandem geometry generalization to unseen front-foil camber `M=2-4` |
+| `val_re_rand` / `test_re_rand` | files `1, 3, 4, 6` | every 4th sample after sorting by `Re` | Cross-regime Reynolds-number generalization across the tandem training domains |
 
-The seven pickle files are divided as follows:
+### File allocation
 
-| File | Samples | Assignment |
-|------|---------|------------|
-| `raceCar_single` (file 0) | 899 | 70% subsample → 90% train, 10% `val_in_dist` |
-| `raceCar_tandem Part1` (file 1, front=NACA2412) | 300 | 70% subsample → train |
-| `raceCar_tandem Part2` (file 2, front=NACA6416) | 300 | 70% subsample → `val_tandem_transfer` |
-| `raceCar_tandem Part3` (file 3, front=NACA9412) | 300 | 70% subsample → train |
-| `cruise Part1` (file 4, Re=1.475M) | 300 | 70% subsample → interior 80% train, frontier 20% `val_ood_cond` |
-| `cruise Part2` (file 5, Re=4.445M) | 300 | 70% subsample → `val_ood_re` |
-| `cruise Part3` (file 6, Re=802K) | 300 | 70% subsample → interior 80% train, frontier 20% `val_ood_cond` |
+| File | Name | Train | Val | Test | Rationale |
+|------|------|------:|----:|-----:|-----------|
+| `0` | raceCar single | `599` | `100` | `200` | random in-distribution sanity check |
+| `1` | raceCar tandem P1 | `~225` | `~25` | `~50` | contributes to stratified `Re` holdout |
+| `2` | raceCar tandem P2 | `0` | `100` | `200` | full geometry holdout: unseen front-foil camber `M=6-8` |
+| `3` | raceCar tandem P3 | `~225` | `~25` | `~50` | contributes to stratified `Re` holdout |
+| `4` | cruise tandem P1 | `~225` | `~25` | `~50` | contributes to stratified `Re` holdout |
+| `5` | cruise tandem P2 | `0` | `100` | `200` | full geometry holdout: unseen front-foil camber `M=2-4` |
+| `6` | cruise tandem P3 | `~225` | `~25` | `~50` | contributes to stratified `Re` holdout |
 
-**Key design choices:**
+Split totals:
 
-- **Part2 files go entirely to val.** raceCar tandem Part2 uses NACA6416 as the front
-  foil, which does not appear as a tandem front foil in any training file. This makes
-  `val_tandem_transfer` a true held-out shape test rather than a re-split of seen pairs.
-  Similarly, cruise Part2's Re=4.445M is above the training ceiling (~1.5M), giving a
-  clean physics-OOD track.
+- train: `1499`
+- validation: `400`
+- test: `800`
 
-- **Frontier detection for `val_ood_cond`.** Cruise Parts 1+3 are split by distance from
-  the centroid in normalized (AoA, gap, stagger) space. The outermost 20% of cases —
-  those with the most extreme combined conditions — are held out. This is better than
-  holding out tails of a single variable, which would leave near-duplicates in train.
+### Why these holdouts?
 
-- **30% subsampling** (SAMPLE_FRACTION=0.70) is applied proportionally to every source
-  before splitting, so no domain is disproportionately thinned.
-
-**1,889 samples** retained (70% of 2,699, balanced across sources): **1,322 train** + 567 val (63 + 210 + 84 + 210).
+- Full-file geometry holdouts give the cleanest separation for camber
+  generalization because the held-out front-foil families do not appear in
+  training at all.
+- Stratified Reynolds-number holdout tests whether one model works across the
+  full `Re` range instead of only at one corner of the distribution.
+- The random single-foil holdout acts as a sanity check so the harder tandem
+  tracks are interpreted against an easier baseline.
 
 ### Training sampler
 
-Even after structured splitting, raw sample counts are unbalanced (raceCar single has
-~4× more training samples than cruise). A `WeightedRandomSampler` gives each of the
-three domain groups — `racecar_single`, `racecar_tandem`, `cruise` — equal expected
-weight per minibatch, preventing the largest domain from dominating the loss and
-obscuring transfer performance on the smaller tandem/cruise groups.
+The active manifest also keeps balanced domain sampling via three train-domain
+groups:
 
-Features:
-- 24-dim input features (adds foil-2 NACA/AoA, gap, stagger)
-- `SURFACE_IDS` includes boundary ID 7 (foil-2 surface nodes)
-- Balanced domain sampler (racecar_single / racecar_tandem / cruise equally weighted)
+- `racecar_single`
+- `racecar_tandem`
+- `cruise`
+
+A `WeightedRandomSampler` gives those groups equal expected minibatch weight so
+the largest domain does not dominate the loss.
+
+---
+
+## Metric contract
+
+Primary harness metric:
+
+- `val_primary/surface_pressure_mae`
+- `test_primary/surface_pressure_mae`
+
+Definition:
+
+- per split, compute
+  `surface_pressure_mae = mean |p_hat - p_true|`
+- use the pressure / `C_p` channel only
+- evaluate **after full denormalization back to the original target space**
+- aggregate globally over all valid surface nodes in the split, not per case
+
+Summary metric:
+
+- `val_eq4/surface_pressure_mae`
+- `test_eq4/surface_pressure_mae`
+
+This is the equal-weight mean of the four active split-specific surface-pressure
+MAEs:
+
+- `single_in_dist`
+- `geom_camber_rc`
+- `geom_camber_cruise`
+- `re_rand`
+
+Secondary diagnostics:
+
+- `mae_surf_Ux`, `mae_surf_Uy`, `mae_surf_p`
+- `mae_vol_Ux`, `mae_vol_Uy`, `mae_vol_p`
+- per-split validation loss
+
+Historical note:
+
+- the old `split_manifest.json` and legacy names `p_in`, `p_oodc`, `p_tan`,
+  `p_re` are still useful for historical lineage
+- the active `tandemfoil/` target does **not** rank runs on that legacy split
+  family anymore
+- do not compare `surface_pressure_mae` on the v2 manifest directly against the
+  paper’s Table 6 `field_mse` numbers
 
 ---
 
@@ -79,22 +128,20 @@ Features:
 
 | File | Purpose |
 |------|---------|
-| `split.py` | One-time script to regenerate the manifest and stats |
-| `prepare_multi.py` | Extended preprocessing: 24-dim x, foil-2 features, boundary ID 7 |
-| `split_manifest.json` | Committed train/val indices (run `split.py` to regenerate) |
-| `split_stats.json` | Committed normalization stats over training set |
+| `split_tandemfoilset_v2.py` | normalize the public `kagent` competition manifest into this repo’s schema |
+| `split_manifest_tandemfoilset_v2.json` | committed active train/val/test manifest |
+| `split_stats.json` | committed normalization stats over the active training split |
+| `prepare_multi.py` | extended preprocessing: 24-dim `x`, foil-2 features, boundary ID `7` |
+| `split.py` | older legacy split generator kept for historical reference |
+| `split_manifest.json` | older legacy structured manifest kept for historical reference |
 
 ---
 
 ## Running
 
 ```bash
-# Standard run (manifest and stats default to the committed files)
+# Standard run (manifest and stats default to the committed active files)
 cd target/icml2026 && python train.py --dataset tandemfoil --agent <your-name> --wandb_name "<your-name>/<description>"
-
-# Debug run (6 train samples, 2 per val split, 3 epochs)
-cd target/icml2026 && python tandemfoil/data/split.py --quick
-cd target/icml2026 && python train.py --dataset tandemfoil --debug
 ```
 
 **W&B project:** `wandb-applied-ai-team / senpai-v1`
@@ -103,15 +150,15 @@ cd target/icml2026 && python train.py --dataset tandemfoil --debug
 
 ## Regenerating the manifest
 
-Only needed if you change `SAMPLE_FRACTION`, the file list, or the split logic:
+Only needed if the public competition split is updated or the active TandemFoil
+parity contract changes:
 
 ```bash
-# Full run (~30-60 min — loads all 7 pickle files twice for two-pass stats)
-python data/split.py
-
-# Quick debug manifest (instant — no data loading, identity normalization)
-python data/split.py --quick
+cd target/icml2026
+python tandemfoil/data/split_tandemfoilset_v2.py
 ```
+
+The legacy `split.py` flow is retained only for historical experiments.
 
 ---
 
@@ -124,8 +171,8 @@ python k8s/launch.py \
   [--n_students 4]
 ```
 
-`launch.py` defaults to `--repo_branch main`. Once this branch is merged to main,
-student pods will clone main and get `train.py`, the committed manifest,
+`launch.py` defaults to `--repo_branch main`. Once this branch is merged to
+main, student pods will clone main and get `train.py`, the committed manifest,
 and the stats file automatically.
 
 ---

--- a/target/icml2026/tandemfoil/program.md
+++ b/target/icml2026/tandemfoil/program.md
@@ -85,6 +85,10 @@ Use the following metric definitions exactly:
 
 Lower is better. For the paper sprint, the decision-driving quantity is **surface pressure MAE on the explicit validation tracks**, with the equal-weight 4-way average used as the benchmark summary.
 
+Do not compare `tandemfoil/` `surface_pressure_mae` directly against the
+original TandemFoilSet paper’s Table 6 `MSE` values. That apples-to-apples
+literature-facing contract lives under `tandemfoil_paper/`.
+
 For held-out reporting after model selection, the trainer also computes the
 analogous `test_eq4/surface_pressure_mae` summary when the four matching test
 tracks are available in the split manifest.

--- a/target/icml2026/tandemfoil_paper/data/README.md
+++ b/target/icml2026/tandemfoil_paper/data/README.md
@@ -60,3 +60,25 @@ dual-foil preprocessing as `tandemfoil/`. The difference is the split contract
 and the metric contract: this benchmark evaluates normalized full-field MSE,
 matching the paper’s Experiment 4 reporting style.
 
+## Metric Contract
+
+Paper-facing comparison metric:
+
+- `field_mse`
+  - full-field MSE over all valid nodes and all three output channels
+    `[Ux, Uy, p]`
+  - computed in the paper’s raw train-stat z-score space
+
+Auxiliary diagnostics:
+
+- `surface_mse`
+- `volume_mse`
+
+These diagnostics are useful for mechanism analysis, but they are **not** the
+Table 6 comparison scalar.
+
+Repo evaluation rule:
+
+- if training uses an optional target transform such as `--asinh-pressure`, the
+  evaluator still decodes predictions back to raw target space before
+  recomputing `field_mse` with the task-local training-set mean/std

--- a/target/icml2026/tandemfoil_paper/program.md
+++ b/target/icml2026/tandemfoil_paper/program.md
@@ -66,8 +66,20 @@ IDs cannot be recovered from the PDF alone.
 
 ## Metrics
 
-The paper reports **normalized full-field MSE** after z-score normalization with
-training-set statistics.
+The paper’s main benchmark tables report **MSE test losses** on the full flow
+field, not a surface-only metric.
+
+Why we interpret it this way:
+
+- Experiment 4 says “Table 6 shows that the `MSE` test losses are higher...”
+- the training appendix says the model predicts three fields:
+  `[Ux, Uy, p]`
+- the appendix later introduces **boundary MSE** separately for the three-airfoil
+  extension, which implies the main-text tables are the overall full-field
+  metric unless boundary restriction is stated explicitly
+
+The paper also says a “standard z-score style normalisation” is used with the
+training-set mean and standard deviation.
 
 This subtarget therefore uses:
 
@@ -81,6 +93,14 @@ This subtarget therefore uses:
   - normalized-space MSE on non-surface nodes only
 
 Lower is better.
+
+Important repo contract:
+
+- `field_mse` is the only paper-facing comparison scalar
+- `surface_mse` and `volume_mse` are auxiliary diagnostics
+- if training enables an extra target transform such as `--asinh-pressure`, the
+  evaluator must still decode predictions back to raw target space and then
+  recompute `field_mse` in the paper’s plain train-stat z-score space
 
 Primary harness aliases:
 
@@ -117,4 +137,3 @@ stack is competitive on the paper-style TandemFoil evaluation.
   stack as `tandemfoil/`, but **not** the noam-style pressure-denorm contract.
 - It is a benchmark-calibration target, not a replacement for the main
   `tandemfoil/` ICML sprint target.
-

--- a/target/icml2026/tests/test_tandemfoil_paper.py
+++ b/target/icml2026/tests/test_tandemfoil_paper.py
@@ -31,6 +31,23 @@ class _IdentityPaperModel(torch.nn.Module):
         }
 
 
+class _FixedPaperModel(torch.nn.Module):
+    def __init__(self, *, surface_preds: torch.Tensor, volume_preds: torch.Tensor | None):
+        super().__init__()
+        self._surface_preds = surface_preds
+        self._volume_preds = volume_preds
+
+    def eval(self):
+        return self
+
+    def forward(self, *, surface_x, surface_mask, volume_x, volume_mask):
+        del surface_x, surface_mask, volume_x, volume_mask
+        return {
+            "surface_preds": self._surface_preds,
+            "volume_preds": self._volume_preds,
+        }
+
+
 def test_uniform_split_uses_80_10_10_counts():
     splits = split_uniform_indices(900, seed=42)
     assert len(splits["train"]) == 720
@@ -73,6 +90,60 @@ def test_paper_eval_reports_normalized_field_mse():
         None,
         [batch],
         TargetTransform(pressure_index=2, stats_mean=torch.zeros(3), stats_std=torch.ones(3)),
+        None,
+        torch.device("cpu"),
+    )
+
+    surface_sq = 3.0
+    volume_sq = 2.0
+    expected_surface = surface_sq / (2 * 3)
+    expected_volume = volume_sq / (1 * 3)
+    expected_field = (surface_sq + volume_sq) / (3 * 3)
+
+    assert math.isclose(metrics["surface_mse"], expected_surface, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(metrics["volume_mse"], expected_volume, rel_tol=1e-6, abs_tol=1e-6)
+    assert math.isclose(metrics["field_mse"], expected_field, rel_tol=1e-6, abs_tol=1e-6)
+
+
+def test_paper_eval_uses_raw_zscore_metric_even_with_asinh_training_transform():
+    raw_surface_target = torch.tensor([[[1.0, 2.0, 3.0], [1.0, 1.0, 1.0]]], dtype=torch.float32)
+    raw_volume_target = torch.tensor([[[2.0, 2.0, 2.0]]], dtype=torch.float32)
+    raw_surface_pred = torch.tensor([[[2.0, 2.0, 3.0], [0.0, 1.0, 2.0]]], dtype=torch.float32)
+    raw_volume_pred = torch.tensor([[[3.0, 1.0, 2.0]]], dtype=torch.float32)
+    train_transform = TargetTransform(
+        pressure_index=2,
+        stats_mean=torch.zeros(3),
+        stats_std=torch.ones(3),
+        asinh_pressure=True,
+        asinh_scale=0.75,
+    )
+    metric_transform = TargetTransform(
+        pressure_index=2,
+        stats_mean=torch.zeros(3),
+        stats_std=torch.ones(3),
+        asinh_pressure=False,
+    )
+    batch = GroupedBatch(
+        case_ids=["paper-case"],
+        dataset_name="tandemfoilset_paper",
+        space_dim=2,
+        surface_x=torch.zeros(1, 2, 4, dtype=torch.float32),
+        surface_y=raw_surface_target,
+        surface_mask=torch.ones(1, 2, dtype=torch.bool),
+        volume_x=torch.zeros(1, 1, 4, dtype=torch.float32),
+        volume_y=raw_volume_target,
+        volume_mask=torch.ones(1, 1, dtype=torch.bool),
+        metadata=[],
+    )
+    metrics = evaluate_grouped(
+        _FixedPaperModel(
+            surface_preds=train_transform.apply(raw_surface_pred),
+            volume_preds=train_transform.apply(raw_volume_pred),
+        ),
+        None,
+        [batch],
+        train_transform,
+        metric_transform,
         torch.device("cpu"),
     )
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,19 @@ class TargetTransform:
         return out
 
 
+def comparison_metric_tensors(
+    preds: torch.Tensor,
+    target: torch.Tensor,
+    *,
+    train_transform: TargetTransform,
+    metric_transform: TargetTransform | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if metric_transform is None:
+        return preds, train_transform.apply(target)
+    pred_raw = train_transform.invert(preds)
+    return metric_transform.apply(pred_raw), metric_transform.apply(target)
+
+
 class TandemTargetTransform:
     def __init__(
         self,
@@ -735,6 +748,7 @@ def evaluate_grouped(
     anp_head: ANPSurfaceDecoder | None,
     loader: DataLoader,
     transform: TargetTransform | TandemTargetTransform,
+    metric_transform: TargetTransform | None,
     device: torch.device,
     *,
     amp_mode: str = "none",
@@ -812,9 +826,16 @@ def evaluate_grouped(
             )
         outputs = float_outputs(outputs)
         if dataset_name == "airfrans":
+            if not isinstance(transform, TargetTransform):
+                raise TypeError("AirfRANS evaluation requires TargetTransform")
             if batch.surface_y is not None and outputs["surface_preds"] is not None:
-                target = transform.apply(batch.surface_y)
-                case_values = (outputs["surface_preds"] - target).square()
+                surface_pred, surface_target = comparison_metric_tensors(
+                    outputs["surface_preds"],
+                    batch.surface_y,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                case_values = (surface_pred - surface_target).square()
                 for case_idx in range(case_values.shape[0]):
                     channel_mean = _case_masked_channel_means(case_values[case_idx], batch.surface_mask[case_idx])
                     if channel_mean is not None:
@@ -824,8 +845,13 @@ def evaluate_grouped(
                             surf_channel_sum = torch.zeros(channel_mean.shape[0], device=device)
                         surf_channel_sum += channel_mean.to(device)
             if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
-                target = transform.apply(batch.volume_y)
-                case_values = (outputs["volume_preds"] - target).square()
+                volume_pred, volume_target = comparison_metric_tensors(
+                    outputs["volume_preds"],
+                    batch.volume_y,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                case_values = (volume_pred - volume_target).square()
                 for case_idx in range(case_values.shape[0]):
                     channel_mean = _case_masked_channel_means(case_values[case_idx], batch.volume_mask[case_idx])
                     if channel_mean is not None:
@@ -837,17 +863,29 @@ def evaluate_grouped(
             continue
 
         if dataset_name == "tandemfoilset_paper":
+            if not isinstance(transform, TargetTransform):
+                raise TypeError("TandemFoil paper evaluation requires TargetTransform")
             if batch.surface_y is not None and outputs["surface_preds"] is not None:
-                target = transform.apply(batch.surface_y)
-                case_values = (outputs["surface_preds"] - target).square()
+                surface_pred, surface_target = comparison_metric_tensors(
+                    outputs["surface_preds"],
+                    batch.surface_y,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                case_values = (surface_pred - surface_target).square()
                 valid = batch.surface_mask.unsqueeze(-1)
                 if paper_surface_sq_sum is None:
                     paper_surface_sq_sum = torch.zeros(case_values.shape[-1], device=device)
                 paper_surface_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device)
                 paper_surface_nodes += int(batch.surface_mask.sum().detach().cpu().item())
             if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
-                target = transform.apply(batch.volume_y)
-                case_values = (outputs["volume_preds"] - target).square()
+                volume_pred, volume_target = comparison_metric_tensors(
+                    outputs["volume_preds"],
+                    batch.volume_y,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                case_values = (volume_pred - volume_target).square()
                 valid = batch.volume_mask.unsqueeze(-1)
                 if paper_volume_sq_sum is None:
                     paper_volume_sq_sum = torch.zeros(case_values.shape[-1], device=device)
@@ -981,6 +1019,7 @@ def evaluate_abupt(
     model: torch.nn.Module,
     loader: DataLoader,
     transform: TargetTransform,
+    metric_transform: TargetTransform | None,
     device: torch.device,
     *,
     amp_mode: str = "none",
@@ -1013,16 +1052,26 @@ def evaluate_abupt(
         outputs = float_outputs(outputs)
         if dataset_name == "airfrans":
             if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
-                target = transform.apply(batch.surface_anchor_target)
-                channel_mean = (outputs["surface_preds"] - target).square().mean(dim=(0, 1))
+                surface_pred, surface_target = comparison_metric_tensors(
+                    outputs["surface_preds"],
+                    batch.surface_anchor_target,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                channel_mean = (surface_pred - surface_target).square().mean(dim=(0, 1))
                 total_surface += float(channel_mean.mean().detach().cpu().item())
                 count_surface += 1
                 if surf_channel_sum is None:
                     surf_channel_sum = torch.zeros(channel_mean.shape[0], device=device)
                 surf_channel_sum += channel_mean.to(device)
             if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
-                target = transform.apply(batch.volume_anchor_target)
-                channel_mean = (outputs["volume_preds"] - target).square().mean(dim=(0, 1))
+                volume_pred, volume_target = comparison_metric_tensors(
+                    outputs["volume_preds"],
+                    batch.volume_anchor_target,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
+                channel_mean = (volume_pred - volume_target).square().mean(dim=(0, 1))
                 total_volume += float(channel_mean.mean().detach().cpu().item())
                 count_volume += 1
                 if vol_channel_sum is None:
@@ -1032,16 +1081,26 @@ def evaluate_abupt(
 
         if dataset_name == "tandemfoilset_paper":
             if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
-                target = transform.apply(batch.surface_anchor_target)
+                surface_pred, surface_target = comparison_metric_tensors(
+                    outputs["surface_preds"],
+                    batch.surface_anchor_target,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
                 if paper_surface_sq_sum is None:
-                    paper_surface_sq_sum = torch.zeros(target.shape[-1], device=device)
-                paper_surface_sq_sum += (outputs["surface_preds"] - target).square().sum(dim=(0, 1)).to(device)
+                    paper_surface_sq_sum = torch.zeros(surface_target.shape[-1], device=device)
+                paper_surface_sq_sum += (surface_pred - surface_target).square().sum(dim=(0, 1)).to(device)
                 paper_surface_nodes += batch.surface_anchor_target.shape[0] * batch.surface_anchor_target.shape[1]
             if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
-                target = transform.apply(batch.volume_anchor_target)
+                volume_pred, volume_target = comparison_metric_tensors(
+                    outputs["volume_preds"],
+                    batch.volume_anchor_target,
+                    train_transform=transform,
+                    metric_transform=metric_transform,
+                )
                 if paper_volume_sq_sum is None:
-                    paper_volume_sq_sum = torch.zeros(target.shape[-1], device=device)
-                paper_volume_sq_sum += (outputs["volume_preds"] - target).square().sum(dim=(0, 1)).to(device)
+                    paper_volume_sq_sum = torch.zeros(volume_target.shape[-1], device=device)
+                paper_volume_sq_sum += (volume_pred - volume_target).square().sum(dim=(0, 1)).to(device)
                 paper_volume_nodes += batch.volume_anchor_target.shape[0] * batch.volume_anchor_target.shape[1]
             continue
 
@@ -1276,6 +1335,7 @@ def evaluate_phase_metrics(
     anp_head: ANPSurfaceDecoder | None,
     loaders: dict[str, DataLoader],
     transform: TargetTransform | TandemTargetTransform,
+    metric_transform: TargetTransform | None,
     device: torch.device,
     phase: str,
 ) -> dict[str, float]:
@@ -1286,6 +1346,7 @@ def evaluate_phase_metrics(
                 forward_model,
                 loader,
                 transform,
+                metric_transform,
                 device,
                 amp_mode=config.amp_mode,
                 max_batches=config.max_eval_batches,
@@ -1296,6 +1357,7 @@ def evaluate_phase_metrics(
                 anp_head,
                 loader,
                 transform,
+                metric_transform,
                 device,
                 amp_mode=config.amp_mode,
                 max_batches=config.max_eval_batches,
@@ -1375,6 +1437,7 @@ def main() -> None:
             phys_stats=phys_stats,
             config=config,
         )
+        metric_transform = None
     else:
         transform = TargetTransform(
             pressure_index=bundle.spec.pressure_output_index,
@@ -1383,6 +1446,17 @@ def main() -> None:
             asinh_pressure=config.asinh_pressure,
             asinh_scale=config.asinh_scale,
         )
+        metric_transform = None
+        if bundle.spec.name in {"airfrans", "tandemfoilset_paper"}:
+            # Keep literature-facing metrics in the dataset's raw z-score space
+            # even when training applies an auxiliary target transform.
+            metric_transform = TargetTransform(
+                pressure_index=bundle.spec.pressure_output_index,
+                stats_mean=bundle.target_stats.y_mean,
+                stats_std=bundle.target_stats.y_std,
+                asinh_pressure=False,
+                asinh_scale=config.asinh_scale,
+            )
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
@@ -1459,6 +1533,7 @@ def main() -> None:
             anp_head=anp_head,
             loaders=val_loaders,
             transform=transform,
+            metric_transform=metric_transform,
             device=device,
             phase="val",
         )
@@ -1518,6 +1593,7 @@ def main() -> None:
             anp_head=anp_head,
             loaders=test_loaders,
             transform=transform,
+            metric_transform=metric_transform,
             device=device,
             phase="test",
         )
@@ -1543,6 +1619,7 @@ def main() -> None:
                 anp_head=anp_head,
                 loaders=test_loaders,
                 transform=transform,
+                metric_transform=metric_transform,
                 device=device,
                 phase="test",
             )


### PR DESCRIPTION
## Summary
- fix `tandemfoil_paper` evaluation so paper-facing `field_mse` stays in the paper's raw train-stat z-score space even when training enables auxiliary target transforms such as `--asinh-pressure`
- add a TandemFoil benchmark memo and refresh the TandemFoil docs so the paper-faithful `field_mse` contract stays clearly separated from the packaged parity target's `surface_pressure_mae` contract
- update TandemFoil guidance/prompts and add a regression test covering the asinh-eval mismatch

## Testing
- `python -m py_compile target/icml2026/train.py`
- `python -m pytest target/icml2026/tests/test_tandemfoil_paper.py -q` *(fails here because `pytest` is not installed in this shell)*
- direct test execution also could not run here because `torch` is not installed in this shell environment
