### PR TITLE
TandemFoil Paper: 3L/224d intermediate width

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -227,7 +227,7 @@ class TargetTransform:
         if self.stats_mean is not None and self.stats_std is not None and self.stats_mean.numel() == out.shape[-1]:
             out = out * self.stats_std.to(out.device) + self.stats_mean.to(out.device)
         if self.asinh_pressure and self.pressure_index is not None:
-            out[..., self.pressure_index] = torch.sinh(out[..., self.pressure_index]) / max(self.asinh_scale, 1e-6)
+            out[..., self.pressure_index] = torch.sinh(out[..., self.pressure_index].clamp(-20.0, 20.0)) / max(self.asinh_scale, 1e-6)
         return out
 
 
@@ -1638,9 +1638,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        primary_metric_str = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        primary_metric_str = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1713,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(primary_metric_str)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

3L/224d is an intermediate point between the current 192d champion (PR #3025, field_mse=0.002383) and the wider 256d being tested by robin (PR #3124). The 224d hidden dimension gives ~37% more parameters than 192d (224²×3 vs 192²×3) while staying below the 256d width.

Key motivation for 224d specifically:
- 4 attention heads divide cleanly into 224d (56 dim per head), giving a cleaner per-head representation than 192d/3=64 (also clean, but 224/4=56 may capture different feature partitioning)
- May capture more pressure field detail than 192d without the instability risk of wider models
- 4L/192d caused pressure overflow (Infinity) — so layer depth is risky; width is the safer axis to explore
- This is a direct ablation point in the width sweep (192 → 224 → 256)

If 224d beats 192d, we have evidence that width is a reliable lever for TFP. If it diverges or underperforms, it sharpens the story that 192d is at or near the sweet spot.

## Instructions

Train a 3-layer model with hidden dim 224 and 4 attention heads on the TandemFoil Paper dataset. All other hyperparameters mirror the champion configuration from PR #3025.

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 \
  --model-slices 64 --model-layers 3 \
  --model-hidden-dim 224 --model-heads 4 \
  --enable-fourier --enable-te-coord-frame \
  --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999 \
  --wandb-group tfp-width-sweep
```

**What to report:**
- `val_primary/field_mse` — primary metric, beat 0.002383 to win
- Whether pressure stays finite throughout training (pressure stability test — flag if field_mse goes to Infinity or NaN at any epoch)
- Whether it beats baseline 0.002383
- Best epoch achieved

## Baseline

Current best metrics (TandemFoil Paper):
- **val_primary/field_mse: 0.002383** (best at epoch 443)
- val/surface_mse: 0.001517
- val/surface_mse_p: 4.81e-05
- val/volume_mse: 0.002397
- Baseline PR: #3025 (haku — 3L/192d, Lion lr=1.25e-4, T_max=10, gc=0.5, EMA=0.999)
- Baseline W&B run: d1xh0o1p (haku/tfp-lion-champion-config)
- Reproduce command:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 \
  --enable-fourier --model-layers 3 \
  --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame \
  --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999
```