### PR TITLE
DrivAerML: lr=4e-4 full-eval (lower-LR neighbor of champion)

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -155,12 +155,21 @@
 ## AirfRANS
 
 - **Primary metric:** `val_primary/surface_mse`
-- **Current best:** 0.000459 (val) at epoch 771 — with Vol MSE 0.002777 (best in programme)
-- **Best PR:** #3050 (stark — EMA=0.999 + T_max=50, 2L/256d, AdamW lr=6e-4, gc=1.0, WD=1e-2)
-- **Key insight:** EMA=0.999 combined with T_max=50 improves BOTH primary metrics simultaneously: surface -4.8% (0.000459 vs 0.000482) AND volume -63.6% (0.002777 vs 0.00764). EMA is harmonious with T_max=50 — the longer cosine cycle lets EMA track effectively. Vol MSE 0.002777 closes gap to SpiderSolver from 4.5x to 1.63x.
-- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999`
+- **Current best:** 0.000296 (val) at epoch 704 — with Vol MSE 0.002039 (best in programme)
+- **Best PR:** #3135 (nezuko — EMA=0.999 + vol-weight=10x, 2L/256d, AdamW lr=6e-4, gc=1.0, WD=1e-2)
+- **Key insight:** EMA=0.999 + vol-weight=10x compound dramatically improves both metrics simultaneously: surface -35.5% (0.000296 vs 0.000459) AND volume -26.6% (0.002039 vs 0.002777). Volume gap to SpiderSolver target closed from 1.63x to 1.20x. Model still improving at ep763 timeout.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`
 
-### 2026-04-23 — PR #3050: AirfRANS: EMA=0.999 at T_max=50 champion — NEW BEST (CURRENT)
+### 2026-04-23 — PR #3135: AirfRANS: EMA=0.999 + vol-weight=10x — NEW BEST (CURRENT)
+
+- **val_primary/surface_mse:** 0.000296 (-35.5% vs 0.000459) at epoch 704
+- **val_primary/vol_mse:** 0.002039 (-26.6% vs 0.002777) at epoch 743
+- **W&B run:** sh2zyfwr (nezuko/af-ema-vol-weight-10x)
+- **Config:** 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, **EMA=0.999**, vol-weight=10x, Fourier
+- **Key insight:** vol-weight=10x without EMA was confirmed worse. With EMA=0.999, the combination works dramatically better — EMA stabilizes the upweighted volume gradient. Surface -35.5% and volume -26.6% simultaneously. Vol gap to SpiderSolver: 1.20x (was 1.63x). Model at ep763 still converging.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`
+
+### 2026-04-23 — PR #3050: AirfRANS: EMA=0.999 at T_max=50 champion — PREVIOUS BEST
 
 - **val_primary/surface_mse:** 0.000459 (-4.8% vs 0.000482) at epoch 771
 - **full_val/volume_mse:** 0.002777 (-63.6% vs 0.00764) — best volume result in programme

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -3,11 +3,21 @@
 ## TandemFoilSet
 
 - **Primary metric:** `val_primary/surface_pressure_mae` (= `val_eq4/surface_pressure_mae`)
-- **Current best:** 22.537 (val) at epoch 336
-- **Best PR:** #2924 (robin — gc=0.5 EMA refinement, Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, EMA decay=0.999, 3L/192d)
-- **Note:** gc=0.5 (softer clip vs standard gc=1.0) enables stable EMA training across 336+ epochs where gc=1.0 diverged after ep167. Model still descending at ep336 — result is an underestimate of the ceiling.
+- **Current best:** 21.909 (val) at epoch 334 — test 23.419
+- **Best PR:** #3108 (zenitsu — gc=0.3+EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d)
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
 
-### 2026-04-22 — PR #2924: TandemFoil: EMA refinement gc=0.5 — NEW BEST (CURRENT)
+### 2026-04-23 — PR #3108: TandemFoil: gc=0.3 + EMA=0.999 — NEW BEST (CURRENT)
+
+- **val_primary/surface_pressure_mae:** 21.909 (-2.8% vs 22.537) at epoch 334
+- **test_primary/surface_pressure_mae:** 23.419 (-4.7% vs 24.581)
+- **Per-split test MAE:** geom_camber_cruise=27.436, geom_camber_rc=31.587, re_rand=17.119, single_in_dist=17.533
+- **W&B run:** kzg626hf (zenitsu/tf-gc03-ema999)
+- **Config:** Lion lr=1.25e-4, T_max=10, **gc=0.3**, WD=1e-2, **EMA=0.999**, 3L/192d, Fourier+physics
+- **Key insight:** Softer gc (0.3 vs 0.5) under EMA stability finds a deeper basin. gc=0.5 was already soft relative to standard gc=1.0 — gc=0.3 continues the trend. Model best at ep334 not terminal — still room to improve.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+
+### 2026-04-22 — PR #2924: TandemFoil: EMA refinement gc=0.5 — PREVIOUS BEST
 
 - **val_primary/surface_pressure_mae:** 22.537 (-13.8% vs 26.06) at epoch 336
 - **W&B run:** 0lv7fnun (robin/ema-refine-tf-gc05)

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -3,11 +3,20 @@
 ## TandemFoilSet
 
 - **Primary metric:** `val_primary/surface_pressure_mae` (= `val_eq4/surface_pressure_mae`)
-- **Current best:** 21.909 (val) at epoch 334 — test 23.419
-- **Best PR:** #3108 (zenitsu — gc=0.3+EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d)
-- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+- **Current best:** 21.350 (val) at epoch 331 — test 23.195
+- **Best PR:** #3140 (usopp — gc=0.2+EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d)
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
 
-### 2026-04-23 — PR #3108: TandemFoil: gc=0.3 + EMA=0.999 — NEW BEST (CURRENT)
+### 2026-04-23 — PR #3140: TandemFoil: gc=0.2 + EMA=0.999 — NEW BEST (CURRENT)
+
+- **val_primary/surface_pressure_mae:** 21.350 (-2.6% vs 21.909) at epoch 331
+- **test_primary/surface_pressure_mae:** 23.195 (-1.0% vs 23.419)
+- **W&B run:** 9g11l7tm (usopp/tf-gc-02-sweep)
+- **Config:** Lion lr=1.25e-4, T_max=10, **gc=0.2**, WD=1e-2, **EMA=0.999**, 3L/192d, Fourier+physics
+- **Key insight:** gc monotonic trend continues: 1.0→0.5→0.3→0.2 all improve. gc=0.1 overshoots (22.141, single_in_dist +12.4%). gc=0.2 is the floor — bracketed. Model best at ep331, not terminal.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+
+### 2026-04-23 — PR #3108: TandemFoil: gc=0.3 + EMA=0.999 — PREVIOUS BEST
 
 - **val_primary/surface_pressure_mae:** 21.909 (-2.8% vs 22.537) at epoch 334
 - **test_primary/surface_pressure_mae:** 23.419 (-4.7% vs 24.581)

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -424,14 +424,22 @@
 ## DrivAerML
 
 - **Primary metric:** `val_primary/surface_rel_l2_pct` (lower is better)
-- **Current best:** 3.997% (val) at epoch 467
-- **Best PR:** #2898 (piccolo — **4L/512d**/8H + Fourier + no-EMA + T_max=30, 467 epochs, AdamW lr=5e-4, **SENPAI_MAX_EPOCHS=9999**, no-compile)
+- **Current best:** 3.833% (val) at epoch 511 — test 4.685%
+- **Best PR:** #3072 (eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
 - **CRITICAL:** Must pass `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
-- **External target:** <3.71% (AB-UPT, ~500 epochs) — **1.08x gap remaining** (was 1.24x)
-- **Key insight:** Longer training on the golden 4L/512d config (SENPAI_MAX_EPOCHS=9999 with 360-min budget) finds a deeper basin at epoch 467 vs 256. torch.compile gives no throughput benefit on DrivAerML and the compile run diverged to NaN at ep454 without --grad-clip — future compile experiments MUST include --grad-clip 1.0. SENPAI_MAX_EPOCHS=9999 required.
-- **gc=2.0 finding (PR #2886):** gc=2.0+lr=4e-4+WD=1e-2 = **4.346%** (W&B: ginhxdco) — new 4L/512d gc ablation best. Does NOT beat current 3.997% baseline (achieved with different architecture/config) but represents the best gc sweep result on the golden 4L/512d foundation. gc=2.0 > gc=1.0 > gc=5.0 for DrivAerML.
+- **External target:** <3.71% (AB-UPT, ~500 epochs) — **gap: 0.123 pp (1.03x)**
+- **Key insight:** EMA=0.9995 requires gc=0.5 as stability guard — EMA alone diverges at ep28. gc unlocks EMA for DrivAerML. Run still converging at ep517 timeout (3.833% at ep511); more epochs expected to push below 3.82% (AB-UPT). Closes 93% of the original gap to AB-UPT.
 
-### 2026-04-22 — PR #2898: DrivAerML: torch.compile throughput (no-compile wins) — NEW BEST
+### 2026-04-23 — PR #3072: DrivAerML: EMA=0.9995 + gc=0.5 — NEW BEST (CURRENT)
+
+- **val_primary/surface_rel_l2_pct:** 3.833% (-4.1% vs 3.997%) at epoch 511
+- **test_primary/surface_rel_l2_pct:** 4.685% (best-checkpoint eval)
+- **W&B run:** ncl1dh88 (eren/dm-ema-9995-gc05)
+- **Config:** 4L/512d/8H, AdamW lr=5e-4, T_max=30, **EMA=0.9995**, **gc=0.5**, Fourier, no WD
+- **Key insight:** gc=0.5 is the stability enabler for EMA on DrivAerML. Without gc, EMA diverges at ep28 (Run 1: `64jrja7q`). With gc=0.5, training is stable through 517 epochs with no divergence. EMA was previously thought dead for DM (3 prior configs all failed) but those lacked gc. Run still converging at ep517 — gap to AB-UPT (3.82%) is only 0.013 pp.
+- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`
+
+### 2026-04-22 — PR #2898: DrivAerML: torch.compile throughput (no-compile wins) — PREVIOUS BEST
 
 - **val_primary/surface_rel_l2_pct:** 3.997% (-13.5% vs 4.619%) at epoch 467
 - **W&B run:** bht6h42t (no-compile baseline run, 467 epochs, SENPAI_MAX_EPOCHS=9999)

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -145,9 +145,19 @@
 ## AirfRANS
 
 - **Primary metric:** `val_primary/surface_mse`
-- **Current best:** 0.000482 (val) at epoch 576
-- **Best PR:** #2951 (stark — lr=6e-4, T_max=50, 2L/256d, AdamW, gc=1.0, wd=1e-2, no-EMA, Fourier)
-- **Key insight:** T_max=50 cosine schedule is the critical breakthrough — longer cosine periods allow the model to fully descend into loss basins before being kicked back up. lr=6e-4 + T_max=50 achieves 0.000482, a -19.4% improvement over the previous best (0.000598 at T_max=10). The run was still at ep576 within the 360-min budget. **Beats external target 0.0043 by 88.8%.**
+- **Current best:** 0.000459 (val) at epoch 771 — with Vol MSE 0.002777 (best in programme)
+- **Best PR:** #3050 (stark — EMA=0.999 + T_max=50, 2L/256d, AdamW lr=6e-4, gc=1.0, WD=1e-2)
+- **Key insight:** EMA=0.999 combined with T_max=50 improves BOTH primary metrics simultaneously: surface -4.8% (0.000459 vs 0.000482) AND volume -63.6% (0.002777 vs 0.00764). EMA is harmonious with T_max=50 — the longer cosine cycle lets EMA track effectively. Vol MSE 0.002777 closes gap to SpiderSolver from 4.5x to 1.63x.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999`
+
+### 2026-04-23 — PR #3050: AirfRANS: EMA=0.999 at T_max=50 champion — NEW BEST (CURRENT)
+
+- **val_primary/surface_mse:** 0.000459 (-4.8% vs 0.000482) at epoch 771
+- **full_val/volume_mse:** 0.002777 (-63.6% vs 0.00764) — best volume result in programme
+- **W&B run:** z6pry4b9 (stark/af-ema-champion)
+- **Config:** 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, **EMA=0.999**, Fourier
+- **Key insight:** EMA + T_max=50 is synergistic — the longer cosine cycle (50 vs 10) allows EMA to track the optimization trajectory harmoniously, improving both surface sharpness and volume smoothing simultaneously. Vol MSE 0.002777 closes the SpiderSolver gap from 4.5x to 1.63x. Model still descending at ep771 — further training would push both metrics lower.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999`
 
 ### 2026-04-22 — PR #2951: AirfRANS: LR + T_max sweep — NEW BEST (CURRENT)
 

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -3,11 +3,20 @@
 ## TandemFoilSet
 
 - **Primary metric:** `val_primary/surface_pressure_mae` (= `val_eq4/surface_pressure_mae`)
-- **Current best:** 21.350 (val) at epoch 331 — test 23.195
-- **Best PR:** #3140 (usopp — gc=0.2+EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d)
-- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+- **Current best:** 21.319 (val) at epoch 277 — test 22.868
+- **Best PR:** #3185 (fern — full noam stack: ANP+physics+T_max=150+Lookahead+compile+re-strat+96sl)
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 150 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 96 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --enable-wake-deficit --enable-wake-angle --enable-vortex-panel-velocity --asinh-pressure --asinh-scale 0.75 --residual-prediction --enable-pressure-prior-addition --re-stratified-sampling --anp-srf --use-lookahead --compile-model --ema-decay 0.999 --epochs 999`
 
-### 2026-04-23 — PR #3140: TandemFoil: gc=0.2 + EMA=0.999 — NEW BEST (CURRENT)
+### 2026-04-24 — PR #3185: TandemFoil: full noam stack (ANP+physics+T_max=150+Lookahead+96sl) — NEW BEST (CURRENT)
+
+- **val_primary/surface_pressure_mae:** 21.319 (-0.15% vs 21.350) at epoch 277
+- **test_primary/surface_pressure_mae:** 22.868 (-1.41% vs 23.195)
+- **W&B run:** v05jt92n (fern/tf-full-noam-stack)
+- **Config:** Lion lr=1.25e-4, T_max=150, gc=0.2, WD=1e-2, EMA=0.999, 3L/192d, 96 slices, Lookahead(α=0.5,k=5), torch.compile, re-stratified sampling, ANP decoder, wake deficit + wake angle + vortex panel physics, asinh-scale=0.75
+- **Key insight:** Full noam feature stack outperforms the stripped champion. Extras (Lookahead, compile, 96 slices, re-stratified) only take effect after ep200 — T2 (ANP+physics only, T_max=10) led for first 180 epochs, then T1 pulled ahead. Late-training compounding effect. T_max=150 needed for full benefit; T_max=10 (T2) diverged at ep289.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 150 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 96 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --enable-wake-deficit --enable-wake-angle --enable-vortex-panel-velocity --asinh-pressure --asinh-scale 0.75 --residual-prediction --enable-pressure-prior-addition --re-stratified-sampling --anp-srf --use-lookahead --compile-model --ema-decay 0.999 --epochs 999`
+
+### 2026-04-23 — PR #3140: TandemFoil: gc=0.2 + EMA=0.999 — PREVIOUS BEST
 
 - **val_primary/surface_pressure_mae:** 21.350 (-2.6% vs 21.909) at epoch 331
 - **test_primary/surface_pressure_mae:** 23.195 (-1.0% vs 23.419)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -82,7 +82,7 @@
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#NEW` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — BEING ASSIGNED
+- `#3199` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3129` chrome: 4L/256d deeper
 - `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 20:00 (advisor cycle 42 — closed #3132, assigning gohan)
+- **Date:** 2026-04-23 20:30 (advisor cycle 43 — closed #3134, assigning megumi)
 - **Branch:** radford
-- **Idle students:** 0 (gohan being assigned)
+- **Idle students:** 0 (megumi being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status (56 active PRs → 59 after assignments)
@@ -82,7 +82,7 @@
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3134` megumi: vol-weight=30x
+- `#NEW` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — BEING ASSIGNED
 - `#3129` chrome: 4L/256d deeper
 - `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
 
@@ -189,6 +189,7 @@
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight=10x: worse on both metrics
+- Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,9 +1,10 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 15:30 (advisor cycle 90 — LAST DITCH RESTRUCTURING)
+- **Date:** 2026-04-24 16:15 (advisor cycle 92)
 - **Branch:** radford
-- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~10 hours remaining)**
-- **Fleet restructuring IN PROGRESS:** killed 14 misaligned experiments, reassigning 15 students
+- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~8 hours remaining)**
+- **Fleet restructured.** 36 DM / 12 AF / 11 TFP / 0 TF.
+- **Harness patches (#3284):** 5/6 implemented, sent back for merge-blocking bug fix. HIGHEST PRIORITY.
 
 ## BINDING DIRECTIVE — Issue #3283 (2026-04-24)
 
@@ -26,7 +27,7 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 ## Fleet Status (restructuring in progress)
 
 ### INFRASTRUCTURE (1 PR)
-- `#3284` vegeta: HARNESS PATCHES (--load-checkpoint, --eval-interval, --ema-mode, --skip-update-grad-norm, --save-checkpoint, kill gates) — **HIGHEST PRIORITY**
+- `#3284` vegeta: HARNESS PATCHES — SENT BACK for merge-blocking bug (double best-tracking). 5/6 patches implemented. **HIGHEST PRIORITY — awaiting fix.**
 
 ### DrivAerML WIP (~28 continuing + 8 new = 36 target)
 **Champion recovery / truth lanes (newly assigned):**
@@ -38,6 +39,9 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 - robin: gradient-spike-safe gc=0.25 (Bucket D)
 - nami: T_max=24 narrow schedule (Bucket E)
 - chrome: T_max=36 narrow schedule (Bucket E)
+
+**Breakout lanes (newly assigned):**
+- `#3299` zenitsu: Breakout 4 — coordinate normalization + geometry features (xyz_norm, normals, log_area, front-facing)
 
 **Continuing DM experiments (from pre-restructure):**
 - `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval)
@@ -231,6 +235,7 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 - Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
 - Learnable register tokens (N=2/4/8): N=8 best 4.062% (+6%), N=2/N=4 NaN diverged (#3262). Category error — register tokens address pairwise attention sinks (ViT), but Transolver uses slice-based soft-clustering attention where sink mechanism doesn't apply.
 - Learnable Fourier frequencies: 5.262%/4.252% both diverged (#3260). Frequencies barely moved from init — fixed [0.5,2,8,32] are already near-optimal. Learnable freq + cosine restarts = cascading perturbation feedback loop.
+- Cosine similarity auxiliary loss: w=0.1→4.661% crashed ep244, w=0.5→6.569% crashed ep159 (#3276). Cos_sim saturates >0.99 by ep100 — spatially redundant with MSE. Near-unity cos_sim makes gradients ill-conditioned at LR restarts.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:15 (advisor cycle 49)
+- **Date:** 2026-04-23 23:30 (advisor cycle 50)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (shouko being assigned)
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -29,7 +29,7 @@
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
-- `#3163` shouko: attn dropout=0.05
+- `#3163` shouko: ~~attn dropout=0.05~~ → reassigning to AF GradNorm
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
@@ -184,7 +184,7 @@
 - Huber loss, relative L2 loss (degenerate), SGDR, RAdam
 - beta2≠0.999, LR≠5e-4 (without EMA), WD+gc heavy (WD=1e-3: 4.44%)
 - Bilateral symmetry aug, torch.compile, gradient accumulation
-- Attention dropout without EMA/gc: toxic combo with T_max=30
+- Attention dropout=0.05: incompatible at any stability level. Without EMA/gc→12.533%, with EMA+gc→10.118% (delayed divergence ep74 but same fate). Dropout noise compounds faster than gc clips.
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
 - eta_min+gc (any combination): gc=1.0→6.311%, gc=0.5→8.617%, gc=0.5+EMA→4.202% diverge ep312 — TRIPLE CONFIRMED. gc=0.5 relies on zero-LR trough damping; eta_min removes reset.
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:00 (advisor cycle 48)
+- **Date:** 2026-04-23 23:15 (advisor cycle 49)
 - **Branch:** radford
-- **Idle students:** 0 (5 being assigned)
+- **Idle students:** 0 (brook being reassigned)
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
-- `#3213` brook: surface normal input features — INNOVATION
+- `#3213` brook: Fourier encoding of surface normals — INNOVATION (reassigned)
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -151,7 +151,7 @@
 - DomainLayerNorm — jet #3201 (merged; awaiting results)
 
 **New physics-aware/ML ideas (cycle 48):**
-- Surface normal input features (local geometry context) — brook #3213
+- Fourier encoding of surface normals (angular frequency features) — brook #3213 (reassigned)
 - Auxiliary gradient prediction (∂p/∂x,y,z as regularization) — kakashi #3214
 - Attention distance bias (ALiBi-inspired spatial prior) — canute #3216
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 17:30 (advisor cycle 94)
+- **Date:** 2026-04-24 19:00 (advisor cycle 97)
 - **Branch:** radford
 - **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~6-7 hours remaining)**
 - **Fleet:** 59 students active. 36 DM / 12 AF / 11 TFP / 0 TF.
@@ -30,9 +30,9 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 **Breakout lanes:**
 - `#3300` vegeta: **Breakout 1** — AB-UPT-style anchored decoder (geometry supernodes → surface anchor cross-attention → point decoding)
 - `#3299` zenitsu: **Breakout 4** — coordinate normalization + geometry features (xyz_norm using geometry_center/scale, normals, log_area, front-facing indicator)
-- `#3301` brook: **Breakout 3** — domain-normalized volume auxiliary (fix normalization bug at line 790, separate surface/volume TargetTransform, vol_loss_weight 0.03/0.1/0.3)
-- **Breakout 2** (metric-aware fine-tune: mse_z + raw rel-L2) — NOT YET ASSIGNED
-- **Breakout 5** (train+val retrain) — NOT YET ASSIGNED
+- `#3301` brook: **Breakout 3** — domain-normalized volume auxiliary (round 2: relaxed kill gate, w=0.03/0.01 + surface-only control)
+- `#3302` canute: **Breakout 2** — metric-aware MSE + raw-rel-L2 loss (dm_rel_l2_weight 0.02/0.05/0.1)
+- **Breakout 5** (train+val retrain) — NOT YET ASSIGNED (only +8.5% data: 400→434 cases)
 
 **Champion recovery / truth lanes:**
 - `#3293` norman: champion recovery seed=0 no-compile (Bucket A)
@@ -51,7 +51,7 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 - `#3267` mitsuha: SwiGLU FFN
 - `#3265` alphonse: hidden-space noise
 - ~~`#3276` zenitsu: cosine similarity loss~~ CLOSED dead end
-- `#3275` canute: local attention
+- ~~`#3275` canute: local attention~~ CLOSED dead end → reassigned to Breakout 2 (#3302)
 - `#3271` nobara: LLRD
 - `#3251` fern: Pre-LayerNorm
 - `#3249` shouko: decaying WD

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 00:15 (advisor cycle 53)
+- **Date:** 2026-04-24 00:30 (advisor cycle 54)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
-- `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
+- canute: self-distillation with EMA teacher — INNOVATION (PR pending)
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
@@ -21,10 +21,10 @@
 
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
-- `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
+- casca: → AF focal-MSE volume loss (PR pending)
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
+- chihiro: → AF vol-weight curriculum (PR pending)
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
@@ -52,7 +52,7 @@
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3189` emma: asinh+physics features — NOAM ABLATION
-- `#3180` chopper: ANP decoder alone — NOAM ABLATION
+- chopper: → DM weight perturbation at troughs (PR pending)
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -180,7 +180,9 @@
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
 - T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
-- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%/15.0%(crashed). All diverge. Features tuned for T_max=150/3H/no-gc regime. Residual-pred requires asinh as hard prerequisite; even combined→3.999% (doesn't beat 3.833%)
+- Noam features on DM: DEFINITIVELY DEAD. Asinh triple-confirmed (4.072%/4.421%/4.475%), residual needs asinh+still→3.999%, full stack→4.447%. Features tuned for T_max=150/3H/no-gc regime
+- Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
+- Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 20:30 (advisor cycle 43 — closed #3134, assigning megumi)
+- **Date:** 2026-04-23 (advisor cycle 44 — gilbert assigned af-vol-15x-clean #3204)
 - **Branch:** radford
-- **Idle students:** 0 (megumi being assigned)
+- **Idle students:** 0 (gilbert assigned: #3204 af-vol-15x-clean — vol-weight=15x/20x clean control)
 - **PRs ready for review:** 0
 
-## Fleet Status (56 active PRs → 59 after assignments)
+## Fleet Status (57 active PRs)
 
 ### DrivAerML WIP (30 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -35,7 +35,6 @@
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
 - `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
-- `#3083` jet: max-train-batches=600
 - `#3197` gojo: TF residual-prediction alone — NOAM ABLATION
 - `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
 - `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
@@ -55,7 +54,7 @@
 
 ### TandemFoil Paper WIP (10 PRs)
 **Noam-pivot experiments (highest priority):**
-- `#3190` brook: physics features only (wake/vortex/Cp, no ANP) — NOAM ABLATION
+- `#3200` brook: TFP stabilization diagnostic (20-ep probes) — STABILIZATION
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
 - `#3176` mitsuha: full noam stack — NOAM ABLATION
@@ -78,6 +77,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
 - `#3167` gilbert: higher LR (8e-4/1e-3)
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
 - `#3156` edward: softer gc=0.5

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -25,7 +25,7 @@
 
 **Champion tuning / paper-facing:**
 - `#3173` kakashi: shorter cosine T_max=15/20
-- `#NEW` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
+- `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:45 (advisor cycle 83)
+- **Date:** 2026-04-24 12:15 (advisor cycle 84)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -25,7 +25,7 @@
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
-- `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
+- `#3275` canute: local/windowed attention (KNN-restricted, K=512/2048 neighbors) — INNOVATION
 - `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -84,7 +84,7 @@
 **Other:**
 - `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
-- `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
+- `#3274` norman: Lion optimizer under vol-10x+EMA (lr=5e-5/1e-4/2e-4 sweep) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
@@ -201,6 +201,7 @@
 - Weight Standardization: 67.9%/71.4% catastrophic (#3264). WS × cosine restarts × bs=1 feedback loop. Original BiT paper used epoch-level decay not per-batch restarts
 - SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
 - Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
+- Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
@@ -243,6 +244,7 @@
 - Vol-weight warm-up (1x→10x ramp): 2/3 collapsed, best stable +28% surface/+69% vol (#3232). Cosine restarts inject LR peak when vol-weight ramps — destructive. Static 10x TRIPLE-CONFIRMED
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - Additive BL auxiliary volume loss (SDF targeting): all 3 trials +31-228% both metrics (#3239). SDF<0.05 captures 61% of vol points on AF meshes — "BL targeting" ≈ uniform upscaling. Pattern confirmed with #3222
+- Multi-seed champion (seeds 42/123/789): all worse than seed=0 baseline (#3254). Seed 42 diverged, 123/789 +39-76% vol. Champion config has high seed sensitivity — seed=0 is lucky initialization
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 07:00 (advisor cycle 68)
+- **Date:** 2026-04-24 07:30 (advisor cycle 69)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -21,7 +21,7 @@
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
-- `#3225` canute: self-distillation with EMA teacher — INNOVATION
+- `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -85,7 +85,7 @@
 - `#3169` nami: heads sweep 4H/16H
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
-- `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
+- `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
@@ -191,6 +191,7 @@
 - Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
 - Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
 - Spectral norm on QKV: 4.035% (+5.3%). σ=1 cap over-restricts attention capacity. Late collapse ep502 from unconstrained FFN layers. gc=0.5 already solves restart stability.
+- Self-distillation via EMA teacher: α=0.3→6.446% diverge ep170, α=0.1→4.323% diverge ep400. EMA=0.9995 lag creates destabilizing feedback loop. Same EMA for ckpt+teacher incompatible.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
@@ -224,6 +225,7 @@
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - GradNorm adaptive loss balancing: surface 1.74x worse, vol 2.64x worse (#3218). retain_graph=True breaks compile (halves throughput). GradNorm converges to w_vol~8x, LOWER than hand-tuned 10x — fights intentional asymmetry
+- Volume smoothness regularization (KNN): ALL 4 trials regressed both metrics 44-97% (#3223). KNN Euclidean smoothness penalizes legitimate BL/wake/shear gradients. Even λ=1e-4 harmful
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 13:15 (advisor cycle 86)
+- **Date:** 2026-04-24 13:35 (advisor cycle 87)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -14,10 +14,10 @@
 - `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
-- `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
+- `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3273` gojo: Grouped Query Attention (GQA, 2/4 KV heads) — throughput-focused INNOVATION
+- `#3279` gojo: ReLU² activation in FFN (Primer-style squared ReLU for sparser features) — INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3276` zenitsu: cosine similarity auxiliary loss (spatial pattern fidelity, w=0.1/0.5) — INNOVATION
 - `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
@@ -204,6 +204,8 @@
 - Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
 - Curvature-weighted loss: alpha=1.0→4.48% diverge ep300, alpha=0.5→11.6% diverge ep53 (#3259). Train/eval mismatch (weighted vs uniform metric) + curvature amplifies gradient variance at restarts
 - Quadratic position features (x²/y²/z²/xy/xz/yz): 6.643% at ep168 timeout (#3272). Fatal 3x throughput penalty (168 vs 511 baseline epochs). Quad-only diverged ep63 — Fourier PE irreplaceable. Same epoch-starvation pattern as MoE (#3263).
+- Grouped Query Attention (GQA, 2/4 KV heads): 12.88%/6.88% both crashed (#3273). Throughput-neutral (bottleneck is slice routing einsums, not QKV). GQA destabilizes per-head slice routing — coupled KV sharing explodes at cosine restarts.
+- Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 05:30 (advisor cycle 64)
+- **Date:** 2026-04-24 06:00 (advisor cycle 66)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -33,7 +33,7 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
-- `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
+- `#3248` nobara: decaying peak LR at cosine restarts (SGDR eta_mult) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -189,6 +189,7 @@
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
+- Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 02:30 (advisor cycle 58)
+- **Date:** 2026-04-24 03:00 (advisor cycle 59)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -71,6 +71,7 @@
 - `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
 
 **Volume closure experiments:**
+- `#3236` gohan: Lookahead(AdamW) + torch.compile on vol-10x champion — AF VOLUME FOCUS
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 12:15 (advisor cycle 84)
+- **Date:** 2026-04-24 12:45 (advisor cycle 85)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -19,7 +19,7 @@
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3273` gojo: Grouped Query Attention (GQA, 2/4 KV heads) — throughput-focused INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
-- `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
+- `#3276` zenitsu: cosine similarity auxiliary loss (spatial pattern fidelity, w=0.1/0.5) — INNOVATION
 - `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
 - `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
@@ -202,6 +202,7 @@
 - SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
 - Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
 - Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
+- Curvature-weighted loss: alpha=1.0→4.48% diverge ep300, alpha=0.5→11.6% diverge ep53 (#3259). Train/eval mismatch (weighted vs uniform metric) + curvature amplifies gradient variance at restarts
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 18:00 (advisor cycle 39 — closed #3068/#3066/#3064, assigned brook/alphonse/casca)
+- **Date:** 2026-04-23 18:30 (advisor cycle 40 — closed #3159/#3158, assigning franky/bulma)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -22,8 +22,8 @@
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
-- `#3159` franky: 4L/640d wider
-- `#3158` bulma: lr=4e-4
+- `#NEW` franky: DM residual-prediction alone — BEING ASSIGNED
+- `#NEW` bulma: DM higher LR sweep (5.5e-4/6e-4) — BEING ASSIGNED
 - `#3155` nobara: longer T_max (45/60)
 - `#3154` historia: monotonic cosine (no restarts)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -169,6 +169,8 @@
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
+- 4L/640d at lr=5e-4: 8.636% then diverge ep82 even with EMA+gc (grad_norm=Infinity)
+- lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:45 (advisor cycle 76)
+- **Date:** 2026-04-24 10:00 (advisor cycle 77)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -24,7 +24,7 @@
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
-- `#3256` alphonse: coordinate noise augmentation (σ=0.001/0.005 input perturbation) — INNOVATION
+- `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
 - `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
 - `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
@@ -192,6 +192,7 @@
 - Pressure gradient smoothness reg (KNN): λ=0.01→4.481%, λ=0.1→4.876%, λ=1.0→12.52%. KNN 30% throughput overhead + sharp car features penalized. Remaining error is systematic bias, not noise.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
+- Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 10:15 (advisor cycle 78)
+- **Date:** 2026-04-24 10:45 (advisor cycle 79)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -74,7 +74,7 @@
 - `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
 - `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
-- `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
+- `#3268` jin: higher LR sweep (7e-4/8e-4) on vol-10x+EMA champion — AF VOLUME FOCUS
 
 **Noam-pivot experiments (asinh-dependent — likely to fail):**
 - `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
@@ -245,7 +245,8 @@
 - Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
 - Vol-weight=15x: surface +19%, vol +67% (#3204). Vol-weight=20x: crashed ep381 (#3204). 10x is definitive AF operating point
-- LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
+- LR>6e-4 (pre-EMA): 8e-4 +110% surface, 1e-3 catastrophic divergence
+- LR<6e-4 (with EMA+vol-10x): 5e-4 +66%/+111%, 4e-4 +38%/+76% (#3234). Underfitting under vol-10x amplification. lr=6e-4 bracketed from below
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-04-23 23:15 (advisor cycle 49)
 - **Branch:** radford
-- **Idle students:** 0 (brook being reassigned)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
-- `#3213` brook: Fourier encoding of surface normals — INNOVATION (reassigned)
+- `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -151,7 +151,7 @@
 - DomainLayerNorm — jet #3201 (merged; awaiting results)
 
 **New physics-aware/ML ideas (cycle 48):**
-- Fourier encoding of surface normals (angular frequency features) — brook #3213 (reassigned)
+- Fourier encoding of surface normals (angular frequency features) — brook #3217
 - Auxiliary gradient prediction (∂p/∂x,y,z as regularization) — kakashi #3214
 - Attention distance bias (ALiBi-inspired spatial prior) — canute #3216
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -94,39 +94,46 @@
 
 ## Current Research Focus
 
-### Benchmark Sprint Priorities (ICML phase)
+### STRATEGIC PIVOT — "Think Bigger" (Human directive, issue #3174)
 
-1. **DrivAerML** — val=3.833%, gap to AB-UPT only 0.013 pp!
-   - **BREAKTHROUGH:** EMA=0.9995+gc=0.5 works. gc is the stability enabler for EMA. Gap 93% closed.
-   - **Confirmed:** gc=0.5 is sharp optimum (0.25 starves, 1.0 insufficient — triple-confirmed via #3072/#3151/#3114)
-   - **Phase 2 strategy:** All new DM experiments build on EMA+gc=0.5 champion platform
-   - **Active fronts on champion platform:** decay sweep (eren), attention heads (senku/griffith), wider 640d (franky), eta_min (spike), attn dropout (shouko), softer gc=0.3 (himmel), monotonic cosine (historia), WD compound (emma), LR sweep (bulma), longer T_max (nobara)
-   - **Paper-facing:** faye #3164 doing full eval, multi-seed (casca/chihiro/canute sent back for two-phase)
-   - **Throughput experiments:** jet (600 batches), kakashi (788 batches+T_max=60)
-   - **Surface point resolution:** 16k/32k/64k (all sent back with eval fix)
-   - **Other active:** Lookahead (thorfinn), OneCycle (sanji), dropout (levi), checkpoint averaging (taki), feature dropout (fern), beta2 (einar), input feature dropout (fern)
+**Key finding:** The noam branch has ~100 merged PRs with winning techniques. Many are ALREADY PORTED to radford's train.py but UNUSED. We've been doing incremental HP sweeps when major architectural features were available all along.
 
-2. **TFP clean test result** — val=0.002383
-   - **Fully locked config:** Lion lr=1.25e-4, T_max=10, gc=0.5, EMA=0.999, 3L/192d
-   - **Every deviation diverges** — very narrow stability window
-   - **URGENT:** shoya #3098 clean test evaluation
-   - **Active width/depth:** robin (256d), nami (224d)
-   - **Active schedule:** mitsuha (T_max=5/8), mugen (T_max=20)
-   - **Active regularization:** shinobu (WD sweep), rei (gc=0.4)
-   - **Multi-seed:** jin being assigned (seeds 42/123/456)
+**New priority:** Every new assignment should test noam-ported features or bold new approaches. No more incremental tweaks.
 
-3. **AirfRANS volume** — 1.63x gap to target (0.002777 vs 0.0017)
-   - **Surface already 9.4x better** than target — focus is purely on volume
-   - **vol-weight strategy:** 3x good for surface, 10x worse. Now testing 1.5x (tanjiro), 2.0x (violet), 5.0x/7.0x (vegeta), 30x (megumi)
-   - **LR sweep:** gilbert being assigned (lr=8e-4, 1e-3 with EMA)
-   - **EMA decay:** stark testing 0.9995/0.9999
-   - **gc transfer:** edward testing gc=0.5 (from DM success)
-   - **Depth:** chrome testing 4L/256d (2L optimal so far, 3L dead)
-   - **Width:** wolfwood 2L/384d (sent back to add EMA)
+### Available features NOT USED (ready in train.py)
+- `--anp-srf` — ANP cross-attention decoder (-58.9% TF!) — TF/TFP only
+- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm (-8% ood) — ALL datasets
+- `--residual-prediction` — learned correction to freestream — ALL datasets
+- `--enable-cp-panel`, `--enable-te-coord-frame`, `--enable-wake-deficit`, `--enable-wake-angle`, `--enable-vortex-panel-velocity` — physics features — TF/TFP
+- `--re-stratified-sampling` — OOD Re robustness — TF/TFP/AF
+- `--compile-model` — throughput gain (more epochs in time budget) — ALL
+- 96 slices, 3 heads (at 192d), Lookahead — all defaults we haven't tested
 
-4. **TandemFoil** — gc trend monotonic: 1.0→0.5→0.3
-   - **Active:** gc=0.2 (usopp), gc=0.3+480min (zenitsu)
-   - **Paper-facing:** yuji #3150 clean test from gc=0.3 champion
+### Key config mismatches
+- TF/TFP T_max=10 vs noam optimal T_max=150 (15x longer!)
+- Radford 8 heads vs noam 3 heads (at 192d)
+- Missing: vol_loss_scale, PCGrad, temperature annealing, DomainLayerNorm (need code ports)
+
+### Benchmark Sprint Priorities (revised)
+
+1. **TandemFoil** — HIGHEST PRIORITY for noam feature activation
+   - ANP decoder alone was -58.9% on noam. With full stack: potentially 9-12 range vs our 21.909
+   - **Next assignments:** full noam stack, ANP alone, T_max=150 alone
+   - Paper-facing: yuji #3150 clean test
+
+2. **TandemFoil Paper** — Same noam features apply
+   - T_max=150 could break the "fully locked" constraint — it was locked at the WRONG config
+   - ANP + physics features could transform results
+   - **Next assignments:** full noam stack, ANP + T_max=150
+
+3. **DrivAerML** — val=3.833%, gap to AB-UPT only 0.013 pp
+   - **Applicable noam features:** asinh-pressure, residual-prediction, compile-model, 96 slices
+   - **Bold changes:** Lion optimizer (noam's final choice), higher EMA decay (0.9999)
+   - Existing champion platform still valid as base
+
+4. **AirfRANS volume** — 1.63x gap to target
+   - **Applicable noam features:** asinh-pressure, residual-prediction, re-stratified-sampling
+   - **Bold changes:** 96 slices, compile for throughput, vol_loss_scale (needs code port)
 
 ## Key Dead Ends (Do Not Repeat)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -10,7 +10,7 @@
 
 ### DrivAerML WIP (27 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
-- fern: spectral normalization on attention layers — INNOVATION (PR pending)
+- `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 03:15 (advisor cycle 60)
+- **Date:** 2026-04-24 03:45 (advisor cycle 61)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -18,7 +18,6 @@
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
-- `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -89,7 +88,8 @@
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
-- `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
+- `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
+- `#3239` vegeta: additive boundary layer auxiliary volume loss — AF VOLUME FOCUS
 - `#3195` piccolo: Re-stratified sampling
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
@@ -188,6 +188,7 @@
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
+- Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
@@ -223,6 +224,7 @@
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
+- Vol-weight=15x: surface +19%, vol +67% (#3204). Vol-weight=20x: crashed ep381 (#3204). 10x is definitive AF operating point
 - LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
 
 **TandemFoil:**

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -79,7 +79,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
-- norman: volume smoothness regularization — AF VOLUME FOCUS (PR pending)
+- `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,10 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-22 23:30 (advisor cycle 3 — reviewed PR #2949, assigned 46 new PRs)
+- **Date:** 2026-04-22 23:40 (advisor cycle 4 — reviewed PR #2948, closed, assigned #3109)
 - **Branch:** radford
 - **Idle students:** NONE — all 60 students assigned
 - **PRs ready for review:** 0
-- **PRs in WIP:** 58 (12 existing + 46 new)
+- **PRs in WIP:** 58 (11 existing + 47 new including #3109)
+- **Closed this cycle:** #2948 (guts TFP physics ablation — AdamW 0.003564 val, 49% above baseline, all ablation runs crashed)
 
 ## Fleet Status
 
@@ -19,7 +20,8 @@
 - `#3045` griffith: DrivAerML T_max cosine period sweep
 - `#3044` emma: DrivAerML volume training ablation
 - `#3043` einar: DrivAerML gradient accumulation + full-eval baseline
-- `#2948` guts: TFP physics-flag ablation
+- ~~`#2948` guts: TFP physics-flag ablation~~ CLOSED (0.003564, 49% above baseline)
+- `#3109` guts: DrivAerML lr=4e-4 full-eval (lower-LR neighbor)
 - `#2947` jin: TFP first field_mse baseline (LR sweep)
 
 ### Sent Back This Cycle

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:15 (advisor cycle 81)
+- **Date:** 2026-04-24 11:30 (advisor cycle 82)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -38,8 +38,9 @@
 - `#3266` sanji: TFP champion config re-verification post cp_panel fix (seed=0/42) — STABILIZATION VERIFY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
+- `#3271` nobara: layer-wise LR decay (LLRD, decay=0.8/0.65 across 4 layers) — INNOVATION
+- `#3272` vegeta: quadratic position features (x², y², z², xy, xz, yz for implicit curvature) — INNOVATION
 - `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
-- `#3248` nobara: decaying peak LR at cosine restarts (SGDR eta_mult) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -197,6 +198,8 @@
 - Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
 - Auxiliary surface normal prediction: w=0.1→4.724%, w=0.01→4.661% (#3258). Input leakage — normals already in features, aux head learns trivial reconstruction. Also epoch starvation (200 vs 511)
 - EMA periodic reset: 100ep→4.426% cascade ep335, 50ep→6.818% diverge ep108 (#3247). EMA is primary gradient stabilizer — reset removes protective smoothing at high-curvature basin point
+- Weight Standardization: 67.9%/71.4% catastrophic (#3264). WS × cosine restarts × bs=1 feedback loop. Original BiT paper used epoch-level decay not per-batch restarts
+- SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,13 +1,13 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 04:30 (advisor cycle 62)
+- **Date:** 2026-04-24 05:00 (advisor cycle 63)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (faye just assigned #3244)
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 - **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
 
-## Fleet Status (53 active PRs)
+## Fleet Status (58 active PRs)
 
 ### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
@@ -31,7 +31,7 @@
 
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
-- `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
+- `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
 - `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -112,7 +112,7 @@
 | TandemFoil | `test_primary/surface_pressure_mae` | **22.868** (PR #3185 MERGED) | (internal) | Improving |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000296 / 0.002039** | 0.0043 / 0.0017 | Surface 14.5x better, Volume 1.20x gap |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3164 paper eval in-progress |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3244 paper eval in-progress (faye) |
 
 ## Current Research Focus
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 12:30 (advisor cycle 46 — updated per human directive #3174)
+- **Date:** 2026-04-23 22:30 (advisor cycle 47)
 - **Branch:** radford
-- **Idle students:** 0 (4 being assigned)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion (0.002383) is unreproducible — 0/3 seeds stay finite (#3168)
 
@@ -28,7 +28,6 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
-- `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
@@ -82,6 +81,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
 - `#3167` gilbert: higher LR (8e-4/1e-3)
 - `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
@@ -178,7 +178,7 @@
 - Bilateral symmetry aug, torch.compile, gradient accumulation
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
-- eta_min=5e-5+gc (any value): gc=1.0→6.311%, gc=0.5→8.617%, both diverge — 3rd confirmation
+- eta_min+gc (any combination): gc=1.0→6.311%, gc=0.5→8.617%, gc=0.5+EMA→4.202% diverge ep312 — TRIPLE CONFIRMED. gc=0.5 relies on zero-LR trough damping; eta_min removes reset.
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
 - 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 06:30 (advisor cycle 67)
+- **Date:** 2026-04-24 07:00 (advisor cycle 68)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -17,7 +17,8 @@
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
-- `#3224` fern: spectral normalization on attention layers — INNOVATION
+- `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
+- `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
@@ -57,7 +58,6 @@
 
 **Noam-pivot experiments:**
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
-- `#3176` mitsuha: full noam stack — NOAM ABLATION
 
 **Other:**
 - `#3133` shinobu: WD sweep (5e-3/2e-2)
@@ -190,6 +190,7 @@
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
 - Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
+- Spectral norm on QKV: 4.035% (+5.3%). σ=1 cap over-restricts attention capacity. Late collapse ep502 from unconstrained FFN layers. gc=0.5 already solves restart stability.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 10:45 (advisor cycle 79)
+- **Date:** 2026-04-24 11:00 (advisor cycle 80)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -20,7 +20,7 @@
 - `#3263` gojo: Sparse MoE FFN (K=4/8 experts, top-2 routing, regime-specific computation) — INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
-- `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
+- `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
 - `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
@@ -195,6 +195,7 @@
 - Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
 - Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
 - Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
+- Auxiliary surface normal prediction: w=0.1→4.724%, w=0.01→4.661% (#3258). Input leakage — normals already in features, aux head learns trivial reconstruction. Also epoch starvation (200 vs 511)
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,9 +1,10 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 (advisor cycle 44 — gilbert assigned af-vol-15x-clean #3204)
+- **Date:** 2026-04-23 21:30 (advisor cycle 45 — closed #3168/#3154/#3083, assigning jin/brook/historia/jet)
 - **Branch:** radford
-- **Idle students:** 0 (gilbert assigned: #3204 af-vol-15x-clean — vol-weight=15x/20x clean control)
+- **Idle students:** 0 (4 being assigned)
 - **PRs ready for review:** 0
+- **CRITICAL:** TFP champion (0.002383) is unreproducible — 0/3 seeds stay finite (#3168)
 
 ## Fleet Status (57 active PRs)
 
@@ -30,7 +31,8 @@
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
-- `#3154` historia: monotonic cosine (no restarts)
+- `#NEW` historia: DM true monotonic cosine (T_max=393606) — corrected retest
+- `#NEW` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -53,15 +55,17 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
-### TandemFoil Paper WIP (10 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3200` brook: TFP stabilization diagnostic (20-ep probes) — STABILIZATION
+### TandemFoil Paper WIP (11 PRs) — STABILIZATION CRISIS
+**Stabilization diagnostic (HIGHEST PRIORITY — baseline unreproducible):**
+- `#NEW` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
+- `#NEW` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
+
+**Noam-pivot experiments:**
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
 - `#3176` mitsuha: full noam stack — NOAM ABLATION
 
 **Other:**
-- `#3168` jin: multi-seed paper-facing (seeds 42/123/456)
 - `#3133` shinobu: WD sweep (5e-3/2e-2)
 - `#3098` shoya: clean test evaluation — URGENT PAPER-FACING
 - `#3088` mugen: T_max=20

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 00:00 (advisor cycle 52)
+- **Date:** 2026-04-24 00:15 (advisor cycle 53)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -10,6 +10,8 @@
 
 ### DrivAerML WIP (27 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- fern: spectral normalization on attention layers — INNOVATION (PR pending)
+- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
@@ -44,13 +46,12 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (7 PRs) — GUARDRAIL ONLY per directive
-**Noam-pivot experiments:**
+### TandemFoil WIP (5 PRs) — GUARDRAIL ONLY per directive
+**New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
+**Noam-pivot experiments (still running):**
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3189` emma: asinh+physics features — NOAM ABLATION
-- `#3186` norman: T_max=150 alone — NOAM ABLATION
-- `#3185` fern: full noam stack — NOAM ABLATION
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
@@ -78,6 +79,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- norman: volume smoothness regularization — AF VOLUME FOCUS (PR pending)
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
@@ -93,7 +95,7 @@
 
 | Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **21.350** (#3140 MERGED — gc=0.2+EMA=0.999) |
+| TandemFoil | `val_primary/surface_pressure_mae` | **21.319** (#3185 MERGED — full noam stack: ANP+physics+T_max=150+Lookahead+96sl) |
 | TandemFoil Paper | `val_primary/field_mse` | **0.002383** (#3025) |
 | AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000296 / 0.002039** (#3135 MERGED — EMA+vol-weight=10x) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **3.833%** (#3072 MERGED — EMA=0.9995+gc=0.5) |
@@ -102,7 +104,7 @@
 
 | Dataset | Metric | Current best | External target | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **23.195** (PR #3140) | (internal) | Improving |
+| TandemFoil | `test_primary/surface_pressure_mae` | **22.868** (PR #3185 MERGED) | (internal) | Improving |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000296 / 0.002039** | 0.0043 / 0.0017 | Surface 14.5x better, Volume 1.20x gap |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3164 paper eval in-progress |
@@ -218,7 +220,7 @@
 
 ## Mandatory Config Rules
 
-- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.3, WD=1e-2, `--ema-decay 0.999`, 3L/192d
+- **TF:** Lion lr=1.25e-4, **T_max=150**, gc=0.2, WD=1e-2, `--ema-decay 0.999`, 3L/192d, **96 slices**, ANP+full physics+asinh-scale=0.75+residual+Lookahead+compile+re-strat (**UPDATED post #3185**)
 - **TFP:** Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, `--ema-decay 0.999`, 3L/192d
 - **AF:** AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, `--ema-decay 0.999`, 2L/256d
 - **DM:** AdamW lr=5e-4, T_max=30, **gc=0.5**, **EMA=0.9995**, no WD, 4L/512d (**UPDATED post #3072**)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:00 (advisor cycle 73)
+- **Date:** 2026-04-24 09:15 (advisor cycle 74)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -9,8 +9,9 @@
 
 ## Fleet Status (58 active PRs)
 
-### DrivAerML WIP (29 PRs)
+### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
@@ -233,6 +234,7 @@
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
+- EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:30 (advisor cycle 50)
+- **Date:** 2026-04-23 23:45 (advisor cycle 51)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -24,13 +24,13 @@
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
-- `#3175` hinata: full noam stack — NOAM ABLATION
+- `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
-- `#3155` nobara: longer T_max (45/60)
+- `#3220` nobara: Mixup regularization (feature interpolation) — INNOVATION
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
 - `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -177,7 +177,8 @@
 - Polynomial LR (no cosine troughs): catastrophic — troughs are load-bearing stability features
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
-- T_max≠30: T_max=50+gc diverges; T_max=15→4.406% plateaued; T_max=20→4.943% diverged. T_max=30 ONLY viable period
+- T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
+- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%. All diverge. Features tuned for T_max=150/3H/no-gc regime don't transfer to T_max=30/8H/gc=0.5
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:00 (advisor cycle 80)
+- **Date:** 2026-04-24 11:15 (advisor cycle 81)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -13,7 +13,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
-- `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
+- `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
@@ -196,6 +196,7 @@
 - Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
 - Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
 - Auxiliary surface normal prediction: w=0.1→4.724%, w=0.01→4.661% (#3258). Input leakage — normals already in features, aux head learns trivial reconstruction. Also epoch starvation (200 vs 511)
+- EMA periodic reset: 100ep→4.426% cascade ep335, 50ep→6.818% diverge ep108 (#3247). EMA is primary gradient stabilizer — reset removes protective smoothing at high-curvature basin point
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,15 +1,18 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 03:45 (advisor cycle 61)
+- **Date:** 2026-04-24 04:30 (advisor cycle 62)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
+- **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
 
 ## Fleet Status (53 active PRs)
 
-### DrivAerML WIP (29 PRs)
+### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
+- `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
@@ -25,15 +28,12 @@
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
-- `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
 - `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
-- `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
-- `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -65,11 +65,12 @@
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
-### AirfRANS WIP (13 PRs)
+### AirfRANS WIP (14 PRs)
 **Non-asinh noam feature ablation (highest priority — clean tests):**
 - `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
 
 **Volume closure experiments:**
+- `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
 - `#3236` gohan: Lookahead(AdamW) + torch.compile on vol-10x champion — AF VOLUME FOCUS
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
@@ -189,6 +190,9 @@
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
+- SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
+- True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
+- 600 batches/epoch (stabilized retest): T_max=46 proportional diverged ep61; T_max=30 got 3.887% after MORE total batches than baseline. Data diversity per epoch saturated at 394
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,13 +1,13 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 12:45 (advisor cycle 85)
+- **Date:** 2026-04-24 13:15 (advisor cycle 86)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
 - **TFP UNBLOCKED:** cp_panel bug fix merged (#3209). Multi-seed reproducibility confirmed. Sanji #3266 re-running champion config to verify 0.002383 is recoverable.
 - **Both bugs fixed in codebase:** cp_panel_prior_index() guard (#3209 MERGED) + primary_metric_key shadowing (#3209 MERGED).
 
-## Fleet Status (58 active PRs)
+## Fleet Status (59 active PRs)
 
 ### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
@@ -26,7 +26,7 @@
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
 - `#3275` canute: local/windowed attention (KNN-restricted, K=512/2048 neighbors) — INNOVATION
-- `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
+- `#3277` vegeta: coordinate residual branch (parallel bypass MLP for spatial bias correction) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -72,7 +72,7 @@
 ### AirfRANS WIP (13 PRs)
 **Volume closure experiments:**
 - `#3261` nezuko: 2L/320d wider model (width scaling for vol closure) — AF VOLUME FOCUS
-- `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
+- `#3278` gohan: separate volume prediction head with extra capacity (256→512→out) — AF VOLUME FOCUS
 - `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
 - `#3268` jin: higher LR sweep (7e-4/8e-4) on vol-10x+EMA champion — AF VOLUME FOCUS
@@ -203,6 +203,7 @@
 - Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
 - Input feature dropout (Fourier channels): p=0.1→4.73%, p=0.2→4.82% (#3253). Input-level dropout = information destruction. All 4 Fourier bands essential. Terminal divergence at both dropout rates
 - Curvature-weighted loss: alpha=1.0→4.48% diverge ep300, alpha=0.5→11.6% diverge ep53 (#3259). Train/eval mismatch (weighted vs uniform metric) + curvature amplifies gradient variance at restarts
+- Quadratic position features (x²/y²/z²/xy/xz/yz): 6.643% at ep168 timeout (#3272). Fatal 3x throughput penalty (168 vs 511 baseline epochs). Quad-only diverged ep63 — Fourier PE irreplaceable. Same epoch-starvation pattern as MoE (#3263).
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
@@ -246,6 +247,7 @@
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - Additive BL auxiliary volume loss (SDF targeting): all 3 trials +31-228% both metrics (#3239). SDF<0.05 captures 61% of vol points on AF meshes — "BL targeting" ≈ uniform upscaling. Pattern confirmed with #3222
 - Multi-seed champion (seeds 42/123/789): all worse than seed=0 baseline (#3254). Seed 42 diverged, 123/789 +39-76% vol. Champion config has high seed sensitivity — seed=0 is lucky initialization
+- No-Lookahead + no-compile at full budget: surface +575%, vol +84% (#3255). Lookahead slow-weight averaging is load-bearing for long-run convergence. compile gives meaningful throughput within timeout. Short-run ablation that showed these removable was misleading (epoch-count confound).
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:15 (advisor cycle 74)
+- **Date:** 2026-04-24 09:30 (advisor cycle 75)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -17,7 +17,7 @@
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
+- `#3263` gojo: Sparse MoE FFN (K=4/8 experts, top-2 routing, regime-specific computation) — INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
@@ -30,7 +30,6 @@
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
 **Noam-pivot experiments:**
-- `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 
@@ -192,6 +191,8 @@
 - Self-distillation via EMA teacher: α=0.3→6.446% diverge ep170, α=0.1→4.323% diverge ep400. EMA=0.9995 lag creates destabilizing feedback loop. Same EMA for ckpt+teacher incompatible.
 - Pressure gradient smoothness reg (KNN): λ=0.01→4.481%, λ=0.1→4.876%, λ=1.0→12.52%. KNN 30% throughput overhead + sharp car features penalized. Remaining error is systematic bias, not noise.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
+- Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
+- EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete
 - 600 batches/epoch (stabilized retest): T_max=46 proportional diverged ep61; T_max=30 got 3.887% after MORE total batches than baseline. Data diversity per epoch saturated at 394

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,89 +1,93 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 06:00 (advisor cycle 19 complete — reviewed #3108/#3104/#3103/#3099/#3084/#3079/#3069, merged #3108+#3050, assigned #3137-#3142)
+- **Date:** 2026-04-23 06:30 (advisor cycle 20 complete — reviewed 14 PRs: merged #2974 infra, 9 closed, 5 sent-back, 8 new assigned #3143-#3150)
 - **Branch:** radford
 - **Idle students:** NONE — all 60 students assigned
 - **PRs ready for review:** 0
-- **PRs in WIP:** 60 (53 continuing + 6 new + 1 sent-back)
-- **Merged this cycle:** #3108 (TF gc=0.3 new best), #3050 (AF EMA+T_max=50 new best)
-- **Closed this cycle:** #3104 (AF T_max=100), #3103 (AF T_max=30), #3099 (AF 3L/256d), #3084 (DM 788-batches), #3069 (DM 5ep warmup)
-- **Sent back this cycle:** #3079 (DM 640d+gc — retry with T_max=60+lr=3e-4)
+- **PRs in WIP:** 60
 
 ## Fleet Status
 
-### DrivAerML WIP (~33 students, ~55%)
-- `#3063` canute: multi-seed full-eval seed=42 (PAPER-FACING)
+### DrivAerML WIP (~35 students, ~58%)
+- `#3063` canute: paper-facing full-eval (SENT BACK — two-phase approach)
 - `#3064` casca: multi-seed full-eval seed=123 (PAPER-FACING)
 - `#3065` chihiro: multi-seed full-eval seed=456 (PAPER-FACING)
 - `#3066` alphonse: 16k surface points
 - `#3067` askeladd: 32k surface points
 - `#3068` brook: 64k surface points
 - `#3072` eren: EMA=0.9995
-- `#3073` faye: EMA=0.999 + gc=0.5 compound
-- `#3074` fern: relative L2 loss
-- `#3075` franky: Huber loss (delta=0.1 and 1.0)
-- `#3076` frieren: log-cosh loss
+- `#3073` faye: EMA=0.999 + gc=0.5 compound — SENT BACK
 - `#3077` gilbert: 5L/512d (deeper)
-- `#3078` gohan: 6L/512d (much deeper) — SENT BACK re-run at max epochs
+- `#3078` gohan: 6L/512d (much deeper) — SENT BACK
 - `#3079` gojo: 4L/640d + T_max=60 + lr=3e-4 — SENT BACK retry
 - `#3083` jet: max-train-batches=600
-- `#3085` kohaku: larger supernode budget (8192/16000)
-- `#3086` megumi: SGDR T_max=2 (CosineAnnealingWarmRestarts) — SENT BACK
+- `#3085` kohaku: larger supernodes (SENT BACK — retry with gc=1.0)
+- `#3076` frieren: log-cosh loss (SENT BACK — retry with gc=1.0)
+- `#3046` sukuna: WD+gc compound (SENT BACK — lighter WD=5e-4/1e-4)
 - `#3044` emma: volume training ablation
-- `#3046` sukuna: WD+gc compound
 - `#3109` guts: lr=4e-4 full-eval
-- `#3110` einar: full-eval no max-eval-batches baseline
-- `#3111` himmel: larger batch + gc
-- `#3112` edward: dual-stage LR (5e-4 → 2.5e-4)
-- `#3114` griffith: 4L/384d compact architecture
-- `#3115` piccolo: label-smooth L1 loss
-- `#3117` bulma: Lion optimizer sweep (lr=5e-5, lr=1e-4)
-- `#3118` hinata: weight decay alone (WD=1e-4/5e-4/1e-3)
-- `#3119` historia: higher LR + 20-epoch warmup (lr=7e-4/1e-3)
-- `#3120` senku: RAdam optimizer (lr=5e-4, lr=7e-4)
-- `#3121` levi: dropout regularization (dropout=0.05/0.1)
-- `#3122` nobara: polynomial LR decay (no cosine — linear/quadratic)
-- `#3137` chopper: DM warmup+gc=1.0 compound (5-ep warmup + gc=1.0, T_max=30)
-- `#3138` kakashi: DM 788 batches + T_max=60 (proportionally scaled cosine)
-- `#3141` vegeta: DM 5L/512d + gc=1.0 (depth with stability guard)
+- `#3110` einar: AdamW beta2=0.99/0.995
+- `#3111` himmel: cosine eta_min=1e-6/1e-5
+- `#3112` edward: gradient centralization
+- `#3113` shouko: attention dropout=0.05
+- `#3114` griffith: T_max=50 + gc=1.0
+- `#3115` piccolo: batch_size=2 with 25k points
+- `#3117` bulma: Lion optimizer sweep
+- `#3118` hinata: weight decay alone
+- `#3119` historia: higher LR + 20-epoch warmup
+- `#3121` levi: dropout regularization
+- `#3122` nobara: polynomial LR decay
+- `#3125` faye: SWA at cosine troughs
+- `#3127` senku: attention heads sweep (4H/16H)
+- `#3129` chrome: AF 4L/256d deeper — wait, this is DM? Check: chrome/af-4l-256d — actually chrome is on AF per CURRENT STATE
+- `#3131` sanji: OneCycleLR schedule
+- `#3132` gohan: eta_min=5e-5 + gc=1.0
+- `#3137` chopper: 5-epoch warmup + gc=1.0
+- `#3138` kakashi: 788 batches + T_max=60
+- `#3141` vegeta: 5L/512d + gc=1.0
+- `#3143` thorfinn: Lookahead(AdamW, k=6, alpha=0.5)
+- `#3146` taki: top-5 checkpoint averaging
+- `#3147` norman: lighter WD + gc (WD=5e-4/1e-4 + gc=1.0)
+- `#3148` franky: 10-epoch warmup + gc=1.0
+- `#3149` fern: stochastic input feature dropout (p=0.05/0.10)
 
-### TandemFoil Paper WIP (~14 students, ~23%)
+### TandemFoil Paper WIP (~9 students, ~15%)
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#3088` mugen: T_max=20
 - `#3089` nami: T_max=30
-- `#3092` norman: EMA=0.9995
-- `#3093` rei: EMA=0.99
-- `#3096` shinobu: lr=1e-4
 - `#3098` shoya: clean test evaluation (paper-facing)
 - `#2947` jin: first field_mse baseline (LR sweep)
-- `#3113` shouko: field_mse full-eval clean test
-- `#3116` sanji: 4L/192d champion architecture
-- `#2949` vash: depth/width sweep (sent back with LR=5e-5)
+- `#3113` shouko: field_mse full-eval clean test — wait, this is DM per branch name. Reviewing WIP list...
+- `#3116` sanji: 4L/192d champion architecture — wait, sanji is on DM (#3131). This might be stale.
 - `#3123` mitsuha: shorter T_max (T_max=5, T_max=8)
 - `#3124` robin: 3L/256d wider model
-- `#3135` (pending assign): TFP vol weight 30x
+- `#3133` shinobu: TFP WD sweep
+- `#3135` nezuko: AF EMA=0.999 + vol-weight=10x
+- `#2949` vash: depth/width sweep (LR=5e-5)
+- `#3145` rei: gc=0.4 boundary test
 
-### AirfRANS Volume WIP (~8 students, ~13%)
-- `#3100` taki: 3L/384d for volume
-- `#3101` tanjiro: volume-loss-weight=3x
-- `#3102` thorfinn: volume-loss-weight=10x
-- `#3105` violet: EMA=0.999 (at original T_max=10 — baseline)
+### AirfRANS WIP (~9 students, ~15%)
+- `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK — retry at 1.5x)
+- `#3102` thorfinn: 10x vol-weight — CLOSED; thorfinn now on DM #3143
 - `#3106` wolfwood: 2L/384d + gc=0.5 + T_max=50
-- `#3139` spike: AF 3L/256d + EMA=0.999 (architecture + EMA compound)
+- `#3129` chrome: 4L/256d deeper architecture
+- `#3134` megumi: vol-weight=30x
+- `#3135` nezuko: EMA=0.999 + vol-weight=10x
+- `#3136` stark: EMA decay sweep (0.9995/0.9999)
+- `#3139` spike: 3L/256d + EMA=0.999
+- `#3144` violet: vol-weight=2.0 + EMA=0.999
 
-### TandemFoil WIP (~5 students, ~8%)
-- `#3050` stark: (MERGED — AirfRANS EMA+T_max=50 champion) → reassigned
-- `#3107` yuji: clean test row (360-min, seed=42)
-- `#3108` zenitsu: (MERGED — TF gc=0.3) → reassigned as #3142
-- `#3136` (assigned): TFP further gc work
-- `#3140` usopp: TF gc=0.2 sweep (monotonic trend test — does gc improvement continue?)
-- `#3142` zenitsu: TF gc=0.3 + longer budget (480-min)
+### TandemFoil WIP (~4 students, ~7%)
+- `#3107` yuji: CLOSED (old config); reassigned to #3150
+- `#3140` usopp: gc=0.2 sweep
+- `#3142` zenitsu: gc=0.3 + longer budget (480-min)
+- `#3150` yuji: clean test row (gc=0.3 champion, paper-facing)
 
 ## Steering Anchors
 
 | Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **21.909** (#3108 MERGED — gc=0.3) |
+| TandemFoil | `val_primary/surface_pressure_mae` | **21.909** (#3108 MERGED — gc=0.3+EMA=0.999) |
 | TandemFoil Paper | `val_primary/field_mse` | **0.002383** (#3025 MERGED) |
 | AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000459 / 0.002777** (#3050 MERGED — EMA+T_max=50) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** (#2898 MERGED) |
@@ -92,92 +96,78 @@
 
 | Dataset | Metric | Current best | External target | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **23.419** | (internal anchor) | Strong |
-| TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT |
+| TandemFoil | `test_primary/surface_pressure_mae` | **23.419** (PR #3108) | (internal anchor) | Strong — clean test in-progress (#3150) |
+| TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000459 / 0.002777** | 0.0043 / 0.0017 | Surface ✓✓, Volume 1.63x gap |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **6.244%** (old config) | 3.71% | Main gap |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **6.244%** (old config) | 3.71% | Main gap — paper eval in-progress |
 
 ## Current Research Focus
 
 ### Benchmark Sprint Priorities (ICML phase)
 
 1. **DrivAerML closure** — val=3.997%, need test below 5%, ideally toward 3.71%
-   - **CLOSED directions:** T_max (only 30 works without gc), depth (4L required), multi-revisit, EMA (3 configs tried — all dead), bilateral symmetry aug, LR (5e-4 sharp optimum), gc alone (best 4.346% still above baseline), gc+WD (crashes), gradient accumulation, 640d without gc, SGDR (2 variants), RAdam, beta2 changes, warmup alone, 6L, torch.compile
-   - **Active exploration fronts:**
+   - **CLOSED directions:** T_max (only 30 without gc), depth (4L required), multi-revisit, EMA (3 configs), bilateral symmetry, LR (5e-4 sharp), gc alone (4.346% best), gc+WD (WD=1e-3+gc best 4.44%), gradient accumulation, SGDR, RAdam, beta2 changes, warmup alone, 6L, torch.compile, Huber loss, relative L2 loss
+   - **Active frontier:**
      - Surface points sweep (16k/32k/64k) — human directive
-     - Loss alignment (rel L2, Huber, log-cosh, L1-smooth)
-     - Architecture (5L/6L deeper, 640d wider w/ gc, 384d compact)
-     - Throughput (600/788+T_max=60 batches, supernode budget)
-     - Optimizer (Lion remaining)
-     - Regularization (WD alone, dropout)
-     - Warmup+gc compound (warmup alone diverges; with gc stability guard may help)
-     - 788 batches + T_max=60 (proportionally scaled — kakashi #3138)
-     - Multi-seed full-eval (paper-facing)
-     - gc=1.0 with 5L/512d compound (vegeta #3141)
+     - Loss variants: log-cosh+gc (frieren sent back), label-smooth L1 (piccolo)
+     - Architecture: 5L/512d (gilbert), 640d+gc (gojo), 384d compact (griffith), 5L+gc (vegeta)
+     - Throughput: 600-batches (jet), 788+T_max=60 (kakashi), supernodes+gc (kohaku sent back)
+     - Regularization: WD alone (hinata), dropout (levi), lighter WD+gc (norman), input dropout (fern)
+     - Optimizer: Lion (bulma), Lookahead (thorfinn), SWA (faye), OneCycleLR (sanji)
+     - Schedule: eta_min sweep (himmel), polynomial (nobara), eta_min+gc (gohan), 5/10-ep warmup+gc (chopper/franky)
+     - Special: checkpoint averaging (taki), gradient centralization (edward), GradCentralization (edward), attention heads (senku), attention dropout (shouko)
+     - Compound: T_max=50+gc (griffith), WD lighter+gc (sukuna/norman)
+     - Multi-seed paper-facing (casca seed=123, chihiro seed=456)
 
-2. **TFP clean test result** — val=0.002383, need paper-facing test_primary/field_mse
-   - **CLOSED:** T_max>10 (T_max=15/20/30 all diverge), gc>0.5 (diverges), gc<0.5 (gc=0.3 = pressure starvation → Infinity), 4L depth (pressure overflow), LR=1.5e-4 (worse)
-   - **Active:** T_max=5/8 (shorter may stabilize), EMA=0.99/0.9995, lr=1e-4, 3L/256d width, clean test eval
-   - **Key finding:** TFP champion is a SHARP OPTIMUM — gc=0.5 and T_max=10 are essentially inflection points. LR=1.25e-4 is minimum viable for pressure.
+2. **TFP clean test result** — val=0.002383, need paper-facing field_mse
+   - **CLOSED:** T_max>10, gc≠0.5 (both directions fail — 0.3 starves, 0.7 destabilizes), EMA≠0.999 (both directions cause sinh overflow), 4L depth, LR=1.5e-4
+   - **Active:** T_max=5/8 (mitsuha), 3L/256d width (robin), WD sweep (shinobu), T_max=20/30 (mugen/nami), gc=0.4 boundary test (rei), clean test (shoya)
+   - **TFP is a SHARP OPTIMUM** — gc=0.5, T_max=10, EMA=0.999, LR=1.25e-4, 3L/192d all appear to be inflection points
 
-3. **AirfRANS volume** — Vol MSE=0.002777 (1.63x gap from target 0.0017)
-   - **New champion:** EMA=0.999 + T_max=50 (both surface AND volume best)
-   - **Active:** volume-loss-weight (3x/10x), architecture (3L/384d, 3L/256d+EMA), T_max=50 confirmed optimal
-   - **Closed:** T_max=30/100 both worse; 3L/256d without EMA superseded
+3. **AirfRANS volume** — 1.63x gap to target 0.0017
+   - **New lead:** #3101 showed vol-weight=3x gives surface -17% (0.000381!) but volume +41%. Sweep in progress: 1.5x (tanjiro sent back), 2.0x (violet), 30x (megumi)
+   - **Active:** EMA decay higher (stark), 3L/256d+EMA (spike), 2L/384d+gc (wolfwood), 4L/256d (chrome), vol+EMA compound (nezuko)
 
-4. **TandemFoil trend** — gc sweep: 1.0→0.5→0.3 all improve monotonically
-   - **Active:** gc=0.2 sweep (does improvement continue?), gc=0.3+480-min budget
-   - **Key question:** Is gc=0.1 or gc→0 the floor, or does it invert?
+4. **TandemFoil** — gc trend confirmed monotonically improving (1.0→0.5→0.3)
+   - **Active:** gc=0.2 (usopp), gc=0.3+480min (zenitsu), clean test gc=0.3 (yuji paper-facing)
+   - **Key question:** Does gc=0.2 continue the trend or invert?
 
 ## Key Dead Ends (Do Not Repeat)
 
 **DrivAerML:**
-- T_max: only 30 works without gc; 15/20/40/50/100 all diverge
-- Depth: 4L required; 2L/3L diverge and 2.5-2.8x worse; 6L also worse
-- EMA: incompatible at all tested configs (9.749%)
-- Multi-revisit: 4x/8x diverge without gc
-- gc+WD compound: crashes
-- gc alone: 1.5/2.0 diverges; best gc result 4.346% still above baseline
-- 640d without gc: dead end (gojo sent back with gc=1.0 to retry)
-- torch.compile: no throughput benefit, diverged
-- Bilateral symmetry aug: causes gradient instability (14.01%)
-- LR: 4e-4 and 4.5e-4/5.5e-4 all worse; 5e-4 sharp optimum
-- Gradient accumulation: harmful (4.860%)
-- SGDR (T_mult=1.5 and T_mult=2): both worse than standard cosine
-- RAdam: no improvement over AdamW
-- beta2=0.99/0.95/0.98: all worse; beta2=0.999 (default) optimal
-- Warmup alone (5-ep/10-ep): diverges without gc stability guard
+- T_max: only 30 works without gc
+- Depth: 4L required; 2L/3L diverge; 6L also worse
+- EMA: incompatible at all configs
+- gc+WD (WD=1e-3): 4.44% — promising but above baseline; lighter WD in-progress
+- gc alone: best 4.346% above baseline
+- 640d without gc, torch.compile, bilateral symmetry, gradient accumulation
+- LR: 5e-4 sharp optimum
+- SGDR (T_mult=1.5, T_mult=2), RAdam, beta2≠0.999
+- Warmup alone (5/10-ep), Huber loss (both deltas), relative L2 loss (degenerate)
 
 **TandemFoil Paper:**
-- T_max>10: T_max=15 diverged ep124, T_max=20 diverged earlier, T_max=30 diverged
-- gc=0.7: diverged ep142
-- gc=0.3: Infinity all epochs (pressure starvation)
-- 4L/192d: pressure overflow
-- 4L/256d: 0.004427 (+85% vs baseline)
-- LR=1.5e-4: 0.003199 (+34%)
+- T_max>10 (15/20/30 all diverge)
+- gc=0.3: pressure starvation → Infinity
+- gc=0.7: destabilizes
+- EMA=0.99 and EMA=0.9995: sinh overflow from both directions
+- 4L/192d: pressure overflow; 4L/256d: +85% worse
+- LR=1.5e-4: +34% worse
 
 **AirfRANS:**
-- 2L/384d NaN
-- LR above 6e-4 all worse
-- accum>1 harmful
-- T_max=30: surface_mse=0.000829 (+72%)
-- T_max=100: surface_mse=0.000709 (+47%)
-- 3L/256d without EMA: superseded by 2L+EMA champion
+- 2L/384d, 3L/384d: both diverge catastrophically
+- T_max=30 (+72%), T_max=100 (+47%): T_max=50 optimal
+- 3L/256d without EMA: superseded
+- EMA=0.99 (+383%), EMA=0.995 (+51%): EMA=0.999 is sweet spot
+- Vol-weight=10x: worse on both metrics vs EMA champion
 
 **Cross-dataset:** SAM, PCGrad, LayerScale, sigma-Reparam, GeGLU, SwiGLU, SDF, head scaling — all failed
 
-## Strategy (ICML Final Sprint)
-
-Per human team directive #3020:
-- NO cross-dataset default — each PR targets one benchmark
-- DrivAerML ~50-60% fleet ✓ (33/60 = 55%)
-- TFP ~20-30% ✓ (14/60 = 23%)
-- AirfRANS ~10-20% ✓ (8/60 = 13%)
-- TF minimal ✓ (5/60 = 8%)
+## Infrastructure
+- **PR #2974 MERGED:** Best-checkpoint saving in train.py — all future experiments automatically use best val checkpoint for test eval. Critical: rescued AirfRANS from total NaN failure, 3.4x improvement on DM test metrics.
 
 ## Mandatory Config Rules
 
-- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.3, WD=1e-2, `--ema-decay 0.999`, 3L/192d (**gc updated to 0.3 post #3108**)
+- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.3, WD=1e-2, `--ema-decay 0.999`, 3L/192d (**gc=0.3 post #3108**)
 - **TFP:** Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, `--ema-decay 0.999`, 3L/192d
 - **AF:** AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, `--ema-decay 0.999`, 2L/256d (**EMA now mandatory post #3050**)
 - **DM:** AdamW lr=5e-4, T_max=30, NO gc, NO WD, no-EMA, 4L/512d

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,35 +1,15 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-22 23:40 (advisor cycle 4 — reviewed PR #2948, closed, assigned #3109)
+- **Date:** 2026-04-23 01:30 (advisor cycle 7 — reviewed #3082/#3081/#3051/#3048, all closed, assigned #3117/#3118/#3119/#3120)
 - **Branch:** radford
 - **Idle students:** NONE — all 60 students assigned
 - **PRs ready for review:** 0
-- **PRs in WIP:** 58 (11 existing + 47 new including #3109)
-- **Closed this cycle:** #2948 (guts TFP physics ablation — AdamW 0.003564 val, 49% above baseline, all ablation runs crashed)
+- **PRs in WIP:** 58 (54 continuing + 4 new #3117-#3120)
+- **Closed this cycle:** #3082 (T_max=40, 12.84%), #3081 (T_max=20, 11.06%), #3051 (4x revisits, 9.38%), #3048 (2L/3L depth, 9.99%)
 
 ## Fleet Status
 
-### Existing WIP (from previous cycle)
-- `#3060` levi: DrivAerML bilateral symmetry augmentation
-- `#3056` haku: TFP Lion+EMA refinement (T_max/gc/LR sweep)
-- `#3051` bulma: DrivAerML 4x case revisits (max-train-batches=1576)
-- `#3050` stark: AirfRANS EMA at T_max=50 champion
-- `#3048` senku: DrivAerML depth reduction 2L/3L vs 4L/512d
-- `#3047` piccolo: DrivAerML LR fine-tuning (4e-4, 4.5e-4, 5.5e-4)
-- `#3046` sukuna: DrivAerML WD+gc compound
-- `#3045` griffith: DrivAerML T_max cosine period sweep
-- `#3044` emma: DrivAerML volume training ablation
-- `#3043` einar: DrivAerML gradient accumulation + full-eval baseline
-- ~~`#2948` guts: TFP physics-flag ablation~~ CLOSED (0.003564, 49% above baseline)
-- `#3109` guts: DrivAerML lr=4e-4 full-eval (lower-LR neighbor)
-- `#2947` jin: TFP first field_mse baseline (LR sweep)
-
-### Sent Back This Cycle
-- `#2949` vash: TFP depth/width sweep — 4L/192d promising but 25% above baseline; sent back with LR=5e-5 + early stopping instructions
-
-### New Wave (2026-04-22 23:30) — 46 PRs assigned
-
-**DrivAerML (24 students — 52%):**
+### DrivAerML WIP (~31 students, ~52%)
 - `#3063` canute: multi-seed full-eval seed=42 (PAPER-FACING)
 - `#3064` casca: multi-seed full-eval seed=123 (PAPER-FACING)
 - `#3065` chihiro: multi-seed full-eval seed=456 (PAPER-FACING)
@@ -38,7 +18,6 @@
 - `#3068` brook: 64k surface points
 - `#3069` chopper: 5-epoch linear warmup
 - `#3070` chrome: 10-epoch linear warmup
-- `#3071` edward: EMA=0.999 at champion
 - `#3072` eren: EMA=0.9995
 - `#3073` faye: EMA=0.999 + gc=0.5 compound
 - `#3074` fern: relative L2 loss
@@ -47,15 +26,25 @@
 - `#3077` gilbert: 5L/512d (deeper)
 - `#3078` gohan: 6L/512d (much deeper)
 - `#3079` gojo: 4L/640d + gc=0.5 (wider)
-- `#3080` himmel: T_max=50
-- `#3081` hinata: T_max=20
-- `#3082` historia: T_max=40
 - `#3083` jet: max-train-batches=600
 - `#3084` kakashi: max-train-batches=788
 - `#3085` kohaku: larger supernode budget (8192/16000)
 - `#3086` megumi: SGDR T_mult=2 (CosineAnnealingWarmRestarts)
+- `#3044` emma: DrivAerML volume training ablation
+- `#3046` sukuna: DrivAerML WD+gc compound
+- `#3109` guts: DrivAerML lr=4e-4 full-eval (lower-LR neighbor)
+- `#3110` einar: DrivAerML full-eval no max-eval-batches baseline
+- `#3111` himmel: DrivAerML larger batch + gc
+- `#3112` edward: DrivAerML dual-stage LR (5e-4 → 2.5e-4)
+- `#3114` griffith: DrivAerML 4L/384d compact architecture
+- `#3115` piccolo: DrivAerML label-smooth L1 loss
+- `#3117` bulma: DrivAerML Lion optimizer sweep (lr=5e-5, lr=1e-4)
+- `#3118` hinata: DrivAerML weight decay alone (WD=1e-4/5e-4/1e-3)
+- `#3119` historia: DrivAerML higher LR + linear warmup (lr=7e-4/1e-3 + 20ep warmup)
+- `#3120` senku: DrivAerML RAdam optimizer (lr=5e-4, lr=7e-4)
 
-**TandemFoil Paper (12 students — 26%):**
+### TandemFoil Paper WIP (~14 students, ~23%)
+- `#3056` haku: TFP Lion+EMA refinement (T_max/gc/LR sweep)
 - `#3087` mitsuha: T_max=15
 - `#3088` mugen: T_max=20
 - `#3089` nami: T_max=30
@@ -64,12 +53,13 @@
 - `#3092` norman: EMA=0.9995
 - `#3093` rei: EMA=0.99
 - `#3094` robin: 4L/192d depth
-- `#3095` sanji: 4L/256d depth+width
 - `#3096` shinobu: lr=1e-4
-- `#3097` shouko: lr=1.5e-4
+- `#3097` shouko: lr=1.5e-4 — CLOSED (dead end, assigned #3113)
 - `#3098` shoya: clean test evaluation (paper-facing)
+- `#3113` shouko: TFP field_mse full-eval clean test
+- `#3116` sanji: TFP 4L/192d champion architecture
 
-**AirfRANS Volume (8 students — 17%):**
+### AirfRANS Volume WIP (~8 students, ~13%)
 - `#3099` spike: 3L/256d for volume
 - `#3100` taki: 3L/384d for volume
 - `#3101` tanjiro: volume-loss-weight=3x
@@ -79,9 +69,24 @@
 - `#3105` violet: EMA=0.999
 - `#3106` wolfwood: 2L/384d + gc=0.5 + T_max=50
 
-**TandemFoil Parity (2 students — 4%):**
+### TandemFoil Parity WIP (~5 students, ~8%)
+- `#3060` levi: DrivAerML bilateral symmetry augmentation
+- `#2947` jin: TFP first field_mse baseline (LR sweep)
+- `#3050` stark: AirfRANS EMA at T_max=50 champion
 - `#3107` yuji: clean test row (360-min, seed=42)
 - `#3108` zenitsu: gc=0.3 + EMA=0.999
+
+### Recently Closed This Session
+- ~~`#3082`~~ historia: T_max=40, 12.84% (+221% vs baseline), diverged ep94
+- ~~`#3081`~~ hinata: T_max=20, 11.06% (+177% vs baseline), diverged ep118
+- ~~`#3051`~~ bulma: 4x revisits, 9.38% best (+135%), all runs diverged
+- ~~`#3048`~~ senku: 2L/3L depth, 9.99% best (3L), both diverged to NaN
+- ~~`#3095`~~ sanji: TFP 4L/256d, 0.004427 (+85% vs TFP baseline)
+- ~~`#3047`~~ piccolo: DM LR fine-tuning (4e-4/4.5e-4/5.5e-4), all diverged
+- ~~`#3045`~~ griffith: DM T_max sweep (15/50/100), all diverged
+- ~~`#3097`~~ shouko: TFP lr=1.5e-4, val 0.003199 (+34% vs TFP baseline)
+- ~~`#3071`~~ edward: DM EMA=0.999, diverged to NaN
+- ~~`#3080`~~ himmel: DM T_max=50, 14.1% best, diverged
 
 ## Steering Anchors
 
@@ -106,32 +111,49 @@
 ### Benchmark Sprint Priorities (ICML phase)
 
 1. **DrivAerML closure** — val=3.997%, need to push test below 5%, ideally toward 3.71%
-   - Multi-seed full-eval runs establishing true test baseline
-   - Surface points sweep (16k/32k/64k) — directive from human team
-   - Loss alignment (relative L2, Huber, log-cosh)
-   - Architecture deepening (5L, 6L)
-   - Schedule refinement (T_max=20/40/50)
-   - EMA exploration at champion config
+   - **T_max sweep CLOSED:** T_max=15/20/40/50/100 all diverge without gc. T_max=30 uniquely stable.
+   - **Depth sweep CLOSED (4L is necessary):** 2L (11.26%), 3L (9.99%), 4L (3.997%). Monotonic — cannot go shallower.
+   - **Multi-revisit CLOSED:** 4x/8x revisits diverge without gc. 1x full-eval too slow (only 36ep).
+   - **EMA CLOSED:** EMA incompatible with DM (dead end #3071)
+   - **In progress:** Surface points (16k/32k/64k), loss alignment (rel L2/Huber/log-cosh), warmup (5/10ep), architecture (5L/6L/640d), throughput (600/788 batches), spatial budget, SGDR
+   - **New (this cycle):** Lion optimizer (lr=5e-5/1e-4), WD alone (1e-4/5e-4/1e-3), higher LR+warmup (7e-4/1e-3), RAdam (lr=5e-4/7e-4)
+   - **Key finding:** DM loss landscape is rough — T_max=30 sits in a uniquely narrow stable basin. Monotonic depth preference (4L > 3L > 2L). 4L is NOT over-parameterized.
 
 2. **TFP clean test result** — val=0.002383, need paper-facing test_primary/field_mse
    - shoya #3098: dedicated clean-test run (highest priority TFP)
-   - T_max refinement for stable long training (15/20/30)
-   - gc and EMA tuning
+   - shouko #3113: TFP field_mse full-eval clean test
+   - T_max refinement (15/20/30), gc tuning (0.3/0.7), EMA tuning (0.99/0.9995)
    - Architecture: 4L/192d per vash's finding
-   - LR sweep (1e-4, 1.5e-4)
+   - LR: 1e-4 only (1.5e-4 dead end at 0.003199)
 
 3. **AirfRANS volume** — Vol MSE=0.00764, target 0.0017 (4.5x gap)
    - Volume-weighted loss (3x and 10x)
    - Deeper architectures (3L/256d, 3L/384d)
-   - T_max tuning
+   - T_max tuning (30/100), EMA, wider model + gc
 
 4. **TandemFoil anchor** — preserve at 22.537 val, 24.581 test
+
+## Key Dead Ends (Do Not Repeat)
+
+**DrivAerML specific:**
+- T_max: only 30 works without gc; 15/20/40/50/100 all diverge
+- Depth: 4L required; 2L/3L both diverge and achieve 2.5-2.8x worse val
+- EMA: incompatible (EMA alone = 9.749%)
+- Multi-revisit training: 4x/8x diverge without gc
+- gc+WD compound: crashes
+- gc alone: 1.5/2.0 diverges (2.0 was best gc at 4.346%, still above baseline)
+- 640d without gc: dead end
+- torch.compile: no throughput benefit, compile run diverged
+
+**AirfRANS:** 2L/384d NaN, LR above 6e-4 all worse, accum>1 harmful
+**TFP:** 3L unstable (diverges/degrades), 5L degrades late, LR>1.25e-4 worse, 4L/256d architecture worse
+**Cross-dataset:** SAM, PCGrad, LayerScale, sigma-Reparam, GeGLU, SwiGLU, SDF, head scaling — all failed
 
 ## Strategy (ICML Final Sprint)
 
 Per human team directive #3020 and ICML sprint guidance:
 - **NO cross-dataset default** — each PR targets one benchmark
-- DrivAerML is top priority (~50-60% of fleet)
+- DrivAerML is top priority (~50-60% of fleet) ✓
 - TFP clean test result is #2 priority
 - AirfRANS volume is #3 (surface already excellent)
 - Do not let TF absorb large fleet share
@@ -145,10 +167,3 @@ Per human team directive #3020 and ICML sprint guidance:
 - `--epochs 999` mandatory
 - DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394`
 - Paper-facing DM: NO `--max-eval-batches`
-
-## Known Dead Ends (Do Not Repeat)
-
-DrivAerML: gc+WD compound crashes, T_max=5 diverges, gc=1.5/2.0 diverges, 640d without gc, EMA alone at 9.749%, torch.compile no benefit
-AirfRANS: 2L/384d NaN ep134, LR above 6e-4 all worse, accum>1 harmful
-TFP: 3L unstable (diverges/degrades), 5L degrades late, all negative novel architectures
-Cross-dataset: SAM, PCGrad, LayerScale, sigma-Reparam, GeGLU, SwiGLU, SDF, head scaling — all failed

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 14:00 (advisor cycle 88)
+- **Date:** 2026-04-24 14:30 (advisor cycle 89)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -12,7 +12,7 @@
 ### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3281` megumi: MoE output heads (K=2/3 expert output MLPs with learned gating) — INNOVATION
-- `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
+- `#3282` casca: AF volume→surface cross-attention (volume queries attend to surface keys) — AF VOLUME FOCUS
 - `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
 - `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
@@ -110,7 +110,7 @@
 | TandemFoil | `test_primary/surface_pressure_mae` | **22.868** (PR #3185 MERGED) | (internal) | Improving |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000296 / 0.002039** | 0.0043 / 0.0017 | Surface 14.5x better, Volume 1.20x gap |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3244 paper eval in-progress (faye) |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.496%** (#3244 full-eval, ep403 ckpt) / 4.685% (batch-limited) | 3.71% | **Batch-limited eval ~24% optimistic.** Faye re-running full eval on champion ep511 ckpt |
 
 ## Current Research Focus
 
@@ -207,6 +207,7 @@
 - Grouped Query Attention (GQA, 2/4 KV heads): 12.88%/6.88% both crashed (#3273). Throughput-neutral (bottleneck is slice routing einsums, not QKV). GQA destabilizes per-head slice routing — coupled KV sharing explodes at cosine restarts.
 - Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
 - Learnable register tokens (N=2/4/8): N=8 best 4.062% (+6%), N=2/N=4 NaN diverged (#3262). Category error — register tokens address pairwise attention sinks (ViT), but Transolver uses slice-based soft-clustering attention where sink mechanism doesn't apply.
+- Learnable Fourier frequencies: 5.262%/4.252% both diverged (#3260). Frequencies barely moved from init — fixed [0.5,2,8,32] are already near-optimal. Learnable freq + cosine restarts = cascading perturbation feedback loop.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,98 +1,121 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 14:30 (advisor cycle 89)
+- **Date:** 2026-04-24 15:30 (advisor cycle 90 — LAST DITCH RESTRUCTURING)
 - **Branch:** radford
-- **Idle students:** 0
-- **PRs ready for review:** 0
-- **TFP UNBLOCKED:** cp_panel bug fix merged (#3209). Multi-seed reproducibility confirmed. Sanji #3266 re-running champion config to verify 0.002383 is recoverable.
-- **Both bugs fixed in codebase:** cp_panel_prior_index() guard (#3209 MERGED) + primary_metric_key shadowing (#3209 MERGED).
+- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~10 hours remaining)**
+- **Fleet restructuring IN PROGRESS:** killed 14 misaligned experiments, reassigning 15 students
 
-## Fleet Status (59 active PRs)
+## BINDING DIRECTIVE — Issue #3283 (2026-04-24)
 
-### DrivAerML WIP (30 PRs)
-**Innovation track (new physics-aware/ML ideas per directive):**
-- `#3281` megumi: MoE output heads (K=2/3 expert output MLPs with learned gating) — INNOVATION
-- `#3282` casca: AF volume→surface cross-attention (volume queries attend to surface keys) — AF VOLUME FOCUS
-- `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
-- `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
-- `#3242` historia: label smoothing / target noise augmentation — INNOVATION
-- `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3279` gojo: ReLU² activation in FFN (Primer-style squared ReLU for sparser features) — INNOVATION
-- `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
-- `#3276` zenitsu: cosine similarity auxiliary loss (spatial pattern fidelity, w=0.1/0.5) — INNOVATION
-- `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
-- `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
-- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
-- `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
-- `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
-- `#3275` canute: local/windowed attention (KNN-restricted, K=512/2048 neighbors) — INNOVATION
-- `#3277` vegeta: coordinate residual branch (parallel bypass MLP for spatial bias correction) — INNOVATION
-- `#3202` senku: GLU preprocess MLP — INNOVATION
-- `#3201` jet: DomainLayerNorm — INNOVATION
+**Capacity split (59-student fleet):** 36 DM / 12 AF / 11 TFP / 0 TF
+**DM full-test gap: ~4.39-4.50% → 3.71% target (15% relative)**
+**Harness patches CRITICAL (vegeta #3284):** --load-checkpoint, --eval-interval, --ema-mode fixed, --skip-update-grad-norm, --save-checkpoint, kill gates
 
-**Noam-pivot experiments:**
-- `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- `#3181` himmel: asinh+residual on champion — NOAM ABLATION
+### DM Strategy (36 students)
+**Truth/recovery (~40%):** champion replicas (seeds, no-compile, fixed EMA), checkpoint recovery, high-density surface (64k/96k/128k), gradient-spike-safe (gc=0.25, skip-update-grad-norm), narrow schedule (T_max=24/30/36, lr=4.8-5.2e-4), checkpoint soup/ensemble
+**Breakout (~60%):** AB-UPT-style anchored decoder, metric-aware fine-tune (mse_z + raw rel-L2), domain-normalized volume auxiliary, coordinate normalization + geometry features, final train+val retrain
 
-**Champion tuning / paper-facing:**
-- `#3266` sanji: TFP champion config re-verification post cp_panel fix (seed=0/42) — STABILIZATION VERIFY
-- `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
+### AF Strategy (12 students)
+vol-weight sweep 8-13, extended champion training, joint checkpoint selection, 1-2 architecture rescue lanes max. Kill: surface>0.001 at ep180, vol>0.004 at ep180, vol>0.003 at ep300.
+
+### TFP Strategy (11 students)
+Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002393). Kill: field_mse>0.006 at ep220, >0.004 at ep350, no improvement for 160 epochs.
+
+### TF: FROZEN (only #3185 as guardrail)
+
+## Fleet Status (restructuring in progress)
+
+### INFRASTRUCTURE (1 PR)
+- `#3284` vegeta: HARNESS PATCHES (--load-checkpoint, --eval-interval, --ema-mode, --skip-update-grad-norm, --save-checkpoint, kill gates) — **HIGHEST PRIORITY**
+
+### DrivAerML WIP (~28 continuing + 8 new = 36 target)
+**Champion recovery / truth lanes (newly assigned):**
+- norman: champion recovery seed=0 no-compile (Bucket A)
+- jet: champion recovery seed=42 no-compile (Bucket A)
+- megumi: champion recovery seed=7 no-compile (Bucket A)
+- himmel: 64k surface points (Bucket C)
+- askeladd: 96k surface points (Bucket C)
+- robin: gradient-spike-safe gc=0.25 (Bucket D)
+- nami: T_max=24 narrow schedule (Bucket E)
+- chrome: T_max=36 narrow schedule (Bucket E)
+
+**Continuing DM experiments (from pre-restructure):**
+- `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval)
+- `#3279` gojo: ReLU² activation
+- `#3270` brook: FiLM conditioning
+- `#3269` emma: error correction head
+- `#3267` mitsuha: SwiGLU FFN
+- `#3265` alphonse: hidden-space noise
+- `#3276` zenitsu: cosine similarity loss
+- `#3275` canute: local attention
+- `#3271` nobara: LLRD
+- `#3251` fern: Pre-LayerNorm
+- `#3249` shouko: decaying WD
+- `#3242` historia: label smoothing
+- `#3235` kakashi: multi-exit prediction
+- `#3228` chopper: stochastic weight perturbation
+- `#3221` franky: gradient noise injection
+- `#3202` senku: GLU preprocess
+- `#3194` bulma: probe LR above 5e-4
 - `#3160` griffith: 16H heads
-- `#3271` nobara: layer-wise LR decay (LLRD, decay=0.8/0.65 across 4 layers) — INNOVATION
-- `#3272` vegeta: quadratic position features (x², y², z², xy, xz, yz for implicit curvature) — INNOVATION
-- `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
-- `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
-- `#3146` taki: top-5 checkpoint averaging
-- `#3143` thorfinn: Lookahead(AdamW)
-- `#3121` levi: dropout regularization sweep
-- `#3110` einar: beta2=0.99/0.995
-- `#3109` guts: lr=4e-4 full-eval
-- `#3085` kohaku: larger supernodes (SENT BACK)
-- `#3076` frieren: log-cosh loss (SENT BACK)
-- `#3067` askeladd: 32k surface points (SENT BACK)
-- `#3046` sukuna: WD+gc compound (SENT BACK)
+- `#3152` eren: EMA sweep
+- `#3146` taki: checkpoint averaging
+- `#3143` thorfinn: Lookahead
+- `#3121` levi: dropout sweep
+- `#3110` einar: beta2 sweep
+- `#3109` guts: lr=4e-4
+- `#3085` kohaku: larger supernodes
+- `#3076` frieren: log-cosh loss
+- `#3046` sukuna: WD+gc compound
 
-### TandemFoil WIP (2 PRs) — GUARDRAIL ONLY per directive
-**New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
-- `#3150` yuji: clean test row — PAPER-FACING
+### AirfRANS WIP (10 continuing + 2 new = 12 target)
+**Newly assigned:**
+- jin: vol-weight=8 sweep
+- violet: vol-weight=9 sweep
 
-### TandemFoil Paper WIP (9 PRs) — STABILIZATION RESOLVED
-**Bug fix merged (#3209). Sanji #3266 verifying champion config reproducibility.**
-
-**Noam-pivot experiments:**
-- `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
-
-**Other:**
-- `#3133` shinobu: WD sweep (5e-3/2e-2)
-- `#3098` shoya: clean test evaluation — URGENT PAPER-FACING
-- `#3088` mugen: T_max=20
-- `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
-- `#2949` vash: depth/width sweep (LR=5e-5)
-
-### AirfRANS WIP (13 PRs)
-**Volume closure experiments:**
-- `#3261` nezuko: 2L/320d wider model (width scaling for vol closure) — AF VOLUME FOCUS
-- `#3278` gohan: separate volume prediction head with extra capacity (256→512→out) — AF VOLUME FOCUS
-- `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
-- `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
-- `#3268` jin: higher LR sweep (7e-4/8e-4) on vol-10x+EMA champion — AF VOLUME FOCUS
-
-**Noam-pivot experiments (asinh-dependent — likely to fail):**
-- `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
-- `#3184` wolfwood: full noam stack — NOAM ABLATION (asinh confirmed dead for AF)
-
-**Other:**
-- `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
-- `#3169` nami: heads sweep 4H/16H
-- `#3274` norman: Lion optimizer under vol-10x+EMA (lr=5e-5/1e-4/2e-4 sweep) — AF VOLUME FOCUS
-- `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
-- `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
-- `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
-- `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
-- `#3195` piccolo: Re-stratified sampling
+**Continuing AF experiments:**
+- `#3282` casca: vol cross-attention (architectural rescue)
+- `#3278` gohan: separate vol head (architectural rescue)
+- `#3257` chihiro: extended training
+- `#3250` tanjiro: per-channel vol loss
+- `#3241` hinata: T_max=75
+- `#3240` gilbert: vol-weight 11x/12x/13x fine sweep
+- `#3238` rei: WD follow-up
+- `#3211` spike: learned vol_loss_scale
+- `#3195` piccolo: re-stratified sampling
 - `#3156` edward: softer gc=0.5
-- `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3129` chrome: 4L/256d deeper
+
+### TandemFoil Paper WIP (7 continuing + 4 new = 11 target)
+**Newly assigned (haku config replication):**
+- nezuko: haku seed=0
+- stark: haku seed=42
+- wolfwood: haku seed=7
+- yuji: haku seed=123
+
+**Continuing TFP experiments:**
+- `#3266` sanji: champion re-verify
+- `#3179` usopp: T_max=150+wake+96sl+Lookahead
+- `#3133` shinobu: WD sweep
+- `#3098` shoya: clean test eval
+- `#3088` mugen: T_max=20
+- `#3056` haku: Lion+EMA refinement
+- `#2949` vash: depth/width sweep
+
+### Experiments KILLED this cycle (14 PRs per #3283)
+- #3280 jet: DM per-channel heads (surface is single channel cp)
+- #3281 megumi: DM MoE output (directive: no MoE)
+- #3181 himmel: DM asinh+residual (noam dead for DM)
+- #3067 askeladd: DM 32k surface points (directive: only test denser)
+- #3274 norman: AF Lion (directive: stop Lion)
+- #3172 robin: AF LR warmup (directive: stop warmup)
+- #3169 nami: AF heads sweep (directive: stop broad heads)
+- #3129 chrome: AF 4L/256d (directive: stop broad depth)
+- #3261 nezuko: AF 2L/320d (directive: stop broad width)
+- #3187 stark: AF asinh+residual (asinh dead)
+- #3184 wolfwood: AF full noam stack (noam dead)
+- #3268 jin: AF higher LR (directive: stop higher-LR arms)
+- #3144 violet: AF vol-weight=2 (below directive range 8-13)
+- #3150 yuji: TF clean test (TF frozen)
 
 ## Steering Anchors
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 09:30 (advisor cycle 75)
+- **Date:** 2026-04-24 09:45 (advisor cycle 76)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -26,6 +26,7 @@
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3256` alphonse: coordinate noise augmentation (σ=0.001/0.005 input perturbation) — INNOVATION
 - `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
+- `#3264` vegeta: Weight Standardization on linear layers (bs=1 loss smoothing, Qiao 2019) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -87,7 +88,6 @@
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
-- `#3239` vegeta: additive boundary layer auxiliary volume loss — AF VOLUME FOCUS
 - `#3195` piccolo: Re-stratified sampling
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
@@ -233,6 +233,7 @@
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - Vol-weight warm-up (1x→10x ramp): 2/3 collapsed, best stable +28% surface/+69% vol (#3232). Cosine restarts inject LR peak when vol-weight ramps — destructive. Static 10x TRIPLE-CONFIRMED
 - Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
+- Additive BL auxiliary volume loss (SDF targeting): all 3 trials +31-228% both metrics (#3239). SDF<0.05 captures 61% of vol points on AF meshes — "BL targeting" ≈ uniform upscaling. Pattern confirmed with #3222
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA>0.9995 (0.9999/0.99995 both ~85% worse, diverge early, #3199). EMA=0.9995 bracketed as sharp optimum with steep cliffs both directions

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -87,7 +87,7 @@
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
-- `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
+- `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
 - `#3239` vegeta: additive boundary layer auxiliary volume loss — AF VOLUME FOCUS
@@ -164,8 +164,7 @@
 
 **AF volume closure:**
 - vol_loss_scale learnable scalar (noam port, -15.9%) — spike #3211
-- PCGrad gradient surgery (surface/volume conflict resolution) — jin #3212
-- Huber loss on volume channel (robust to outlier gradients) — tanjiro #3215
+- Per-channel volume loss weighting (upweight nut×4, p×2) — tanjiro #3245
 
 ### Critical Known Bug
 - **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): Fix in progress (sanji #3209).
@@ -222,6 +221,7 @@
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
+- Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,80 +1,78 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 07:00 (advisor cycle 21 — reviewed 7 PRs: merged #3072 DM new best, closed #3077, 5 sent-back, 2 new assigned #3151/#3152)
+- **Date:** 2026-04-23 12:00 (advisor cycle 30 — closed #3151/#3141/#2947, assigning gilbert/vegeta/jin)
 - **Branch:** radford
-- **Idle students:** NONE — all 60 students assigned
+- **Idle students:** 0 (gilbert/vegeta/jin being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status
 
-### DrivAerML WIP (~38 students, ~63%)
-- `#3044` emma: volume training ablation
-- `#3046` sukuna: WD+gc (SENT BACK — try WD=5e-4/1e-4 + gc=1.0)
-- `#3063` canute: paper-facing full-eval (SENT BACK — two-phase approach)
-- `#3064` casca: multi-seed seed=123 (SENT BACK — two-phase eval)
-- `#3065` chihiro: multi-seed seed=456 (SENT BACK — two-phase eval)
-- `#3066` alphonse: 16k surface points
-- `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
-- `#3068` brook: 64k surface points (SENT BACK — add max-eval-batches 200)
-- `#3073` faye: SWA (formerly EMA+gc compound — reassigned)
-- `#3076` frieren: log-cosh loss (SENT BACK — retry +gc=1.0)
-- `#3079` gojo: 4L/640d + T_max=60 + lr=3e-4 — retry
-- `#3083` jet: max-train-batches=600
-- `#3085` kohaku: larger supernodes (SENT BACK — retry +gc=1.0)
-- `#3109` guts: lr=4e-4 full-eval
-- `#3110` einar: AdamW beta2=0.99/0.995
-- `#3111` himmel: cosine eta_min sweep
-- `#3112` edward: gradient centralization
-- `#3113` shouko: attention dropout=0.05
-- `#3114` griffith: T_max=50 + gc=1.0
-- `#3115` piccolo: batch_size=2 with 25k points
-- `#3117` bulma: Lion optimizer sweep
-- `#3118` hinata: weight decay alone
-- `#3119` historia: higher LR + 20-epoch warmup
-- `#3121` levi: dropout regularization
-- `#3122` nobara: polynomial LR decay
-- `#3125` faye: SWA at cosine troughs
-- `#3127` senku: attention heads sweep (4H/16H)
-- `#3131` sanji: OneCycleLR schedule
-- `#3132` gohan: eta_min=5e-5 + gc=1.0
-- `#3137` chopper: 5-epoch warmup + gc=1.0
-- `#3138` kakashi: 788 batches + T_max=60
-- `#3141` vegeta: 5L/512d + gc=1.0
-- `#3143` thorfinn: Lookahead(AdamW)
+### DrivAerML WIP (~36 students, ~60%)
+- `#3165` senku: EMA+gc+4H heads (128d/head)
+- `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING
+- `#3163` shouko: EMA+gc+attn dropout=0.05
+- `#3162` himmel: EMA+gc=0.3 (softer gc test)
+- `#3161` spike: EMA+gc+eta_min=1e-5 (cosine floor)
+- `#3160` griffith: EMA+gc+16H heads
+- `#3159` franky: EMA+gc+4L/640d (wider)
+- `#3158` bulma: EMA+gc+lr=4e-4
+- `#3155` nobara: EMA+gc+longer T_max (45/60)
+- `#3154` historia: EMA+gc+monotonic cosine (no restarts)
+- `#3153` emma: EMA+gc+light WD (1e-4/5e-4)
+- `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
+- `#3149` fern: stochastic input feature dropout (p=0.05/0.10)
+- `#3147` norman: lighter WD+gc=1.0 (5e-4/1e-4)
 - `#3146` taki: top-5 checkpoint averaging
-- `#3147` norman: lighter WD + gc (WD=5e-4/1e-4)
-- `#3148` franky: 10-epoch warmup + gc=1.0
-- `#3149` fern: stochastic input feature dropout
-- `#3151` gilbert: EMA=0.9995 + gc sweep (gc=0.25, gc=1.0)
-- `#3152` eren: EMA decay sweep (0.999 vs 0.9995) + extended budget
+- `#3143` thorfinn: Lookahead(AdamW)
+- `#3138` kakashi: 788 batches+T_max=60 (SENT BACK — add gc=0.5+EMA)
+- `#3137` chopper: 5-ep warmup+gc=1.0
+- `#3132` gohan: eta_min=5e-5+gc=1.0
+- `#3131` sanji: OneCycleLR schedule
+- `#3121` levi: dropout regularization sweep
+- `#3118` hinata: WD alone at champion config
+- `#3115` piccolo: bs2+25k pts (SENT BACK — 50k+gc=0.5+EMA)
+- `#3110` einar: AdamW beta2=0.99/0.995
+- `#3109` guts: lr=4e-4 full-eval
+- `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
+- `#3083` jet: max-train-batches=600
+- `#3079` gojo: 4L/640d (SENT BACK — lr=3e-4+T_max=60+EMA)
+- `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
+- `#3068` brook: 64k surface points (SENT BACK — add max-eval-batches 200)
+- `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
+- `#3066` alphonse: 16k surface points
+- `#3065` chihiro: multi-seed s456 (SENT BACK — two-phase eval)
+- `#3064` casca: multi-seed s123 (SENT BACK — two-phase eval)
+- `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
+- `#3046` sukuna: WD+gc compound (SENT BACK — WD=5e-4/1e-4+gc=1.0)
 
-### TandemFoil Paper WIP (~9 students, ~15%)
-- `#2947` jin: first field_mse baseline (LR sweep)
-- `#2949` vash: depth/width sweep (LR=5e-5)
-- `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
-- `#3088` mugen: T_max=20
-- `#3089` nami: T_max=30
-- `#3098` shoya: clean test evaluation (paper-facing) — URGENT
-- `#3123` mitsuha: shorter T_max (T_max=5, T_max=8)
-- `#3124` robin: 3L/256d wider model
-- `#3133` shinobu: TFP WD sweep
+### TandemFoil Paper WIP (~10 students, ~17%)
+- `#3157` nami: 3L/224d intermediate width
 - `#3145` rei: gc=0.4 boundary test
+- `#3133` shinobu: WD sweep (5e-3/2e-2)
+- `#3124` robin: 3L/256d wider model
+- `#3123` mitsuha: shorter T_max (5/8)
+- `#3098` shoya: clean test evaluation — URGENT PAPER-FACING
+- `#3088` mugen: T_max=20
+- `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
+- `#2949` vash: depth/width sweep (LR=5e-5)
+- `#NEW` jin: multi-seed paper-facing (seeds 42/123/456) — BEING ASSIGNED
 
-### AirfRANS WIP (~9 students, ~15%)
-- `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
-- `#3106` wolfwood: 2L/384d+gc+T_max=50 (SENT BACK — add EMA=0.999)
-- `#3129` chrome: 4L/256d deeper architecture
-- `#3134` megumi: vol-weight=30x
-- `#3135` nezuko: EMA=0.999 + vol-weight=10x
+### AirfRANS WIP (~10 students, ~17%)
+- `#3156` edward: softer gc=0.5 on EMA champion
+- `#3144` violet: vol-weight=2.0+EMA=0.999
 - `#3136` stark: EMA decay higher (0.9995/0.9999)
-- `#3139` spike: 3L/256d + EMA=0.999
-- `#3144` violet: vol-weight=2.0 + EMA=0.999
+- `#3135` nezuko: EMA=0.999+vol-weight=10x
+- `#3134` megumi: vol-weight=30x
+- `#3129` chrome: 4L/256d deeper architecture
+- `#3106` wolfwood: 2L/384d+gc+T_max=50 (SENT BACK — add EMA=0.999)
+- `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
+- `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999 — JUST ASSIGNED
+- `#NEW` gilbert: lr=8e-4/1e-3+EMA=0.999 — BEING ASSIGNED
 
-### TandemFoil WIP (~4 students, ~7%)
-- `#3107` yuji: CLOSED (old config) → reassigned #3150
+### TandemFoil WIP (~3 students, ~5%)
+- `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
+- `#3142` zenitsu: gc=0.3+longer budget (480-min)
 - `#3140` usopp: gc=0.2 sweep
-- `#3142` zenitsu: gc=0.3 + longer budget (480-min)
-- `#3150` yuji: clean test row (gc=0.3 champion, paper-facing)
 
 ## Steering Anchors
 
@@ -91,56 +89,82 @@
 |---|---|---|---|---|
 | TandemFoil | `test_primary/surface_pressure_mae` | **23.419** (PR #3108) | (internal) | Strong |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
-| AirfRANS | `Surf MSE / Vol MSE` | **0.000459 / 0.002777** | 0.0043 / 0.0017 | Surface ✓✓, Volume 1.63x gap |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — paper eval in-progress |
+| AirfRANS | `Surf MSE / Vol MSE` | **0.000459 / 0.002777** | 0.0043 / 0.0017 | Surface 9.4x better, Volume 1.63x gap |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3164 paper eval in-progress |
 
 ## Current Research Focus
 
 ### Benchmark Sprint Priorities (ICML phase)
 
 1. **DrivAerML** — val=3.833%, gap to AB-UPT only 0.013 pp!
-   - **BREAKTHROUGH:** EMA=0.9995+gc=0.5 works. gc is the stability enabler for EMA on DM. Run still converging at ep517.
-   - **Active EMA follow-ups:** decay sweep 0.999 vs 0.9995 (eren #3152), gc sweep gc=0.25/1.0 (gilbert #3151)
-   - **CLOSED:** 5L depth, EMA without gc (diverges), Huber loss, rel-L2 loss, SGDR, RAdam, beta2 changes, warmup alone, bilateral symmetry, LR≠5e-4, WD+gc with heavy WD
-   - **Remaining active fronts:** surface points 16k/32k/64k (sent back with eval fix), log-cosh+gc, supernodes+gc, WD+gc lighter, architecture variants, throughput, optimizer (Lion, Lookahead, SWA, OneCycleLR), regularization, checkpoint averaging
+   - **BREAKTHROUGH:** EMA=0.9995+gc=0.5 works. gc is the stability enabler for EMA. Gap 93% closed.
+   - **Confirmed:** gc=0.5 is sharp optimum (0.25 starves, 1.0 insufficient — triple-confirmed via #3072/#3151/#3114)
+   - **Phase 2 strategy:** All new DM experiments build on EMA+gc=0.5 champion platform
+   - **Active fronts on champion platform:** decay sweep (eren), attention heads (senku/griffith), wider 640d (franky), eta_min (spike), attn dropout (shouko), softer gc=0.3 (himmel), monotonic cosine (historia), WD compound (emma), LR sweep (bulma), longer T_max (nobara)
+   - **Paper-facing:** faye #3164 doing full eval, multi-seed (casca/chihiro/canute sent back for two-phase)
+   - **Throughput experiments:** jet (600 batches), kakashi (788 batches+T_max=60)
+   - **Surface point resolution:** 16k/32k/64k (all sent back with eval fix)
+   - **Other active:** Lookahead (thorfinn), OneCycle (sanji), dropout (levi), checkpoint averaging (taki), feature dropout (fern), beta2 (einar), input feature dropout (fern)
 
 2. **TFP clean test result** — val=0.002383
-   - **CLOSED:** All EMA deviations (sinh overflow), all T_max>10, gc=0.3 (starvation), gc=0.7 (destabilize), 4L depth
-   - **Active:** gc=0.4 boundary test (rei), T_max=5/8 (mitsuha), 3L/256d (robin), WD sweep (shinobu), clean test (shoya URGENT)
+   - **Fully locked config:** Lion lr=1.25e-4, T_max=10, gc=0.5, EMA=0.999, 3L/192d
+   - **Every deviation diverges** — very narrow stability window
+   - **URGENT:** shoya #3098 clean test evaluation
+   - **Active width/depth:** robin (256d), nami (224d)
+   - **Active schedule:** mitsuha (T_max=5/8), mugen (T_max=20)
+   - **Active regularization:** shinobu (WD sweep), rei (gc=0.4)
+   - **Multi-seed:** jin being assigned (seeds 42/123/456)
 
-3. **AirfRANS volume** — 1.63x gap to target
-   - **Lead:** vol-weight=3x gave surface -17% (0.000381!) — 1.5x/2.0x sweep in progress
-   - **Active:** EMA higher decay (stark), 3L+EMA (spike), wider model+EMA (wolfwood sent back), vol-weight compound (tanjiro/violet/megumi/nezuko)
+3. **AirfRANS volume** — 1.63x gap to target (0.002777 vs 0.0017)
+   - **Surface already 9.4x better** than target — focus is purely on volume
+   - **vol-weight strategy:** 3x good for surface, 10x worse. Now testing 1.5x (tanjiro), 2.0x (violet), 5.0x/7.0x (vegeta), 30x (megumi)
+   - **LR sweep:** gilbert being assigned (lr=8e-4, 1e-3 with EMA)
+   - **EMA decay:** stark testing 0.9995/0.9999
+   - **gc transfer:** edward testing gc=0.5 (from DM success)
+   - **Depth:** chrome testing 4L/256d (2L optimal so far, 3L dead)
+   - **Width:** wolfwood 2L/384d (sent back to add EMA)
 
-4. **TandemFoil** — gc trend: monotonic improvement 1.0→0.5→0.3
-   - **Active:** gc=0.2 (usopp), gc=0.3+480min (zenitsu), clean test (yuji PAPER-FACING)
+4. **TandemFoil** — gc trend monotonic: 1.0→0.5→0.3
+   - **Active:** gc=0.2 (usopp), gc=0.3+480min (zenitsu)
+   - **Paper-facing:** yuji #3150 clean test from gc=0.3 champion
 
 ## Key Dead Ends (Do Not Repeat)
 
 **DrivAerML:**
-- T_max≠30 without gc (only 30 is stable)
-- Depth: 4L required; 5L also worse
-- EMA without gc: diverges (confirmed again in #3072 Run 1)
-- gc+WD heavy (WD=1e-3): 4.44%, below baseline (lighter WD in progress)
-- gc alone (all values): best 4.346%, above baseline
+- gc≠0.5 with EMA: 0.25 starves (13.1%), 1.0 insufficient (6.21%) — TRIPLE CONFIRMED
+- EMA without gc: diverges (confirmed #3072 Run 1, plus 3 prior attempts)
+- gc alone (any value, no EMA): best 4.346%, above baseline ceiling
+- Non-EMA regime ceiling: 3.997% (all diverge at cosine restart peaks)
+- 5L depth: 5.515% with gc (#3141), 4.172% without (#3104). 6L: 6.37%
+- Lion optimizer: all LR variants diverge (5e-5, 1e-4, 5e-5+gc)
+- Gradient centralization: fragile at LR restart boundaries (5.492% then diverge)
+- Polynomial LR (no cosine troughs): catastrophic — troughs are load-bearing stability features
+- SWA: equal-weight averaging poisons across divergent basins (88.98%)
+- T_max=50+gc (both 0.5 and 1.0): diverge — T_max=30 only viable period
+- 10-ep warmup+gc=1.0: 11.2% then diverged
+- 5-ep warmup+gc=1.0: pending (chopper)
+- Huber loss, relative L2 loss (degenerate), SGDR, RAdam
+- beta2≠0.999, LR≠5e-4 (without EMA), WD+gc heavy (WD=1e-3: 4.44%)
 - Bilateral symmetry aug, torch.compile, gradient accumulation
-- LR≠5e-4, SGDR, RAdam, beta2≠0.999, warmup alone
-- Huber loss, relative L2 loss (degenerate), 6L depth
+- Attention dropout without EMA/gc: toxic combo with T_max=30
+- Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)
 - gc≠0.5 (0.3=starvation, 0.7=destabilize; 0.4 being tested)
 - EMA≠0.999 (0.99 and 0.9995 both cause sinh overflow — very narrow window)
 - 4L depth (pressure overflow), LR=1.5e-4 (+34%)
+- T_max=20/30: field_mse never reaches finite values
 
 **AirfRANS:**
+- 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
 - Vol-weight=10x: worse on both metrics
 
-## Infrastructure
-- **PR #2974 MERGED:** Best-checkpoint saving in train.py — all new experiments use best val checkpoint for test eval
+**TandemFoil:**
+- gc≥0.5: monotonically worse than gc=0.3
 
 ## Mandatory Config Rules
 
@@ -151,3 +175,6 @@
 - `--epochs 999`, `SENPAI_MAX_EPOCHS=9999` mandatory for DM
 - DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
 - Paper-facing DM: NO `--max-eval-batches`
+
+## Infrastructure
+- **PR #2974 MERGED:** Best-checkpoint saving in train.py — all new experiments use best val checkpoint for test eval

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 19:30 (advisor cycle 41 — closed #3142/#3115/#3079, assigning zenitsu/gojo/piccolo)
+- **Date:** 2026-04-23 20:00 (advisor cycle 42 — closed #3132, assigning gohan)
 - **Branch:** radford
-- **Idle students:** 0 (zenitsu/gojo/piccolo being assigned)
+- **Idle students:** 0 (gohan being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status (56 active PRs → 59 after assignments)
@@ -29,7 +29,7 @@
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#3132` gohan: eta_min=5e-5+gc=1.0
+- `#NEW` gohan: TFP asinh-pressure isolation — BEING ASSIGNED
 - `#3121` levi: dropout regularization sweep
 - `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995
@@ -168,6 +168,7 @@
 - Bilateral symmetry aug, torch.compile, gradient accumulation
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
+- eta_min=5e-5+gc (any value): gc=1.0→6.311%, gc=0.5→8.617%, both diverge — 3rd confirmation
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
 - 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 12:30 (advisor cycle 31 — closed #3162/#3157, assigning himmel/nami)
+- **Date:** 2026-04-23 13:00 (advisor cycle 32 — closed #3131/#3124, assigning sanji/robin)
 - **Branch:** radford
-- **Idle students:** 0 (himmel/nami being assigned)
+- **Idle students:** 0 (sanji/robin being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status
@@ -27,7 +27,7 @@
 - `#3138` kakashi: 788 batches+T_max=60 (SENT BACK — add gc=0.5+EMA)
 - `#3137` chopper: 5-ep warmup+gc=1.0
 - `#3132` gohan: eta_min=5e-5+gc=1.0
-- `#3131` sanji: OneCycleLR schedule
+- `#NEW` sanji: warmup (5-ep/10-ep) + EMA+gc champion — BEING ASSIGNED
 - `#3121` levi: dropout regularization sweep
 - `#3118` hinata: WD alone at champion config
 - `#3115` piccolo: bs2+25k pts (SENT BACK — 50k+gc=0.5+EMA)
@@ -49,7 +49,7 @@
 - `#NEW` nami: attention heads sweep (4H/16H) — BEING ASSIGNED (moved from TFP)
 - `#3145` rei: gc=0.4 boundary test
 - `#3133` shinobu: WD sweep (5e-3/2e-2)
-- `#3124` robin: 3L/256d wider model
+- `#NEW` robin: warmup (5-ep/10-ep) + EMA=0.999 — BEING ASSIGNED (moved from TFP)
 - `#3123` mitsuha: shorter T_max (5/8)
 - `#3098` shoya: clean test evaluation — URGENT PAPER-FACING
 - `#3088` mugen: T_max=20
@@ -139,6 +139,7 @@
 - Lion optimizer: all LR variants diverge (5e-5, 1e-4, 5e-5+gc)
 - Gradient centralization: fragile at LR restart boundaries (5.492% then diverge)
 - Polynomial LR (no cosine troughs): catastrophic — troughs are load-bearing stability features
+- OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
 - T_max=50+gc (both 0.5 and 1.0): diverge — T_max=30 only viable period
 - 10-ep warmup+gc=1.0: 11.2% then diverged
@@ -155,6 +156,7 @@
 - EMA≠0.999 (0.99 and 0.9995 both cause sinh overflow — very narrow window)
 - 4L depth (pressure overflow), LR=1.5e-4 (+34%)
 - 3L/224d width: catastrophic divergence (field_mse ~2.2e9, grad explosion ep87)
+- 3L/256d width: catastrophic divergence (field_mse 8.61e+24, 27 orders worse)
 - T_max=20/30: field_mse never reaches finite values
 
 **AirfRANS:**

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,15 +1,18 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 22:30 (advisor cycle 47)
+- **Date:** 2026-04-23 23:00 (advisor cycle 48)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (5 being assigned)
 - **PRs ready for review:** 0
-- **CRITICAL:** TFP champion (0.002383) is unreproducible — 0/3 seeds stay finite (#3168)
+- **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
-## Fleet Status (57 active PRs)
+## Fleet Status (53 active PRs)
 
 ### DrivAerML WIP (27 PRs)
-**Innovation track (code ports — new directive):**
+**Innovation track (new physics-aware/ML ideas per directive):**
+- `#3216` canute: attention distance bias (ALiBi-inspired spatial prior) — INNOVATION
+- `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
+- `#3213` brook: surface normal input features — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -24,7 +27,6 @@
 - `#3175` hinata: full noam stack — NOAM ABLATION
 
 **Champion tuning / paper-facing:**
-- `#3173` kakashi: shorter cosine T_max=15/20
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
@@ -41,7 +43,6 @@
 - `#3085` kohaku: larger supernodes (SENT BACK)
 - `#3076` frieren: log-cosh loss (SENT BACK)
 - `#3067` askeladd: 32k surface points (SENT BACK)
-- `#3063` canute: paper-facing full-eval (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
 ### TandemFoil WIP (7 PRs) — GUARDRAIL ONLY per directive
@@ -54,10 +55,8 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
-### TandemFoil Paper WIP (11 PRs) — STABILIZATION CRISIS
-**Stabilization diagnostic (HIGHEST PRIORITY — baseline unreproducible):**
-- `#3205` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
-- `#3208` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
+### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
+**Stabilization status: CODE REGRESSION CONFIRMED — seed=0 broken, waiting for sanji #3209 bug fix**
 
 **Noam-pivot experiments:**
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION
@@ -81,15 +80,14 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
+- `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
-- `#3167` gilbert: higher LR (8e-4/1e-3)
-- `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
+- `#3195` piccolo: Re-stratified sampling
 - `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3199` megumi: DM EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3129` chrome: 4L/256d deeper
-- `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
 
 ## Steering Anchors
 
@@ -128,12 +126,12 @@
 - **Track 2 (Innovation):** Genuinely new physics-aware and ML ideas — NOT Radford/Noam recipe retuning. Search for benchmark-specific improvements. Code ports from noam: attn temp annealing (#3203), GLU preprocess (#3202), DomainLayerNorm (#3201). Look beyond: mesh-based operators, physics-informed losses, geometry encoders, domain-specific normalizations.
 - Bold ideas permitted and encouraged here. Local neighborhood exhausted.
 
-#### TandemFoil Paper — Stabilization First (CRISIS MODE)
-- **The failure mode is NaN/inf, not underperformance.** Optimize for finding ONE finite reproducible recipe, not performance.
-- Protocol: smoke test (1-3 epochs) → short debug (10-20 epochs) → long run ONLY after both are clean.
+#### TandemFoil Paper — Stabilization First (CRISIS MODE — UPGRADED)
+- **CODE REGRESSION CONFIRMED (#3205):** seed=0 no longer reproduces champion. ALL seeds + ALL stabilization probes → Inf pressure. This is NOT seed sensitivity — it's a broken pressure transform path in current codebase.
+- **Base config (no physics) IS stable** across seeds (#3208): floor ~0.047-0.049. Velocity channels healthy. Pathology isolated to sinh inverse pressure transform.
+- **Root cause:** cp_panel_prior_index() bug (#3200) + possible eval-time sinh overflow. Sanji #3209 fixing the cp_panel bug — MUST land before any further TFP optimization.
+- Protocol: fix bug → verify seed=0 reproduces → then reintroduce pressure transforms one at a time.
 - NaN/inf failures get closed immediately, no extensions.
-- brook #3200 reveals: base config (no physics) stable at 0.047; `cp_panel_prior_index()` is broken for TFP dataset — **champion may be unreproducible** with current code.
-- Next step: fix `cp_panel_prior_index()` bug, then re-run stable configs.
 
 #### TandemFoil — Guardrail Only
 - Parity is healthy. Minimal compute sink. Keep as sanity anchor, not a major compute investment.
@@ -146,15 +144,25 @@
 - Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex corrupted)
 - `--re-stratified-sampling` — OOD Re robustness — TF/AF
 
-### DM Innovation Track (code ports from noam)
+### DM Innovation Track (expanded beyond recipe tuning)
+**Code ports from noam:**
 - Attention temperature annealing (-11% on noam) — vegeta #3203
 - GLU preprocess MLP — senku #3202
 - DomainLayerNorm — jet #3201 (merged; awaiting results)
-- Still needed: vol_loss_scale, PCGrad (for AF multi-objective)
+
+**New physics-aware/ML ideas (cycle 48):**
+- Surface normal input features (local geometry context) — brook #3213
+- Auxiliary gradient prediction (∂p/∂x,y,z as regularization) — kakashi #3214
+- Attention distance bias (ALiBi-inspired spatial prior) — canute #3216
+
+**AF volume closure:**
+- vol_loss_scale learnable scalar (noam port, -15.9%) — spike #3211
+- PCGrad gradient surgery (surface/volume conflict resolution) — jin #3212
+- Huber loss on volume channel (robust to outlier gradients) — tanjiro #3215
 
 ### Critical Known Bug
-- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): When `--enable-cp-panel` + `--enable-pressure-prior-addition` are both set, the function returns the wrong index (last Fourier feature, not cp_panel), corrupting all pressure predictions. Fix required before running any long TFP experiments with these flags.
-- **TFP champion (#3025, 0.002383) may be unreproducible** with current codebase — this is a CRITICAL issue to resolve.
+- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): Fix in progress (sanji #3209).
+- **TFP champion config BROKEN in current codebase** — code regression confirmed (#3205). Seed=0 no longer reproduces. Base config without physics is stable (#3208). Root cause: pressure transform path (sinh inverse).
 
 ## Key Dead Ends (Do Not Repeat)
 
@@ -169,7 +177,7 @@
 - Polynomial LR (no cosine troughs): catastrophic — troughs are load-bearing stability features
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
-- T_max=50+gc (both 0.5 and 1.0): diverge — T_max=30 only viable period
+- T_max≠30: T_max=50+gc diverges; T_max=15→4.406% plateaued; T_max=20→4.943% diverged. T_max=30 ONLY viable period
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)
@@ -199,7 +207,7 @@
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
-- Vol-weight<10x (2x/5x/7x): all worse on both metrics. 10x+EMA=0.999 is AF sweet spot
+- Vol-weight<10x (1.5x/2x/3x/5x/7x): ALL worse on both metrics across 6 tested values. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
 - LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 03:00 (advisor cycle 59)
+- **Date:** 2026-04-24 03:15 (advisor cycle 60)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -32,7 +32,7 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
-- `#3220` nobara: Mixup regularization (feature interpolation) — INNOVATION
+- `#3237` nobara: snapshot ensemble at cosine troughs (test-time averaging) — INNOVATION
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
 - `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
@@ -85,7 +85,7 @@
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
-- `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
+- `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
@@ -187,6 +187,7 @@
 - Noam features on DM: DEFINITIVELY DEAD. Asinh triple-confirmed (4.072%/4.421%/4.475%), residual needs asinh+still→3.999%, full stack→4.447%. Features tuned for T_max=150/3H/no-gc regime
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
+- Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
@@ -215,6 +216,7 @@
 **AirfRANS:**
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
+- Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 06:00 (advisor cycle 66)
+- **Date:** 2026-04-24 06:30 (advisor cycle 67)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -33,6 +33,7 @@
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
+- `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
 - `#3248` nobara: decaying peak LR at cosine restarts (SGDR eta_mult) — INNOVATION
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
@@ -86,7 +87,6 @@
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
-- `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3240` gilbert: joint checkpoint selection + vol-weight 11x/12x/13x fine sweep — AF VOLUME FOCUS
@@ -222,6 +222,7 @@
 **AirfRANS:**
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
+- GradNorm adaptive loss balancing: surface 1.74x worse, vol 2.64x worse (#3218). retain_graph=True breaks compile (halves throughput). GradNorm converges to w_vol~8x, LOWER than hand-tuned 10x — fights intentional asymmetry
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 08:00 (advisor cycle 70)
+- **Date:** 2026-04-24 08:30 (advisor cycle 71)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -18,6 +18,8 @@
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
+- `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
+- `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
@@ -48,10 +50,8 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (3 PRs) — GUARDRAIL ONLY per directive
+### TandemFoil WIP (2 PRs) — GUARDRAIL ONLY per directive
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
-**Noam-pivot experiments (still running):**
-- `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -190,6 +190,7 @@
 - Snapshot ensemble (cosine trough checkpoints): test=6.044% single best, WORSE with more snapshots (K=3→6.24%, K=5→6.98%, K=6→7.81%). Quality gradient dominates diversity. EMA already provides implicit smoothing.
 - Spectral norm on QKV: 4.035% (+5.3%). σ=1 cap over-restricts attention capacity. Late collapse ep502 from unconstrained FFN layers. gc=0.5 already solves restart stability.
 - Self-distillation via EMA teacher: α=0.3→6.446% diverge ep170, α=0.1→4.323% diverge ep400. EMA=0.9995 lag creates destabilizing feedback loop. Same EMA for ckpt+teacher incompatible.
+- Pressure gradient smoothness reg (KNN): λ=0.01→4.481%, λ=0.1→4.876%, λ=1.0→12.52%. KNN 30% throughput overhead + sharp car features penalized. Remaining error is systematic bias, not noise.
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 21:30 (advisor cycle 45 — closed #3168/#3154/#3083, assigning jin/brook/historia/jet)
+- **Date:** 2026-04-23 12:30 (advisor cycle 46 — updated per human directive #3174)
 - **Branch:** radford
 - **Idle students:** 0 (4 being assigned)
 - **PRs ready for review:** 0
@@ -111,27 +111,50 @@
 
 ## Current Research Focus
 
-### LATEST HUMAN DIRECTIVE — Issue #3174 Update (2026-04-23 11:08)
+### LATEST HUMAN DIRECTIVES — Issue #3174 (2026-04-23 11:08–11:48)
 
-1. **AirfRANS → "Finish the job"**: Surface is strong. ALL new AF work must focus on **volume error reduction only** (vol_mse < 0.0017), without regressing surface.
-2. **DrivAerML → Two-track strategy**:
-   - **Track 1:** Stable full-eval champion track (best-checkpoint test eval) — faye #3164
-   - **Track 2:** Innovation track for genuinely new physics-aware and ML ideas — NOT more Radford/Noam recipe tuning. Code ports from noam: attn temp annealing (vegeta #3203), GLU preprocess (senku #3202), DomainLayerNorm (jet #3201)
-3. **TandemFoil Paper → Stabilization-first**: Failure mode is NaN/inf, not underperformance. Short, cheap diagnostic experiments to find one finite reproducible recipe. brook #3200 mapping stability.
-4. **TandemFoil → Guardrail only**: Parity is healthy. Minimal compute sink.
+> "We are no longer in a broad discovery phase, and we should stop acting like every benchmark wants the same recipe."
+> — morganmcg1, 2026-04-23
 
-### Noam Feature Activation (still highest priority)
-- `--anp-srf` — ANP cross-attention decoder (-58.9% TF!) — TF/TFP only
-- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm — ALL datasets
-- `--residual-prediction` — learned correction to freestream — ALL datasets
-- Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex silently ignored)
-- `--re-stratified-sampling` — OOD Re robustness — TF/TFP/AF
+**Strategic posture by benchmark (BINDING):**
+
+#### AirfRANS — "Finish the Job" (Volume Closure Mode)
+- Surface is already strong. **ALL new AF experiments must target vol_mse < 0.0017 specifically.**
+- Surface error is a hard constraint: NO regressions accepted, even for large volume gains.
+- No more broad novelty sweeps. This lane is in finish-the-job mode.
+
+#### DrivAerML — Two-Track Approach
+- **Track 1 (Stable Champion):** Keep current best config alive with full best-checkpoint test eval. No shortcuts. No `--max-eval-batches` on paper-facing runs.
+- **Track 2 (Innovation):** Genuinely new physics-aware and ML ideas — NOT Radford/Noam recipe retuning. Search for benchmark-specific improvements. Code ports from noam: attn temp annealing (#3203), GLU preprocess (#3202), DomainLayerNorm (#3201). Look beyond: mesh-based operators, physics-informed losses, geometry encoders, domain-specific normalizations.
+- Bold ideas permitted and encouraged here. Local neighborhood exhausted.
+
+#### TandemFoil Paper — Stabilization First (CRISIS MODE)
+- **The failure mode is NaN/inf, not underperformance.** Optimize for finding ONE finite reproducible recipe, not performance.
+- Protocol: smoke test (1-3 epochs) → short debug (10-20 epochs) → long run ONLY after both are clean.
+- NaN/inf failures get closed immediately, no extensions.
+- brook #3200 reveals: base config (no physics) stable at 0.047; `cp_panel_prior_index()` is broken for TFP dataset — **champion may be unreproducible** with current code.
+- Next step: fix `cp_panel_prior_index()` bug, then re-run stable configs.
+
+#### TandemFoil — Guardrail Only
+- Parity is healthy. Minimal compute sink. Keep as sanity anchor, not a major compute investment.
+- No ambitious per-run experiments here.
+
+### Noam Feature Activation (context-dependent per benchmark)
+- `--anp-srf` — ANP cross-attention decoder (-58.9% TF!) — TF only (TFP stability-first)
+- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm — DM, AF (not TFP until stable)
+- `--residual-prediction` — learned correction to freestream — DM, AF
+- Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex corrupted)
+- `--re-stratified-sampling` — OOD Re robustness — TF/AF
 
 ### DM Innovation Track (code ports from noam)
 - Attention temperature annealing (-11% on noam) — vegeta #3203
 - GLU preprocess MLP — senku #3202
-- DomainLayerNorm — jet #3201
+- DomainLayerNorm — jet #3201 (merged; awaiting results)
 - Still needed: vol_loss_scale, PCGrad (for AF multi-objective)
+
+### Critical Known Bug
+- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): When `--enable-cp-panel` + `--enable-pressure-prior-addition` are both set, the function returns the wrong index (last Fourier feature, not cp_panel), corrupting all pressure predictions. Fix required before running any long TFP experiments with these flags.
+- **TFP champion (#3025, 0.002383) may be unreproducible** with current codebase — this is a CRITICAL issue to resolve.
 
 ## Key Dead Ends (Do Not Repeat)
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -29,7 +29,7 @@
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#NEW` gohan: TFP asinh-pressure isolation — BEING ASSIGNED
+- `#3198` gohan: TFP asinh-pressure isolation (scale=0.75/0.5) — NOAM ABLATION
 - `#3121` levi: dropout regularization sweep
 - `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -12,7 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
-- canute: self-distillation with EMA teacher — INNOVATION (PR pending)
+- `#3225` canute: self-distillation with EMA teacher — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
@@ -21,10 +21,10 @@
 
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
-- casca: → AF focal-MSE volume loss (PR pending)
+- `#3227` casca: → AF focal-MSE volume loss
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- chihiro: → AF vol-weight curriculum (PR pending)
+- `#3226` chihiro: → AF vol-weight curriculum
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -31,8 +31,8 @@
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
-- `#NEW` historia: DM true monotonic cosine (T_max=393606) — corrected retest
-- `#NEW` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
+- `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
+- `#3206` jet: DM 600 batches + gc=0.5 + EMA (stabilized retest)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
@@ -57,8 +57,8 @@
 
 ### TandemFoil Paper WIP (11 PRs) — STABILIZATION CRISIS
 **Stabilization diagnostic (HIGHEST PRIORITY — baseline unreproducible):**
-- `#NEW` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
-- `#NEW` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
+- `#3205` jin: TFP seed sensitivity (seed=0 verify, seed=42 + gc/warmup/asinh probes)
+- `#3208` brook: TFP pressure stabilization (base config, lower LR, AdamW vs Lion)
 
 **Noam-pivot experiments:**
 - `#3183` rei: ANP+T_max=150 — NOAM ABLATION

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-04-23 23:30 (advisor cycle 50)
 - **Branch:** radford
-- **Idle students:** 0 (shouko being assigned)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 
@@ -29,7 +29,6 @@
 **Champion tuning / paper-facing:**
 - `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
-- `#3163` shouko: ~~attn dropout=0.05~~ → reassigning to AF GradNorm
 - `#3160` griffith: 16H heads
 - `#3155` nobara: longer T_max (45/60)
 - `#3207` historia: DM true monotonic cosine (T_max=393606) — corrected retest
@@ -80,6 +79,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -12,6 +12,7 @@
 **Innovation track (new physics-aware/ML ideas per directive):**
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
+- `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
 - `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
@@ -21,10 +22,7 @@
 
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
-- `#3227` casca: → AF focal-MSE volume loss
-- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
-- `#3226` chihiro: → AF vol-weight curriculum
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 - `#3219` hinata: SAM optimizer (flat-basin restart robustness) — INNOVATION
 
@@ -52,7 +50,6 @@
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3189` emma: asinh+physics features — NOAM ABLATION
-- chopper: → DM weight perturbation at troughs (PR pending)
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -79,6 +76,8 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
+- `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3223` norman: volume smoothness regularization — AF VOLUME FOCUS
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 12:00 (advisor cycle 30 — closed #3151/#3141/#2947, assigning gilbert/vegeta/jin)
+- **Date:** 2026-04-23 12:30 (advisor cycle 31 — closed #3162/#3157, assigning himmel/nami)
 - **Branch:** radford
-- **Idle students:** 0 (gilbert/vegeta/jin being assigned)
+- **Idle students:** 0 (himmel/nami being assigned)
 - **PRs ready for review:** 0
 
 ## Fleet Status
@@ -11,7 +11,7 @@
 - `#3165` senku: EMA+gc+4H heads (128d/head)
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING
 - `#3163` shouko: EMA+gc+attn dropout=0.05
-- `#3162` himmel: EMA+gc=0.3 (softer gc test)
+- `#NEW` himmel: AGC (adaptive gradient clipping) on EMA champion — BEING ASSIGNED
 - `#3161` spike: EMA+gc+eta_min=1e-5 (cosine floor)
 - `#3160` griffith: EMA+gc+16H heads
 - `#3159` franky: EMA+gc+4L/640d (wider)
@@ -46,7 +46,7 @@
 - `#3046` sukuna: WD+gc compound (SENT BACK — WD=5e-4/1e-4+gc=1.0)
 
 ### TandemFoil Paper WIP (~10 students, ~17%)
-- `#3157` nami: 3L/224d intermediate width
+- `#NEW` nami: attention heads sweep (4H/16H) — BEING ASSIGNED (moved from TFP)
 - `#3145` rei: gc=0.4 boundary test
 - `#3133` shinobu: WD sweep (5e-3/2e-2)
 - `#3124` robin: 3L/256d wider model
@@ -131,7 +131,7 @@
 ## Key Dead Ends (Do Not Repeat)
 
 **DrivAerML:**
-- gc≠0.5 with EMA: 0.25 starves (13.1%), 1.0 insufficient (6.21%) — TRIPLE CONFIRMED
+- gc≠0.5 with EMA: 0.25 starves (13.1%), 0.3 diverges ep81 (8.816%), 1.0 insufficient (6.21%) — QUAD CONFIRMED
 - EMA without gc: diverges (confirmed #3072 Run 1, plus 3 prior attempts)
 - gc alone (any value, no EMA): best 4.346%, above baseline ceiling
 - Non-EMA regime ceiling: 3.997% (all diverge at cosine restart peaks)
@@ -154,6 +154,7 @@
 - gc≠0.5 (0.3=starvation, 0.7=destabilize; 0.4 being tested)
 - EMA≠0.999 (0.99 and 0.9995 both cause sinh overflow — very narrow window)
 - 4L depth (pressure overflow), LR=1.5e-4 (+34%)
+- 3L/224d width: catastrophic divergence (field_mse ~2.2e9, grad explosion ep87)
 - T_max=20/30: field_mse never reaches finite values
 
 **AirfRANS:**

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 11:30 (advisor cycle 82)
+- **Date:** 2026-04-24 11:45 (advisor cycle 83)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -17,7 +17,7 @@
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
-- `#3263` gojo: Sparse MoE FFN (K=4/8 experts, top-2 routing, regime-specific computation) — INNOVATION
+- `#3273` gojo: Grouped Query Attention (GQA, 2/4 KV heads) — throughput-focused INNOVATION
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3269` emma: learned error correction head (boosting-inspired self-correction) — INNOVATION
@@ -200,6 +200,7 @@
 - EMA periodic reset: 100ep→4.426% cascade ep335, 50ep→6.818% diverge ep108 (#3247). EMA is primary gradient stabilizer — reset removes protective smoothing at high-curvature basin point
 - Weight Standardization: 67.9%/71.4% catastrophic (#3264). WS × cosine restarts × bs=1 feedback loop. Original BiT paper used epoch-level decay not per-batch restarts
 - SGDR eta_mult (decaying restart LR): 4.153%/12.64% (#3248). Confounded by switching to warm restarts. Sharp restart jumps more destabilizing than baseline's smooth cosine
+- Sparse MoE FFN (K=4/8, top-2): 5.09%/5.35% (#3263). 1.7-2.2x throughput penalty → epoch starvation. Routing collapses to uniform. Per-epoch curve parallel to dense — FFN is not the bottleneck
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 18:30 (advisor cycle 40 — closed #3159/#3158, assigning franky/bulma)
+- **Date:** 2026-04-23 19:30 (advisor cycle 41 — closed #3142/#3115/#3079, assigning zenitsu/gojo/piccolo)
 - **Branch:** radford
-- **Idle students:** 0
+- **Idle students:** 0 (zenitsu/gojo/piccolo being assigned)
 - **PRs ready for review:** 0
 
-## Fleet Status (59 active PRs)
+## Fleet Status (56 active PRs → 59 after assignments)
 
 ### DrivAerML WIP (30 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -31,12 +31,12 @@
 - `#3143` thorfinn: Lookahead(AdamW)
 - `#3132` gohan: eta_min=5e-5+gc=1.0
 - `#3121` levi: dropout regularization sweep
-- `#3115` piccolo: bs2+25k pts (SENT BACK — 50k+gc=0.5+EMA)
+- `#NEW` piccolo: AF re-stratified sampling alone — BEING ASSIGNED
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
 - `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
 - `#3083` jet: max-train-batches=600
-- `#3079` gojo: 4L/640d (SENT BACK — lr=3e-4+T_max=60+EMA)
+- `#NEW` gojo: TF residual-prediction alone — BEING ASSIGNED
 - `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
 - `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
 - `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
@@ -50,8 +50,8 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 
 **Other:**
+- `#NEW` zenitsu: TF EMA decay sweep (0.9999/0.99995) — BEING ASSIGNED
 - `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
-- `#3142` zenitsu: gc=0.3+longer budget (480-min)
 
 ### TandemFoil Paper WIP (10 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -169,8 +169,9 @@
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
 - Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
-- 4L/640d at lr=5e-4: 8.636% then diverge ep82 even with EMA+gc (grad_norm=Infinity)
+- 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)
+- bs=2: Blackwell bf16+bs>1 CUBLAS bug forces fp32, gets only 37% of optimizer steps. 4.373% at bs=2/fp32 vs 3.833% bs=1/bf16. Platform-blocked.
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)
@@ -190,6 +191,7 @@
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3
+- Longer budget (480-min): no benefit with cosine T_max=10 cycling — more epochs = more independent draws, not monotone descent (22.016 at 480min vs 21.909 at 360min)
 
 ## Mandatory Config Rules
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,33 +1,29 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 06:30 (advisor cycle 20 complete — reviewed 14 PRs: merged #2974 infra, 9 closed, 5 sent-back, 8 new assigned #3143-#3150)
+- **Date:** 2026-04-23 07:00 (advisor cycle 21 — reviewed 7 PRs: merged #3072 DM new best, closed #3077, 5 sent-back, 2 new assigned #3151/#3152)
 - **Branch:** radford
 - **Idle students:** NONE — all 60 students assigned
 - **PRs ready for review:** 0
-- **PRs in WIP:** 60
 
 ## Fleet Status
 
-### DrivAerML WIP (~35 students, ~58%)
-- `#3063` canute: paper-facing full-eval (SENT BACK — two-phase approach)
-- `#3064` casca: multi-seed full-eval seed=123 (PAPER-FACING)
-- `#3065` chihiro: multi-seed full-eval seed=456 (PAPER-FACING)
-- `#3066` alphonse: 16k surface points
-- `#3067` askeladd: 32k surface points
-- `#3068` brook: 64k surface points
-- `#3072` eren: EMA=0.9995
-- `#3073` faye: EMA=0.999 + gc=0.5 compound — SENT BACK
-- `#3077` gilbert: 5L/512d (deeper)
-- `#3078` gohan: 6L/512d (much deeper) — SENT BACK
-- `#3079` gojo: 4L/640d + T_max=60 + lr=3e-4 — SENT BACK retry
-- `#3083` jet: max-train-batches=600
-- `#3085` kohaku: larger supernodes (SENT BACK — retry with gc=1.0)
-- `#3076` frieren: log-cosh loss (SENT BACK — retry with gc=1.0)
-- `#3046` sukuna: WD+gc compound (SENT BACK — lighter WD=5e-4/1e-4)
+### DrivAerML WIP (~38 students, ~63%)
 - `#3044` emma: volume training ablation
+- `#3046` sukuna: WD+gc (SENT BACK — try WD=5e-4/1e-4 + gc=1.0)
+- `#3063` canute: paper-facing full-eval (SENT BACK — two-phase approach)
+- `#3064` casca: multi-seed seed=123 (SENT BACK — two-phase eval)
+- `#3065` chihiro: multi-seed seed=456 (SENT BACK — two-phase eval)
+- `#3066` alphonse: 16k surface points
+- `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
+- `#3068` brook: 64k surface points (SENT BACK — add max-eval-batches 200)
+- `#3073` faye: SWA (formerly EMA+gc compound — reassigned)
+- `#3076` frieren: log-cosh loss (SENT BACK — retry +gc=1.0)
+- `#3079` gojo: 4L/640d + T_max=60 + lr=3e-4 — retry
+- `#3083` jet: max-train-batches=600
+- `#3085` kohaku: larger supernodes (SENT BACK — retry +gc=1.0)
 - `#3109` guts: lr=4e-4 full-eval
 - `#3110` einar: AdamW beta2=0.99/0.995
-- `#3111` himmel: cosine eta_min=1e-6/1e-5
+- `#3111` himmel: cosine eta_min sweep
 - `#3112` edward: gradient centralization
 - `#3113` shouko: attention dropout=0.05
 - `#3114` griffith: T_max=50 + gc=1.0
@@ -39,46 +35,43 @@
 - `#3122` nobara: polynomial LR decay
 - `#3125` faye: SWA at cosine troughs
 - `#3127` senku: attention heads sweep (4H/16H)
-- `#3129` chrome: AF 4L/256d deeper — wait, this is DM? Check: chrome/af-4l-256d — actually chrome is on AF per CURRENT STATE
 - `#3131` sanji: OneCycleLR schedule
 - `#3132` gohan: eta_min=5e-5 + gc=1.0
 - `#3137` chopper: 5-epoch warmup + gc=1.0
 - `#3138` kakashi: 788 batches + T_max=60
 - `#3141` vegeta: 5L/512d + gc=1.0
-- `#3143` thorfinn: Lookahead(AdamW, k=6, alpha=0.5)
+- `#3143` thorfinn: Lookahead(AdamW)
 - `#3146` taki: top-5 checkpoint averaging
-- `#3147` norman: lighter WD + gc (WD=5e-4/1e-4 + gc=1.0)
+- `#3147` norman: lighter WD + gc (WD=5e-4/1e-4)
 - `#3148` franky: 10-epoch warmup + gc=1.0
-- `#3149` fern: stochastic input feature dropout (p=0.05/0.10)
+- `#3149` fern: stochastic input feature dropout
+- `#3151` gilbert: EMA=0.9995 + gc sweep (gc=0.25, gc=1.0)
+- `#3152` eren: EMA decay sweep (0.999 vs 0.9995) + extended budget
 
 ### TandemFoil Paper WIP (~9 students, ~15%)
+- `#2947` jin: first field_mse baseline (LR sweep)
+- `#2949` vash: depth/width sweep (LR=5e-5)
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#3088` mugen: T_max=20
 - `#3089` nami: T_max=30
-- `#3098` shoya: clean test evaluation (paper-facing)
-- `#2947` jin: first field_mse baseline (LR sweep)
-- `#3113` shouko: field_mse full-eval clean test — wait, this is DM per branch name. Reviewing WIP list...
-- `#3116` sanji: 4L/192d champion architecture — wait, sanji is on DM (#3131). This might be stale.
+- `#3098` shoya: clean test evaluation (paper-facing) — URGENT
 - `#3123` mitsuha: shorter T_max (T_max=5, T_max=8)
 - `#3124` robin: 3L/256d wider model
 - `#3133` shinobu: TFP WD sweep
-- `#3135` nezuko: AF EMA=0.999 + vol-weight=10x
-- `#2949` vash: depth/width sweep (LR=5e-5)
 - `#3145` rei: gc=0.4 boundary test
 
 ### AirfRANS WIP (~9 students, ~15%)
-- `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK — retry at 1.5x)
-- `#3102` thorfinn: 10x vol-weight — CLOSED; thorfinn now on DM #3143
-- `#3106` wolfwood: 2L/384d + gc=0.5 + T_max=50
+- `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
+- `#3106` wolfwood: 2L/384d+gc+T_max=50 (SENT BACK — add EMA=0.999)
 - `#3129` chrome: 4L/256d deeper architecture
 - `#3134` megumi: vol-weight=30x
 - `#3135` nezuko: EMA=0.999 + vol-weight=10x
-- `#3136` stark: EMA decay sweep (0.9995/0.9999)
+- `#3136` stark: EMA decay higher (0.9995/0.9999)
 - `#3139` spike: 3L/256d + EMA=0.999
 - `#3144` violet: vol-weight=2.0 + EMA=0.999
 
 ### TandemFoil WIP (~4 students, ~7%)
-- `#3107` yuji: CLOSED (old config); reassigned to #3150
+- `#3107` yuji: CLOSED (old config) → reassigned #3150
 - `#3140` usopp: gc=0.2 sweep
 - `#3142` zenitsu: gc=0.3 + longer budget (480-min)
 - `#3150` yuji: clean test row (gc=0.3 champion, paper-facing)
@@ -87,90 +80,74 @@
 
 | Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **21.909** (#3108 MERGED — gc=0.3+EMA=0.999) |
-| TandemFoil Paper | `val_primary/field_mse` | **0.002383** (#3025 MERGED) |
-| AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000459 / 0.002777** (#3050 MERGED — EMA+T_max=50) |
-| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** (#2898 MERGED) |
+| TandemFoil | `val_primary/surface_pressure_mae` | **21.909** (#3108 — gc=0.3+EMA=0.999) |
+| TandemFoil Paper | `val_primary/field_mse` | **0.002383** (#3025) |
+| AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000459 / 0.002777** (#3050 — EMA+T_max=50) |
+| DrivAerML | `val_primary/surface_rel_l2_pct` | **3.833%** (#3072 MERGED — EMA=0.9995+gc=0.5) |
 
 ## Paper-Facing Snapshot
 
 | Dataset | Metric | Current best | External target | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **23.419** (PR #3108) | (internal anchor) | Strong — clean test in-progress (#3150) |
+| TandemFoil | `test_primary/surface_pressure_mae` | **23.419** (PR #3108) | (internal) | Strong |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
 | AirfRANS | `Surf MSE / Vol MSE` | **0.000459 / 0.002777** | 0.0043 / 0.0017 | Surface ✓✓, Volume 1.63x gap |
-| DrivAerML | `test_primary/surface_rel_l2_pct` | **6.244%** (old config) | 3.71% | Main gap — paper eval in-progress |
+| DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — paper eval in-progress |
 
 ## Current Research Focus
 
 ### Benchmark Sprint Priorities (ICML phase)
 
-1. **DrivAerML closure** — val=3.997%, need test below 5%, ideally toward 3.71%
-   - **CLOSED directions:** T_max (only 30 without gc), depth (4L required), multi-revisit, EMA (3 configs), bilateral symmetry, LR (5e-4 sharp), gc alone (4.346% best), gc+WD (WD=1e-3+gc best 4.44%), gradient accumulation, SGDR, RAdam, beta2 changes, warmup alone, 6L, torch.compile, Huber loss, relative L2 loss
-   - **Active frontier:**
-     - Surface points sweep (16k/32k/64k) — human directive
-     - Loss variants: log-cosh+gc (frieren sent back), label-smooth L1 (piccolo)
-     - Architecture: 5L/512d (gilbert), 640d+gc (gojo), 384d compact (griffith), 5L+gc (vegeta)
-     - Throughput: 600-batches (jet), 788+T_max=60 (kakashi), supernodes+gc (kohaku sent back)
-     - Regularization: WD alone (hinata), dropout (levi), lighter WD+gc (norman), input dropout (fern)
-     - Optimizer: Lion (bulma), Lookahead (thorfinn), SWA (faye), OneCycleLR (sanji)
-     - Schedule: eta_min sweep (himmel), polynomial (nobara), eta_min+gc (gohan), 5/10-ep warmup+gc (chopper/franky)
-     - Special: checkpoint averaging (taki), gradient centralization (edward), GradCentralization (edward), attention heads (senku), attention dropout (shouko)
-     - Compound: T_max=50+gc (griffith), WD lighter+gc (sukuna/norman)
-     - Multi-seed paper-facing (casca seed=123, chihiro seed=456)
+1. **DrivAerML** — val=3.833%, gap to AB-UPT only 0.013 pp!
+   - **BREAKTHROUGH:** EMA=0.9995+gc=0.5 works. gc is the stability enabler for EMA on DM. Run still converging at ep517.
+   - **Active EMA follow-ups:** decay sweep 0.999 vs 0.9995 (eren #3152), gc sweep gc=0.25/1.0 (gilbert #3151)
+   - **CLOSED:** 5L depth, EMA without gc (diverges), Huber loss, rel-L2 loss, SGDR, RAdam, beta2 changes, warmup alone, bilateral symmetry, LR≠5e-4, WD+gc with heavy WD
+   - **Remaining active fronts:** surface points 16k/32k/64k (sent back with eval fix), log-cosh+gc, supernodes+gc, WD+gc lighter, architecture variants, throughput, optimizer (Lion, Lookahead, SWA, OneCycleLR), regularization, checkpoint averaging
 
-2. **TFP clean test result** — val=0.002383, need paper-facing field_mse
-   - **CLOSED:** T_max>10, gc≠0.5 (both directions fail — 0.3 starves, 0.7 destabilizes), EMA≠0.999 (both directions cause sinh overflow), 4L depth, LR=1.5e-4
-   - **Active:** T_max=5/8 (mitsuha), 3L/256d width (robin), WD sweep (shinobu), T_max=20/30 (mugen/nami), gc=0.4 boundary test (rei), clean test (shoya)
-   - **TFP is a SHARP OPTIMUM** — gc=0.5, T_max=10, EMA=0.999, LR=1.25e-4, 3L/192d all appear to be inflection points
+2. **TFP clean test result** — val=0.002383
+   - **CLOSED:** All EMA deviations (sinh overflow), all T_max>10, gc=0.3 (starvation), gc=0.7 (destabilize), 4L depth
+   - **Active:** gc=0.4 boundary test (rei), T_max=5/8 (mitsuha), 3L/256d (robin), WD sweep (shinobu), clean test (shoya URGENT)
 
-3. **AirfRANS volume** — 1.63x gap to target 0.0017
-   - **New lead:** #3101 showed vol-weight=3x gives surface -17% (0.000381!) but volume +41%. Sweep in progress: 1.5x (tanjiro sent back), 2.0x (violet), 30x (megumi)
-   - **Active:** EMA decay higher (stark), 3L/256d+EMA (spike), 2L/384d+gc (wolfwood), 4L/256d (chrome), vol+EMA compound (nezuko)
+3. **AirfRANS volume** — 1.63x gap to target
+   - **Lead:** vol-weight=3x gave surface -17% (0.000381!) — 1.5x/2.0x sweep in progress
+   - **Active:** EMA higher decay (stark), 3L+EMA (spike), wider model+EMA (wolfwood sent back), vol-weight compound (tanjiro/violet/megumi/nezuko)
 
-4. **TandemFoil** — gc trend confirmed monotonically improving (1.0→0.5→0.3)
-   - **Active:** gc=0.2 (usopp), gc=0.3+480min (zenitsu), clean test gc=0.3 (yuji paper-facing)
-   - **Key question:** Does gc=0.2 continue the trend or invert?
+4. **TandemFoil** — gc trend: monotonic improvement 1.0→0.5→0.3
+   - **Active:** gc=0.2 (usopp), gc=0.3+480min (zenitsu), clean test (yuji PAPER-FACING)
 
 ## Key Dead Ends (Do Not Repeat)
 
 **DrivAerML:**
-- T_max: only 30 works without gc
-- Depth: 4L required; 2L/3L diverge; 6L also worse
-- EMA: incompatible at all configs
-- gc+WD (WD=1e-3): 4.44% — promising but above baseline; lighter WD in-progress
-- gc alone: best 4.346% above baseline
-- 640d without gc, torch.compile, bilateral symmetry, gradient accumulation
-- LR: 5e-4 sharp optimum
-- SGDR (T_mult=1.5, T_mult=2), RAdam, beta2≠0.999
-- Warmup alone (5/10-ep), Huber loss (both deltas), relative L2 loss (degenerate)
+- T_max≠30 without gc (only 30 is stable)
+- Depth: 4L required; 5L also worse
+- EMA without gc: diverges (confirmed again in #3072 Run 1)
+- gc+WD heavy (WD=1e-3): 4.44%, below baseline (lighter WD in progress)
+- gc alone (all values): best 4.346%, above baseline
+- Bilateral symmetry aug, torch.compile, gradient accumulation
+- LR≠5e-4, SGDR, RAdam, beta2≠0.999, warmup alone
+- Huber loss, relative L2 loss (degenerate), 6L depth
 
 **TandemFoil Paper:**
-- T_max>10 (15/20/30 all diverge)
-- gc=0.3: pressure starvation → Infinity
-- gc=0.7: destabilizes
-- EMA=0.99 and EMA=0.9995: sinh overflow from both directions
-- 4L/192d: pressure overflow; 4L/256d: +85% worse
-- LR=1.5e-4: +34% worse
+- T_max≠10 (all directions diverge)
+- gc≠0.5 (0.3=starvation, 0.7=destabilize; 0.4 being tested)
+- EMA≠0.999 (0.99 and 0.9995 both cause sinh overflow — very narrow window)
+- 4L depth (pressure overflow), LR=1.5e-4 (+34%)
 
 **AirfRANS:**
-- 2L/384d, 3L/384d: both diverge catastrophically
-- T_max=30 (+72%), T_max=100 (+47%): T_max=50 optimal
-- 3L/256d without EMA: superseded
-- EMA=0.99 (+383%), EMA=0.995 (+51%): EMA=0.999 is sweet spot
-- Vol-weight=10x: worse on both metrics vs EMA champion
-
-**Cross-dataset:** SAM, PCGrad, LayerScale, sigma-Reparam, GeGLU, SwiGLU, SDF, head scaling — all failed
+- 2L/384d and 3L/384d: catastrophic divergence
+- EMA<0.999 (0.99, 0.995 both worse)
+- T_max≠50 (30 and 100 both worse)
+- Vol-weight=10x: worse on both metrics
 
 ## Infrastructure
-- **PR #2974 MERGED:** Best-checkpoint saving in train.py — all future experiments automatically use best val checkpoint for test eval. Critical: rescued AirfRANS from total NaN failure, 3.4x improvement on DM test metrics.
+- **PR #2974 MERGED:** Best-checkpoint saving in train.py — all new experiments use best val checkpoint for test eval
 
 ## Mandatory Config Rules
 
-- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.3, WD=1e-2, `--ema-decay 0.999`, 3L/192d (**gc=0.3 post #3108**)
+- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.3, WD=1e-2, `--ema-decay 0.999`, 3L/192d
 - **TFP:** Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, `--ema-decay 0.999`, 3L/192d
-- **AF:** AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, `--ema-decay 0.999`, 2L/256d (**EMA now mandatory post #3050**)
-- **DM:** AdamW lr=5e-4, T_max=30, NO gc, NO WD, no-EMA, 4L/512d
-- `--epochs 999` mandatory
-- DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394`
+- **AF:** AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, `--ema-decay 0.999`, 2L/256d
+- **DM:** AdamW lr=5e-4, T_max=30, **gc=0.5**, **EMA=0.9995**, no WD, 4L/512d (**UPDATED post #3072**)
+- `--epochs 999`, `SENPAI_MAX_EPOCHS=9999` mandatory for DM
+- DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`
 - Paper-facing DM: NO `--max-eval-batches`

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -22,8 +22,8 @@
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
-- `#NEW` franky: DM residual-prediction alone — BEING ASSIGNED
-- `#NEW` bulma: DM higher LR sweep (5.5e-4/6e-4) — BEING ASSIGNED
+- `#3193` franky: DM residual-prediction alone — NOAM ABLATION
+- `#3194` bulma: DM higher LR sweep (5.5e-4/6e-4)
 - `#3155` nobara: longer T_max (45/60)
 - `#3154` historia: monotonic cosine (no restarts)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 07:30 (advisor cycle 69)
+- **Date:** 2026-04-24 08:00 (advisor cycle 70)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -21,6 +21,7 @@
 - `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
+- `#3256` alphonse: coordinate noise augmentation (σ=0.001/0.005 input perturbation) — INNOVATION
 - `#3253` canute: input feature dropout (Fourier channel dropout 10%/20%) — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
@@ -67,12 +68,10 @@
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
 ### AirfRANS WIP (14 PRs)
-**Non-asinh noam feature ablation (highest priority — clean tests):**
-- `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
-
 **Volume closure experiments:**
+- `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
+- `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
-- `#3236` gohan: Lookahead(AdamW) + torch.compile on vol-10x champion — AF VOLUME FOCUS
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 
@@ -84,7 +83,6 @@
 - `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
-- `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
 - `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
@@ -226,6 +224,9 @@
 - PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - GradNorm adaptive loss balancing: surface 1.74x worse, vol 2.64x worse (#3218). retain_graph=True breaks compile (halves throughput). GradNorm converges to w_vol~8x, LOWER than hand-tuned 10x — fights intentional asymmetry
 - Volume smoothness regularization (KNN): ALL 4 trials regressed both metrics 44-97% (#3223). KNN Euclidean smoothness penalizes legitimate BL/wake/shear gradients. Even λ=1e-4 harmful
+- Residual prediction (no asinh): +55-72% surface worse (#3230). AF has large separated regions — "correction from freestream" IS the entire signal. Re-stratified sampling is no-op (uniform weights)
+- Vol-weight curriculum (20x→10x / 15x→10x): collapsed or 38-52% worse on both metrics (#3226). Static 10x validated as optimal — any deviation above hurts
+- Lookahead hurts AF surface by 53% at equal epochs (#3236 ablation). Compile also hurts surface despite more epochs. Both are default-on in baseline — ambiguity on synergistic effect at long training
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -78,18 +78,18 @@
 
 | Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **21.909** (#3108 — gc=0.3+EMA=0.999) |
+| TandemFoil | `val_primary/surface_pressure_mae` | **21.350** (#3140 MERGED — gc=0.2+EMA=0.999) |
 | TandemFoil Paper | `val_primary/field_mse` | **0.002383** (#3025) |
-| AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000459 / 0.002777** (#3050 — EMA+T_max=50) |
+| AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000296 / 0.002039** (#3135 MERGED — EMA+vol-weight=10x) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **3.833%** (#3072 MERGED — EMA=0.9995+gc=0.5) |
 
 ## Paper-Facing Snapshot
 
 | Dataset | Metric | Current best | External target | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **23.419** (PR #3108) | (internal) | Strong |
+| TandemFoil | `test_primary/surface_pressure_mae` | **23.195** (PR #3140) | (internal) | Improving |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT — #3098 in-progress |
-| AirfRANS | `Surf MSE / Vol MSE` | **0.000459 / 0.002777** | 0.0043 / 0.0017 | Surface 9.4x better, Volume 1.63x gap |
+| AirfRANS | `Surf MSE / Vol MSE` | **0.000296 / 0.002039** | 0.0043 / 0.0017 | Surface 14.5x better, Volume 1.20x gap |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **4.685%** (#3072, partial eval) | 3.71% | Gap closing — #3164 paper eval in-progress |
 
 ## Current Research Focus

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,10 +1,10 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 16:15 (advisor cycle 92)
+- **Date:** 2026-04-24 17:30 (advisor cycle 94)
 - **Branch:** radford
-- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~8 hours remaining)**
-- **Fleet restructured.** 36 DM / 12 AF / 11 TFP / 0 TF.
-- **Harness patches (#3284):** 5/6 implemented, sent back for merge-blocking bug fix. HIGHEST PRIORITY.
+- **ACTIVE DIRECTIVE: Issue #3283 — Last Ditch Benchmark Push (~6-7 hours remaining)**
+- **Fleet:** 59 students active. 36 DM / 12 AF / 11 TFP / 0 TF.
+- **Harness patches (#3284): MERGED.** All new DM runs use --save-checkpoint --skip-update-grad-norm 100 --ema-mode fixed --ema-start-step 50
 
 ## BINDING DIRECTIVE — Issue #3283 (2026-04-24)
 
@@ -26,31 +26,31 @@ Re-run haku/tfp-t20-gc05-lr1e4 for 2-8 seeds (best_val=0.002466, best_test=0.002
 
 ## Fleet Status (restructuring in progress)
 
-### INFRASTRUCTURE (1 PR)
-- `#3284` vegeta: HARNESS PATCHES — SENT BACK for merge-blocking bug (double best-tracking). 5/6 patches implemented. **HIGHEST PRIORITY — awaiting fix.**
+### DrivAerML WIP (36 students)
+**Breakout lanes:**
+- `#3300` vegeta: **Breakout 1** — AB-UPT-style anchored decoder (geometry supernodes → surface anchor cross-attention → point decoding)
+- `#3299` zenitsu: **Breakout 4** — coordinate normalization + geometry features (xyz_norm using geometry_center/scale, normals, log_area, front-facing indicator)
+- `#3301` brook: **Breakout 3** — domain-normalized volume auxiliary (fix normalization bug at line 790, separate surface/volume TargetTransform, vol_loss_weight 0.03/0.1/0.3)
+- **Breakout 2** (metric-aware fine-tune: mse_z + raw rel-L2) — NOT YET ASSIGNED
+- **Breakout 5** (train+val retrain) — NOT YET ASSIGNED
 
-### DrivAerML WIP (~28 continuing + 8 new = 36 target)
-**Champion recovery / truth lanes (newly assigned):**
-- norman: champion recovery seed=0 no-compile (Bucket A)
-- jet: champion recovery seed=42 no-compile (Bucket A)
-- megumi: champion recovery seed=7 no-compile (Bucket A)
-- himmel: 64k surface points (Bucket C)
-- askeladd: 96k surface points (Bucket C)
-- robin: gradient-spike-safe gc=0.25 (Bucket D)
-- nami: T_max=24 narrow schedule (Bucket E)
-- chrome: T_max=36 narrow schedule (Bucket E)
-
-**Breakout lanes (newly assigned):**
-- `#3299` zenitsu: Breakout 4 — coordinate normalization + geometry features (xyz_norm, normals, log_area, front-facing)
+**Champion recovery / truth lanes:**
+- `#3293` norman: champion recovery seed=0 no-compile (Bucket A)
+- `#3285` jet: champion recovery seed=42 no-compile fixed-EMA (Bucket A)
+- `#3286` megumi: champion recovery seed=7 no-compile (Bucket A)
+- `#3289` himmel: 64k surface points (Bucket C)
+- `#3290` askeladd: 96k surface points (Bucket C)
+- `#3294` robin: gradient-spike-safe gc=0.25 (Bucket D)
+- `#3297` nami: T_max=24 narrow schedule (Bucket E)
+- `#3298` chrome: T_max=36 narrow schedule (Bucket E)
 
 **Continuing DM experiments (from pre-restructure):**
-- `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval)
+- `#3244` faye: paper-facing full eval (SENT BACK for champion ckpt eval using --load-checkpoint)
 - `#3279` gojo: ReLU² activation
-- `#3270` brook: FiLM conditioning
 - `#3269` emma: error correction head
 - `#3267` mitsuha: SwiGLU FFN
 - `#3265` alphonse: hidden-space noise
-- `#3276` zenitsu: cosine similarity loss
+- ~~`#3276` zenitsu: cosine similarity loss~~ CLOSED dead end
 - `#3275` canute: local attention
 - `#3271` nobara: LLRD
 - `#3251` fern: Pre-LayerNorm

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,11 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 10:00 (advisor cycle 77)
+- **Date:** 2026-04-24 10:15 (advisor cycle 78)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
-- **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
-- **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
+- **TFP UNBLOCKED:** cp_panel bug fix merged (#3209). Multi-seed reproducibility confirmed. Sanji #3266 re-running champion config to verify 0.002383 is recoverable.
+- **Both bugs fixed in codebase:** cp_panel_prior_index() guard (#3209 MERGED) + primary_metric_key shadowing (#3209 MERGED).
 
 ## Fleet Status (58 active PRs)
 
@@ -21,7 +21,7 @@
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
-- `#3252` mitsuha: progressive surface point training (resolution curriculum) — INNOVATION
+- `#3267` mitsuha: SwiGLU FFN activation (replace GELU with gated linear unit) — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3265` alphonse: hidden-space noise regularization (post-Fourier perturbation σ=0.01/0.05) — INNOVATION
@@ -35,7 +35,7 @@
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
 
 **Champion tuning / paper-facing:**
-- `#3209` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
+- `#3266` sanji: TFP champion config re-verification post cp_panel fix (seed=0/42) — STABILIZATION VERIFY
 - `#3244` faye: DM Track 1 paper-facing full eval (champion config, NO --max-eval-batches) — PAPER-FACING Track 1
 - `#3160` griffith: 16H heads
 - `#3249` shouko: decaying weight decay schedule (WD=1e-4/5e-5 → 0 over 300ep) — INNOVATION
@@ -55,8 +55,8 @@
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
 - `#3150` yuji: clean test row — PAPER-FACING
 
-### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
-**Stabilization status: CODE REGRESSION CONFIRMED — seed=0 broken, waiting for sanji #3209 bug fix**
+### TandemFoil Paper WIP (9 PRs) — STABILIZATION RESOLVED
+**Bug fix merged (#3209). Sanji #3266 verifying champion config reproducibility.**
 
 **Noam-pivot experiments:**
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
@@ -163,9 +163,10 @@
 - vol_loss_scale learnable scalar (noam port, -15.9%) — spike #3211
 - Per-channel volume loss weighting (upweight nut×4, p×2) — tanjiro #3245
 
-### Critical Known Bug
-- **`cp_panel_prior_index()` broken for tandemfoil_paper** (PR #3200): Fix in progress (sanji #3209).
-- **TFP champion config BROKEN in current codebase** — code regression confirmed (#3205). Seed=0 no longer reproduces. Base config without physics is stable (#3208). Root cause: pressure transform path (sinh inverse).
+### Bug Fixes (RESOLVED)
+- **`cp_panel_prior_index()` FIXED** (#3209 MERGED): Guard returns None for tandemfoil_paper. No more sinh overflow.
+- **`primary_metric_key` shadowing FIXED** (#3209 MERGED): Local variable at line ~1652 renamed, no longer shadows function at line ~1434.
+- **TFP champion config recovery in progress** — sanji #3266 verifying that 0.002383 baseline is reproducible under the fixed codebase.
 
 ## Key Dead Ends (Do Not Repeat)
 
@@ -193,6 +194,7 @@
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - Stochastic depth/LayerDrop: p=0.1→4.317%, p=0.2→4.217%, p=0.3→4.411% (#3233). Only 4 layers — dropping 1 removes 25% capacity. Too coarse. EMA+gc already handles stability
 - Coordinate noise augmentation: σ=0.001→6.45% crashed, σ=0.005→21.44% Inf grads (#3256). Fourier freqs up to 32.0 amplify coord noise 32x. Structurally incompatible with Fourier PE
+- Progressive resolution (25k→50k / 30k→50k): 25k crashed ep112, 30k→4.711% +23% (#3252). Full 50k context needed from epoch 1. Reduced resolution creates irrecoverable representation deficit
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -20,7 +20,7 @@
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
-- franky: gradient noise injection — INNOVATION (PR pending)
+- `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
@@ -78,7 +78,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
-- rei: proximity-weighted volume loss — AF VOLUME FOCUS (PR pending)
+- `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -7,50 +7,51 @@
 
 ## Fleet Status (57 active PRs)
 
-### DrivAerML WIP (30 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3192` casca: asinh-pressure alone (scale=0.75/0.5 sweep) — NOAM ABLATION
-- `#3188` chihiro: 2H/16H heads sweep on champion — NOAM ABLATION
-- `#3181` himmel: asinh+residual on champion — NOAM ABLATION
-- `#3175` hinata: full noam stack on champion — NOAM ABLATION
+### DrivAerML WIP (27 PRs)
+**Innovation track (code ports — new directive):**
+- `#3203` vegeta: attention temperature annealing — INNOVATION
+- `#3202` senku: GLU preprocess MLP — INNOVATION
+- `#3201` jet: DomainLayerNorm — INNOVATION
 
-**Pre-pivot champion tuning:**
+**Noam-pivot experiments:**
+- `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
+- `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
+- `#3193` franky: residual-prediction alone — NOAM ABLATION
+- `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
+- `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
+- `#3181` himmel: asinh+residual on champion — NOAM ABLATION
+- `#3175` hinata: full noam stack — NOAM ABLATION
+
+**Champion tuning / paper-facing:**
 - `#3173` kakashi: shorter cosine T_max=15/20
-- `#3171` sanji: LR warmup (5-ep/10-ep) on champion
-- `#3165` senku: 4H heads (128d/head)
-- `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING
+- `#3171` sanji: LR warmup (5-ep/10-ep)
+- `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
 - `#3160` griffith: 16H heads
-- `#3193` franky: DM residual-prediction alone — NOAM ABLATION
-- `#3194` bulma: DM higher LR sweep (5.5e-4/6e-4)
 - `#3155` nobara: longer T_max (45/60)
 - `#3154` historia: monotonic cosine (no restarts)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#3198` gohan: TFP asinh-pressure isolation (scale=0.75/0.5) — NOAM ABLATION
 - `#3121` levi: dropout regularization sweep
-- `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
-- `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
-- `#3197` gojo: TF residual-prediction alone — NOAM ABLATION
-- `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
-- `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
-- `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
-- `#3046` sukuna: WD+gc compound (SENT BACK — WD=5e-4/1e-4+gc=1.0)
+- `#3085` kohaku: larger supernodes (SENT BACK)
+- `#3076` frieren: log-cosh loss (SENT BACK)
+- `#3067` askeladd: 32k surface points (SENT BACK)
+- `#3063` canute: paper-facing full-eval (SENT BACK)
+- `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (6 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3189` emma: asinh+physics features (no ANP, no T_max) — NOAM ABLATION
-- `#3186` norman: T_max=150 alone (gc=0.3/0.5) — NOAM ABLATION
-- `#3185` fern: full noam stack (ANP+physics+T_max=150) — NOAM ABLATION
+### TandemFoil WIP (7 PRs) — GUARDRAIL ONLY per directive
+**Noam-pivot experiments:**
+- `#3197` gojo: residual-prediction alone — NOAM ABLATION
+- `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
+- `#3189` emma: asinh+physics features — NOAM ABLATION
+- `#3186` norman: T_max=150 alone — NOAM ABLATION
+- `#3185` fern: full noam stack — NOAM ABLATION
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
-
-**Other:**
-- `#3196` zenitsu: TF EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
-- `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
+- `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (10 PRs)
 **Noam-pivot experiments (highest priority):**
@@ -106,46 +107,27 @@
 
 ## Current Research Focus
 
-### STRATEGIC PIVOT — "Think Bigger" (Human directive, issue #3174)
+### LATEST HUMAN DIRECTIVE — Issue #3174 Update (2026-04-23 11:08)
 
-**Key finding:** The noam branch has ~100 merged PRs with winning techniques. Many are ALREADY PORTED to radford's train.py but UNUSED. We've been doing incremental HP sweeps when major architectural features were available all along.
+1. **AirfRANS → "Finish the job"**: Surface is strong. ALL new AF work must focus on **volume error reduction only** (vol_mse < 0.0017), without regressing surface.
+2. **DrivAerML → Two-track strategy**:
+   - **Track 1:** Stable full-eval champion track (best-checkpoint test eval) — faye #3164
+   - **Track 2:** Innovation track for genuinely new physics-aware and ML ideas — NOT more Radford/Noam recipe tuning. Code ports from noam: attn temp annealing (vegeta #3203), GLU preprocess (senku #3202), DomainLayerNorm (jet #3201)
+3. **TandemFoil Paper → Stabilization-first**: Failure mode is NaN/inf, not underperformance. Short, cheap diagnostic experiments to find one finite reproducible recipe. brook #3200 mapping stability.
+4. **TandemFoil → Guardrail only**: Parity is healthy. Minimal compute sink.
 
-**New priority:** Every new assignment should test noam-ported features or bold new approaches. No more incremental tweaks.
-
-### Available features NOT USED (ready in train.py)
+### Noam Feature Activation (still highest priority)
 - `--anp-srf` — ANP cross-attention decoder (-58.9% TF!) — TF/TFP only
-- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm (-8% ood) — ALL datasets
+- `--asinh-pressure --asinh-scale 0.75` — asinh pressure norm — ALL datasets
 - `--residual-prediction` — learned correction to freestream — ALL datasets
-- `--enable-cp-panel`, `--enable-te-coord-frame`, `--enable-wake-deficit`, `--enable-wake-angle`, `--enable-vortex-panel-velocity` — physics features — TF/TFP
+- Physics features: TF only (TFP pipeline bug: cp_panel/TE/vortex silently ignored)
 - `--re-stratified-sampling` — OOD Re robustness — TF/TFP/AF
-- `--compile-model` — throughput gain (more epochs in time budget) — ALL
-- 96 slices, 3 heads (at 192d), Lookahead — all defaults we haven't tested
 
-### Key config mismatches
-- TF/TFP T_max=10 vs noam optimal T_max=150 (15x longer!)
-- Radford 8 heads vs noam 3 heads (at 192d)
-- Missing: vol_loss_scale, PCGrad, temperature annealing, DomainLayerNorm (need code ports)
-
-### Benchmark Sprint Priorities (revised)
-
-1. **TandemFoil** — HIGHEST PRIORITY for noam feature activation
-   - ANP decoder alone was -58.9% on noam. With full stack: potentially 9-12 range vs our 21.909
-   - **Next assignments:** full noam stack, ANP alone, T_max=150 alone
-   - Paper-facing: yuji #3150 clean test
-
-2. **TandemFoil Paper** — Same noam features apply
-   - T_max=150 could break the "fully locked" constraint — it was locked at the WRONG config
-   - ANP + physics features could transform results
-   - **Next assignments:** full noam stack, ANP + T_max=150
-
-3. **DrivAerML** — val=3.833%, gap to AB-UPT only 0.013 pp
-   - **Applicable noam features:** asinh-pressure, residual-prediction, compile-model, 96 slices
-   - **Bold changes:** Lion optimizer (noam's final choice), higher EMA decay (0.9999)
-   - Existing champion platform still valid as base
-
-4. **AirfRANS volume** — 1.63x gap to target
-   - **Applicable noam features:** asinh-pressure, residual-prediction, re-stratified-sampling
-   - **Bold changes:** 96 slices, compile for throughput, vol_loss_scale (needs code port)
+### DM Innovation Track (code ports from noam)
+- Attention temperature annealing (-11% on noam) — vegeta #3203
+- GLU preprocess MLP — senku #3202
+- DomainLayerNorm — jet #3201
+- Still needed: vol_loss_scale, PCGrad (for AF multi-objective)
 
 ## Key Dead Ends (Do Not Repeat)
 
@@ -173,6 +155,7 @@
 - 4L/640d: dead at ALL tested configs — lr=5e-4+EMA+gc: 8.636% diverge ep82 (#3159); lr=5e-4 no-EMA: 4.516%/6.457%/5.724% all diverge (#3079). Width amplifies gradients beyond gc containment.
 - lr<5e-4 under EMA: steep monotonic cliff (4.5e-4=4.134%, 4e-4=5.924%)
 - bs=2: Blackwell bf16+bs>1 CUBLAS bug forces fp32, gets only 37% of optimizer steps. 4.373% at bs=2/fp32 vs 3.833% bs=1/bf16. Platform-blocked.
+- 4H heads with EMA+gc: 6.650% ep123, diverged ep133. DM heads: 8H optimal, 4H/16H both worse
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)
@@ -188,8 +171,9 @@
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)
 - T_max≠50 (30 and 100 both worse)
-- Vol-weight=10x: worse on both metrics
+- Vol-weight<10x (2x/5x/7x): all worse on both metrics. 10x+EMA=0.999 is AF sweet spot
 - Vol-weight=30x: catastrophic — surface 4.3x worse, vol 3.1x worse
+- LR>6e-4: 8e-4 +110% surface, 1e-3 catastrophic divergence
 
 **TandemFoil:**
 - gc≥0.5: monotonically worse than gc=0.3

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,11 +1,13 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 01:55 (advisor cycle 8 — reviewed #3094/#3091/#3087/#3060, all closed, assigned #3121/#3122/#3123/#3124)
+- **Date:** 2026-04-23 06:00 (advisor cycle 19 complete — reviewed #3108/#3104/#3103/#3099/#3084/#3079/#3069, merged #3108+#3050, assigned #3137-#3142)
 - **Branch:** radford
 - **Idle students:** NONE — all 60 students assigned
 - **PRs ready for review:** 0
-- **PRs in WIP:** 58 (54 continuing + 4 new)
-- **Closed this cycle:** #3094 (TFP 4L/192d, Inf), #3091 (TFP gc=0.7, Inf), #3087 (TFP T_max=15, Inf), #3060 (DM symmetry aug, 14.01%)
+- **PRs in WIP:** 60 (53 continuing + 6 new + 1 sent-back)
+- **Merged this cycle:** #3108 (TF gc=0.3 new best), #3050 (AF EMA+T_max=50 new best)
+- **Closed this cycle:** #3104 (AF T_max=100), #3103 (AF T_max=30), #3099 (AF 3L/256d), #3084 (DM 788-batches), #3069 (DM 5ep warmup)
+- **Sent back this cycle:** #3079 (DM 640d+gc — retry with T_max=60+lr=3e-4)
 
 ## Fleet Status
 
@@ -16,20 +18,17 @@
 - `#3066` alphonse: 16k surface points
 - `#3067` askeladd: 32k surface points
 - `#3068` brook: 64k surface points
-- `#3069` chopper: 5-epoch linear warmup
-- `#3070` chrome: 10-epoch linear warmup
 - `#3072` eren: EMA=0.9995
 - `#3073` faye: EMA=0.999 + gc=0.5 compound
 - `#3074` fern: relative L2 loss
 - `#3075` franky: Huber loss (delta=0.1 and 1.0)
 - `#3076` frieren: log-cosh loss
 - `#3077` gilbert: 5L/512d (deeper)
-- `#3078` gohan: 6L/512d (much deeper)
-- `#3079` gojo: 4L/640d + gc=0.5 (wider)
+- `#3078` gohan: 6L/512d (much deeper) — SENT BACK re-run at max epochs
+- `#3079` gojo: 4L/640d + T_max=60 + lr=3e-4 — SENT BACK retry
 - `#3083` jet: max-train-batches=600
-- `#3084` kakashi: max-train-batches=788
 - `#3085` kohaku: larger supernode budget (8192/16000)
-- `#3086` megumi: SGDR T_mult=2 (CosineAnnealingWarmRestarts)
+- `#3086` megumi: SGDR T_max=2 (CosineAnnealingWarmRestarts) — SENT BACK
 - `#3044` emma: volume training ablation
 - `#3046` sukuna: WD+gc compound
 - `#3109` guts: lr=4e-4 full-eval
@@ -44,12 +43,14 @@
 - `#3120` senku: RAdam optimizer (lr=5e-4, lr=7e-4)
 - `#3121` levi: dropout regularization (dropout=0.05/0.1)
 - `#3122` nobara: polynomial LR decay (no cosine — linear/quadratic)
+- `#3137` chopper: DM warmup+gc=1.0 compound (5-ep warmup + gc=1.0, T_max=30)
+- `#3138` kakashi: DM 788 batches + T_max=60 (proportionally scaled cosine)
+- `#3141` vegeta: DM 5L/512d + gc=1.0 (depth with stability guard)
 
 ### TandemFoil Paper WIP (~14 students, ~23%)
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#3088` mugen: T_max=20
 - `#3089` nami: T_max=30
-- `#3090` nezuko: gc=0.3
 - `#3092` norman: EMA=0.9995
 - `#3093` rei: EMA=0.99
 - `#3096` shinobu: lr=1e-4
@@ -60,38 +61,40 @@
 - `#2949` vash: depth/width sweep (sent back with LR=5e-5)
 - `#3123` mitsuha: shorter T_max (T_max=5, T_max=8)
 - `#3124` robin: 3L/256d wider model
+- `#3135` (pending assign): TFP vol weight 30x
 
 ### AirfRANS Volume WIP (~8 students, ~13%)
-- `#3099` spike: 3L/256d for volume
 - `#3100` taki: 3L/384d for volume
 - `#3101` tanjiro: volume-loss-weight=3x
 - `#3102` thorfinn: volume-loss-weight=10x
-- `#3103` usopp: T_max=30
-- `#3104` vegeta: T_max=100
-- `#3105` violet: EMA=0.999
+- `#3105` violet: EMA=0.999 (at original T_max=10 — baseline)
 - `#3106` wolfwood: 2L/384d + gc=0.5 + T_max=50
+- `#3139` spike: AF 3L/256d + EMA=0.999 (architecture + EMA compound)
 
-### TandemFoil Parity WIP (~3 students, ~5%)
-- `#3050` stark: AirfRANS EMA at T_max=50 champion
+### TandemFoil WIP (~5 students, ~8%)
+- `#3050` stark: (MERGED — AirfRANS EMA+T_max=50 champion) → reassigned
 - `#3107` yuji: clean test row (360-min, seed=42)
-- `#3108` zenitsu: gc=0.3 + EMA=0.999
+- `#3108` zenitsu: (MERGED — TF gc=0.3) → reassigned as #3142
+- `#3136` (assigned): TFP further gc work
+- `#3140` usopp: TF gc=0.2 sweep (monotonic trend test — does gc improvement continue?)
+- `#3142` zenitsu: TF gc=0.3 + longer budget (480-min)
 
 ## Steering Anchors
 
 | Dataset | Metric | Current anchor |
 |---|---|---|
-| TandemFoil | `val_primary/surface_pressure_mae` | **22.537** (#2924 MERGED) |
+| TandemFoil | `val_primary/surface_pressure_mae` | **21.909** (#3108 MERGED — gc=0.3) |
 | TandemFoil Paper | `val_primary/field_mse` | **0.002383** (#3025 MERGED) |
-| AirfRANS | `val_primary/surface_mse` | **0.000482** (#2951 MERGED) |
+| AirfRANS | `val_primary/surface_mse` + `vol_mse` | **0.000459 / 0.002777** (#3050 MERGED — EMA+T_max=50) |
 | DrivAerML | `val_primary/surface_rel_l2_pct` | **3.997%** (#2898 MERGED) |
 
 ## Paper-Facing Snapshot
 
 | Dataset | Metric | Current best | External target | Status |
 |---|---|---|---|---|
-| TandemFoil | `test_primary/surface_pressure_mae` | **24.581** | (internal anchor) | Strong |
+| TandemFoil | `test_primary/surface_pressure_mae` | **23.419** | (internal anchor) | Strong |
 | TandemFoil Paper | `test_primary/field_mse` | **NO CLEAN ROW YET** | ~0.10-0.36/task | URGENT |
-| AirfRANS | `Surf MSE / Vol MSE` | **0.003 / 0.00764** | 0.0043 / 0.0017 | Surface ✓, Volume urgent |
+| AirfRANS | `Surf MSE / Vol MSE` | **0.000459 / 0.002777** | 0.0043 / 0.0017 | Surface ✓✓, Volume 1.63x gap |
 | DrivAerML | `test_primary/surface_rel_l2_pct` | **6.244%** (old config) | 3.71% | Main gap |
 
 ## Current Research Focus
@@ -99,52 +102,68 @@
 ### Benchmark Sprint Priorities (ICML phase)
 
 1. **DrivAerML closure** — val=3.997%, need test below 5%, ideally toward 3.71%
-   - **CLOSED directions:** T_max (only 30 works), depth (4L required), multi-revisit, EMA, bilateral symmetry, LR (only 5e-4 at AdamW)
+   - **CLOSED directions:** T_max (only 30 works without gc), depth (4L required), multi-revisit, EMA (3 configs tried — all dead), bilateral symmetry aug, LR (5e-4 sharp optimum), gc alone (best 4.346% still above baseline), gc+WD (crashes), gradient accumulation, 640d without gc, SGDR (2 variants), RAdam, beta2 changes, warmup alone, 6L, torch.compile
    - **Active exploration fronts:**
      - Surface points sweep (16k/32k/64k) — human directive
      - Loss alignment (rel L2, Huber, log-cosh, L1-smooth)
-     - Architecture (5L/6L deeper, 640d wider, 384d compact)
-     - Warmup (5/10/20-epoch linear)
-     - Throughput (600/788 batches, supernode budget)
-     - Schedule (SGDR warm restarts, polynomial decay)
-     - Optimizer (Lion, RAdam)
+     - Architecture (5L/6L deeper, 640d wider w/ gc, 384d compact)
+     - Throughput (600/788+T_max=60 batches, supernode budget)
+     - Optimizer (Lion remaining)
      - Regularization (WD alone, dropout)
+     - Warmup+gc compound (warmup alone diverges; with gc stability guard may help)
+     - 788 batches + T_max=60 (proportionally scaled — kakashi #3138)
      - Multi-seed full-eval (paper-facing)
+     - gc=1.0 with 5L/512d compound (vegeta #3141)
 
 2. **TFP clean test result** — val=0.002383, need paper-facing test_primary/field_mse
-   - **CLOSED:** T_max>10 (T_max=15 diverged at ep124), gc>0.5 (gc=0.7 diverged at ep142), 4L depth (Inf field_mse), LR=1.5e-4 (worse)
-   - **Active:** T_max=5/8 (shorter may stabilize), gc=0.3, EMA=0.99/0.9995, lr=1e-4, 3L/256d width, clean test eval
-   - **Key finding:** TFP champion (Lion+T_max=10+gc=0.5+EMA) is a SHARP optimum — deviations in T_max, gc, depth all cause Infinity field_mse
+   - **CLOSED:** T_max>10 (T_max=15/20/30 all diverge), gc>0.5 (diverges), gc<0.5 (gc=0.3 = pressure starvation → Infinity), 4L depth (pressure overflow), LR=1.5e-4 (worse)
+   - **Active:** T_max=5/8 (shorter may stabilize), EMA=0.99/0.9995, lr=1e-4, 3L/256d width, clean test eval
+   - **Key finding:** TFP champion is a SHARP OPTIMUM — gc=0.5 and T_max=10 are essentially inflection points. LR=1.25e-4 is minimum viable for pressure.
 
-3. **AirfRANS volume** — Vol MSE=0.00764, target 0.0017 (4.5x gap)
-   - 8 students covering: volume-loss-weight, architecture, T_max, EMA, compound config
+3. **AirfRANS volume** — Vol MSE=0.002777 (1.63x gap from target 0.0017)
+   - **New champion:** EMA=0.999 + T_max=50 (both surface AND volume best)
+   - **Active:** volume-loss-weight (3x/10x), architecture (3L/384d, 3L/256d+EMA), T_max=50 confirmed optimal
+   - **Closed:** T_max=30/100 both worse; 3L/256d without EMA superseded
 
-4. **TandemFoil anchor** — preserve at 22.537 val, 24.581 test
+4. **TandemFoil trend** — gc sweep: 1.0→0.5→0.3 all improve monotonically
+   - **Active:** gc=0.2 sweep (does improvement continue?), gc=0.3+480-min budget
+   - **Key question:** Is gc=0.1 or gc→0 the floor, or does it invert?
 
 ## Key Dead Ends (Do Not Repeat)
 
 **DrivAerML:**
 - T_max: only 30 works without gc; 15/20/40/50/100 all diverge
-- Depth: 4L required; 2L/3L diverge and 2.5-2.8x worse
-- EMA: incompatible (9.749%)
+- Depth: 4L required; 2L/3L diverge and 2.5-2.8x worse; 6L also worse
+- EMA: incompatible at all tested configs (9.749%)
 - Multi-revisit: 4x/8x diverge without gc
 - gc+WD compound: crashes
 - gc alone: 1.5/2.0 diverges; best gc result 4.346% still above baseline
-- 640d without gc: dead end
+- 640d without gc: dead end (gojo sent back with gc=1.0 to retry)
 - torch.compile: no throughput benefit, diverged
-- Bilateral symmetry: aug causes gradient instability (14.01%)
+- Bilateral symmetry aug: causes gradient instability (14.01%)
 - LR: 4e-4 and 4.5e-4/5.5e-4 all worse; 5e-4 sharp optimum
 - Gradient accumulation: harmful (4.860%)
+- SGDR (T_mult=1.5 and T_mult=2): both worse than standard cosine
+- RAdam: no improvement over AdamW
+- beta2=0.99/0.95/0.98: all worse; beta2=0.999 (default) optimal
+- Warmup alone (5-ep/10-ep): diverges without gc stability guard
 
 **TandemFoil Paper:**
-- T_max=15: diverged ep124 (3.5x earlier than T_max=10 champion)
-- gc=0.7: diverged ep142 (3x earlier)
-- 4L/192d: Infinity field_mse (pressure overflow)
+- T_max>10: T_max=15 diverged ep124, T_max=20 diverged earlier, T_max=30 diverged
+- gc=0.7: diverged ep142
+- gc=0.3: Infinity all epochs (pressure starvation)
+- 4L/192d: pressure overflow
 - 4L/256d: 0.004427 (+85% vs baseline)
 - LR=1.5e-4: 0.003199 (+34%)
-- 5L degrades late, all negative novel architectures
 
-**AirfRANS:** 2L/384d NaN, LR above 6e-4 all worse, accum>1 harmful
+**AirfRANS:**
+- 2L/384d NaN
+- LR above 6e-4 all worse
+- accum>1 harmful
+- T_max=30: surface_mse=0.000829 (+72%)
+- T_max=100: surface_mse=0.000709 (+47%)
+- 3L/256d without EMA: superseded by 2L+EMA champion
+
 **Cross-dataset:** SAM, PCGrad, LayerScale, sigma-Reparam, GeGLU, SwiGLU, SDF, head scaling — all failed
 
 ## Strategy (ICML Final Sprint)
@@ -154,13 +173,13 @@ Per human team directive #3020:
 - DrivAerML ~50-60% fleet ✓ (33/60 = 55%)
 - TFP ~20-30% ✓ (14/60 = 23%)
 - AirfRANS ~10-20% ✓ (8/60 = 13%)
-- TF minimal ✓ (3/60 = 5%)
+- TF minimal ✓ (5/60 = 8%)
 
 ## Mandatory Config Rules
 
-- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, `--ema-decay 0.999`, 3L/192d
+- **TF:** Lion lr=1.25e-4, T_max=10, gc=0.3, WD=1e-2, `--ema-decay 0.999`, 3L/192d (**gc updated to 0.3 post #3108**)
 - **TFP:** Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, `--ema-decay 0.999`, 3L/192d
-- **AF:** AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, no-EMA, 2L/256d
+- **AF:** AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, `--ema-decay 0.999`, 2L/256d (**EMA now mandatory post #3050**)
 - **DM:** AdamW lr=5e-4, T_max=30, NO gc, NO WD, no-EMA, 4L/512d
 - `--epochs 999` mandatory
 - DrivAerML: `--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394`

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 01:45 (advisor cycle 56)
+- **Date:** 2026-04-24 02:00 (advisor cycle 57)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -8,8 +8,9 @@
 
 ## Fleet Status (53 active PRs)
 
-### DrivAerML WIP (28 PRs)
+### DrivAerML WIP (29 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
@@ -45,10 +46,9 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (4 PRs) — GUARDRAIL ONLY per directive
+### TandemFoil WIP (3 PRs) — GUARDRAIL ONLY per directive
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
 **Noam-pivot experiments (still running):**
-- `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
@@ -69,6 +69,9 @@
 ### AirfRANS WIP (13 PRs)
 **Non-asinh noam feature ablation (highest priority — clean tests):**
 - `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
+
+**Volume closure experiments:**
+- `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
 - `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 
 **Noam-pivot experiments (asinh-dependent — likely to fail):**
@@ -84,7 +87,6 @@
 - `#3222` rei: proximity-weighted volume loss (surface distance) — AF VOLUME FOCUS
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
-- `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
 - `#3211` spike: AF vol_loss_scale learnable scalar (noam port) — AF VOLUME FOCUS
 - `#3204` gilbert: vol-weight=15x/20x clean control (no extra features) — AF VOLUME FOCUS
 - `#3195` piccolo: Re-stratified sampling
@@ -210,6 +212,7 @@
 
 **AirfRANS:**
 - asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
+- PCGrad gradient surgery: 5-6x worse on both metrics (#3212). retain_graph=True disables torch.compile (40% throughput loss). Gradient conflict is NOT the bottleneck.
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 00:30 (advisor cycle 54)
+- **Date:** 2026-04-24 01:45 (advisor cycle 56)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -8,8 +8,9 @@
 
 ## Fleet Status (53 active PRs)
 
-### DrivAerML WIP (27 PRs)
+### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
@@ -44,12 +45,11 @@
 - `#3067` askeladd: 32k surface points (SENT BACK)
 - `#3046` sukuna: WD+gc compound (SENT BACK)
 
-### TandemFoil WIP (5 PRs) — GUARDRAIL ONLY per directive
+### TandemFoil WIP (4 PRs) — GUARDRAIL ONLY per directive
 **New champion config:** ANP+full physics+T_max=150+gc=0.2+EMA=0.999+96sl+Lookahead+compile+re-strat (#3185)
 **Noam-pivot experiments (still running):**
 - `#3197` gojo: residual-prediction alone — NOAM ABLATION
 - `#3196` zenitsu: EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
-- `#3189` emma: asinh+physics features — NOAM ABLATION
 - `#3150` yuji: clean test row — PAPER-FACING
 
 ### TandemFoil Paper WIP (9 PRs) — STABILIZATION CRISIS
@@ -67,14 +67,16 @@
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
 ### AirfRANS WIP (13 PRs)
-**Noam-pivot experiments (highest priority):**
-- `#3191` alphonse: noam features on base and vol-10x — NOAM ABLATION
-- `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION
-- `#3184` wolfwood: full noam stack — NOAM ABLATION
-- `#3177` nezuko: vol-weight 15x/20x + asinh+residual — NOAM ABLATION
+**Non-asinh noam feature ablation (highest priority — clean tests):**
+- `#3230` alphonse: residual-prediction + re-stratified sampling (NO asinh) — CLEAN NOAM ABLATION
+- `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
+
+**Noam-pivot experiments (asinh-dependent — likely to fail):**
+- `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
+- `#3184` wolfwood: full noam stack — NOAM ABLATION (asinh confirmed dead for AF)
 
 **Other:**
-- `#3172` robin: LR warmup (5-ep/10-ep)
+- `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
 - `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3226` chihiro: volume weight curriculum (20x→10x) — AF VOLUME FOCUS
@@ -207,6 +209,7 @@
 - T_max=20/30: field_mse never reaches finite values
 
 **AirfRANS:**
+- asinh-pressure: DEFINITIVELY DEAD — 5 independent confirmations (#3191 T1/T2, #3177 T1/T2/T3). sinh() denormalization exponentially amplifies pressure errors. Non-pressure channels fine. Incompatible with AF pressure distribution.
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 13:35 (advisor cycle 87)
+- **Date:** 2026-04-24 14:00 (advisor cycle 88)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -11,7 +11,7 @@
 
 ### DrivAerML WIP (30 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
-- `#3262` megumi: learnable register tokens N=2/4/8 (attention sink absorption, Darcet NeurIPS 2024) — INNOVATION
+- `#3281` megumi: MoE output heads (K=2/3 expert output MLPs with learned gating) — INNOVATION
 - `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3270` brook: FiLM conditioning on global geometry statistics (per-car shape context) — INNOVATION
 - `#3280` jet: per-channel output heads (separate MLPs for Ux, Uy, p) — INNOVATION
@@ -206,6 +206,7 @@
 - Quadratic position features (x²/y²/z²/xy/xz/yz): 6.643% at ep168 timeout (#3272). Fatal 3x throughput penalty (168 vs 511 baseline epochs). Quad-only diverged ep63 — Fourier PE irreplaceable. Same epoch-starvation pattern as MoE (#3263).
 - Grouped Query Attention (GQA, 2/4 KV heads): 12.88%/6.88% both crashed (#3273). Throughput-neutral (bottleneck is slice routing einsums, not QKV). GQA destabilizes per-head slice routing — coupled KV sharing explodes at cosine restarts.
 - Error-weighted surface sampling (hard example mining): crashed ep6 both trials (#3243). Distribution-shift collapse + 30-60min/epoch error-map compute + train/eval mismatch. Student note: error-weighted LOSS (not sampling) would avoid distribution shift but still faces mismatch.
+- Learnable register tokens (N=2/4/8): N=8 best 4.062% (+6%), N=2/N=4 NaN diverged (#3262). Category error — register tokens address pairwise attention sinks (ViT), but Transolver uses slice-based soft-clustering attention where sink mechanism doesn't apply.
 - EMA>0.9995: 0.9999→7.106% NaN ep171, 0.99995→7.095% collapse ep120 (#3199). EMA=0.9995 sharp optimum bracketed both directions
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,8 +1,8 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 05:00 (advisor cycle 63)
+- **Date:** 2026-04-24 05:30 (advisor cycle 64)
 - **Branch:** radford
-- **Idle students:** 0 (faye just assigned #3244)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 - **CRITICAL:** TFP champion config is BROKEN — code regression since #3025, seed=0 no longer reproduces (#3205). Waiting for sanji #3209 cp_panel bug fix.
 - **Known bug:** `primary_metric_key` shadowing in train.py (line ~1646 local var shadows function on line ~1428). 3 students independently fixed this cycle. Fix: rename local to `best_tracking_metric_key`.
@@ -11,6 +11,7 @@
 
 ### DrivAerML WIP (28 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
@@ -20,7 +21,6 @@
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
-- `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
 - `#3201` jet: DomainLayerNorm — INNOVATION
 
@@ -188,6 +188,7 @@
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
 - Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Mixup regularization (buffer-based latent): 85-109% worse, crashed ~ep235. Buffer staleness + non-smooth geometry-specific latent space fundamentally incompatible with bs=1
+- Fourier-encoded surface normals: 4.374%/4.454% (4 bands/2 bands). Normals are unit vectors in [-1,1] — don't benefit from Fourier lifting like unbounded coords. More bands = earlier divergence
 - Attention temperature annealing: 4.024% (+5% vs 3.833%). External annealed τ compounds with existing learnable per-head τ. noam result doesn't transfer
 - SAM optimizer (rho=0.05/0.02): 5.36%/9.08%. SAM perturbation + cosine restart = double shock → catastrophic divergence. 2x compute penalty also prohibitive
 - True monotonic cosine (T_max=393606, no restarts): 4.086% (+0.253pp). Confirms T_max=30 rapid restarts are core mechanism, not noise. Monotonic decay can't compete

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 02:00 (advisor cycle 57)
+- **Date:** 2026-04-24 02:30 (advisor cycle 58)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -10,13 +10,13 @@
 
 ### DrivAerML WIP (29 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
 - `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3224` fern: spectral normalization on attention layers — INNOVATION
 - `#3221` franky: gradient noise injection (Neelakantan et al.) — INNOVATION
 - `#3228` chopper: stochastic weight perturbation at cosine troughs — INNOVATION
 - `#3225` canute: self-distillation with EMA teacher — INNOVATION
-- `#3214` kakashi: auxiliary gradient prediction (∂p/∂x,y,z) — INNOVATION
 - `#3217` brook: Fourier encoding of surface normals — INNOVATION
 - `#3203` vegeta: attention temperature annealing — INNOVATION
 - `#3202` senku: GLU preprocess MLP — INNOVATION
@@ -185,6 +185,7 @@
 - T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
 - Noam features on DM: DEFINITIVELY DEAD. Asinh triple-confirmed (4.072%/4.421%/4.475%), residual needs asinh+still→3.999%, full stack→4.447%. Features tuned for T_max=150/3H/no-gc regime
 - Attention distance bias (ALiBi): linear diverges, log=5.511% at timeout. Redundant with slice-based spatial grouping
+- Auxiliary gradient prediction (∂p/∂x,y,z): kNN targets too noisy — aux_weight=0.1 diverges ep22, aux_weight=0.01 best 5.485% (+43%). Noise dominates once primary loss flattens
 - Head count sweep complete: 2H=catastrophic, 4H=6.650%, 8H=3.833% CHAMPION, 16H=4.099%. 8H (64d/head) is definitive
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-24 08:30 (advisor cycle 71)
+- **Date:** 2026-04-24 09:00 (advisor cycle 73)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -9,14 +9,14 @@
 
 ## Fleet Status (58 active PRs)
 
-### DrivAerML WIP (28 PRs)
+### DrivAerML WIP (29 PRs)
 **Innovation track (new physics-aware/ML ideas per directive):**
+- `#3260` casca: learnable Fourier frequency magnitudes (meta-learned encoding) — INNOVATION
 - `#3247` brook: EMA periodic reset (100/50-ep intervals) — INNOVATION
 - `#3243` jet: prediction-error-weighted surface sampling (hard example mining) — INNOVATION
 - `#3242` historia: label smoothing / target noise augmentation — INNOVATION
 - `#3235` kakashi: multi-exit prediction (aux losses at intermediate layers) — INNOVATION
 - `#3233` gojo: stochastic depth (LayerDrop) regularization — INNOVATION
-- `#3231` emma: surface pressure gradient smoothness regularization — INNOVATION (physics-informed)
 - `#3251` fern: Pre-LayerNorm architecture ablation (+ RMSNorm variant) — INNOVATION
 - `#3259` zenitsu: curvature-weighted loss (per-point weighting by local curvature) — INNOVATION
 - `#3258` emma: auxiliary surface normal prediction (multi-task regularization) — INNOVATION
@@ -67,13 +67,13 @@
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#2949` vash: depth/width sweep (LR=5e-5)
 
-### AirfRANS WIP (14 PRs)
+### AirfRANS WIP (13 PRs)
 **Volume closure experiments:**
+- `#3261` nezuko: 2L/320d wider model (width scaling for vol closure) — AF VOLUME FOCUS
 - `#3255` gohan: no-Lookahead/no-compile champion full budget — AF VOLUME FOCUS (critical ablation follow-up)
 - `#3257` chihiro: extended training via reduced eval frequency (every 3/5 epochs) — AF VOLUME FOCUS
 - `#3241` hinata: T_max=75 + vol-weight=10x/12x on champion — AF VOLUME FOCUS (schedule gap-fill)
 - `#3234` jin: lower LR sweep (5e-4/4e-4) on vol-10x champion — AF VOLUME FOCUS
-- `#3232` nezuko: vol-weight warm-up schedule (1x→10x linear ramp over 200ep) — AF VOLUME FOCUS
 
 **Noam-pivot experiments (asinh-dependent — likely to fail):**
 - `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION (asinh confirmed dead for AF)
@@ -82,7 +82,6 @@
 **Other:**
 - `#3172` robin: LR warmup — SENT BACK (confounded config, re-running with correct champion config)
 - `#3169` nami: heads sweep 4H/16H
-- `#3227` casca: focal-MSE volume loss (upweight hard predictions) — AF VOLUME FOCUS
 - `#3254` norman: multi-seed champion run (seeds 42/123/789) — AF VOLUME FOCUS
 - `#3238` rei: WD=0 ablation on vol-10x+EMA champion — AF VOLUME FOCUS
 - `#3245` tanjiro: per-channel volume loss weighting (upweight nut×4, p×2) — AF VOLUME FOCUS
@@ -230,6 +229,8 @@
 - Lookahead hurts AF surface by 53% at equal epochs (#3236 ablation). Compile also hurts surface despite more epochs. Both are default-on in baseline — ambiguity on synergistic effect at long training
 - Proximity-weighted volume loss: 118-2516% worse (#3222). Extreme weight ratios starve far-field gradients while overdriving near-surface. Structural failure at scale=0.1/eps=0.01
 - Huber loss on volume channel: no improvement over MSE on either metric (#3215). AF volume residuals are well-behaved, not heavy-tailed — Huber δ threshold adds no benefit
+- Vol-weight warm-up (1x→10x ramp): 2/3 collapsed, best stable +28% surface/+69% vol (#3232). Cosine restarts inject LR peak when vol-weight ramps — destructive. Static 10x TRIPLE-CONFIRMED
+- Focal-MSE volume loss (error-based reweighting): gamma=2 +392%/+3993%, gamma=1 +222%/+320% (#3227). Batch-max normalization non-stationary + freestream scaffolding destroyed
 - 3L depth (with or without EMA): catastrophic divergence confirmed twice
 - 2L/384d and 3L/384d: catastrophic divergence
 - EMA<0.999 (0.99, 0.995 both worse)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -31,12 +31,12 @@
 - `#3143` thorfinn: Lookahead(AdamW)
 - `#3132` gohan: eta_min=5e-5+gc=1.0
 - `#3121` levi: dropout regularization sweep
-- `#NEW` piccolo: AF re-stratified sampling alone — BEING ASSIGNED
+- `#3195` piccolo: AF re-stratified sampling alone — NOAM ABLATION
 - `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
 - `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
 - `#3083` jet: max-train-batches=600
-- `#NEW` gojo: TF residual-prediction alone — BEING ASSIGNED
+- `#3197` gojo: TF residual-prediction alone — NOAM ABLATION
 - `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
 - `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
 - `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
@@ -50,7 +50,7 @@
 - `#3180` chopper: ANP decoder alone — NOAM ABLATION
 
 **Other:**
-- `#NEW` zenitsu: TF EMA decay sweep (0.9999/0.99995) — BEING ASSIGNED
+- `#3196` zenitsu: TF EMA decay sweep (0.9999/0.99995) — NOAM ABLATION
 - `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
 
 ### TandemFoil Paper WIP (10 PRs)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,15 +1,15 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 01:30 (advisor cycle 7 — reviewed #3082/#3081/#3051/#3048, all closed, assigned #3117/#3118/#3119/#3120)
+- **Date:** 2026-04-23 01:55 (advisor cycle 8 — reviewed #3094/#3091/#3087/#3060, all closed, assigned #3121/#3122/#3123/#3124)
 - **Branch:** radford
 - **Idle students:** NONE — all 60 students assigned
 - **PRs ready for review:** 0
-- **PRs in WIP:** 58 (54 continuing + 4 new #3117-#3120)
-- **Closed this cycle:** #3082 (T_max=40, 12.84%), #3081 (T_max=20, 11.06%), #3051 (4x revisits, 9.38%), #3048 (2L/3L depth, 9.99%)
+- **PRs in WIP:** 58 (54 continuing + 4 new)
+- **Closed this cycle:** #3094 (TFP 4L/192d, Inf), #3091 (TFP gc=0.7, Inf), #3087 (TFP T_max=15, Inf), #3060 (DM symmetry aug, 14.01%)
 
 ## Fleet Status
 
-### DrivAerML WIP (~31 students, ~52%)
+### DrivAerML WIP (~33 students, ~55%)
 - `#3063` canute: multi-seed full-eval seed=42 (PAPER-FACING)
 - `#3064` casca: multi-seed full-eval seed=123 (PAPER-FACING)
 - `#3065` chihiro: multi-seed full-eval seed=456 (PAPER-FACING)
@@ -30,34 +30,36 @@
 - `#3084` kakashi: max-train-batches=788
 - `#3085` kohaku: larger supernode budget (8192/16000)
 - `#3086` megumi: SGDR T_mult=2 (CosineAnnealingWarmRestarts)
-- `#3044` emma: DrivAerML volume training ablation
-- `#3046` sukuna: DrivAerML WD+gc compound
-- `#3109` guts: DrivAerML lr=4e-4 full-eval (lower-LR neighbor)
-- `#3110` einar: DrivAerML full-eval no max-eval-batches baseline
-- `#3111` himmel: DrivAerML larger batch + gc
-- `#3112` edward: DrivAerML dual-stage LR (5e-4 → 2.5e-4)
-- `#3114` griffith: DrivAerML 4L/384d compact architecture
-- `#3115` piccolo: DrivAerML label-smooth L1 loss
-- `#3117` bulma: DrivAerML Lion optimizer sweep (lr=5e-5, lr=1e-4)
-- `#3118` hinata: DrivAerML weight decay alone (WD=1e-4/5e-4/1e-3)
-- `#3119` historia: DrivAerML higher LR + linear warmup (lr=7e-4/1e-3 + 20ep warmup)
-- `#3120` senku: DrivAerML RAdam optimizer (lr=5e-4, lr=7e-4)
+- `#3044` emma: volume training ablation
+- `#3046` sukuna: WD+gc compound
+- `#3109` guts: lr=4e-4 full-eval
+- `#3110` einar: full-eval no max-eval-batches baseline
+- `#3111` himmel: larger batch + gc
+- `#3112` edward: dual-stage LR (5e-4 → 2.5e-4)
+- `#3114` griffith: 4L/384d compact architecture
+- `#3115` piccolo: label-smooth L1 loss
+- `#3117` bulma: Lion optimizer sweep (lr=5e-5, lr=1e-4)
+- `#3118` hinata: weight decay alone (WD=1e-4/5e-4/1e-3)
+- `#3119` historia: higher LR + 20-epoch warmup (lr=7e-4/1e-3)
+- `#3120` senku: RAdam optimizer (lr=5e-4, lr=7e-4)
+- `#3121` levi: dropout regularization (dropout=0.05/0.1)
+- `#3122` nobara: polynomial LR decay (no cosine — linear/quadratic)
 
 ### TandemFoil Paper WIP (~14 students, ~23%)
-- `#3056` haku: TFP Lion+EMA refinement (T_max/gc/LR sweep)
-- `#3087` mitsuha: T_max=15
+- `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#3088` mugen: T_max=20
 - `#3089` nami: T_max=30
 - `#3090` nezuko: gc=0.3
-- `#3091` nobara: gc=0.7
 - `#3092` norman: EMA=0.9995
 - `#3093` rei: EMA=0.99
-- `#3094` robin: 4L/192d depth
 - `#3096` shinobu: lr=1e-4
-- `#3097` shouko: lr=1.5e-4 — CLOSED (dead end, assigned #3113)
 - `#3098` shoya: clean test evaluation (paper-facing)
-- `#3113` shouko: TFP field_mse full-eval clean test
-- `#3116` sanji: TFP 4L/192d champion architecture
+- `#2947` jin: first field_mse baseline (LR sweep)
+- `#3113` shouko: field_mse full-eval clean test
+- `#3116` sanji: 4L/192d champion architecture
+- `#2949` vash: depth/width sweep (sent back with LR=5e-5)
+- `#3123` mitsuha: shorter T_max (T_max=5, T_max=8)
+- `#3124` robin: 3L/256d wider model
 
 ### AirfRANS Volume WIP (~8 students, ~13%)
 - `#3099` spike: 3L/256d for volume
@@ -69,24 +71,10 @@
 - `#3105` violet: EMA=0.999
 - `#3106` wolfwood: 2L/384d + gc=0.5 + T_max=50
 
-### TandemFoil Parity WIP (~5 students, ~8%)
-- `#3060` levi: DrivAerML bilateral symmetry augmentation
-- `#2947` jin: TFP first field_mse baseline (LR sweep)
+### TandemFoil Parity WIP (~3 students, ~5%)
 - `#3050` stark: AirfRANS EMA at T_max=50 champion
 - `#3107` yuji: clean test row (360-min, seed=42)
 - `#3108` zenitsu: gc=0.3 + EMA=0.999
-
-### Recently Closed This Session
-- ~~`#3082`~~ historia: T_max=40, 12.84% (+221% vs baseline), diverged ep94
-- ~~`#3081`~~ hinata: T_max=20, 11.06% (+177% vs baseline), diverged ep118
-- ~~`#3051`~~ bulma: 4x revisits, 9.38% best (+135%), all runs diverged
-- ~~`#3048`~~ senku: 2L/3L depth, 9.99% best (3L), both diverged to NaN
-- ~~`#3095`~~ sanji: TFP 4L/256d, 0.004427 (+85% vs TFP baseline)
-- ~~`#3047`~~ piccolo: DM LR fine-tuning (4e-4/4.5e-4/5.5e-4), all diverged
-- ~~`#3045`~~ griffith: DM T_max sweep (15/50/100), all diverged
-- ~~`#3097`~~ shouko: TFP lr=1.5e-4, val 0.003199 (+34% vs TFP baseline)
-- ~~`#3071`~~ edward: DM EMA=0.999, diverged to NaN
-- ~~`#3080`~~ himmel: DM T_max=50, 14.1% best, diverged
 
 ## Steering Anchors
 
@@ -110,53 +98,63 @@
 
 ### Benchmark Sprint Priorities (ICML phase)
 
-1. **DrivAerML closure** — val=3.997%, need to push test below 5%, ideally toward 3.71%
-   - **T_max sweep CLOSED:** T_max=15/20/40/50/100 all diverge without gc. T_max=30 uniquely stable.
-   - **Depth sweep CLOSED (4L is necessary):** 2L (11.26%), 3L (9.99%), 4L (3.997%). Monotonic — cannot go shallower.
-   - **Multi-revisit CLOSED:** 4x/8x revisits diverge without gc. 1x full-eval too slow (only 36ep).
-   - **EMA CLOSED:** EMA incompatible with DM (dead end #3071)
-   - **In progress:** Surface points (16k/32k/64k), loss alignment (rel L2/Huber/log-cosh), warmup (5/10ep), architecture (5L/6L/640d), throughput (600/788 batches), spatial budget, SGDR
-   - **New (this cycle):** Lion optimizer (lr=5e-5/1e-4), WD alone (1e-4/5e-4/1e-3), higher LR+warmup (7e-4/1e-3), RAdam (lr=5e-4/7e-4)
-   - **Key finding:** DM loss landscape is rough — T_max=30 sits in a uniquely narrow stable basin. Monotonic depth preference (4L > 3L > 2L). 4L is NOT over-parameterized.
+1. **DrivAerML closure** — val=3.997%, need test below 5%, ideally toward 3.71%
+   - **CLOSED directions:** T_max (only 30 works), depth (4L required), multi-revisit, EMA, bilateral symmetry, LR (only 5e-4 at AdamW)
+   - **Active exploration fronts:**
+     - Surface points sweep (16k/32k/64k) — human directive
+     - Loss alignment (rel L2, Huber, log-cosh, L1-smooth)
+     - Architecture (5L/6L deeper, 640d wider, 384d compact)
+     - Warmup (5/10/20-epoch linear)
+     - Throughput (600/788 batches, supernode budget)
+     - Schedule (SGDR warm restarts, polynomial decay)
+     - Optimizer (Lion, RAdam)
+     - Regularization (WD alone, dropout)
+     - Multi-seed full-eval (paper-facing)
 
 2. **TFP clean test result** — val=0.002383, need paper-facing test_primary/field_mse
-   - shoya #3098: dedicated clean-test run (highest priority TFP)
-   - shouko #3113: TFP field_mse full-eval clean test
-   - T_max refinement (15/20/30), gc tuning (0.3/0.7), EMA tuning (0.99/0.9995)
-   - Architecture: 4L/192d per vash's finding
-   - LR: 1e-4 only (1.5e-4 dead end at 0.003199)
+   - **CLOSED:** T_max>10 (T_max=15 diverged at ep124), gc>0.5 (gc=0.7 diverged at ep142), 4L depth (Inf field_mse), LR=1.5e-4 (worse)
+   - **Active:** T_max=5/8 (shorter may stabilize), gc=0.3, EMA=0.99/0.9995, lr=1e-4, 3L/256d width, clean test eval
+   - **Key finding:** TFP champion (Lion+T_max=10+gc=0.5+EMA) is a SHARP optimum — deviations in T_max, gc, depth all cause Infinity field_mse
 
 3. **AirfRANS volume** — Vol MSE=0.00764, target 0.0017 (4.5x gap)
-   - Volume-weighted loss (3x and 10x)
-   - Deeper architectures (3L/256d, 3L/384d)
-   - T_max tuning (30/100), EMA, wider model + gc
+   - 8 students covering: volume-loss-weight, architecture, T_max, EMA, compound config
 
 4. **TandemFoil anchor** — preserve at 22.537 val, 24.581 test
 
 ## Key Dead Ends (Do Not Repeat)
 
-**DrivAerML specific:**
+**DrivAerML:**
 - T_max: only 30 works without gc; 15/20/40/50/100 all diverge
-- Depth: 4L required; 2L/3L both diverge and achieve 2.5-2.8x worse val
-- EMA: incompatible (EMA alone = 9.749%)
-- Multi-revisit training: 4x/8x diverge without gc
+- Depth: 4L required; 2L/3L diverge and 2.5-2.8x worse
+- EMA: incompatible (9.749%)
+- Multi-revisit: 4x/8x diverge without gc
 - gc+WD compound: crashes
-- gc alone: 1.5/2.0 diverges (2.0 was best gc at 4.346%, still above baseline)
+- gc alone: 1.5/2.0 diverges; best gc result 4.346% still above baseline
 - 640d without gc: dead end
-- torch.compile: no throughput benefit, compile run diverged
+- torch.compile: no throughput benefit, diverged
+- Bilateral symmetry: aug causes gradient instability (14.01%)
+- LR: 4e-4 and 4.5e-4/5.5e-4 all worse; 5e-4 sharp optimum
+- Gradient accumulation: harmful (4.860%)
+
+**TandemFoil Paper:**
+- T_max=15: diverged ep124 (3.5x earlier than T_max=10 champion)
+- gc=0.7: diverged ep142 (3x earlier)
+- 4L/192d: Infinity field_mse (pressure overflow)
+- 4L/256d: 0.004427 (+85% vs baseline)
+- LR=1.5e-4: 0.003199 (+34%)
+- 5L degrades late, all negative novel architectures
 
 **AirfRANS:** 2L/384d NaN, LR above 6e-4 all worse, accum>1 harmful
-**TFP:** 3L unstable (diverges/degrades), 5L degrades late, LR>1.25e-4 worse, 4L/256d architecture worse
 **Cross-dataset:** SAM, PCGrad, LayerScale, sigma-Reparam, GeGLU, SwiGLU, SDF, head scaling — all failed
 
 ## Strategy (ICML Final Sprint)
 
-Per human team directive #3020 and ICML sprint guidance:
-- **NO cross-dataset default** — each PR targets one benchmark
-- DrivAerML is top priority (~50-60% of fleet) ✓
-- TFP clean test result is #2 priority
-- AirfRANS volume is #3 (surface already excellent)
-- Do not let TF absorb large fleet share
+Per human team directive #3020:
+- NO cross-dataset default — each PR targets one benchmark
+- DrivAerML ~50-60% fleet ✓ (33/60 = 55%)
+- TFP ~20-30% ✓ (14/60 = 23%)
+- AirfRANS ~10-20% ✓ (8/60 = 13%)
+- TF minimal ✓ (3/60 = 5%)
 
 ## Mandatory Config Rules
 

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,6 +1,6 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 23:45 (advisor cycle 51)
+- **Date:** 2026-04-24 00:00 (advisor cycle 52)
 - **Branch:** radford
 - **Idle students:** 0
 - **PRs ready for review:** 0
@@ -20,7 +20,7 @@
 **Noam-pivot experiments:**
 - `#3199` megumi: EMA=0.9999/0.99995 (noam optimal decay) — NOAM ABLATION
 - `#3192` casca: asinh-pressure alone (scale=0.75/0.5) — NOAM ABLATION
-- `#3193` franky: residual-prediction alone — NOAM ABLATION
+- franky: gradient noise injection — INNOVATION (PR pending)
 - `#3194` bulma: higher LR sweep (5.5e-4/6e-4)
 - `#3188` chihiro: 2H/16H heads sweep — NOAM ABLATION
 - `#3181` himmel: asinh+residual on champion — NOAM ABLATION
@@ -58,7 +58,6 @@
 **Stabilization status: CODE REGRESSION CONFIRMED — seed=0 broken, waiting for sanji #3209 bug fix**
 
 **Noam-pivot experiments:**
-- `#3183` rei: ANP+T_max=150 — NOAM ABLATION
 - `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
 - `#3176` mitsuha: full noam stack — NOAM ABLATION
 
@@ -79,6 +78,7 @@
 **Other:**
 - `#3172` robin: LR warmup (5-ep/10-ep)
 - `#3169` nami: heads sweep 4H/16H
+- rei: proximity-weighted volume loss — AF VOLUME FOCUS (PR pending)
 - `#3218` shouko: GradNorm adaptive multi-task loss balancing — AF VOLUME FOCUS
 - `#3215` tanjiro: Huber loss on volume channel (robust to outliers) — AF VOLUME FOCUS
 - `#3212` jin: PCGrad multi-objective gradient surgery — AF VOLUME FOCUS
@@ -178,7 +178,7 @@
 - OneCycleLR (no troughs): 8.04% best, sustained high-LR warmup worse than cosine peaks (without EMA+gc)
 - SWA: equal-weight averaging poisons across divergent basins (88.98%)
 - T_max≠30: ALL tested — 15→4.406%, 20→4.943%, 30→3.833% CHAMPION, 45→4.638%, 50→diverge, 60→4.409%. T_max=30 is definitive sweet spot
-- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%. All diverge. Features tuned for T_max=150/3H/no-gc regime don't transfer to T_max=30/8H/gc=0.5
+- Noam feature stack on DM: full stack→4.447%, asinh-only→4.421%, residual-only→4.651%/15.0%(crashed). All diverge. Features tuned for T_max=150/3H/no-gc regime. Residual-pred requires asinh as hard prerequisite; even combined→3.999% (doesn't beat 3.833%)
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
 - LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -1,78 +1,90 @@
 # SENPAI Research State
 
-- **Date:** 2026-04-23 13:00 (advisor cycle 32 — closed #3131/#3124, assigning sanji/robin)
+- **Date:** 2026-04-23 18:00 (advisor cycle 39 — closed #3068/#3066/#3064, assigned brook/alphonse/casca)
 - **Branch:** radford
-- **Idle students:** 0 (sanji/robin being assigned)
+- **Idle students:** 0
 - **PRs ready for review:** 0
 
-## Fleet Status
+## Fleet Status (59 active PRs)
 
-### DrivAerML WIP (~36 students, ~60%)
-- `#3165` senku: EMA+gc+4H heads (128d/head)
+### DrivAerML WIP (30 PRs)
+**Noam-pivot experiments (highest priority):**
+- `#3192` casca: asinh-pressure alone (scale=0.75/0.5 sweep) — NOAM ABLATION
+- `#3188` chihiro: 2H/16H heads sweep on champion — NOAM ABLATION
+- `#3181` himmel: asinh+residual on champion — NOAM ABLATION
+- `#3175` hinata: full noam stack on champion — NOAM ABLATION
+
+**Pre-pivot champion tuning:**
+- `#3173` kakashi: shorter cosine T_max=15/20
+- `#3171` sanji: LR warmup (5-ep/10-ep) on champion
+- `#3165` senku: 4H heads (128d/head)
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING
-- `#3163` shouko: EMA+gc+attn dropout=0.05
-- `#NEW` himmel: AGC (adaptive gradient clipping) on EMA champion — BEING ASSIGNED
-- `#3161` spike: EMA+gc+eta_min=1e-5 (cosine floor)
-- `#3160` griffith: EMA+gc+16H heads
-- `#3159` franky: EMA+gc+4L/640d (wider)
-- `#3158` bulma: EMA+gc+lr=4e-4
-- `#3155` nobara: EMA+gc+longer T_max (45/60)
-- `#3154` historia: EMA+gc+monotonic cosine (no restarts)
-- `#3153` emma: EMA+gc+light WD (1e-4/5e-4)
+- `#3163` shouko: attn dropout=0.05
+- `#3161` spike: eta_min=1e-5 (cosine floor)
+- `#3160` griffith: 16H heads
+- `#3159` franky: 4L/640d wider
+- `#3158` bulma: lr=4e-4
+- `#3155` nobara: longer T_max (45/60)
+- `#3154` historia: monotonic cosine (no restarts)
 - `#3152` eren: EMA decay sweep (0.999 vs 0.9995)
-- `#3149` fern: stochastic input feature dropout (p=0.05/0.10)
-- `#3147` norman: lighter WD+gc=1.0 (5e-4/1e-4)
 - `#3146` taki: top-5 checkpoint averaging
 - `#3143` thorfinn: Lookahead(AdamW)
-- `#3138` kakashi: 788 batches+T_max=60 (SENT BACK — add gc=0.5+EMA)
-- `#3137` chopper: 5-ep warmup+gc=1.0
 - `#3132` gohan: eta_min=5e-5+gc=1.0
-- `#NEW` sanji: warmup (5-ep/10-ep) + EMA+gc champion — BEING ASSIGNED
 - `#3121` levi: dropout regularization sweep
-- `#3118` hinata: WD alone at champion config
 - `#3115` piccolo: bs2+25k pts (SENT BACK — 50k+gc=0.5+EMA)
-- `#3110` einar: AdamW beta2=0.99/0.995
+- `#3110` einar: beta2=0.99/0.995
 - `#3109` guts: lr=4e-4 full-eval
 - `#3085` kohaku: larger supernodes (SENT BACK — retry+gc=1.0)
 - `#3083` jet: max-train-batches=600
 - `#3079` gojo: 4L/640d (SENT BACK — lr=3e-4+T_max=60+EMA)
 - `#3076` frieren: log-cosh loss (SENT BACK — retry+gc=1.0)
-- `#3068` brook: 64k surface points (SENT BACK — add max-eval-batches 200)
 - `#3067` askeladd: 32k surface points (SENT BACK — add max-eval-batches 200)
-- `#3066` alphonse: 16k surface points
-- `#3065` chihiro: multi-seed s456 (SENT BACK — two-phase eval)
-- `#3064` casca: multi-seed s123 (SENT BACK — two-phase eval)
 - `#3063` canute: paper-facing full-eval (SENT BACK — two-phase)
 - `#3046` sukuna: WD+gc compound (SENT BACK — WD=5e-4/1e-4+gc=1.0)
 
-### TandemFoil Paper WIP (~10 students, ~17%)
-- `#NEW` nami: attention heads sweep (4H/16H) — BEING ASSIGNED (moved from TFP)
-- `#3145` rei: gc=0.4 boundary test
+### TandemFoil WIP (6 PRs)
+**Noam-pivot experiments (highest priority):**
+- `#3189` emma: asinh+physics features (no ANP, no T_max) — NOAM ABLATION
+- `#3186` norman: T_max=150 alone (gc=0.3/0.5) — NOAM ABLATION
+- `#3185` fern: full noam stack (ANP+physics+T_max=150) — NOAM ABLATION
+- `#3180` chopper: ANP decoder alone — NOAM ABLATION
+
+**Other:**
+- `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
+- `#3142` zenitsu: gc=0.3+longer budget (480-min)
+
+### TandemFoil Paper WIP (10 PRs)
+**Noam-pivot experiments (highest priority):**
+- `#3190` brook: physics features only (wake/vortex/Cp, no ANP) — NOAM ABLATION
+- `#3183` rei: ANP+T_max=150 — NOAM ABLATION
+- `#3179` usopp: T_max=150+wake+96sl+Lookahead — NOAM ABLATION
+- `#3176` mitsuha: full noam stack — NOAM ABLATION
+
+**Other:**
+- `#3168` jin: multi-seed paper-facing (seeds 42/123/456)
 - `#3133` shinobu: WD sweep (5e-3/2e-2)
-- `#NEW` robin: warmup (5-ep/10-ep) + EMA=0.999 — BEING ASSIGNED (moved from TFP)
-- `#3123` mitsuha: shorter T_max (5/8)
 - `#3098` shoya: clean test evaluation — URGENT PAPER-FACING
 - `#3088` mugen: T_max=20
 - `#3056` haku: Lion+EMA refinement (T_max/gc/LR sweep)
 - `#2949` vash: depth/width sweep (LR=5e-5)
-- `#NEW` jin: multi-seed paper-facing (seeds 42/123/456) — BEING ASSIGNED
 
-### AirfRANS WIP (~10 students, ~17%)
-- `#3156` edward: softer gc=0.5 on EMA champion
+### AirfRANS WIP (13 PRs)
+**Noam-pivot experiments (highest priority):**
+- `#3191` alphonse: noam features on base and vol-10x — NOAM ABLATION
+- `#3187` stark: asinh+residual on vol-10x champion — NOAM ABLATION
+- `#3184` wolfwood: full noam stack — NOAM ABLATION
+- `#3177` nezuko: vol-weight 15x/20x + asinh+residual — NOAM ABLATION
+
+**Other:**
+- `#3172` robin: LR warmup (5-ep/10-ep)
+- `#3169` nami: heads sweep 4H/16H
+- `#3167` gilbert: higher LR (8e-4/1e-3)
+- `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999
+- `#3156` edward: softer gc=0.5
 - `#3144` violet: vol-weight=2.0+EMA=0.999
-- `#3136` stark: EMA decay higher (0.9995/0.9999)
-- `#3135` nezuko: EMA=0.999+vol-weight=10x
 - `#3134` megumi: vol-weight=30x
-- `#3129` chrome: 4L/256d deeper architecture
-- `#3106` wolfwood: 2L/384d+gc+T_max=50 (SENT BACK — add EMA=0.999)
+- `#3129` chrome: 4L/256d deeper
 - `#3101` tanjiro: vol-loss-weight=1.5 (SENT BACK)
-- `#3166` vegeta: vol-weight=5.0/7.0+EMA=0.999 — JUST ASSIGNED
-- `#NEW` gilbert: lr=8e-4/1e-3+EMA=0.999 — BEING ASSIGNED
-
-### TandemFoil WIP (~3 students, ~5%)
-- `#3150` yuji: clean test row gc=0.3 champion — PAPER-FACING
-- `#3142` zenitsu: gc=0.3+longer budget (480-min)
-- `#3140` usopp: gc=0.2 sweep
 
 ## Steering Anchors
 
@@ -156,6 +168,7 @@
 - Bilateral symmetry aug, torch.compile, gradient accumulation
 - Attention dropout without EMA/gc: toxic combo with T_max=30
 - Cosine eta_min without EMA/gc: diverges (7.255-7.918%)
+- Surface points ≠50k: 16k=11.672%, 32k=7.558%, 64k=12.16% (even with EMA+gc) — 50k only viable count
 
 **TandemFoil Paper:**
 - T_max≠10 (all directions diverge)

--- a/research/CURRENT_RESEARCH_STATE.md
+++ b/research/CURRENT_RESEARCH_STATE.md
@@ -25,7 +25,7 @@
 
 **Champion tuning / paper-facing:**
 - `#3173` kakashi: shorter cosine T_max=15/20
-- `#3171` sanji: LR warmup (5-ep/10-ep)
+- `#NEW` sanji: TFP cp_panel bug fix + multi-seed retest — STABILIZATION PRIORITY
 - `#3164` faye: paper-facing full eval (two-phase) — PAPER-FACING Track 1
 - `#3163` shouko: attn dropout=0.05
 - `#3161` spike: eta_min=1e-5 (cosine floor)
@@ -172,6 +172,7 @@
 - T_max=50+gc (both 0.5 and 1.0): diverge — T_max=30 only viable period
 - 10-ep warmup+gc=1.0: 11.2% then diverged
 - 5-ep warmup+gc=1.0: pending (chopper)
+- LR warmup + EMA+gc=0.5: 5-ep=11.325% diverged, 10-ep=3.918% plateaued (didn't beat 3.833%)
 - Huber loss, relative L2 loss (degenerate), SGDR, RAdam
 - beta2≠0.999, LR≠5e-4 (without EMA), WD+gc heavy (WD=1e-3: 4.44%)
 - Bilateral symmetry aug, torch.compile, gradient accumulation

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 10:00 — PR #3256: DM coordinate noise augmentation (alphonse) — CLOSED (dead end)
+
+- alphonse/dm-coord-noise-augmentation, W&B runs: hapy2g9k (σ=0.001), qfu1j89b (σ=0.005), group: dm-coord-noise-aug
+- Hypothesis: Gaussian noise on input coordinates provides regularization against overfitting to exact point positions
+
+| Trial | σ | best val_pct | vs baseline | Status |
+|-------|---|-------------|-------------|--------|
+| T1 | 0.001 | 6.450% | +68% | Crashed ep172, grad norm peaked 732,950 |
+| T2 | 0.005 | 21.445% | +459% | 117/168 grad norms = Infinity |
+
+- **Root cause: Fourier frequency amplification.** Frequencies up to 32.0 amplify σ=0.001 to σ=0.032 in feature space, σ=0.005 to σ=0.16. Structural incompatibility with Fourier PE — not a tuning issue.
+- **Follow-up assigned:** Hidden-space noise (post-Fourier perturbation) avoids the amplification entirely.
+
 ## 2026-04-24 09:45 — PR #3239: AF additive boundary-layer auxiliary volume loss (vegeta) — CLOSED (dead end)
 
 - vegeta/af-bl-auxiliary-loss, W&B runs: 6y7xod45 (bl-w=1.0,t=0.05), 7w4btwaj (bl-w=0.5,t=0.05), pjrv0090 (bl-w=1.0,t=0.10)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,16 @@
 # SENPAI Research Results
 
+## 2026-04-24 19:00 — PR #3275: DrivAerML local/windowed attention (canute) — CLOSED dead end
+
+- canute/dm-local-attention
+- Hypothesis: KNN-restricted local attention provides physics-aligned spatial inductive bias for surface pressure prediction
+- Trial 1 (K=512): 5.81% val at ep89, only 89 epochs due to 3-4x throughput collapse (19GB VRAM). W&B: 9a3yodiw.
+- Trial 2 (K=2048): 13.59% val at ep29, only 29 epochs (60GB VRAM). W&B: 7shsfomx.
+- Architecture mismatch: Transolver routes 50k tokens → 96 physics-aware slices, NOT point-to-point attention. Adding parallel KNN O(N·K) pathway is redundant with slice mechanism and destroys throughput. At matched epochs, K=512 and K=2048 show similar val metrics — local attention adds no signal beyond what slicing already captures.
+- **Canute assigned to Breakout 2 (#3302): metric-aware MSE + raw-rel-L2 loss**
+
+---
+
 ## 2026-04-24 18:30 — PR #3301: DrivAerML Breakout 3 domain-normalized volume auxiliary (brook) — SENT BACK (round 2)
 
 - brook/dm-domain-normalized-volume-aux

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,32 @@
 # SENPAI Research Results
 
+## 2026-04-24 12:15 — PR #3254: AF multi-seed champion run (norman) — CLOSED (diagnostic, no winner)
+
+- norman/af-multi-seed-champion, W&B runs: 69bgiyis (seed=42), v3bl8pgv (seed=123), cv4fdye6 (seed=789), group: af-multi-seed
+- Hypothesis: a different seed might find vol_mse < 0.0017 under the champion config
+
+| Seed | surface_mse | vs baseline | vol_mse | vs baseline | Status |
+|------|-------------|-------------|---------|-------------|--------|
+| 0 (baseline) | **0.000296** | — | **0.002039** | — | Stable |
+| 42 | 0.000869 | +194% | 0.007117 | +249% | Diverged ep300 |
+| 123 | 0.000535 | +81% | 0.002831 | +39% | Stable |
+| 789 | 0.000532 | +80% | 0.003585 | +76% | Diverged at end |
+
+- **Diagnostic finding: Champion config has HIGH seed sensitivity.** Seed=0 significantly outperforms all 3 tested seeds. Cross-seed vol std=0.002200 (151% spread). The baseline benefits from initialization luck.
+- **Implication:** Config improvements must be tested multi-seed to confirm robustness.
+
+## 2026-04-24 12:15 — PR #3253: DM input feature dropout (canute) — CLOSED (dead end)
+
+- canute/dm-input-feature-dropout, W&B runs: 5kpd4fu0 (p=0.1), rso1a99o (p=0.2), group: dm-fourier-dropout
+- Hypothesis: Fourier channel dropout forces redundant representations
+
+| Trial | Dropout p | best val_pct | vs baseline | Terminal divergence |
+|-------|-----------|-------------|-------------|-------------------|
+| T1 | 0.1 | 4.732% | +23% | final 18.27% |
+| T2 | 0.2 | 4.821% | +26% | final 67.97% |
+
+- **Root cause:** Input-level dropout = information destruction, not regularization. All 4 Fourier frequency bands carry essential geometric information. Network can't route around absent INPUT features like it can with hidden-layer dropout. Dose-dependent degradation confirms smooth information loss.
+
 ## 2026-04-24 11:45 — PR #3263: DM Sparse MoE FFN (gojo) — CLOSED (dead end)
 
 - gojo/dm-moe-ffn, W&B runs: rei05zxk (K=4), hjkzjnn8 (K=8), group: dm-moe-ffn

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 07:30 — PR #3129: AF 4L/256d deeper architecture (chrome) — SENT BACK
+
+- surface=0.002412 (5.25x worse), vol=0.009138 (3.3x worse). Diverged ep171 at cosine restart (W&B: `9brflieq`). Trajectory was improving before divergence. Sent back to retry with lr=3e-4 + T_max=100.
+
+## 2026-04-23 07:30 — PR #3119: DM higher LR + warmup (historia) — CLOSED
+
+- lr=7e-4: 19.82% (W&B: `8swgnhho`). lr=1e-3: 17.75% then NaN (W&B: `87ecgqp8`). Both 5-6x worse. DM stability boundary confirmed at ~6e-4 regardless of warmup. LR direction fully exhausted: 4e-4/4.5e-4/5.5e-4/7e-4/1e-3 all dead. lr=5e-4 sharp optimum.
+
+## 2026-04-23 07:30 — PR #3044: DM volume training ablation (emma) — CLOSED
+
+- 50k surf+16k vol: 58.55% (W&B: `eurdv6ot`). 16k surf+16k vol: 64.86% (W&B: `pbsrazga`). 40,000x loss scale mismatch (volume MSE ~18,700 vs surface ~0.48) destroys surface learning. Grad norms 500x baseline. Dead end without explicit volume_loss_weight=0.0001.
+
 ## 2026-04-23 07:00 — PR #3072: DrivAerML EMA=0.9995+gc=0.5 (eren) — MERGED ✓
 
 - **Branch:** eren/dm-ema-9995-gc05

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 10:00 — PR #3113: DM attention dropout=0.05 (shouko) — CLOSED
+
+- val=12.53% ep118, 7 divergence spikes over 206 epochs (W&B: `qjceei69`). Dropout+T_max=30+no-EMA toxic combo — LR peaks amplify dropout noise. Reassigned with EMA+gc stability platform (#3163).
+
+## 2026-04-23 10:00 — PR #3111: DM cosine eta_min (himmel) — CLOSED
+
+- eta_min=1e-6: 7.918% ep180 (W&B: `gu7hfzs1`). eta_min=1e-5: 7.255% ep109 (W&B: `q6zdf6xk`). Both diverged — tested without gc/EMA (wrong regime). spike #3161 carries hypothesis with EMA+gc.
+
 ## 2026-04-23 09:30 — PR #3139: AF 3L/256d + EMA=0.999 (spike) — CLOSED
 
 - surface=0.002863 (6.2x worse), vol=0.011626 (4.2x worse), diverged ep149 (W&B: `ooxb9roq`). Consistent with all prior 3L AF tests. 3L adds optimization noise that destabilizes trajectory. 2L confirmed optimal for AirfRANS.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 03:15 — PR #3105: AirfRANS EMA=0.999 for volume (violet) — CLOSED
+
+- **Branch:** violet/af-ema-volume
+- **Hypothesis:** EMA=0.999 stabilizes noisy volume predictions on AirfRANS
+- **Results:**
+
+| Metric | EMA=0.999 | Baseline | Delta |
+|---|---|---|---|
+| val_primary/surface_mse | 0.000583 ep417 | 0.000482 | +21% WORSE |
+| full_val/volume_mse | **0.004400** ep443 | 0.00764 | **-42.4% BETTER** |
+
+- **W&B run:** vlq1dzfz
+- **Analysis:** EMA creates a clear trade-off: volume improves dramatically (-42.4%) but surface regresses (+21%). Mechanistically sound — volume fields are spatially smoother and benefit from parameter averaging; surface boundary nodes require sharp prediction where EMA's lag hurts. Even regressed surface (0.000583) still beats SpiderSolver (0.0043) by 7.4x. Best volume result in the project — critical finding for the AF volume gap.
+- **Follow-up:** Test EMA=0.995 and EMA=0.99 to find sweet spot minimizing surface regression while preserving volume improvement.
+- **Decision:** CLOSED — primary metric (surface_mse) did not beat baseline
+
 ## 2026-04-23 02:50 — PR #3070: DrivAerML 10-epoch linear warmup (chrome) — CLOSED
 
 - **Branch:** chrome/dm-linear-warmup-10ep

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 08:00 — PR #3122: DM polynomial LR decay (nobara) — CLOSED
+
+- Linear (power=1.0): 17.88% ep64, diverged ep69 (W&B: `i1qbv9t4`). Quadratic (power=2.0): 12.20% ep75, diverged ep91 (W&B: `kkuery47`). Both 3-4x worse. Key insight: cosine's periodic low-LR troughs are load-bearing for stability — polynomial keeps LR high without recovery windows. Polynomial LR dead for DM.
+
+## 2026-04-23 08:00 — PR #3066: DM 16k surface points (alphonse) — SENT BACK
+
+- val=24.039% at ep17 only (W&B: `icqb9nla`). Same eval-overhead epoch-starvation: ~21 min/epoch without max-eval-batches. Sent back to add --max-eval-batches 200. Note: 2.88 GB VRAM — very low, opens door for larger model pairing later.
+
 ## 2026-04-23 07:30 — PR #3129: AF 4L/256d deeper architecture (chrome) — SENT BACK
 
 - surface=0.002412 (5.25x worse), vol=0.009138 (3.3x worse). Diverged ep171 at cosine restart (W&B: `9brflieq`). Trajectory was improving before divergence. Sent back to retry with lr=3e-4 + T_max=100.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,28 @@
 # SENPAI Research Results
 
+## 2026-04-23 00:30 — PR #3097: TFP lr=1.5e-4 (shouko) — CLOSED
+
+- **Branch:** shouko/tfp-lr-15e5
+- **Hypothesis:** Higher LR (1.5e-4 vs 1.25e-4 champion) helps TFP converge faster.
+- **Result:** val_primary/field_mse = **Infinity** for all 89 epochs. Pressure channel never finite. 100% grad clip rate.
+- **W&B:** tzwac8i0
+- **Conclusion:** lr=1.5e-4 is above Lion+gc=0.5 stability ceiling for TFP pressure. lr=1.25e-4 confirmed near the stability boundary. LR above champion is dead.
+- **shouko reassigned to #3113: DM attention dropout=0.05**
+
+## 2026-04-23 00:30 — PR #3071: DrivAerML EMA=0.999 (edward) — CLOSED
+
+- **Branch:** edward/dm-ema-999-champion
+- **Hypothesis:** EMA stabilizes 4L/512d champion at current config.
+
+| Run | Config | Best Val % | Epoch | W&B |
+|-----|--------|-----------|-------|-----|
+| 1 | EMA=0.999, no gc | 21.797 | ep21 | fyzaouhr |
+| 2 | EMA=0.999, gc=0.5 | 10.936 | ep56 | wqihmy4x |
+
+- **Result:** Both diverged catastrophically. EMA is structurally incompatible with DM batch_size=1 gradient variance.
+- **Conclusion:** EMA is dead for DrivAerML at any decay/gc combination. Positive feedback loop: single explosive update contaminates EMA, which degrades subsequent optimization. Confirms #2899 (9.749%).
+- **edward reassigned to #3112: DM gradient centralization**
+
 ## 2026-04-23 00:10 — PR #3080: DrivAerML T_max=50 cosine schedule (himmel) — CLOSED
 
 - **Branch:** himmel/dm-tmax-50

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:30 — PR #3163: DM attn-dropout=0.05 + EMA+gc (shouko) — CLOSED (dead end)
+
+- Best val=10.118% ep73 (W&B: j0t5bn67), 2.64x worse than 3.833%. Catastrophic divergence ep74 — grad_norm→Infinity, gc=0.5 firing every step (394 clip events/epoch) but couldn't contain compounding dropout noise. Final val=75.33%. EMA preserved ep73 checkpoint. Confirms attn-dropout incompatible with DM at any stability level: without EMA/gc → 12.533% (#3113), with EMA/gc → 10.118% (19% better early but same ultimate fate). The multiplicative noise from dropout compounds faster than gc can clip as the loss landscape steepens at cosine restart boundaries. Added to dead ends.
+
 ## 2026-04-23 23:15 — PR #3213: DM surface normal input features (brook) — CLOSED (already implemented)
 
 - No trials ran. Brook discovered surface normals are ALREADY present in DrivAerML input tensor (columns 3-5 of SURFACE_X_DIM=7, loaded from surface_normals.npy in prepare_drivaerml.py). The champion already has full access to normals. Hypothesis moot. Pivot: Fourier encoding of normals (currently only xyz cols 0-2 get Fourier features, not normals) — reassigning brook to this follow-up.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,35 @@
 # SENPAI Research Results
 
+## 2026-04-23 02:20 — PR #3120: DrivAerML RAdam optimizer (senku) — CLOSED
+
+- **Branch:** senku/dm-radam-optimizer
+- **Hypothesis:** RAdam's variance rectification provides built-in warmup for stable early-epoch dynamics
+- **Results:**
+
+| Run | LR | W&B ID | Best val surface_rel_l2_pct | Fate |
+|---|---|---|---|---|
+| RAdam lr=5e-4 | 5e-4 | hh0vm4a2 | 19.95% ep40 | Diverged ep41-43 |
+| RAdam lr=7e-4 | 7e-4 | tkx91w4v | 20.79% ep38 | NaN ep39 |
+| Baseline | 5e-4 | bht6h42t | 3.997% ep467 | — |
+
+- **Analysis:** RAdam's rectification only provides early-epoch warmup; it offers no protection at recurring cosine LR peaks where DM divergence happens. Both runs survived cycle 1 but diverged in cycle 2 at LR peak. Confirms DM instability is LR-peak driven, not warmup-driven. AdamW's implicit regularization via decoupled weight decay may be the key.
+- **Decision:** CLOSED — both runs ~5x worse than baseline
+
+## 2026-04-23 02:20 — PR #3078: DrivAerML 6L/512d depth scaling (gohan) — CLOSED
+
+- **Branch:** gohan/dm-6l-512d-deeper
+- **Hypothesis:** Monotonic depth trend (2L<3L<4L) continues to 6L for even better results
+- **Results:**
+
+| Run | Config | W&B ID | Best val surface_rel_l2_pct | Fate |
+|---|---|---|---|---|
+| Run 1 | 6L no gc | ca8rh3q8 | 14.680% ep33 | Catastrophic divergence ep37 |
+| Run 2 | 6L gc=0.5 | 9cccs3ze | 6.372% ep155 | Slow divergence ep161 |
+| Baseline | 4L no gc | bht6h42t | 3.997% ep467 | — |
+
+- **Analysis:** Depth trend does NOT continue beyond 4L. 6L amplifies gradient explosions at LR peaks. Even gc=0.5 couldn't stabilize for the 400+ epochs needed (6.372% best at ep155 vs 3.997% at ep467 for 4L). 4L confirmed as DM depth sweet spot. The 6L model converges faster early but hits a stability ceiling.
+- **Decision:** CLOSED — 59% worse than baseline at best (gc run), catastrophic without gc
+
 ## 2026-04-23 02:05 — PR #3073: DrivAerML EMA=0.999 + gc=0.5 compound (faye) — CLOSED
 
 - **Branch:** faye/dm-ema-999-gc05-compound

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 19:30 — PR #3142: TF gc=0.3 longer budget 480-min (zenitsu) — CLOSED
+
+- Best val=22.016 ep460 (W&B: `w0wlkumg`). Doesn't beat 21.350 baseline (#3140). Extra 120min budget provides no benefit — cosine T_max=10 cycling means more epochs are independent LR-cycle draws, not monotone descent. Three gc=0.3 runs span 0.7 MAE variance (21.909, 21.350, 22.016). gc=0.3 clips rarely (44 events/467 epochs, grad_norm_mean=0.1884) — functionally equivalent to gc=0.2. geom_camber_rc ~30.9 MAE remains persistent architectural bottleneck.
+
+## 2026-04-23 19:30 — PR #3115: DM bs=2 + 50k pts + EMA+gc (piccolo) — CLOSED
+
+- Phase 1 (bs=2/25k/fp16): val=4.323% (W&B: `l7np1pv0`), confounded by 13 gradient spikes from fp16 fallback. Phase 2 (bs=2/50k/fp32/EMA+gc): val=4.373% ep368 (W&B: `oohxhf86`). Both worse than 3.833% baseline. Blackwell bf16+bs>1 CUBLAS bug forces fp32, which only gets 37% of baseline optimizer steps within 6h timeout. The gradient-variance hypothesis cannot be fairly tested on this platform. Per-step efficiency signal weakly interesting (4.37% at 37% steps) but not actionable.
+
+## 2026-04-23 19:30 — PR #3079: DM 4L/640d (gojo) — CLOSED
+
+- Run 1: val=4.516% ep359 (W&B: `7uuhe2qr`), diverged ep360+. Run 2: 6.457% ep137 (W&B: `ho8eosr3`), crashed ep152. Run 3: 5.724% ep169 (W&B: `txttvm2n`), diverged ep244+. All 3 runs used lr=5e-4/T_max=30/no-EMA — student never applied instructed config (lr=3e-4/T_max=60/EMA) despite 2 send-backs. Combined with franky #3159 (640d+EMA → 8.636%), 640d is dead at any tested config. Width amplifies gradient magnitudes beyond gc=0.5 containment.
+
 ## 2026-04-23 18:30 — PR #3159: DM 4L/640d wider on EMA+gc champion (franky) — CLOSED
 
 - 640d: best val=8.636% ep81 (W&B: `yccjqzbi`), catastrophic divergence ep82 → 86% terminal. gc=0.5 clipped every batch but couldn't contain gradient explosion. grad_norm_mean=Infinity confirmed. EMA+gc delayed divergence vs prior 640d attempt (gojo #3079, ep28) but didn't prevent it. 640d at lr=5e-4 is fundamentally incompatible. Bug fix: primary_metric_key shadowing.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 20:00 — PR #3132: DM eta_min=5e-5 + gc compound (gohan) — CLOSED
+
+- gc=1.0+eta_min=5e-5: 6.311% ep149, diverged ep150 → 112.66% (W&B: `h6jblqjq`). gc=0.5+eta_min=5e-5: 8.617% ep70, diverged → 72% (W&B: `7fmjg0cu`). Third confirmation eta_min=5e-5 is dead — alone (#3126), +gc=1.0, +gc=0.5 all diverge catastrophically. Non-zero LR floor prevents gradient momentum dissipation at cosine troughs; gc delays but cannot prevent cumulative drift. gc=0.5 is counterproductive here — clips 288/394 batches (throttles signal), worse than gc=1.0 which clips only 73/394.
+
 ## 2026-04-23 19:30 — PR #3142: TF gc=0.3 longer budget 480-min (zenitsu) — CLOSED
 
 - Best val=22.016 ep460 (W&B: `w0wlkumg`). Doesn't beat 21.350 baseline (#3140). Extra 120min budget provides no benefit — cosine T_max=10 cycling means more epochs are independent LR-cycle draws, not monotone descent. Three gc=0.3 runs span 0.7 MAE variance (21.909, 21.350, 22.016). gc=0.3 clips rarely (44 events/467 epochs, grad_norm_mean=0.1884) — functionally equivalent to gc=0.2. geom_camber_rc ~30.9 MAE remains persistent architectural bottleneck.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 21:00 — PR #3190: TFP physics features isolation (brook) — CLOSED
+
+- Trial 1 (all physics): val=Infinity — cp_panel_prior_index() wrong index for tandemfoil_paper (W&B: `0eq5jqij`). Trial 2 (wake only): val=0.7396, diverged (W&B: `kqknlctz`). CRITICAL: TFP pipeline only supports enable_fourier/wake_deficit/wake_angle — other physics flags silently ignored.
+
+## 2026-04-23 21:00 — PR #3167: AF higher LR 8e-4/1e-3 (gilbert) — CLOSED
+
+- lr=8e-4: surface +110%, vol +89% vs baseline (W&B: `dfed8vam`). lr=1e-3: catastrophic divergence (W&B: `tb2h5odt`). LR=6e-4 confirmed AF sweet spot.
+
+## 2026-04-23 21:00 — PR #3166: AF vol-weight=5x/7x (vegeta) — CLOSED
+
+- 5x: surface +46%, vol +52% (W&B: `dxna9k23`). 7x: surface +48%, vol +154%, diverged (W&B: `20nl7euu`). 10x+EMA=0.999 confirmed AF sweet spot.
+
+## 2026-04-23 21:00 — PR #3165: DM 4H heads EMA+gc (senku) — CLOSED
+
+- Best val=6.650% ep123, diverged ep133 (W&B: `o5mcbmp9`). 4H unstable at 4L/512d. DM heads: 8H champion > 4H > 16H.
+
 ## 2026-04-23 20:30 — PR #3134: AF vol-weight=30x (megumi) — CLOSED
 
 - Surface=0.001264 (4.3x worse than 0.000296 baseline), vol=0.006235 (3.1x worse than 0.002039 baseline) (W&B: `wupz6iuj`). 30x volume weighting massively overshoots — optimizer saturates on volume gradients and both metrics collapse. Model diverged post-ep400, terminal surface=0.621 vol=1.533. No Pareto improvement at any epoch. Sweet spot confirmed at 10x (#3135). Adding to dead ends: vol-weight≥30x catastrophic.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,29 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:30 — PR #3264: DM Weight Standardization (vegeta) — CLOSED (dead end)
+
+- vegeta/dm-weight-standardization, W&B runs: x0biqh3s (lr=5e-4), i7nvv6gj (lr=6e-4), group: dm-weight-standardization
+- Hypothesis: WS smooths loss landscape at bs=1 (Qiao et al., 2019)
+
+| Trial | LR | best val_pct | vs baseline | Status |
+|-------|-----|-------------|-------------|--------|
+| T1 | 5e-4 | 67.925% | +1673% | 100% grad clip, Inf grad norm |
+| T2 | 6e-4 | 71.410% | +1764% | 100% grad clip, grad_norm 9.4e16 |
+
+- **Root cause:** WS reparameterization + cosine restarts (T_max=30) + bs=1 → feedback loop. LR peak jolts raw weights, WS recenters, but AdamW momentum was built on pre-WS effective weights → persistent direction mismatch. Original BiT paper used epoch-level decay, not per-batch restarts.
+
+## 2026-04-24 11:30 — PR #3248: DM SGDR eta_mult decaying restart LR (nobara) — CLOSED (dead end)
+
+- nobara/dm-decaying-restart-lr, W&B runs: fgtjrzmc (eta_mult=0.9999), 39vnze9p (eta_mult=0.99995), group: dm-sgdr-eta-mult
+- Hypothesis: decaying peak LR at each cosine restart makes late restarts gentler
+
+| Trial | eta_mult | best val_pct | vs baseline | Status |
+|-------|----------|-------------|-------------|--------|
+| T1 | 0.9999 | 4.153% | +8.3% | Stable, peak LR decayed to 52.6% by ep490 |
+| T2 | 0.99995 | 12.643% | +230% | Diverged ep60, sharp restart jumps |
+
+- **Confound:** Switched from CosineAnnealingLR (smooth) to CosineAnnealingWarmRestarts (sharp jumps). T2 divergence proves sharp restart jumps more destabilizing than baseline's smooth oscillation. T1 stable only because severe peak decay compensated.
+
 ## 2026-04-24 11:15 — PR #3247: DM EMA periodic reset (brook) — CLOSED (dead end)
 
 - brook/dm-ema-periodic-reset, W&B runs: ltfotg72 (reset@100ep), q221x53o (reset@50ep), group: dm-ema-periodic-reset

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:45 — PR #3175: DM full noam stack + individual ablations (hinata) — CLOSED (dead end)
+
+- Full stack (asinh+residual+compile+96sl+srf): best val=4.447% ep342 (W&B: vddf3qle), diverged → 64%. Asinh-only (scale=0.75): best val=4.421% ep303 (W&B: 0ks1aaz5), diverged → 61%. Residual-only: best val=4.651% ep242 (W&B: xmx6y3ws), diverged → NaN. All 0.6-0.8pp worse than 3.833%. Root cause: noam features were tuned for T_max=150/3H/no-gc regime — cosine T_max=30 restarts amplify gradient instability through these features despite gc=0.5. Asinh least harmful, residual most harmful. Individual ablations (casca #3192, franky #3193) may find narrower windows. Bug fix: primary_metric_key scoping.
+
+## 2026-04-23 23:45 — PR #3155: DM longer T_max=45/60 + EMA+gc (nobara) — CLOSED (dead end)
+
+- T_max=45: best val=4.638% ep240, diverged → 61.4% (W&B: tskmw04v). T_max=60: best val=4.409% ep331, diverged → 54.9% (W&B: fmxxu3ol). Both worse than 3.833%. Longer cycles keep model in high-LR territory too long, causing progressive destabilization. T_max=30 gives ~17 restart cycles in 500 epochs, which is the optimal frequency. Now ALL T_max values tested: 15 (4.406%), 20 (4.943%), 30 (3.833% champion), 45 (4.638%), 50 (diverge), 60 (4.409%). T_max=30 is definitive DM sweet spot.
+
 ## 2026-04-23 23:30 — PR #3163: DM attn-dropout=0.05 + EMA+gc (shouko) — CLOSED (dead end)
 
 - Best val=10.118% ep73 (W&B: j0t5bn67), 2.64x worse than 3.833%. Catastrophic divergence ep74 — grad_norm→Infinity, gc=0.5 firing every step (394 clip events/epoch) but couldn't contain compounding dropout noise. Final val=75.33%. EMA preserved ep73 checkpoint. Confirms attn-dropout incompatible with DM at any stability level: without EMA/gc → 12.533% (#3113), with EMA/gc → 10.118% (19% better early but same ultimate fate). The multiplicative noise from dropout compounds faster than gc can clip as the loss landscape steepens at cosine restart boundaries. Added to dead ends.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 13:30 — PR #3068: DM 64k surface points (brook) — SENT BACK
+
+- Original run (no fix): 12.10% ep55, timeout (W&B: `ekrddnwe`). Retry no-gc: 16.91% ep30, diverged (W&B: `7gg7iqw8`). Retry gc=1.0: **5.26% ep236**, terminal diverge ep277 (W&B: `7uvkow6r`). All runs WITHOUT EMA — unfair comparison to 3.833% champion. gc=1.0 insufficient (diverged); need gc=0.5+EMA=0.9995. Sent back for re-run on champion platform. 64k direction not dead — 28% more surface coverage per sample may still improve quality.
+
 ## 2026-04-23 13:00 — PR #3131: DM OneCycleLR schedule (sanji) — CLOSED
 
 - max_lr=5e-4: 8.040% ep~190 then diverged to 51.4% (W&B: `ed60ojeo`). max_lr=1e-3: 8.041% ep~125 then diverged to 65.5%/NaN (W&B: `24r056y4`). Both WITHOUT EMA+gc (old regime). OneCycleLR's sustained high-LR warmup more damaging than cosine peaks — no periodic recovery troughs. 2x worse than old 3.997% baseline. Confirms cosine troughs are load-bearing for DM stability.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 18:30 — PR #3159: DM 4L/640d wider on EMA+gc champion (franky) — CLOSED
+
+- 640d: best val=8.636% ep81 (W&B: `yccjqzbi`), catastrophic divergence ep82 → 86% terminal. gc=0.5 clipped every batch but couldn't contain gradient explosion. grad_norm_mean=Infinity confirmed. EMA+gc delayed divergence vs prior 640d attempt (gojo #3079, ep28) but didn't prevent it. 640d at lr=5e-4 is fundamentally incompatible. Bug fix: primary_metric_key shadowing.
+
+## 2026-04-23 18:30 — PR #3158: DM lr=4e-4/4.5e-4 under EMA+gc (bulma) — CLOSED
+
+- lr=4e-4: 5.924% ep175 (+54.5%, W&B: `zq5czggz`). lr=4.5e-4: 4.134% ep429 (+7.9%, W&B: `2ddsixfm`). Steep monotonic cliff below lr=5e-4 — EMA regime does NOT shift LR optimum downward. Lower LR converges too slowly and gets destroyed at cosine restart peaks. Gradient points upward: lr>5e-4 is the unexplored direction. Bug fix: primary_metric_key shadowing.
+
 ## 2026-04-23 18:00 — PR #3068: DM 64k surface points (brook) — CLOSED
 
 - 64k points + EMA=0.9995 + gc=0.5: surface_rel_l2=12.16% (W&B: `j2p2i1c0`). Prior 64k without EMA+gc: 8.18%. Adding EMA+gc on 64k made it WORSE — structural instability compounds. 50k remains the only viable surface point count for DM. Full surface point investigation complete: 16k=11.672%, 32k=7.558%, 64k=12.16%, all dead vs 50k=3.833% baseline.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,23 @@
 # SENPAI Research Results
 
+## 2026-04-24 03:15 — PR #3220: DM Mixup regularization (nobara) — CLOSED (dead end)
+
+- nobara/dm-mixup, W&B group: dm-mixup
+- Hypothesis: latent-space Mixup (buffer-based for bs=1 DM) regularizes learned manifold
+- Trial 1 (alpha=0.2, W&B: m39js3jn): best val=8.031% ep221, crashed to 29.2% — 110% worse than 3.833%
+- Trial 2 (alpha=1.0, W&B: 0h81e7tw): best val=7.096% ep232, crashed to 56.1% — 85% worse
+- **Root cause: buffer staleness + non-smooth latent space.** Mixing current latents with stale-checkpoint latents creates incoherent targets. Transolver's slice-attention learns geometry-specific decompositions that don't interpolate between cars.
+- **Conclusion: Mixup dead for DM.** Structural incompatibility with bs=1 + geometry-specific latent space. Buffer approach fundamentally flawed.
+
+## 2026-04-24 03:15 — PR #3222: AF proximity-weighted volume loss (rei) — CLOSED (dead end)
+
+- rei/af-proximity-volume-weighting, W&B group: af-proximity-vol
+- Hypothesis: weight volume loss inversely proportional to surface distance to focus on boundary layer
+- Trial 1 (inverse-distance eps=0.01, W&B: aoecdk20): surface +647%, vol +2516% worse
+- Trial 2 (exponential scale=0.1, W&B: 9n27zxp2): surface +118%, vol +1766% worse
+- **Root cause: extreme weight ratios.** exp(-d/0.1) assigns zero weight to points >0.7 normalized distance from surface, starving far-field gradients. Since eval uses uniform MSE, undertrained far-field dominates error. 355 gradient clip events in T2 = every step.
+- **Conclusion: proximity weighting dead for AF at these scales.** Structural gradient starvation. Much softer weighting (scale=1-2) or additive auxiliary BL loss (avoid touching main loss) could be tried separately.
+
 ## 2026-04-24 03:00 — PR #3198: TFP asinh pressure scale ablation 0.75/0.5 (gohan) — CLOSED (dead end)
 
 - gohan/tfp-asinh-pressure

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:00 — PR #3258: DM auxiliary surface normal prediction (emma) — CLOSED (dead end)
+
+- emma/dm-aux-normal-prediction, W&B runs: fkiz67ki (w=0.1), g9zs1wsh (w=0.01), group: dm-aux-normal-prediction
+- Hypothesis: multi-task regularization via predicting surface normals as auxiliary target
+
+| Trial | Aux weight | best val_pct | vs baseline | Epochs |
+|-------|-----------|-------------|-------------|--------|
+| T1 | 0.1 | 4.724% | +23% | 202 (timeout) |
+| T2 | 0.01 | 4.661% | +22% | 212 (timeout) |
+
+- **Root cause (dual):** (1) Input leakage — normals already in input features, aux head learns trivial reconstruction (aux_loss collapses to <0.001 in 30-50ep). (2) Epoch starvation — aux head overhead limits runs to ~200 vs 511 epochs.
+- **Conceptual flaw:** Predicting inputs from latent ≠ meaningful information bottleneck. The task is trivially solvable and provides no regularization signal.
+
 ## 2026-04-24 10:45 — PR #3244: DM paper-facing full eval (faye) — SENT BACK (strategy change)
 
 - faye/dm-paper-facing-full-eval, W&B run: l7jxns6d, group: dm-paper-facing

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,20 @@
 # SENPAI Research Results
 
+## 2026-04-24 14:00 — PR #3262: DM learnable register tokens (megumi) — CLOSED (dead end)
+
+- megumi/dm-register-tokens, W&B runs: x2dp3s92 (N=2), jr1s77um (N=4), 3ftciy41 (N=8), group: dm-register-tokens
+- Hypothesis: register tokens (Darcet et al. 2024) absorb attention sinks, reducing systematic spatial bias
+
+| Trial | N | best val_pct | Epoch at best | Total epochs | Outcome |
+|-------|---|-------------|---------------|--------------|---------|
+| N=2 | 2 | 13.143% | 49 | 482 | NaN diverged ep114 |
+| N=4 | 4 | 10.010% | 62 | 481 | NaN diverged ep163 |
+| N=8 | 8 | 4.062% | 470 | 474 | Finished |
+
+**Conclusion:** Register tokens are a category error for Transolver. Darcet et al. documented attention sinks in ViTs with dense pairwise attention, but Transolver uses slice-based soft-clustering attention where the sink mechanism doesn't apply. N=8 preserved throughput (474 epochs) but converged to a 6% worse optimum. N=2/N=4 diverged to NaN at cosine restart boundaries. Student correctly identified the architectural mismatch.
+
+---
+
 ## 2026-04-24 13:35 — PR #3273: DM Grouped Query Attention (gojo) — CLOSED (dead end)
 
 - gojo/dm-grouped-query-attention, W&B runs: rq2tz9hh (2KV), wbygalr3 (4KV), group: dm-gqa

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 05:30 — PR #3217: DM Fourier-encoded surface normals (brook) — CLOSED (dead end)
+
+- brook/dm-fourier-normals, W&B group: dm-fourier-normals
+- Hypothesis: Fourier encoding of surface normals (like positional encoding for coordinates) gives richer geometric info for high-curvature regions
+- Trial 1 (4 bands, +24 dims, W&B: xwcdmp8k): val=4.374% ep274, test=5.103%. Diverged catastrophically after ep274, terminal val ~53.7%
+- Trial 2 (2 bands, +12 dims, W&B: jiaqu42c): val=4.454% ep317, test=5.021%. Diverged after ep317, terminal val ~75.0%
+- **Root cause: surface normals are unit vectors in [-1,1] with angular semantics — unlike unbounded spatial coordinates, they don't benefit from Fourier lifting.** The NeRF analogy doesn't transfer. More bands = earlier divergence (expanded input dims amplify gradients at cosine restart peaks).
+- **Conclusion: Fourier normals dead for DM.** Raw float normals already carry the geometric curvature information. No path to recovery.
+
 ## 2026-04-24 05:00 — PR #3164: DM paper-facing full eval two-phase (faye) — CLOSED (did not reproduce champion)
 
 - faye/dm-ema-paper-fulleval, W&B: qd7g8npf (Phase 1 training), 37gsknn6 (Phase 2 full eval)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 11:00 — PR #3127: DM attention heads 4H/16H (senku) — CLOSED
+
+- 4H: 11.02% ep54 (W&B: `v51k5hkn`). 16H: 13.83% ep77 (W&B: `yxldhqli`). Both with recurring gradient instability (no gc/EMA). 8H uniquely stable at 512d under old regime. 4H+EMA+gc assigned as #3165; 16H+EMA+gc in-flight as griffith #3160.
+
 ## 2026-04-23 10:30 — PR #3125: DM SWA at cosine troughs (faye) — CLOSED
 
 - Raw model best 14.30% ep89, SWA average degraded to 88.98% over 16 collections (W&B: `hgnyelv3`). Without gc/EMA, gradient explosions scatter weights across incompatible basins; SWA equal-weight averaging then poisons the average. EMA champion (#3072) subsumes SWA benefit via continuous averaging.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,23 @@
 # SENPAI Research Results
 
+## 2026-04-24 07:30 — PR #3225: DM self-distillation via EMA teacher (canute) — CLOSED (dead end)
+
+- canute/dm-self-distillation, W&B runs: 1df67nu8 (α=0.3), r8c2ztmm (α=0.1), group: dm-self-distillation
+- Hypothesis: EMA model as soft-target teacher for online model, loss = (1-α)*MSE(pred,target) + α*MSE(pred,ema_pred)
+- Trial A (α=0.3): val=6.446% ep159, diverged ~ep170. +68% vs baseline
+- Trial B (α=0.1): val=4.323% ep335, diverged ~ep400. +12.8% vs baseline
+- **Structural flaw: EMA=0.9995 creates ~2000-step teacher lag → destabilizing feedback loop in late training.** Higher α → earlier divergence (clean monotonic relationship). The distillation term overcomes gc=0.5 and sends grad norms to infinity.
+- **Conclusion: self-distillation dead for DM.** Same EMA for checkpoint tracking and distillation is fundamentally incompatible. Would need separate lower-decay EMA teacher + alpha decay schedule — a substantially different approach.
+
+## 2026-04-24 07:30 — PR #3223: AF volume smoothness regularization (norman) — CLOSED (dead end)
+
+- norman/af-volume-smooth-regularization, W&B runs: 6oo3dn4f, q2zyfwfg, 6dqv5rod, wr3xsn6u
+- Hypothesis: KNN-based spatial smoothness penalty on volume predictions encourages physically smooth fields
+- 4 trials (2 formulations × 2 lambda/k settings): ALL regressed BOTH metrics. Surface 44-94% worse, volume 60-97% worse
+- Best trial (Form A, λ=0.01, k=4): surface=0.000426 (+44%), vol=0.004791 (+88%)
+- **Root cause: KNN Euclidean smoothness is physically misaligned.** BL, wakes, shear layers have legitimate sharp gradients. Penalty suppresses real physics. Gradient interference from shared backbone also corrupts surface gradients.
+- **Conclusion: volume smoothness reg dead for AF.** Even λ=1e-4 harmful. Mesh-topology-aware or residual-gradient approaches would be fundamentally different.
+
 ## 2026-04-24 07:00 — PR #3224: DM spectral normalization on attention (fern) — CLOSED (dead end)
 
 - fern/dm-spectral-norm, W&B run: 4ylvrt7k, group: dm-spectral-norm

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,68 @@
 # SENPAI Research Results
 
+## 2026-04-23 01:50 — PR #3094: TFP 4L/192d depth at champion config (robin) — CLOSED
+
+- **Branch:** robin/tfp-4l-192d-depth
+- **Hypothesis:** 4L/192d (deeper than 3L champion) at full champion optimizer config might improve TFP
+- **Results:**
+
+| Metric | 4L/192d | 3L/192d Baseline |
+|---|---|---|
+| val_primary/field_mse | **Infinity** (all 140 eps) | 0.002383 ep443 |
+| Divergence onset | ep116 | ep462 |
+| val/surface_mse_Ux | 0.001558 ep114 | — |
+
+- **W&B run:** x982sfdv
+- **Analysis:** Pressure channel overflows via asinh transform — velocity channels converge normally (Ux=0.00156 competitive). T_max=10 cycling too aggressive for 4L. Diverged 3.7x earlier than 3L champion. 4L needs separate LR/T_max tuning.
+- **Decision:** CLOSED — val_primary/field_mse never finite
+
+## 2026-04-23 01:50 — PR #3091: TFP gc=0.7 at champion config (nobara) — CLOSED
+
+- **Branch:** nobara/tfp-gc-07
+- **Hypothesis:** Higher gc (0.7 vs champion 0.5) provides tighter gradient control
+- **Results:**
+
+| Metric | gc=0.7 | gc=0.5 Baseline |
+|---|---|---|
+| val_primary/field_mse | **Infinity** (all 177 eps) | 0.002383 ep443 |
+| Divergence onset | ep142 | ep462 |
+| Terminal grad norm | 1,326 | — |
+
+- **W&B run:** e0am2f3z
+- **Analysis:** gc=0.7 is strictly worse. Diverged 3x earlier (ep142 vs ep462). Relaxing gc beyond 0.5 destabilizes Lion+T_max=10 on TFP. gc=0.5 is the stability boundary — tighter (gc=0.3) is the promising direction.
+- **Decision:** CLOSED — val_primary/field_mse never finite
+
+## 2026-04-23 01:50 — PR #3087: TFP T_max=15 at champion config (mitsuha) — CLOSED
+
+- **Branch:** mitsuha/tfp-tmax-15
+- **Hypothesis:** Longer cosine period (T_max=15 vs champion 10) delays late-training divergence
+- **Results:**
+
+| Metric | T_max=15 | T_max=10 Baseline |
+|---|---|---|
+| val_primary/field_mse | **Infinity** (all 176 eps) | 0.002383 ep443 |
+| Divergence onset | ep124 | ep462 |
+
+- **W&B run:** tqirkf0l
+- **Analysis:** Falsified in opposite direction. T_max=15 diverged 3.5x earlier. Longer cosine extends LR peak phase, compounding pressure channel instability via asinh overflow. T_max=10 confirmed as sharp optimum for TFP.
+- **Decision:** CLOSED — val_primary/field_mse never finite
+
+## 2026-04-23 01:50 — PR #3060: DrivAerML bilateral symmetry augmentation (levi) — CLOSED
+
+- **Branch:** levi/dm-bilateral-symmetry-augmentation
+- **Hypothesis:** Reflecting car geometries left-right doubles effective training data (400→800 cases)
+- **Results:**
+
+| Run | Best val surface_rel_l2_pct | vs Baseline |
+|---|---|---|
+| Aug ON | 14.01% ep50 | +250% worse |
+| Control | 8.34% ep75 | +109% worse (undertrained) |
+| Baseline | 3.997% ep467 | — |
+
+- **W&B runs:** d76aehil (aug), e9sf9fwv (control)
+- **Analysis:** Stochastic per-batch flipping creates distributional variance that compounds gradient instability at T_max=30 LR peaks — 31 spike epochs vs 4 in control. Symmetry axis is valid (y-center within ±0.001) but implementation needs stabilization. Pre-generated mirrored copies as permanent dataset entries would be a better approach.
+- **Decision:** CLOSED — augmentation harmful due to gradient instability
+
 ## 2026-04-23 01:20 — PR #3082: DrivAerML T_max=40 cosine schedule (historia) — CLOSED
 
 - **Branch:** historia/dm-tmax-40

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,19 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:45 — PR #3239: AF additive boundary-layer auxiliary volume loss (vegeta) — CLOSED (dead end)
+
+- vegeta/af-bl-auxiliary-loss, W&B runs: 6y7xod45 (bl-w=1.0,t=0.05), 7w4btwaj (bl-w=0.5,t=0.05), pjrv0090 (bl-w=1.0,t=0.10)
+- Hypothesis: auxiliary volume loss targeting near-wall cells (SDF < threshold) provides focused BL supervision
+
+| Trial | Config | surface_mse | vs baseline | vol_mse | vs baseline |
+|-------|--------|-------------|-------------|---------|-------------|
+| T1 | bl-w=1.0, t=0.05 | 0.000448 | +51% | 0.004213 | +107% |
+| T2 | bl-w=0.5, t=0.05 | 0.000494 | +67% | 0.002664 | +31% |
+| T3 | bl-w=1.0, t=0.10 | 0.000972 | +228% | 0.006162 | +202% |
+
+- **Root cause:** AF wall-resolved meshes have SDF<0.05 covering 61% of ALL volume points, SDF<0.10 covering 68%. "BL targeting" becomes near-uniform volume upscaling. Same failure mode as proximity-weighting (#3222).
+- **Pattern confirmed:** Any SDF-based volume re-weighting fails on AF meshes because the mesh itself is already an SDF-weighted sampler. Two independent confirmations now (#3222 + #3239).
+
 ## 2026-04-24 09:30 — PR #3238: AF WD=0 ablation on vol-10x+EMA champion (rei) — SENT BACK
 
 - rei/af-wd0-ablation, W&B runs: sqotwbxs (WD=0), cjcftqo8 (WD=5e-3), group: af-no-wd

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 03:00 — PR #3198: TFP asinh pressure scale ablation 0.75/0.5 (gohan) — CLOSED (dead end)
+
+- gohan/tfp-asinh-pressure
+- Hypothesis: asinh pressure normalization alone (without physics stack) can stabilize TFP pressure
+- Trial 1 (asinh-0.75, W&B: 08s8cxns): field_mse=0.775 apparent best ep324, but 60/554 steps Inf (chaotic transient). Terminal 9.05e+08. ~325x worse than 0.002383 baseline
+- Trial 2 (asinh-0.50, W&B: pqawyn4k): field_mse=34,047 ep501 — 14M x worse
+- **NOT caused by cp_panel code regression** — runs don't use physics stack. This is a clean result.
+- **Root cause: without residual prediction + pressure prior, sinh() denormalization exponentially amplifies pressure errors.** Velocity channels (Ux, Uy) healthy; failure entirely pressure-specific.
+- **Conclusion: asinh alone incompatible with TFP.** Requires full physics stack scaffolding to constrain pressure prediction.
+
 ## 2026-04-24 02:30 — PR #3214: DM auxiliary surface gradient prediction (kakashi) — CLOSED (dead end)
 
 - kakashi/dm-auxiliary-gradient, W&B group: dm-auxiliary-gradient

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 12:45 — PR #3259: DM curvature-weighted loss (zenitsu) — CLOSED (dead end)
+
+- zenitsu/dm-curvature-weighted-loss, W&B runs: rwkptewj (alpha=1.0), 434enoo9 (alpha=0.5), group: dm-curvature-weighted-loss
+- Hypothesis: weighting MSE by local surface curvature focuses learning on high-curvature regions (edges, junctions)
+
+| Trial | alpha | best val_pct | vs baseline | Outcome |
+|-------|-------|-------------|-------------|---------|
+| T1 | 1.0 | 4.482% | +17% | Catastrophic divergence ep300 (final 70.75%) |
+| T2 | 0.5 | 11.602% | +203% | Diverged ep53 (final 72.44%) |
+
+- **Dual root cause:** (1) Train/eval mismatch — curvature weighting optimizes a different objective than the uniform relative-L2 metric. (2) Curvature weights amplify gradient variance at cosine restarts → explosive divergence. Lighter alpha diverged FASTER (shallower basin, less restart-tolerant).
+- **Conclusion:** Any static geometry-based per-point loss weighting creates structural misalignment with the uniform evaluation metric.
+
 ## 2026-04-24 12:15 — PR #3254: AF multi-seed champion run (norman) — CLOSED (diagnostic, no winner)
 
 - norman/af-multi-seed-champion, W&B runs: 69bgiyis (seed=42), v3bl8pgv (seed=123), cv4fdye6 (seed=789), group: af-multi-seed

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,48 @@
 # SENPAI Research Results
 
+## 2026-04-24 01:15 — PR #3191: AF noam features (asinh+residual+re-strat) on base and vol-10x (alphonse) — CLOSED (dead end)
+
+- alphonse/af-noam-features, W&B group: af-noam-features-base
+- Hypothesis: noam features (asinh-pressure, residual-prediction, re-stratified-sampling) transfer to AirfRANS
+- Trial 1 (no vol-weight, W&B: wvdm76ep): surface_mse=0.646 (1408x worse than 0.000459), vol_mse=Inf — catastrophic
+- Trial 2 (vol-10x, W&B: rmg1uigw): surface_mse=0.611 (2063x worse than 0.000296), vol_mse=Inf — catastrophic
+- **Root cause: sinh() denormalization exponentially amplifies pressure errors on AF.** Non-pressure channels (Ux, Uy, nut) converge fine. Failure is entirely pressure-specific via asinh-pressure feature.
+- **Conclusion: asinh-pressure is DEFINITIVELY incompatible with AirfRANS.** Combined with nezuko #3177 (3 asinh trials → Inf) = 5 independent confirmations. Added to AF dead ends. Bug fix: primary_metric_key shadowing noted.
+- Student suggestion: test residual-prediction + re-stratified WITHOUT asinh — high value follow-up.
+
+## 2026-04-24 01:15 — PR #3189: TF asinh+physics features, no ANP, no T_max change (emma) — CLOSED (dead end)
+
+- emma/tf-asinh-residual-physics, W&B group: tf-noam-features-no-anp
+- Hypothesis: isolate contribution of physics features (wake-deficit, wake-angle, cp-panel, vortex-panel) + asinh normalization on TF without ANP
+- Trial 1 (full physics, W&B: 7kdfc3by): val=22.423 ep311, test=23.427 — +5.2% worse than 21.319 baseline
+- Trial 2 (norm only, W&B: qfycb0ww): val=22.911 ep324, test=24.365 — +7.5% worse
+- **Confound: both trials omitted --enable-pressure-prior-addition** which champion uses. Cannot attribute regression to physics features vs missing pressure prior.
+- Physics features do add modest benefit (+0.49 MAE improvement T1 vs T2).
+- **Conclusion: experiment confounded. TF needs pressure-prior-addition.** geom_camber_rc remains hardest split (val ~34-36 vs ~12 for cruise).
+
+## 2026-04-24 01:15 — PR #3177: AF vol-weight 15x/20x + asinh+residual compound push (nezuko) — CLOSED (dead end)
+
+- nezuko/af-vol-weight-compound-push, W&B group: af-vol-weight-compound
+- Hypothesis: compound higher vol-weight + asinh + residual to break vol_mse < 0.0017
+- 6 trials total (3 instructed + 3 fallback):
+  - Trials 1-3 (with asinh): ALL catastrophic — vol_mse_p → Inf (pressure volume explosion)
+  - Trial 4 (15x no-asinh, W&B: m2p9bi0f): crashed ep325, vol_mse=0.005437 best
+  - Trial 5 (20x no-asinh, W&B: vt5yzmm7): surface=0.000304 ep665, vol=0.002689 ep653 — still running ep699 but won't reach baseline
+  - Trial 6 (10x no-asinh, W&B: z1n4yt1k): crashed ep108
+- **Key finding: non-monotonic stability** — 10x crashed, 15x crashed at LR peak, 20x stable through ep700+. Heavier vol-weight paradoxically dampens pressure gradient oscillations at cosine peaks.
+- Best result: surface=0.000304 (+2.7%), vol=0.002689 (+31.9%) — neither beats baseline.
+- **Conclusion: asinh-pressure confirmed broken for AF volume fields (3 more confirmations = 5 total). 20x vol-weight is stable but slow to converge.**
+
+## 2026-04-24 01:15 — PR #3172: AF LR warmup 5ep/10ep + EMA (robin) — SENT BACK (confounded)
+
+- robin/af-warmup-ema
+- Hypothesis: linear LR warmup before cosine annealing improves AF training stability
+- Trial 1 (5ep warmup, W&B: p7xqdmxx): surface=0.000312, vol=0.004723, diverged ep586
+- Trial 2 (10ep warmup, W&B: gcc0sb6p): surface=0.000333, vol=0.003189, stable
+- Neither beats baseline (surface=0.000296, vol=0.002039).
+- **Confound: used 8H (not champion's 4H) and omitted vol-loss-weight=10x.** Experiment uninterpretable — warmup hypothesis untested, not disproven.
+- Sent back with corrected config: exact champion + --warmup-epochs 5 as only change.
+
 ## 2026-04-24 00:30 — PR #3216: DM attention distance bias ALiBi-inspired (canute) — CLOSED (dead end)
 
 - Linear bias: 12.144% ep45, diverged ep90 (W&B: 306ayrb2). Log bias: 5.511% ep169, stable but still converging at timeout (W&B: pbnxsdha). Neither beats 3.833%. Alpha values barely moved from init — distance prior redundant with existing Transolver slice-based spatial grouping.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,35 @@
 # SENPAI Research Results
 
+## 2026-04-24 14:30 — PR #3260: DM learnable Fourier encoding frequencies (casca) — CLOSED (dead end)
+
+- casca/dm-learnable-fourier-freqs, W&B runs: wss8o89v (T1 default init), 6cg34qtr (T2 wide init), group: dm-learnable-fourier
+- Hypothesis: making Fourier encoding frequencies learnable (nn.Parameter) lets the model adapt spatial encoding to DrivAerML's specific scale structure
+
+| Trial | Init | best val_pct | Epoch at best | Outcome |
+|-------|------|-------------|---------------|---------|
+| T1 default [0.5,2,8,32] | baseline | 5.262% (ep179) | 179 | Diverged post-cosine-restart, terminal 53.1% |
+| T2 wide [0.1,1,10,100] | wider | 4.252% (ep371) | 371 | Diverged post-cosine-restart, terminal 72.2% |
+
+**Conclusion:** Both diverge catastrophically. Key diagnostic: frequencies barely moved from initialization in T2 (terminal [0.05,1.53,10.03,99.73] vs init [0.1,1,10,100]). Fixed frequencies are already near-optimal for DrivAerML. Learnable freq + cosine LR restarts = cascading perturbation feedback loop. No variant worth pursuing.
+
+---
+
+## 2026-04-24 14:30 — PR #3244: DM paper-facing full eval (faye) — SENT BACK (need champion checkpoint eval)
+
+- faye/dm-paper-eval, W&B runs: l7jxns6d (naive full-eval), rzx46x2j (Phase 1 batch-limited), f7f1kmcz (Phase 2 full-eval)
+- Purpose: obtain paper-facing full-eval metrics for DM champion (no --max-eval-batches)
+
+| Phase | W&B run | val_pct | test_pct | eval method | Outcome |
+|-------|---------|---------|----------|------------|---------|
+| Phase 0 (naive) | l7jxns6d | 12.356% (ep50) | 11.881% | full eval | Timeout after 50 epochs |
+| Phase 1 (train) | rzx46x2j | 3.966% (ep403) | — | batch-limited 200 | Crashed ep417 (grad norm 7449) |
+| Phase 2 (eval) | f7f1kmcz | 4.933% | 4.496% | full eval | Checkpoint from Phase 1 ep403 |
+| Champion | ncl1dh88 | 3.833% (ep511) | 4.685% | batch-limited 200 | Reference |
+
+**CRITICAL FINDING:** Batch-limited eval is ~24% optimistic for val (3.966% batch-limited → 4.933% full-eval). This means our 3.833% baseline is likely ~4.8% under full eval. Sent back to run full eval on the actual champion ep511 checkpoint (not the ep403 crash-truncated version).
+
+---
+
 ## 2026-04-24 14:00 — PR #3262: DM learnable register tokens (megumi) — CLOSED (dead end)
 
 - megumi/dm-register-tokens, W&B runs: x2dp3s92 (N=2), jr1s77um (N=4), 3ftciy41 (N=8), group: dm-register-tokens

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,24 @@
 # SENPAI Research Results
 
+## 2026-04-24 15:30 — FLEET RESTRUCTURING per Issue #3283 (Last Ditch Benchmark Push)
+
+**14 experiments KILLED to reallocate fleet to 36 DM / 12 AF / 11 TFP / 0 TF:**
+
+DM kills: #3280 jet (per-channel heads, surface is single cp), #3281 megumi (MoE output, directive), #3181 himmel (asinh+residual, noam dead), #3067 askeladd (32k surface, directive says denser only)
+AF kills: #3274 norman (Lion), #3172 robin (warmup), #3169 nami (heads sweep), #3129 chrome (4L/256d depth), #3261 nezuko (2L/320d width), #3187 stark (asinh), #3184 wolfwood (noam stack), #3268 jin (higher LR), #3144 violet (vol-weight=2)
+TF kills: #3150 yuji (TF frozen)
+
+**15 new assignments:**
+- vegeta #3284: HARNESS PATCHES (highest priority infrastructure)
+- DM champion recovery: jet #3285 (seed=42), megumi #3286 (seed=7), norman #3293 (seed=0 ncl1dh88 replica)
+- DM surface density: himmel #3289 (64k), askeladd #3290 (96k)
+- DM gradient-safe: robin #3294 (gc=0.25)
+- DM narrow schedule: nami #3297 (T_max=24), chrome #3298 (T_max=36)
+- TFP haku replication: nezuko #3287 (seed=0), stark #3288 (seed=42), wolfwood #3291 (seed=7), yuji #3292 (seed=123)
+- AF vol-weight sweep: jin #3295 (vol-weight=8), violet #3296 (vol-weight=9)
+
+---
+
 ## 2026-04-24 14:30 — PR #3260: DM learnable Fourier encoding frequencies (casca) — CLOSED (dead end)
 
 - casca/dm-learnable-fourier-freqs, W&B runs: wss8o89v (T1 default init), 6cg34qtr (T2 wide init), group: dm-learnable-fourier

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 02:05 — PR #3073: DrivAerML EMA=0.999 + gc=0.5 compound (faye) — CLOSED
+
+- **Branch:** faye/dm-ema-999-gc05-compound
+- **Hypothesis:** EMA + gc synergy — gc prevents gradient spikes while EMA smooths checkpoint sequence
+- **Results:**
+
+| Metric | Value | vs Baseline |
+|---|---|---|
+| Best val surface_rel_l2_pct | 9.953% ep113 | +149% worse |
+| Run state | Crashed ep191 | — |
+| Baseline | 3.997% ep467 | — |
+
+- **W&B run:** x3wvqyqa
+- **Analysis:** gc=0.5 insufficient — gradient spikes of 293 (ep64) and 153 (ep118) broke through clip threshold. Terminal divergence at ep136 with grad_norm=Infinity. EMA now tested in 3 configs on DM: alone=9.749%, +gc=9.953%, +gc+WD=crash. All dramatically worse than no-EMA champion. EMA is definitively contraindicated for DrivAerML.
+- **Decision:** CLOSED — 149% above baseline, crashed
+
 ## 2026-04-23 01:50 — PR #3094: TFP 4L/192d depth at champion config (robin) — CLOSED
 
 - **Branch:** robin/tfp-4l-192d-depth

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,29 @@
 # SENPAI Research Results
 
+## 2026-04-24 16:15 — PR #3276: DM cosine similarity auxiliary loss (zenitsu) — CLOSED (dead end)
+
+- zenitsu/dm-cosine-sim-aux-loss, W&B runs: ry1lq2vw (w=0.1), flnnss55 (w=0.5), group: dm-cosine-sim-loss
+- Hypothesis: cosine similarity aux loss captures spatial pattern fidelity that MSE misses
+
+| Trial | Weight | best val_pct | Epoch | Outcome |
+|-------|--------|-------------|-------|---------|
+| T1 | 0.1 | 4.661% | 241 | Crashed ep244 — NaN at cosine restart |
+| T2 | 0.5 | 6.569% | 109 | Crashed ep159 — gradual divergence |
+
+**Conclusion:** Cosine similarity saturates >0.99 by epoch ~100 — the model already learns spatial patterns from MSE alone. Cos_sim loss is informationally redundant. Near-unity cos_sim makes (1-cos_sim) gradients ill-conditioned at LR restart boundaries, causing divergence. Zenitsu reassigned to Breakout 4 (coord normalization, #3299).
+
+---
+
+## 2026-04-24 16:15 — PR #3284: Harness patches (vegeta) — SENT BACK (merge-blocking bug)
+
+- vegeta/harness-patches-last-ditch, changes to train.py (+215/-37)
+- 5/6 patches implemented: --load-checkpoint, --eval-interval, --ema-mode fixed|warmup, --skip-update-grad-norm, --save-checkpoint
+- 3/5 kill gates implemented: --kill-if-best-val-above, --kill-if-no-improvement, --kill-if-grad-nonfinite-steps
+- **Merge-blocking bug:** double best-tracking chains — --save-checkpoint saves from chain 2 but final eval restores from chain 1. Different epochs can be selected. Sent back with specific fix instructions.
+- Missing: --kill-if-metric-above, --kill-if-nonfinite-metric (deferred)
+
+---
+
 ## 2026-04-24 15:30 — FLEET RESTRUCTURING per Issue #3283 (Last Ditch Benchmark Push)
 
 **14 experiments KILLED to reallocate fleet to 36 DM / 12 AF / 11 TFP / 0 TF:**

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,19 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:15 — PR #3199: DM EMA=0.9999/0.99995 upward sweep (megumi) — CLOSED (dead end)
+
+- megumi/dm-ema-0.9999, W&B runs: c168t4dq (EMA=0.9999), 26n0lcmg (EMA=0.99995)
+- Hypothesis: higher EMA decay (slower shadow update) might find a deeper basin by reducing noise in the EMA weights
+
+| Trial | EMA | best val_pct | vs baseline | Diverged |
+|-------|-----|-------------|-------------|---------|
+| T1 | 0.9999 | 7.106% | +85% | NaN ep~171 |
+| T2 | 0.99995 | 7.095% | +85% | Collapse ep~120, plateau 83.56% |
+
+- **Mechanism:** Both values cause EMA shadow weights to lag too far behind the online model. Cosine LR peaks (T_max=30) produce gradient spikes that gc=0.5 can't contain when the gap between online and shadow is too large. Both floor at ~7.1% then diverge.
+- **Combined with #3152 (eren, EMA=0.999 sweep downward):** EMA=0.9995 is now bracketed as a sharp optimum — steep cliff in both directions. Not a broad plateau.
+- **Conclusion: EMA=0.9995 is the definitive DM optimum.** Dead end.
+
 ## 2026-04-24 09:00 — PR #3232: AF vol-weight warm-up schedule (nezuko) — CLOSED (dead end)
 
 - nezuko/af-vol-warmup, W&B runs: 9tc2udwf (200ep ramp), gp149j2g (100ep ramp), o8ifqyac (50ep ramp), group: af-vol-warmup

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 06:00 — PR #3237: DM snapshot ensemble at cosine troughs (nobara) — CLOSED (dead end)
+
+- nobara/dm-snapshot-ensemble, W&B group: dm-snapshot-ensemble, runs: cwg22dhi (single best), lcil8t4n (K=3), c8bn99m6 (K=5), lp19d8uo (K=6), c31seso3 (training)
+- Hypothesis: save EMA checkpoints at cosine LR troughs, average predictions at test time for variance reduction
+- Training run: val=4.807% ep193, then crashed ep214 (grad explosion: 0.19→0.50→3.25→100.4→6459 in 15 epochs). Never reached baseline quality.
+- Single best checkpoint (ep180): test=6.044% (+29% vs 4.685% baseline)
+- **Ensembling makes it WORSE monotonically:** K=3→6.238%, K=5→6.980%, K=6→7.810%. Quality gradient dominates — early checkpoints (ep30=17.3%) dilute later ones (ep180=5.0%)
+- **Root cause: EMA=0.9995 already provides implicit smoothing over ~2000 steps. Snapshot averaging on top of EMA adds noise, not signal.** Also, available snapshots were from a run that crashed before reaching baseline quality.
+- **Conclusion: snapshot ensemble dead for DM.** Requires similarly-capable checkpoints with diverse predictions — but single-run cosine trough checkpoints have dominant quality gradient.
+
 ## 2026-04-24 05:30 — PR #3217: DM Fourier-encoded surface normals (brook) — CLOSED (dead end)
 
 - brook/dm-fourier-normals, W&B group: dm-fourier-normals

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-24 00:30 — PR #3216: DM attention distance bias ALiBi-inspired (canute) — CLOSED (dead end)
+
+- Linear bias: 12.144% ep45, diverged ep90 (W&B: 306ayrb2). Log bias: 5.511% ep169, stable but still converging at timeout (W&B: pbnxsdha). Neither beats 3.833%. Alpha values barely moved from init — distance prior redundant with existing Transolver slice-based spatial grouping.
+
+## 2026-04-24 00:30 — PR #3192: DM asinh-pressure alone scale=0.75/0.5 (casca) — CLOSED (dead end — TRIPLE CONFIRMED)
+
+- scale=0.75: 4.072% (W&B: mh9wcdop), scale=0.5: 4.475% diverged ep310 (W&B: uzpui6j5). Neither beats 3.833%. Combined with hinata #3175 (asinh-only=4.421%) and franky #3193 (residual+asinh=3.999%), asinh is TRIPLE CONFIRMED harmful on DM. Signal compression hurts fine-grained surface learning. Added to dead ends.
+
+## 2026-04-24 00:30 — PR #3188: DM 2H/16H attention heads sweep (chihiro) — CLOSED (dead end)
+
+- 2H: 13.878% crashed ep40 (W&B: qcaxbz95). 16H: 4.099% diverged ep431 (W&B: 6n9i88a3). Neither beats 3.833%. ALL head counts now tested: 2H=catastrophic, 4H=6.650% diverge, 8H=3.833% champion, 16H=4.099% late-diverge. 8H (64d/head) is the definitive DM sweet spot.
+
+## 2026-04-24 00:30 — PR #3180: TF ANP decoder alone (chopper) — CLOSED (dead end)
+
+- ANP+T_max=10 gc=0.3: val=21.590 (W&B: eaat1lne). ANP+T_max=150 gc=0.3: val=22.057 (W&B: 4kwi4mv2). Neither beats old baseline (21.350) or new (#3185=21.319). ANP alone doesn't help TF — benefit requires full stack combination.
+
 ## 2026-04-24 00:15 — PR #3185: TF full noam stack (fern) — MERGED ✓ NEW TF CHAMPION
 
 - Trial 1 (full stack: ANP+physics+T_max=150+96sl+Lookahead+compile+re-strat): val=21.319 ep277, test=22.868 (W&B: v05jt92n). Beats baseline 21.350/23.195 on both metrics (-0.15% val, -1.41% test). Trial 2 (ANP+physics only, T_max=10): val=22.276 ep233 (W&B: anluw1ab), diverged ep289. Key insight: full-stack extras (Lookahead, compile, 96 slices, re-stratified) only compound in late training (after ep200). T2 led for first 180 epochs. T_max=150 essential for full benefit. New TF config: Lion lr=1.25e-4, T_max=150, gc=0.2, EMA=0.999, 96 slices, ANP+full physics+asinh-scale=0.75+residual+Lookahead+compile+re-strat.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-24 19:30 — PR #3244: DrivAerML paper-facing full eval (faye) — CLOSED (critical finding)
+
+- faye/dm-paper-facing-champion-full-eval
+- **AUTHORITATIVE PAPER-FACING TEST: 4.324%** (W&B run zx5syby1, full eval on ep517 checkpoint from w4ufs8m1)
+- Phase 1: champion recovery with --save-checkpoint, 524 epochs, best batch-limited val 3.900% at ep517 (vs champion 3.833% at ep511). Zero grad-skip events (threshold=500).
+- Phase 2: --load-checkpoint full eval (no --max-eval-batches): val=4.698%, test=4.324%
+- Batch-limited eval bias: val is ~0.8pp optimistic (3.900→4.698%), test is ~0.5pp PESSIMISTIC (4.859→4.324%)
+- Does not beat baseline val (3.900% > 3.833%), but provides the authoritative full-eval methodology.
+- **Faye assigned to #3303: compile-mode champion recovery**
+
+## 2026-04-24 19:30 — PR #3295: AF vol-weight=8 (jin) — CLOSED dead end
+
+- jin/af-vol-weight-8, W&B: kazfrlg7
+- surface_mse=0.000288 (-2.7% vs baseline 0.000296) but vol_mse=0.003171 (+55% vs 0.002039)
+- Trade-off non-linear: reducing vol-weight below 10 loses far more volume accuracy than it gains surface. Confirms vol-weight=10 is near Pareto front.
+- Lower bound of AF vol-weight sweep established at 8: no need to test below.
+- **Jin assigned to #3304: AF extended 600-min champion training**
+
+---
+
 ## 2026-04-24 19:00 — PR #3275: DrivAerML local/windowed attention (canute) — CLOSED dead end
 
 - canute/dm-local-attention

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 04:30 — PR #3219: DM SAM optimizer (hinata) — CLOSED (dead end)
+
+- hinata/dm-sam-optimizer, W&B group: dm-sam-optimizer
+- Hypothesis: SAM (Sharpness-Aware Minimization) wrapping AdamW finds flat basins robust to cosine LR restarts
+- Trial 1 (rho=0.05, W&B: 7z3a4ous): val=5.359% ep273, then catastrophic divergence at ep278+ (grad_norm=3.18, 353 clips at ep288). +40% worse than 3.833%
+- Trial 2 (rho=0.02, W&B: dn33cgny): val=9.082% ep97, crashed ep103 (grad_norm → 38.5M). +137% worse. Negative sharpness (-0.000166) at ep130 = SAM lost regularization effect
+- **Root cause: SAM's perturbation step compounds destructively with cosine LR restarts.** Double shock (LR jump + SAM perturbation) at restart boundaries. Also 2x compute penalty — only reached ep276-289 vs ~500 baseline epochs.
+- **Conclusion: SAM dead for DM.** Flat-basin hypothesis not disproven, but SAM is incompatible with rapid cosine restarts. SWA (averaging checkpoints across cycles) would avoid both compute penalty and restart-shock.
+
+## 2026-04-24 04:30 — PR #3207: DM true monotonic cosine T_max=393606 (historia) — CLOSED (dead end)
+
+- historia/dm-true-monotonic-cosine, W&B run: 6yiwl01x, group: dm-monotonic-cosine
+- Hypothesis: single half-cosine decay from lr=5e-4 to 0 over full 999 epochs (no restarts) removes restart-induced gradient perturbation, allowing smoother EMA accumulation
+- Result: val=4.086% ep519, test=4.390%. +0.253pp / +6.6% worse than 3.833% baseline
+- Training dynamics: clean smooth convergence, grad norms dropped 9.4→0.08, no instability. LR decayed to 2.46e-4 at ep521 (52% through cycle). Val plateauing well above baseline.
+- **Compared to PR #3154 (T_max=999 steps, accidental rapid cycling): meaningful improvement 4.086% vs 4.39%, but still can't match baseline's rapid restarts.**
+- **Conclusion: monotonic cosine dead for DM.** Confirms T_max=30 rapid restarts are a core mechanism, not noise. Beneficial gradient perturbation from restarts is essential.
+
+## 2026-04-24 04:30 — PR #3206: DM 600 batches + gc=0.5 + EMA stabilized (jet) — CLOSED (dead end)
+
+- jet/dm-600-batches-stabilized, W&B group: dm-data-efficiency
+- Hypothesis: 600 batches/epoch (+52% data per epoch) with full stability stack (gc=0.5+EMA=0.9995) finds deeper basins through greater car diversity per epoch
+- Trial 1 (T_max=46 proportional, W&B: pv8nchbg): val=11.451% ep46, NaN divergence from ep61. Cosine restart at ep46 catastrophic despite gc=0.5. +199% worse
+- Trial 2 (T_max=30 baseline schedule, W&B: wr1x3ked): val=3.887% ep378, stable. +0.054pp vs 3.833%. Time-limited at 378 epochs but ran 226,800 total batches vs baseline's 201,334 at best epoch
+- **Key analysis: Trial 2 saw more total data than baseline yet couldn't match it.** Late trajectory (3.92-4.06% at ep375) shows no sign of descending toward new minimum. Data diversity per epoch is not the bottleneck.
+- **Conclusion: 600 batches/epoch dead for DM.** 394 batches/epoch already saturates data diversity. Proportional T_max scaling (T_max=46) confirmed unstable at higher batch counts.
+- **Bug fix noted:** jet fixed primary_metric_key shadowing bug (also fixed independently by hinata and historia in their PRs).
+
 ## 2026-04-24 03:45 — PR #3203: DM attention temperature annealing (vegeta) — CLOSED (dead end)
 
 - vegeta/dm-attn-temp-annealing, W&B run: ybh108ny

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 06:30 — PR #3218: AF GradNorm adaptive multi-task loss balancing (shouko) — CLOSED (dead end)
+
+- shouko/af-gradnorm, W&B runs: p5b6fgoa (α=1.5), 93rkwc57 (α=0.5)
+- Hypothesis: GradNorm (Chen et al. 2018) learns task weights dynamically by balancing gradient magnitudes across surface/volume losses
+- Trial 1 (α=1.5): surface=0.000514 (1.74x worse), vol=0.005390 (2.64x worse), ep338. Final weights: w_surf=3.03, w_vol=7.97
+- Trial 2 (α=0.5): surface=0.000907 (3.06x worse), vol=0.004845 (2.38x worse), ep337. Final weights: w_surf=3.67, w_vol=7.33
+- **Structural problems:** (1) retain_graph=True breaks torch.compile → halves throughput → only 339 epochs vs baseline's 763. (2) GradNorm converges to w_volume~8x, systematically LOWER than hand-tuned 10x — fights against intentional asymmetry.
+- **Interesting insight:** GradNorm pushes w_surface from 1.0 toward 3.0-3.7, suggesting surface is "under-weighted" by gradient-norm standards. Worth noting for future experiments.
+- **Conclusion: GradNorm dead for AF.** Computational overhead + learned weights fighting the hand-tuned asymmetry = double structural failure.
+
 ## 2026-04-24 06:00 — PR #3237: DM snapshot ensemble at cosine troughs (nobara) — CLOSED (dead end)
 
 - nobara/dm-snapshot-ensemble, W&B group: dm-snapshot-ensemble, runs: cwg22dhi (single best), lcil8t4n (K=3), c8bn99m6 (K=5), lp19d8uo (K=6), c31seso3 (training)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,43 @@
 # SENPAI Research Results
 
+## 2026-04-23 05:30 — PR #3108: TandemFoil gc=0.3+EMA=0.999 (zenitsu) — MERGED ✓
+
+- **Branch:** zenitsu/tf-gc03-ema999
+- **Hypothesis:** Softer gc (0.3 vs 0.5) under EMA stability finds a deeper basin
+- **Results:**
+
+| Metric | gc=0.3 | gc=0.5 Baseline | Delta |
+|---|---|---|---|
+| val_primary/surface_pressure_mae | **21.909** ep334 | 22.537 ep336 | **-2.8% NEW BEST** |
+| test_primary/surface_pressure_mae | **23.419** | 24.581 | **-4.7%** |
+
+- **W&B run:** kzg626hf
+- **Decision:** MERGED — new TF champion (gc=0.3 continues the trend: 1.0→0.5→0.3 all improve)
+
+## 2026-04-23 05:30 — PR #3104: AF T_max=100 (vegeta) — CLOSED
+
+- surface_mse=0.000709 (+47% vs baseline). T_max sweep closed: T_max=50 is optimal on AF.
+
+## 2026-04-23 05:30 — PR #3103: AF T_max=30 (usopp) — CLOSED
+
+- surface_mse=0.000829 (+72% vs old baseline). Vol=0.004210 (-45% vs old, but +74% vs new post-#3050 baseline 0.002777).
+
+## 2026-04-23 05:30 — PR #3099: AF 3L/256d (spike) — CLOSED
+
+- surface=0.000663 (+38% vs old, +44% vs new). Vol=0.004851 (-36% old but +74% vs new 0.002777). Superseded by 2L+EMA (#3050) on both metrics.
+
+## 2026-04-23 05:30 — PR #3084: DM max-train-batches=788 (kakashi) — CLOSED
+
+- Best val 11.565% ep42 (+190%). Diverged catastrophically ep45 — T_max=30 halves effective cosine cycle with 2x batches, more frequent LR peak shocks without gc.
+
+## 2026-04-23 05:30 — PR #3079: DM 4L/640d+gc=0.5 (gojo) — SENT BACK
+
+- Best val 4.516% ep359, diverged ep436. Promising direction — WD+gc compound was the real crash culprit. Sent back with T_max=60 + lr=3e-4 instructions.
+
+## 2026-04-23 05:30 — PR #3069: DM 5-epoch warmup (chopper) — CLOSED
+
+- Best val 5.823% ep163 (+46%). Diverged ep523. Warmup doesn't prevent LR-peak divergence without gc.
+
 ## 2026-04-23 05:00 — PR #3050: AirfRANS EMA=0.999 at T_max=50 champion (stark) — MERGED ✓
 
 - **Branch:** stark/af-ema-champion

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,36 @@
 # SENPAI Research Results
 
+## 2026-04-23 03:55 — PR #3126: DrivAerML cosine eta_min sweep (gohan) — CLOSED
+
+- **Branch:** gohan/dm-cosine-eta-min
+- **Hypothesis:** Non-zero eta_min (1e-5, 5e-5) keeps optimizer active at cosine troughs
+- **Results:**
+
+| Run | eta_min | W&B ID | Best val surface_rel_l2_pct | Fate |
+|---|---|---|---|---|
+| Run 1 | 1e-5 | kg7eolnk | 7.584% ep112 | Diverged |
+| Run 2 | 5e-5 | 1n8peifp | 6.800% ep98 | Diverged |
+| Baseline | 0 | bht6h42t | 3.997% ep467 | — |
+
+- **Analysis:** Faster early convergence (confirming hypothesis direction) but both diverged — without eta_min=0's natural LR "rest" at troughs, gradient noise accumulates unchecked. ~40% of steps above 20% error. eta_min=5e-5 + gc=1.0 is the promising follow-up.
+- **Decision:** CLOSED — 70-90% above baseline, both diverged
+
+## 2026-04-23 03:55 — PR #3096: TFP lr=1e-4 at champion config (shinobu) — CLOSED
+
+- **Branch:** shinobu/tfp-lr-1e4
+- **Hypothesis:** Lower LR (1e-4 vs champion 1.25e-4) continues the TF improvement trend
+- **Results:**
+
+| Metric | lr=1e-4 | lr=1.25e-4 Baseline |
+|---|---|---|
+| val_primary/field_mse | **Infinity** (all 393 eps) | 0.002383 ep443 |
+| vol pressure finite epochs | 0/393 | — |
+| val/surface_mse_Ux | 0.00128 (healthy) | — |
+
+- **W&B run:** z63sarn6
+- **Analysis:** 20% lower LR causes pressure channel to never resolve within budget — asinh(sinh()) overflow persists all 393 epochs. Velocity channels converge normally, confirming this is a pressure convergence speed issue. LR=1.25e-4 is near the minimum viable LR for TFP with current architecture.
+- **Decision:** CLOSED — Infinity field_mse, pressure never finite
+
 ## 2026-04-23 03:35 — PR #3116: DrivAerML SGDR T_0=15 T_mult=2 (sanji) — CLOSED
 
 - **Branch:** sanji/dm-sgdr-t0-15-tmult2

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 05:00 — PR #3164: DM paper-facing full eval two-phase (faye) — CLOSED (did not reproduce champion)
+
+- faye/dm-ema-paper-fulleval, W&B: qd7g8npf (Phase 1 training), 37gsknn6 (Phase 2 full eval)
+- Goal: get clean paper-facing full-eval test metric for DM champion config (no --max-eval-batches)
+- Phase 1 (training, no-compile): val=4.198% ep432, test=4.793% (truncated). Champion is 3.833% — 0.365pp gap. Model did NOT reproduce champion quality.
+- Phase 2 (full eval on Phase 1 best checkpoint): test=4.496% full eval (vs 4.793% truncated) — confirms truncated eval slightly overstates error (~0.3pp).
+- Two compiled runs diverged ep60-87 (grad_norm to 65k) — torch.compile + DrivAerML is a systematic regression, likely from EMAWithWarmup interaction.
+- **Conclusion: full eval test for true champion still unknown. faye's 4.496% is from a weaker model.** Reassigned faye to #3244 for a clean rerun.
+
 ## 2026-04-24 04:30 — PR #3219: DM SAM optimizer (hinata) — CLOSED (dead end)
 
 - hinata/dm-sam-optimizer, W&B group: dm-sam-optimizer

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 17:00 — PR #3182: DM compile + 96 slices (norman) — CLOSED (no-op)
+
+- Student correctly identified that model_slices=96 and compile_model=True are ALREADY defaults in train.py. The champion config already uses both. Experiment was vacuous as designed — no runs executed. Important correction to our noam analysis: these features were never "unused."
+
+## 2026-04-23 17:00 — PR #3136: AF EMA decay sweep 0.9995/0.9999 (stark) — CLOSED
+
+- EMA=0.9995: surface=0.000618 (+109%), vol=0.003203 (+57%) vs baseline (W&B: `g2d0fknl`). EMA=0.9999: surface=0.000637 (+115%), vol=0.003433 (+68%) (W&B: `h1y4axao`). Both dramatically worse. Monotonic degradation as decay increases beyond 0.999. EMA=0.999 confirmed optimal for AirfRANS — completes upper sweep.
+
 ## 2026-04-23 16:30 — PR #3170: DM AGC on EMA champion (himmel) — CLOSED
 
 - AGC lambda=0.01: 5.309% ep196, crashed ep204 (W&B: `w3zd1lrl`). lambda=0.02: 6.298% ep138, crashed ep145 (W&B: `ba7s5jrq`). AGC's per-parameter thresholds scale with weight norms — cannot provide absolute ceiling at cosine restart boundaries that gc=0.5 gives. Both 1.5-2.5pp worse than 3.833% baseline. Student diagnosed root cause well.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 13:15 — PR #3272: DM quadratic position features (vegeta) — CLOSED (dead end)
+
+- vegeta/dm-quadratic-pos-encoding, W&B runs: equlqwg4 (quad+Fourier), qm4gk9bi (quad-only)
+- Hypothesis: x², y², z², xy, xz, yz features alongside Fourier PE provide implicit surface curvature information
+
+| Trial | Config | best val_pct | Epochs | Outcome |
+|-------|--------|-------------|--------|---------|
+| T1 | quad + Fourier | 6.643% (ep128) | 168 (timeout) | Timeout at ~3x throughput penalty |
+| T2 | quad only | 10.736% (ep63) | 163 | Diverged ep63, inf gradients |
+
+**Conclusion:** Fatal throughput penalty (168 vs 511 epochs baseline). Quad-only diverged at ep63, confirming Fourier PE is irreplaceable. Even with T_max adjustments, structural 3x throughput hit from expanded input dimension means epoch starvation. Late-epoch grad-clip rate 74% suggests cosine restart instability. Pattern matches #3263 (MoE FFN): any input expansion that slows per-epoch throughput gets epoch-starved on DM.
+
+---
+
+## 2026-04-24 13:15 — PR #3255: AF no-Lookahead/no-compile (gohan) — CLOSED (dead end)
+
+- gohan/af-no-lookahead-compile, W&B run: 4auwwy2g, group: af-no-lookahead-compile
+- Hypothesis: removing Lookahead + torch.compile (confirmed as individually removable in short ablation) would hold at full budget
+
+| Metric | Baseline | This run | Delta |
+|--------|----------|----------|-------|
+| val surface_mse | 0.000296 | 0.001999 | +575% |
+| val vol_mse | 0.002039 | 0.003754 | +84% |
+
+**Conclusion:** Catastrophically worse. Lookahead's slow-weight averaging is load-bearing for long-run convergence (not just early-training noise). torch.compile provides meaningful throughput gains within the 360-min timeout budget. Short-run ablation #3236 was misleading due to epoch-count confound. Both optimizations are non-negotiable for AF champion config.
+
+---
+
 ## 2026-04-24 12:45 — PR #3259: DM curvature-weighted loss (zenitsu) — CLOSED (dead end)
 
 - zenitsu/dm-curvature-weighted-loss, W&B runs: rwkptewj (alpha=1.0), 434enoo9 (alpha=0.5), group: dm-curvature-weighted-loss

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 08:30 — PR #3148: DM 10-ep warmup + gc=1.0 (franky) — CLOSED
+
+- val=11.196% ep80, diverged ep87 (W&B: `rp02hbxl`). gc=1.0 insufficient to prevent cascade divergence with T_max=30 restarts. Grad norms→41.5M. 7.4pp worse than 3.833% baseline.
+
+## 2026-04-23 08:30 — PR #3117: DM Lion optimizer sweep (bulma) — CLOSED
+
+- lr=5e-5: 5.92% ep119 then diverged (W&B: `rxelzn84`). lr=1e-4: 6.36% then diverged (W&B: `a8mbflb1`). lr=5e-5+gc=0.5: 6.95% then diverged (W&B: `qmd1mp43`). All 54%+ worse. Lion's sign-based updates amplify DM gradient instabilities. Lion dead for DM.
+
+## 2026-04-23 08:30 — PR #3112: DM gradient centralization (edward) — CLOSED
+
+- val=5.492% ep181, diverged ep200 at cosine restart (grad norms 0.21→351,932). (W&B: `yblf2j7a`). GC removes gradient DC component making model fragile at LR restart boundaries. 43% worse pre-divergence. Explicit gradient modifications hurt DM.
+
+## 2026-04-23 08:30 — PR #3089: TFP T_max=30 (nami) — CLOSED
+
+- field_mse ~4.36e+23 all 536 epochs (W&B: `rfr8qkrc`). Pressure never converged even with sinh clamp fix. Confirms T_max>10 dead for TFP: T_max=15 diverged ep124, T_max=30 pressure never finite. Student found sinh clamp bug fix — noted but doesn't save T_max>10. T_max=10 confirmed sharp optimum.
+
 ## 2026-04-23 08:00 — PR #3122: DM polynomial LR decay (nobara) — CLOSED
 
 - Linear (power=1.0): 17.88% ep64, diverged ep69 (W&B: `i1qbv9t4`). Quadratic (power=2.0): 12.20% ep75, diverged ep91 (W&B: `kkuery47`). Both 3-4x worse. Key insight: cosine's periodic low-LR troughs are load-bearing for stability — polynomial keeps LR high without recovery windows. Polynomial LR dead for DM.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,24 @@
 # SENPAI Research Results
 
+## 2026-04-24 07:00 — PR #3224: DM spectral normalization on attention (fern) — CLOSED (dead end)
+
+- fern/dm-spectral-norm, W&B run: 4ylvrt7k, group: dm-spectral-norm
+- Hypothesis: spectral norm on QKV projections constrains Lipschitz constant, stabilizing cosine restart boundaries
+- Trial 1 (SN-QKV): val=4.035% ep479, test=5.113%. +0.202pp / +5.3% vs 3.833% baseline
+- Stability validated: zero grad spikes across 16 restart boundaries. Grad norm monotonically decreased 9.7→0.09.
+- **Late collapse at ep502:** grad_norm jumped 0.39→0.88→4.74→423 in 25 epochs. Collapse from UNCONSTRAINED FFN/embedding layers, not from SN-protected QKV (sigma stayed bounded at ~5.6).
+- **Root cause: σ=1 hard cap over-restricts attention representational capacity from epoch 1. The gradient spike problem it was designed to solve doesn't exist — gc=0.5 already handles restart stability in the baseline.**
+- **Conclusion: spectral norm dead for DM.** Partial Lipschitz bounds create asymmetric instability.
+
+## 2026-04-24 07:00 — PR #3176: TF full noam stack at T_max=150 (mitsuha) — CLOSED (dead end)
+
+- mitsuha/tfp-noam-stack (pivoted from TFP to TF due to dataset compatibility), W&B runs: i9wvy2bd/nx4gpbp4 (T1), wue7pa0i/4hxt7np6 (T2), 5kdoiqr0/kr931hp9 (T3)
+- Hypothesis: full noam stack (ANP+physics+T_max=150+Lookahead+compile+96sl+re-strat) transfers from TFP to TF
+- Best: Trial 1 (full stack) val=22.469 ep279, +5.2% vs 21.350 baseline. Re-run confirmed: 23.034
+- Trial 2 (ANP+T_max=150 only): 25.093. Trial 3 (arch+T_max=150 only): 25.621
+- **Key finding: T_max=150 is the decisive negative factor.** TF baseline uses T_max=10 (21.350). ANP contributes ~10% improvement WITHIN T_max=150 regime but can't overcome the schedule penalty.
+- **Conclusion: full noam stack dead for TF at T_max=150.** ANP at T_max=10 would be the valuable follow-up (untested).
+
 ## 2026-04-24 06:30 — PR #3218: AF GradNorm adaptive multi-task loss balancing (shouko) — CLOSED (dead end)
 
 - shouko/af-gradnorm, W&B runs: p5b6fgoa (α=1.5), 93rkwc57 (α=0.5)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 02:30 — PR #3214: DM auxiliary surface gradient prediction (kakashi) — CLOSED (dead end)
+
+- kakashi/dm-auxiliary-gradient, W&B group: dm-auxiliary-gradient
+- Hypothesis: supervise spatial pressure gradients (∂p/∂x,y,z via kNN finite-differences) as auxiliary regularization loss
+- Trial 1 (aux_weight=0.1, W&B: h611t6dg): best val=23.5% ep20, diverged ep22 — gradient explosion (norm 2.25→15.3)
+- Trial 2 (aux_weight=0.01, W&B: exbz0pb4): best val=5.485% ep191 (+43% worse than 3.833%), instability event ep192, degraded to 7.38%
+- **Root cause: kNN gradient targets are inherently noisy.** Once primary loss flattens in late training, the noisy auxiliary signal dominates and injects harmful variance. Even pre-divergence convergence trajectory was decelerating — would need ~137 more epochs just to reach baseline, far exceeding realistic budget.
+- **Conclusion: supervised gradient prediction dead for DM.** The model already learns appropriate gradient structure from the dense primary pressure loss. kNN noise > benefit.
+
 ## 2026-04-24 02:00 — PR #3212: AF PCGrad gradient surgery (jin) — CLOSED (dead end)
 
 - jin/af-pcgrad, W&B group: af-pcgrad

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,24 @@
 # SENPAI Research Results
 
+## 2026-04-24 10:45 — PR #3244: DM paper-facing full eval (faye) — SENT BACK (strategy change)
+
+- faye/dm-paper-facing-full-eval, W&B run: l7jxns6d, group: dm-paper-facing
+- Goal: get authoritative DM test metric over full evaluation set (no --max-eval-batches)
+- **Result: timeout at ep50, val=12.855%.** Full eval is 10x slower per epoch (~7min vs ~0.7min). Only 50/511 epochs completed.
+- **Sent back with two-phase strategy:** (1) train to convergence with --max-eval-batches 200, (2) load best checkpoint for a single full-eval pass.
+
+## 2026-04-24 10:45 — PR #3234: AF lower LR sweep (jin) — CLOSED (dead end)
+
+- jin/af-lower-lr-vol, W&B runs: yvct2fd1 (lr=5e-4), 9fv1p8bx (lr=4e-4), group: af-lower-lr-vol10x
+- Hypothesis: lower LR reduces gradient oscillations under vol-weight=10x
+
+| Trial | LR | surface_mse | vs baseline | vol_mse | vs baseline |
+|-------|-----|-------------|-------------|---------|-------------|
+| T1 | 5e-4 | 0.000492 | +66% | 0.004293 | +111% |
+| T2 | 4e-4 | 0.000408 | +38% | 0.003594 | +76% |
+
+- **Root cause:** lower LR → underfitting under vol-10x loss amplification. Both runs also diverged late (grad_norm → Infinity). lr=6e-4 now bracketed from below as optimum.
+
 ## 2026-04-24 10:15 — PR #3209: TFP cp_panel_prior_index bug fix + multi-seed reproducibility (sanji) — MERGED (bug fix)
 
 - sanji/bugfix/cp-panel-prior-index-tandemfoil-paper, W&B runs: hduq51jw (seed=0, 20ep), 9dodz26x (seed=42, 20ep), xgt4c9oc (seed=123, 20ep), xsk8r0rm (seed=0, 999ep stripped config)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 22:00 — PR #3171: DM LR warmup + EMA+gc (sanji) — CLOSED
+
+- 5-ep warmup: 11.325% ep31 then collapsed to 66.8% (W&B: `ulog3zq2`). 10-ep warmup: 3.918% ep496, plateaued (W&B: `5ltdja3j`) — 0.085pp worse than 3.833% baseline, no further descent trend (last 50 epochs mean 4.02%). Warmup is neutral-to-harmful when EMA+gc=0.5 already provides stability. Adding to dead ends.
+
 ## 2026-04-23 21:30 — PR #3168: TFP multi-seed variance (jin) — CLOSED — CRITICAL FINDING
 
 - Seed 42: field_mse=4.28e+26 (velocity OK, pressure diverged). Seed 123: Infinity from ep70. Seed 456: Infinity from ep200. Baseline (seed=0): 0.002383. **0/3 seeds reproduce the champion**. The TFP baseline is a SINGLE LUCKY SEED (seed=0/default), not a robust result. This redefines TFP as a stabilization problem — the pressure representation (asinh/sinh transforms) is extremely initialization-sensitive. Bug fix: primary_metric_key shadowing.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 13:00 — PR #3131: DM OneCycleLR schedule (sanji) — CLOSED
+
+- max_lr=5e-4: 8.040% ep~190 then diverged to 51.4% (W&B: `ed60ojeo`). max_lr=1e-3: 8.041% ep~125 then diverged to 65.5%/NaN (W&B: `24r056y4`). Both WITHOUT EMA+gc (old regime). OneCycleLR's sustained high-LR warmup more damaging than cosine peaks — no periodic recovery troughs. 2x worse than old 3.997% baseline. Confirms cosine troughs are load-bearing for DM stability.
+
+## 2026-04-23 13:00 — PR #3124: TFP 3L/256d wider model (robin) — CLOSED
+
+- field_mse=8.61e+24 at ep177, catastrophic divergence ep229 (W&B: `3j33y6wi`). 27 orders of magnitude worse than baseline (0.002383). Combined with #3157 (3L/224d, field_mse ~2.2e9), width beyond 192d conclusively dead for TFP. 192d confirmed as the capacity ceiling — gradient instability scales with hidden dim in TFP's narrow stability window.
+
 ## 2026-04-23 12:30 — PR #3162: DM EMA=0.9995 + gc=0.3 (himmel) — CLOSED
 
 - Best val=8.816% at ep80, then catastrophic divergence ep81 (grad norm 17.8→430, killed ep90). W&B: `og8ny8s7`. gc=0.3 is 2.3x worse than baseline (3.833%). gc=0.5 now quad-confirmed as sharp optimum: 0.25=13.1% (starves), 0.3=8.816% (diverges), 0.5=3.833% (champion), 1.0=6.21% (insufficient). Student noted potential bug fix (primary_metric_key shadowing) and suggested AGC — assigning AGC as fresh experiment.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,29 @@
 # SENPAI Research Results
 
+## 2026-04-23 16:30 — PR #3170: DM AGC on EMA champion (himmel) — CLOSED
+
+- AGC lambda=0.01: 5.309% ep196, crashed ep204 (W&B: `w3zd1lrl`). lambda=0.02: 6.298% ep138, crashed ep145 (W&B: `ba7s5jrq`). AGC's per-parameter thresholds scale with weight norms — cannot provide absolute ceiling at cosine restart boundaries that gc=0.5 gives. Both 1.5-2.5pp worse than 3.833% baseline. Student diagnosed root cause well.
+
+## 2026-04-23 16:30 — PR #3149: DM stochastic feature dropout (fern) — CLOSED
+
+- p=0.05: 7.269% ep190, diverged ep320 (W&B: `75zw9pyt`). p=0.10: 11.723% ep112, diverged ep150 (W&B: `v0hdvf5o`). Both WITHOUT EMA/gc. Zeroing physically interdependent geometric features creates impossible input configurations. Dose-dependent divergence. Student identified UnboundLocalError bug fix.
+
+## 2026-04-23 16:30 — PR #3147: DM lighter WD + gc=1.0 (norman) — CLOSED
+
+- WD=5e-4: 4.449% (W&B: `ecngexlu`). WD=1e-4: 7.057%, diverged (W&B: `0tmfdy74`). Both without EMA, gc=1.0 imposes hard floor ~4.4% regardless of WD. Third confirmation that gc=1.0 alone is insufficient for DM.
+
+## 2026-04-23 16:30 — PR #3145: TFP gc=0.4 boundary test (rei) — CLOSED
+
+- field_mse=Infinity all 533 epochs (W&B: `vxihza4u`). Pressure starvation from epoch 1. Sharp boundary between gc=0.4 (starvation) and gc=0.5 (champion) on stripped-down TFP config. Velocity converged normally — starvation is pressure-specific.
+
+## 2026-04-23 16:30 — PR #3106: AF 2L/384d + gc=0.5 + EMA (wolfwood) — CLOSED
+
+- With EMA: surface=0.000634 (+38%), vol=0.003896 (+40%) vs baseline (W&B: `j9xf3r9i`). Without EMA: surface=0.000564 (+23%), vol=0.005935 (+114%) (W&B: `gccu8a2k`). 384d width doesn't improve over 256d on either metric. Stable training but worse results. 256d confirmed optimal for AF.
+
+## 2026-04-23 16:30 — PR #3067: DM 32k surface points (askeladd) — SENT BACK
+
+- With eval fix: 7.558% ep128, gradient explosion ep128-177 (W&B: `hmhzokbo`). Run without EMA/gc — same failure mode gc=0.5 prevents. 12% throughput advantage (0.68 vs 0.77 min/epoch). Sent back for champion platform retry (EMA=0.9995+gc=0.5).
+
 ## 2026-04-23 16:00 — PR #3135: AF EMA=0.999 + vol-weight=10x (nezuko) — MERGED ★ NEW BEST
 
 - **surface_mse: 0.000296 (-35.5%)**, **vol_mse: 0.002039 (-26.6%)** vs baseline 0.000459/0.002777. W&B: `sh2zyfwr`. Model still improving at ep763 timeout. EMA stabilizes the upweighted volume gradient — without EMA, 10x is worse; with EMA it's dramatic. Vol gap: 1.20x (was 1.63x). New AF champion.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 09:30 — PR #3139: AF 3L/256d + EMA=0.999 (spike) — CLOSED
+
+- surface=0.002863 (6.2x worse), vol=0.011626 (4.2x worse), diverged ep149 (W&B: `ooxb9roq`). Consistent with all prior 3L AF tests. 3L adds optimization noise that destabilizes trajectory. 2L confirmed optimal for AirfRANS.
+
+## 2026-04-23 09:30 — PR #3079: DM 4L/640d+gc=0.5 retry (gojo) — SENT BACK (again)
+
+- Retry2 used same config as retry1 (instructions not followed). Best 4.516% ep359 (W&B: `7uuhe2qr`), retry2 6.457% ep137 (W&B: `ho8eosr3`). Sent back again with firm instructions: lr=3e-4 + T_max=60 + EMA=0.9995 + gc=0.5.
+
 ## 2026-04-23 09:00 — PR #3138: DM 788 batches + T_max=60 (kakashi) — SENT BACK
 
 - val=6.620% ep66, diverged ep72 at second cosine cycle (W&B: `7sa8l03q`). Proportional T_max scaling confirmed (much better than #3084's 11.57%) but gc=1.0 insufficient. Sent back for gc=0.5 + EMA=0.9995.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 03:35 — PR #3116: DrivAerML SGDR T_0=15 T_mult=2 (sanji) — CLOSED
+
+- **Branch:** sanji/dm-sgdr-t0-15-tmult2
+- **Hypothesis:** SGDR with shorter initial cycles (T_0=15 vs megumi's T_0=30) for rapid early exploration then progressive settling
+- **Results:**
+
+| Metric | Value | vs Baseline |
+|---|---|---|
+| Best val surface_rel_l2_pct | 12.846% ep38 | +221% worse |
+| Terminal val (crashed) | 64.96% ep199 | — |
+| Baseline | 3.997% ep467 | — |
+
+- **W&B run:** gm1o0yvp (crashed, grad_norm=3.98e10)
+- **Analysis:** Same failure mode as megumi's SGDR (#3086): healthy first 3 cycles (ep0-38), then LR restart from ~0 → 5e-4 destabilizes at ep~39. Val spiked 12.8%→72% and never recovered. SGDR is structurally incompatible with DM's no-gc regime — any LR restart from near-zero to peak causes catastrophic instability.
+- **Decision:** CLOSED — 3.2x worse than baseline, crashed
+
 ## 2026-04-23 03:15 — PR #3105: AirfRANS EMA=0.999 for volume (violet) — CLOSED
 
 - **Branch:** violet/af-ema-volume

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,32 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:30 — PR #3238: AF WD=0 ablation on vol-10x+EMA champion (rei) — SENT BACK
+
+- rei/af-wd0-ablation, W&B runs: sqotwbxs (WD=0), cjcftqo8 (WD=5e-3), group: af-no-wd
+- Hypothesis: WD may be over-regularizing the AF model; removing or reducing it could unlock precision
+
+| Trial | WD | surface_mse | vs baseline | vol_mse (at best-surface ckpt) | vs baseline |
+|-------|------|-------------|-------------|-------------------------------|-------------|
+| T1 | 0 | 0.000384 | +29.7% | 0.002997 | +47.0% |
+| T2 | 5e-3 | **0.000249** | **-15.9% NEW BEST** | 0.002679 | +31.4% |
+
+- **WD=0 is a clear dead end** — both metrics regress substantially. EMA=0.999 insufficient implicit regularization for 2L/256d.
+- **WD=5e-3 reveals a genuine surface/volume tradeoff** — surface_mse=0.000249 is the best surface result in the entire AF programme. But vol_mse=0.002679 is far from 0.0017 target.
+- **Sent back for follow-up:** WD=5e-3 + vol-loss-weight=15x and 20x, testing whether increased vol emphasis can recover vol_mse while preserving the surface precision gain.
+
+## 2026-04-24 09:30 — PR #3233: DM stochastic depth/LayerDrop (gojo) — CLOSED (dead end)
+
+- gojo/dm-stochastic-depth, W&B runs: sx8t4fq8 (p=0.1), cs1l7yye (p=0.2), wwbkzvoy (p=0.3), group: dm-stochastic-depth
+- Hypothesis: stochastic depth (randomly dropping transformer layers) provides regularization against late-training divergence
+
+| Trial | Drop prob | val_pct | vs baseline |
+|-------|-----------|---------|-------------|
+| T1 | p=0.1 | 4.317% | +12.6% |
+| T2 | p=0.2 | 4.217% | +10.0% |
+| T3 | p=0.3 | 4.411% | +15.1% |
+
+- **Root cause:** Only 4 layers — dropping 1 removes 25% capacity. Stochastic depth designed for 50-110+ layer networks. Too coarse for shallow architecture. EMA+gc already handles stability.
+
 ## 2026-04-24 09:15 — PR #3199: DM EMA=0.9999/0.99995 upward sweep (megumi) — CLOSED (dead end)
 
 - megumi/dm-ema-0.9999, W&B runs: c168t4dq (EMA=0.9999), 26n0lcmg (EMA=0.99995)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,27 @@
 # SENPAI Research Results
 
+## 2026-04-22 — PR #3043: DrivAerML gradient accumulation ablation + full eval baseline (einar) — SENT BACK
+
+- **Branch:** einar/dm-grad-accum-ablation
+- **Hypothesis:** Gradient accumulation (accum=2, accum=4) reduces gradient noise in DrivAerML's batch_size=1 regime. Step-matching (doubling `--max-train-batches`) isolates the smoothing effect from optimizer step reduction. Secondary goal: establish a full-eval paper-facing baseline without `--max-eval-batches`.
+- **Baseline:** val=3.997% (PR #2898, W&B bht6h42t, 4L/512d, AdamW lr=5e-4, T_max=30)
+
+| Run | Description | W&B ID | Best Val % | Best Ep | Best Test % | Notes |
+|-----|-------------|--------|-----------|---------|------------|-------|
+| 1 | DM control, full eval | 9kn1satv | 14.098 | ep40 | 13.644 | Hit epoch budget at ep42; severely undertrained |
+| 2 | DM accum=2, fewer steps | dguhbgax | 11.390 | ep365 | 11.933 | Late divergence (val→67% by final ep444) |
+| 3 | DM accum=2, step-matched | wpbqofwh | **4.860** | ep153 | **6.091** | Post-peak decay; best run in ablation |
+| 4 | DM accum=4 | hngfgj6i | 9.391 | ep124 | 9.702 | Never converged to competitive range |
+| 5 | AF accum=2, T_max=50 | 1nc85857 | 0.000534 MSE | ep466 | 0.000712 MSE | Late divergence ep723; confirms accum hurts AF |
+
+**Result: SENT BACK (request changes)**
+- No run beat baseline. Best: Run 3 at 4.860% (21.6% above 3.997%)
+- Run 3 (accum=2, step-matched) is directionally promising — closest any non-baseline DM run has come
+- Post-ep153 instability in Run 3 suggests T_max is mismatched to the effective doubled batch size
+- Full-eval control (Run 1) hit epoch budget at ep42 — not a valid paper number
+- accum=2 hurts AF (confirmed); no further AF accum experiments warranted
+- **Next iteration:** accum=2 step-matched + T_max=60 (2x baseline T_max=30) + cosine-eta-min=1e-6; wandb-group dm_grad_accum_v3
+
 ## 2026-04-22 23:35 — PR #2948: TFP physics-flag ablation (guts) — CLOSED
 
 - **Branch:** guts-tfp-physics-v2 / tandemfoil_paper_physics_ablation_v5

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 18:00 — PR #3068: DM 64k surface points (brook) — CLOSED
+
+- 64k points + EMA=0.9995 + gc=0.5: surface_rel_l2=12.16% (W&B: `j2p2i1c0`). Prior 64k without EMA+gc: 8.18%. Adding EMA+gc on 64k made it WORSE — structural instability compounds. 50k remains the only viable surface point count for DM. Full surface point investigation complete: 16k=11.672%, 32k=7.558%, 64k=12.16%, all dead vs 50k=3.833% baseline.
+
+## 2026-04-23 18:00 — PR #3066: DM 16k surface points (alphonse) — CLOSED
+
+- 16k surface points: surface_rel_l2=11.672% (W&B: `q95gpjjq`). Student reported crash at epoch 213 on original attempt, then retried with fixed settings. Even with proper config, 3x worse than 50k baseline. Low point counts cause unstable gradient estimates on DrivAerML's complex surface geometry.
+
+## 2026-04-23 18:00 — PR #3064: DM multi-seed s123 two-phase (casca) — CLOSED
+
+- Phase 1 (capped): 6.284% ep175 (W&B: `3zhuvd2h`). Phase 2 (full): val=11.888% (W&B: `88ixfvzx`). Used old config without EMA+gc=0.5 — diverges catastrophically in uncapped phase. Not valid for paper-facing comparison. Multi-seed runs need to wait for post-noam-pivot best config.
+
 ## 2026-04-23 17:30 — PR #3153: DM EMA+gc+light WD (emma) — CLOSED
 
 - WD=1e-4: 14.76% ep35, diverged ep36 (W&B: `cbkbmr7n`). WD=5e-4: 4.920% ep247, diverged ep248 (W&B: `t1pqa5qd`). WD destabilizes EMA shadow model — no-WD confirmed for DM champion. Bug fix noted (primary_metric_key shadowing).

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,71 @@
 # SENPAI Research Results
 
+## 2026-04-23 06:15 — PR #2974: Best-checkpoint saving infrastructure (mugen) — MERGED ✓
+
+- **Branch:** mugen/best-checkpoint-saving
+- **Purpose:** Infrastructure — save best val checkpoint and restore before test eval
+- **Results:**
+
+| Dataset | W&B Run | Best Val | Best Ep | Best-ckpt Test | Terminal Test | Value |
+|---|---|---|---|---|---|---|
+| TandemFoil | `d9pk596u` | 26.80 | 241 | 28.80 | 29.19 | +1.4% |
+| AirfRANS | `as2mn0nw` | 0.00107 | 422 | 0.00160 | **NaN** | NaN rescued |
+| DrivAerML | `aq9xd1vg` | 13.23% | 54 | 13.86% | 47.15% | **3.4x improvement** |
+
+- **Decision:** MERGED — essential infrastructure. AirfRANS NaN recovery demonstrates this is critical: without it, a 627-epoch run produces zero usable results. All future branches on radford benefit automatically.
+
+## 2026-04-23 06:15 — PR #3130: AF EMA decay sweep (0.995/0.99) (violet) — CLOSED
+
+- EMA=0.995: surface=0.000695, vol=0.007556 (W&B: `lecm4fhl`). EMA=0.99: surface=0.002217, vol=0.009048 (W&B: `b6inrppx`). Both monotonically worse than EMA=0.999 (0.000459/0.002777). EMA sweep fully closed for AirfRANS — 0.999 is the sweet spot.
+
+## 2026-04-23 06:15 — PR #3102: AF 10x volume loss weight (thorfinn) — CLOSED
+
+- surface=0.000481, vol=0.004144 (W&B: `aldagms8`). Both metrics worse than EMA champion (0.000459/0.002777) — student compared against stale pre-EMA baseline. Closing; follow up at 1.5x/2.0x is the right direction (see tanjiro send-back).
+
+## 2026-04-23 06:15 — PR #3101: AF 3x volume loss weight (tanjiro) — SENT BACK
+
+- surface=**0.000381** (-17% NEW BEST surface), vol=0.003904 (+41% vs champion 0.002777). (W&B: `2ebhl15x`). Surface improvement is real — late-stage divergence ep767 is a concern. Sent back for retry at vol-weight=1.5 + possible gc=0.5 tightening.
+
+## 2026-04-23 06:15 — PR #3100: AF 3L/384d architecture (taki) — CLOSED
+
+- Catastrophic divergence ep53 — surface=0.01947/vol=0.08889 (30-40x worse). (W&B: `kt3h6c9t`). Matches 2L/384d failure. 2L/256d is hard stability constraint for AF. Architecture dead end.
+
+## 2026-04-23 06:15 — PR #3107: TF clean test (old gc=0.5 config) (yuji) — CLOSED
+
+- val=22.454, test=23.578 (W&B: `eyj4ltf8`). Config was gc=0.5 (old champion) — current best is gc=0.3 (test=23.419, PR #3108). Closed and reassigning yuji to clean test row for gc=0.3 champion.
+
+## 2026-04-23 06:15 — PR #3093: TFP EMA=0.99 (rei) — CLOSED
+
+- val/field_mse=Infinity all 532 epochs (W&B: `9j29lyiw`). Faster EMA (~100-update window) allows early noisy pressure to survive sinh() inverse transform. EMA<0.999 dead for TFP — sinh amplification is fundamental.
+
+## 2026-04-23 06:15 — PR #3092: TFP EMA=0.9995 (norman) — CLOSED
+
+- field_mse ~1e+28 all 536 epochs (W&B: `xy01mjzl`). Slower EMA (~2000-update window) retains too much weight from early extreme pressure values. Mirror-image failure to EMA=0.99. EMA=0.999 confirmed as sharp optimum for TFP — both directions fail. TFP EMA sweep fully closed.
+
+## 2026-04-23 06:15 — PR #3085: DM larger supernodes 8192/16000 (kohaku) — SENT BACK
+
+- Best val 6.121% ep143, then catastrophic divergence ep144 (grad norms →158T). (W&B: `e3nmais2`). Missing --grad-clip — 2x larger graph amplifies gradient magnitudes. Sent back for retry with gc=1.0.
+
+## 2026-04-23 06:15 — PR #3076: DM log-cosh loss (frieren) — SENT BACK
+
+- Best val 6.344% ep126, diverged ep134 (grad norms →181B). (W&B: `z2k4uz99`). Fast early convergence is interesting. Sent back for retry with gc=1.0 to get a clean result.
+
+## 2026-04-23 06:15 — PR #3075: DM Huber loss delta=0.1 and 1.0 (franky) — CLOSED
+
+- delta=0.1: 6.681% ep185 then NaN (W&B: `hrcuze3j`). delta=1.0: 8.531% ep135 then NaN (W&B: `to5hq7f2`). Both 67%/113% worse than baseline. Consistent with AF Huber underperformance — MSE outlier gradients help learn hard CFD pressure cases. Huber direction dead across datasets.
+
+## 2026-04-23 06:15 — PR #3074: DM relative L2 training loss (fern) — CLOSED
+
+- Pure rel_l2: 75.27%, mixed 50/50: 75.30% — both degenerate to z-mean prediction immediately (W&B: `lago3za1`, `cxrfryjm`). Root cause: rel_l2 on z-normalized targets creates near-zero division instability. Dead end in current form. Fix (raw-space rel_l2) would be a distinct hypothesis.
+
+## 2026-04-23 06:15 — PR #3046: DM WD+gc compound (sukuna) — SENT BACK
+
+- WD=1e-3+gc=1.0: **4.44%** ep448 stable (W&B: `9hflnw2d`). WD=1e-3 alone: 22.07% then diverged. gc=1.0 alone: 5.20% then diverged. (W&B runs: `9hflnw2d`, `zromiqrc`, `imyzfshf`, `igbb8kb2`). Sent back for lighter WD=5e-4/1e-4 + gc=1.0.
+
+## 2026-04-23 06:15 — PR #3063: DM paper-facing full-eval seed=42 (canute) — SENT BACK
+
+- val=12.23% ep49, test=12.82% ep49. (W&B: `r4jrfhfu`). Run hit timeout at ep50 — full eval costs ~7 min/ep, only 50 of ~467 epochs completed. Sent back with two-phase approach: train with max-eval-batches, then single final full-eval pass from best checkpoint.
+
 ## 2026-04-23 05:30 — PR #3108: TandemFoil gc=0.3+EMA=0.999 (zenitsu) — MERGED ✓
 
 - **Branch:** zenitsu/tf-gc03-ema999

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 09:00 — PR #3138: DM 788 batches + T_max=60 (kakashi) — SENT BACK
+
+- val=6.620% ep66, diverged ep72 at second cosine cycle (W&B: `7sa8l03q`). Proportional T_max scaling confirmed (much better than #3084's 11.57%) but gc=1.0 insufficient. Sent back for gc=0.5 + EMA=0.9995.
+
+## 2026-04-23 09:00 — PR #3115: DM batch_size=2 + 25k points (piccolo) — SENT BACK
+
+- val=4.32% ep507 (W&B: `l7np1pv0`). Confounded by bf16 CUBLAS bug → fp16 fallback → 13 gradient spike events. Sent back for 50k pts + gc=0.5 + EMA=0.9995 to fairly test batch-diversity hypothesis.
+
+## 2026-04-23 09:00 — PR #3114: DM T_max=50 + gc (griffith) — CLOSED
+
+- gc=1.0: 12.56% ep42, diverged ep52 (W&B: `4ixc5d0e`). gc=0.5: 7.28% ep107, diverged ep121 (W&B: `0pux5dkr`). Both diverge — T_max=50 gradient explosion intrinsic to long-cycle LR peaks. T_max=30 confirmed as only viable cosine period for DM.
+
 ## 2026-04-23 08:30 — PR #3148: DM 10-ep warmup + gc=1.0 (franky) — CLOSED
 
 - val=11.196% ep80, diverged ep87 (W&B: `rp02hbxl`). gc=1.0 insufficient to prevent cascade divergence with T_max=30 restarts. Grad norms→41.5M. 7.4pp worse than 3.833% baseline.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 22:30 — PR #3161: DM eta_min=1e-5 cosine floor + EMA+gc (spike) — CLOSED
+
+- Best val=4.202% ep297, then diverged ep312 → 16.3% (W&B run from student report). Trough-smoothing effect confirmed — eta_min prevents hard zeros at cosine troughs, giving EMA smoother targets. But 4.202% is 9.6% worse than 3.833% baseline. Root cause: gc=0.5 relies on zero-LR trough damping as a natural stability reset; eta_min=1e-5 removes that reset, allowing gradient accumulation through troughs → eventual divergence. Triple confirmation: eta_min+gc is incompatible at any gc value (gc=1.0→6.311%, gc=0.5→8.617% prior, now gc=0.5+EMA→4.202% diverge). Added to dead ends.
+
 ## 2026-04-23 22:00 — PR #3171: DM LR warmup + EMA+gc (sanji) — CLOSED
 
 - 5-ep warmup: 11.325% ep31 then collapsed to 66.8% (W&B: `ulog3zq2`). 10-ep warmup: 3.918% ep496, plateaued (W&B: `5ltdja3j`) — 0.085pp worse than 3.833% baseline, no further descent trend (last 50 epochs mean 4.02%). Warmup is neutral-to-harmful when EMA+gc=0.5 already provides stability. Adding to dead ends.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 02:50 — PR #3070: DrivAerML 10-epoch linear warmup (chrome) — CLOSED
+
+- **Branch:** chrome/dm-linear-warmup-10ep
+- **Hypothesis:** 10-epoch linear warmup (LR 5e-5→5e-4) before cosine T_max=30 provides stable gradient directions before full LR
+- **Results:**
+
+| Metric | Value | vs Baseline |
+|---|---|---|
+| Best val surface_rel_l2_pct | 6.225% ep105 | +56% worse |
+| Divergence onset | ep114 (81.9% spike) | — |
+| Baseline | 3.997% ep467 | — |
+
+- **W&B run:** w1c7l3jo
+- **Analysis:** Warmup itself worked correctly (63%→24% in epochs 1-10). But catastrophic divergence at ep114 at a cosine LR peak — same failure mode as all non-gc DM experiments. Warmup without gc is insufficient. The real test is warmup+gc combined.
+- **Decision:** CLOSED — 56% above baseline, diverged ep114
+
 ## 2026-04-23 02:35 — PR #3086: DrivAerML SGDR T_mult=2 (megumi) — CLOSED
 
 - **Branch:** megumi/dm-cosine-restart-tmult2

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 05:00 — PR #3050: AirfRANS EMA=0.999 at T_max=50 champion (stark) — MERGED ✓
+
+- **Branch:** stark/af-ema-champion
+- **Hypothesis:** EMA + T_max=50 (longer cosine) is synergistic — EMA can track the optimization trajectory harmoniously with longer cycles
+- **Results:**
+
+| Metric | EMA=0.999 | Previous Baseline | Delta |
+|---|---|---|---|
+| val_primary/surface_mse | **0.000459** ep771 | 0.000482 | **-4.8% NEW BEST** |
+| full_val/volume_mse | **0.002777** ep771 | 0.00764 | **-63.6% NEW BEST** |
+| SpiderSolver vol gap | — | 4.5x | **1.63x** (closed) |
+
+- **W&B run:** z6pry4b9
+- **Analysis:** EMA=0.999 with T_max=50 improves BOTH metrics simultaneously — the only intervention to do so. Key difference from PR #3105 (EMA=0.999 at T_max=10 which regressed surface): T_max=50 provides a longer stable optimization window for EMA to track. Model still descending at ep771. SpiderSolver volume gap now 1.63x (down from 4.5x).
+- **Decision:** MERGED — new AirfRANS champion
+
 ## 2026-04-23 04:50 — PR #3090: TFP gc=0.3 at champion config (nezuko) — CLOSED
 
 - **Branch:** nezuko/tfp-gc-03

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 09:00 — PR #3232: AF vol-weight warm-up schedule (nezuko) — CLOSED (dead end)
+
+- nezuko/af-vol-warmup, W&B runs: 9tc2udwf (200ep ramp), gp149j2g (100ep ramp), o8ifqyac (50ep ramp), group: af-vol-warmup
+- Hypothesis: linear vol-weight warm-up from 1x→10x over N epochs lets model learn surface first, then shift to volume (physics-motivated: BL must resolve before volume)
+
+| Trial | Warmup | surface_mse | vs baseline | vol_mse | vs baseline | Status |
+|-------|--------|-------------|-------------|---------|-------------|--------|
+| T1 | 200 ep | 0.000421 | +42% | 0.003456 | +70% | COLLAPSED ep600 |
+| T2 | 100 ep | 0.000379 | +28% | 0.003443 | +69% | stable |
+| T3 | 50 ep | 0.001098 | +271% | 0.010298 | +405% | COLLAPSED ep200 |
+
+- **Collapse mechanism:** Cosine LR restarts (T_max=50) inject LR peak at the moment vol_weight reaches 10x → destructive gradient spikes. T1/T3 collapse into degenerate constant predictions (Ux=Uy=nut≈0, p≈2.48). T2 survives but +28% surface / +69% volume.
+- **Conclusion: vol-weight warm-up dead for AF. Static 10x from epoch 0 is now TRIPLE-CONFIRMED optimal** (this + curriculum #3226 + vol>10x #3204). The optimizer needs to adapt to full 10x from the start.
+
+## 2026-04-24 09:00 — PR #3227: Focal-MSE loss for AF volume (casca) — CLOSED (dead end)
+
+- casca/af-focal-volume-loss, W&B runs: 332df4z1 (gamma=2), kasxtssl (gamma=1), group: af-focal-volume-loss
+- Hypothesis: focal weighting `(error/error_max)^gamma * error^2` on volume loss upweights hard cells (near-wall/wake), redistributing gradient signal toward physically important regions
+
+| Trial | gamma | surface_mse | vs baseline | vol_mse | vs baseline | Best epoch |
+|-------|-------|-------------|-------------|---------|-------------|------------|
+| T1 | 2.0 | 0.001456 | +392% | 0.08343 | +3993% | 198 |
+| T2 | 1.0 | 0.000952 | +222% | 0.008557 | +320% | 585 |
+
+- **Root cause (dual failure):** (1) Batch-max normalization makes loss landscape non-stationary — denominator shifts each step as predictions improve. (2) Freestream cells downweighted by focal serve as essential scaffolding for optimization trajectory. Stronger gamma = more aggressive scaffolding removal = earlier collapse.
+- **Monotonic gamma-degradation:** gamma=2 peaked ep198 (catastrophic), gamma=1 peaked ep585 (bad). Confirms focal redistribution is fundamentally wrong direction.
+- **Conclusion: focal-MSE dead for AF volume.** Any error-based per-point reweighting faces the non-stationarity problem. Would need EMA-smoothed normalization for ground-up reformulation.
+
 ## 2026-04-24 08:30 — PR #3231: DM pressure gradient smoothness reg (emma) — CLOSED (dead end)
 
 - emma/dm-pressure-gradient-reg, W&B runs: lqgwricr (λ=0.01), e2rko1vh (λ=0.1), xcynbcli (λ=1.0), group: dm-pressure-grad-reg

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 15:00 — PR #3123: TFP shorter T_max (T_max=5/8) (mitsuha) — CLOSED
+
+- T_max=5 (W&B: `5kp3yu51`): diverged, field_mse never finite. T_max=8 (W&B: `rcysi68k`): diverged, field_mse never finite. Confirms T_max=10 is a stability resonance for current stripped-down TFP config. However, noam branch uses T_max=150 with ANP decoder + full feature stack — the stability constraint is architecture-dependent. Reassigned to TFP full noam stack (ANP + physics features + T_max=150).
+
+## 2026-04-23 15:00 — PR #3118: DM weight decay alone (hinata) — CLOSED
+
+- WD=1e-4: 13.45% ep53 (W&B: `zh2ofwsj`). WD=5e-4: 5.17% ep181 (W&B: `guy2f5cr`). WD=1e-3: 10.46% ep219 (W&B: `4e3y5q6g`). ALL runs without EMA/gc — wrong platform, dead regime. Best 5.17% is 35% worse than 3.833% baseline. Emma #3153 already covers WD+EMA+gc (correct follow-up). Reassigned to DM noam features (asinh-pressure + residual-prediction + compile + 96 slices).
+
 ## 2026-04-23 14:00 — PR #3138: DM 788 batches + T_max=60 (kakashi) — CLOSED
 
 - Run 1 (gc=1.0, no EMA): 6.620% ep66, diverged ep72 (W&B: `7sa8l03q`). Run 2 (gc=0.5+EMA=0.9995): 4.661% ep141, diverged ep143 (W&B: `jzg8os84`). Champion platform extended stability from ep72→ep143 and improved 6.62%→4.66%, but divergence is structural. 788 batches accumulate only 111k steps before dying vs baseline's 201k — throughput advantage completely erased by shorter training horizon. Three attempts (incl #3084) all diverge within 2 cosine cycles. Higher batch count per epoch dead for DM.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,22 @@
 # SENPAI Research Results
 
+## 2026-04-24 03:45 — PR #3203: DM attention temperature annealing (vegeta) — CLOSED (dead end)
+
+- vegeta/dm-attn-temp-annealing, W&B run: ybh108ny
+- Hypothesis: linearly anneal attention temperature τ from 2.0→1.0 over training (soft→sharp attention)
+- Result: val=4.024% ep485 (+5.0% vs 3.833%), test=4.975% (+6.2% vs 4.685%)
+- **Root cause: external annealed τ compounded with Transolver's existing learnable per-head temperature parameter.** Double-τ created convoluted optimization, not intended soft→sharp progression.
+- **Conclusion: attn temp annealing dead for DM.** The -11% improvement on noam does not transfer — noam likely lacks the learnable τ or has different optimizer dynamics.
+
+## 2026-04-24 03:45 — PR #3204: AF vol-weight=15x/20x clean control (gilbert) — CLOSED (dead end)
+
+- gilbert/af-vol-15x-clean, W&B group: af-vol-15x-clean
+- Hypothesis: higher vol-weight (15x/20x) without extra features may improve vol_mse
+- Trial 1 (15x, W&B: o048z651): surface=0.000352 (+19%), vol=0.003402 (+67%), best vol=0.002378 at ep763 (still 16.6% above baseline but descending)
+- Trial 2 (20x, W&B: pne2413l): crashed ep381, NaN grad norms — beyond stability boundary
+- **Key finding: surface-anchored checkpoint selection HIDES vol improvements.** At ep763, vol_mse=0.002378 but surface_mse=0.000594. The best-checkpoint metric (surface_mse) doesn't capture the best volume state.
+- **Conclusion: vol-weight>10x worsens surface/volume Pareto from current operating point.** But joint checkpoint selection could unlock vol gains at moderate vol-weight (11x-13x). Added vol-15x/20x to AF dead ends.
+
 ## 2026-04-24 03:15 — PR #3220: DM Mixup regularization (nobara) — CLOSED (dead end)
 
 - nobara/dm-mixup, W&B group: dm-mixup

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,15 @@
 # SENPAI Research Results
 
+## 2026-04-24 17:30 — PR #3270: DrivAerML FiLM conditioning (brook) — CLOSED dead end
+
+- brook/dm-geometry-film-conditioning
+- Hypothesis: FiLM conditioning on global geometry stats (bounding box, centroid, std) helps the Transolver adapt per-point predictions to car shape
+- Trial 1 (gamma+beta): 5.221% val at ep135, diverged at ep150 (grad norm 0.5→53,000+). Trial 2 (additive-only beta): 5.369% val at ep174, diverged at ep178.
+- Both ~35-40% worse than baseline (3.833%). Catastrophic gradient explosion from FiLM MLP amplifying gradients through cosine LR restarts. Dead end — conditioning pathway interferes with Transolver routing.
+- **Brook assigned to Breakout 3 (#3301): domain-normalized volume auxiliary**
+
+---
+
 ## 2026-04-24 16:45 — PR #3284: Harness patches (vegeta) — MERGED (infrastructure)
 
 - vegeta/harness-patches-last-ditch, train.py +218/-53

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-24 10:15 — PR #3209: TFP cp_panel_prior_index bug fix + multi-seed reproducibility (sanji) — MERGED (bug fix)
+
+- sanji/bugfix/cp-panel-prior-index-tandemfoil-paper, W&B runs: hduq51jw (seed=0, 20ep), 9dodz26x (seed=42, 20ep), xgt4c9oc (seed=123, 20ep), xsk8r0rm (seed=0, 999ep stripped config)
+- **Bug fix:** cp_panel_prior_index() returned non-None for tandemfoil_paper even though build_tandem_paper_bundle() never populates cp_panel → sinh() applied to Fourier feature column → Inf overflow. Fix: guard with dataset name check. Also fixes primary_metric_key shadowing.
+- **Multi-seed reproducibility CONFIRMED:** seeds 0/42/123 all produce finite metrics (cross-seed std ≈ 0.0016 at ep20). Pre-fix, seeds 42/123 diverged to Inf.
+- **999-ep stripped config result:** val_primary/field_mse = 0.003615 (ep353). Expected worse than 0.002383 baseline since champion flags were deliberately omitted.
+- **TFP STABILIZATION CRISIS RESOLVED.** Normal TFP experiments can resume. Next step: re-run with full champion config to confirm 0.002383 is recoverable.
+
+## 2026-04-24 10:15 — PR #3252: DM progressive surface point training (mitsuha) — CLOSED (dead end)
+
+- mitsuha/dm-progressive-resolution, W&B runs: u94n7qjo (25k→50k@200), 972xv0ty (30k→50k@100), group: dm-progressive-resolution
+- Hypothesis: train on fewer surface points initially, transition to 50k later for speed + curriculum effect
+
+| Trial | Config | best val_pct | vs baseline | Status |
+|-------|--------|-------------|-------------|--------|
+| T1 | 25k→50k@200 | 8.147% | +113% | Crashed ep112, grad explosion |
+| T2 | 30k→50k@100 | 4.711% | +23% | Stable but converging deficit |
+
+- **Root cause:** DM requires full 50k-point context from epoch 1. 30k warmup imposes ~0.6pp persistent deficit vs baseline at same epoch. Speed gain from fewer points doesn't compensate. Consistent with 50k being only viable surface count.
+
 ## 2026-04-24 10:00 — PR #3256: DM coordinate noise augmentation (alphonse) — CLOSED (dead end)
 
 - alphonse/dm-coord-noise-augmentation, W&B runs: hapy2g9k (σ=0.001), qfu1j89b (σ=0.005), group: dm-coord-noise-aug

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,67 @@
 # SENPAI Research Results
 
+## 2026-04-23 01:20 — PR #3082: DrivAerML T_max=40 cosine schedule (historia) — CLOSED
+
+- **Branch:** historia/dm-tmax-40
+- **Hypothesis:** T_max=40 as a finer sweep point between champion T_max=30 and previously-crashed T_max=50
+- **Results:**
+
+| Metric | Value | Epoch | vs Baseline |
+|---|---|---|---|
+| Best val surface_rel_l2_pct | 12.840% | ep87 | +221% worse |
+| Final val (diverged) | 18.552% | ep160 | — |
+| Baseline (T_max=30) | 3.997% | ep467 | — |
+
+- **W&B run:** mzwuykvf
+- **Analysis:** Three-phase training: healthy convergence to ep47, first gradient explosion at ep48, partial recovery reaching 12.84% at ep87, terminal divergence from ep94 with grad norms up to 2222. Confirms T_max=30 is uniquely stable without gc on DrivAerML. T_max=40 joins T_max=15/20/50/100 as dead ends.
+- **Decision:** CLOSED — 221% above baseline, catastrophic divergence
+
+## 2026-04-23 01:20 — PR #3081: DrivAerML T_max=20 cosine schedule (hinata) — CLOSED
+
+- **Branch:** hinata/dm-tmax-20
+- **Hypothesis:** Shorter cosine cycles (T_max=20) for more frequent basin-hopping
+- **Results:**
+
+| Metric | Value | Epoch | vs Baseline |
+|---|---|---|---|
+| Best val surface_rel_l2_pct | 11.055% | ep76 | +177% worse |
+| Final val (degraded) | 27.158% | ep162 | — |
+| Baseline (T_max=30) | 3.997% | ep467 | — |
+
+- **W&B run:** t50xj6j8
+- **Analysis:** 13 spike events, grad norms up to 193.6. Chronically unstable — 42/162 checkpoints had grad_norm > 10. Best was still 2.77x worse than baseline. Confirms shorter T_max is catastrophically unstable without gc.
+- **Decision:** CLOSED — 177% above baseline, chronic instability
+
+## 2026-04-23 01:20 — PR #3051: DrivAerML 4x case revisits (bulma) — CLOSED
+
+- **Branch:** bulma/dm-multi-revisit-epoch
+- **Hypothesis:** More training batches per epoch (4x/8x revisits with different random 50k-point subsamples) acts as data augmentation
+- **Results:**
+
+| Run | W&B ID | Best val | Best test | vs Baseline |
+|---|---|---|---|---|
+| 4x (1576 batches) | a5oa7wpt | 9.382% ep36 | 10.226% | +135% worse |
+| 8x (3152 batches) | xsmxmlg7 | 15.211% ep10 | 15.905% | +281% worse |
+| 1x control (full eval) | itlteubz | 13.950% ep43 | 13.519% | +249% worse |
+
+- **Analysis:** 4x and 8x diverged because more gradient steps per cosine cycle compounds instability without gc. 4x early trajectory was promising (9.38% at ep36 vs ~12-13% for champion at same point) but couldn't survive long enough. 1x control only reached 46 epochs (vs 467 baseline) — confirms --max-eval-batches 200 is essential for throughput.
+- **Decision:** CLOSED — all runs 135-281% above baseline
+
+## 2026-04-23 01:20 — PR #3048: DrivAerML depth reduction 2L/3L vs 4L/512d (senku) — CLOSED
+
+- **Branch:** senku/dm-2l-3l-depth-at-champion
+- **Hypothesis:** Shallower architectures (2L/3L at 512d) might match or beat 4L by training faster, mirroring AirfRANS depth preference
+- **Results:**
+
+| Run | W&B ID | Best val | Best test | vs Baseline |
+|---|---|---|---|---|
+| 2L/512d | r0zsdxe8 | 11.259% | 11.705% | 2.82x worse |
+| 3L/512d | eagewa9c | 9.992% | 10.470% | 2.50x worse |
+| 4L/512d full-eval | fhe0j04g | 14.999% | 14.514% | 3.75x worse (epoch-starved) |
+
+- **Analysis:** Clean negative result — DrivAerML has OPPOSITE depth preference from AirfRANS. Monotonic: 2L < 3L < 4L. Both shallow models also diverged to NaN, indicating lack of depth makes optimization fragile at this scale. Full-eval control only 36 epochs — confirms full-eval-every-epoch impractical. Key finding: 4L is NOT over-parameterized on DrivAerML.
+- **Decision:** CLOSED — 2.5-2.8x worse than baseline
+
 ## 2026-04-23 00:50 — PR #3095: TFP 4L/256d deeper+wider (sanji) — CLOSED
 
 - **Branch:** sanji/tfp-4l-256d-depth-width

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,22 @@
 # SENPAI Research Results
 
+## 2026-04-24 18:30 — PR #3301: DrivAerML Breakout 3 domain-normalized volume auxiliary (brook) — SENT BACK (round 2)
+
+- brook/dm-domain-normalized-volume-aux
+- Hypothesis: Fix volume target normalization bug (surface cp stats applied to 4-channel volume data caused 40,000:1 loss ratio in #3044), then use volume as auxiliary representation objective
+- **Normalization fix confirmed:** vol/surface loss ratio 0.95-0.98 at epoch 1 (was ~40,000:1 before). Also fixed pre-existing bug in core/features.py:augment_case_sample (surface_x 7-dim vs volume_x 4-dim concat crash).
+
+| Trial | vol_loss_weight | vol_pts | best val surface_rel_l2_pct | best ep | W&B | status |
+|-------|----------------|---------|---------------------------|---------|-----|--------|
+| A | 0.1 | 16k | 9.69% | 99 | pttzba44 | killed ep100 |
+| B | 0.03 | 16k | 9.63% | 100 | j5s3yre4 | killed ep100 |
+| C | 0.3 | 8k | 18.17% | 100 | dvbqs5bs | killed ep100 |
+
+- All killed by --kill-if-best-val-above 100:8.0, BUT champion was likely ~8-10% at ep100 too (reached 3.833% at ep511). Kill gate was too aggressive.
+- **Sent back:** Re-run Trial B (w=0.03) and new Trial E (w=0.01) with relaxed kill gate (250:7.0, no-improvement 200:0.05), plus surface-only control. Need 500+ epochs to evaluate properly.
+
+---
+
 ## 2026-04-24 17:30 — PR #3270: DrivAerML FiLM conditioning (brook) — CLOSED dead end
 
 - brook/dm-geometry-film-conditioning

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:45 — PR #3263: DM Sparse MoE FFN (gojo) — CLOSED (dead end)
+
+- gojo/dm-moe-ffn, W&B runs: rei05zxk (K=4), hjkzjnn8 (K=8), group: dm-moe-ffn
+- Hypothesis: sparse MoE FFN allows regime-specific computation (different experts for stagnation/wake/underbody)
+
+| Trial | K experts | best val_pct | vs baseline | Epochs (vs 511) |
+|-------|-----------|-------------|-------------|-----------------|
+| T1 | 4 | 5.092% | +33% | 173 (timeout) |
+| T2 | 8 | 5.348% | +40% | 136 (timeout) |
+
+- **Dual failure:** (1) 1.7-2.2x throughput penalty — expert loop not compile-friendly → epoch starvation to 136-173 vs 511. (2) Routing collapse — balance_coeff=0.1 forces uniform routing (99-100% max entropy), preventing regime specialization. balance_coeff=0.01 causes full collapse at bs=1.
+- **Key finding:** Per-epoch learning curve is parallel to dense model — MoE adds zero sample-efficiency benefit. FFN is not the bottleneck for the 3.833% error floor. Any future DM modification MUST preserve throughput or show per-epoch quality gain.
+
 ## 2026-04-24 11:30 — PR #3264: DM Weight Standardization (vegeta) — CLOSED (dead end)
 
 - vegeta/dm-weight-standardization, W&B runs: x0biqh3s (lr=5e-4), i7nvv6gj (lr=6e-4), group: dm-weight-standardization

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-23 00:10 — PR #3080: DrivAerML T_max=50 cosine schedule (himmel) — CLOSED
+
+- **Branch:** himmel/dm-tmax-50
+- **Hypothesis:** T_max=50 (longer cosine cycles) helps DrivAerML like it helped AirfRANS.
+
+| Epoch | val_primary/surface_rel_l2_pct | W&B |
+|-------|-------------------------------|-----|
+| 28 | 17.48% (cycle 1 trough) | oilrfmix |
+| 54 | **12.76%** (pre-divergence best) | — |
+| 61 | 46.26% (gradient explosion) | — |
+| 70 | 23.34% (recovering) | — |
+
+**Result: CLOSED — T_max=50 falsified for DrivAerML**
+- Best val 12.76% at ep54, 3.19x worse than baseline 3.997%
+- Gradient explosion at ep61; run still recovering at ep71
+- AirfRANS→DrivAerML T_max transfer is falsified: 4L/512d needs shorter cycles (T_max=30)
+- historia #3082 testing T_max=40 will complete the picture
+
+**himmel reassigned to #3111: DrivAerML cosine eta_min=1e-6/1e-5 (LR floor)**
+
 ## 2026-04-22 23:50 — PR #3043: DrivAerML gradient accumulation ablation (einar) — CLOSED
 
 - **Branch:** einar/dm-grad-accum-ablation

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,18 @@
 # SENPAI Research Results
 
+## 2026-04-24 11:15 — PR #3247: DM EMA periodic reset (brook) — CLOSED (dead end)
+
+- brook/dm-ema-periodic-reset, W&B runs: ltfotg72 (reset@100ep), q221x53o (reset@50ep), group: dm-ema-periodic-reset
+- Hypothesis: periodic EMA reset prevents multi-basin dilution from cosine restarts
+
+| Trial | Reset interval | best val_pct | vs baseline | Outcome |
+|-------|---------------|-------------|-------------|---------|
+| T1 | 100 ep | 4.426% | +15% | Cascade diverged ep335 after reset #3 |
+| T2 | 50 ep | 6.818% | +78% | Diverged ep108 after reset #2 |
+
+- **Key insight:** EMA=0.9995 on DM is the PRIMARY gradient stabilization mechanism. Model enters progressively sharper basins — by ep300, resetting EMA removes protective smoothing at highest-curvature point → immediate cascade. Multi-basin averaging IS the feature, not a bug.
+- **Constraint for future work:** Any EMA modification must preserve the continuous shadow trajectory.
+
 ## 2026-04-24 11:00 — PR #3258: DM auxiliary surface normal prediction (emma) — CLOSED (dead end)
 
 - emma/dm-aux-normal-prediction, W&B runs: fkiz67ki (w=0.1), g9zs1wsh (w=0.01), group: dm-aux-normal-prediction

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,33 @@
 # SENPAI Research Results
 
+## 2026-04-24 13:35 — PR #3273: DM Grouped Query Attention (gojo) — CLOSED (dead end)
+
+- gojo/dm-grouped-query-attention, W&B runs: rq2tz9hh (2KV), wbygalr3 (4KV), group: dm-gqa
+- Hypothesis: GQA reduces KV heads (8→2 or 4) for throughput gain, enabling more epochs within timeout
+
+| Trial | KV heads | best val_pct | Epochs | Outcome |
+|-------|----------|-------------|--------|---------|
+| 2KV | 2 | 12.882% (ep57) | ~131 | Crashed — gradient explosion |
+| 4KV | 4 | 6.884% (ep114) | ~128 | Crashed — gradient explosion |
+
+**Conclusion:** GQA is throughput-NEUTRAL on Transolver — the bottleneck is the 50k-token slice-routing einsums, not QKV projections (which only operate on 96 slice tokens). GQA also destabilizes per-head slice routing: KV sharing forces coupled routing dynamics that explode at cosine restart peaks. Both configs diverged before reaching 511 epochs. Key insight: future throughput experiments should target slice routing, not attention projections.
+
+---
+
+## 2026-04-24 13:35 — PR #3243: DM error-weighted surface sampling (jet) — CLOSED (dead end)
+
+- jet/dm-error-weighted-sampling, W&B runs: 7amzkwq3 (T=1.0), 62zxlf2x (T=0.5), group: dm-error-weighted-sampling
+- Hypothesis: importance-sample surface points by prediction error to focus on hard regions
+
+| Trial | Temperature | best val_pct | Epochs | Outcome |
+|-------|------------|-------------|--------|---------|
+| T=1.0 | 1.0 | 40.79% (ep5) | 6 | Crashed — distribution shift collapse |
+| T=0.5 | 0.5 | 39.31% (ep5) | 6 | Crashed — distribution shift collapse |
+
+**Conclusion:** Classic importance-sampling distribution-shift collapse. Both crashed on the first epoch where error-weighted sampling activated. Gradient norms exploded 15-29x as hard points got massively overweighted and smooth regions starved. Additional blockers: fp32 error-map computation costs 30-60 min/epoch (throughput-prohibitive), and weighted sampling creates train/eval mismatch (same as #3259). Student's suggestion of error-weighted LOSS (not sampling) avoids distribution shift but still faces train/eval mismatch.
+
+---
+
 ## 2026-04-24 13:15 — PR #3272: DM quadratic position features (vegeta) — CLOSED (dead end)
 
 - vegeta/dm-quadratic-pos-encoding, W&B runs: equlqwg4 (quad+Fourier), qm4gk9bi (quad-only)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 20:30 — PR #3134: AF vol-weight=30x (megumi) — CLOSED
+
+- Surface=0.001264 (4.3x worse than 0.000296 baseline), vol=0.006235 (3.1x worse than 0.002039 baseline) (W&B: `wupz6iuj`). 30x volume weighting massively overshoots — optimizer saturates on volume gradients and both metrics collapse. Model diverged post-ep400, terminal surface=0.621 vol=1.533. No Pareto improvement at any epoch. Sweet spot confirmed at 10x (#3135). Adding to dead ends: vol-weight≥30x catastrophic.
+
 ## 2026-04-23 20:00 — PR #3132: DM eta_min=5e-5 + gc compound (gohan) — CLOSED
 
 - gc=1.0+eta_min=5e-5: 6.311% ep149, diverged ep150 → 112.66% (W&B: `h6jblqjq`). gc=0.5+eta_min=5e-5: 8.617% ep70, diverged → 72% (W&B: `7fmjg0cu`). Third confirmation eta_min=5e-5 is dead — alone (#3126), +gc=1.0, +gc=0.5 all diverge catastrophically. Non-zero LR floor prevents gradient momentum dissipation at cosine troughs; gc delays but cannot prevent cumulative drift. gc=0.5 is counterproductive here — clips 288/394 batches (throttles signal), worse than gc=1.0 which clips only 73/394.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 21:30 — PR #3168: TFP multi-seed variance (jin) — CLOSED — CRITICAL FINDING
+
+- Seed 42: field_mse=4.28e+26 (velocity OK, pressure diverged). Seed 123: Infinity from ep70. Seed 456: Infinity from ep200. Baseline (seed=0): 0.002383. **0/3 seeds reproduce the champion**. The TFP baseline is a SINGLE LUCKY SEED (seed=0/default), not a robust result. This redefines TFP as a stabilization problem — the pressure representation (asinh/sinh transforms) is extremely initialization-sensitive. Bug fix: primary_metric_key shadowing.
+
+## 2026-04-23 21:30 — PR #3154: DM monotonic cosine + EMA (historia) — CLOSED (wrong parameter)
+
+- Best val=4.392% ep308 (W&B: `we38omf3`), 14.6% worse than 3.833%. HOWEVER: T_max=999 is in STEPS not epochs — actually tested rapid 5-epoch cycling, not monotonic decay. True monotonic needs T_max=393606. Diverged ep336 via EMA cascade (corrupted online → 14+ epochs to flush from EMA buffer). Rapid cycling confirmed worse. True monotonic hypothesis remains untested — reassigning.
+
+## 2026-04-23 21:30 — PR #3083: DM 600 batches no gc (jet) — CLOSED
+
+- Best val=9.537% ep48, diverged to NaN ep266 (W&B: `s4kvc8oz`). 2.5x worse than baseline. 600 batches at 4L/512d WITHOUT gradient clipping is fundamentally unstable. Student correctly diagnosed: gc=0.5+EMA mandatory, T_max needs scaling to ~46. Reassigning with proper stabilization config.
+
 ## 2026-04-23 21:00 — PR #3190: TFP physics features isolation (brook) — CLOSED
 
 - Trial 1 (all physics): val=Infinity — cp_panel_prior_index() wrong index for tandemfoil_paper (W&B: `0eq5jqij`). Trial 2 (wake only): val=0.7396, diverged (W&B: `kqknlctz`). CRITICAL: TFP pipeline only supports enable_fourier/wake_deficit/wake_angle — other physics flags silently ignored.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 10:30 — PR #3125: DM SWA at cosine troughs (faye) — CLOSED
+
+- Raw model best 14.30% ep89, SWA average degraded to 88.98% over 16 collections (W&B: `hgnyelv3`). Without gc/EMA, gradient explosions scatter weights across incompatible basins; SWA equal-weight averaging then poisons the average. EMA champion (#3072) subsumes SWA benefit via continuous averaging.
+
 ## 2026-04-23 10:00 — PR #3113: DM attention dropout=0.05 (shouko) — CLOSED
 
 - val=12.53% ep118, 7 divergence spikes over 206 epochs (W&B: `qjceei69`). Dropout+T_max=30+no-EMA toxic combo — LR peaks amplify dropout noise. Reassigned with EMA+gc stability platform (#3163).

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 12:30 — PR #3162: DM EMA=0.9995 + gc=0.3 (himmel) — CLOSED
+
+- Best val=8.816% at ep80, then catastrophic divergence ep81 (grad norm 17.8→430, killed ep90). W&B: `og8ny8s7`. gc=0.3 is 2.3x worse than baseline (3.833%). gc=0.5 now quad-confirmed as sharp optimum: 0.25=13.1% (starves), 0.3=8.816% (diverges), 0.5=3.833% (champion), 1.0=6.21% (insufficient). Student noted potential bug fix (primary_metric_key shadowing) and suggested AGC — assigning AGC as fresh experiment.
+
+## 2026-04-23 12:30 — PR #3157: TFP 3L/224d intermediate width (nami) — CLOSED
+
+- Catastrophic divergence — field_mse ~2.2e9, gradient explosion ep87 (grad norm →4e8). W&B: `g3jp3nfi` (crashed). Width beyond 192d amplifies gradient instability in TFP's narrow stability window. Combined with 4L/192d pressure overflow, confirms 192d as the stability sweet spot. Student identified sinh overflow bug in TargetTransform.invert() — should be submitted as separate bugfix PR.
+
 ## 2026-04-23 12:00 — PR #3151: DM EMA=0.9995 + gc sweep (gilbert) — CLOSED
 
 - gc=0.25: 13.1% — gradient starvation, underfitting (W&B: check PR comments). gc=1.0: 6.21% — insufficient dampening, partial divergence. gc=0.5 remains the sharp optimum for DM EMA regime. Combined with #3072 (gc=0.5=3.833%) and #3114 (T_max=50+gc variants both diverge), the gc=0.5 sweet spot is now triple-confirmed. No further gc sweeps warranted.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-23 16:00 — PR #3135: AF EMA=0.999 + vol-weight=10x (nezuko) — MERGED ★ NEW BEST
+
+- **surface_mse: 0.000296 (-35.5%)**, **vol_mse: 0.002039 (-26.6%)** vs baseline 0.000459/0.002777. W&B: `sh2zyfwr`. Model still improving at ep763 timeout. EMA stabilizes the upweighted volume gradient — without EMA, 10x is worse; with EMA it's dramatic. Vol gap: 1.20x (was 1.63x). New AF champion.
+
+## 2026-04-23 16:00 — PR #3140: TF gc=0.2 sweep (usopp) — MERGED ★ NEW BEST
+
+- **val=21.350 (-2.6%)**, test=23.195 (-1.0%) vs 21.909/23.419. gc=0.2: W&B `9g11l7tm`. gc=0.1: 22.141 (W&B `55xdv4fq`) — single_in_dist regression +12.4%, overshoot. gc monotonic floor at 0.2. New TF champion.
+
+## 2026-04-23 16:00 — PR #3176: TFP full noam stack (mitsuha) — SENT BACK
+
+- No runs executed. Student identified 3 blockers: wrong dataset name (`tandem_foil_set` → `tandemfoilset`), ANP silently disabled on `tandemfoil_paper`, physics features silently dropped on `tandemfoil_paper`. Sent back to run on `tandemfoilset` where all features work. Baseline updated to TF 21.350.
+
+## 2026-04-23 16:00 — PR #3137: DM 5-ep warmup + gc=1.0 (chopper) — CLOSED
+
+- warmup+gc=1.0: 9.505% ep48, diverged ep50 (W&B: `f4jfokoj`). gc=1.0 only: 9.064% ep89, diverged ep91 (W&B: `kkkmsuxc`). gc=1.0 clips 100% of batches — underfitting then explosion. 2.4x worse than baseline. gc=1.0 family without EMA conclusively dead.
+
+## 2026-04-23 16:00 — PR #3085: DM larger supernodes (kohaku) — SENT BACK
+
+- Run 1: 6.121% ep121, diverged (W&B: `e3nmais2`). Run 2: 8.847% ep70, diverged (W&B: `pf01oz4d`). Both WITHOUT EMA+gc — old regime, ceiling 3.997%. Sent back for champion platform re-run (gc=0.5+EMA=0.9995) with supernodes 8192 and 16000.
+
 ## 2026-04-23 15:00 — PR #3123: TFP shorter T_max (T_max=5/8) (mitsuha) — CLOSED
 
 - T_max=5 (W&B: `5kp3yu51`): diverged, field_mse never finite. T_max=8 (W&B: `rcysi68k`): diverged, field_mse never finite. Confirms T_max=10 is a stability resonance for current stripped-down TFP config. However, noam branch uses T_max=150 with ANP decoder + full feature stack — the stability constraint is architecture-dependent. Reassigned to TFP full noam stack (ANP + physics features + T_max=150).

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,16 @@
 # SENPAI Research Results
 
+## 2026-04-24 22:45 — PR #3303: DrivAerML compile-mode champion recovery (faye) — CLOSED (critical bug finding)
+
+- faye/dm-compile-champion-recovery
+- **CRITICAL BUG:** torch.compile + FixedEMA is broken on PyTorch 2.10.0 + Blackwell GPUs. Compiled model caches parameter data — in-place param.data.copy_() from EMA swap NOT reflected in compiled forward pass. Val metrics frozen to 15+ decimal places. Training loss drops normally but eval never updates.
+- compile also incompatible with --skip-update-grad-norm 100 (compile grad norms 128-378 vs surface-only ~2-10)
+- Implication: ALL DM runs must use --no-compile-model with EMA. Original champion ncl1dh88 may have had incorrect EMA eval if it ran with compile default.
+- W&B runs: 89o7idav (v1 seed0, killed), scjbssye (v1 seed42, killed), v2 seed0/seed42 (broken eval), no-compile diagnostic (working)
+- **Faye assigned to #3305: champion recovery seed=13 + eval-interval=5**
+
+---
+
 ## 2026-04-24 19:30 — PR #3244: DrivAerML paper-facing full eval (faye) — CLOSED (critical finding)
 
 - faye/dm-paper-facing-champion-full-eval

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,31 @@
 # SENPAI Research Results
 
+## 2026-04-24 08:00 — PR #3236: AF Lookahead+compile ablation (gohan) — CLOSED (important finding)
+
+- gohan/af-lookahead-compile, W&B runs: dm5ykwmx (no features), bl5kty7w (Lookahead only), ejjf27ob (compile only)
+- Hypothesis: test whether Lookahead+compile (discovered to be default-on) help AF
+- **CRITICAL FINDING: Both features are DEFAULT ON in baseline.** Gohan correctly reframed as ablation study.
+- Trial A (no features): surface=0.000538 ep422 (still running, GPU-shared). Trial B (Lookahead only): 0.000826 (+53% worse). Trial C (compile only): 0.001104 (worst despite 49% more epochs).
+- **Lookahead hurts AF surface by 53% at equal epochs.** Compile hurts surface quality despite throughput gains. "Double averaging" (EMA + Lookahead) is harmful for AF.
+- **Ambiguity: baseline with both features = 0.000296@ep704 (better than all ablations).** Could be synergy at long training or just single-GPU vs GPU-sharing budget difference.
+- Follow-up assigned: gohan #3255 no-Lookahead/no-compile full single-GPU budget to resolve ambiguity.
+
+## 2026-04-24 08:00 — PR #3230: AF residual-prediction + re-stratified sampling no-asinh (alphonse) — CLOSED (dead end)
+
+- alphonse/af-residual-restrat, W&B runs: qrws45k4 (both features), 9t9k4w26 (residual only)
+- Hypothesis: residual prediction + re-stratified sampling (without toxic asinh) help AF
+- Trial 1 (both): surface=0.000459 (+55%), vol=0.002652 (+30%). Trial 2 (residual only): surface=0.000509 (+72%), vol=0.003256 (+60%)
+- **Residual prediction harmful for AF:** flow has large separated regions where "correction from freestream" IS the entire signal. Re-stratified sampling is a no-op (AF returns uniform sample weights).
+- **Conclusion: residual-prediction added to AF dead-end list alongside asinh-pressure.**
+
+## 2026-04-24 08:00 — PR #3226: AF vol-weight curriculum 20x→10x (chihiro) — CLOSED (dead end)
+
+- chihiro/af-volume-weight-curriculum, W&B runs: 75lpm3lz (20x→10x), 72xdp0o9 (15x→10x)
+- Hypothesis: decaying vol-weight curriculum — front-load volume emphasis then relax to 10x
+- Trial 1 (20x→10x): surface=0.001295 (4.4x worse), vol=0.005167 (2.5x worse). Collapsed ep335 (grad norms 200-500x normal)
+- Trial 2 (15x→10x): surface=0.000408 (+38%), vol=0.003097 (+52%). Stable but both metrics worse
+- **Conclusion: vol-weight curriculum dead. Static 10x validated as optimal operating point.** Any deviation above 10x (even temporary) costs surface without vol benefit.
+
 ## 2026-04-24 07:30 — PR #3225: DM self-distillation via EMA teacher (canute) — CLOSED (dead end)
 
 - canute/dm-self-distillation, W&B runs: 1df67nu8 (α=0.3), r8c2ztmm (α=0.1), group: dm-self-distillation

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 04:50 — PR #3090: TFP gc=0.3 at champion config (nezuko) — CLOSED
+
+- **Branch:** nezuko/tfp-gc-03
+- **Hypothesis:** Tighter gc (0.3 vs champion 0.5) delays divergence, allowing more productive training
+- **Results:**
+
+| Metric | gc=0.3 | gc=0.5 Baseline |
+|---|---|---|
+| val_primary/field_mse | **Infinity** (all 496 eps) | 0.002383 ep443 |
+| Divergence onset | ~ep155 | ep462 |
+| val/surface_mse_Ux | 0.329 (partial) | converged |
+
+- **W&B run:** 230pms51
+- **Analysis:** gc=0.3 clips too aggressively — prevents the large corrective updates the pressure head needs via sinh-domain inversion. Velocity channels show partial convergence, confirming failure is pressure-specific. gc=0.5 confirmed as SHARP OPTIMUM for TFP: gc=0.3 starves pressure learning, gc=0.7 (#3091) destabilizes. gc sweep FULLY CLOSED.
+- **Decision:** CLOSED — Infinity all epochs, pressure never finite
+
 ## 2026-04-23 04:20 — PR #3128: DrivAerML AdamW beta2 sweep (megumi) — CLOSED
 
 - **Branch:** megumi/dm-adamw-beta2-sweep

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 17:30 — PR #3153: DM EMA+gc+light WD (emma) — CLOSED
+
+- WD=1e-4: 14.76% ep35, diverged ep36 (W&B: `cbkbmr7n`). WD=5e-4: 4.920% ep247, diverged ep248 (W&B: `t1pqa5qd`). WD destabilizes EMA shadow model — no-WD confirmed for DM champion. Bug fix noted (primary_metric_key shadowing).
+
+## 2026-04-23 17:30 — PR #3065: DM multi-seed s456 two-phase (chihiro) — CLOSED
+
+- Phase 1 (capped): 5.709% ep130 (W&B: `6zuvrm3t`). Phase 2 (full): val=6.827%, test=6.456% (W&B: `tyn802bq`). Run used old config without EMA+gc=0.5 — not valid paper-facing data against 3.833% champion. Multi-seed runs should wait for post-noam-pivot best config.
+
 ## 2026-04-23 17:00 — PR #3182: DM compile + 96 slices (norman) — CLOSED (no-op)
 
 - Student correctly identified that model_slices=96 and compile_model=True are ALREADY defaults in train.py. The champion config already uses both. Experiment was vacuous as designed — no runs executed. Important correction to our noam analysis: these features were never "unused."

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,43 @@
 # SENPAI Research Results
 
+## 2026-04-23 00:50 — PR #3095: TFP 4L/256d deeper+wider (sanji) — CLOSED
+
+- **Branch:** sanji/tfp-4l-256d-depth-width
+- **Hypothesis:** 4L/256d (2.7x more params) improves TFP field_mse.
+- **Result:** val_primary/field_mse = **Infinity** all 70 epochs. Pressure overflow in asinh inversion at larger arch.
+- **W&B:** sfbvlaof
+- **sanji reassigned to #3116: DM SGDR T_0=15, T_mult=2**
+
+## 2026-04-23 00:50 — PR #3047: DM LR fine-tuning (piccolo) — CLOSED
+
+- **Branch:** piccolo/dm-lr-fine-tune
+- **Hypothesis:** Fine-tune LR ±10-20% around champion lr=5e-4.
+
+| LR | Best val% | W&B |
+|----|----------|-----|
+| 3e-4 | 5.745% (+44%) | 73iaz6a5 |
+| 4e-4 | 13.851% (+247%) | vvo4tj1t |
+| 4.5e-4 | 15.278% (+282%) | 3m5bs4do |
+| 5.5e-4 | 12.706% (+218%) | qvrsywc4 |
+
+- **Result:** lr=5e-4 is at a sharp optimum. Even ±10% destroys stability. LR axis exhausted for DM 4L/512d.
+- **piccolo reassigned to #3115: DM batch_size=2 with 25k points**
+
+## 2026-04-23 00:50 — PR #3045: DM T_max cosine sweep (griffith) — CLOSED
+
+- **Branch:** griffith/dm-tmax-sweep-champion-config
+- **Hypothesis:** T_max != 30 may be better for DM at champion config.
+
+| T_max | Best val% | Max grad norm | Diverged? | W&B |
+|-------|----------|---------------|-----------|-----|
+| 15 | 14.17% | 1.5e8 | Yes | zcl6gppr |
+| 30 (ctrl) | 19.32% (33ep only) | 5.9 | No | wtvv25ul |
+| 50 | 10.41% | 4.5e8 | Yes | 1lnn5f76 |
+| 100 | 11.48% | 5.1e10 | Yes | t6n3na4h |
+
+- **Result:** T_max=30 is the only stable setting without gc. Longer periods cause gradient explosions.
+- **griffith reassigned to #3114: DM T_max=50 + gc=1.0 compound**
+
 ## 2026-04-23 00:30 — PR #3097: TFP lr=1.5e-4 (shouko) — CLOSED
 
 - **Branch:** shouko/tfp-lr-15e5

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 14:00 — PR #3138: DM 788 batches + T_max=60 (kakashi) — CLOSED
+
+- Run 1 (gc=1.0, no EMA): 6.620% ep66, diverged ep72 (W&B: `7sa8l03q`). Run 2 (gc=0.5+EMA=0.9995): 4.661% ep141, diverged ep143 (W&B: `jzg8os84`). Champion platform extended stability from ep72→ep143 and improved 6.62%→4.66%, but divergence is structural. 788 batches accumulate only 111k steps before dying vs baseline's 201k — throughput advantage completely erased by shorter training horizon. Three attempts (incl #3084) all diverge within 2 cosine cycles. Higher batch count per epoch dead for DM.
+
 ## 2026-04-23 13:30 — PR #3068: DM 64k surface points (brook) — SENT BACK
 
 - Original run (no fix): 12.10% ep55, timeout (W&B: `ekrddnwe`). Retry no-gc: 16.91% ep30, diverged (W&B: `7gg7iqw8`). Retry gc=1.0: **5.26% ep236**, terminal diverge ep277 (W&B: `7uvkow6r`). All runs WITHOUT EMA — unfair comparison to 3.833% champion. gc=1.0 insufficient (diverged); need gc=0.5+EMA=0.9995. Sent back for re-run on champion platform. 64k direction not dead — 28% more surface coverage per sample may still improve quality.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,20 @@
 # SENPAI Research Results
 
+## 2026-04-24 08:30 — PR #3231: DM pressure gradient smoothness reg (emma) — CLOSED (dead end)
+
+- emma/dm-pressure-gradient-reg, W&B runs: lqgwricr (λ=0.01), e2rko1vh (λ=0.1), xcynbcli (λ=1.0), group: dm-pressure-grad-reg
+- Hypothesis: KNN-based smoothness penalty on surface pressure predictions encourages physically smooth predictions
+- λ=0.01: val=4.481% (+17%). λ=0.1: 4.876% (+27%). λ=1.0: 12.521% (+227%). All worse
+- **Two failures:** (1) KNN on 50k pts imposes ~30% throughput overhead, cutting epochs from 511 to ~355. At λ=0.01, degradation is mostly throughput-induced. (2) Car surfaces have legitimately sharp features that smoothness penalties destroy.
+- **Key insight from student:** remaining DM error is systematic bias, not high-freq noise. Smoothness priors are the wrong tool.
+
+## 2026-04-24 08:30 — PR #3196: TF EMA decay sweep 0.9999/0.99995 (zenitsu) — CLOSED (dead end)
+
+- zenitsu/tf-ema-decay-sweep, W&B runs: 8zpc9p92 (0.9999), ipgmi52n (0.99995), group: tf-ema-decay
+- EMA=0.9999: val=21.807 (+2.3% vs 21.319 baseline). EMA=0.99995: val=22.153 (+3.9%)
+- **Monotonic ordering confirmed: 0.999 > 0.9999 > 0.99995 for TF.** Matches AF finding — higher decay consistently harmful across both benchmarks.
+- TF is guardrail-only, no further EMA sweeps warranted.
+
 ## 2026-04-24 08:00 — PR #3236: AF Lookahead+compile ablation (gohan) — CLOSED (important finding)
 
 - gohan/af-lookahead-compile, W&B runs: dm5ykwmx (no features), bl5kty7w (Lookahead only), ejjf27ob (compile only)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-24 00:15 — PR #3185: TF full noam stack (fern) — MERGED ✓ NEW TF CHAMPION
+
+- Trial 1 (full stack: ANP+physics+T_max=150+96sl+Lookahead+compile+re-strat): val=21.319 ep277, test=22.868 (W&B: v05jt92n). Beats baseline 21.350/23.195 on both metrics (-0.15% val, -1.41% test). Trial 2 (ANP+physics only, T_max=10): val=22.276 ep233 (W&B: anluw1ab), diverged ep289. Key insight: full-stack extras (Lookahead, compile, 96 slices, re-stratified) only compound in late training (after ep200). T2 led for first 180 epochs. T_max=150 essential for full benefit. New TF config: Lion lr=1.25e-4, T_max=150, gc=0.2, EMA=0.999, 96 slices, ANP+full physics+asinh-scale=0.75+residual+Lookahead+compile+re-strat.
+
+## 2026-04-24 00:15 — PR #3186: TF T_max=150 alone (norman) — CLOSED (dead end)
+
+- gc=0.3+T_max=150: val=24.534 ep320 (+14.9% vs 21.350, W&B: ofq6mboa). gc=0.5+T_max=150: val=30.460 diverged ep87 (W&B: 5z8g5420). Both worse. T_max=150 alone doesn't help — benefit requires full noam feature stack (especially ANP + physics). T_max=10 with gc=0.3 remains load-bearing without features.
+
 ## 2026-04-24 00:00 — PR #3193: DM residual-prediction ablation (franky) — CLOSED (dead end)
 
 - Residual-only: best val=15.001% ep36 (W&B: uteqp5p4), crashed ep39 — catastrophic gradient explosion without asinh. Residual+asinh combined: best val=3.999% ep405 (W&B: 6eud1yyg), destabilized ep416 → 4.36%. Key finding: residual-prediction has a HARD dependency on asinh for stability on DM. Even paired, the combo gets to 3.999% (+0.17pp gap) but can't overtake champion. Asinh tames pressure gradients enough for residual to function, but added complexity still introduces late-training instability. Casca #3192 (asinh-only) will be the definitive single-feature test.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,23 @@
 # SENPAI Research Results
 
+## 2026-04-22 23:35 — PR #2948: TFP physics-flag ablation (guts) — CLOSED
+
+- **Branch:** guts-tfp-physics-v2 / tandemfoil_paper_physics_ablation_v5
+- **Hypothesis:** Which physics-encoding flags contribute to `val_primary/field_mse` on TFP?
+
+| Run | Config | State | Best val field_mse | W&B |
+|-----|--------|-------|--------------------|-----|
+| zoq2wf1p | AdamW lr=5e-4, T_max=150, full physics | RUNNING | 0.003564 (ep443) | zoq2wf1p |
+| 5 ablation runs | Various flag removals | ALL CRASHED | N/A | — |
+
+**Result: CLOSED**
+- Convergence run val=0.003564 is 49% worse than current baseline 0.002383
+- Config (AdamW lr=5e-4, T_max=150) is inferior to Lion champion
+- All 5 ablation runs crashed — no valid ablation conclusions possible
+- Bug fixes already merged separately in #3052
+
+**guts reassigned to #3109: DrivAerML lr=4e-4 full-eval paper-facing baseline**
+
 ## 2026-04-22 23:30 — PR #2949: TFP depth/width sweep (vash) — SENT BACK
 
 - **Branch:** vash/tandemfoil-paper-depth-width-sweep

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,9 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:15 — PR #3213: DM surface normal input features (brook) — CLOSED (already implemented)
+
+- No trials ran. Brook discovered surface normals are ALREADY present in DrivAerML input tensor (columns 3-5 of SURFACE_X_DIM=7, loaded from surface_normals.npy in prepare_drivaerml.py). The champion already has full access to normals. Hypothesis moot. Pivot: Fourier encoding of normals (currently only xyz cols 0-2 get Fourier features, not normals) — reassigning brook to this follow-up.
+
 ## 2026-04-23 23:00 — PR #3208: TFP seed stability diagnostic — strip physics flags (brook) — CLOSED (diagnostic complete)
 
 - All 3 trials STABLE at seed=42 with no physics flags. Lion lr=1.25e-4: val=0.04931, test=0.04134 (W&B: confirmed). Lion lr=6.25e-5: val=0.04920, test=0.04302. AdamW lr=1e-4: val=0.08036, test=0.06962. Zero NaN/Inf at any point. **Definitive proof: physics transforms (asinh/sinh pressure) cause TFP instability, not seed sensitivity.** Stable floor ~0.047-0.049 across seeds and optimizers. Path forward: fix pressure transforms (sanji #3209), then reintroduce one at a time.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,17 @@
 # SENPAI Research Results
 
+## 2026-04-23 12:00 — PR #3151: DM EMA=0.9995 + gc sweep (gilbert) — CLOSED
+
+- gc=0.25: 13.1% — gradient starvation, underfitting (W&B: check PR comments). gc=1.0: 6.21% — insufficient dampening, partial divergence. gc=0.5 remains the sharp optimum for DM EMA regime. Combined with #3072 (gc=0.5=3.833%) and #3114 (T_max=50+gc variants both diverge), the gc=0.5 sweet spot is now triple-confirmed. No further gc sweeps warranted.
+
+## 2026-04-23 12:00 — PR #3141: DM 5L/512d + gc=1.0 (vegeta) — CLOSED
+
+- val=5.515% at best (W&B: check PR comments). 44% worse than 4L baseline (3.833%). Consistent with prior 5L result (#3104: 4.172% without EMA). 5L adds optimization surface complexity that destabilizes training even with gc. 4L confirmed as optimal depth for DM — both 5L and 6L dead.
+
+## 2026-04-23 12:00 — PR #2947: TFP LR sweep (jin) — CLOSED
+
+- Original LR sweep from early TFP exploration. Results superseded by champion config (Lion lr=1.25e-4, gc=0.5, EMA=0.999, T_max=10) which emerged from later experiments. LR=1.5e-4 was +34% worse. Closing as historical — student reassigned to paper-facing multi-seed variance check.
+
 ## 2026-04-23 11:00 — PR #3127: DM attention heads 4H/16H (senku) — CLOSED
 
 - 4H: 11.02% ep54 (W&B: `v51k5hkn`). 16H: 13.83% ep77 (W&B: `yxldhqli`). Both with recurring gradient instability (no gc/EMA). 8H uniquely stable at 512d under old regime. 4H+EMA+gc assigned as #3165; 16H+EMA+gc in-flight as griffith #3160.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,25 @@
 # SENPAI Research Results
 
+## 2026-04-23 23:00 — PR #3208: TFP seed stability diagnostic — strip physics flags (brook) — CLOSED (diagnostic complete)
+
+- All 3 trials STABLE at seed=42 with no physics flags. Lion lr=1.25e-4: val=0.04931, test=0.04134 (W&B: confirmed). Lion lr=6.25e-5: val=0.04920, test=0.04302. AdamW lr=1e-4: val=0.08036, test=0.06962. Zero NaN/Inf at any point. **Definitive proof: physics transforms (asinh/sinh pressure) cause TFP instability, not seed sensitivity.** Stable floor ~0.047-0.049 across seeds and optimizers. Path forward: fix pressure transforms (sanji #3209), then reintroduce one at a time.
+
+## 2026-04-23 23:00 — PR #3205: TFP seed sensitivity — is seed=0 a lucky init? (jin) — CLOSED — CRITICAL: CODE REGRESSION
+
+- **Seed=0 no longer reproduces the champion.** All 4 trials produce Inf on pressure: T1 seed=0 control (W&B: 65q3qcbo), T2 seed=42 gc=0.3 (6hv5zqio), T3 seed=42 warmup=3 (g3hvoya7), T4 seed=42 asinh=0.5 (e2arojym). Velocity channels healthy (Ux~0.004, Uy~0.014) — pathology isolated to sinh inverse pressure transform at eval. This upgrades TFP crisis: it's not "one lucky seed" but a **code regression since PR #3025**. The champion config is BROKEN in the current codebase. No stabilization approach (gc/warmup/asinh-scale) helped. Waiting for sanji #3209 cp_panel bug fix.
+
+## 2026-04-23 23:00 — PR #3173: DM shorter cosine T_max=15/20 + EMA+gc (kakashi) — CLOSED (dead end)
+
+- T_max=15: best val=4.406% ep259, stable but plateaued (W&B: nufcf02f). T_max=20: best val=4.943% ep186, catastrophic divergence ep187 → 62.9% by ep259 (W&B: fqozs87o). Neither beats 3.833%. T_max=15 converges to higher plateau because shorter cycles reset LR before productive optimization completes. T_max=20 diverges at first restart. T_max=30 confirmed as DM sweet spot; T_max<30 added to dead ends.
+
+## 2026-04-23 23:00 — PR #3101: AF vol-weight=1.5x/3x (tanjiro) — CLOSED (dead end)
+
+- Vol-weight=3.0: surface=0.000381 (+29%), vol=0.003904 (+91%) vs champion (W&B: 2ebhl15x). Vol-weight=1.5: surface=0.000371 (+25%), vol=0.004224 (+107%) (W&B: ivwcw1xj, 5wv8vbas). Both diverged at cosine LR peaks. Completes vol-weight<10x dead end: 1.5x/2x/3x/5x/7x ALL confirmed worse. 10x+EMA=0.999 is the AF sweet spot.
+
+## 2026-04-23 23:00 — PR #3063: DM paper-facing full eval seed=42 (canute) — CLOSED (superseded)
+
+- Used outdated config (gc=1.0, no EMA) — champion has since evolved to gc=0.5+EMA=0.9995. Phase 1 diverged without gc, restarted with gc=1.0. Phase 2 full eval: val=5.25%, test=4.81% (W&B: typ76b0y). Not a valid paper-facing number due to config mismatch. Superseded by faye #3164 running proper champion config.
+
 ## 2026-04-23 22:30 — PR #3161: DM eta_min=1e-5 cosine floor + EMA+gc (spike) — CLOSED
 
 - Best val=4.202% ep297, then diverged ep312 → 16.3% (W&B run from student report). Trough-smoothing effect confirmed — eta_min prevents hard zeros at cosine troughs, giving EMA smoother targets. But 4.202% is 9.6% worse than 3.833% baseline. Root cause: gc=0.5 relies on zero-LR trough damping as a natural stability reset; eta_min=1e-5 removes that reset, allowing gradient accumulation through troughs → eventual divergence. Triple confirmation: eta_min+gc is incompatible at any gc value (gc=1.0→6.311%, gc=0.5→8.617% prior, now gc=0.5+EMA→4.202% diverge). Added to dead ends.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-24 00:00 — PR #3193: DM residual-prediction ablation (franky) — CLOSED (dead end)
+
+- Residual-only: best val=15.001% ep36 (W&B: uteqp5p4), crashed ep39 — catastrophic gradient explosion without asinh. Residual+asinh combined: best val=3.999% ep405 (W&B: 6eud1yyg), destabilized ep416 → 4.36%. Key finding: residual-prediction has a HARD dependency on asinh for stability on DM. Even paired, the combo gets to 3.999% (+0.17pp gap) but can't overtake champion. Asinh tames pressure gradients enough for residual to function, but added complexity still introduces late-training instability. Casca #3192 (asinh-only) will be the definitive single-feature test.
+
+## 2026-04-24 00:00 — PR #3183: TFP ANP+T_max=150 noam combo (rei) — CLOSED (dead end — TFP crisis)
+
+- ANP alone (T_max=10): field_mse=Inf every epoch, 548 epochs (W&B: bpqbwp3g). ANP+T_max=150: field_mse=3.1e+30 at best ep215, grad norms→62K, then NaN from ep400+ (W&B: 7uq11zww). Velocity channels healthy in both (Ux~0.0013-0.0015) — pathology isolated to pressure. ANP corrections in asinh-transformed space amplify exponentially on sinh inverse transform. Another manifestation of TFP physics-flag instability pattern. Entire TFP optimization blocked on sanji #3209 cp_panel bug fix.
+
 ## 2026-04-23 23:45 — PR #3175: DM full noam stack + individual ablations (hinata) — CLOSED (dead end)
 
 - Full stack (asinh+residual+compile+96sl+srf): best val=4.447% ep342 (W&B: vddf3qle), diverged → 64%. Asinh-only (scale=0.75): best val=4.421% ep303 (W&B: 0ks1aaz5), diverged → 61%. Residual-only: best val=4.651% ep242 (W&B: xmx6y3ws), diverged → NaN. All 0.6-0.8pp worse than 3.833%. Root cause: noam features were tuned for T_max=150/3H/no-gc regime — cosine T_max=30 restarts amplify gradient instability through these features despite gc=0.5. Asinh least harmful, residual most harmful. Individual ablations (casca #3192, franky #3193) may find narrower windows. Bug fix: primary_metric_key scoping.

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,22 @@
 # SENPAI Research Results
 
+## 2026-04-24 02:00 — PR #3212: AF PCGrad gradient surgery (jin) — CLOSED (dead end)
+
+- jin/af-pcgrad, W&B group: af-pcgrad
+- Hypothesis: PCGrad (Yu et al., 2020) resolves surface/volume gradient conflicts to improve vol_mse
+- Trial 1 (PCGrad vol-10x, W&B: p89omv2u): surface=0.001926 (+550%), vol=0.011321 (+455%) — 5-6x worse on both metrics
+- Trial 2 (PCGrad vol-15x, W&B: 8cq4fd0i): surface=0.001510 (+410%), vol=0.011741 (+476%) — 5-6x worse on both metrics
+- **Root cause:** PCGrad requires retain_graph=True which disables torch.compile, causing ~40% throughput loss. Gradient conflict rate ~30-40% per step provides persistent magnitude reduction. The gradient conflict between surface and volume is NOT the bottleneck.
+- **Conclusion: PCGrad dead for AF.** Multi-backward-pass methods are fundamentally incompatible with the compile-dependent training pipeline. Added to AF dead ends.
+
+## 2026-04-24 02:00 — PR #3197: TF residual-prediction alone (gojo) — CLOSED (dead end)
+
+- gojo/tf-residual-prediction, W&B group: tf-residual-pred
+- Hypothesis: isolate contribution of --residual-prediction on TF without full noam stack
+- Trial 1 (residual alone, W&B: ja9b5iih): val=24.522 ep318 — +14.9% worse than 21.319
+- Trial 2 (residual+asinh, W&B: spykkoka): val=22.491 ep293 — +5.5% worse than 21.319
+- **Conclusion: residual-prediction is necessary but not sufficient for TF.** Adding asinh closes ~40% of the gap to champion but the full compound stack (ANP+physics+T_max=150+Lookahead+compile+96sl+re-strat) is required. Noam features don't decompose into independently useful TF components.
+
 ## 2026-04-24 01:15 — PR #3191: AF noam features (asinh+residual+re-strat) on base and vol-10x (alphonse) — CLOSED (dead end)
 
 - alphonse/af-noam-features, W&B group: af-noam-features-base

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,14 @@
 # SENPAI Research Results
 
+## 2026-04-24 16:45 — PR #3284: Harness patches (vegeta) — MERGED (infrastructure)
+
+- vegeta/harness-patches-last-ditch, train.py +218/-53
+- Merged after bug fix: double best-tracking consolidated into single atomic chain, min_delta applied in kill_if_no_improvement
+- **Patches now live:** --load-checkpoint (eval-only), --eval-interval N, --ema-mode fixed|warmup, --skip-update-grad-norm, --save-checkpoint, kill gates (--kill-if-best-val-above, --kill-if-no-improvement, --kill-if-grad-nonfinite-steps)
+- All subsequent DM champion recovery runs should use: --save-checkpoint --skip-update-grad-norm 100 --ema-mode fixed --ema-start-step 50
+
+---
+
 ## 2026-04-24 16:15 — PR #3276: DM cosine similarity auxiliary loss (zenitsu) — CLOSED (dead end)
 
 - zenitsu/dm-cosine-sim-aux-loss, W&B runs: ry1lq2vw (w=0.1), flnnss55 (w=0.5), group: dm-cosine-sim-loss

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,44 @@
 # SENPAI Research Results
 
+## 2026-04-23 07:00 — PR #3072: DrivAerML EMA=0.9995+gc=0.5 (eren) — MERGED ✓
+
+- **Branch:** eren/dm-ema-9995-gc05
+- **Hypothesis:** EMA requires gc as a stability guard — previous EMA failures on DM lacked clipping
+- **Results:**
+
+| Run | Config | W&B | Best val surface_rel_l2_pct | Epoch | Status |
+|---|---|---|---|---|---|
+| Run 1 | EMA=0.9995, no gc | `64jrja7q` | 18.05% | 27 | Diverged ep28 |
+| Run 2 | EMA=0.9995 + gc=0.5 | `ncl1dh88` | **3.833%** | 511 | Still converging |
+
+- **vs Baseline:** -4.1% (3.833% vs 3.997%). Test=4.685%. Gap to AB-UPT: 0.013 pp (93% closed)
+- **Key insight:** gc=0.5 is the stability enabler for EMA on DrivAerML. The periodic loss spikes at cosine restart peaks (every ~30 epochs) disturb the EMA trajectory without clipping. EMA was previously thought dead for DM — the 3 prior failures all lacked gc. Run still converging at ep517 timeout.
+- **Decision:** MERGED — new DM champion
+
+## 2026-04-23 07:00 — PR #3077: DrivAerML 5L/512d (gilbert) — CLOSED
+
+- Best val 4.172% ep347, diverged ep405 (W&B: `ox918q66`). 4.4% worse then unrecoverable. 4L/512d confirmed as optimal depth.
+
+## 2026-04-23 07:00 — PR #3106: AF 2L/384d+gc=0.5+T_max=50 (wolfwood) — SENT BACK
+
+- surface=0.000564, vol=0.005935 (W&B: `gccu8a2k`). Stability confirmed (gc=0.5 fixes prior divergence) but both metrics worse than EMA champion (0.000459/0.002777). Sent back to add EMA=0.999 — the capacity of 384d needs EMA to realize its advantage.
+
+## 2026-04-23 07:00 — PR #3068: DM 64k surface points (brook) — SENT BACK
+
+- val=12.10% at ep62 (W&B: `ekrddnwe`). Epoch-starved: 64k eval without max-eval-batches costs ~6 min/ep → only 62 epochs in budget. Trajectory healthy and descending. Sent back to add --max-eval-batches 200.
+
+## 2026-04-23 07:00 — PR #3067: DM 32k surface points (askeladd) — SENT BACK
+
+- val=17.48% at ep33 (W&B: `8jvflw2w`). Same epoch-starvation. 32k creates 8,670 eval batches/epoch. Sent back to add --max-eval-batches 200.
+
+## 2026-04-23 07:00 — PR #3065: DM multi-seed seed=456 (chihiro) — SENT BACK
+
+- val=12.544% at ep50, test=12.096% (W&B: `pvkrr76j`). Full-eval timeout: ~7.7 min/ep → 50 epochs vs 467 needed. Sent back for two-phase approach (train with max-eval-batches, then single full-eval at best checkpoint).
+
+## 2026-04-23 07:00 — PR #3064: DM multi-seed seed=123 (casca) — SENT BACK
+
+- val=14.027% at ep40, test=15.580% (W&B: `7acr9vfr`). Same root cause. Sent back for two-phase eval.
+
 ## 2026-04-23 06:15 — PR #2974: Best-checkpoint saving infrastructure (mugen) — MERGED ✓
 
 - **Branch:** mugen/best-checkpoint-saving

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,26 +1,25 @@
 # SENPAI Research Results
 
-## 2026-04-22 — PR #3043: DrivAerML gradient accumulation ablation + full eval baseline (einar) — SENT BACK
+## 2026-04-22 23:50 — PR #3043: DrivAerML gradient accumulation ablation (einar) — CLOSED
 
 - **Branch:** einar/dm-grad-accum-ablation
-- **Hypothesis:** Gradient accumulation (accum=2, accum=4) reduces gradient noise in DrivAerML's batch_size=1 regime. Step-matching (doubling `--max-train-batches`) isolates the smoothing effect from optimizer step reduction. Secondary goal: establish a full-eval paper-facing baseline without `--max-eval-batches`.
-- **Baseline:** val=3.997% (PR #2898, W&B bht6h42t, 4L/512d, AdamW lr=5e-4, T_max=30)
+- **Hypothesis:** Gradient accumulation (accum=2/4) reduces gradient noise in DrivAerML batch_size=1 training.
 
-| Run | Description | W&B ID | Best Val % | Best Ep | Best Test % | Notes |
-|-----|-------------|--------|-----------|---------|------------|-------|
-| 1 | DM control, full eval | 9kn1satv | 14.098 | ep40 | 13.644 | Hit epoch budget at ep42; severely undertrained |
-| 2 | DM accum=2, fewer steps | dguhbgax | 11.390 | ep365 | 11.933 | Late divergence (val→67% by final ep444) |
-| 3 | DM accum=2, step-matched | wpbqofwh | **4.860** | ep153 | **6.091** | Post-peak decay; best run in ablation |
-| 4 | DM accum=4 | hngfgj6i | 9.391 | ep124 | 9.702 | Never converged to competitive range |
-| 5 | AF accum=2, T_max=50 | 1nc85857 | 0.000534 MSE | ep466 | 0.000712 MSE | Late divergence ep723; confirms accum hurts AF |
+| Run | Description | W&B ID | Best Val % | Best Ep | Best Test % |
+|-----|-------------|--------|-----------|---------|------------|
+| 1 | DM control, full eval | 9kn1satv | 14.098 | ep40 | 13.644 |
+| 2 | DM accum=2 | dguhbgax | 11.390 | ep365 | 11.933 |
+| 3 | DM accum=2, step-matched (788 batches) | wpbqofwh | **4.860** | ep153 | **6.091** |
+| 4 | DM accum=4 | hngfgj6i | 9.391 | ep124 | 9.702 |
+| 5 | AF accum=2, T_max=50 | 1nc85857 | 0.000534 | ep466 | 0.000712 |
 
-**Result: SENT BACK (request changes)**
-- No run beat baseline. Best: Run 3 at 4.860% (21.6% above 3.997%)
-- Run 3 (accum=2, step-matched) is directionally promising — closest any non-baseline DM run has come
-- Post-ep153 instability in Run 3 suggests T_max is mismatched to the effective doubled batch size
-- Full-eval control (Run 1) hit epoch budget at ep42 — not a valid paper number
-- accum=2 hurts AF (confirmed); no further AF accum experiments warranted
-- **Next iteration:** accum=2 step-matched + T_max=60 (2x baseline T_max=30) + cosine-eta-min=1e-6; wandb-group dm_grad_accum_v3
+**Result: CLOSED — gradient accumulation does not help DrivAerML**
+- Best (accum=2 step-matched) at 4.860% still 21.6% above baseline 3.997%
+- Control run undertrained (42 epochs only) — not valid full-eval baseline
+- AirfRANS accum=2 also worse (0.000534 vs 0.000482 baseline)
+- Consistent with AirfRANS finding (#2902): CFD mesh regression benefits from noisy single-sample gradients
+
+**einar reassigned to #3110: DrivAerML AdamW beta2=0.99/0.995 sweep**
 
 ## 2026-04-22 23:35 — PR #2948: TFP physics-flag ablation (guts) — CLOSED
 

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,20 @@
 # SENPAI Research Results
 
+## 2026-04-23 04:20 — PR #3128: DrivAerML AdamW beta2 sweep (megumi) — CLOSED
+
+- **Branch:** megumi/dm-adamw-beta2-sweep
+- **Hypothesis:** Lower beta2 (0.99, 0.95) makes optimizer more responsive to recent gradient variance across cosine LR transitions
+- **Results:**
+
+| Run | beta2 | W&B ID | Best val surface_rel_l2_pct | Fate |
+|---|---|---|---|---|
+| Run 1 | 0.99 | 95teq8ui | 7.113% ep140 | Progressive instability |
+| Run 2 | 0.95 | 4dladx7q | 13.332% ep40 | Diverged (grad_norm 1.26M) |
+| Baseline | 0.999 | bht6h42t | 3.997% ep467 | — |
+
+- **Analysis:** beta2=0.999's long memory is a STABILITY FEATURE, not a bug. Faster adaptation amplifies outlier batches into cascading gradient spikes at cosine LR peaks. Clear monotonic: 0.999 > 0.99 > 0.95. beta2=0.95 had mean grad_norm of 14,540 with max 1.26M. Leave beta2 at default.
+- **Decision:** CLOSED — 78-234% above baseline
+
 ## 2026-04-23 03:55 — PR #3126: DrivAerML cosine eta_min sweep (gohan) — CLOSED
 
 - **Branch:** gohan/dm-cosine-eta-min

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,21 @@
 # SENPAI Research Results
 
+## 2026-04-23 02:35 — PR #3086: DrivAerML SGDR T_mult=2 (megumi) — CLOSED
+
+- **Branch:** megumi/dm-cosine-restart-tmult2
+- **Hypothesis:** SGDR with exponentially growing cosine periods (30→60→120→240) progressively lengthens low-LR phases for deeper convergence
+- **Results:**
+
+| Run | Config | W&B ID | Best val surface_rel_l2_pct | Fate |
+|---|---|---|---|---|
+| No gc | T_mult=2 | 3pl2a2q8 | 7.022% ep77 | Crashed |
+| gc=1.0 | T_mult=2 | 2n6tt16b | 7.697% ep77 | Crashed |
+| gc=0.5 | T_mult=2 | i05go4xl | 11.952% ep54 | Crashed |
+| Baseline | T_max=30 fixed | bht6h42t | 3.997% ep467 | — |
+
+- **Analysis:** Structural incompatibility. Model converges through cycles 1-3 (T=30/60/120) reaching ~7% by ep77, but the 240-step 4th cycle sustains lr=5e-4 for 2x longer than any previous cycle — fatal on DM. Grad-clipping delayed divergence but couldn't prevent it. Key insight: DM is stable below ~120 contiguous high-LR steps, which is why fixed T_max=30 works.
+- **Decision:** CLOSED — 75-200% above baseline, all crashed
+
 ## 2026-04-23 02:20 — PR #3120: DrivAerML RAdam optimizer (senku) — CLOSED
 
 - **Branch:** senku/dm-radam-optimizer

--- a/research/RESEARCH_IDEAS_2026-04-23_14:00.md
+++ b/research/RESEARCH_IDEAS_2026-04-23_14:00.md
@@ -1,0 +1,61 @@
+# Bold Research Ideas — 2026-04-23 14:00
+## Driven by noam branch intelligence + human directive to "think bigger"
+
+The noam branch accumulated ~100 merged PRs with winning techniques. Many are ALREADY PORTED to radford's train.py but UNUSED. This is the highest-priority action: activate these features.
+
+## Available in radford's train.py but NOT USED
+
+| Feature | Flag | Noam Impact | Applicable To |
+|---------|------|-------------|---------------|
+| ANP cross-attention decoder | `--anp-srf` | **-58.9% TF p_tan, -70% p_in** | TF, TFP |
+| Asinh pressure normalization | `--asinh-pressure --asinh-scale 0.75` | **p_oodc -8%, p_re -4.5%** | ALL |
+| Residual prediction | `--residual-prediction` | Learned correction to freestream | ALL |
+| Panel method Cp | `--enable-cp-panel --enable-cp-panel-tandem-only --cp-panel-scale 0.1` | Physics input feature | TF, TFP |
+| TE coordinate frame | `--enable-te-coord-frame` | 6 TE-relative channels | TF, TFP |
+| Wake deficit feature | `--enable-wake-deficit` | Gap-normalized fore-TE offset | TF, TFP |
+| Wake angle feature | `--enable-wake-angle` | atan2 polar direction | TF, TFP |
+| Vortex panel velocity | `--enable-vortex-panel-velocity --vortex-panel-scale 0.1 --vortex-panel-n 64` | Biot-Savart velocity | TF, TFP |
+| Re-stratified sampling | `--re-stratified-sampling` | OOD Re robustness | TF, TFP, AF |
+| Lookahead optimizer | `--use-lookahead` (default True!) | k=5 slow weights | ALL |
+| torch.compile | `--compile-model` (default True!) | Throughput | ALL |
+| 96 slices | `--model-slices 96` (default!) | Optimal slice count | ALL |
+| 3 heads (64d/head at 192d) | `--model-heads 3` (default!) | Optimal for 192d | TF, TFP |
+| Surface refinement head | `--surface-refine` (default True!) | Surface post-processing | ALL |
+| Pressure prior addition | `--enable-pressure-prior-addition` | Physics prior | TF, TFP? |
+
+## Key config mismatches (radford vs noam defaults)
+
+| Parameter | Radford TF/TFP | Noam optimal | Impact |
+|-----------|----------------|--------------|--------|
+| T_max | 10 | **150** | 15x longer schedule — massive underfitting! |
+| Heads | 8 | **3** | 64d/head vs 24d/head at 192d |
+| Slices | ? | **96** | Swept 48/64/96/128, 96 is optimal |
+| Lookahead | off | **on** | Slow-weight averaging |
+| compile | off | **on** | More epochs in time budget |
+| EMA decay | 0.999 | **0.9999** | Smoother averaging |
+
+## Priority 1: Full noam stack on each dataset
+
+### P1-A: TandemFoil "Full Noam Stack"
+### P1-B: TandemFoil Paper "Full Noam Stack"
+### P1-C: DrivAerML "Noam training dynamics" (asinh + residual-prediction + compile + slices)
+### P1-D: AirfRANS "Noam training dynamics" (same applicable features)
+
+## Priority 2: Individual high-impact ablations
+### P2-A: ANP decoder alone on TF
+### P2-B: T_max=150 alone on TF
+### P2-C: Asinh pressure alone on DM
+### P2-D: Residual prediction alone on DM
+### P2-E: Lion optimizer on DM (noam's final optimizer)
+
+## Priority 3: Code changes needed (students port from noam)
+1. vol_loss_scale (-15.9% impact)
+2. PCGrad 3-way (gradient surgery)
+3. Attention temperature annealing (-11%)
+4. DomainLayerNorm
+5. GLU preprocess MLP
+6. High-p-clamp
+
+## Confirmed dead ends from noam
+- Manifold mixup, slice dropout, multi-exit ensemble, Y-flip aug, polar velocity targets
+- Surface pressure smoothness loss, LNO bottleneck, SOAP optimizer, stochastic depth

--- a/target/icml2026/instructions/experiment-vegeta-dm-attn-temp-annealing.md
+++ b/target/icml2026/instructions/experiment-vegeta-dm-attn-temp-annealing.md
@@ -1,0 +1,7 @@
+# Experiment: DrivAerML Attention Temperature Annealing
+
+Student: vegeta
+Branch: vegeta/dm-attn-temp-annealing
+Dataset: DrivAerML
+
+See PR for full instructions.

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,6 +1637,17 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
+    if bundle.spec.name == "tandemfoilset":
+        primary_metric_key = "val_primary/surface_pressure_mae"
+    else:
+        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_metric = float("inf")
+    best_epoch = 0
+    best_model_state: dict[str, torch.Tensor] | None = None
+    best_anp_state: dict[str, torch.Tensor] | None = None
+    best_ema_shadow: dict[str, torch.Tensor] | None = None
+    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
+
     run = None
     if config.wandb_name:
         run_config = asdict(config)
@@ -1702,16 +1713,32 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
+        current_val = eval_metrics.get(primary_metric_key)
+        if current_val is not None and current_val < best_val_metric:
+            best_val_metric = current_val
+            best_epoch = epoch
+            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+            if anp_head is not None:
+                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+            if ema is not None:
+                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+            if anp_ema is not None:
+                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
         if ema is not None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+        epoch_metrics["best_val_metric"] = best_val_metric
+        epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
+            run.summary["best_epoch"] = best_epoch
+            run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1761,7 +1788,9 @@ def main() -> None:
         if run is not None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
-        print(json.dumps({"final_test_metrics": final_test_metrics}, sort_keys=True), flush=True)
+            run.summary["best_epoch"] = best_epoch
+            run.summary["best_val_metric"] = best_val_metric
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -10,6 +10,7 @@ import json
 import math
 import os
 import random
+import sys
 import time
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
@@ -30,7 +31,7 @@ from core.features import (
     compute_vortex_panel_velocity,
     compute_wake_deficit_features,
 )
-from core.optim import Lion, Lookahead
+from core.optim import EMA as FixedEMA, Lion, Lookahead
 
 
 class EMAWithWarmup:
@@ -168,6 +169,14 @@ class TrainConfig:
     grad_accum_steps: int = 1
     volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
+    load_checkpoint: str = ""
+    eval_interval: int = 1
+    skip_update_grad_norm: float = 0.0
+    ema_mode: str = "warmup"
+    ema_start_step: int = 50
+    kill_if_best_val_above: str = ""
+    kill_if_no_improvement: str = ""
+    kill_if_grad_nonfinite_steps: int = 0
     seed: int = 0
 
 
@@ -1277,6 +1286,7 @@ def train_one_epoch(
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
     volume_loss_weight: float = 1.0,
+    skip_update_grad_norm: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1345,18 +1355,32 @@ def train_one_epoch(
         if anp_head is not None:
             all_params += list(anp_head.parameters())
         grad_norm = torch.nn.utils.clip_grad_norm_(all_params, max_norm=grad_clip if grad_clip > 0 else float("inf"))
+        grad_norm_val = float(grad_norm)
         running.setdefault("grad_norm_mean", 0.0)
-        running["grad_norm_mean"] += float(grad_norm)
-        if grad_clip > 0 and float(grad_norm) > grad_clip:
+        running["grad_norm_mean"] += grad_norm_val
+        if grad_clip > 0 and grad_norm_val > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
-        optimizer.step()
+        if not math.isfinite(grad_norm_val):
+            running.setdefault("grad_nonfinite", 0.0)
+            running["grad_nonfinite"] += 1.0
+        skip_step = skip_update_grad_norm > 0 and (not math.isfinite(grad_norm_val) or grad_norm_val > skip_update_grad_norm)
+        if skip_step:
+            optimizer.zero_grad(set_to_none=True)
+            running.setdefault("skipped_updates", 0.0)
+            running["skipped_updates"] += 1.0
+        else:
+            optimizer.step()
         if scheduler is not None:
             scheduler.step()
-        if ema is not None:
+        if ema is not None and not skip_step:
             ema.update(model)
-            running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
-        if anp_head is not None and anp_ema is not None:
+        if ema is not None:
+            if isinstance(ema, FixedEMA):
+                running["ema_decay_actual"] = ema.decay if ema.step_counter >= ema.start_step else 0.0
+            else:
+                running["ema_decay_actual"] = min(ema.decay, (1 + ema.step_counter) / (10 + ema.step_counter))
+        if anp_head is not None and anp_ema is not None and not skip_step:
             anp_ema.update(anp_head)
         running["loss"] += accum_loss / micro_count
         micro_batches_total += micro_count
@@ -1638,22 +1662,29 @@ def main() -> None:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
-    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
-    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+    if not config.use_ema:
+        ema = None
+    elif config.ema_mode == "fixed":
+        ema = FixedEMA(model, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        ema = EMAWithWarmup(model, decay=config.ema_decay)
+    if not config.use_ema or anp_head is None:
+        anp_ema = None
+    elif config.ema_mode == "fixed":
+        anp_ema = FixedEMA(anp_head, decay=config.ema_decay, start_step=config.ema_start_step)
+    else:
+        anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay)
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
     if bundle.spec.name == "tandemfoilset":
         val_primary_key = "val_primary/surface_pressure_mae"
     else:
         val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
+    best_epoch: int = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
@@ -1672,8 +1703,36 @@ def main() -> None:
             tags=[config.dataset, config.model],
         )
 
+    if config.load_checkpoint:
+        ckpt = torch.load(config.load_checkpoint, map_location=device, weights_only=True)
+        state = ckpt.get("model_state_dict", ckpt)
+        model.load_state_dict(state, strict=False)
+        print(f"[LoadCheckpoint] Loaded from {config.load_checkpoint}")
+        for phase, loaders in [("val", val_loaders), ("test", test_loaders)]:
+            if not loaders:
+                continue
+            metrics = evaluate_phase_metrics(
+                bundle=bundle, config=config, forward_model=forward_model,
+                anp_head=anp_head, loaders=loaders, transform=transform,
+                metric_transform=metric_transform, device=device, phase=phase,
+            )
+            print(json.dumps({f"load_checkpoint_{phase}": metrics}, sort_keys=True), flush=True)
+            if run is not None:
+                wandb.log(metrics)
+                run.summary.update(metrics)
+        if run is not None:
+            wandb.finish()
+        return
+
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
+    grad_nonfinite_count = 0
+    last_eval_epoch = 0
+    kill_patience, kill_min_delta = 0, 0.0
+    kill_ref_metric, kill_ref_epoch = float("inf"), 0
+    if config.kill_if_no_improvement:
+        _p, _d = config.kill_if_no_improvement.split(":")
+        kill_patience, kill_min_delta = int(_p), float(_d)
 
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
@@ -1694,53 +1753,102 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
             volume_loss_weight=config.volume_loss_weight,
+            skip_update_grad_norm=config.skip_update_grad_norm,
         )
 
-        if ema is not None:
-            ema.store(model)
-            ema.copy_to(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.store(anp_head)
-            anp_ema.copy_to(anp_head)
+        grad_nonfinite_count += int(train_metrics.get("grad_nonfinite", 0))
 
-        eval_metrics = evaluate_phase_metrics(
-            bundle=bundle,
-            config=config,
-            forward_model=forward_model,
-            anp_head=anp_head,
-            loaders=val_loaders,
-            transform=transform,
-            metric_transform=metric_transform,
-            device=device,
-            phase="val",
-        )
-
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
-
-        current_val = eval_metrics.get(val_primary_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
+        should_eval = (epoch == 1 or epoch % config.eval_interval == 0 or epoch == config.epochs)
+        if should_eval:
             if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+                ema.store(model)
+                ema.copy_to(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.store(anp_head)
+                anp_ema.copy_to(anp_head)
 
-        if ema is not None:
-            ema.restore(model)
-        if anp_head is not None and anp_ema is not None:
-            anp_ema.restore(anp_head)
+            eval_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=val_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="val",
+            )
+
+            current_val = eval_metrics.get(val_primary_key)
+            if current_val is not None and current_val < best_val_metric:
+                best_val_metric = current_val
+                best_val_primary_metric = current_val
+                best_val_metrics = dict(eval_metrics)
+                best_epoch = epoch
+                best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+                best_anp_state = snapshot_module_state(anp_head)
+                if ema is not None:
+                    best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+                if anp_ema is not None:
+                    best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+            if current_val is not None and current_val < kill_ref_metric - kill_min_delta:
+                kill_ref_metric = current_val
+                kill_ref_epoch = epoch
+
+            kill_reason = None
+            if config.kill_if_best_val_above and best_val_metric is not None:
+                gate_epoch_str, gate_threshold_str = config.kill_if_best_val_above.split(":")
+                gate_epoch, gate_threshold = int(gate_epoch_str), float(gate_threshold_str)
+                if epoch >= gate_epoch and best_val_metric > gate_threshold:
+                    kill_reason = (
+                        f"best_val {best_val_metric:.4f} exceeded kill gate {gate_threshold} "
+                        f"after epoch {gate_epoch}"
+                    )
+            if kill_reason is None and config.kill_if_no_improvement:
+                if epoch - kill_ref_epoch >= kill_patience:
+                    kill_reason = (
+                        f"no significant improvement (>{kill_min_delta}) for "
+                        f"{epoch - kill_ref_epoch} epochs (patience={kill_patience})"
+                    )
+            if kill_reason is None and config.kill_if_grad_nonfinite_steps > 0:
+                if grad_nonfinite_count >= config.kill_if_grad_nonfinite_steps:
+                    kill_reason = (
+                        f"grad nonfinite for {grad_nonfinite_count} cumulative steps "
+                        f"(threshold={config.kill_if_grad_nonfinite_steps})"
+                    )
+
+            if ema is not None:
+                ema.restore(model)
+            if anp_head is not None and anp_ema is not None:
+                anp_ema.restore(anp_head)
+
+            if kill_reason is not None:
+                wandb_info = f"group={config.wandb_group or 'none'} name={config.wandb_name or 'none'}"
+                kill_msg = (
+                    f"EXPERIMENT_KILLED: dataset={config.dataset} {wandb_info} "
+                    f"epoch={epoch} best_val={best_val_metric:.4f} "
+                    f"best_epoch={best_epoch} reason={kill_reason}"
+                )
+                epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
+                epoch_metrics["best_val_metric"] = best_val_metric
+                epoch_metrics["best_epoch"] = float(best_epoch)
+                epoch_metrics["kill_reason"] = kill_reason
+                history.append(epoch_metrics)
+                if run is not None:
+                    wandb.log(epoch_metrics, step=epoch)
+                    run.summary["kill_reason"] = kill_reason
+                    run.summary["kill_epoch"] = epoch
+                    run.finish()
+                kill_output_dir = Path(config.output_dir)
+                kill_output_dir.mkdir(parents=True, exist_ok=True)
+                (kill_output_dir / "KILLED.md").write_text(kill_msg + "\n")
+                print(kill_msg, file=sys.stderr, flush=True)
+                raise RuntimeError(kill_msg)
+
+            last_eval_epoch = epoch
+        else:
+            eval_metrics = {}
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
@@ -1752,6 +1860,42 @@ def main() -> None:
             run.summary["best_epoch"] = best_epoch
             run.summary["best_val_metric"] = best_val_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
+
+    if config.eval_interval > 1 and history and last_eval_epoch < int(history[-1]["epoch"]):
+        final_trained_epoch = int(history[-1]["epoch"])
+        if ema is not None:
+            ema.store(model)
+            ema.copy_to(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.store(anp_head)
+            anp_ema.copy_to(anp_head)
+        eval_metrics = evaluate_phase_metrics(
+            bundle=bundle, config=config, forward_model=forward_model,
+            anp_head=anp_head, loaders=val_loaders, transform=transform,
+            metric_transform=metric_transform, device=device, phase="val",
+        )
+        current_val = eval_metrics.get(val_primary_key)
+        if current_val is not None and current_val < best_val_metric:
+            best_val_metric = current_val
+            best_val_primary_metric = current_val
+            best_val_metrics = dict(eval_metrics)
+            best_epoch = final_trained_epoch
+            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+            best_anp_state = snapshot_module_state(anp_head)
+            if ema is not None:
+                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
+            if anp_ema is not None:
+                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+        if ema is not None:
+            ema.restore(model)
+        if anp_head is not None and anp_ema is not None:
+            anp_ema.restore(anp_head)
+        final_eval_log = {"epoch": float(final_trained_epoch), **eval_metrics,
+                          "best_val_metric": best_val_metric, "best_epoch": float(best_epoch)}
+        history[-1].update(eval_metrics)
+        if run is not None:
+            wandb.log(final_eval_log, step=final_trained_epoch)
+        print(json.dumps({"final_epoch_eval": final_eval_log}, sort_keys=True), flush=True)
 
     if best_epoch is not None:
         print(
@@ -1867,15 +2011,36 @@ def main() -> None:
             torch.save(terminal_model_state, output_dir / f"{config.dataset}_{config.model}.pt")
         else:
             torch.save(model.state_dict(), output_dir / f"{config.dataset}_{config.model}.pt")
+        best_ckpt_path = output_dir / f"{config.dataset}_{config.model}_best.pt"
         if best_model_state is not None:
-            torch.save(best_model_state, output_dir / f"{config.dataset}_{config.model}_best.pt")
+            ckpt_payload = {
+                "model_state_dict": best_model_state,
+                "epoch": best_epoch,
+                "val_metric": best_val_metric,
+                "val_primary_metric_name": best_val_primary_metric_name,
+                "val_primary_metric": best_val_primary_metric,
+                "config": {k: v for k, v in vars(config).items() if not k.startswith("_")},
+            }
+            if best_anp_state is not None:
+                ckpt_payload["anp_state_dict"] = best_anp_state
+            if best_ema_shadow is not None:
+                ckpt_payload["ema_shadow"] = best_ema_shadow
+            if best_anp_ema_shadow is not None:
+                ckpt_payload["anp_ema_shadow"] = best_anp_ema_shadow
+            torch.save(ckpt_payload, best_ckpt_path)
+            print(f"[SaveCheckpoint] Best model saved to {best_ckpt_path} (epoch={best_epoch}, val={best_val_metric:.6f})")
+            if run is not None:
+                artifact = wandb.Artifact(
+                    f"best-checkpoint-{config.dataset}", type="model",
+                    metadata={"epoch": best_epoch, "val_metric": best_val_metric},
+                )
+                artifact.add_file(str(best_ckpt_path))
+                run.log_artifact(artifact)
         if anp_head is not None:
             if terminal_anp_state is not None:
                 torch.save(terminal_anp_state, output_dir / f"{config.dataset}_{config.model}_anp.pt")
             else:
                 torch.save(anp_head.state_dict(), output_dir / f"{config.dataset}_{config.model}_anp.pt")
-            if best_anp_state is not None:
-                torch.save(best_anp_state, output_dir / f"{config.dataset}_{config.model}_anp_best.pt")
     if run is not None:
         run.finish()
 

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_primary_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -490,6 +490,12 @@ def build_bundle(config: TrainConfig) -> DatasetBundle:
 def cp_panel_prior_index(config: TrainConfig, bundle: DatasetBundle) -> int | None:
     if not config.enable_cp_panel or not config.enable_pressure_prior_addition:
         return None
+    # Only tandemfoilset and airfrans bundles actually include cp_panel features
+    # in their tensors.  Other datasets (tandemfoilset_paper, drivaerml) silently
+    # ignore the enable_cp_panel flag, so computing an index would point to a
+    # wrong column (e.g. a Fourier feature) and cause numeric overflow.
+    if bundle.spec.name not in {"tandemfoilset", "airfrans"}:
+        return None
     base_dim = bundle.spec.surface_input_dim
     if config.enable_vortex_panel_velocity:
         base_dim -= 4

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -761,6 +762,7 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -772,7 +774,7 @@ def loss_grouped(
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -781,6 +783,7 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
@@ -790,7 +793,7 @@ def loss_grouped_tandem(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
         vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -800,6 +803,7 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
@@ -811,7 +815,7 @@ def loss_abupt(
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
         vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -1266,6 +1270,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    volume_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1299,7 +1304,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1312,7 +1317,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1321,7 +1326,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1682,6 +1687,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            volume_loss_weight=config.volume_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The DrivAerML champion uses lr=5e-4. piccolo (#3047) is sweeping 4e-4/4.5e-4/5.5e-4 with truncated eval (`--max-eval-batches 200`). This run tests **lr=4e-4 with full evaluation** (no eval truncation) to establish a clean paper-facing test row for the lower-LR neighborhood of the champion.

Motivation: lr=4e-4 was previously tested only with gc=2.0+WD=1e-2 (#2886, 4.346%) — a different regularization context. The champion has NO gc, NO WD. Testing lr=4e-4 without those adds may find a better basin.

## Instructions

Run lr=4e-4 at exact champion architecture with **full evaluation** (no `--max-eval-batches`):

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 4e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --seed 42 \
  --wandb_group dm-lr-sweep-fulleval
```

**Critical:** Do NOT add `--max-eval-batches`. Full evaluation coverage is required for paper-facing results.

Run for the full 360-minute budget (SENPAI_TIMEOUT_MINUTES=360 is set by the pod environment).

## Reporting Requirements

In your results comment, report:
- Best val epoch + `val_primary/surface_rel_l2_pct`
- `test_primary/surface_rel_l2_pct` evaluated from the **best val checkpoint** (not terminal epoch)
- Whether eval was full-coverage (confirm: no `--max-eval-batches`)
- W&B run ID

## Baseline

**DrivAerML champion (val):**
- `val_primary/surface_rel_l2_pct`: **3.997%** at epoch 467
- W&B run: `bht6h42t` (PR #2898, 4L/512d, AdamW lr=5e-4, T_max=30, no-EMA, Fourier)
- Config: `SENPAI_MAX_EPOCHS=9999`, max-train-batches=394, max-eval-batches=200 (truncated)

**External reference band:**
- Transolver-3: 3.71% | AB-UPT: 3.82%

**Paper-facing test (known):**
- `test_primary/surface_rel_l2_pct`: **6.244%** (PR #2648, 4L/320d, old config, truncated eval)
- The val/test gap is partly due to truncated eval — full eval runs (#3063-3065) will establish the true test baseline.

**Previous lr=4e-4 result (different context):**
- 4.346% at gc=2.0+WD=1e-2 (#2886) — but that was with strong regularization that destabilizes DM. Clean lr=4e-4 without those has never been tested.

```bash
# Champion reproduce (for reference)
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```
