### PR TITLE
AirfRANS: vol-weight 15x/20x + asinh-pressure + residual-prediction compound push

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1642,10 +1642,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1715,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(best_val_primary_metric_name)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The current AirfRANS champion (PR #3135) reached vol_mse=0.002039 — 1.20x above the SpiderSolver target of 0.0017 — using EMA=0.999 + vol-weight=10x. Two noam-branch features (asinh-pressure normalization and residual-prediction) have independently shown vol improvements. Compounding all three levers simultaneously — higher vol-weight (15x, 20x) + asinh-pressure + residual-prediction — on top of the EMA champion config should push vol_mse below 0.0017 in a single round.

Key intuitions:
- Heavier vol-weight (15x → 20x) keeps shifting gradient budget toward interior flow field without destabilizing surface loss (EMA acts as a stabilizer here)
- asinh-pressure softens pressure outliers that currently dominate vol loss, making the higher weight signal cleaner
- residual-prediction reduces the raw magnitude of the learning target, further concentrating gradient signal on hard regions

## Instructions

Run **all three trials** in parallel (one per available GPU set). Use `--wandb_group af-vol-weight-push-noam` on every run so results are grouped in W&B.

**Trial 1 — vol-weight=15x + EMA + asinh + residual:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 15.0 \
  --asinh-pressure --asinh-scale 0.75 --residual-prediction \
  --wandb_group af-vol-weight-push-noam
```

**Trial 2 — vol-weight=20x + EMA + asinh + residual:**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 20.0 \
  --asinh-pressure --asinh-scale 0.75 --residual-prediction \
  --wandb_group af-vol-weight-push-noam
```

**Trial 3 — vol-weight=10x champion + asinh + residual (ablation: what do the noam features add on top of the existing champion?):**
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0 \
  --asinh-pressure --asinh-scale 0.75 --residual-prediction \
  --wandb_group af-vol-weight-push-noam
```

**Target:** vol_mse < 0.0017 (SpiderSolver threshold). Report best vol_mse and surface_mse for each trial, plus epoch at which each achieved its best. If any trial shows surface_mse degradation > 5% vs baseline (>0.000311), flag it.

Budget: ~6 hours GPU time.

## Baseline

Current best (PR #3135, nezuko/af-ema-vol-weight-10x, W&B run: `sh2zyfwr`):
- `val_primary/surface_mse`: **0.000296** (epoch 704)
- `val_primary/vol_mse`: **0.002039** (epoch 743)
- Config: 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, vol-weight=10x, Fourier
- SpiderSolver vol target: 0.0017 (current gap: 1.20x)

Reproduce champion:
```bash
cd target/icml2026 && python train.py \
  --dataset airfrans --airfrans-task full \
  --optimizer adamw --lr 6e-4 --cosine-t-max 50 \
  --grad-clip 1.0 --weight-decay 1e-2 \
  --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 \
  --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0
```