### PR TITLE
AirfRANS: linear LR warmup (5ep, 10ep) + EMA=0.999

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -168,6 +168,7 @@ class TrainConfig:
     grad_accum_steps: int = 1
     save_checkpoint: bool = False
     seed: int = 0
+    warmup_epochs: int = 0
 
 
 @dataclass
@@ -1623,9 +1624,21 @@ def main() -> None:
         params.extend(list(anp_head.parameters()))
     optimizer = build_optimizer(params, config)
     scheduler = None
+    base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
     if config.cosine_t_max > 0:
-        base_optimizer = optimizer.optimizer if isinstance(optimizer, Lookahead) else optimizer
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(base_optimizer, T_max=config.cosine_t_max)
+
+    if config.warmup_epochs > 0:
+        warmup_steps = config.warmup_epochs * len(train_loader)
+        warmup_sched = torch.optim.lr_scheduler.LinearLR(
+            base_optimizer, start_factor=0.01, end_factor=1.0, total_iters=warmup_steps
+        )
+        if scheduler is not None:
+            scheduler = torch.optim.lr_scheduler.SequentialLR(
+                base_optimizer, schedulers=[warmup_sched, scheduler], milestones=[warmup_steps]
+            )
+        else:
+            scheduler = warmup_sched
 
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
@@ -1638,9 +1651,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        checkpoint_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        checkpoint_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1713,7 +1726,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(checkpoint_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

LR warmup has not been tested on the AirfRANS champion config (EMA=0.999, T_max=50, 2L/256d). A linear warmup phase could stabilize early training dynamics and help the model find a better loss basin before the full learning rate kicks in. This is especially relevant for vol_mse, which sits at 0.002777 vs a target of ~0.0017 — a 1.63x gap that surface_mse doesn't have. Early-training instability may be causing the model to lock into a suboptimal basin for volume prediction; warmup gives the optimizer a gentler on-ramp.

Two warmup lengths are tested: 5 epochs (short warmup, minimal overhead) and 10 epochs (longer warmup, smoother ramp). All other hyperparameters are locked to the champion config.

## Instructions

Run both trials. Use `--wandb_group af-warmup-ema` so runs are grouped in W&B.

**Mandatory config (do not change):**
- Optimizer: AdamW, lr=6e-4, weight-decay=1e-2
- Cosine annealing: T_max=50
- Grad clip: 1.0
- EMA: --ema-decay 0.999
- Architecture: 2 layers, 256 hidden dim, 8 heads
- Fourier features: enabled

**Dead ends — do not try:**
- 3L depth (catastrophic for AirfRANS)
- EMA < 0.999
- T_max ≠ 50
- vol-weight = 10x

**Trial 1 — 5-epoch warmup:**
```
cd target/icml2026 && python train.py --dataset airfrans --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 8 --epochs 999 --ema-decay 0.999 --warmup-epochs 5 --wandb_group af-warmup-ema
```

**Trial 2 — 10-epoch warmup:**
```
cd target/icml2026 && python train.py --dataset airfrans --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 8 --epochs 999 --ema-decay 0.999 --warmup-epochs 10 --wandb_group af-warmup-ema
```

**Reporting requirements:**
Report **both** `surface_mse` and `vol_mse` for each trial (best val checkpoint), compared against baseline:
- Baseline surface_mse: **0.000459**
- Baseline vol_mse: **0.002777**

Include the W&B run ID for each trial.

## Baseline

- val/surface_mse: **0.000459** (epoch 771)
- val/vol_mse: **0.002777**
- Best PR: #3050 (stark — EMA=0.999 + T_max=50)
- W&B run: `z6pry4b9`
- Reproduce command:
  ```
  cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999
  ```