### PR TITLE
DrivAerML: stochastic input feature dropout (p=0.05, p=0.10)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    input_feature_dropout: float = 0.0
 
 
 @dataclass
@@ -1266,6 +1267,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    input_feature_dropout: float = 0.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1304,21 +1306,25 @@ def train_one_epoch(
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
                     prepared = transform.prepare_batch(batch)
+                    srf_x = F.dropout(prepared.surface_x, p=input_feature_dropout, training=True) if input_feature_dropout > 0 else prepared.surface_x
+                    vol_x = F.dropout(prepared.volume_x, p=input_feature_dropout, training=True) if input_feature_dropout > 0 and prepared.volume_x is not None else prepared.volume_x
                     with autocast_context(device, amp_mode):
                         outputs = model(
-                            surface_x=prepared.surface_x,
+                            surface_x=srf_x,
                             surface_mask=prepared.surface_mask,
-                            volume_x=prepared.volume_x,
+                            volume_x=vol_x,
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
                         loss, _ = loss_grouped_tandem(prepared, outputs)
                 else:
+                    srf_x = F.dropout(batch.surface_x, p=input_feature_dropout, training=True) if input_feature_dropout > 0 else batch.surface_x
+                    vol_x = F.dropout(batch.volume_x, p=input_feature_dropout, training=True) if input_feature_dropout > 0 and batch.volume_x is not None else batch.volume_x
                     with autocast_context(device, amp_mode):
                         outputs = model(
-                            surface_x=batch.surface_x,
+                            surface_x=srf_x,
                             surface_mask=batch.surface_mask,
-                            volume_x=batch.volume_x,
+                            volume_x=vol_x,
                             volume_mask=batch.volume_mask,
                         )
                         loss, _ = loss_grouped(batch, outputs, transform)
@@ -1637,10 +1643,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1682,6 +1684,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            input_feature_dropout=config.input_feature_dropout,
         )
 
         if ema is not None:
@@ -1713,7 +1716,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Independent dropout on node input features (geometry coordinates, normals, etc.) during training prevents the model from relying on any single geometric feature descriptor, forcing it to learn redundant representations and improving generalization. This is analogous to DropConnect applied at the input layer. We test two dropout rates: p=0.05 (light) and p=0.10 (moderate). Dropout is only active during training (`self.training=True`), never at eval time.

The intuition: if the model learns to predict pressure even when some geometric features are randomly masked, it must build a more robust internal representation. This is a common regularization technique in tabular/feature-based ML (used widely in Kaggle competitions) and has been shown to help in geometric deep learning when input features are correlated.

## Instructions

Add an `--input-feature-dropout` float argument to `train.py` (default `0.0`). Apply `F.dropout(x, p=args.input_feature_dropout, training=model.training)` to the node input feature tensor `x` immediately **before** it is passed into the first attention/message-passing layer. Do **not** apply this to edge features or any intermediate hidden representations — only the raw node input features.

Run two variants back-to-back in the same job using `--wandb_group dm-input-dropout`:

**Variant A — p=0.05 (light dropout):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --input-feature-dropout 0.05 \
  --wandb_group dm-input-dropout --wandb_name dm-input-dropout-p005
```

**Variant B — p=0.10 (moderate dropout):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --input-feature-dropout 0.10 \
  --wandb_group dm-input-dropout --wandb_name dm-input-dropout-p010
```

Run both variants to at least 300 epochs (or until the cosine schedule completes at T_max=30 cycles), whichever comes first. Report `val_primary/surface_rel_l2_pct` for both variants at the best validation checkpoint.

## Baseline

Current best DrivAerML metrics (PR #2898, piccolo — 4L/512d/8H + Fourier + no-EMA + T_max=30):
- `val_primary/surface_rel_l2_pct = 3.997%` at epoch 467
- Baseline W&B run: `bht6h42t`
- External target: <3.71% (AB-UPT, ~500 epochs) — 1.08x gap remaining

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --no-use-ema --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200
```