### PR TITLE
DrivAerML: Bilateral left-right symmetry augmentation

### DIFF
--- a/.branch_init
+++ b/.branch_init
@@ -1,0 +1,1 @@
+# levi/dm-bilateral-symmetry-augmentation

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    drivaerml_symmetry_aug: bool = False
 
 
 @dataclass
@@ -570,6 +571,32 @@ def autocast_context(device: torch.device, amp_mode: str):
     if not supports_bf16():
         return nullcontext()
     return torch.autocast(device_type="cuda", dtype=torch.bfloat16)
+
+
+def apply_drivaerml_symmetry_flip(batch: GroupedBatch, *, space_dim: int = 3) -> GroupedBatch:
+    surface_x = batch.surface_x.clone()
+    surface_x[:, :, 1] = -surface_x[:, :, 1]
+    surface_x[:, :, space_dim + 1] = -surface_x[:, :, space_dim + 1]
+    base_dim = 2 * space_dim + 1
+    feat_dim = surface_x.shape[-1]
+    if feat_dim > base_dim:
+        cols_per_freq = 2 * space_dim
+        n_freqs = (feat_dim - base_dim) // cols_per_freq
+        for i in range(n_freqs):
+            y_sin_col = base_dim + i * cols_per_freq + 1
+            surface_x[:, :, y_sin_col] = -surface_x[:, :, y_sin_col]
+    return GroupedBatch(
+        case_ids=batch.case_ids,
+        dataset_name=batch.dataset_name,
+        space_dim=batch.space_dim,
+        surface_x=surface_x,
+        surface_y=batch.surface_y,
+        surface_mask=batch.surface_mask,
+        volume_x=batch.volume_x,
+        volume_y=batch.volume_y,
+        volume_mask=batch.volume_mask,
+        metadata=batch.metadata,
+    )
 
 
 def float_outputs(outputs: dict[str, torch.Tensor | None]) -> dict[str, torch.Tensor | None]:
@@ -1266,11 +1293,13 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    drivaerml_symmetry_aug: bool = False,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
         anp_head.train()
     running = {"loss": 0.0}
+    sym_aug_count = 0
     steps = 0
     micro_batches_total = 0
     batches = loader if max_batches <= 0 else itertools.islice(loader, max_batches)
@@ -1302,6 +1331,9 @@ def train_one_epoch(
                     loss, _ = loss_abupt(batch, outputs, transform)
             else:
                 batch = batch.to(device)
+                if drivaerml_symmetry_aug and batch.dataset_name == "drivaerml" and torch.rand(1).item() < 0.5:
+                    batch = apply_drivaerml_symmetry_flip(batch, space_dim=batch.space_dim)
+                    sym_aug_count += 1
                 if isinstance(transform, TandemTargetTransform):
                     prepared = transform.prepare_batch(batch)
                     with autocast_context(device, amp_mode):
@@ -1356,6 +1388,8 @@ def train_one_epoch(
         running["grad_norm_mean"] /= max(steps, 1)
     running["train_steps"] = float(steps)
     running["micro_batches"] = float(micro_batches_total)
+    if sym_aug_count > 0:
+        running["symmetry_aug_flips"] = float(sym_aug_count)
     if scheduler is not None:
         running["lr"] = float(optimizer.param_groups[0]["lr"])
     return running
@@ -1671,6 +1705,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            drivaerml_symmetry_aug=config.drivaerml_symmetry_aug,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Cars in zero-yaw flow have **exact bilateral (left-right) symmetry** along the longitudinal (xz) plane. Mirroring each training case — negating the y-coordinate and the y-component of surface normals, while leaving scalar Cp targets unchanged — produces a **physically valid, novel training example at zero compute cost**. This doubles the effective training set from 400 to 800 cases.

This is the 3D analogue of horizontal flip augmentation that routinely wins Kaggle competitions on image tasks. For DrivAerML with only 400 training cases, doubling the dataset is one of the highest-impact, lowest-risk changes possible.

**Prerequisite:** Verify that DrivAerML cars are axis-aligned with the symmetry plane at y=0 (or at the car centerline). If not, compute the centerline from the point cloud bounds.

**Note:** This is a DrivAerML-specific experiment, justified because bilateral symmetry is a physical property unique to the zero-yaw automotive flow domain. TandemFoil airfoils at different AoA do not have simple reflective symmetry.

## Instructions

**Step 1: Verify car symmetry axis**

Before implementing, check the DrivAerML data to confirm:
```python
# In the data loader or a debug script
for case in dataset:
    y_coords = case['pos'][:, 1]  # y-coordinate
    y_center = (y_coords.max() + y_coords.min()) / 2
    print(f"y center: {y_center}, y range: [{y_coords.min()}, {y_coords.max()}]")
```
If `y_center ≈ 0`, mirror about y=0. Otherwise, mirror about `y_center`.

**Step 2: Add `--drivaerml-symmetry-aug` flag to train.py**

```python
parser.add_argument('--drivaerml-symmetry-aug', action='store_true', default=False,
                    help='Mirror DrivAerML cases along y-axis (bilateral symmetry augmentation)')
```

**Step 3: Implement in the DrivAerML data loader (TRAINING ONLY)**

During training, with 50% probability per batch, flip the case:
```python
if args.drivaerml_symmetry_aug and self.training:
    if torch.rand(1).item() < 0.5:
        # Mirror y-coordinate
        pos[:, 1] = -pos[:, 1]  # (or 2*y_center - pos[:, 1] if not centered at 0)
        # Mirror y-component of surface normals if they exist as inputs
        if 'normals' in data:
            data['normals'][:, 1] = -data['normals'][:, 1]
        # Scalar targets (Cp / pressure) are UNCHANGED by reflection
```

**Key implementation details:**
- Apply ONLY during training (not validation/test)
- Flip with 50% probability (so model sees both original and mirrored)
- Only flip the y-coordinate and y-component of any vector features
- Scalar targets (pressure) are invariant under reflection — DO NOT modify targets
- If the model uses input features beyond xyz coords (e.g., surface normals), flip their y-component too

**Step 4: Run 2 DrivAerML experiments**

Use `--wandb_group levi-dm-symmetry-aug` for all runs.

```bash
cd target/icml2026

# Run 1: Symmetry augmentation ON
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --drivaerml-symmetry-aug --wandb_group levi-dm-symmetry-aug

# Run 2: Control (no augmentation — should reproduce baseline ~3.997%)
SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group levi-dm-symmetry-aug
```

**Results to report:**
- Best val `surface_rel_l2_pct` and epoch for both runs
- W&B run IDs
- Whether the augmented run improves over control
- If the symmetry check reveals cars are NOT axis-aligned, report the y-center distribution

## Baseline

| Dataset | Metric | Baseline | W&B run | Config |
|---------|--------|----------|---------|--------|
| DrivAerML | val_primary/surface_rel_l2_pct | **3.997%** | bht6h42t | 4L/512d, AdamW lr=5e-4, T_max=30, no gc, no WD, no-EMA |

Reproduce: `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`