### PR TITLE
DrivAerML: 2-head vs 16-head attention sweep on DM champion

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1635,17 +1635,13 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
-
     if bundle.spec.name == "tandemfoilset":
         primary_metric_key = "val_primary/surface_pressure_mae"
     else:
         primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = primary_metric_key
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None


### PR DESCRIPTION
## Hypothesis

At 512d hidden, the current DM champion uses 8 attention heads (64d/head). Noam's experiments on the AirfRANS architecture found that 3 heads were optimal at 192d (64d/head), suggesting per-head dimensionality matters. We want to understand whether the current 8H/64d-per-head choice is optimal for DrivAerML at 512d.

Valid head counts for 512d: 1, 2, 4, 8, 16, 32, 64, ... (must divide 512 evenly). In-flight coverage: senku #3165 tests 4 heads (128d/head), griffith #3160 tests 16 heads. This PR fills the remaining gap with **2 heads (256d/head)** — the widest-attention regime not yet tested. We also include **16 heads (32d/head)** as Trial 2 in case griffith #3160 was run without the EMA+gc stability combo required for DrivAerML convergence.

The hypothesis: wider per-head attention (fewer, larger heads) may be better suited to 3D aerodynamic surface point clouds where each attention head needs to capture long-range global pressure gradients, as opposed to the narrow multi-head regime more common in NLP.

## Instructions

Keep all other DM champion hyperparameters exactly as the baseline. Only vary `--model-heads`. Use `--wandb_group dm-heads-sweep` so all head-count runs (including senku and griffith) are visible together.

**Trial 1 — 2 heads (256d/head, very wide attention):**

```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 2 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-heads-sweep
```

**Trial 2 — 16 heads (32d/head, narrow attention):**

```bash
cd target/icml2026
SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw \
  --lr 5e-4 \
  --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 \
  --model-hidden-dim 512 \
  --model-heads 16 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 \
  --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --wandb_group dm-heads-sweep
```

Run Trial 1 first; if it beats baseline, that's the result to report. Run Trial 2 after (or in parallel on a second GPU if available). Report both results with W&B run IDs.

**Important:** Both trials must use `--ema-decay 0.9995` together with `--grad-clip 0.5`. EMA alone (without gc=0.5) diverges on DrivAerML around epoch 28. Do not remove either flag.

## Baseline

Current DrivAerML best (PR #3072, eren/dm-ema-9995-gc05):

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** (epoch 511) |
| test/surface_rel_l2_pct | 4.685% |
| Config | 4L / 512d / **8H** / AdamW lr=5e-4 / T_max=30 / EMA=0.9995 / gc=0.5 / Fourier / no WD |

- W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target: AB-UPT <3.71% (gap: 0.123 pp)
- Reproduce:
  ```bash
  cd target/icml2026
  SENPAI_MAX_EPOCHS=9999 python train.py \
    --dataset drivaerml --optimizer adamw --lr 5e-4 \
    --cosine-t-max 30 --grad-clip 0.5 --enable-fourier \
    --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
    --epochs 999 --batch-size 1 \
    --drivaerml-train-surface-points 50000 \
    --drivaerml-eval-surface-points 50000 \
    --max-train-batches 394 --max-eval-batches 200 \
    --ema-decay 0.9995
  ```