### PR TITLE
TFP: ANP decoder + cosine T_max=150 (noam-branch combo)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1642,17 +1642,6 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
-    best_val_metric = float("inf")
-    best_epoch = 0
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-    best_ema_shadow: dict[str, torch.Tensor] | None = None
-    best_anp_ema_shadow: dict[str, torch.Tensor] | None = None
-
     run = None
     if config.wandb_name:
         run_config = asdict(config)
@@ -1719,32 +1708,20 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
-        if current_val is not None and current_val < best_val_metric:
-            best_val_metric = current_val
-            best_epoch = epoch
-            best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
-            if anp_head is not None:
-                best_anp_state = {k: v.cpu().clone() for k, v in anp_head.state_dict().items()}
-            if ema is not None:
-                best_ema_shadow = {k: v.cpu().clone() for k, v in ema.shadow.items()}
-            if anp_ema is not None:
-                best_anp_ema_shadow = {k: v.cpu().clone() for k, v in anp_ema.shadow.items()}
-
         if ema is not None:
             ema.restore(model)
         if anp_head is not None and anp_ema is not None:
             anp_ema.restore(anp_head)
 
         epoch_metrics = {"epoch": float(epoch), **train_metrics, **eval_metrics}
-        epoch_metrics["best_val_metric"] = best_val_metric
-        epoch_metrics["best_epoch"] = float(best_epoch)
+        epoch_metrics["best_val_metric"] = best_val_primary_metric
+        epoch_metrics["best_epoch"] = float(best_epoch) if best_epoch is not None else 0.0
         history.append(epoch_metrics)
         if run is not None:
             wandb.log(epoch_metrics, step=epoch)
             run.summary["epoch"] = epoch
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
+            run.summary["best_val_metric"] = best_val_primary_metric
         print(json.dumps(epoch_metrics, sort_keys=True), flush=True)
 
     if best_epoch is not None:
@@ -1795,8 +1772,8 @@ def main() -> None:
             wandb.log(final_test_metrics, step=int(history[-1]["epoch"]) if history else 0)
             run.summary.update(final_test_metrics)
             run.summary["best_epoch"] = best_epoch
-            run.summary["best_val_metric"] = best_val_metric
-        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_metric}, sort_keys=True), flush=True)
+            run.summary["best_val_metric"] = best_val_primary_metric
+        print(json.dumps({"final_test_metrics": final_test_metrics, "best_epoch": best_epoch, "best_val_metric": best_val_primary_metric}, sort_keys=True), flush=True)
 
         if best_model_state is not None:
             restore_module_state(model, best_model_state)


### PR DESCRIPTION
## Hypothesis

The two strongest individual improvements on the noam branch are:
1. **ANP (Attentive Neural Process) SRF decoder** (`--anp-srf`) — improves surface/field reconstruction quality
2. **Cosine annealing T_max=150** — longer cycles let the optimizer explore more of the loss landscape before cooling, improving final basin depth

Both were proven independently on the noam branch. This PR tests whether they **compound** on TandemFoil Paper (TFP), targeting the current best val_primary/field_mse = 0.002383 (PR #3025).

## Instructions

Run **two trials** using `--wandb_group tfp-anp-tmax150` so they appear together in W&B.

**IMPORTANT:** Start with a **3-epoch smoke test** of Trial 2 (the smaller config). If you see NaN in `val_primary/field_mse` at epoch 3, stop immediately and report. Only proceed to full runs if the smoke test passes.

---

### Trial 2 — ANP alone, T_max=10 (isolate the ANP contribution; run smoke test first)

3-epoch smoke test:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --ema-decay 0.999 \
  --anp-srf \
  --epochs 3 \
  --wandb_group tfp-anp-tmax150
```

If smoke test passes (no NaN), run full training:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --ema-decay 0.999 \
  --anp-srf \
  --epochs 999 \
  --wandb_group tfp-anp-tmax150
```

---

### Trial 1 — ANP + T_max=150 (key combo)

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 150 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --ema-decay 0.999 \
  --anp-srf \
  --epochs 999 \
  --wandb_group tfp-anp-tmax150
```

---

## Reporting

For each trial, report:
- `val_primary/field_mse` (primary metric — lower is better)
- `val/surface_mse`, `val/surface_mse_p`, `val/volume_mse`
- W&B run ID and best epoch

## Baseline

Current best (PR #3025, haku/tfp-lion-champion-config, W&B run `d1xh0o1p`):
- **val_primary/field_mse: 0.002383** (best val, epoch 443 — 45.1% improvement over prior best)
- val/surface_mse: 0.001517
- val/surface_mse_p: 4.81e-05
- val/volume_mse: 0.002397

Reproduce baseline:
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.5 --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 \
  --ema-decay 0.999
```

**Target: beat val_primary/field_mse = 0.002383**