### PR TITLE
DrivAerML: Lookahead optimizer wrapping AdamW

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -122,6 +122,8 @@ class TrainConfig:
     weight_decay: float = 1e-4
     optimizer: str = "lion"
     use_lookahead: bool = True
+    lookahead_k: int = 6
+    lookahead_alpha: float = 0.5
     use_ema: bool = True
     ema_decay: float = 0.9999
     num_workers: int = -1
@@ -546,11 +548,22 @@ def build_optimizer(params, config: TrainConfig):
         optimizer = Lion(params, lr=config.lr, weight_decay=config.weight_decay)
     elif config.optimizer == "adamw":
         optimizer = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay)
+    elif config.optimizer == "lookahead-adamw":
+        base = torch.optim.AdamW(params, lr=config.lr, weight_decay=config.weight_decay)
+        return Lookahead(base, alpha=config.lookahead_alpha, k=config.lookahead_k)
     else:
         raise ValueError(f"Unknown optimizer: {config.optimizer}")
     if config.use_lookahead:
-        optimizer = Lookahead(optimizer)
+        optimizer = Lookahead(optimizer, alpha=config.lookahead_alpha, k=config.lookahead_k)
     return optimizer
+
+
+def sync_lookahead(optimizer) -> None:
+    """Copy slow weights to fast weights so model params reflect the averaged trajectory."""
+    if isinstance(optimizer, Lookahead):
+        for slow_group, fast_group in zip(optimizer._slow_weights, optimizer.param_groups):
+            for slow, fast in zip(slow_group, fast_group["params"]):
+                fast.data.copy_(slow)
 
 
 def resolve_num_workers(config: TrainConfig, dataset_name: str) -> int:
@@ -1637,16 +1650,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-    best_ema_shadow: dict[str, torch.Tensor] | None = None
-    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
     run = None
     if config.wandb_name:
@@ -1713,17 +1717,9 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
-            if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
 
         if ema is not None:
             ema.restore(model)
@@ -1732,7 +1728,7 @@ def main() -> None:
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
         epoch_metrics["best_val_metric"] = best_val_metric
-        epoch_metrics["best_epoch"] = float(best_epoch)
+        epoch_metrics["best_epoch"] = float(best_epoch) if best_epoch is not None else 0.0
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
@@ -1783,6 +1779,7 @@ def main() -> None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
+        sync_lookahead(optimizer)
         terminal_model_state = snapshot_module_state(model)
         terminal_anp_state = snapshot_module_state(anp_head)
         if run is not None:
@@ -1850,6 +1847,7 @@ def main() -> None:
         final_test_metrics=final_test_metrics,
     )
     if config.save_checkpoint:
+        sync_lookahead(optimizer)
         output_dir.mkdir(parents=True, exist_ok=True)
         if terminal_model_state is not None:
             torch.save(terminal_model_state, output_dir / f"{config.dataset}_{config.model}.pt")


### PR DESCRIPTION
## Hypothesis

The Lookahead optimizer (Zhang et al., 2019 — https://arxiv.org/abs/1907.08610) wraps any inner optimizer and performs k fast inner steps, then interpolates the weights back toward a set of "slow" weights with step size alpha. This implicit ensemble averaging reduces gradient noise and variance, often improving both convergence speed and final generalization. We hypothesize that wrapping AdamW (our current best optimizer) with Lookahead will reduce the DrivAerML surface_rel_l2_pct below the current 3.997% baseline.

The mechanism: every k=6 steps, slow weights ← slow weights + alpha * (fast weights - slow weights). The fast weights are then reset to the slow weights. This creates a trajectory smoothing effect that can escape sharp minima, similar in spirit to SWA/EMA but applied during optimization rather than post-hoc.

Reference implementation: `torchcontrib.optim.Lookahead` (pip install torchcontrib), or implement in ~10 lines wrapping any optimizer.

## Instructions

Add Lookahead optimizer support to `target/icml2026/train.py`:

1. Add two new CLI flags:
   - `--optimizer lookahead-adamw` (add `"lookahead-adamw"` as a valid choice alongside existing optimizer options)
   - `--lookahead-k INT` (default=6, number of fast inner steps)
   - `--lookahead-alpha FLOAT` (default=0.5, slow weight interpolation rate)

2. When `--optimizer lookahead-adamw` is specified, wrap the AdamW optimizer with Lookahead:
   ```python
   from torchcontrib.optim import Lookahead
   base_optimizer = torch.optim.AdamW(params, lr=args.lr, weight_decay=args.weight_decay)
   optimizer = Lookahead(base_optimizer, k=args.lookahead_k, alpha=args.lookahead_alpha)
   ```
   Install via: `pip install torchcontrib`

3. Call `optimizer.sync_lookahead()` before saving checkpoints to ensure slow weights are persisted (important for correct checkpoint recovery).

4. Run the following training command:

```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer lookahead-adamw \
  --lookahead-k 6 \
  --lookahead-alpha 0.5 \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --wandb_group dm-optimizer-lookahead
```

All other hyperparameters (architecture, Fourier features, no-EMA, cosine T_max=30) are identical to the current champion config (PR #2898) so any improvement is attributable solely to the Lookahead wrapper.

## Baseline

Current best DrivAerML metrics (PR #2898 — piccolo, 4L/512d/8H + Fourier + no-EMA + T_max=30, 467 epochs, AdamW lr=5e-4):

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.997%** |

- Baseline W&B run: `bht6h42t`
- External target: <3.71% (AB-UPT, ~500 epochs) — 1.08x gap remaining
- Reproduce command:
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200
```

Please report `val_primary/surface_rel_l2_pct` (best validation epoch) and the W&B run ID when complete.