### PR TITLE
TF: ANP cross-attention decoder ablation on champion config

### DIFF
--- a/BASELINE.md
+++ b/BASELINE.md
@@ -155,12 +155,21 @@
 ## AirfRANS
 
 - **Primary metric:** `val_primary/surface_mse`
-- **Current best:** 0.000459 (val) at epoch 771 — with Vol MSE 0.002777 (best in programme)
-- **Best PR:** #3050 (stark — EMA=0.999 + T_max=50, 2L/256d, AdamW lr=6e-4, gc=1.0, WD=1e-2)
-- **Key insight:** EMA=0.999 combined with T_max=50 improves BOTH primary metrics simultaneously: surface -4.8% (0.000459 vs 0.000482) AND volume -63.6% (0.002777 vs 0.00764). EMA is harmonious with T_max=50 — the longer cosine cycle lets EMA track effectively. Vol MSE 0.002777 closes gap to SpiderSolver from 4.5x to 1.63x.
-- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999`
+- **Current best:** 0.000296 (val) at epoch 704 — with Vol MSE 0.002039 (best in programme)
+- **Best PR:** #3135 (nezuko — EMA=0.999 + vol-weight=10x, 2L/256d, AdamW lr=6e-4, gc=1.0, WD=1e-2)
+- **Key insight:** EMA=0.999 + vol-weight=10x compound dramatically improves both metrics simultaneously: surface -35.5% (0.000296 vs 0.000459) AND volume -26.6% (0.002039 vs 0.002777). Volume gap to SpiderSolver target closed from 1.63x to 1.20x. Model still improving at ep763 timeout.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`
 
