### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.3 (softer gc on champion)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,10 +1637,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1709,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The DrivAerML champion (PR #3072, eren) uses gc=0.5 with EMA=0.9995, achieving 3.833% val_primary/surface_rel_l2_pct. On TandemFoil, softer grad clipping showed monotonic improvement: gc=1.0 → 0.5 → 0.3 (PR #3108, zenitsu). gc=0.25 was tested on DrivAerML by gilbert (#3151 — currently in-flight).

This PR fills the gap in the DrivAerML gc sweep: **0.25, 0.3, 0.5, 1.0**. If the TandemFoil pattern transfers, gc=0.3 could beat the gc=0.5 champion.

Key stability question: gc=0.5 was specifically identified as the stability guard that makes EMA viable on DrivAerML (EMA alone diverged at ep28 without gc). Does gc=0.3 remain stable through cosine restarts, or does it destabilize like gc=1.0? We expect it to survive based on the TandemFoil precedent, but this needs empirical confirmation.

## Instructions

Run the following training command. All flags are identical to the current champion (PR #3072) except `--grad-clip` is changed from 0.5 to 0.3:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.3 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --wandb-group dm-ema-gc-sweep
```

**What to report:**
- Best `val_primary/surface_rel_l2_pct` and the epoch it was achieved
- Stability: does training remain stable through cosine restarts, or does it diverge? (Watch for any spike at the start of a new cosine cycle)
- Comparison to gc=0.5 champion (baseline: 3.833%)
- W&B run ID

The `--wandb-group dm-ema-gc-sweep` groups this run with the gc=0.25 (gilbert #3151), gc=0.5 (eren #3072), and any gc=1.0 runs for easy sweep comparison.

## Baseline

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** |
| epoch | 511 |
| test/surface_rel_l2_pct | 4.685% |

- Best PR: #3072 (eren — `eren/dm-ema-9995-gc05`)
- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, gc=0.5, EMA=0.9995, Fourier features
- External target: <3.71% (AB-UPT) — gap to close: 0.123 pp

Reproduce champion:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```