### PR TITLE
DrivAerML: polynomial LR decay (no cosine annealing)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,8 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    lr_schedule: str = "cosine"
+    lr_poly_power: float = 1.0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1623,8 +1625,10 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
-    if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+    if config.lr_schedule == "polynomial":
+        scheduler = torch.optim.lr_scheduler.PolynomialLR(base_optimizer, total_iters=config.epochs, power=config.lr_poly_power)
+    elif config.cosine_t_max > 0:
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
@@ -1656,12 +1660,13 @@ def main() -> None:
     for epoch in range(1, config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
+        batch_scheduler = scheduler if config.lr_schedule != "polynomial" else None
         train_metrics = train_one_epoch(
             model=forward_model,
             anp_head=anp_head,
             loader=train_loader,
             optimizer=optimizer,
-            scheduler=scheduler,
+            scheduler=batch_scheduler,
             ema=ema,
             anp_ema=anp_ema,
             transform=transform,
@@ -1672,6 +1677,11 @@ def main() -> None:
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
         )
+
+        if config.lr_schedule == "polynomial" and scheduler is not None:
+            scheduler.step()
+            base_opt = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+            train_metrics["lr"] = float(base_opt.param_groups[0]["lr"])
 
         if ema is not None:
             ema.store(model)


### PR DESCRIPTION
## Hypothesis

Every DrivAerML experiment uses CosineAnnealingLR. The cosine schedule's periodic LR peaks are the root cause of most divergence failures — T_max deviations, multi-revisit, depth reduction, and symmetry augmentation all diverge at cosine LR peaks.

A monotonic LR decay (polynomial or linear) eliminates the periodic peaks entirely. The LR starts at 5e-4 and smoothly decays to near-zero, never revisiting high LR territory. This trades the basin-hopping benefits of cosine cycling for gradient stability.

If the champion's success at T_max=30 is mainly about spending most training time at LOW LR (the cosine trough), then a monotonic decay that keeps LR low for even longer should match or beat it.

## Instructions

Replace `CosineAnnealingLR` with `PolynomialLR` in train.py. Run two decay profiles:

**Run 1: Linear decay (power=1.0)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --lr-schedule polynomial \
  --lr-poly-power 1.0 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-polynomial-lr
```

**Run 2: Quadratic decay (power=2.0)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --lr-schedule polynomial \
  --lr-poly-power 2.0 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-polynomial-lr
```

Implementation: `torch.optim.lr_scheduler.PolynomialLR(optimizer, total_iters=999, power=X)`. Add `--lr-schedule` flag (cosine|polynomial) and `--lr-poly-power` flag. If --lr-schedule=cosine, use current CosineAnnealingLR. If polynomial, use PolynomialLR. No --grad-clip, no --weight-decay. Report best val_primary/surface_rel_l2_pct.

## Baseline

- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467
- **Config:** 4L/512d/8H, AdamW lr=5e-4, CosineAnnealingLR T_max=30, no-EMA, Fourier
- **W&B run:** bht6h42t
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`