### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + light WD (WD=1e-4 and WD=5e-4)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,10 +1637,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1709,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The EMA=0.9995+gc=0.5 champion (PR #3072, 3.833%) uses **no weight decay**. Light WD may improve generalization by preventing weight magnitudes from growing during the long training run, complementing EMA's exponential averaging effect. This tests whether WD and EMA are synergistic or antagonistic on DrivAerML.

Context from prior experiments:
- PR #3072 (eren): EMA=0.9995 + gc=0.5 + **no WD** → **3.833%** ← current champion
- PR #3046 (sukuna): WD=1e-3 + gc=1.0 + **no EMA** → 4.44% — WD alone doesn't help without EMA
- The question: does WD become beneficial when EMA is smoothing the weight trajectory?

Two WD levels to bracket the answer:
- **WD=1e-4** (very light) — gentle regularization, minimal interference with EMA
- **WD=5e-4** (moderate) — stronger regularization, more comparable to standard practice

Target: sub-3.82% (beat AB-UPT external baseline).

## Instructions

Run both variants sequentially. Use the same architecture and optimizer config as PR #3072 — the **only change** is adding `--weight-decay`.

**Variant 1: WD=1e-4 (very light)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --weight-decay 1e-4 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-wd-compound
```

**Variant 2: WD=5e-4 (moderate)**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --weight-decay 5e-4 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-wd-compound
```

Note: `--wandb-group dm-ema-wd-compound` groups both runs together in W&B for easy comparison.

## Baseline

| Metric | Value | Source |
|--------|-------|--------|
| val_primary/surface_rel_l2_pct | **3.833%** | PR #3072, EMA=0.9995+gc=0.5, no WD, ep511 |
| test_primary/surface_rel_l2_pct | 4.685% | PR #3072, best-checkpoint eval |
| External target (AB-UPT) | <3.71% | ~500 epochs |

**Reproduce champion:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
```

## What to report

For **each variant**, report:
- Best `val_primary/surface_rel_l2_pct` and at which epoch
- W&B run ID
- Compare vs 3.833% (no WD champion) and vs 4.44% (WD=1e-3+gc=1.0, no-EMA, PR #3046)
- Note: if either variant diverges early, report the divergence epoch and last stable val metric

Target: sub-**3.82%** on val to beat AB-UPT external baseline.