### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + monotonic cosine (no restarts)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,14 +1637,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
@@ -1713,7 +1706,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The current best DrivAerML configuration (PR #3072, 3.833%) uses cosine annealing with restarts every T_max=30 epochs. Each restart creates a loss spike at the restart peak, and EMA with decay=0.9995 takes ~10 epochs to flush each spike — wasting a significant portion of our 999-epoch convergence budget on recovery rather than descent.

A single long monotonic cosine decay (T_max=999, no restarts) should:
1. Eliminate restart-induced spikes entirely, giving EMA a smooth signal throughout training
2. Allow EMA to track a steadily improving model rather than a cyclically perturbed one
3. Potentially push val_primary/surface_rel_l2_pct below 3.82% (closing gap toward the AB-UPT external target of 3.71%)

The hypothesis is that the EMA + cosine restarts combination is actively counterproductive: restarts were designed for SGD-style escape from sharp minima, but with AdamW + EMA the restart spikes are pure noise.

## Instructions

Run the following command. The only change vs the current best (PR #3072) is `--cosine-t-max 999` (was 30) — a single monotonic cosine decay over the full training run, with no restarts:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 999 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-schedule
```

**Key change:** `--cosine-t-max 999` (was `30`) — single long monotonic cosine decay, no restarts.

All other hyperparameters are identical to the current champion (PR #3072): AdamW lr=5e-4, gc=0.5, EMA=0.9995, 4L/512d/8H architecture, 50k surface points, batch-size 1.

**What to report:** Please report val_primary/surface_rel_l2_pct at best validation checkpoint, the epoch it was achieved, and the W&B run ID. Also note whether the training loss curve was visibly smoother than restart-based runs.

## Baseline

Current best metrics (PR #3072 — eren, EMA=0.9995 + gc=0.5):
- val_primary/surface_rel_l2_pct: **3.833%** (epoch 511)
- test_primary/surface_rel_l2_pct: 4.685%
- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target: <3.71% (AB-UPT, ~500 epochs)
- Immediate sub-target: <3.82%

Reproduce current best:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
```