### PR TITLE
TF: T_max=150 alone — isolate schedule from ANP (gc=0.3, 0.5)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1642,10 +1642,7 @@ def main() -> None:
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
 
-    if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
-    else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    val_primary_key = primary_metric_key(bundle, phase="val")
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1716,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_primary_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The current TF champion (PR #3140) uses T_max=10 (rapid cosine cycling) with gc=0.2. The noam stack (fern #3185) uses T_max=150 — a 15x longer schedule. We don't know whether the schedule change alone drives improvement, because fern also adds ANP and extra physics features simultaneously.

This is the **missing ablation**: does T_max=150 help TandemFoil even without ANP or new physics features?

In-flight context:
- chopper (#3180): ANP + T_max=10 vs ANP + T_max=150 (ANP confound)
- fern (#3185): full noam stack with T_max=150 (ANP + physics confound)
- **this PR**: T_max=150 alone, stripped config — isolates the schedule

## Instructions

Run two trials back-to-back. Use `--wandb_group tf-tmax150-alone` on all runs.

**Trial 1** — gc=0.3 (TF's previous champion grad-clip), T_max=150, Fourier only (no extra physics flags):

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 150 \
  --grad-clip 0.3 \
  --weight-decay 1e-2 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --epochs 999 \
  --ema-decay 0.999 \
  --wandb_group tf-tmax150-alone
```

**Trial 2** — gc=0.5 (noam's gc), T_max=150, same stripped config:

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 150 \
  --grad-clip 0.5 \
  --weight-decay 1e-2 \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --enable-fourier \
  --epochs 999 \
  --ema-decay 0.999 \
  --wandb_group tf-tmax150-alone
```

Note: intentionally omitting `--model-slices 64` and all physics flags (`--enable-te-coord-frame`, `--enable-cp-panel`, `--enable-cp-panel-tandem-only`, `--asinh-pressure`, `--residual-prediction`, `--enable-pressure-prior-addition`) to keep this a clean schedule ablation.

Report `val_primary/surface_pressure_mae` at best val checkpoint for both trials.

## Baseline

Current TandemFoil best (PR #3140, student: usopp):
- `val_primary/surface_pressure_mae`: **21.350** (epoch 331; test: 23.195)
- Config: Lion lr=1.25e-4, T_max=10, gc=0.2, WD=1e-2, EMA=0.999, 3L/192d, Fourier+all physics
- W&B run: `9g11l7tm` (group: `usopp/tf-gc-02-sweep`)
- Previous best gc=0.3: 21.909 (PR #3108, W&B: `kzg626hf`)

Reproduce command:
```bash
cd target/icml2026 && python train.py --dataset tandemfoil --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.2 --weight-decay 1e-2 --model-slices 64 --model-layers 3 --model-hidden-dim 192 --model-heads 3 --enable-fourier --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only --asinh-pressure --residual-prediction --enable-pressure-prior-addition --epochs 999 --ema-decay 0.999
```