### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + eta_min=1e-5 (cosine floor)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -160,6 +160,7 @@ class TrainConfig:
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
     cosine_t_max: int = 150
+    cosine_eta_min: float = 0.0
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
     surface_anchor_points: int = 8_000
@@ -1625,7 +1626,7 @@ def main() -> None:
     scheduler = None
     if config.cosine_t_max > 0:
         base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max, eta_min=config.cosine_eta_min)
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
@@ -1638,9 +1639,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        best_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        best_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1714,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The EMA champion (#3072) uses CosineAnnealingLR which decays to eta_min=0. At each 30-epoch cosine trough, LR=0 means zero gradient updates — EMA's averaging pipeline stalls for several epochs because there is nothing to integrate. Adding eta_min=1e-5 maintains a tiny learning rate floor, so the optimizer always makes incremental updates and EMA continues averaging throughout training. This should smooth the EMA convergence curve and potentially find a deeper loss basin.

PR #3111 (himmel) tests eta_min WITHOUT EMA — this experiment tests it WITH EMA=0.9995 to see if the compound is synergistic. The two together address the stalling mechanism directly: EMA=0.9995 slows weight averaging and gc=0.5 prevents gradient explosions, but neither helps when updates drop to zero entirely.

## Instructions

**Step 1:** Check if `--cosine-eta-min` exists in `target/icml2026/train.py`. If it does not, add it:
- Parse `--cosine-eta-min` as a float argument (default `0.0` to stay backward-compatible with existing runs)
- Wire it to `CosineAnnealingLR(optimizer, T_max=args.cosine_t_max, eta_min=args.cosine_eta_min)`

**Step 2:** Run:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --cosine-eta-min 1e-5 \
  --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --wandb-group dm-ema-eta-min
```

**Step 3:** Report:
- Best `val_primary/surface_rel_l2_pct`, epoch number, and W&B run ID
- Whether the EMA loss trajectory is smoother at cosine troughs compared to #3072 (fewer / smaller spikes)
- Baseline to beat: **3.833%**

## Baseline

- `val_primary/surface_rel_l2_pct`: **3.833%** at epoch 511
- `test_primary/surface_rel_l2_pct`: **4.685%**
- Baseline PR: #3072 (eren — EMA=0.9995 + gc=0.5, eta_min=0)
- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, EMA=0.9995, gc=0.5, eta_min=**0**
- External target: <3.71% (AB-UPT, ~500 epochs)
- Reproduce baseline: `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`