### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + 4L/640d (wider model on champion config)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,10 +1637,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1709,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The 4L/640d architecture provides 56% more parameters than 4L/512d. Previous 640d tests failed because they lacked gradient clipping (gojo #3079 diverged at ep28 without gc) or used a non-optimal config (T_max=60 + lr=3e-4). With EMA=0.9995+gc=0.5 providing both stability and implicit ensemble averaging — the proven champion recipe from PR #3072 — the wider model may capture more complex flow interactions and push below 3.83%.

This is the missing cell in the architecture sweep: 640d width + champion stability config. The prior 640d failure was a config failure, not an architecture failure.

## Instructions

Run the following training command:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 640 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --wandb-group dm-ema-architecture
```

Key differences from baseline (PR #3072):
- `--model-hidden-dim 640` (was 512) — 56% more parameters
- `--model-heads 8` unchanged
- All other hyperparameters identical to champion config

Report: best `val_primary/surface_rel_l2_pct`, the epoch it occurred, and confirm stability (no divergence) through the full training budget.

## Baseline

- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- `test_primary/surface_rel_l2_pct`: 4.685%
- Baseline PR: #3072 (eren/dm-ema-9995-gc05), W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, EMA=0.9995, gc=0.5, Fourier, no WD
- External target: <3.71% (AB-UPT); current gap: 0.123 pp (1.03x)

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```