### PR TITLE
DrivAerML: attention dropout=0.05 at champion config

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -106,6 +106,7 @@ class TrainConfig:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    attn_dropout: float = 0.0
     drivaerml_train_surface_points: int = 0
     drivaerml_eval_surface_points: int = 0
     drivaerml_train_volume_points: int = 0
@@ -502,7 +503,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
         "n_hidden": config.model_hidden_dim,
-        "dropout": config.model_dropout,
+        "dropout": config.attn_dropout if config.attn_dropout > 0 else config.model_dropout,
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,


### PR DESCRIPTION
## Hypothesis

The 4L/512d DrivAerML model uses dropout=0.0 everywhere. Adding light attention dropout (p=0.05) forces attention heads to learn redundant, distributed representations instead of overfitting to dominant local mesh patterns. DrivAerML's surface meshes are highly structured (nearby points strongly correlated) — dropout may prevent the model from memorizing local mesh topology.

**Risk is low:** 0.05 dropout is very conservative. spike (#2995) tested 0.1 on TF/AF/DM but that was cross-dataset and used a different architecture/config. This is a focused DrivAerML-only test at the exact 4L/512d champion config with lighter dropout.

## Instructions

Add `--attn-dropout 0.05` flag to train.py. In the Transolver `nn.MultiheadAttention` calls, set `dropout=args.attn_dropout`.

Run one variant:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --attn-dropout 0.05 \
  --wandb_group dm-attn-dropout
```

## Reporting Requirements
- Best val `surface_rel_l2_pct` + epoch
- Test at best val checkpoint
- W&B run ID

## Baseline

**DrivAerML champion:**
- `val_primary/surface_rel_l2_pct`: **3.997%** at epoch 467
- W&B: `bht6h42t` (4L/512d, AdamW lr=5e-4, T_max=30, attn dropout=0.0)
- External: Transolver-3 3.71% | AB-UPT 3.82%

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```
