### PR TITLE
AirfRANS: volume-loss-weight=30x for aggressive volume improvement

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -164,6 +164,7 @@ class TrainConfig:
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
+    volume_loss_weight: float = 1.0
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
@@ -761,6 +762,7 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -772,7 +774,7 @@ def loss_grouped(
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -781,6 +783,7 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
@@ -790,7 +793,7 @@ def loss_grouped_tandem(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
         vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -800,6 +803,7 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
@@ -811,7 +815,7 @@ def loss_abupt(
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
         vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -1266,6 +1270,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    volume_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1299,7 +1304,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1312,7 +1317,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1321,7 +1326,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1671,6 +1676,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            volume_loss_weight=config.volume_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

AirfRANS has a 4.5x gap on volume MSE (0.00764 vs SpiderSolver's 0.0017) while surface MSE already beats SpiderSolver by 9x (0.000482 vs 0.0043). The model is clearly under-weighting volume in the loss function.

PRs #3101 (3x) and #3102 (10x) test moderate volume loss weights. Given the 4.5x gap, even 10x may be insufficient — the model needs to dramatically shift its attention toward volume fields. 30x explicitly tells the optimizer that volume errors are 30x more important than surface errors, which should force the model to reallocate capacity.

The surface MSE has 9x headroom above SpiderSolver — we can afford significant surface regression if volume improves proportionally.

## Instructions

**Run 1: volume-loss-weight=30x**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset airfrans \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 2 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --epochs 999 \
  --volume-loss-weight 30.0 \
  --wandb_group af-volume-weight-sweep
```

If train.py doesn't have --volume-loss-weight, add it: multiply the volume component of the loss by this factor before combining with the surface loss. The default should be 1.0 (current behavior).

Report BOTH metrics:
- val_primary/surface_mse (baseline: 0.000482, SpiderSolver: 0.0043)
- val_primary/volume_mse (baseline: 0.00764, SpiderSolver: 0.0017)

## Baseline

- **val_primary/surface_mse:** 0.000482 (PR #2951 MERGED, beats SpiderSolver 0.0043 by 9x)
- **val_primary/volume_mse:** 0.00764 (4.5x above SpiderSolver 0.0017)
- **Config:** 2L/256d, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, no-EMA
- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --no-use-ema --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999`