### PR TITLE
DrivAerML: 5-epoch linear warmup + cosine T_max=30

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    warmup_epochs: int = 0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,19 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        cosine_sched = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            total_batches = config.max_train_batches if config.max_train_batches > 0 else len(train_loader)
+            steps_per_epoch = math.ceil(total_batches / config.grad_accum_steps)
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup_sched = torch.optim.lr_scheduler.LinearLR(
+                base_optimizer, start_factor=0.2, end_factor=1.0, total_iters=warmup_steps
+            )
+            scheduler = torch.optim.lr_scheduler.SequentialLR(
+                base_optimizer, schedulers=[warmup_sched, cosine_sched], milestones=[warmup_steps]
+            )
+        else:
+            scheduler = cosine_sched
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

The DrivAerML champion uses cosine annealing starting from full LR at epoch 0. A linear warmup ramp in early epochs could prevent cold-start instability and find a better initial basin. 5-epoch warmup is gentle enough to not waste budget.

## Instructions

Add a 5-epoch linear warmup before cosine annealing. Implement as follows:
- For epochs 0-4: use `lr = base_lr * (epoch + 1) / 5` (linear ramp from lr/5 to lr)
- For epochs 5+: standard cosine annealing with T_max=30
- Simplest implementation: `torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=0.2, end_factor=1.0, total_iters=5)` for first 5 epochs, then switch to `CosineAnnealingLR(optimizer, T_max=30)`
- Or use `SequentialLR([LinearLR(...), CosineAnnealingLR(...)], milestones=[5])`
- Add a `--warmup-epochs` flag (default 0)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --warmup-epochs 5 \
  --wandb_group dm-warmup-sweep
```

## Reporting Requirements
- Best val `surface_rel_l2_pct` + epoch
- Test `surface_rel_l2_pct` at best val checkpoint
- W&B run ID

## Baseline

**DrivAerML baselines:**
- val best: `3.997%` @ ep467 (PR #2898, W&B: `bht6h42t`, 4L/512d, AdamW lr=5e-4, T_max=30)
- test best: `6.244%` (PR #2648, 4L/320d, truncated eval — OLDER CONFIG)
- External targets: AB-UPT 3.82% | Transolver-3: 3.71%

```bash
# DrivAerML champion (val 3.997% @ ep467)
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```
