### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + 16 attention heads

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,14 +1637,9 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    primary_metric_key_str = primary_metric_key(bundle, phase="val")
     best_val_metric = float("inf")
     best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
     best_ema_shadow: dict[str, torch.Tensor] | None = None
     best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
@@ -1713,7 +1708,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(primary_metric_key_str)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The current DrivAerML champion (PR #3072) uses 8 attention heads at 64d/head (4L/512d/8H config). We hypothesize that increasing to 16 heads (32d/head, same total hidden dim 512d) will enable finer-grained spatial attention — each head specialises on a narrower subspace of the surface geometry, which may improve local pressure feature resolution on aerodynamic surfaces.

Prior work: senku tested 4H and 16H variants in PR #3127 **without** EMA+gc and did not beat baseline. That result is insufficient to conclude heads don't matter — EMA=0.9995 + gc=0.5 is a critical stability mechanism on DrivAerML (EMA alone diverges at ep28 without gc). This PR adds EMA+gc to the 16H variant to give it a fair test.

Reference: Multi-head attention head count vs. head dimension tradeoffs are well-studied in NLP (Voita et al. 2019 "Analyzing Multi-Head Self-Attention") and have shown that head specialization is architecture-dependent.

## Instructions

Start from the DrivAerML champion config (4L/512d/8H, EMA=0.9995, gc=0.5) and change only the number of attention heads from 8 to 16:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 16 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --wandb-group dm-ema-heads
```

Key change vs. champion: `--model-heads 16` (was 8). Head dim goes from 64d to 32d. All other hyperparameters are identical to #3072.

**What to report:**
- Best `val_primary/surface_rel_l2_pct` and the epoch it was achieved
- Training stability (any divergence or instability events?)
- VRAM usage comparison vs. 8H champion
- W&B run link and run ID

## Baseline

Current DrivAerML best (PR #3072, eren — EMA=0.9995 + gc=0.5, 4L/512d/8H):

| Metric | Value |
|--------|-------|
| `val_primary/surface_rel_l2_pct` | **3.833%** |
| Epoch | 511 |

- Baseline W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target (AB-UPT): <3.71% (~500 epochs) — gap is 0.123pp

Reproduce champion:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```