### PR TITLE
DrivAerML: gradient centralization (implicit regularizer)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    grad_centralization: bool = False
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -451,6 +452,15 @@ def parse_args() -> TrainConfig:
             parser.add_argument(arg_name, type=type(field_value), default=field_value)
     namespace = parser.parse_args()
     return TrainConfig(**vars(namespace))
+
+
+def centralize_gradients(optimizer):
+    for group in optimizer.param_groups:
+        for p in group['params']:
+            if p.grad is None:
+                continue
+            if p.grad.dim() > 1:
+                p.grad.data -= p.grad.data.mean(dim=tuple(range(1, p.grad.dim())), keepdim=True)
 
 
 def build_bundle(config: TrainConfig) -> DatasetBundle:
@@ -1266,6 +1276,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    use_grad_centralization: bool = False,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1339,6 +1350,8 @@ def train_one_epoch(
         if grad_clip > 0 and float(grad_norm) > grad_clip:
             running.setdefault("grad_clip_events", 0.0)
             running["grad_clip_events"] += 1.0
+        if use_grad_centralization:
+            centralize_gradients(optimizer)
         optimizer.step()
         if scheduler is not None:
             scheduler.step()
@@ -1671,6 +1684,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            use_grad_centralization=config.grad_centralization,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

Gradient centralization (Yong et al. 2020, "Gradient Centralization: A New Optimization Technique for DNNs") subtracts the per-tensor gradient mean before the optimizer step. This acts as an implicit regularizer by constraining the weight space to a manifold where activation means are preserved, and projects gradients to a lower-variance subspace.

For DrivAerML's batch_size=1 training with high gradient variance, GC may smooth the optimization trajectory without the instability introduced by explicit regularizers (WD crashed at ep178, gc=2.0 diverged). Unlike gradient clipping which truncates, GC centers — it preserves gradient direction while reducing inter-sample drift.

**Reference:** https://arxiv.org/abs/2004.01461

## Instructions

Add `--grad-centralization` flag to train.py. When active, apply gradient centralization as a pre-step hook:

```python
def centralize_gradients(optimizer):
    for group in optimizer.param_groups:
        for p in group['params']:
            if p.grad is None:
                continue
            if p.grad.dim() > 1:  # only centralize weight tensors, not biases
                p.grad.data -= p.grad.data.mean(dim=tuple(range(1, p.grad.dim())), keepdim=True)
```

Call `centralize_gradients(optimizer)` after `loss.backward()` and before `optimizer.step()`.

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --grad-centralization \
  --wandb_group dm-grad-centralization
```

## Reporting Requirements
- Best val `surface_rel_l2_pct` + epoch
- Test at best val checkpoint
- W&B run ID

## Baseline

**DrivAerML champion:**
- `val_primary/surface_rel_l2_pct`: **3.997%** at epoch 467
- W&B: `bht6h42t` (4L/512d, AdamW lr=5e-4, T_max=30, no gc/WD/EMA)
- External: Transolver-3 3.71% | AB-UPT 3.82%

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```
