### PR TITLE
AirfRANS: 3x volume loss weight to improve Vol MSE

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1651,14 +1651,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
@@ -1728,7 +1721,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -761,6 +762,8 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    *,
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -772,8 +775,10 @@ def loss_grouped(
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
-        total = total + vol_loss
+        total = total + volume_loss_weight * vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
+        if volume_loss_weight != 1.0:
+            metrics["volume_loss_weighted"] = float((volume_loss_weight * vol_loss).detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
 
@@ -1266,6 +1271,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    volume_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1321,9 +1327,14 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, loss_parts = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
 
             accum_loss += float(loss.detach().cpu().item())
+            if not isinstance(transform, TandemTargetTransform) and model_name != "reference_abupt":
+                for k, v in loss_parts.items():
+                    if k != "loss":
+                        running.setdefault(k, 0.0)
+                        running[k] += v
             (loss / grad_accum_steps).backward()
             micro_count += 1
 
@@ -1352,6 +1363,9 @@ def train_one_epoch(
         steps += 1
 
     running["loss"] /= max(steps, 1)
+    for k in ("surface_loss", "volume_loss", "volume_loss_weighted"):
+        if k in running:
+            running[k] /= max(micro_batches_total, 1)
     if "grad_norm_mean" in running:
         running["grad_norm_mean"] /= max(steps, 1)
     running["train_steps"] = float(steps)
@@ -1682,6 +1696,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            volume_loss_weight=config.volume_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The current AirfRANS loss treats surface and volume nodes with equal weight. But our volume MSE (0.00764) is far above SpiderSolver (0.0017) while surface is already excellent. Adding explicit volume loss weighting (3x) should redirect gradient signal toward improving volume predictions.

**Implementation:** In the loss computation, multiply the volume-node MSE contribution by 3.0:
```python
total_loss = surface_mse + 3.0 * volume_mse
```

## Instructions

Add `--volume-loss-weight 3.0` flag to train.py. When active, multiply the volume component of the loss by the specified weight.

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 \
  --volume-loss-weight 3.0 \
  --wandb_group af-volume-loss-weight
```

**Watch:** Surface MSE may increase as volume gets more gradient attention. Track both.

## Reporting Requirements
- Best val `surface_mse` AND `volume_mse`
- Test pair at best val checkpoint
- W&B run ID
- Compare Surf/Vol tradeoff vs champion

## Baseline

**AirfRANS baselines:**
- val surface_mse: `0.000482` @ ep576 (PR #2951, W&B: `pr4wsbfm`)
- Paper pair: Surf MSE = 0.003, Vol MSE = 0.00764 (from PR #2824)
- External target (SpiderSolver): Surf MSE 0.0043 / Vol MSE 0.0017
- **Surface is already below target; volume (0.00764 vs 0.0017) needs 4.5x improvement**
