### PR TITLE
DrivAerML: OneCycleLR schedule (single warmup-then-decay, no restarts)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -159,6 +159,7 @@ class TrainConfig:
     asinh_scale: float = 0.75
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
+    lr_schedule: str = "cosine"
     cosine_t_max: int = 150
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
@@ -1623,8 +1624,24 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
-    if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+    if config.lr_schedule == "onecycle":
+        if config.max_train_batches > 0:
+            micro_per_epoch = config.max_train_batches
+        else:
+            micro_per_epoch = len(train_loader)
+        steps_per_epoch = (micro_per_epoch + config.grad_accum_steps - 1) // config.grad_accum_steps
+        total_steps = config.epochs * steps_per_epoch
+        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            base_optimizer,
+            max_lr=config.lr,
+            total_steps=total_steps,
+            pct_start=0.3,
+            anneal_strategy='cos',
+            div_factor=25,
+            final_div_factor=1e4,
+        )
+    elif config.cosine_t_max > 0:
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
@@ -1641,6 +1658,11 @@ def main() -> None:
     if config.wandb_name:
         run_config = asdict(config)
         run_config["effective_batch_size"] = config.batch_size * config.grad_accum_steps
+        if config.lr_schedule == "onecycle" and scheduler is not None:
+            run_config["onecycle_total_steps"] = scheduler.total_steps
+            run_config["onecycle_pct_start"] = 0.3
+            run_config["onecycle_div_factor"] = 25
+            run_config["onecycle_final_div_factor"] = 1e4
         run = wandb.init(
             project=os.getenv("WANDB_PROJECT", "senpai-v1"),
             entity=os.getenv("WANDB_ENTITY"),


### PR DESCRIPTION
## Hypothesis

Every DrivAerML schedule failure shares the same root cause: **periodic LR restarts from near-zero back to peak LR**. CosineAnnealingLR restarts every T_max=30 epochs, SGDR restarts at exponentially growing intervals — both create repeated high-LR episodes that cause gradient explosions without gc.

OneCycleLR (Smith & Topin 2019) is fundamentally different: it does ONE warmup from low LR to max LR (first ~30% of training), then monotonically decays to near-zero for the remaining ~70%. After the single peak, LR only goes down — **no periodic restarts, no repeated gradient shocks**.

This directly addresses the ~120-step high-LR stability limit we've identified. With OneCycleLR, the model spends only the first ~30% of training at elevated LR, then the entire remaining 70% at progressively lower (stable) LR. The champion at T_max=30 spends roughly 50% of each cycle at elevated LR, repeated 15 times.

Reference: "Super-Convergence: Very Fast Training of Neural Networks Using Large Learning Rates" (Smith & Topin, 2019).

## Instructions

Replace CosineAnnealingLR with OneCycleLR. PyTorch provides `torch.optim.lr_scheduler.OneCycleLR`.

**Run 1: OneCycleLR max_lr=5e-4 (same peak as champion)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --lr-schedule onecycle \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-onecycle-lr
```

**Run 2: OneCycleLR max_lr=1e-3 (higher peak, relying on OneCycle's annihilation)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 1e-3 \
  --lr-schedule onecycle \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-onecycle-lr
```

Implementation: add `--lr-schedule onecycle` flag. When selected, use:
```python
scheduler = torch.optim.lr_scheduler.OneCycleLR(
    optimizer,
    max_lr=args.lr,
    total_steps=total_steps,  # total_epochs * steps_per_epoch
    pct_start=0.3,            # 30% warmup
    anneal_strategy='cos',    # cosine annealing after peak
    div_factor=25,            # initial_lr = max_lr/25
    final_div_factor=1e4      # min_lr = initial_lr/10000
)
```
Step the scheduler per BATCH (not per epoch) — OneCycleLR requires per-step scheduling. No --grad-clip, no --weight-decay. Report best val_primary/surface_rel_l2_pct.

## Baseline

- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467
- **Config:** 4L/512d/8H, AdamW lr=5e-4, CosineAnnealingLR T_max=30, no-EMA, Fourier
- **W&B run:** bht6h42t
- **Reproduce:** `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`