### PR TITLE
DrivAerML: 10-epoch linear warmup + cosine T_max=30

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    warmup_epochs: int = 0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,18 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            steps_per_epoch = config.max_train_batches if config.max_train_batches > 0 else len(train_loader)
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+                base_optimizer, start_factor=0.1, end_factor=1.0, total_iters=warmup_steps,
+            )
+            scheduler = torch.optim.lr_scheduler.SequentialLR(
+                base_optimizer, schedulers=[warmup_scheduler, cosine_scheduler], milestones=[warmup_steps],
+            )
+        else:
+            scheduler = cosine_scheduler
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
@@ -1707,7 +1719,9 @@ def main() -> None:
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
-        epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        _lr_optim = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+        current_lr = _lr_optim.param_groups[0]["lr"]
+        epoch_metrics = {"epoch": float(epoch), "lr": current_lr, **train_metrics, **eval_metrics}
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)


### PR DESCRIPTION
## Hypothesis

10-epoch warmup provides a more gradual ramp than 5-epoch. AB-UPT uses Lion with a warmup+cosine schedule for DrivAerML.

## Instructions

Add a 10-epoch linear warmup before cosine annealing:
- Implement `SequentialLR([LinearLR(optimizer, start_factor=0.1, end_factor=1.0, total_iters=10), CosineAnnealingLR(optimizer, T_max=30)], milestones=[10])`
- Add `--warmup-epochs 10` flag

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --warmup-epochs 10 \
  --wandb_group dm-warmup-sweep
```

## Reporting Requirements
- Best val + test `surface_rel_l2_pct`
- W&B run ID

## Baseline

**DrivAerML baselines:**
- val best: `3.997%` @ ep467 (PR #2898, W&B: `bht6h42t`, 4L/512d, AdamW lr=5e-4, T_max=30)
- test best: `6.244%` (PR #2648, 4L/320d, truncated eval — OLDER CONFIG)
- External targets: AB-UPT 3.82% | Transolver-3: 3.71%
