### PR TITLE
DrivAerML: LR warmup on EMA+gc=0.5 champion (5-ep & 10-ep)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -159,6 +159,7 @@ class TrainConfig:
     asinh_scale: float = 0.75
     residual_prediction: bool = False
     re_stratified_sampling: bool = False
+    warmup_epochs: int = 0
     cosine_t_max: int = 150
     geometry_points: int = 25_000
     geometry_supernodes: int = 4_096
@@ -1623,9 +1624,24 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
     if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        cosine_sched = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+        if config.warmup_epochs > 0:
+            if config.max_train_batches > 0:
+                micro_per_epoch = config.max_train_batches
+            else:
+                micro_per_epoch = len(train_loader)
+            steps_per_epoch = (micro_per_epoch + config.grad_accum_steps - 1) // config.grad_accum_steps
+            warmup_steps = config.warmup_epochs * steps_per_epoch
+            warmup_sched = torch.optim.lr_scheduler.LinearLR(
+                base_optimizer, start_factor=0.01, end_factor=1.0, total_iters=warmup_steps,
+            )
+            scheduler = torch.optim.lr_scheduler.SequentialLR(
+                base_optimizer, [warmup_sched, cosine_sched], milestones=[warmup_steps],
+            )
+        else:
+            scheduler = cosine_sched
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
@@ -1637,10 +1653,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    val_metric_key = primary_metric_key(bundle, phase="val")
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1726,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

LR warmup combined with the full EMA+gc champion platform has never been tested on DrivAerML. Two prior warmup-only runs diverged without EMA: franky (#3148, 10-ep warmup + gc=1.0, reached 11.2% then diverged) and chopper (#3137, 5-ep warmup + gc=1.0). The hypothesis is that EMA's exponential moving average smooths the warmup→full-LR transition, allowing the model to survive where warmup alone failed.

EMA (decay=0.9995) + gradient clipping (gc=0.5) is the proven stability package for DrivAerML — it took eren from divergence at ep28 to a new best of 3.833%. Adding warmup on top of this stable platform may let the model settle into a better initial basin before the cosine schedule kicks in, potentially improving convergence below 3.833%.

Key question: Does warmup+EMA survive and improve where warmup alone diverged?

## Instructions

Run two trials back-to-back (or in parallel if two GPUs are available). Both use the full EMA+gc=0.5 champion config, differing only in warmup length.

**Trial 1 — 5-epoch warmup:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --warmup-epochs 5 \
  --wandb_group dm-warmup-ema-gc
```

**Trial 2 — 10-epoch warmup:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --warmup-epochs 10 \
  --wandb_group dm-warmup-ema-gc
```

Report the best `val_primary/surface_rel_l2_pct` for each trial, the W&B run IDs, and whether either run diverged. Note the epoch at which the best val metric was achieved.

## Baseline

Current best DrivAerML metrics (PR #3072, eren — EMA=0.9995 + gc=0.5, 4L/512d/8H, AdamW lr=5e-4, T_max=30):
- **val_primary/surface_rel_l2_pct: 3.833%** (epoch 511)
- test surface_rel_l2_pct: 4.685%
- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target: <3.71% (AB-UPT)

Reproduce baseline:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995
```