### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + lr=4e-4 (LR under EMA regime)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1638,9 +1638,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1713,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

lr=5e-4 was a sharp optimum **without** EMA (lr=4e-4 previously scored 4.14%, lr=5.5e-4 was worse). With EMA=0.9995+gc=0.5 now active, EMA smooths the loss surface — potentially widening the LR basin so that a slightly lower LR (lr=4e-4) reaches a different, smoother convergence trajectory and a better final result.

The rationale: EMA acts as implicit regularization during training, which historically shifts the optimal LR downward by 10–20%. The current baseline at lr=5e-4 may be sitting in a steeper valley that EMA has partially flattened — moving left to lr=4e-4 or lr=4.5e-4 may find a broader basin with lower asymptotic loss.

Also run lr=4.5e-4 as an intermediate data point to map the LR curve under EMA.

## Instructions

Run two variants. Everything identical to PR #3072 except `--lr`. Use `--wandb-group dm-ema-lr-sweep` so both runs appear together in W&B.

**Variant 1 — lr=4e-4:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 4e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-lr-sweep
```

**Variant 2 — lr=4.5e-4:**
```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 4.5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-lr-sweep
```

**Report:** Best `val_primary/surface_rel_l2_pct` for each variant + epoch achieved. Compare convergence speed vs the lr=5e-4 baseline.

## Baseline

Current best (DrivAerML):
- `val_primary/surface_rel_l2_pct`: **3.833%** (epoch 511) — test 4.685%
- Config: 4L/512d/8H, AdamW lr=5e-4, EMA=0.9995, gc=0.5, cosine T_max=30
- PR: #3072 (eren — dm-ema-9995-gc05)
- W&B run: `ncl1dh88` ([eren/dm-ema-9995-gc05](https://wandb.ai/wandb/senpai/runs/ncl1dh88))
- External target: <3.71% (AB-UPT)

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
```