### PR TITLE
Cross-dataset: 2-layer MLP output head at champion configs

### DIFF
--- a/.branch_init
+++ b/.branch_init
@@ -1,0 +1,1 @@
+# violet/deep-output-head


### PR DESCRIPTION
## Hypothesis

The current model uses a single linear layer as its output projection (hidden_dim → output_channels). This linear decoder may be a capacity bottleneck — the rich transformer representations encode complex physical relationships, but a single matrix multiplication may not have enough expressivity to map these to accurate pressure and velocity fields.

Replacing the final linear layer with a 2-layer MLP (hidden_dim → GELU → output_dim) adds a learned non-linear transformation at the output head. This has shown consistent improvements in other transformer-based regression tasks, including vision transformers applied to dense prediction. The GELU activation allows the model to selectively suppress irrelevant features before the final projection.

This is an architectural change, NOT a hyperparameter tweak — it increases the model's output expressivity at minimal parameter cost (~hidden_dim extra parameters per output channel).

## Instructions

**Step 1: Add `--deep-output-head` flag to train.py**

```python
parser.add_argument('--deep-output-head', action='store_true', default=False,
                    help='Use 2-layer MLP output head (hidden→GELU→output) instead of linear')
```

**Step 2: Modify the model output head**

Locate where the model's final output projection is defined (likely something like `self.out_proj = nn.Linear(hidden_dim, output_dim)` in the Transolver model class). When `--deep-output-head` is passed, replace it with:

```python
if args.deep_output_head:
    self.out_proj = nn.Sequential(
        nn.Linear(hidden_dim, hidden_dim),
        nn.GELU(),
        nn.Linear(hidden_dim, output_dim)
    )
else:
    self.out_proj = nn.Linear(hidden_dim, output_dim)
```

**Important:** Initialize the second linear layer weights to near-zero (e.g., `nn.init.normal_(self.out_proj[-1].weight, std=0.02)`) to preserve the model's initial output scale and avoid training instability from a random output initialization.

**Step 3: Run 4 experiments (one per benchmark)**

Use `--wandb_group violet-deep-output-head` for all runs.

**DrivAerML (1 run) — NO grad-clip, NO weight-decay:**
```bash
cd target/icml2026

SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --deep-output-head --wandb_group violet-deep-output-head
```

**AirfRANS (1 run):**
```bash
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 \
  --weight-decay 1e-2 --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 \
  --deep-output-head --wandb_group violet-deep-output-head
```

**TandemFoil (1 run):**
```bash
python train.py --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --model-slices 64 --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999 \
  --deep-output-head --wandb_group violet-deep-output-head
```

**TandemFoil Paper (1 run):**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --enable-fourier --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --deep-output-head --wandb_group violet-deep-output-head
```

**Results to report** (for each run):
- Best val metric and epoch (not final epoch)
- W&B run ID
- Whether metric beat or missed baseline
- Early training loss curve behavior (does it converge faster or slower than baseline?)
- If DM diverges, note at which epoch and grad norm level

## Baseline

| Dataset | Metric | Baseline | W&B run | Config |
|---------|--------|----------|---------|--------|
| DrivAerML | val_primary/surface_rel_l2_pct | **3.997%** | bht6h42t | 4L/512d, AdamW lr=5e-4, T_max=30, no gc, no WD |
| AirfRANS | val_primary/surface_mse | **0.000482** | pr4wsbfm | 2L/256d, AdamW lr=6e-4, T_max=50, gc=1.0 |
| TandemFoil | val_primary/surface_pressure_mae | **22.537** | 0lv7fnun | 3L/192d, Lion lr=1.25e-4, gc=0.5, EMA=0.999 |
| TandemFoil Paper | val_primary/field_mse | **0.002383** | d1xh0o1p | 3L/192d, Lion lr=1.25e-4, gc=0.5, EMA=0.999 |