### PR TITLE
DrivAerML: higher LR + linear warmup (widening the stable LR basin)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    warmup_epochs: int = 0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,15 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            steps_per_epoch = min(len(train_loader), config.max_train_batches) if config.max_train_batches > 0 else len(train_loader)
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            start_factor = 1e-5 / config.lr
+            warmup = torch.optim.lr_scheduler.LinearLR(base_optimizer, start_factor=start_factor, end_factor=1.0, total_iters=warmup_steps)
+            scheduler = torch.optim.lr_scheduler.SequentialLR(base_optimizer, schedulers=[warmup, cosine], milestones=[warmup_steps])
+        else:
+            scheduler = cosine
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

LR=5e-4 was found to be a sharp optimum on DrivAerML — small deviations cause catastrophic divergence. However, this was tested without warmup. Linear warmup gradually builds LR from 0, which can stabilize higher peak LRs that would otherwise diverge from cold start.

A higher peak LR (7e-4 or 1e-3) with 20-epoch linear warmup to the peak, then cosine decay with T_max=30, could reach a deeper loss basin faster. The warmup allows the optimizer to find a stable trajectory before hitting the high LR region.

PRs #3069 (5-epoch warmup) and #3070 (10-epoch warmup) test warmup at the champion lr=5e-4. This PR tests warmup at HIGHER LR to see if it widens the stable operating range.

## Instructions

Implement linear LR warmup in train.py using a LinearLR scheduler chained before the cosine annealing. Run two configurations:

**Run 1: lr=7e-4 with 20-epoch warmup**
- Start LR: 1e-5, ramp linearly to 7e-4 over 20 epochs
- Then: CosineAnnealingLR with T_max=30 and eta_min=1e-6
- Use `torch.optim.lr_scheduler.SequentialLR([LinearLR(..., start_factor=1e-5/7e-4, end_factor=1.0, total_iters=20), CosineAnnealingLR(T_max=30)], milestones=[20])`

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 7e-4 \
  --cosine-t-max 30 \
  --warmup-epochs 20 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-higher-lr-warmup
```

**Run 2: lr=1e-3 with 20-epoch warmup**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 1e-3 \
  --cosine-t-max 30 \
  --warmup-epochs 20 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-higher-lr-warmup
```

If train.py doesn't have a --warmup-epochs flag, add it: implement SequentialLR with LinearLR for warmup_epochs then cosine for remainder. No --grad-clip, no --weight-decay.

Report best val_primary/surface_rel_l2_pct for both runs.

## Baseline

- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467
- **Config:** 4L/512d/8H, AdamW lr=5e-4, T_max=30, no-EMA, Fourier, no gc, no WD, no warmup
- **W&B run:** bht6h42t
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`