### PR TITLE
AirfRANS: vol-weight=5.0 & 7.0 + EMA=0.999 — filling 3x→10x gap

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    vol_loss_weight: float = 1.0
 
 
 @dataclass
@@ -761,6 +762,7 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    vol_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -772,7 +774,7 @@ def loss_grouped(
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss_weight * vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -781,6 +783,7 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    vol_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
@@ -790,7 +793,7 @@ def loss_grouped_tandem(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
         vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss_weight * vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -800,6 +803,7 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    vol_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
@@ -811,7 +815,7 @@ def loss_abupt(
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
         vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
-        total = total + vol_loss
+        total = total + vol_loss_weight * vol_loss
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -1266,6 +1270,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    vol_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1299,7 +1304,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, vol_loss_weight=vol_loss_weight)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1312,7 +1317,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, vol_loss_weight=vol_loss_weight)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1321,7 +1326,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, vol_loss_weight=vol_loss_weight)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1631,7 +1636,6 @@ def main() -> None:
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1641,6 +1645,7 @@ def main() -> None:
         primary_metric_key = "val_primary/surface_pressure_mae"
     else:
         primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = primary_metric_key
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1682,6 +1687,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            vol_loss_weight=config.vol_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

vol-weight=3x (PR #3127) gave a strong surface improvement (-17%, surface_mse=0.000381!) but the volume improvement was modest. vol-weight=10x was too aggressive and hurt both metrics. The sweet spot for volume MSE improvement likely lies between 3x and 10x. We test 5x and 7x to find it, pairing with EMA=0.999 which proved essential for surface quality.

**Target:** Keep surface_mse competitive (ideally near 0.000381) while pushing vol_mse toward the SpiderSolver target of ~0.0017.

## Instructions

Run **two trials** using the mandatory AF config (AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, 2L/256d/8H). Use `--wandb_group af-vol-weight-5x-7x` to group runs.

**Trial 1 — vol-weight=5.0:**
```bash
cd target/icml2026 && python train.py --dataset airfrans --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 8 --epochs 999 --ema-decay 0.999 --vol-loss-weight 5.0 --wandb_group af-vol-weight-5x-7x
```

**Trial 2 — vol-weight=7.0:**
```bash
cd target/icml2026 && python train.py --dataset airfrans --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 8 --epochs 999 --ema-decay 0.999 --vol-loss-weight 7.0 --wandb_group af-vol-weight-5x-7x
```

**What to report:** For each trial, report `val_primary/surface_mse` and `full_val/volume_mse` at the best validation checkpoint. Compare both against baseline. Flag whether vol_mse is trending toward 0.0017.

## Baseline

Current best — PR #3050 (stark — EMA=0.999 + T_max=50, 2L/256d, AdamW lr=6e-4, gc=1.0, WD=1e-2):
- **val_primary/surface_mse:** 0.000459 (target to beat)
- **full_val/volume_mse:** 0.002777 (target to beat; SpiderSolver target ~0.0017)
- **W&B run:** z6pry4b9
- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999`

## Context: vol-weight sweep so far

| vol-weight | surface_mse | vol_mse | vs baseline surface | vs baseline vol |
|---|---|---|---|---|
| 1.0 (baseline) | 0.000459 | 0.002777 | — | — |
| 1.5 (tanjiro, WIP) | TBD | TBD | — | — |
| 2.0 (violet, WIP) | TBD | TBD | — | — |
| 3.0 (PR #3127) | 0.000381 | ~0.002777 | **-17%** | ~flat |
| **5.0 (this PR, Trial 1)** | TBD | TBD | — | — |
| **7.0 (this PR, Trial 2)** | TBD | TBD | — | — |
| 10.0 (nezuko, WIP) | worse | worse | — | — |
| 30.0 (megumi, WIP) | much worse | TBD | — | — |

Dead ends: 3L depth, EMA<0.999, T_max≠50, vol-weight=10x