### PR TITLE
DrivAerML: 5-epoch warmup + gc=1.0 compound (stabilized warmup)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -165,6 +165,7 @@ class TrainConfig:
     surface_anchor_points: int = 8_000
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
+    warmup_epochs: int = 0
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
@@ -1625,7 +1626,16 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            batches_per_epoch = min(len(train_loader), config.max_train_batches) if config.max_train_batches > 0 else len(train_loader)
+            steps_per_epoch = max(batches_per_epoch // config.grad_accum_steps, 1)
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup = torch.optim.lr_scheduler.LinearLR(base_optimizer, start_factor=1e-7, end_factor=1.0, total_iters=warmup_steps)
+            scheduler = torch.optim.lr_scheduler.SequentialLR(base_optimizer, [warmup, cosine], milestones=[warmup_steps])
+            print(f"[warmup] {config.warmup_epochs} epochs = {warmup_steps} steps linear warmup, then cosine T_max={config.cosine_t_max}")
+        else:
+            scheduler = cosine
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None


### PR DESCRIPTION
## Hypothesis

5-epoch warmup alone (#3069) achieved 5.823% best before diverging at ep523 — the warmup direction was not wrong, just unstable. The warmup hypothesis is: gradual LR ramp allows the optimizer to establish stable update directions before hitting full lr=5e-4. The gap: warmup without gc still hits catastrophic LR-peak explosions.

This compounds warmup + gc=1.0 to provide the missing stability floor. gc=1.0 (hard gradient ceiling) + 5-epoch warmup (gradual start) together should enable stable training past the ep150+ region where warmup-only runs diverged.

## Instructions

**Run: 5-epoch linear warmup + gc=1.0 + T_max=30**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 1.0 \
  --warmup-epochs 5 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-warmup-gc-compound
```

Note: best gc result on DM without warmup was 4.346% (gc=2.0, PR #2886) which still didn't beat baseline 3.997%. The warmup may push gc below baseline if the combination is synergistic. Also run without warmup for comparison:

**Control: gc=1.0 only (no warmup)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-warmup-gc-compound
```

## Baseline
- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467 (no gc, no warmup)
- **Best gc result:** 4.346% gc=2.0 (#2886)