### PR TITLE
DrivAerML: EMA=0.9995 + gc sweep (gc=0.25, gc=1.0)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1630,17 +1630,9 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1703,23 +1695,16 @@ def main() -> None:
             phase="val",
         )
 
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
+        current_val = eval_metrics.get(best_val_primary_metric_name)
+        if current_val is not None and (
+            best_val_primary_metric is None or current_val < best_val_primary_metric
         ):
             best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
+            best_val_primary_metric = current_val
+            best_val_metric = current_val
             best_val_metrics = dict(eval_metrics)
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
-
-        current_val = eval_metrics.get(primary_metric_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
             if ema is not None:
                 best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
             if anp_ema is not None:


### PR DESCRIPTION
## Hypothesis

PR #3072 established that EMA decay=0.9995 + grad-clip=0.5 yields the current best DrivAerML result of 3.833%. However, gc=0.5 was chosen as a stability fix rather than through principled tuning. The cosine annealing restarts (T_max=30) create periodic gradient spikes that disturb the EMA trajectory — the optimal clipping threshold that balances gradient signal vs. EMA-destabilising noise is unknown.

**gc=0.25 (tighter):** Reduces cosine restart gradient spikes more aggressively, potentially producing a smoother EMA trajectory and lower variance in surface pressure predictions. Risk: may over-suppress useful gradient signal, slowing convergence.

**gc=1.0 (looser):** Allows more gradient signal through, which may accelerate convergence to a better minimum. Risk: larger periodic spikes at cosine restarts may perturb the EMA weights and degrade val_primary.

Target: beat 3.833% and push below 3.82% (AB-UPT external target).

## Instructions

Run both variants to completion. Use `--wandb_group dm-ema-gc-sweep` so both runs are grouped in W&B.

**Variant 1 — gc=0.25 (tighter clipping):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.25 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-ema-gc-sweep
```

**Variant 2 — gc=1.0 (looser clipping):**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 1.0 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-ema-gc-sweep
```

**Reporting:** For each variant, report:
- Best `val_primary/surface_rel_l2_pct` (epoch it was achieved)
- Final `val_primary/surface_rel_l2_pct`
- W&B run ID and link
- Per-surface breakdown: `p_in`, `p_oodc`, `p_tan`, `p_re`
- Whether training was stable (no NaN/divergence)

If either variant beats 3.833%, note the epoch and the gap to baseline. If gc=0.25 variant is unstable or diverges early, stop it and note the failure mode.

## Baseline

Current best (DrivAerML):
- **val_primary/surface_rel_l2_pct: 3.833%** (epoch 511)
- **test surface_rel_l2_pct: 4.685%**
- **Best PR:** #3072 (eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
- **Baseline W&B run:** `ncl1dh88` (eren/dm-ema-9995-gc05)
- **External target:** <3.82% (beat AB-UPT at 3.82%)

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995
```

**CRITICAL dataset flags — must be present in every DrivAerML run:**
`--batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200`