### PR TITLE
TFP: multi-seed variance check — paper-facing reproducibility (3 seeds)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1637,10 +1637,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    _primary_key = best_val_primary_metric_name
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1710,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The TFP champion config (Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, EMA=0.999, 3L/192d + Fourier) achieved val_primary/field_mse=0.002383 in PR #3025. Before we include this result in the ICML 2026 paper we need to verify reproducibility across multiple seeds and obtain clean **test** metrics with variance bars (mean ± std).

This is a paper-facing run. The goal is not to beat the baseline — it is to confirm the result is stable and to populate the paper's results table with honest test metrics.

## Instructions

Run the champion TFP config with three fixed seeds. Use `--wandb_group tfp-multi-seed-paper` so all runs appear together in W&B.

**IMPORTANT — config is fixed. Do NOT change any hyperparameter.** All dead ends have already been explored:
- T_max must be 10 — other values cause gradient starvation (T_max<10) or destabilization (T_max>10)
- grad-clip must be 0.5 — 0.3 causes gradient starvation, 0.7 destabilizes
- EMA decay must be 0.999 — other values (e.g. 0.9999) cause sinh overflow
- 4L depth is worse than 3L
- lr=1.5e-4 is worse than 1.25e-4
- model-heads=8 as specified below

```bash
# seed=42
cd target/icml2026 && python train.py --dataset tandem_foil_set --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 8 --epochs 999 --ema-decay 0.999 --seed 42 --wandb_group tfp-multi-seed-paper

# seed=123
cd target/icml2026 && python train.py --dataset tandem_foil_set --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 8 --epochs 999 --ema-decay 0.999 --seed 123 --wandb_group tfp-multi-seed-paper

# seed=456
cd target/icml2026 && python train.py --dataset tandem_foil_set --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 8 --epochs 999 --ema-decay 0.999 --seed 456 --wandb_group tfp-multi-seed-paper
```

### What to report

For each seed, report:
- `val_primary/field_mse` (best validation checkpoint)
- `test_primary/field_mse` (evaluated from best validation checkpoint — **not** terminal epoch)
- W&B run ID

Then compute and report:
- Mean ± std for both `val_primary/field_mse` and `test_primary/field_mse` across the 3 seeds

This is the number that goes in the paper. We need the test metric from the best val checkpoint — not the last epoch. Please ensure you retrieve it correctly.

## Baseline

- **Best val_primary/field_mse:** 0.002383 (epoch 443)
- **PR:** #3025 (student: haku, branch: haku/tfp-lion-champion-config)
- **W&B run:** `d1xh0o1p`
- **Config:** Lion lr=1.25e-4, cosine T_max=10, gc=0.5, WD=1e-2, EMA=0.999, 3L/192d, Fourier+physics
- **Additional metrics at best checkpoint:**
  - val/surface_mse: 0.001517
  - val/surface_mse_p: 4.81e-05
  - val/volume_mse: 0.002397
- **Note:** Training diverged at ep462 but EMA preserved the ep443 best checkpoint — EMA is critical
- **Reproduce baseline:**
  ```
  cd target/icml2026 && python train.py --dataset tandemfoil_paper --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
  ```