### PR TITLE
DrivAerML: EMA=0.9995 + gc=0.5 + 4 attention heads (128d/head)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1638,9 +1638,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_primary_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1713,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

PR #3127 showed 4H (128d/head) had faster initial descent than 16H but diverged without gc/EMA. With the stability platform (EMA+gc), 4H's larger per-head dimension may capture richer spatial features per attention head — each head has 128d of representational capacity vs 64d at 8H. griffith (#3160) tests 16H (32d/head); this tests 4H to complete the heads sweep: 4H, 8H (champion), 16H under EMA+gc.

## Instructions

Run the following command:

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml --optimizer adamw --lr 5e-4 \
  --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier --model-layers 4 --model-hidden-dim 512 \
  --model-heads 4 --epochs 999 --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 --wandb-group dm-ema-heads
```

Report: best val metric, epoch, and training stability. Compare to 8H champion (3.833%) and note if 4H's faster initial descent (observed in #3127) persists under EMA+gc.

## Baseline

- val_primary/surface_rel_l2_pct: **3.833%** at epoch 511
- Best PR: #3072 (eren — EMA=0.9995+gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30)
- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target: <3.71% (AB-UPT, ~500 epochs) — gap: 0.123 pp (1.03x)
- Reproduce baseline:
  ```bash
  cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995
  ```