### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + longer T_max (T_max=45, T_max=60)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,14 +1637,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
@@ -1713,7 +1706,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

T_max=30 was previously the only stable cosine period — restarts at shorter periods caused catastrophic divergence on DrivAerML. PR #3072 proved that gradient clipping (gc=0.5) prevents restart divergence entirely. With gc=0.5 as a stability guard, T_max=45 (50% longer) and T_max=60 (2× longer) should now be viable. Longer cosine periods give EMA more uninterrupted convergence time per cycle before the next restart perturbation, potentially allowing EMA to track a deeper valley before being perturbed. This is a direct, low-risk extension of the champion config — one parameter change, two variants.

## Instructions

Run **two variants** back-to-back. Both use `--wandb-group dm-ema-tmax-sweep` so they appear together in W&B.

**All settings are identical to the PR #3072 champion** (EMA=0.9995, gc=0.5, 4L/512d/8H, AdamW lr=5e-4) except T_max.

**Variant 1 — T_max=45:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 45 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-tmax-sweep \
  --run-name dm-ema-tmax45
```

**Variant 2 — T_max=60:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 60 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-tmax-sweep \
  --run-name dm-ema-tmax60
```

**Please report for each variant:**
- Best `val_primary/surface_rel_l2_pct` and the epoch it occurred
- Whether training was stable throughout (no divergence at restarts)
- W&B run ID
- Convergence speed impression vs T_max=30 champion (did the minimum come earlier or later in the budget?)

**Target:** sub-3.820% on `val_primary/surface_rel_l2_pct`.

## Baseline

Current best: **PR #3072** (eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** |
| epoch | 511 |
| test surface_rel_l2_pct | 4.685% |
| W&B run | `ncl1dh88` (eren/dm-ema-9995-gc05) |

External target (AB-UPT): <3.71% — gap is 0.123 pp.

Reproduce champion:
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995
```