### PR TITLE
TandemFoil: ANP cross-attention decoder (--anp-srf) vs 21.350

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1636,7 +1636,6 @@ def main() -> None:
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
     best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
     best_val_primary_metric: float | None = None
     best_val_metrics: dict[str, float] = {}
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1646,6 +1645,7 @@ def main() -> None:
         primary_metric_key = "val_primary/surface_pressure_mae"
     else:
         primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = primary_metric_key
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None


### PR DESCRIPTION
## Hypothesis

The ANP (Attentive Neural Process) cross-attention decoder — enabled via `--anp-srf` — was the single largest architectural gain on the noam branch, delivering a −58.9% drop in p_tan on AirfRANS. We hypothesize it will also improve TandemFoil surface pressure prediction, potentially beating the current best of 21.350.

The core idea: rather than a fixed decoder, the ANP decoder conditions each surface query on a cross-attention over the encoded field, giving the model a flexible, context-aware readout. This is especially well-suited to the multi-foil geometry of TandemFoil where local surface context matters.

We run two trials to isolate the effect of the cosine schedule:
- **Trial 1** — ANP + current TF champion schedule (T_max=10)
- **Trial 2** — ANP + noam's optimal schedule (T_max=150)

## Instructions

**Step 0: 3-epoch smoke test of Trial 1**

First run Trial 1 for 3 epochs only to verify there are no NaN or divergence issues:

```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 3 --ema-decay 0.999 --anp-srf --wandb_group tf-anp-ablation
```

- If training produces NaN losses or diverges in the first 3 epochs: **stop and report immediately** with the error output. Do not proceed to the full runs.
- If training is clean after 3 epochs: proceed with both full trials in parallel.

**Step 1: Run both trials in parallel (full training)**

**Trial 1 — ANP + T_max=10 (current TF champion schedule):**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.3 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 999 --ema-decay 0.999 --anp-srf --wandb_group tf-anp-ablation
```

**Trial 2 — ANP + T_max=150 (noam's optimal schedule):**
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 150 --grad-clip 0.3 --weight-decay 1e-2 --enable-fourier --model-layers 3 --model-hidden-dim 192 --model-heads 3 --epochs 999 --ema-decay 0.999 --anp-srf --wandb_group tf-anp-ablation
```

**Step 2: Report results**

For each trial, report:
- `val_primary/surface_pressure_mae` (best epoch)
- `test_primary/surface_pressure_mae` (from best val checkpoint)
- Individual surface metrics: `p_in`, `p_oodc`, `p_tan`, `p_re`
- W&B run ID and link

**Target:** Beat `val_primary/surface_pressure_mae = 21.350`

## Baseline

Current TandemFoil best (PR #3140, usopp — gc=0.2 + EMA=0.999):

| Metric | Value |
|--------|-------|
| `val_primary/surface_pressure_mae` | **21.350** (epoch 331) |
| `test_primary/surface_pressure_mae` | 23.195 |

- W&B run: `9g11l7tm` (usopp/tf-gc-02-sweep)
- Reproduce command:
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```

Note: The trial commands above use `--grad-clip 0.3` (vs baseline gc=0.2) — this is intentional to give the ANP decoder slightly more gradient headroom during early training.