### PR TITLE
TFP: Lion+EMA refinement — T_max/gc/LR sweep beyond 0.002383

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1597,7 +1597,7 @@ def main() -> None:
             asinh_scale=config.asinh_scale,
         )
         metric_transform = None
-        if bundle.spec.name in {"airfrans", "tandemfoilset_paper"}:
+        if bundle.spec.name in {"airfrans"}:
             # Keep literature-facing metrics in the dataset's raw z-score space
             # even when training applies an auxiliary target transform.
             metric_transform = TargetTransform(


### PR DESCRIPTION
## Hypothesis

PR #3025 established a new TFP best of **0.002383** (45.1% improvement) using the TF champion config: Lion lr=1.25e-4, T_max=10, gc=0.5, EMA=0.999. The run diverged at epoch 462 (known T_max=10 instability from rapid cosine cycling), but EMA preserved the best checkpoint at ep443.

Three levers to refine from here:

1. **T_max** — increasing from 10 to 20/30 reduces restart frequency, potentially avoiding the ep462 divergence and allowing 600+ stable epochs
2. **gc** — gc=0.5 was the key that enabled stable EMA for TF (gc=1.0 diverged at ep167 in TF). gc=0.3 may be even more stable on TFP
3. **LR** — 1.25e-4 is the TF optimum, but TFP may prefer a slightly different value

This is a single-dataset TFP ablation (exception to cross-dataset rule) because #3025 just established a major TFP breakthrough and the immediate priority is to push deeper before other experiments converge on this config.

## Instructions

Run 6 experiments on 6 GPUs. Use `--wandb_group haku-tfp-lion-v2` for all runs.

All runs start from the #3025 winning config (Lion lr=1.25e-4, T_max=10, gc=0.5, EMA=0.999, 3L/192d, all physics flags) and vary ONE lever at a time (or test proven compound combinations).

**Run 1 — T_max=20, gc=0.5, lr=1.25e-4 (longer period, same gc):**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 20 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 --wandb_group haku-tfp-lion-v2
```

**Run 2 — T_max=30, gc=0.5, lr=1.25e-4 (even longer period):**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 --wandb_group haku-tfp-lion-v2
```

**Run 3 — T_max=10, gc=0.3, lr=1.25e-4 (softer clip, same period):**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 \
  --grad-clip 0.3 --weight-decay 1e-2 \
  --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 --wandb_group haku-tfp-lion-v2
```

**Run 4 — T_max=10, gc=0.5, lr=1e-4 (lower LR):**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 --wandb_group haku-tfp-lion-v2
```

**Run 5 — T_max=20, gc=0.3, lr=1.25e-4 (longer period + softer gc):**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 20 \
  --grad-clip 0.3 --weight-decay 1e-2 \
  --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 --wandb_group haku-tfp-lion-v2
```

**Run 6 — T_max=20, gc=0.5, lr=1e-4 (longer period + lower LR):**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1e-4 --cosine-t-max 20 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 --wandb_group haku-tfp-lion-v2
```

## Design Summary

| Run | T_max | gc | LR | Lever changed |
|---|---|---|---|---|
| 1 | 20 | 0.5 | 1.25e-4 | T_max +1 step |
| 2 | 30 | 0.5 | 1.25e-4 | T_max +2 steps |
| 3 | 10 | 0.3 | 1.25e-4 | gc softer |
| 4 | 10 | 0.5 | 1e-4 | LR lower |
| 5 | 20 | 0.3 | 1.25e-4 | T_max + gc compound |
| 6 | 20 | 0.5 | 1e-4 | T_max + LR compound |

## Reporting

Report `val_primary/field_mse` for each run (lower is better). Include W&B run IDs, best epoch, final epoch, and whether the run diverged or stayed stable to timeout. Note the epoch of divergence if it occurs.

## Baseline

- **TandemFoil Paper:** `val_primary/field_mse` = **0.002383** (#3025 — Lion lr=1.25e-4, T_max=10, gc=0.5, EMA=0.999, 3L/192d, all physics flags)
- **W&B reference run:** d1xh0o1p (best at epoch 443, diverged ep462)
- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`