### PR TITLE
AirfRANS: asinh-pressure + residual + re-stratified on AF base (noam features)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        val_metric_key = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        val_metric_key = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(val_metric_key)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

The AF champion (#3135, surface_mse=0.000296) uses EMA=0.999 + vol-weight=10x. Recent experiments (#3184 wolfwood, #3187 stark) are testing asinh-pressure + residual-prediction + re-stratified-sampling on top of the full vol-weight=10x stack. This PR isolates the \"noam feature\" combination (asinh-pressure + residual-prediction + re-stratified-sampling) on the **base AF champion** (no vol-weight), then also tests it with vol-weight=10x — giving us a clean read of whether these three features compound on the base EMA config independently of the volume weighting.

Three noam features being stacked:
- `--asinh-pressure --asinh-scale 0.75` — stabilizes heavy-tailed pressure distribution
- `--residual-prediction` — predicts delta from flow field mean, reduces output range
- `--re-stratified-sampling` — re-weights mini-batches to oversample hard Reynolds-number regimes

Both trials use the same AdamW base config (lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, 2L/256d/8H, Fourier) from the AF champion lineage.

**Note on model-heads:** The AF champion uses `--model-heads 4` (hidden_dim 256 / heads 4 = head_dim 64). These trials use `--model-heads 8` (head_dim 32) as specified — note this if results diverge unexpectedly.

## Instructions

Run both trials sequentially on the same node (or in parallel on separate GPUs). Report `val_primary/surface_mse` AND `val_primary/vol_mse` for both.

### Trial 1 — Noam features on AF base champion (NO vol-weight)
Compare against PR #3050: surface_mse=0.000459, vol_mse=0.002777

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 \
  --model-hidden-dim 256 \
  --model-heads 8 \
  --epochs 999 \
  --ema-decay 0.999 \
  --asinh-pressure \
  --asinh-scale 0.75 \
  --residual-prediction \
  --re-stratified-sampling \
  --wandb_group af-noam-features-base
```

### Trial 2 — Noam features + vol-weight=10x
Compare against PR #3135: surface_mse=0.000296, vol_mse=0.002039

```bash
cd target/icml2026 && python train.py \
  --dataset airfrans \
  --optimizer adamw \
  --lr 6e-4 \
  --cosine-t-max 50 \
  --grad-clip 1.0 \
  --weight-decay 1e-2 \
  --enable-fourier \
  --model-layers 2 \
  --model-hidden-dim 256 \
  --model-heads 8 \
  --epochs 999 \
  --ema-decay 0.999 \
  --vol-loss-weight 10.0 \
  --asinh-pressure \
  --asinh-scale 0.75 \
  --residual-prediction \
  --re-stratified-sampling \
  --wandb_group af-noam-features-base
```

## Baseline

### Trial 1 target (AF base champion, no vol-weight) — PR #3050
- **val_primary/surface_mse:** 0.000459
- **val_primary/vol_mse:** 0.002777
- **W&B run:** z6pry4b9 (stark/af-ema-champion)
- **Config:** 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, Fourier, no vol-weight

### Trial 2 target (AF champion, vol-weight=10x) — PR #3135
- **val_primary/surface_mse:** 0.000296
- **val_primary/vol_mse:** 0.002039
- **W&B run:** sh2zyfwr (nezuko/af-ema-vol-weight-10x)
- **Config:** 2L/256d/4H, AdamW lr=6e-4, T_max=50, gc=1.0, WD=1e-2, EMA=0.999, Fourier, vol-weight=10x

## What to report

In your results comment, include for **each trial**:
- Best `val_primary/surface_mse` (and epoch)
- Best `val_primary/vol_mse` (and epoch)
- W&B run ID and link
- Whether it beats the relevant baseline above

Also note: wolfwood (#3184) and stark (#3187) are running the same noam features on slightly different stacks — cross-reference their results if available.