### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + attention dropout=0.05

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -106,6 +106,7 @@ class TrainConfig:
     model_mlp_ratio: int = 4
     model_slices: int = 96
     model_dropout: float = 0.0
+    attn_dropout: float = 0.0
     drivaerml_train_surface_points: int = 0
     drivaerml_eval_surface_points: int = 0
     drivaerml_train_volume_points: int = 0
@@ -502,7 +503,7 @@ def build_model(config: TrainConfig, bundle: DatasetBundle) -> torch.nn.Module:
     transolver_kwargs = {
         "n_layers": config.model_layers,
         "n_hidden": config.model_hidden_dim,
-        "dropout": config.model_dropout,
+        "dropout": config.attn_dropout if config.attn_dropout > 0 else config.model_dropout,
         "n_head": config.model_heads,
         "mlp_ratio": config.model_mlp_ratio,
         "slice_num": config.model_slices,
@@ -1631,16 +1632,13 @@ def main() -> None:
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
     if bundle.spec.name == "tandemfoilset":
         primary_metric_key = "val_primary/surface_pressure_mae"
     else:
         primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = primary_metric_key
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None


### PR DESCRIPTION
## Hypothesis

PR #3113 showed that `attn-dropout=0.05` *without* EMA+gc causes catastrophic divergence (7 spike events — dropout noise amplified by cosine restart peaks). With `EMA=0.9995 + gc=0.5` now established as the stability platform on DrivAerML (PR #3072, 3.833%), dropout should act as useful regularization rather than a destabilizer:

- **gc=0.5** clips the cosine restart spike that previously triggered dropout-induced divergence
- **EMA=0.9995** smooths the noisy per-step weight signal that dropout amplifies
- **attn-dropout=0.05** forces the model to build redundant attention patterns across point cloud neighborhoods → better generalization to unseen car geometries at test time

The hypothesis is that the stability gains from EMA+gc are sufficient to tame 5% attention dropout, and the added regularization will reduce the validation gap to the AB-UPT external target (<3.71%).

## Instructions

Starting from the EMA+gc=0.5 baseline (PR #3072), add `--attn-dropout 0.05` and run a full DrivAerML training:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --attn-dropout 0.05 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb-group dm-ema-regularization
```

**What to report:**
- Best `val_primary/surface_rel_l2_pct` and the epoch it occurred
- Stability: did any divergence spikes occur? How many? (Compare to PR #3113's 7 spikes without gc)
- W&B run ID and link

**Baseline to beat:** 3.833%

## Baseline

Current best DrivAerML metrics (PR #3072 — eren, EMA=0.9995 + gc=0.5, no dropout):

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** |
| epoch | 511 |
| test surface_rel_l2_pct | 4.685% |

- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target: <3.71% (AB-UPT) — gap: 0.123 pp (1.03x away)
- Reproduce command:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
```