### PR TITLE
AirfRANS: softer gc=0.5 on EMA champion (gc reduction transfer from TF)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,10 +1637,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1709,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

TandemFoil experiments showed a clear monotonic improvement as grad-clip was softened: gc=1.0 → gc=0.5+EMA improved by -13.8%, then gc=0.3+EMA improved a further -2.8%. The AirfRANS EMA champion (PR #3050, stark) currently uses gc=1.0. We hypothesise that the same gc-reduction transfer applies to AirfRANS: reducing gc from 1.0 → 0.5 will allow the optimizer to take larger gradient steps in the flat regions of the AirfRANS loss landscape, improving surface and volume MSE.

The TandemFoil gc pattern is strong enough evidence to motivate a direct cross-dataset transfer test. If gc=0.5 beats gc=1.0 on AirfRANS, we follow up with gc=0.3.

## Instructions

Start from the AirfRANS EMA champion config (PR #3050) and change only `--grad-clip` from 1.0 to 0.5. Everything else stays identical.

```bash
cd target/icml2026
python train.py \
  --dataset airfrans \
  --airfrans-task full \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 0.5 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 \
  --model-hidden-dim 256 \
  --model-heads 4 \
  --epochs 999 \
  --ema-decay 0.999 \
  --wandb-group af-gc-sweep
```

Key change vs champion: `--grad-clip 0.5` (was 1.0). All other flags are identical to PR #3050.

**What to report:** Compare `val_primary/surface_mse` and `full_val/volume_mse` against the gc=1.0 champion below. Report best checkpoint metrics (not terminal epoch).

## Baseline

Current AirfRANS champion — PR #3050 (stark/af-ema-champion):
- `val_primary/surface_mse`: **0.000459** (ep771)
- `full_val/volume_mse`: **0.002777**
- Config: 2L/256d/4H, AdamW lr=6e-4, cosine T_max=50, **gc=1.0**, WD=1e-2, EMA=0.999, Fourier enabled
- W&B run: `z6pry4b9` — https://wandb.ai/wandb/senpai/runs/z6pry4b9
- Reproduce champion: `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999`

**Target to beat:** surface_mse < 0.000459 and/or vol_mse < 0.002777