### PR TITLE
TF: Full noam feature stack — ANP + all physics + T_max=150 + compile + Lookahead

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_primary_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_primary_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The ANP decoder (`--anp-srf`) alone delivered −58.9% on the noam dataset. We hypothesize that stacking it with every other currently-proven TF/noam improvement — expanded physics features, longer cosine annealing (T_max=150), 96 slices, `torch.compile`, and Lookahead optimizer — will compound those gains on TandemFoil and push `val_primary/surface_pressure_mae` into the 9–12 range (vs current best 21.350).

Component-level evidence:
- **ANP decoder** (`--anp-srf`): −58.9% on noam (chopper/tf-anp-decoder, in-flight)
- **96 slices**: minor throughput/capacity gain used in noam experiments
- **T_max=150**: longer cosine cycle avoids premature LR collapse (rei/tfp-anp-t150, in-flight)
- **torch.compile + Lookahead**: throughput/stability improvements from wolfwood/af-noam-stack
- **Wake deficit / wake angle / vortex panel velocity**: full physics feature set, TF-specific

All components have prior evidence — this PR tests whether they stack cleanly on TF.

## Instructions

### Smoke test first (mandatory)

Before running full training, run a 3-epoch smoke test of Trial 1:

```bash
cd target/icml2026
python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 150 \
  --grad-clip 0.2 \
  --weight-decay 1e-2 \
  --model-slices 96 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --enable-wake-deficit \
  --enable-wake-angle \
  --enable-vortex-panel-velocity \
  --asinh-pressure \
  --asinh-scale 0.75 \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --re-stratified-sampling \
  --anp-srf \
  --use-lookahead \
  --compile-model \
  --ema-decay 0.999 \
  --epochs 3 \
  --wandb_group tf-full-noam-stack
```

If any metric is NaN after epoch 1 or 2, stop immediately and report the error in a PR comment. Do not proceed to full training.

If the smoke test passes (no NaN), proceed to:

---

### Trial 1 — Full stack (primary)

```bash
cd target/icml2026
python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 150 \
  --grad-clip 0.2 \
  --weight-decay 1e-2 \
  --model-slices 96 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --enable-wake-deficit \
  --enable-wake-angle \
  --enable-vortex-panel-velocity \
  --asinh-pressure \
  --asinh-scale 0.75 \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --re-stratified-sampling \
  --anp-srf \
  --use-lookahead \
  --compile-model \
  --ema-decay 0.999 \
  --epochs 999 \
  --wandb_group tf-full-noam-stack
```

---

### Trial 2 — ANP + physics only (ablation, no compile/Lookahead/T_max change)

Run this in parallel if you have GPU capacity, otherwise after Trial 1:

```bash
cd target/icml2026
python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.2 \
  --weight-decay 1e-2 \
  --model-slices 64 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --enable-wake-deficit \
  --enable-wake-angle \
  --enable-vortex-panel-velocity \
  --asinh-pressure \
  --asinh-scale 0.75 \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --anp-srf \
  --ema-decay 0.999 \
  --epochs 999 \
  --wandb_group tf-full-noam-stack
```

Trial 2 isolates the ANP decoder + physics contribution, holding T_max, slices, compile, and Lookahead at baseline values.

---

### Reporting

For each trial, report in a PR comment:
- W&B run ID and link
- Best `val_primary/surface_pressure_mae` (epoch of best)
- `test_primary/surface_pressure_mae` at best val checkpoint
- Whether Trial 1 beat Trial 2 (to understand which components drove the gain)
- Any NaN, divergence, or unexpected training behaviour

Target to beat: **21.350**

## Baseline

Current TF best (PR #3140, student: usopp):
- `val_primary/surface_pressure_mae`: **21.350** (epoch 331)
- `test_primary/surface_pressure_mae`: 23.195
- W&B run: `9g11l7tm` (usopp/tf-gc-02-sweep)
- Config: Lion lr=1.25e-4, T_max=10, gc=0.2, WD=1e-2, EMA=0.999, 3L/192d, Fourier+physics (no ANP, no wake features, no Lookahead, no compile)

Reproduce baseline:
```bash
cd target/icml2026
python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.2 \
  --weight-decay 1e-2 \
  --model-slices 64 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --enable-te-coord-frame \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --asinh-pressure \
  --residual-prediction \
  --enable-pressure-prior-addition \
  --epochs 999 \
  --ema-decay 0.999
```