### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 paper-facing full eval (two-phase)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -167,6 +167,8 @@ class TrainConfig:
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
+    resume_checkpoint: str = ""
+    eval_only: bool = False
     seed: int = 0
 
 
@@ -1610,6 +1612,10 @@ def main() -> None:
 
     train_loader, val_loaders, test_loaders = build_loaders(config, bundle, num_workers=resolved_num_workers)
     model = build_model(config, bundle).to(device)
+    if config.resume_checkpoint:
+        state_dict = torch.load(config.resume_checkpoint, map_location=device, weights_only=True)
+        model.load_state_dict(state_dict)
+        print(json.dumps({"resumed_checkpoint": config.resume_checkpoint}), flush=True)
     forward_model = torch.compile(model) if config.compile_model and device.type == "cuda" else model
     anp_head = None
     if bundle.spec.name == "tandemfoilset" and config.anp_srf:
@@ -1618,17 +1624,22 @@ def main() -> None:
             output_dim=bundle.spec.surface_output_dim,
         ).to(device)
 
-    params = list(model.parameters())
-    if anp_head is not None:
-        params.extend(list(anp_head.parameters()))
-    optimizer = build_optimizer(params, config)
-    scheduler = None
-    if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
-
-    ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
-    anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
+    if config.eval_only:
+        ema = None
+        anp_ema = None
+        optimizer = None
+        scheduler = None
+    else:
+        params = list(model.parameters())
+        if anp_head is not None:
+            params.extend(list(anp_head.parameters()))
+        optimizer = build_optimizer(params, config)
+        scheduler = None
+        if config.cosine_t_max > 0:
+            base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
+        anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
@@ -1637,10 +1648,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1664,7 +1671,13 @@ def main() -> None:
     start_time = time.monotonic()
     timeout_seconds = None if not timeout_env else float(timeout_env) * 60.0
 
-    for epoch in range(1, config.epochs + 1):
+    if config.eval_only:
+        best_model_state = snapshot_module_state(model)
+        best_anp_state = snapshot_module_state(anp_head)
+        best_epoch = 0
+        print(json.dumps({"eval_only": True, "checkpoint": config.resume_checkpoint}), flush=True)
+
+    for epoch in range(1, 0 if config.eval_only else config.epochs + 1):
         if timeout_seconds is not None and epoch > 1 and (time.monotonic() - start_time) >= timeout_seconds:
             break
         train_metrics = train_one_epoch(
@@ -1713,7 +1726,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

This is a paper-facing evaluation run, not a new hypothesis. We need the TRUE `test_primary/surface_rel_l2_pct` for the ICML paper from the champion config (EMA=0.9995+gc=0.5). The current test=4.685% from PR #3072 used `--max-eval-batches 200` (truncated eval). Full eval requires ~7 min/epoch, making it too expensive to run every epoch.

**Two-phase approach:**
1. Train to convergence with `--max-eval-batches 200` (same as champion)
2. Load best checkpoint and run one final full eval without `--max-eval-batches`

## Baseline

- **val_primary/surface_rel_l2_pct:** 3.833% (partial eval, PR #3072)
- **test_primary/surface_rel_l2_pct:** 4.685% (partial eval, PR #3072) — TRUNCATED, NEED TRUE NUMBER
- **Best PR:** #3072 (eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
- **External target:** <3.71% (AB-UPT, ~500 epochs)
- **Baseline W&B run:** ncl1dh88

## Instructions

### Phase 1: Train to convergence (same as champion config)

Run the champion config to convergence. This replicates PR #3072 and should achieve ~3.833% val or better:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --wandb-group dm-paper-eval
```

The best-checkpoint saving (PR #2974) saves the best val checkpoint automatically. Note the path to the best val checkpoint from the training output.

### Phase 2: Full eval of the best checkpoint

After Phase 1 completes, load the best val checkpoint and run a full evaluation WITHOUT `--max-eval-batches`. This gives the paper-facing test metric:

```bash
cd target/icml2026 && python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 8 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --ema-decay 0.9995 --wandb-group dm-paper-eval \
  --resume <path-to-best-val-checkpoint> --eval-only
```

If `--eval-only` is not a supported flag, run for 0 or 1 additional epochs from the best checkpoint with no `--max-eval-batches` and report the test metric from that run.

**Important:** Do NOT include `--max-eval-batches` in Phase 2. We need the full test set evaluation.

## What to report

Please report in a PR comment:
1. **Best val_primary/surface_rel_l2_pct** from Phase 1 (should match ~3.833%)
2. **test_primary/surface_rel_l2_pct from FULL eval** (no `--max-eval-batches`) — **THIS IS THE PAPER NUMBER**
3. Whether the full-eval test is better or worse than the truncated 4.685%
4. W&B run IDs for both phases