### PR TITLE
DrivAerML: eta_min=5e-5 + gc=1.0 compound (stabilized non-zero LR floor)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_eta_min: float = 0.0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,7 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max, eta_min=config.cosine_eta_min)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

Your previous experiment (PR #3126) showed that eta_min=5e-5 enables faster early convergence on DrivAerML (6.800% at ep98 vs champion at ~12% at same point), but diverged because removing the LR "rest" at cosine troughs allows gradient noise to accumulate unchecked.

This follow-up combines eta_min=5e-5 with gc=1.0 to provide the missing stability. The gc caps gradient norms at each step, preventing the accumulation that killed the eta_min-only run. The combination should preserve the faster early convergence while enabling the 400+ epoch training needed to reach baseline territory.

Note: gc alone on DM has been tested — best gc result was 4.346% (gc=2.0, PR #2886). eta_min alone diverged at 6.800%. The compound hypothesis is that gc provides the stability floor that eta_min removes, unlocking the faster convergence signal.

## Instructions

**Run 1: eta_min=5e-5 + gc=1.0**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --cosine-eta-min 5e-5 \
  --grad-clip 1.0 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-eta-min-gc-compound
```

**Run 2: eta_min=5e-5 + gc=0.5 (lighter clipping)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --cosine-eta-min 5e-5 \
  --grad-clip 0.5 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-eta-min-gc-compound
```

If --cosine-eta-min was already added for #3126, reuse it. Otherwise add the flag and pass to CosineAnnealingLR's eta_min parameter. Report best val_primary/surface_rel_l2_pct.

## Baseline

- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467
- **Config:** 4L/512d/8H, AdamW lr=5e-4, T_max=30, eta_min=0, no gc, no-EMA
- **W&B run:** bht6h42t
- **Your #3126 result:** eta_min=5e-5 alone → 6.800% (faster early convergence, diverged)
- **Best gc result:** gc=2.0 → 4.346% (PR #2886)