### PR TITLE
Cross-dataset: Auxiliary flow-condition prediction head

### DIFF
--- a/.branch_init
+++ b/.branch_init
@@ -1,0 +1,1 @@
+# mitsuha/aux-flow-condition-head


### PR DESCRIPTION
## Hypothesis

Add a lightweight auxiliary prediction head that predicts the flow condition (Reynolds number / inlet conditions) from the model's mean-pooled latent representation. The auxiliary loss (MSE on log-normalized Re, weight λ=0.1) forces the latent space to retain **flow-regime-discriminative features**, directly targeting out-of-distribution (OOD) generalization.

**Why this should work:**
- TandemFoil has explicit OOD-Re splits (re_rand) — if the model encodes Re in its latent space, it should generalize better to unseen Re values
- AirfRANS operates across different Reynolds numbers — same mechanism applies
- DrivAerML has varying freestream conditions — encoding flow conditions helps distinguish aerodynamic regimes
- The auxiliary head adds ~1k parameters (negligible overhead) and λ=0 recovers baseline exactly

**References:** Auxiliary task learning for domain generalization is well-established (Caruana 1997). Predicting physical parameters as auxiliary tasks has shown improvements in physics-informed neural networks (Raissi et al. 2019).

## Instructions

**Step 1: Add arguments to train.py**

```python
parser.add_argument('--aux-re-prediction', action='store_true', default=False,
                    help='Add auxiliary head to predict Reynolds number / flow condition')
parser.add_argument('--aux-re-loss-weight', type=float, default=0.1,
                    help='Weight for auxiliary Re prediction loss')
```

**Step 2: Add auxiliary prediction head to the model**

After the Transolver's main output, add:
```python
if args.aux_re_prediction:
    # Mean-pool the latent representation to get a case-level embedding
    case_embedding = latent.mean(dim=-2)  # (B, hidden_dim) or (hidden_dim,) for B=1
    # Predict log-normalized Re from case embedding
    self.re_head = nn.Linear(hidden_dim, 1)
    re_pred = self.re_head(case_embedding)
```

**Step 3: Compute auxiliary loss in the training loop**

```python
if args.aux_re_prediction:
    # Get the ground-truth flow condition for this case
    # For TandemFoil: Re is available from the dataset metadata
    # For AirfRANS: Re is available from the task parameters
    # For DrivAerML: use freestream velocity or dynamic pressure
    # Normalize: re_target = log(Re / Re_mean)  (log-normalize to ~N(0,1) range)
    aux_loss = F.mse_loss(re_pred, re_target)
    total_loss = main_loss + args.aux_re_loss_weight * aux_loss
```

**IMPORTANT:** The flow condition / Re value must be accessible from the dataset. Check each dataset's data format:
- **TandemFoil:** The split name contains Re info (re_rand). Check if Re is stored in the data files.
- **AirfRANS:** Reynolds number is a simulation parameter — look for it in the data metadata.
- **DrivAerML:** Freestream velocity or dynamic pressure should be in the case metadata.
- **TFP:** Similar to TandemFoil.

If Re is not directly available for a dataset, use any scalar flow condition that varies across cases (e.g., AoA for TandemFoil, inlet velocity for AirfRANS). The key is predicting SOMETHING that characterizes the flow regime.

If a dataset truly has no accessible per-case scalar flow condition, skip that dataset for the auxiliary head (but still train normally on it).

**Step 4: Run 4 experiments (one per benchmark)**

Use `--wandb_group mitsuha-aux-re-head` for all runs.

**DrivAerML:**
```bash
cd target/icml2026

SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --aux-re-prediction --aux-re-loss-weight 0.1 --wandb_group mitsuha-aux-re-head
```

**AirfRANS:**
```bash
python train.py --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 \
  --weight-decay 1e-2 --no-use-ema --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 \
  --aux-re-prediction --aux-re-loss-weight 0.1 --wandb_group mitsuha-aux-re-head
```

**TandemFoil:**
```bash
python train.py --dataset tandemfoil \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --model-slices 64 --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-fourier --enable-te-coord-frame --enable-cp-panel \
  --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999 \
  --aux-re-prediction --aux-re-loss-weight 0.1 --wandb_group mitsuha-aux-re-head
```

**TandemFoil Paper:**
```bash
python train.py --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --enable-fourier --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --aux-re-prediction --aux-re-loss-weight 0.1 --wandb_group mitsuha-aux-re-head
```

**Results to report:**
- Best val primary metric and epoch for each dataset
- Whether Re/flow-condition was successfully extracted from each dataset
- Auxiliary loss convergence (does the Re prediction improve over training?)
- Whether TF OOD-Re split (re_rand) improves more than in-distribution splits

## Baseline

| Dataset | Metric | Baseline | W&B run |
|---------|--------|----------|---------|
| DrivAerML | val_primary/surface_rel_l2_pct | **3.997%** | bht6h42t |
| AirfRANS | val_primary/surface_mse | **0.000482** | pr4wsbfm |
| TandemFoil | val_primary/surface_pressure_mae | **22.537** | 0lv7fnun |
| TandemFoil Paper | val_primary/field_mse | **0.002383** | d1xh0o1p |