### PR TITLE
TandemFoil Paper: gc=0.4 boundary test (between starvation and champion)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1630,12 +1630,6 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
         primary_metric_key = "val_primary/surface_pressure_mae"
@@ -1647,6 +1641,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
+    best_val_primary_metric_name = primary_metric_key
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
 
     run = None
     if config.wandb_name:


### PR DESCRIPTION
## Hypothesis

gc=0.3 causes pressure starvation on TandemFoil Paper — field_mse diverges to Infinity (PR #3090). gc=0.5 is the current champion at 0.002383 field_mse (PR #3025). gc=0.4 sits exactly between them and may either converge to a finite (possibly champion-beating) result or reveal that the starvation boundary lies above gc=0.3.

The sinh-domain inversion for pressure requires large corrective gradient updates. When gc is too low, those updates are clipped before they can correct the inversion, causing field_mse to diverge. gc=0.4 is a critical test: if it converges, the starvation boundary is narrower than expected and we may find room for softer clipping to improve generalization; if it starves, we know the safe region starts at gc≈0.5.

## Instructions

Run a single TandemFoil Paper training with `--grad-clip 0.4`. All other hyperparameters match the champion config from PR #3025 exactly.

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.4 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --ema-decay 0.999 \
  --wandb_group tfp-gc-sweep
```

**Early-stop signal:** If `val_primary/field_mse` is `Infinity` at epoch 100, that is pressure starvation — report it immediately and stop training. We don't need to run to epoch 999 to confirm starvation. If it converges, run to completion.

**Report:**
- Best `val_primary/field_mse` (from EMA checkpoint)
- Whether field_mse was Infinity at any checkpoint
- Epoch at which field_mse first went Infinity (if applicable)
- W&B run ID and link

## Baseline

Current best metrics for TandemFoil Paper — PR #3025 (haku/tfp-lion-champion-config):
- val_primary/field_mse: **0.002383** (epoch 443)
- val/surface_mse: 0.001517
- val/surface_mse_p: 4.81e-05
- val/volume_mse: 0.002397
- Config: Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, EMA=0.999, 3L/192d, Fourier+physics
- W&B run: `d1xh0o1p`
- Reproduce: `cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`