### PR TITLE
DrivAerML: lighter WD + gc=1.0 (WD=5e-4 and WD=1e-4 sweep)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,14 +1637,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
@@ -1713,7 +1706,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

PR #3046 (sukuna, WD=1e-3+gc=1.0) achieved 4.44% — stable training but above the 3.997% baseline. Our hypothesis is that WD=1e-3 slightly over-regularizes the 4L/512d model capacity. The current best (PR #2898) uses AdamW's default WD=1e-2 without gradient clipping. WD=1e-3 may already be beneficial but at a sub-optimal level; lighter WD (5e-4 or 1e-4) combined with gc=1.0 for stability may find a deeper basin.

Both gc=1.0 and WD reduction are independent stability/regularization levers — this sweep isolates whether the WD level or the gc interaction is the limiting factor in sukuna's result.

## Instructions

Run both variants sequentially. Use `--wandb-group dm-wd-gc-light` so both runs appear together in W&B.

**Variant 1: WD=5e-4 + gc=1.0**

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --grad-clip 1.0 \
  --weight-decay 5e-4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --epochs 999 \
  --wandb-group dm-wd-gc-light
```

**Variant 2: WD=1e-4 + gc=1.0** (run after Variant 1)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --grad-clip 1.0 \
  --weight-decay 1e-4 \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --epochs 999 \
  --wandb-group dm-wd-gc-light
```

**Report** the best `val_primary/surface_rel_l2_pct` for each variant, compare to sukuna's 4.44% (WD=1e-3+gc=1.0) and the no-WD/no-gc baseline (3.997%). Include W&B run IDs for both variants.

## Baseline

Current best metrics (PR #2898, piccolo):
- `val_primary/surface_rel_l2_pct`: **3.997%** (epoch 467)
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, no-EMA, Fourier, no grad-clip, default WD=1e-2
- W&B run: bht6h42t
- External target: <3.71% (AB-UPT)

Reference (PR #3046, sukuna — WD=1e-3+gc=1.0):
- `val_primary/surface_rel_l2_pct`: **4.44%** — stable but above baseline

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --no-use-ema \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200
```