### PR TITLE
DrivAerML: AdamW beta2=0.99/0.995 faster adaptation

### DIFF
--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,27 @@
 # SENPAI Research Results
 
+## 2026-04-22 — PR #3043: DrivAerML gradient accumulation ablation + full eval baseline (einar) — SENT BACK
+
+- **Branch:** einar/dm-grad-accum-ablation
+- **Hypothesis:** Gradient accumulation (accum=2, accum=4) reduces gradient noise in DrivAerML's batch_size=1 regime. Step-matching (doubling `--max-train-batches`) isolates the smoothing effect from optimizer step reduction. Secondary goal: establish a full-eval paper-facing baseline without `--max-eval-batches`.
+- **Baseline:** val=3.997% (PR #2898, W&B bht6h42t, 4L/512d, AdamW lr=5e-4, T_max=30)
+
+| Run | Description | W&B ID | Best Val % | Best Ep | Best Test % | Notes |
+|-----|-------------|--------|-----------|---------|------------|-------|
+| 1 | DM control, full eval | 9kn1satv | 14.098 | ep40 | 13.644 | Hit epoch budget at ep42; severely undertrained |
+| 2 | DM accum=2, fewer steps | dguhbgax | 11.390 | ep365 | 11.933 | Late divergence (val→67% by final ep444) |
+| 3 | DM accum=2, step-matched | wpbqofwh | **4.860** | ep153 | **6.091** | Post-peak decay; best run in ablation |
+| 4 | DM accum=4 | hngfgj6i | 9.391 | ep124 | 9.702 | Never converged to competitive range |
+| 5 | AF accum=2, T_max=50 | 1nc85857 | 0.000534 MSE | ep466 | 0.000712 MSE | Late divergence ep723; confirms accum hurts AF |
+
+**Result: SENT BACK (request changes)**
+- No run beat baseline. Best: Run 3 at 4.860% (21.6% above 3.997%)
+- Run 3 (accum=2, step-matched) is directionally promising — closest any non-baseline DM run has come
+- Post-ep153 instability in Run 3 suggests T_max is mismatched to the effective doubled batch size
+- Full-eval control (Run 1) hit epoch budget at ep42 — not a valid paper number
+- accum=2 hurts AF (confirmed); no further AF accum experiments warranted
+- **Next iteration:** accum=2 step-matched + T_max=60 (2x baseline T_max=30) + cosine-eta-min=1e-6; wandb-group dm_grad_accum_v3
+
 ## 2026-04-22 23:35 — PR #2948: TFP physics-flag ablation (guts) — CLOSED
 
 - **Branch:** guts-tfp-physics-v2 / tandemfoil_paper_physics_ablation_v5

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -121,6 +121,7 @@ class TrainConfig:
     lr: float = 3e-4
     weight_decay: float = 1e-4
     optimizer: str = "lion"
+    adam_beta2: float = 0.999
     use_lookahead: bool = True
     use_ema: bool = True
     ema_decay: float = 0.9999
@@ -545,7 +546,7 @@ def build_optimizer(params, config: TrainConfig):
     if config.optimizer == "lion":
         optimizer = Lion(params, lr=config.lr, weight_decay=config.weight_decay)
     elif config.optimizer == "adamw":
-        optimizer = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay)
+        optimizer = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay, betas=(0.9, config.adam_beta2))
     else:
         raise ValueError(f"Unknown optimizer: {config.optimizer}")
     if config.use_lookahead:


### PR DESCRIPTION
## Hypothesis

PyTorch AdamW defaults to beta2=0.999, which means the second-moment estimate adapts over ~1000 steps. DrivAerML has a non-stationary loss landscape: cosine LR cycling (T_max=30) creates periodic gradient magnitude changes, and batch_size=1 with random surface-point sampling creates high variance. Faster second-moment adaptation (beta2=0.99, adapting over ~100 steps) may better track these rapid changes and find deeper basins.

This is a completely unexplored hyperparameter axis for DrivAerML. jet (#3028) was assigned a beta sweep but is now on a different experiment.

## Instructions

Run two variants — beta2=0.99 and beta2=0.995 — at the exact champion config:

**Run 1: beta2=0.99 (faster adaptation)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --adam-beta2 0.99 \
  --wandb_group dm-adamw-beta-sweep
```

**Run 2: beta2=0.995 (intermediate)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --adam-beta2 0.995 \
  --wandb_group dm-adamw-beta-sweep
```

**Implementation:** Add `--adam-beta2` flag to train.py. When building the AdamW optimizer, pass `betas=(0.9, args.adam_beta2)` instead of the default `(0.9, 0.999)`.

**Divergence check:** If either run diverges before epoch 30, add `--grad-clip 0.5` and re-run.

## Reporting Requirements
- Best val `surface_rel_l2_pct` + epoch for each variant
- Test `surface_rel_l2_pct` at best val checkpoint
- W&B run IDs

## Baseline

**DrivAerML champion (val):**
- `val_primary/surface_rel_l2_pct`: **3.997%** at epoch 467
- W&B run: `bht6h42t` (PR #2898, 4L/512d, AdamW lr=5e-4, T_max=30, betas default (0.9, 0.999))
- External targets: Transolver-3 3.71% | AB-UPT 3.82%

```bash
# Champion reproduce
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```
