### PR TITLE
TandemFoil Paper: T_max=30 at champion config

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -227,7 +227,7 @@ class TargetTransform:
         if self.stats_mean is not None and self.stats_std is not None and self.stats_mean.numel() == out.shape[-1]:
             out = out * self.stats_std.to(out.device) + self.stats_mean.to(out.device)
         if self.asinh_pressure and self.pressure_index is not None:
-            out[..., self.pressure_index] = torch.sinh(out[..., self.pressure_index]) / max(self.asinh_scale, 1e-6)
+            out[..., self.pressure_index] = torch.sinh(out[..., self.pressure_index].clamp(-40.0, 40.0)) / max(self.asinh_scale, 1e-6)
         return out
 
 
@@ -972,8 +972,8 @@ def evaluate_grouped(
                 case_values = (surface_pred - surface_target).square()
                 valid = batch.surface_mask.unsqueeze(-1)
                 if paper_surface_sq_sum is None:
-                    paper_surface_sq_sum = torch.zeros(case_values.shape[-1], device=device)
-                paper_surface_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device)
+                    paper_surface_sq_sum = torch.zeros(case_values.shape[-1], device=device, dtype=torch.float64)
+                paper_surface_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device=device, dtype=torch.float64)
                 paper_surface_nodes += int(batch.surface_mask.sum().detach().cpu().item())
             if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
                 volume_pred, volume_target = comparison_metric_tensors(
@@ -985,8 +985,8 @@ def evaluate_grouped(
                 case_values = (volume_pred - volume_target).square()
                 valid = batch.volume_mask.unsqueeze(-1)
                 if paper_volume_sq_sum is None:
-                    paper_volume_sq_sum = torch.zeros(case_values.shape[-1], device=device)
-                paper_volume_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device)
+                    paper_volume_sq_sum = torch.zeros(case_values.shape[-1], device=device, dtype=torch.float64)
+                paper_volume_sq_sum += (case_values * valid).sum(dim=(0, 1)).to(device=device, dtype=torch.float64)
                 paper_volume_nodes += int(batch.volume_mask.sum().detach().cpu().item())
             continue
 


### PR DESCRIPTION
## Hypothesis

T_max=30 (like TandemFoil parity champion) may be more stable for TFP as well, while still providing enough LR oscillation for basin exploration. Tests whether the divergence pattern is purely a T_max=10 issue.

## Instructions

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --wandb_group tfp-tmax-sweep
```

## Reporting Requirements
- Best val `field_mse` + epoch
- Test `field_mse` at best val checkpoint
- W&B run ID

**Paper-facing metric:** `test_primary/field_mse` (normalized full-field MSE).

## Baseline

**TFP baselines:**
- val best: `field_mse = 0.002383` @ ep443 (PR #3025, W&B: `d1xh0o1p`)
- Config: Lion lr=1.25e-4, T_max=10, gc=0.5, EMA=0.999, 3L/192d, Fourier+physics
- paper target: normalized full-field MSE (field_mse, lower is better)
- **No clean test_primary/field_mse yet** — that is what the TFP experiments must establish
