### PR TITLE
DrivAerML: cosine eta_min=1e-6/1e-5 (LR floor at cycle trough)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_eta_min: float = 0.0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,7 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max, eta_min=config.cosine_eta_min)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

The current cosine schedule (`CosineAnnealingLR(T_max=30)`) drives LR down to `eta_min=0` at each cycle trough. At LR=0 the optimizer takes zero-sized steps — wasted computation. Setting `eta_min` to a small positive value (e.g. 1e-6 or 1e-5) ensures the model continues making progress even at cycle troughs, and may also reduce the abruptness of the LR transition from 0→peak when a new cycle starts.

PyTorch's `CosineAnnealingLR` already supports the `eta_min` parameter — it just defaults to 0.

## Instructions

Add `--cosine-eta-min` flag to train.py. When building `CosineAnnealingLR`, pass `eta_min=args.cosine_eta_min`.

Run two variants:

**Run 1: eta_min=1e-6 (conservative floor)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --cosine-eta-min 1e-6 \
  --wandb_group dm-eta-min-sweep
```

**Run 2: eta_min=1e-5 (higher floor)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --cosine-eta-min 1e-5 \
  --wandb_group dm-eta-min-sweep
```

**Implementation:** One line change in the scheduler setup:
```python
scheduler = CosineAnnealingLR(optimizer, T_max=args.cosine_t_max, eta_min=args.cosine_eta_min)
```

## Reporting Requirements
- Best val `surface_rel_l2_pct` + epoch for each variant
- Test at best val checkpoint
- W&B run IDs

## Baseline

**DrivAerML champion:**
- `val_primary/surface_rel_l2_pct`: **3.997%** at epoch 467
- W&B run: `bht6h42t` (PR #2898, 4L/512d, AdamW lr=5e-4, T_max=30, eta_min=0)
- External targets: Transolver-3 3.71% | AB-UPT 3.82%

```bash
# Champion reproduce
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```
