### PR TITLE
TandemFoil: asinh-scale=0.75 + wake/vortex physics, no ANP, no T_max change

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1635,18 +1635,13 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
         primary_metric_key = "val_primary/surface_pressure_mae"
     else:
         primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
+    best_val_metrics: dict[str, float] = {}
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
     best_anp_state: dict[str, torch.Tensor] | None = None
@@ -1709,19 +1704,10 @@ def main() -> None:
             phase="val",
         )
 
-        current_primary_metric = eval_metrics.get(best_val_primary_metric_name)
-        if current_primary_metric is not None and (
-            best_val_primary_metric is None or current_primary_metric < best_val_primary_metric
-        ):
-            best_epoch = epoch
-            best_val_primary_metric = current_primary_metric
-            best_val_metrics = dict(eval_metrics)
-            best_model_state = snapshot_module_state(model)
-            best_anp_state = snapshot_module_state(anp_head)
-
         current_val = eval_metrics.get(primary_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
+            best_val_metrics = dict(eval_metrics)
             best_epoch = epoch
             best_model_state = {k: v.cpu().clone() for k, v in model.state_dict().items()}
             if anp_head is not None:
@@ -1753,8 +1739,8 @@ def main() -> None:
                 {
                     "best_checkpoint": {
                         "epoch": float(best_epoch),
-                        "val_primary_metric_name": best_val_primary_metric_name,
-                        "val_primary_metric": best_val_primary_metric,
+                        "val_primary_metric_name": primary_metric_key,
+                        "val_primary_metric": best_val_metric,
                     }
                 },
                 sort_keys=True,
@@ -1815,10 +1801,10 @@ def main() -> None:
             if run is not None:
                 best_checkpoint_metrics: dict[str, float | int | str] = {
                     "best_epoch": int(best_epoch) if best_epoch is not None else -1,
-                    "best_val_primary_metric_name": best_val_primary_metric_name or "",
+                    "best_val_primary_metric_name": primary_metric_key,
                 }
-                if best_val_primary_metric is not None:
-                    best_checkpoint_metrics["best_val_primary_metric"] = best_val_primary_metric
+                if best_val_metric < float("inf"):
+                    best_checkpoint_metrics["best_val_primary_metric"] = best_val_metric
                 best_checkpoint_metrics.update({f"best_val/{key}": value for key, value in best_val_metrics.items()})
                 best_checkpoint_metrics.update({f"best_test/{key}": value for key, value in best_test_metrics.items()})
                 best_checkpoint_metrics.update(best_checkpoint_metric_aliases(best_val_metrics))
@@ -1849,8 +1835,8 @@ def main() -> None:
         bundle,
         history,
         best_epoch=best_epoch,
-        best_val_primary_metric_name=best_val_primary_metric_name,
-        best_val_primary_metric=best_val_primary_metric,
+        best_val_primary_metric_name=primary_metric_key,
+        best_val_primary_metric=best_val_metric if best_val_metric < float("inf") else None,
         best_val_metrics=best_val_metrics,
         best_test_metrics=best_test_metrics,
         final_test_metrics=final_test_metrics,


### PR DESCRIPTION
## Hypothesis

The current TF champion (PR #3140, val=21.350) uses `--enable-pressure-prior-addition` but we don't know how much of the improvement from noam's full stack (PR #3136) was driven by:
- (a) the asinh normalization + residual prediction alone
- (b) the wake/vortex physics features
- (c) the ANP architecture
- (d) the T_max=150 schedule

This ablation isolates the contribution of noam's **training changes + physics features** from the architectural (ANP) and schedule (T_max=150) changes. We keep the TF champion architecture (3L/192d/3H, Lion, T_max=10, gc=0.3, EMA=0.999) and test:

- **Trial 1**: asinh-scale=0.75 + residual + all physics features (wake-deficit, wake-angle, cp-panel-tandem-only, vortex-panel-velocity n=64)
- **Trial 2**: asinh-scale=0.75 + residual only — no extra physics features (isolates normalization/prediction changes from physics features)

**Ablation matrix context (in-flight):**
| Student | ANP | T_max=150 | noam physics | This PR |
|---------|-----|-----------|--------------|---------|
| chopper | yes | no | no | — |
| fern | yes | yes | yes | — |
| norman | no | yes | no | — |
| **emma** | **no** | **no** | **yes** | **← you** |

This fills the missing cell: noam physics features WITHOUT ANP or schedule change.

## Instructions

**Run a 3-epoch smoke test of Trial 1 first.** Report `val_primary/surface_pressure_mae` after 3 epochs so we can check the training is stable before committing to full runs. Target: beat **21.350**.

### Trial 1 — Full physics features (run first)

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.3 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --epochs 999 \
  --ema-decay 0.999 \
  --asinh-pressure \
  --asinh-scale 0.75 \
  --residual-prediction \
  --enable-te-coord-frame \
  --enable-wake-deficit \
  --enable-wake-angle \
  --enable-cp-panel \
  --enable-cp-panel-tandem-only \
  --cp-panel-scale 0.1 \
  --enable-vortex-panel-velocity \
  --vortex-panel-scale 0.1 \
  --vortex-panel-n 64 \
  --wandb_group tf-noam-features-no-anp
```

Key differences from champion (#3140): `--asinh-scale 0.75` added, `--enable-wake-deficit`, `--enable-wake-angle`, `--enable-vortex-panel-velocity` added, `--cp-panel-scale 0.1`, `--vortex-panel-scale 0.1`, `--vortex-panel-n 64` added, `--enable-pressure-prior-addition` REMOVED, gc=0.3 (champion had 0.2).

### Trial 2 — Normalization only, no extra physics

```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil \
  --optimizer lion \
  --lr 1.25e-4 \
  --cosine-t-max 10 \
  --grad-clip 0.3 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 3 \
  --model-hidden-dim 192 \
  --model-heads 3 \
  --epochs 999 \
  --ema-decay 0.999 \
  --asinh-pressure \
  --asinh-scale 0.75 \
  --residual-prediction \
  --wandb_group tf-noam-features-no-anp
```

This is a minimal change: only `--asinh-scale 0.75` and `--residual-prediction` added (with `--enable-pressure-prior-addition` removed). No extra physics features. If this beats baseline, the normalization change alone is doing the work.

### Order of runs

1. **Smoke test Trial 1** (3 epochs) — check stability, report `val_primary/surface_pressure_mae`
2. **Full run Trial 1** (epochs=999) — if smoke test looks healthy
3. **Full run Trial 2** (epochs=999) — run in parallel with or after Trial 1

Report both W&B run IDs and best `val_primary/surface_pressure_mae` for each trial.

## Baseline

Current TandemFoil best:
- **val_primary/surface_pressure_mae: 21.350** (epoch 331)
- test_primary/surface_pressure_mae: 23.195
- Best PR: #3140 (usopp — gc=0.2 + EMA=0.999, Lion lr=1.25e-4, T_max=10, WD=1e-2, 3L/192d/3H)
- W&B run: `9g11l7tm` (usopp/tf-gc-02-sweep)
- Reproduce command:
  ```bash
  cd target/icml2026 && python train.py \
    --dataset tandemfoil \
    --optimizer lion \
    --lr 1.25e-4 \
    --cosine-t-max 10 \
    --grad-clip 0.2 \
    --weight-decay 1e-2 \
    --model-slices 64 \
    --model-layers 3 \
    --model-hidden-dim 192 \
    --model-heads 3 \
    --enable-fourier \
    --enable-te-coord-frame \
    --enable-cp-panel \
    --enable-cp-panel-tandem-only \
    --asinh-pressure \
    --residual-prediction \
    --enable-pressure-prior-addition \
    --epochs 999 \
    --ema-decay 0.999
  ```