### PR TITLE
DrivAerML: SGDR T_0=15, T_mult=2 (progressive cosine restarts)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_t_mult: int = 0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,12 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.cosine_t_mult > 0:
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+                base_optimizer, T_0=config.cosine_t_max, T_mult=config.cosine_t_mult
+            )
+        else:
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

SGDR (CosineAnnealingWarmRestarts) with T_0=15 and T_mult=2 starts with short 15-epoch cycles for rapid exploration, then doubles to 30 (matching champion T_max), then 60 for deep settling. This progressive schedule combines fast early exploration with longer late-training convergence.

megumi (#3086) is testing T_0=30, T_mult=2. This tests T_0=15 — shorter initial cycles that match the fast micro-cycling the model seems to prefer early, with later cycles matching and exceeding the champion period.

**Schedule:** cycles at epochs 0-15, 15-45, 45-105, 105-225, 225-465...

## Instructions

Implement `CosineAnnealingWarmRestarts(optimizer, T_0=15, T_mult=2)`:

```python
scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer, T_0=15, T_mult=2)
```

Add `--cosine-t-mult 2` and set T_0 via `--cosine-t-max 15`.

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 15 \
  --cosine-t-mult 2 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-sgdr-sweep
```

**Warning from #3045:** T_max=15 alone diverged without gc (val=14.17%, grad norm 1.5e8). But SGDR T_mult=2 means the restart at epoch 15 jumps LR from trough back to peak — this may trigger the same explosion. If divergence occurs before ep30, add `--grad-clip 1.0` and document.

**Critical:** Must save best checkpoint (save model whenever val improves). Report from best checkpoint, not terminal epoch.

## Reporting Requirements
- Best val `surface_rel_l2_pct` + epoch
- Whether divergence occurred (and at which cycle boundary)
- Test at best val checkpoint
- W&B run ID

## Baseline

**DrivAerML champion:** val=**3.997%** @ ep467 (PR #2898, T_max=30, no SGDR)
- W&B: `bht6h42t`
- External: Transolver-3 3.71% | AB-UPT 3.82%
