### PR TITLE
TFP: Physics features isolation — wake deficit, vortex panel, Cp panel

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        _checkpoint_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        _checkpoint_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(_checkpoint_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The TFP champion (PR #3025, gc=0.5+EMA) already uses --enable-te-coord-frame, --enable-cp-panel, and --enable-cp-panel-tandem-only. However, it has **not** been tested with the extended physics features: wake deficit, wake angle, vortex panel velocity, or additional Cp panel scaling controls. Adding wake-aware features should improve generalization on tandem foil configurations where the rear foil operates in the front foil's wake — a physically distinctive regime that the network may currently represent only implicitly.

This PR **isolates physics feature contributions** from architectural/schedule changes (no ANP, no T_max change). In-flight PRs cover noam stack (#3176), T_max=150+wake (#3179), and ANP+T_max=150 (#3183) — none test physics features alone on the TFP champion config.

Two trials:
- **Trial 1:** All new physics features (wake deficit + wake angle + vortex panel + extended Cp panel) on champion config
- **Trial 2:** Wake features only (minimal addition) to attribute contribution

## Instructions

**Note:** The dataset flag should be `--dataset tandemfoil_paper` (not `tandem_foil_set` — that is not a registered alias). Use the commands below which have the corrected flag.

**Step 0 — 3-epoch smoke test (Trial 1 only):**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --epochs 3 --ema-decay 0.999 \
  --enable-te-coord-frame \
  --enable-wake-deficit --enable-wake-angle \
  --enable-cp-panel --enable-cp-panel-tandem-only --cp-panel-scale 0.1 \
  --enable-vortex-panel-velocity --vortex-panel-scale 0.1 --vortex-panel-n 64 \
  --wandb_group tfp-physics-only
```
Report val_primary/field_mse after 3 epochs to confirm no crash/NaN before full run.

**Trial 1 — All physics features (gc=0.5, T_max=10):**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --epochs 999 --ema-decay 0.999 \
  --enable-te-coord-frame \
  --enable-wake-deficit --enable-wake-angle \
  --enable-cp-panel --enable-cp-panel-tandem-only --cp-panel-scale 0.1 \
  --enable-vortex-panel-velocity --vortex-panel-scale 0.1 --vortex-panel-n 64 \
  --wandb_group tfp-physics-only
```

**Trial 2 — Wake features only (minimal addition):**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --epochs 999 --ema-decay 0.999 \
  --enable-te-coord-frame \
  --enable-wake-deficit --enable-wake-angle \
  --wandb_group tfp-physics-only
```

Run Trial 1 first (full run after smoke test passes). If Trial 1 beats baseline, run Trial 2 to isolate wake vs full physics contribution. If Trial 1 fails, run Trial 2 as the fallback to test the simpler subset.

**Report in your results comment:**
- W&B run IDs for each trial
- val_primary/field_mse at best epoch for each trial
- Any convergence differences vs champion (divergence timing, EMA smoothing)

## Baseline

**TandemFoil Paper — Current Best (PR #3025):**
- **val_primary/field_mse:** 0.002383 at epoch 443
- **W&B run:** (see PR #3025)
- **Config:** Lion lr=1.25e-4, T_max=10, gc=0.5, WD=1e-2, EMA=0.999, 3L/192d, Fourier + --enable-te-coord-frame + --enable-cp-panel + --enable-cp-panel-tandem-only + --asinh-pressure + --residual-prediction + --enable-pressure-prior-addition
- **Target:** beat val_primary/field_mse < 0.002383

**Reproduce champion:**
```bash
cd target/icml2026 && python train.py \
  --dataset tandemfoil_paper \
  --optimizer lion --lr 1.25e-4 --cosine-t-max 10 --grad-clip 0.5 \
  --weight-decay 1e-2 --enable-fourier \
  --model-layers 3 --model-hidden-dim 192 --model-heads 3 \
  --enable-te-coord-frame --enable-cp-panel --enable-cp-panel-tandem-only \
  --asinh-pressure --residual-prediction --enable-pressure-prior-addition \
  --epochs 999 --ema-decay 0.999
```