### PR TITLE
DrivAerML: top-5 checkpoint averaging at test time

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+import heapq
 import itertools
 import json
 import math
@@ -167,6 +168,7 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
+    checkpoint_averaging_k: int = 1
     seed: int = 0
 
 
@@ -1638,15 +1640,18 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_primary_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
+
+    # Top-k checkpoint heap for averaging: entries are (-metric, epoch, model_state, anp_state)
+    topk_heap: list[tuple[float, int, dict[str, torch.Tensor], dict[str, torch.Tensor] | None]] = []
 
     run = None
     if config.wandb_name:
@@ -1713,7 +1718,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch
@@ -1724,6 +1729,17 @@ def main() -> None:
                 best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
             if anp_ema is not None:
                 best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
+
+        if current_val is not None and config.checkpoint_averaging_k > 1:
+            should_add = len(topk_heap) < config.checkpoint_averaging_k or current_val < -topk_heap[0][0]
+            if should_add:
+                ckpt_model = {k: v.cpu().clone() for k, v in model.state_dict().items()}
+                ckpt_anp = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()} if anp_head is not None else None
+                entry = (-current_val, epoch, ckpt_model, ckpt_anp)
+                if len(topk_heap) < config.checkpoint_averaging_k:
+                    heapq.heappush(topk_heap, entry)
+                else:
+                    heapq.heapreplace(topk_heap, entry)
 
         if ema is not None:
             ema.restore(model)
@@ -1833,6 +1849,55 @@ def main() -> None:
                     sort_keys=True,
                 )
             )
+            restore_module_state(model, terminal_model_state)
+            restore_module_state(anp_head, terminal_anp_state)
+
+        if len(topk_heap) > 1 and config.checkpoint_averaging_k > 1:
+            heap_epochs = sorted([-neg_m for neg_m, ep, _, _ in topk_heap])
+            avg_epochs = [ep for _, ep, _, _ in topk_heap]
+            print(
+                json.dumps(
+                    {"checkpoint_averaging": {"k": len(topk_heap), "epochs": sorted(avg_epochs), "metrics": heap_epochs}},
+                    sort_keys=True,
+                ),
+                flush=True,
+            )
+            model_states = [entry[2] for entry in topk_heap]
+            averaged_model_state: dict[str, torch.Tensor] = {}
+            for key in model_states[0]:
+                averaged_model_state[key] = (
+                    torch.stack([s[key].float() for s in model_states]).mean(dim=0).to(model_states[0][key].dtype)
+                )
+            restore_module_state(model, averaged_model_state)
+
+            anp_states = [entry[3] for entry in topk_heap if entry[3] is not None]
+            if anp_states and anp_head is not None:
+                averaged_anp_state: dict[str, torch.Tensor] = {}
+                for key in anp_states[0]:
+                    averaged_anp_state[key] = (
+                        torch.stack([s[key].float() for s in anp_states]).mean(dim=0).to(anp_states[0][key].dtype)
+                    )
+                restore_module_state(anp_head, averaged_anp_state)
+
+            avg_test_metrics = evaluate_phase_metrics(
+                bundle=bundle,
+                config=config,
+                forward_model=forward_model,
+                anp_head=anp_head,
+                loaders=test_loaders,
+                transform=transform,
+                metric_transform=metric_transform,
+                device=device,
+                phase="test",
+            )
+            avg_prefixed = {f"avg_ckpt_{key}": value for key, value in avg_test_metrics.items()}
+            print(json.dumps({"averaged_checkpoint_test_metrics": avg_test_metrics}, sort_keys=True), flush=True)
+            if run is not None:
+                wandb.log(avg_prefixed, step=int(history[-1]["epoch"]) if history else 0)
+                run.summary.update(avg_prefixed)
+                run.summary["checkpoint_averaging_k"] = len(topk_heap)
+                run.summary["checkpoint_averaging_epochs"] = sorted(avg_epochs)
+
             restore_module_state(model, terminal_model_state)
             restore_module_state(anp_head, terminal_anp_state)
 


### PR DESCRIPTION
## Hypothesis

Checkpoint averaging (a Polyak averaging variant) reduces the variance across cosine annealing minima and improves generalization. Instead of using a single best checkpoint, we save the top-5 best validation checkpoints (by `surface_rel_l2_pct`) during training and average their state dicts element-wise before the final test evaluation. This is an implicit ensemble that is well-established in NLP/CV (closely related to Stochastic Weight Averaging / SWA) and costs zero additional GPU time.

This extends PR #2974 (single best checkpoint saving) to maintain a top-k heap of checkpoints. The hypothesis is that the best single checkpoint can lie on a sharp valley of the loss landscape, while the average of several nearby minima tends to fall in a flatter, better-generalizing region.

## Instructions

Modify `target/icml2026/train.py` as follows:

1. **Add a `--checkpoint-averaging-k` argument** (int, default 1 for backward compatibility). When `k > 1`, maintain a min-heap of the k best validation checkpoints by `surface_rel_l2_pct`.

2. **Heap management**: After each validation pass, if the current `surface_rel_l2_pct` is better than the worst checkpoint in the heap (or the heap has fewer than k entries), save the checkpoint to disk (e.g. `best_ckpt_{rank}.pt`) and update the heap. Prune any checkpoint that is no longer in the top-k.

3. **Post-training averaging**: At the end of training (after all epochs complete), load all k saved checkpoints, average their `state_dict` tensors element-wise, load the averaged weights into the model, and run a final test evaluation pass. Report this as the primary result.

4. Also report the single-best-checkpoint result (without averaging) so we can isolate the delta.

Run with:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --epochs 999 \
  --checkpoint-averaging-k 5 \
  --wandb-group dm-checkpoint-averaging
```

**Note:** `--checkpoint-averaging-k` is a new argument you must add to `train.py`. The existing best-checkpoint logic (from PR #2974) saves one checkpoint — extend it to save top-k and average at the end.

## Baseline

Current best DrivAerML metrics (PR #2898, W&B run `bht6h42t`, epoch 467):

| Metric | Value |
|--------|-------|
| `val_primary/surface_rel_l2_pct` | **3.997%** |

Architecture: 4L/512d/8H + Fourier + no-EMA + cosine T_max=30, AdamW lr=5e-4.

Reproduce command:
```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --enable-fourier \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --epochs 999
```

## What to Report

Please report both:
- **(a) Single best checkpoint** `val_primary/surface_rel_l2_pct` — what the model achieves with the single best saved checkpoint (as in PR #2974)
- **(b) Averaged checkpoint** `val_primary/surface_rel_l2_pct` — what the model achieves after averaging the top-5 checkpoints element-wise

The delta (b − a) is the key result. Baseline to beat: **3.997%**.