### PR TITLE
DrivAerML: volume training ablation — surface+volume vs surface-only

### DIFF
--- a/target/icml2026/core/features.py
+++ b/target/icml2026/core/features.py
@@ -272,21 +272,33 @@ def augment_case_sample(
 
     surface_x = sample.surface_x
     volume_x = sample.volume_x
-    full_x = torch.cat([surface_x, volume_x], dim=0) if volume_x is not None else surface_x
 
-    appended_full: list[torch.Tensor] = []
-    if enable_fourier:
-        full_x = append_fourier_features(full_x, sample.space_dim, fourier_freqs)
-    if enable_cp_panel and sample.dataset_name == "airfrans":
-        appended_full.append(_compute_airfrans_cp_panel(full_x))
-    if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):
-        appended_full.append(_compute_tandem_wake_deficit(full_x, include_angle=enable_wake_angle))
-    if appended_full:
-        full_x = torch.cat([full_x, *appended_full], dim=1)
-
-    num_surface = sample.surface_x.shape[0]
-    surface_x = full_x[:num_surface]
-    volume_x = full_x[num_surface:] if sample.volume_x is not None else None
+    can_cat = volume_x is None or surface_x.shape[1] == volume_x.shape[1]
+    if can_cat:
+        full_x = torch.cat([surface_x, volume_x], dim=0) if volume_x is not None else surface_x
+        if enable_fourier:
+            full_x = append_fourier_features(full_x, sample.space_dim, fourier_freqs)
+        appended_full: list[torch.Tensor] = []
+        if enable_cp_panel and sample.dataset_name == "airfrans":
+            appended_full.append(_compute_airfrans_cp_panel(full_x))
+        if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):
+            appended_full.append(_compute_tandem_wake_deficit(full_x, include_angle=enable_wake_angle))
+        if appended_full:
+            full_x = torch.cat([full_x, *appended_full], dim=1)
+        num_surface = sample.surface_x.shape[0]
+        surface_x = full_x[:num_surface]
+        volume_x = full_x[num_surface:] if sample.volume_x is not None else None
+    else:
+        if enable_fourier:
+            surface_x = append_fourier_features(surface_x, sample.space_dim, fourier_freqs)
+            volume_x = append_fourier_features(volume_x, sample.space_dim, fourier_freqs)
+        appended_srf: list[torch.Tensor] = []
+        if enable_cp_panel and sample.dataset_name == "airfrans":
+            appended_srf.append(_compute_airfrans_cp_panel(surface_x))
+        if enable_wake_deficit and sample.dataset_name.startswith("tandemfoilset"):
+            appended_srf.append(_compute_tandem_wake_deficit(surface_x, include_angle=enable_wake_angle))
+        if appended_srf:
+            surface_x = torch.cat([surface_x, *appended_srf], dim=1)
     return CaseSample(
         case_id=sample.case_id,
         dataset_name=sample.dataset_name,


### PR DESCRIPTION
## Hypothesis

Our current DrivAerML recipe trains on **surface points only** (`--surface-only-drivaerml`, 50k surface points per case). AB-UPT — which achieves our 3.71% target — trains on **both surface AND volume points**. Adding volume flow-field context may help the model predict surface quantities better by giving it information about the surrounding flow structure (boundary layer thickness, wake topology, separation regions) that isn't directly visible from surface data alone.

The human research team (issue #3020) specifically directs: **"Matched 16k/16k surface-volume only if the joint path is stable."**

This experiment is the first test of volume training on DrivAerML in the radford programme.

## Instructions

### Runs (4 DM runs — surface+volume ablation)

Use `--wandb_group dm_volume_ablation` for all runs. All use the golden DM config (AdamW lr=5e-4, T_max=30, no-EMA, Fourier, 4L/512d).

**Run 1 — 50k surface + 16k volume (add volume to baseline):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --no-surface-only-drivaerml \
  --drivaerml-train-surface-points 50000 --drivaerml-train-volume-points 16000 \
  --drivaerml-eval-surface-points 50000 --drivaerml-eval-volume-points 16000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm_volume_ablation
```
Adds 16k volume points on top of the standard 50k surface budget. Total points per case: 66k. Tests whether volume context helps surface prediction at a manageable throughput cost.

**Run 2 — 16k surface + 16k volume (matched budget per human directive):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --no-surface-only-drivaerml \
  --drivaerml-train-surface-points 16000 --drivaerml-train-volume-points 16000 \
  --drivaerml-eval-surface-points 50000 --drivaerml-eval-volume-points 16000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm_volume_ablation
```
The human-specified matched 16k/16k budget. Total 32k points per case (vs baseline 50k surface-only). Faster epochs → more epochs per 360-min → potentially deeper convergence despite lower per-epoch resolution.

**Run 3 — 16k surface only (throughput control):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 16000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm_volume_ablation
```
Same 16k surface as Run 2 but NO volume points. Isolates the volume contribution from the throughput effect. If Run 2 > Run 3, volume points are helping. If Run 3 > Run 2, the volume points are noise.

**Run 4 — 50k surface only (baseline control, FULL EVAL):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --wandb_group dm_volume_ablation
```
**NOTE: NO --max-eval-batches.** This is the surface-only baseline with full-coverage eval for paper-facing comparison. Same as the current champion config (#2898).

### GPU Priority
- **GPUs 0-3:** Run all 4 DM runs in parallel (batch_size=1, 1 GPU each)
- Run 4 (full-eval baseline control) should complete without interruption

### Important Notes
- If `--no-surface-only-drivaerml` causes errors or crashes, report immediately — this flag may require additional data preparation for volume mesh points.
- **Smoke test first:** Run each config for 3 epochs before committing to full 360-min budget. If any crash, stop and report.
- Use full-coverage eval (no --max-eval-batches) on Run 4 only. Runs 1-3 use --max-eval-batches 200 for iteration speed.

### Reporting
For each run, report:
1. Best `val_primary/surface_rel_l2_pct` and the epoch
2. Final (last-epoch) val metric
3. `test_primary/surface_rel_l2_pct` at final epoch
4. Epochs completed in the 360-min budget (throughput comparison is critical)
5. Whether volume runs crashed/diverged

### Key Comparisons
- **Run 1 vs Run 4:** Does adding volume context to the full 50k surface budget help?
- **Run 2 vs Run 3:** Does volume context help at the reduced 16k surface budget?
- **Run 3 vs Run 4:** What's the throughput/accuracy tradeoff of 16k vs 50k surface-only?

## Baseline

**DrivAerML (target to beat):**
- `val_primary/surface_rel_l2_pct`: **3.997%** at epoch 467
- W&B run: bht6h42t (#2898 piccolo)
- Config: AdamW lr=5e-4, T_max=30, no-EMA, Fourier, 4L/512d, surface-only 50k
- External target: **3.71%** (AB-UPT trains on surface+volume)
- Val/test gap: val=3.997% but test≈5.93%

**Note on AB-UPT:** The 3.71% target was achieved by AB-UPT which uses geometry-separated encoding and trains on both surface AND volume data. Our surface-only approach might be missing the volume signal that AB-UPT captures. This experiment tests that hypothesis directly.