### PR TITLE
DrivAerML: RAdam optimizer (rectified Adam with built-in warmup)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -546,6 +546,8 @@ def build_optimizer(params, config: TrainConfig):
         optimizer = Lion(params, lr=config.lr, weight_decay=config.weight_decay)
     elif config.optimizer == "adamw":
         optimizer = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay)
+    elif config.optimizer == "radam":
+        optimizer = torch.optim.RAdam(params, lr=config.lr, weight_decay=config.weight_decay)
     else:
         raise ValueError(f"Unknown optimizer: {config.optimizer}")
     if config.use_lookahead:


### PR DESCRIPTION
## Hypothesis

RAdam (Rectified Adam, Liu et al. 2019) adds a rectification term that corrects the adaptive learning rate variance in the early training phases, effectively providing a principled built-in warmup without needing an explicit warmup schedule. This addresses the known DrivAerML instability issue (gradient explosions from cold-start high LR) from a different angle than linear warmup.

DrivAerML is extremely sensitive to gradient stability (T_max=30 is the only stable cosine period; all other T_max values diverge). RAdam's variance rectification may provide more stable early-epoch dynamics, potentially allowing the model to reach a better basin than standard AdamW.

Reference: "On the Variance of the Adaptive Learning Rate and Beyond" (Liu et al. 2019, ICLR 2020).

## Instructions

RAdam is available in PyTorch as `torch.optim.RAdam`. Add it as an optimizer option in train.py alongside adamw/lion.

**Run 1: RAdam lr=5e-4 (same as AdamW champion)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer radam \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-radam-optimizer
```

**Run 2: RAdam lr=7e-4 (slightly higher, RAdam's built-in warmup may stabilize it)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer radam \
  --lr 7e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-radam-optimizer
```

To add RAdam support in train.py: `optimizer = torch.optim.RAdam(params, lr=args.lr)`. No --grad-clip, no --weight-decay (matching champion regularization strategy). T_max=30 (only stable cosine period on DrivAerML).

Report best val_primary/surface_rel_l2_pct for both runs from W&B.

## Baseline

- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467
- **Config:** 4L/512d/8H, AdamW lr=5e-4, T_max=30, no-EMA, Fourier, no gc, no WD
- **W&B run:** bht6h42t
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`