-### 2026-04-23 — PR #3050: AirfRANS: EMA=0.999 at T_max=50 champion — NEW BEST (CURRENT)
+### 2026-04-23 — PR #3135: AirfRANS: EMA=0.999 + vol-weight=10x — NEW BEST (CURRENT)
+
+- **val_primary/surface_mse:** 0.000296 (-35.5% vs 0.000459) at epoch 704
+- **val_primary/vol_mse:** 0.002039 (-26.6% vs 0.002777) at epoch 743
+- **W&B run:** sh2zyfwr (nezuko/af-ema-vol-weight-10x)
+- **Config:** 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, **EMA=0.999**, vol-weight=10x, Fourier
+- **Key insight:** vol-weight=10x without EMA was confirmed worse. With EMA=0.999, the combination works dramatically better — EMA stabilizes the upweighted volume gradient. Surface -35.5% and volume -26.6% simultaneously. Vol gap to SpiderSolver: 1.20x (was 1.63x). Model at ep763 still converging.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset airfrans --airfrans-task full --optimizer adamw --lr 6e-4 --cosine-t-max 50 --grad-clip 1.0 --weight-decay 1e-2 --enable-fourier --model-layers 2 --model-hidden-dim 256 --model-heads 4 --epochs 999 --ema-decay 0.999 --vol-loss-weight 10.0`
+
+### 2026-04-23 — PR #3050: AirfRANS: EMA=0.999 at T_max=50 champion — PREVIOUS BEST
 
 - **val_primary/surface_mse:** 0.000459 (-4.8% vs 0.000482) at epoch 771
 - **full_val/volume_mse:** 0.002777 (-63.6% vs 0.00764) — best volume result in programme

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -3,11 +3,20 @@
 ## TandemFoilSet
 
 - **Primary metric:** `val_primary/surface_pressure_mae` (= `val_eq4/surface_pressure_mae`)
-- **Current best:** 21.909 (val) at epoch 334 — test 23.419
-- **Best PR:** #3108 (zenitsu — gc=0.3+EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d)
-- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+- **Current best:** 21.350 (val) at epoch 331 — test 23.195
+- **Best PR:** #3140 (usopp — gc=0.2+EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d)
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
 
-### 2026-04-23 — PR #3108: TandemFoil: gc=0.3 + EMA=0.999 — NEW BEST (CURRENT)
+### 2026-04-23 — PR #3140: TandemFoil: gc=0.2 + EMA=0.999 — NEW BEST (CURRENT)
+
+- **val_primary/surface_pressure_mae:** 21.350 (-2.6% vs 21.909) at epoch 331
+- **test_primary/surface_pressure_mae:** 23.195 (-1.0% vs 23.419)
+- **W&B run:** 9g11l7tm (usopp/tf-gc-02-sweep)
+- **Config:** Lion lr=1.25e-4, T_max=10, **gc=0.2**, WD=1e-2, **EMA=0.999**, 3L/192d, Fourier+physics
+- **Key insight:** gc monotonic trend continues: 1.0→0.5→0.3→0.2 all improve. gc=0.1 overshoots (22.141, single_in_dist +12.4%). gc=0.2 is the floor — bracketed. Model best at ep331, not terminal.
+- **Reproduce:** `cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999`
+
+### 2026-04-23 — PR #3108: TandemFoil: gc=0.3 + EMA=0.999 — PREVIOUS BEST
 
 - **val_primary/surface_pressure_mae:** 21.909 (-2.8% vs 22.537) at epoch 334
 - **test_primary/surface_pressure_mae:** 23.419 (-4.7% vs 24.581)

--- a/research/EXPERIMENTS_LOG.md
+++ b/research/EXPERIMENTS_LOG.md
@@ -1,5 +1,13 @@
 # SENPAI Research Results
 
+## 2026-04-23 15:00 — PR #3123: TFP shorter T_max (T_max=5/8) (mitsuha) — CLOSED
+
+- T_max=5 (W&B: `5kp3yu51`): diverged, field_mse never finite. T_max=8 (W&B: `rcysi68k`): diverged, field_mse never finite. Confirms T_max=10 is a stability resonance for current stripped-down TFP config. However, noam branch uses T_max=150 with ANP decoder + full feature stack — the stability constraint is architecture-dependent. Reassigned to TFP full noam stack (ANP + physics features + T_max=150).
+
+## 2026-04-23 15:00 — PR #3118: DM weight decay alone (hinata) — CLOSED
+
+- WD=1e-4: 13.45% ep53 (W&B: `zh2ofwsj`). WD=5e-4: 5.17% ep181 (W&B: `guy2f5cr`). WD=1e-3: 10.46% ep219 (W&B: `4e3y5q6g`). ALL runs without EMA/gc — wrong platform, dead regime. Best 5.17% is 35% worse than 3.833% baseline. Emma #3153 already covers WD+EMA+gc (correct follow-up). Reassigned to DM noam features (asinh-pressure + residual-prediction + compile + 96 slices).
+
 ## 2026-04-23 14:00 — PR #3138: DM 788 batches + T_max=60 (kakashi) — CLOSED
 
 - Run 1 (gc=1.0, no EMA): 6.620% ep66, diverged ep72 (W&B: `7sa8l03q`). Run 2 (gc=0.5+EMA=0.9995): 4.661% ep141, diverged ep143 (W&B: `jzg8os84`). Champion platform extended stability from ep72→ep143 and improved 6.62%→4.66%, but divergence is structural. 788 batches accumulate only 111k steps before dying vs baseline's 201k — throughput advantage completely erased by shorter training horizon. Three attempts (incl #3084) all diverge within 2 cosine cycles. Higher batch count per epoch dead for DM.

--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -166,6 +166,7 @@ class TrainConfig:
     volume_anchor_points: int = 8_000
     grad_clip: float = 0.0
     grad_accum_steps: int = 1
+    volume_loss_weight: float = 1.0
     save_checkpoint: bool = False
     seed: int = 0
 
@@ -761,6 +762,7 @@ def loss_grouped(
     batch: GroupedBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.surface_x.device)
     metrics: dict[str, float] = {}
@@ -772,7 +774,7 @@ def loss_grouped(
     if batch.volume_y is not None and outputs["volume_preds"] is not None and batch.volume_mask is not None:
         target = transform.apply(batch.volume_y)
         vol_loss = F.mse_loss(outputs["volume_preds"][batch.volume_mask], target[batch.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -781,6 +783,7 @@ def loss_grouped(
 def loss_grouped_tandem(
     prepared: TandemPreparedBatch,
     outputs: dict[str, torch.Tensor | None],
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=prepared.surface_x.device)
     metrics: dict[str, float] = {}
@@ -790,7 +793,7 @@ def loss_grouped_tandem(
         metrics["surface_loss"] = float(surf_loss.detach().cpu().item())
     if prepared.volume_target is not None and outputs["volume_preds"] is not None and prepared.volume_mask is not None:
         vol_loss = F.mse_loss(outputs["volume_preds"][prepared.volume_mask], prepared.volume_target[prepared.volume_mask])
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -800,6 +803,7 @@ def loss_abupt(
     batch: ABUPTBatch,
     outputs: dict[str, torch.Tensor | None],
     transform: TargetTransform,
+    volume_loss_weight: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, float]]:
     total = torch.tensor(0.0, device=batch.geometry_position.device)
     metrics: dict[str, float] = {}
@@ -811,7 +815,7 @@ def loss_abupt(
     if batch.volume_anchor_target is not None and outputs["volume_preds"] is not None:
         vol_target = transform.apply(batch.volume_anchor_target)
         vol_loss = F.mse_loss(outputs["volume_preds"], vol_target)
-        total = total + vol_loss
+        total = total + vol_loss * volume_loss_weight
         metrics["volume_loss"] = float(vol_loss.detach().cpu().item())
     metrics["loss"] = float(total.detach().cpu().item())
     return total, metrics
@@ -1266,6 +1270,7 @@ def train_one_epoch(
     max_batches: int = 0,
     grad_clip: float = 0.0,
     grad_accum_steps: int = 1,
+    volume_loss_weight: float = 1.0,
 ) -> dict[str, float]:
     model.train()
     if anp_head is not None:
@@ -1299,7 +1304,7 @@ def train_one_epoch(
                         surface_anchor_position=batch.surface_anchor_position,
                         volume_anchor_position=batch.volume_anchor_position,
                     )
-                    loss, _ = loss_abupt(batch, outputs, transform)
+                    loss, _ = loss_abupt(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
             else:
                 batch = batch.to(device)
                 if isinstance(transform, TandemTargetTransform):
@@ -1312,7 +1317,7 @@ def train_one_epoch(
                             volume_mask=prepared.volume_mask,
                         )
                         outputs = maybe_apply_anp(outputs, prepared, anp_head)
-                        loss, _ = loss_grouped_tandem(prepared, outputs)
+                        loss, _ = loss_grouped_tandem(prepared, outputs, volume_loss_weight=volume_loss_weight)
                 else:
                     with autocast_context(device, amp_mode):
                         outputs = model(
@@ -1321,7 +1326,7 @@ def train_one_epoch(
                             volume_x=batch.volume_x,
                             volume_mask=batch.volume_mask,
                         )
-                        loss, _ = loss_grouped(batch, outputs, transform)
+                        loss, _ = loss_grouped(batch, outputs, transform, volume_loss_weight=volume_loss_weight)
 
             accum_loss += float(loss.detach().cpu().item())
             (loss / grad_accum_steps).backward()
@@ -1682,6 +1687,7 @@ def main() -> None:
             max_batches=config.max_train_batches,
             grad_clip=config.grad_clip,
             grad_accum_steps=config.grad_accum_steps,
+            volume_loss_weight=config.volume_loss_weight,
         )
 
         if ema is not None:


### PR DESCRIPTION
## Hypothesis

The ANP (Asymmetric Node-wise Propagation) cross-attention decoder (`--anp-srf`) was the single largest improvement in the noam research campaign (-58.9% p_tan, -70% p_in on a noam-era config), yet it has never been tested on the current TandemFoil champion configuration (PR #3140). We hypothesize that applying ANP to the champion config will yield a significant further reduction in val_primary/surface_pressure_mae.

Physical motivation: ANP adds asymmetric cross-attention where aft-foil nodes attend to all fore-foil surface nodes, directly capturing how the fore-foil wake perturbs the aft-foil pressure field. This is the dominant physical interaction in tandem configurations and is not captured by the standard symmetric message-passing architecture.

The `--anp-srf` flag is already implemented in `train.py` — this is a pure evaluation of its isolated effect on the best known config.

## Instructions

**Safety check first:** Run Trial 1 for exactly 3 epochs. If `val_primary/surface_pressure_mae` is NaN at epoch 3, stop immediately and report — do not proceed to the full runs.

**Trial 1 — ANP decoder + TF champion (T_max=10):**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoilset \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.2 \
  --weight-decay 1e-2 \
  --model-slices 64 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --ema-decay 0.999 \
  --anp-srf \
  --wandb_group tf-anp-ablation
```

**Trial 2 — ANP decoder + longer schedule (T_max=150):**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoilset \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 150 \
  --grad-clip 0.2 \
  --weight-decay 1e-2 \
  --model-slices 64 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --ema-decay 0.999 \
  --anp-srf \
  --wandb_group tf-anp-ablation
```

Budget: 6 hours total across both trials.

Report `val_primary/surface_pressure_mae` for each trial (best val checkpoint). Target: beat 21.350.

## Baseline

Current TandemFoil best (PR #3140):
- val_primary/surface_pressure_mae: **21.350** (epoch 331)
- test/surface_pressure_mae: 23.195
- W&B run: `9g11l7tm` (usopp/tf-gc-02-sweep)
- Config: Lion lr=1.25e-4, T_max=10, gc=0.2, WD=1e-2, EMA=0.999, 3L/192d, 64 slices, Fourier+physics flags

Reproduce baseline:
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```