### PR TITLE
DrivAerML: AdamW beta2 sweep (faster variance adaptation)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -165,6 +165,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
+    adam_beta2: float = 0.999
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
@@ -545,7 +546,7 @@ def build_optimizer(params, config: TrainConfig):
     if config.optimizer == "lion":
         optimizer = Lion(params, lr=config.lr, weight_decay=config.weight_decay)
     elif config.optimizer == "adamw":
-        optimizer = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay)
+        optimizer = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay, betas=(0.9, config.adam_beta2))
     else:
         raise ValueError(f"Unknown optimizer: {config.optimizer}")
     if config.use_lookahead:


### PR DESCRIPTION
## Hypothesis

AdamW's default beta2=0.999 means the second-moment estimate (squared gradient running average) has a half-life of ~693 steps. Over 467 epochs with ~394 steps/epoch (~184k total steps), stale gradient variance estimates can accumulate, especially through the cosine LR peak/trough transitions.

Reducing beta2 to 0.99 (half-life ~69 steps) or 0.95 (half-life ~14 steps) makes the optimizer adapt faster to gradient magnitude changes. This is particularly relevant for DrivAerML where gradient norms vary dramatically across cosine phases — the optimizer should scale its steps based on RECENT gradient variance, not stale estimates from hundreds of steps ago.

This approach targets a different mechanism than warmup/RAdam (which only help early training) or schedule changes (which change the LR shape). Beta2 affects how the optimizer responds to gradient changes THROUGHOUT training.

Reference: "Decoupled Weight Decay Regularization" (Loshchilov & Hutter 2019) and the observation that lower beta2 often helps in settings with non-stationary gradient statistics.

## Instructions

Add a --adam-beta2 flag to train.py. Run two values:

**Run 1: beta2=0.99**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --adam-beta2 0.99 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-adamw-beta2
```

**Run 2: beta2=0.95**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --adam-beta2 0.95 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-adamw-beta2
```

Implementation: pass beta2 to AdamW as `betas=(0.9, args.adam_beta2)`. Keep beta1=0.9 (default). No --grad-clip, no --weight-decay. Report best val_primary/surface_rel_l2_pct for both runs.

## Baseline

- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467
- **Config:** 4L/512d/8H, AdamW lr=5e-4 (betas=(0.9, 0.999) default), T_max=30, no-EMA, Fourier
- **W&B run:** bht6h42t
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`