### PR TITLE
DrivAerML: CosineAnnealingWarmRestarts T_mult=2 (SGDR)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_t_mult: int = 1
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,12 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.cosine_t_mult > 1:
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+                base_optimizer, T_0=config.cosine_t_max, T_mult=config.cosine_t_mult
+            )
+        else:
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

SGDR (Loshchilov & Hutter 2017) with T_mult=2 doubles the restart period after each restart (T0=30, then 60, then 120). This allows short early exploration cycles followed by long settling phases. PR #2895 (mugen) found a transient DrivAerML minimum using this approach but couldn't capture it — with best-checkpoint saving now in place, this approach can be properly evaluated.

## Instructions

Implement `CosineAnnealingWarmRestarts(optimizer, T_0=30, T_mult=2)`:
```python
scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=30, T_mult=2)
```

Add `--cosine-t-mult 2` flag (keep existing `--cosine-t-max 30` as `T_0`).

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --cosine-t-mult 2 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-sgdr-sweep
```

**Critical:** Must save best checkpoint (save model whenever `val_primary/surface_rel_l2_pct` improves). Report from best checkpoint, not terminal epoch.

## Reporting Requirements
- Best val `surface_rel_l2_pct` + epoch
- Test at best val checkpoint
- W&B run ID

## Baseline

**DrivAerML baselines:**
- val best: `3.997%` @ ep467 (PR #2898, W&B: `bht6h42t`, 4L/512d, AdamW lr=5e-4, T_max=30)
- test best: `6.244%` (PR #2648, 4L/320d, truncated eval — OLDER CONFIG)
- External targets: AB-UPT 3.82% | Transolver-3: 3.71%
