### PR TITLE
DrivAerML: log-cosh loss (smooth robust alternative to MSE)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    loss: str = "mse"
 
 
 @dataclass
@@ -757,21 +758,36 @@ def _named_channel_metrics(prefix: str, values: torch.Tensor, names: tuple[str, 
     return metrics
 
 
+def log_cosh_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    diff = pred - target
+    # log(cosh(x)) = |x| + log(1 + exp(-2|x|)) - ln(2), numerically stable
+    return torch.mean(diff.abs() + F.softplus(-2.0 * diff.abs()) - math.log(2.0))
+
+
+def get_loss_fn(loss_name: str):
+    if loss_name == "mse":
+        return F.mse_loss
+    if loss_name == "log_cosh":
+        return log_cosh_loss
+    raise ValueError(f"Unknown loss: {loss_name}")
+
+
 def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    loss_fn=F.mse_loss,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
     if batch.surface_y is not None and outputs["surface_preds"] is not None:
         target = transform.apply(batch.surface_y)
-        surf_loss = F.mse_loss(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
+        surf_loss = loss_fn(outputs["surface_preds"][batch.surface_mask], target[batch.surface_mask])
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
-        vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
+        vol_loss = loss_fn(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -781,15 +797,16 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    loss_fn=F.mse_loss,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
     if outputs["surface_preds"] is not None:
-        surf_loss = F.mse_loss(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask])
+        surf_loss = loss_fn(outputs["surface_preds"][prepared.surface_mask], prepared.surface_target[prepared.surface_mask])
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
-        vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
+        vol_loss = loss_fn(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -800,17 +817,18 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    loss_fn=F.mse_loss,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
     if batch.surface_anchor_target is not None and outputs["surface_preds"] is not None:
         surf_target = transform.apply(batch.surface_anchor_target)
-        surf_loss = F.mse_loss(outputs["surface_preds"], surf_target)
+        surf_loss = loss_fn(outputs["surface_preds"], surf_target)
         total = total + surf_loss
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
-        vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
+        vol_loss = loss_fn(outputs["volume_preds"], vol_target)
         total = total + vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
@@ -1266,6 +1284,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    loss_fn=F.mse_loss,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1299,7 +1318,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, loss_fn=loss_fn)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1312,7 +1331,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, loss_fn=loss_fn)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1321,7 +1340,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, loss_fn=loss_fn)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1671,6 +1690,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            loss_fn=get_loss_fn(config.loss),
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Log-cosh loss = log(cosh(pred - target)) is twice differentiable everywhere, approximates L2 for small errors and L1 for large errors. Smoother than Huber (no discontinuity in derivative). May help with the DrivAerML outlier problem in a way that's more gradient-stable than Huber.

**Formula:** L(r) = log(cosh(r)) = log((exp(r) + exp(-r)) / 2)

## Instructions

Implement `--loss log_cosh` in train.py:

```python
def log_cosh_loss(pred, target):
    diff = pred - target
    return torch.mean(torch.log(torch.cosh(diff + 1e-12)))
```

Run one variant:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --loss log_cosh --wandb_group dm-loss-alignment
```

## Reporting Requirements
- Best val `surface_rel_l2_pct`
- Test at best val checkpoint
- W&B run ID

## Baseline

**DrivAerML baselines:**
- val best: `3.997%` @ ep467 (PR #2898, W&B: `bht6h42t`, 4L/512d, AdamW lr=5e-4, T_max=30)
- test best: `6.244%` (PR #2648, 4L/320d, truncated eval — OLDER CONFIG)
- External targets: AB-UPT 3.82% | Transolver-3: 3.71%
