### PR TITLE
AirfRANS: Higher LR (8e-4/1e-3) sweep with EMA=0.999 stabilization

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,17 +1637,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-    best_ema_shadow: dict[str, torch.Tensor] | None = None
-    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
-
     run = None
     if config.wandb_name:
         run_config = asdict(config)
@@ -1713,32 +1702,20 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
-            if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
-
         if ema is not None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-        epoch_metrics["best_val_metric"] = best_val_metric
-        epoch_metrics["best_epoch"] = float(best_epoch)
+        epoch_metrics["best_val_metric"] = best_val_primary_metric if best_val_primary_metric is not None else float("inf")
+        epoch_metrics["best_epoch"] = float(best_epoch) if best_epoch is not None else 0.0
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
+            run.summary["best_val_metric"] = best_val_primary_metric if best_val_primary_metric is not None else float("inf")
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1789,8 +1766,8 @@ def main() -> None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
-        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
+            run.summary["best_val_metric"] = best_val_primary_metric
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_primary_metric}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)


### PR DESCRIPTION
## Hypothesis

EMA=0.999 with timm-style warmup provides training stability that may allow a more aggressive learning rate than the current champion (lr=6e-4). The AF volume gap remains 1.63x relative to SpiderSolver — vol-weight tuning has been exhausted, so the next lever is LR dynamics. We hypothesize that lr=8e-4 (and possibly lr=1e-3) paired with EMA=0.999 can converge to a lower surface_mse and/or vol_mse than the current best.

Prior sweep (PR #2951) showed lr=1e-3 diverged **without** EMA. With EMA=0.999 locking in a stable shadow model, the same LR may now be viable. This is a targeted 2-trial sweep: one safe step (8e-4) and one aggressive (1e-3).

## Instructions

Run both trials. Use `--wandb_group af-lr-sweep-ema` so both runs appear together in W&B.

**Mandatory locked config (do not change):**
- Optimizer: AdamW, WD=1e-2
- Cosine annealing: T_max=50
- Gradient clip: gc=1.0
- EMA decay: 0.999
- Architecture: 2L / 256d / 8H
- Fourier features: enabled

**Trial 1 — lr=8e-4 (safe step up):**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 8e-4 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 8 \
  --epochs 999 --ema-decay 0.999 \
  --wandb_group af-lr-sweep-ema
```

**Trial 2 — lr=1e-3 (aggressive; EMA may now stabilize):**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 1e-3 \
  --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 --model-hidden-dim 256 --model-heads 8 \
  --epochs 999 --ema-decay 0.999 \
  --wandb_group af-lr-sweep-ema
```

**If Trial 2 (lr=1e-3) diverges or is clearly worse after 100 epochs, stop it early and report.**

**Report for each trial:**
- W&B run ID and link
- Best `val_primary/surface_mse` (epoch at which it occurred)
- `full_val/volume_mse` at that checkpoint
- Whether the run was stable throughout

## Baseline

Current AF champion — PR #3050 (stark/af-ema-champion):

| Metric | Value |
|--------|-------|
| val_primary/surface_mse | **0.000459** (epoch 771) |
| full_val/volume_mse | **0.002777** |
| W&B run | `z6pry4b9` |

Reproduce command:
```bash
cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999
```

Beat surface_mse < 0.000459 to be a winner. vol_mse improvement (< 0.002777) is also valuable even if surface_mse is similar.