### PR TITLE
DrivAerML: noam features on DM champion (asinh+residual+compile+96sl)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1630,23 +1630,12 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
+    best_epoch: int = 0
     best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
-
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-    best_ema_shadow: dict[str, torch.Tensor] | None = None
-    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
 
     run = None
     if config.wandb_name:
@@ -1713,32 +1702,20 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
-            if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
-
         if ema is not None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-        epoch_metrics["best_val_metric"] = best_val_metric
+        epoch_metrics["best_val_metric"] = best_val_primary_metric if best_val_primary_metric is not None else float("inf")
         epoch_metrics["best_epoch"] = float(best_epoch)
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
+            run.summary["best_val_metric"] = best_val_primary_metric if best_val_primary_metric is not None else float("inf")
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1789,8 +1766,8 @@ def main() -> None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
-        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
+            run.summary["best_val_metric"] = best_val_primary_metric if best_val_primary_metric is not None else float("inf")
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_primary_metric if best_val_primary_metric is not None else float("inf")}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)


### PR DESCRIPTION
## Hypothesis

Add the full noam branch feature set to the DM EMA+gc champion platform (PR #3072, 3.833%). The noam branch demonstrated that asinh pressure normalization alone gave ~8% improvement on OOD metrics. Together with residual prediction (reduces target dynamic range by learning corrections to freestream), torch.compile (enables more epochs within time budget), and 96 slices (found optimal on noam branch), these features are already implemented in train.py but have **never been tested together on DrivAerML**.

We stack them onto the EMA=0.9995 + gc=0.5 champion config (4L/512d/8H, AdamW lr=5e-4, T_max=30) to isolate their contribution on the DrivAerML surface pressure task. Note: torch.compile without grad-clip diverged at ep454 on DrivAerML (PR #2898) — all trials include `--grad-clip 0.5` to mitigate this.

## Instructions

**SMOKE TEST FIRST**: Run Trial 1 for exactly 3 epochs before anything else. If NaN or crash, stop immediately and report. If smoke test passes, run all 3 trials in parallel across available GPUs within a 6-hour budget.

Report `val_primary/surface_rel_l2_pct` for each trial. Target: beat **3.833%**.

Use `--wandb_group dm-noam-features` for all runs so related runs are grouped in W&B.

---

### Trial 1 — Full noam feature stack (smoke test first, then full run)

```bash
# Step 1: Smoke test (3 epochs only)
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 96 \
  --asinh-pressure --asinh-scale 0.75 \
  --residual-prediction \
  --surface-refine \
  --compile-model \
  --ema-decay 0.9995 \
  --epochs 3 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-noam-features

# Step 2: If smoke test passes (no NaN, no crash), full run:
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --model-slices 96 \
  --asinh-pressure --asinh-scale 0.75 \
  --residual-prediction \
  --surface-refine \
  --compile-model \
  --ema-decay 0.9995 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-noam-features
```

---

### Trial 2 — Asinh pressure normalization only (no residual, no compile, no 96 slices)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --asinh-pressure --asinh-scale 0.75 \
  --ema-decay 0.9995 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-noam-features
```

---

### Trial 3 — Residual prediction only (no asinh, no compile, no 96 slices)

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --residual-prediction \
  --ema-decay 0.9995 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --wandb_group dm-noam-features
```

---

**When reporting results**, include for each trial:
- Best `val_primary/surface_rel_l2_pct` and the epoch it occurred
- W&B run ID
- Any instability (loss spikes, NaN, divergence)

## Baseline

- **val_primary/surface_rel_l2_pct**: 3.833% at epoch 511
- **test_primary/surface_rel_l2_pct**: 4.685%
- **W&B run**: `ncl1dh88` (eren/dm-ema-9995-gc05), PR #3072
- **External target**: <3.71% (AB-UPT, ~500 epochs); gap to close: 0.123 pp
- **Reproduce champion**:
  ```bash
  cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
    --dataset drivaerml \
    --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 \
    --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 \
    --batch-size 1 \
    --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 --max-eval-batches 200 \
    --ema-decay 0.9995
  ```