### PR TITLE
DrivAerML: residual-prediction ablation on DM champion

### DIFF
--- a/target/icml2026/train.py
+++ b/target/icml2026/train.py
@@ -1635,17 +1635,14 @@ def main() -> None:
     ema = EMAWithWarmup(model, decay=config.ema_decay) if config.use_ema else None
     anp_ema = EMAWithWarmup(anp_head, decay=config.ema_decay) if config.use_ema and anp_head is not None else None
     history: list[dict[str, float]] = []
-    best_epoch: int | None = None
-    best_val_primary_metric_name = primary_metric_key(bundle, phase="val")
-    best_val_primary_metric: float | None = None
-    best_val_metrics: dict[str, float] = {}
-    best_model_state: dict[str, torch.Tensor] | None = None
-    best_anp_state: dict[str, torch.Tensor] | None = None
 
     if bundle.spec.name == "tandemfoilset":
         primary_metric_key = "val_primary/surface_pressure_mae"
     else:
         primary_metric_key = f"val_primary/{bundle.spec.default_metric}"
+    best_val_primary_metric_name = primary_metric_key
+    best_val_primary_metric: float | None = None
+    best_val_metrics: dict[str, float] = {}
     best_val_metric = float("inf")
     best_epoch = 0
     best_model_state: dict[str, torch.Tensor] | None = None


### PR DESCRIPTION
## Hypothesis

`--residual-prediction` has never been tested in isolation for DrivAerML on the radford branch. The related PRs only test:
- casca #3192: `--asinh-pressure` alone
- himmel #3181: `--asinh-pressure --residual-prediction` combined

Neither isolates residual prediction as a single variable. This PR fills that gap with a clean ablation.

Residual prediction adds a learned correction on top of the freestream baseline, giving the model an easier regression target. On the noam branch this was part of the winning stack. If it helps DM independently of asinh-pressure, it should be mergeable on its own and composable with asinh downstream.

## Instructions

**Step 1 — 3-epoch smoke test (Trial 1 only):**

Run Trial 1 for 3 epochs first and report `val_primary/surface_rel_l2_pct` before committing to the full run.

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 3 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --residual-prediction \
  --wandb_group dm-residual-pred-ablation
```

If the 3-epoch run is not obviously diverging, proceed to the full trials below.

---

**Trial 1 — residual-prediction only (full run):**

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --residual-prediction \
  --wandb_group dm-residual-pred-ablation
```

**Trial 2 — residual-prediction + asinh-pressure (redundancy check vs himmel #3181):**

```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995 \
  --residual-prediction \
  --asinh-pressure --asinh-scale 1.0 \
  --wandb_group dm-residual-pred-ablation
```

Run Trial 2 in parallel with Trial 1 (different GPU).

**Target:** `val_primary/surface_rel_l2_pct` < **3.833%**

Report best val metric and W&B run ID for each trial. Note the epoch at which the best checkpoint was found.

## Baseline

Current DrivAerML best (PR #3072, student: eren):
- `val_primary/surface_rel_l2_pct`: **3.833%** (epoch 511)
- test `surface_rel_l2_pct`: 4.685%
- W&B run: `ncl1dh88`
- Config: 4L/512d/8H, AdamW lr=5e-4, T_max=30, EMA=0.9995, gc=0.5, Fourier, no WD, no residual-prediction, no asinh

Reproduce command:
```bash
cd target/icml2026 && SENPAI_MAX_EPOCHS=9999 python train.py \
  --dataset drivaerml \
  --optimizer adamw --lr 5e-4 --cosine-t-max 30 \
  --grad-clip 0.5 \
  --enable-fourier \
  --model-layers 4 --model-hidden-dim 512 --model-heads 8 \
  --epochs 999 \
  --batch-size 1 \
  --drivaerml-train-surface-points 50000 \
  --drivaerml-eval-surface-points 50000 \
  --max-train-batches 394 --max-eval-batches 200 \
  --ema-decay 0.9995
```

External target for reference: AB-UPT ~3.71% (~500 epochs). Gap to close: 0.123 pp.