### PR TITLE
DrivAerML: 788 batches/epoch + T_max=60 (proportionally scaled schedule)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,17 +1637,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-    best_ema_shadow: dict[str, torch.Tensor] | None = None
-    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
-
     run = None
     if config.wandb_name:
         run_config = asdict(config)
@@ -1713,32 +1702,20 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
-            if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
-
         if ema is not None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-        epoch_metrics["best_val_metric"] = best_val_metric
+        epoch_metrics["best_val_primary_metric"] = best_val_primary_metric
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
+            run.summary["best_val_primary_metric"] = best_val_primary_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1789,8 +1766,8 @@ def main() -> None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
-        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
+            run.summary["best_val_primary_metric"] = best_val_primary_metric
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_primary_metric": best_val_primary_metric}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)


### PR DESCRIPTION
## Hypothesis

Your previous experiment (#3084) showed that 788 batches/epoch diverges because T_max=30 (epoch-based) effectively halves the cosine cycle with 2x batches, creating more frequent LR peak shocks. The fix: scale T_max proportionally. With 788 batches/epoch (2x more than champion's 394), T_max should be 2x longer (T_max=60) to maintain the same number of effective training steps per cosine cycle.

## Instructions

**Run: 788 batches + T_max=60 (proportionally scaled) + gc=1.0 for stability**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 60 --grad-clip 1.0 \
  --no-use-ema --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 788 --max-eval-batches 200 \
  --wandb_group dm-batches-scaled-tmax
```

gc=1.0 is included for gradient stability at the higher batch count. Report best val_primary/surface_rel_l2_pct.

## Baseline
- **val_primary/surface_rel_l2_pct:** 3.997% at epoch 467
- **Your #3084 result:** 11.565% best (788 batches, T_max=30) — diverged at ep45