### PR TITLE
DrivAerML: asinh pressure normalization alone on DM champion (scale sweep)

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1643,9 +1643,9 @@ def main() -> None:
     best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
-        primary_metric_key = "val_primary/surface_pressure_mae"
+        primary_metric_key_str = "val_primary/surface_pressure_mae"
     else:
-        primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+        primary_metric_key_str = f"val_primary/{bundle.spec.default_metric}"
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None
@@ -1719,7 +1719,7 @@ def main() -> None:
             best_model_state = snapshot_module_state(model)
             best_anp_state = snapshot_module_state(anp_head)
 
-        current_val = eval_metrics.get(primary_metric_key)
+        current_val = eval_metrics.get(primary_metric_key_str)
         if current_val is not None and current_val < best_val_metric:
             best_val_metric = current_val
             best_epoch = epoch


### PR DESCRIPTION
## Hypothesis

Asinh pressure normalization (`--asinh-pressure`) may reduce surface_rel_l2 on the DrivAerML champion model by compressing the large dynamic range of pressure values before they enter the loss and model output heads. PR #3181 (himmel) is testing **asinh + residual prediction combined** on DM, but no one has tested **asinh alone** — making this the cleanest single-variable ablation of the asinh feature on DM.

Two scale values are tested: 0.75 (stronger compression) and 0.5 (milder compression). Everything else is frozen at the DM champion configuration (PR #3072).

This is a deliberate isolation experiment. If asinh alone moves the needle, we know the feature carries value independently of residual prediction. If it doesn't, and himmel's combined run improves, we can attribute the gain to residual prediction rather than asinh.

## Instructions

Run **both trials** on the DrivAerML champion config (4L/512d/8H, AdamW, EMA=0.9995, gc=0.5, Fourier, no WD). Do not change any other flag.

**Trial 1 — asinh-scale 0.75:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --asinh-pressure --asinh-scale 0.75 \
  --wandb_group dm-asinh-ablation
```

**Trial 2 — asinh-scale 0.5:**
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --asinh-pressure --asinh-scale 0.5 \
  --wandb_group dm-asinh-ablation
```

Both runs go in the same `--wandb_group dm-asinh-ablation` so they appear together in W&B.

**Reporting:** In your PR comment report `val_primary/surface_rel_l2_pct` for both trials (best val epoch), plus the W&B run IDs.

## Baseline

Current DrivAerML best (PR #3072, eren — EMA=0.9995 + gc=0.5):

| Metric | Value |
|--------|-------|
| val_primary/surface_rel_l2_pct | **3.833%** (epoch 511) |
| test surface_rel_l2_pct | 4.685% |

- Baseline W&B run: `ncl1dh88` (eren/dm-ema-9995-gc05)
- External target: <3.71% (AB-UPT, ~500 epochs)
- Reproduce: `cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py --dataset drivaerml --optimizer adamw --lr 5e-4 --cosine-t-max 30 --grad-clip 0.5 --enable-fourier --model-layers 4 --model-hidden-dim 512 --model-heads 8 --epochs 999 --batch-size 1 --drivaerml-train-surface-points 50000 --drivaerml-eval-surface-points 50000 --max-train-batches 394 --max-eval-batches 200 --ema-decay 0.9995`

Beat target: `val_primary/surface_rel_l2_pct < 3.833%`