### PR TITLE
DrivAerML: torch.compile(mode='default') — JIT without CUDA graphs

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1609,7 +1609,7 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
-    forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
+    forward_model = torch.compile(model, mode="default") if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
         anp_head = ANPSurfaceDecoder(


### PR DESCRIPTION
## Hypothesis

PR #2992 showed compile(mode='reduce-overhead') fails due to CUDA graphs requiring fixed tensor shapes. But mode='default' does NOT use CUDA graphs — it only applies JIT fusion passes. This may provide 10-30% throughput improvement without the shape-incompatibility crash. More epochs in the same wall-clock budget → deeper convergence. Testing on both DM and AF where compile overhead should be smaller (smaller meshes, faster epochs).

## Current Baselines
- DM: val_primary/surface_rel_l2_pct = **3.997%** (AdamW lr=5e-4, T_max=30, no-EMA, 4L/512d, NO gc, NO WD)
- AF: val_primary/surface_mse = **0.000482** (AdamW lr=6e-4, T_max=50, no-EMA, 2L/256d)

## Implementation

Modify `train.py` to wrap the model with `torch.compile(model, mode='default')` when a --compile flag is provided (check how the existing compile flag works in the codebase). Use mode='default' specifically — NOT 'reduce-overhead' or 'max-autotune'.

## Runs

**Run 1 — DM compile(mode='default')**
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --grad-clip 1.0 --compile --wandb_group dm_compile_default
```
(--grad-clip 1.0 for compile stability per #2898 insight)

**Run 2 — DM no-compile control**
```bash
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --grad-clip 1.0 --wandb_group dm_compile_default
```

**Run 3 — AF compile(mode='default')**
```bash
python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --compile --wandb_group dm_compile_default
```

## Expected outcome
Report epochs/minute for Run 1 vs Run 2 to quantify compile speedup. If compile provides >10% throughput gain and final metric is competitive, this unlocks free improvement for all future DM runs.

## Notes
- The key question is: does mode='default' crash on variable-length point cloud inputs? If it does, note the error and close.
- Report both throughput (epochs/min) and final metric for Run 1 vs Run 2
- If compile crashes, try wrapping only the encoder or decoder, not the full model